### PR TITLE
fix(security): validate ExtraFlags/CLIFlags against dangerous flag denylist

### DIFF
--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -129,10 +130,70 @@ func resolveCLIPath(name string) string {
 	return ""
 }
 
+// forbiddenFlagPrefixes lists flag prefixes that must never appear in the
+// free-form ExtraFlags / CLIFlags fields.  These are already modelled as
+// explicit, typed boolean fields on ExecOptions (DangerouslySkipPerms, Bare,
+// NoSessionPersistence) or reviewed values (PermissionMode).  Allowing them
+// via a free-form string would let a crafted config or API call bypass the
+// safety boundaries that the explicit fields enforce.
+var forbiddenFlagPrefixes = []string{
+	"--dangerously-skip-permissions",
+	"--danger",
+	"--allow-dangerously",
+}
+
+// forbiddenFlagValues is the set of values that are forbidden regardless of
+// which flag they follow.  "bypassPermissions" is the permission-mode value
+// that grants unrestricted tool access — it must be set only through the
+// explicit PermissionMode field, never injected via free-form strings.
+var forbiddenFlagValues = map[string]struct{}{
+	"bypassPermissions": {},
+}
+
+// ValidateExtraFlags splits flags on whitespace and rejects any token that
+// matches a dangerous flag prefix or a forbidden value (issue #5).
+// It returns a descriptive error naming the offending token so callers can
+// log it and surface it clearly to the user.
+func ValidateExtraFlags(flags string) error {
+	tokens := strings.Fields(flags)
+	for i, tok := range tokens {
+		// Check against dangerous flag prefixes (case-insensitive).
+		lower := strings.ToLower(tok)
+		for _, prefix := range forbiddenFlagPrefixes {
+			if strings.HasPrefix(lower, strings.ToLower(prefix)) {
+				return fmt.Errorf(
+					"executor: flag %q is forbidden in ExtraFlags/CLIFlags — use the dedicated config field instead",
+					tok,
+				)
+			}
+		}
+		// Check forbidden values (e.g. "bypassPermissions" after --permission-mode).
+		if _, bad := forbiddenFlagValues[tok]; bad {
+			prev := ""
+			if i > 0 {
+				prev = tokens[i-1]
+			}
+			return fmt.Errorf(
+				"executor: value %q (after %q) is forbidden in ExtraFlags/CLIFlags — use the dedicated permissionMode config field instead",
+				tok, prev,
+			)
+		}
+	}
+	return nil
+}
+
 // Execute runs the AI CLI with the given prompt and options, returning the parsed result.
 func (e *Executor) Execute(cli, prompt string, opts ExecOptions) (*ReviewResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), executionTimeout)
 	defer cancel()
+
+	// Validate free-form flags before they reach the subprocess.
+	// Reject dangerous flags that are already modelled as explicit typed fields;
+	// log a warning and surface the error to the caller (issue #5).
+	if err := ValidateExtraFlags(opts.ExtraFlags); err != nil {
+		slog.Warn("executor: ExtraFlags validation failed", "err", err)
+		return nil, err
+	}
 
 	// Resolve full path — uses login shell to find binaries in Homebrew/npm/etc.
 	cliPath := resolveCLIPath(cli)

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -84,3 +84,69 @@ func TestBuildPrompt(t *testing.T) {
 		t.Error("prompt too long — diff not normalized")
 	}
 }
+
+func TestValidateExtraFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   string
+		wantErr bool
+	}{
+		{
+			name:    "empty — allowed",
+			flags:   "",
+			wantErr: false,
+		},
+		{
+			name:    "safe flags — allowed",
+			flags:   "--output json --verbose",
+			wantErr: false,
+		},
+		{
+			name:    "--dangerously-skip-permissions — rejected",
+			flags:   "--dangerously-skip-permissions",
+			wantErr: true,
+		},
+		{
+			name:    "--dangerously-skip-permissions mixed with safe flags — rejected",
+			flags:   "--output json --dangerously-skip-permissions",
+			wantErr: true,
+		},
+		{
+			name:    "--danger prefix — rejected",
+			flags:   "--dangerous-flag",
+			wantErr: true,
+		},
+		{
+			name:    "--allow-dangerously prefix — rejected",
+			flags:   "--allow-dangerously-skip-permissions",
+			wantErr: true,
+		},
+		{
+			name:    "bypassPermissions value — rejected",
+			flags:   "--permission-mode bypassPermissions",
+			wantErr: true,
+		},
+		{
+			name:    "bypassPermissions value standalone — rejected",
+			flags:   "bypassPermissions",
+			wantErr: true,
+		},
+		{
+			name:    "case-insensitive --DANGER prefix — rejected",
+			flags:   "--DANGEROUSLY-SKIP-PERMISSIONS",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := executor.ValidateExtraFlags(tc.flags)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for flags %q, got nil", tc.flags)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for flags %q: %v", tc.flags, err)
+			}
+		})
+	}
+}

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/heimdallr/daemon/internal/executor"
 	"github.com/heimdallr/daemon/internal/pipeline"
 	"github.com/heimdallr/daemon/internal/sse"
 	"github.com/heimdallr/daemon/internal/store"
