### PR TITLE
feat: add make run-linux target for Docker-based GUI testing

### DIFF
--- a/Dockerfile.linux-verify
+++ b/Dockerfile.linux-verify
@@ -18,7 +18,11 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ── System dependencies (matches CI: build.yml → Install dependencies) ────────
-# Includes both build-time and runtime deps (for make run-linux).
+#
+# The -dev packages are needed at build time (Flutter + Go compilation).
+# The runtime packages (dbus-x11, libcanberra-gtk3-module, mesa-utils) add ~5 MB
+# and allow this same image to be reused for `make run-linux` (interactive GUI
+# testing on the host desktop) without needing a separate Dockerfile.
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
       clang cmake ninja-build pkg-config \
       libgtk-3-dev liblzma-dev libstdc++-12-dev \

--- a/Dockerfile.linux-verify
+++ b/Dockerfile.linux-verify
@@ -6,6 +6,9 @@
 #   daemon tests → flutter pub get → flutter test →
 #   daemon build → flutter build linux --release → verify output artifacts
 #
+# The resulting image can also be used to run the app on the host desktop:
+#   make run-linux
+#
 # Usage:
 #   docker build -f Dockerfile.linux-verify -t heimdallr-verify .
 #   (or simply: make verify-linux)
@@ -15,12 +18,15 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ── System dependencies (matches CI: build.yml → Install dependencies) ────────
+# Includes both build-time and runtime deps (for make run-linux).
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
       clang cmake ninja-build pkg-config \
       libgtk-3-dev liblzma-dev libstdc++-12-dev \
       libayatana-appindicator3-dev libnotify-dev \
       libsecret-1-dev \
       git curl unzip xz-utils wget ca-certificates make \
+      libayatana-appindicator3-1 libnotify4 libsecret-1-0 \
+      dbus-x11 libcanberra-gtk3-module mesa-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Go 1.21 (matches daemon/go.mod) ──────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,17 @@ verify-linux:
 # Requires:
 #   - heimdallr-verify image (run 'make verify-linux' first)
 #   - X11 display (DISPLAY env var set — XWayland counts)
-#   - Docker with access to /dev/dri (GPU)
+#
+# GPU acceleration is used when /dev/dri exists; otherwise the app falls
+# back to software rendering (llvmpipe) automatically.
+#
+# --net=host is required so the container can reach the X11 unix socket
+# and the host D-Bus session bus without complex network plumbing.
+# --ipc=host is required for MIT-SHM (X11 shared memory transport),
+# without which GTK falls back to slow network-style rendering.
+#
+# The container runs as the current user (not root) to avoid file
+# ownership issues with the persisted config directory.
 #
 # Config is persisted to ~/.config/heimdallr between runs.
 # Pass GITHUB_TOKEN to connect to GitHub:
@@ -242,27 +252,54 @@ LINUX_BUNDLE := /app/flutter_app/build/linux/x64/release/bundle
 run-linux:
 	@command -v docker >/dev/null || { echo "❌  Docker is required."; exit 1; }
 	@test -n "$$DISPLAY" || { echo "❌  No DISPLAY set — need X11 (or XWayland)."; exit 1; }
-	@docker image inspect heimdallr-verify >/dev/null 2>&1 || { echo "❌  Image 'heimdallr-verify' not found. Run 'make verify-linux' first."; exit 1; }
+	@docker image inspect heimdallr-verify >/dev/null 2>&1 || \
+	  { echo "❌  Image 'heimdallr-verify' not found. Run 'make verify-linux' first."; exit 1; }
 	@mkdir -p "$$HOME/.config/heimdallr"
-	@echo "▶  Launching Heimdallr (Linux) via Docker..."
-	@echo "   Close the app window or press Ctrl-C to stop."
-	@xhost +local:docker 2>/dev/null || true
+	@# Remove stale container from a previous interrupted run (if any).
+	@docker rm -f heimdallr-run 2>/dev/null || true
+	@# --- Single shell block so the EXIT trap covers everything -----------
+	@ENV_FILE=$$(mktemp) ; \
+	cleanup() { \
+	  xhost -local:docker 2>/dev/null || true ; \
+	  rm -f "$$ENV_FILE" ; \
+	} ; \
+	trap cleanup EXIT ; \
+	\
+	echo "DISPLAY=$$DISPLAY" > "$$ENV_FILE" ; \
+	echo "HEIMDALLR_DAEMON_PATH=/app/daemon/bin/heimdallr" >> "$$ENV_FILE" ; \
+	if [ -n "$$GITHUB_TOKEN" ]; then \
+	  echo "GITHUB_TOKEN=$$GITHUB_TOKEN" >> "$$ENV_FILE" ; \
+	fi ; \
+	UID_VAL=$$(id -u) ; \
+	GID_VAL=$$(id -g) ; \
+	if [ -e /run/user/$$UID_VAL/bus ]; then \
+	  DBUS_ARGS="-v /run/user/$$UID_VAL/bus:/run/user/$$UID_VAL/bus:ro" ; \
+	  echo "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$$UID_VAL/bus" >> "$$ENV_FILE" ; \
+	fi ; \
+	GPU_ARGS="" ; \
+	if [ -e /dev/dri ]; then \
+	  GPU_ARGS="--device /dev/dri" ; \
+	else \
+	  echo "⚠  /dev/dri not found — using software rendering (llvmpipe)." ; \
+	fi ; \
+	\
+	echo "▶  Launching Heimdallr (Linux) via Docker..." ; \
+	echo "   Close the app window or press Ctrl-C to stop." ; \
+	xhost +local:docker 2>/dev/null || true ; \
+	\
 	docker run --rm \
 	  --name heimdallr-run \
