### PR TITLE
fix(security): authenticate mutating API endpoints with per-daemon token

### DIFF
--- a/daemon/cmd/heimdallr/main.go
+++ b/daemon/cmd/heimdallr/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -77,8 +80,15 @@ func main() {
 	ghClient := gh.NewClient(token)
 	exec := executor.New()
 
+	// Load or create the per-daemon API token.  All mutating HTTP endpoints
+	// require this token in X-Heimdallr-Token (security issue #3).
+	apiToken, err := loadOrCreateAPIToken(dataDir())
+	if err != nil {
+		slog.Warn("could not create API token — mutating endpoints unprotected", "err", err)
+	}
+
 	p := pipeline.New(s, ghClient, exec, &notifyWithSSE{notifier: notifier})
-	srv := server.New(s, broker, p)
+	srv := server.New(s, broker, p, apiToken)
 
 	// cfgMu protects cfg and sched so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
@@ -405,4 +415,35 @@ type notifyWithSSE struct {
 
 func (n *notifyWithSSE) Notify(title, message string) {
 	n.notifier.Notify(title, message)
+}
+
+// loadOrCreateAPIToken reads an existing token from <dataDir>/api_token, or
+// generates a new cryptographically-random one and writes it with mode 0600.
+// The token is used by the HTTP server to authenticate all mutating requests
+// (POST/PUT/DELETE) — see security issue #3.
+func loadOrCreateAPIToken(dir string) (string, error) {
+	path := filepath.Join(dir, "api_token")
+
+	// Try to read existing token first.
+	data, err := os.ReadFile(path)
+	if err == nil {
+		tok := strings.TrimSpace(string(data))
+		if len(tok) >= 32 {
+			return tok, nil
+		}
+	}
+
+	// Generate a new 32-byte random token (64 hex chars).
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("api_token: generate random: %w", err)
+	}
+	tok := hex.EncodeToString(buf)
+
+	// Write with mode 0600 so only the owning user can read it.
+	if err := os.WriteFile(path, []byte(tok+"\n"), 0600); err != nil {
+		return "", fmt.Errorf("api_token: write %s: %w", path, err)
+	}
+	slog.Info("api_token: created new token", "path", path)
+	return tok, nil
 }

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/hmac"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -26,13 +27,39 @@ type Server struct {
 	meFn            func() (string, error)
 	// configFn returns the current running config as a JSON-serializable map.
 	configFn func() map[string]any
+	// apiToken is required on all state-mutating requests (POST/PUT/DELETE).
+	// Empty string disables authentication (should not happen in production).
+	apiToken string
 }
 
 // New creates a new Server. p may be nil if the pipeline is not yet configured.