@@ -294,6 +295,16 @@ func (srv *Server) handleUpsertAgent(w http.ResponseWriter, r *http.Request) {
 	if a.ID == "" || a.Name == "" {
 		http.Error(w, "id and name are required", http.StatusBadRequest)
 		return
+	}
+	// Validate CLIFlags against the dangerous-flag denylist before storing.
+	// A compromised or malicious API call must not be able to inject flags like
+	// --dangerously-skip-permissions into stored agents (issue #5).
+	if a.CLIFlags != "" {
+		if err := executor.ValidateExtraFlags(a.CLIFlags); err != nil {
+			slog.Warn("server: CLIFlags validation failed", "agent_id", a.ID, "err", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 	if err := srv.store.UpsertAgent(&a); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -97,3 +97,41 @@ func TestHandlerPutConfig(t *testing.T) {
 func itoa(n int64) string {
 	return fmt.Sprintf("%d", n)
 }
+
+func TestHandlerUpsertAgent_ValidCLIFlags(t *testing.T) {
+	srv, _ := setupServer(t)
+	body := `{"id":"agent1","name":"Test Agent","cli_flags":"--output json"}`
+	req := httptest.NewRequest("POST", "/agents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("upsert agent with valid cli_flags: status %d, body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerUpsertAgent_DangerousCLIFlags(t *testing.T) {
+	srv, _ := setupServer(t)
+	tests := []struct {
+		name  string
+		flags string
+	}{
+		{"dangerously-skip-permissions", "--dangerously-skip-permissions"},
+		{"danger prefix", "--dangerous-flag"},
+		{"allow-dangerously prefix", "--allow-dangerously-anything"},
+		{"bypassPermissions value", "--permission-mode bypassPermissions"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"id":"agent2","name":"Evil Agent","cli_flags":"` + tc.flags + `"}`
+			req := httptest.NewRequest("POST", "/agents", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("upsert agent with dangerous cli_flags %q: expected 400, got %d (body: %s)",
+					tc.flags, w.Code, w.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5 — adds `ValidateExtraFlags()` that rejects dangerous flags (--dangerously-skip-permissions, etc.) from the free-form `ExtraFlags` and `CLIFlags` fields. These flags are already modeled as explicit boolean config fields; the free-form field should not be able to bypass safety boundaries.

## Changes

- **`daemon/internal/executor/executor.go`**: adds `ValidateExtraFlags(flags string) error` — a denylist validator that:
  - Splits the string with `strings.Fields`
  - Rejects any flag matching `--dangerously-skip-permissions`, `--danger*`, `--allow-dangerously*` (case-insensitive prefix match)
  - Rejects the value `bypassPermissions` (forbidden even when preceded by `--permission-mode`)
  - Returns a descriptive error naming the rejected flag
  - Logs a `slog.Warn` before returning the error
  - Called at the top of `Execute()` before any subprocess args are built

- **`daemon/internal/server/handlers.go`**: calls `executor.ValidateExtraFlags(a.CLIFlags)` in `handleUpsertAgent()` before persisting the agent — returns HTTP 400 with the error message if rejected

- **`daemon/internal/executor/executor_test.go`**: `TestValidateExtraFlags` — 9 table-driven cases covering safe flags, each forbidden pattern, case-insensitivity, and mixed good+bad input

- **`daemon/internal/server/handlers_test.go`**: `TestHandlerUpsertAgent_ValidCLIFlags` and `TestHandlerUpsertAgent_DangerousCLIFlags` — verifies 200 for safe flags and 400 for each forbidden pattern

## Security rationale

`ExtraFlags` (from TOML config) and `CLIFlags` (from the agents store via `POST /agents`) are split with `strings.Fields` and appended directly to the subprocess `args` slice. An attacker with write access to either path could inject `--dangerously-skip-permissions`, granting the AI CLI unrestricted filesystem and tool access. The fix enforces the same safety contract that the explicit typed fields (`DangerouslySkipPerms bool`, `PermissionMode string`) already model.