-	  -e DISPLAY=$$DISPLAY \
-	  -e HEIMDALLR_DAEMON_PATH=/app/daemon/bin/heimdallr \
-	  $(if $(GITHUB_TOKEN),-e GITHUB_TOKEN=$(GITHUB_TOKEN),) \
+	  --env-file "$$ENV_FILE" \
+	  --user "$$UID_VAL:$$GID_VAL" \
 	  -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
 	  -v /run/dbus:/run/dbus:ro \
-	  -v /run/user/$$(id -u)/bus:/run/user/$$(id -u)/bus:ro \
-	  -e DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$$(id -u)/bus \
-	  -v "$$HOME/.config/heimdallr:/root/.config/heimdallr" \
-	  --device /dev/dri \
+	  $$DBUS_ARGS \
+	  -v "$$HOME/.config/heimdallr:$$HOME/.config/heimdallr" \
+	  $$GPU_ARGS \
 	  --ipc=host \
 	  --net=host \
 	  heimdallr-verify \
 	  $(LINUX_BUNDLE)/heimdallr
-	@xhost -local:docker 2>/dev/null || true
 
 clean:
 	cd daemon && make clean

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 endif
 
 .PHONY: build-daemon build-app test dev dev-daemon dev-stop \
-        release-local package-macos install-service verify-linux clean
+        release-local package-macos install-service verify-linux run-linux clean
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 
@@ -219,6 +219,50 @@ verify-linux:
 	docker build -f Dockerfile.linux-verify -t heimdallr-verify .
 	@echo ""
 	@echo "✅  Linux build verification passed"
+
+# ── Run the Linux app from Docker (manual testing) ───────────────────────────
+#
+# Launches the release-built app from the heimdallr-verify Docker image,
+# forwarding X11, D-Bus, and GPU so it renders on your desktop.
+#
+# Requires:
+#   - heimdallr-verify image (run 'make verify-linux' first)
+#   - X11 display (DISPLAY env var set — XWayland counts)
+#   - Docker with access to /dev/dri (GPU)
+#
+# Config is persisted to ~/.config/heimdallr between runs.
+# Pass GITHUB_TOKEN to connect to GitHub:
+#   GITHUB_TOKEN=ghp_... make run-linux
+#
+# Usage:
+#   make run-linux
+
+LINUX_BUNDLE := /app/flutter_app/build/linux/x64/release/bundle
+
+run-linux:
+	@command -v docker >/dev/null || { echo "❌  Docker is required."; exit 1; }
+	@test -n "$$DISPLAY" || { echo "❌  No DISPLAY set — need X11 (or XWayland)."; exit 1; }
+	@docker image inspect heimdallr-verify >/dev/null 2>&1 || { echo "❌  Image 'heimdallr-verify' not found. Run 'make verify-linux' first."; exit 1; }
+	@mkdir -p "$$HOME/.config/heimdallr"
+	@echo "▶  Launching Heimdallr (Linux) via Docker..."
+	@echo "   Close the app window or press Ctrl-C to stop."
+	@xhost +local:docker 2>/dev/null || true
+	docker run --rm \
+	  --name heimdallr-run \
+	  -e DISPLAY=$$DISPLAY \
+	  -e HEIMDALLR_DAEMON_PATH=/app/daemon/bin/heimdallr \
+	  $(if $(GITHUB_TOKEN),-e GITHUB_TOKEN=$(GITHUB_TOKEN),) \
+	  -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
+	  -v /run/dbus:/run/dbus:ro \
+	  -v /run/user/$$(id -u)/bus:/run/user/$$(id -u)/bus:ro \
+	  -e DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$$(id -u)/bus \
+	  -v "$$HOME/.config/heimdallr:/root/.config/heimdallr" \
+	  --device /dev/dri \
+	  --ipc=host \
+	  --net=host \
+	  heimdallr-verify \
+	  $(LINUX_BUNDLE)/heimdallr
+	@xhost -local:docker 2>/dev/null || true
 
 clean:
 	cd daemon && make clean


### PR DESCRIPTION
## Summary

- Adds a `make run-linux` Makefile target that launches the Heimdallr app from the `heimdallr-verify` Docker image directly on the host desktop
- Forwards X11, D-Bus session bus, and GPU (`/dev/dri`) so the app renders natively with system tray support
- Adds runtime dependencies (`dbus-x11`, `libcanberra-gtk3-module`, `mesa-utils`, `libayatana-appindicator3-1`, `libnotify4`, `libsecret-1-0`) to `Dockerfile.linux-verify`
- Config is persisted to `~/.config/heimdallr` between runs

## Usage

```bash
# Build the Docker image first (if not already built)
make verify-linux

# Launch the app on your desktop
make run-linux

# With GitHub token
GITHUB_TOKEN=ghp_... make run-linux
```

## Requirements

- Docker
- X11 display (XWayland works)
- `/dev/dri` for GPU access (falls back to software rendering if unavailable)

## Related

- Follows up on PR #11 (fix: Linux taskbar icon)
- Issue #10