-func New(s *store.Store, broker *sse.Broker, p *pipeline.Pipeline) *Server {
-	srv := &Server{store: s, broker: broker, pipeline: p}
+// apiToken must be the value returned by LoadOrCreateAPIToken — it is required
+// on all mutating endpoints to prevent cross-process/browser config poisoning.
+func New(s *store.Store, broker *sse.Broker, p *pipeline.Pipeline, apiToken string) *Server {
+	srv := &Server{store: s, broker: broker, pipeline: p, apiToken: apiToken}
 	srv.router = srv.buildRouter()
 	return srv
+}
+
+// authMiddleware rejects POST/PUT/DELETE requests that do not carry the correct
+// X-Heimdallr-Token header. GET endpoints and the SSE stream are unrestricted
+// because they are read-only; the mutating endpoints are where the risk lies
+// (see security issue #3).
+func (srv *Server) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if srv.apiToken != "" {
+			switch r.Method {
+			case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+				token := r.Header.Get("X-Heimdallr-Token")
+				// Constant-time comparison to prevent timing attacks.
+				if !hmac.Equal([]byte(token), []byte(srv.apiToken)) {
+					http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+					return
+				}
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // SetReloadFn wires the config-reload callback called by POST /reload.
@@ -72,6 +99,7 @@ func (srv *Server) Shutdown(ctx context.Context) error {
 
 func (srv *Server) buildRouter() chi.Router {
 	r := chi.NewRouter()
+	r.Use(srv.authMiddleware)
 	r.Get("/health", srv.handleHealth)
 	r.Get("/me", srv.handleMe)
 	r.Get("/prs", srv.handleListPRs)

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -24,7 +24,7 @@ func setupServer(t *testing.T) (*server.Server, *store.Store) {
 	broker := sse.NewBroker()
 	broker.Start()
 	t.Cleanup(broker.Stop)
-	srv := server.New(s, broker, nil)
+	srv := server.New(s, broker, nil, "")
 	return srv, s
 }
 

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:http/http.dart' as http;
 import '../models/pr.dart';
 import '../models/review.dart';
@@ -6,11 +7,35 @@ import '../models/review.dart';
 class ApiClient {
   final http.Client _client;
   final int port;
+  String? _cachedToken;
 
   ApiClient({http.Client? httpClient, this.port = 7842})
       : _client = httpClient ?? http.Client();
 
   Uri _uri(String path) => Uri.parse('http://127.0.0.1:$port$path');
+
+  /// Returns the API token read from the daemon's token file, or null if not found.
+  /// Cached after first successful read.
+  Future<String?> _apiToken() async {
+    if (_cachedToken != null) return _cachedToken;
+    final home = Platform.environment['HOME'] ?? '';
+    if (home.isEmpty) return null;
+    final file = File('$home/.local/share/heimdallr/api_token');
+    if (await file.exists()) {
+      _cachedToken = (await file.readAsString()).trim();
+    }
+    return _cachedToken;
+  }
+
+  /// Headers for mutating requests (POST/PUT/DELETE).
+  /// Includes X-Heimdallr-Token to satisfy the auth middleware (issue #3).
+  Future<Map<String, String>> _authHeaders() async {
+    final token = await _apiToken();
+    return {
+      'Content-Type': 'application/json',
+      if (token != null && token.isNotEmpty) 'X-Heimdallr-Token': token,
+    };
+  }
 
   Future<bool> checkHealth() async {
     try {
@@ -47,21 +72,24 @@ class ApiClient {
   }
 
   Future<void> triggerReview(int prId) async {
-    final resp = await _client.post(_uri('/prs/$prId/review'));
+    final resp = await _client.post(_uri('/prs/$prId/review'),
+        headers: await _authHeaders());
     if (resp.statusCode != 202) {
       throw ApiException('POST /prs/$prId/review failed: ${resp.statusCode}');
     }
   }
 
   Future<void> dismissPR(int prId) async {
-    final resp = await _client.post(_uri('/prs/$prId/dismiss'));
+    final resp = await _client.post(_uri('/prs/$prId/dismiss'),
+        headers: await _authHeaders());
     if (resp.statusCode != 200) {
       throw ApiException('POST /prs/$prId/dismiss failed: ${resp.statusCode}');
     }
   }
 
   Future<void> undismissPR(int prId) async {
-    final resp = await _client.post(_uri('/prs/$prId/undismiss'));
+    final resp = await _client.post(_uri('/prs/$prId/undismiss'),
+        headers: await _authHeaders());
     if (resp.statusCode != 200) {
       throw ApiException('POST /prs/$prId/undismiss failed: ${resp.statusCode}');
     }
@@ -70,7 +98,7 @@ class ApiClient {
   /// Tells the daemon to reload its config from disk and restart the poll scheduler.
   Future<void> reloadConfig() async {
     try {
-      await _client.post(_uri('/reload'));
+      await _client.post(_uri('/reload'), headers: await _authHeaders());
     } catch (_) {
       // Best-effort — daemon may not be running
     }
@@ -95,13 +123,14 @@ class ApiClient {
 
   Future<void> upsertAgent(Map<String, dynamic> agent) async {
     final resp = await _client.post(_uri('/agents'),
-        headers: {'Content-Type': 'application/json'},
+        headers: await _authHeaders(),
         body: jsonEncode(agent));
     if (resp.statusCode != 200) throw ApiException('POST /agents failed: ${resp.statusCode}');
   }
 
   Future<void> deleteAgent(String id) async {
-    final resp = await _client.delete(_uri('/agents/$id'));
+    final resp = await _client.delete(_uri('/agents/$id'),
+        headers: await _authHeaders());
     if (resp.statusCode != 200) throw ApiException('DELETE /agents/$id failed: ${resp.statusCode}');
   }
 
@@ -121,7 +150,7 @@ class ApiClient {
   Future<void> updateConfig(Map<String, dynamic> config) async {
     final resp = await _client.put(
       _uri('/config'),
-      headers: {'Content-Type': 'application/json'},
+      headers: await _authHeaders(),
       body: jsonEncode(config),
     );
     if (resp.statusCode != 200) {


### PR DESCRIPTION
## Summary

Fixes **Issue #3** — Unauthenticated `PUT /config` enables RCE via config poisoning.

### Problem
All POST/PUT/DELETE endpoints on `:7842` were completely unauthenticated. Any local process or browser tab (`fetch("http://127.0.0.1:7842/config", {method:"PUT",...})`) could:
- Overwrite daemon config (chaining into the shell injection fixed in #8)
- Add malicious agents via `POST /agents`
- Trigger reviews or dismiss PRs arbitrarily

### Solution

**Token generation (daemon):**
- `loadOrCreateAPIToken()` generates a 32-byte cryptographically-random token at startup
- Written to `~/.local/share/heimdallr/api_token` with mode `0600` (owner-readable only)
- Persisted across restarts — regenerated only if missing or too short

**Auth middleware (daemon):**
- `authMiddleware` checks `X-Heimdallr-Token` on all POST/PUT/DELETE requests
- Uses `hmac.Equal` (constant-time) to prevent timing attacks
- GET endpoints remain open (read-only, no mutation risk)
- Empty token = no auth enforced (tests, graceful degradation)

**Flutter client:**
- `_apiToken()` reads the token file at `~/.local/share/heimdallr/api_token` (cached)
- `_authHeaders()` adds `X-Heimdallr-Token` to all mutating requests
- All 7 mutating methods updated: `triggerReview`, `dismissPR`, `undismissPR`, `reloadConfig`, `upsertAgent`, `deleteAgent`, `updateConfig`

### Why this works against browser attacks
A malicious page cannot read the token file (browser sandbox), so cross-origin `fetch()` calls to `:7842` will be rejected with 401 on all mutating endpoints.

## Test plan
- [x] `go test ./...` — all green (server tests use empty token = no auth)
- [x] `flutter analyze` — no issues
- [x] Existing Flutter API calls continue to work (token read from file before first request)