### PR TITLE
feat: rename project from Heimdallr to Heimdallm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build-linux:
-    name: Build Heimdallr Linux packages (.deb / .rpm / .AppImage)
+    name: Build Heimdallm Linux packages (.deb / .rpm / .AppImage)
     runs-on: ubuntu-22.04
 
     steps:
@@ -86,51 +86,51 @@ jobs:
             echo "❌ Bundle not found at $BUNDLE"
             exit 1
           fi
-          if [ ! -f "daemon/bin/heimdallr" ]; then
-            echo "❌ daemon/bin/heimdallr not found"
+          if [ ! -f "daemon/bin/heimdallm" ]; then
+            echo "❌ daemon/bin/heimdallm not found"
             exit 1
           fi
 
           # Embed daemon binary
-          cp "daemon/bin/heimdallr" "$BUNDLE/heimdalld"
-          chmod +x "$BUNDLE/heimdallr" "$BUNDLE/heimdalld"
+          cp "daemon/bin/heimdallm" "$BUNDLE/heimdalld"
+          chmod +x "$BUNDLE/heimdallm" "$BUNDLE/heimdalld"
 
           echo "Bundle contents:"
           ls -lh "$BUNDLE"
 
           # Build staging tree: mirrors installed filesystem
           STAGING="staging"
-          OPT="$STAGING/opt/heimdallr"
+          OPT="$STAGING/opt/heimdallm"
           mkdir -p "$OPT"
           mkdir -p "$STAGING/usr/bin"
           mkdir -p "$STAGING/usr/share/applications"
           mkdir -p dist
 
           cp -r "$BUNDLE/." "$OPT/"
-          chmod +x "$OPT/heimdallr" "$OPT/heimdalld"
+          chmod +x "$OPT/heimdallm" "$OPT/heimdalld"
 
-          # /usr/bin/heimdallr → /opt/heimdallr/heimdallr
-          ln -s /opt/heimdallr/heimdallr "$STAGING/usr/bin/heimdallr"
+          # /usr/bin/heimdallm → /opt/heimdallm/heimdallm
+          ln -s /opt/heimdallm/heimdallm "$STAGING/usr/bin/heimdallm"
 
           # Icons – install pre-generated sizes for proper taskbar/dock rendering
           for SIZE in 48 128 256 512; do
             ICON_DIR="$STAGING/usr/share/icons/hicolor/${SIZE}x${SIZE}/apps"
             mkdir -p "$ICON_DIR"
-            cp "flutter_app/assets/icons/${SIZE}.png" "$ICON_DIR/heimdallr.png"
+            cp "flutter_app/assets/icons/${SIZE}.png" "$ICON_DIR/heimdallm.png"
           done
 
           # Desktop entry – filename must match APPLICATION_ID for GNOME taskbar mapping
           printf '%s\n' \
             '[Desktop Entry]' \
-            'Name=Heimdallr' \
+            'Name=Heimdallm' \
             'Comment=AI-powered GitHub PR review agent' \
-            'Exec=/opt/heimdallr/heimdallr' \
-            'Icon=heimdallr' \
+            'Exec=/opt/heimdallm/heimdallm' \
+            'Icon=heimdallm' \
             'Type=Application' \
             'Categories=Development;' \
-            'StartupWMClass=com.theburrowhub.heimdallr' \
+            'StartupWMClass=com.theburrowhub.heimdallm' \
             'StartupNotify=true' \
-            > "$STAGING/usr/share/applications/com.theburrowhub.heimdallr.desktop"
+            > "$STAGING/usr/share/applications/com.theburrowhub.heimdallm.desktop"
 
           echo "BUNDLE=$BUNDLE"   >> "$GITHUB_ENV"
           echo "STAGING=$STAGING" >> "$GITHUB_ENV"
@@ -143,20 +143,20 @@ jobs:
           fpm \
             -s dir \
             -t deb \
-            -n heimdallr \
+            -n heimdallm \
             -v "$VERSION" \
             --architecture amd64 \
             --description "AI-powered GitHub PR review agent" \
-            --url "https://github.com/theburrowhub/heimdallr" \
+            --url "https://github.com/theburrowhub/heimdallm" \
             --depends "libgtk-3-0" \
             --depends "libayatana-appindicator3-1" \
             --depends "libnotify4" \
             --depends "libsecret-1-0" \
-            --package "dist/heimdallr_${VERSION}_amd64.deb" \
+            --package "dist/heimdallm_${VERSION}_amd64.deb" \
             -C "$STAGING" \
             .
-          ls -lh "dist/heimdallr_${VERSION}_amd64.deb"
-          echo "DEB_PATH=dist/heimdallr_${VERSION}_amd64.deb" >> "$GITHUB_ENV"
+          ls -lh "dist/heimdallm_${VERSION}_amd64.deb"
+          echo "DEB_PATH=dist/heimdallm_${VERSION}_amd64.deb" >> "$GITHUB_ENV"
 
       # ── .rpm (Fedora / RHEL / openSUSE) ──────────────────────────────────────
       - name: Build .rpm package
@@ -164,19 +164,19 @@ jobs:
           fpm \
             -s dir \
             -t rpm \
-            -n heimdallr \
+            -n heimdallm \
             -v "$VERSION" \
             --architecture x86_64 \
             --description "AI-powered GitHub PR review agent" \
-            --url "https://github.com/theburrowhub/heimdallr" \
+            --url "https://github.com/theburrowhub/heimdallm" \
             --depends "gtk3" \
             --depends "libnotify" \
             --depends "libsecret" \
-            --package "dist/heimdallr-${VERSION}-1.x86_64.rpm" \
+            --package "dist/heimdallm-${VERSION}-1.x86_64.rpm" \
             -C "$STAGING" \
             .
-          ls -lh "dist/heimdallr-${VERSION}-1.x86_64.rpm"
-          echo "RPM_PATH=dist/heimdallr-${VERSION}-1.x86_64.rpm" >> "$GITHUB_ENV"
+          ls -lh "dist/heimdallm-${VERSION}-1.x86_64.rpm"
+          echo "RPM_PATH=dist/heimdallm-${VERSION}-1.x86_64.rpm" >> "$GITHUB_ENV"
 
       # ── .AppImage (universal — Arch, NixOS, and any other distro) ────────────
       - name: Build AppImage
@@ -192,27 +192,27 @@ jobs:
             '#!/bin/bash' \
             'SELF="$(readlink -f "$0")"' \
             'HERE="${SELF%/*}"' \
-            'exec "$HERE/heimdallr" "$@"' \
+            'exec "$HERE/heimdallm" "$@"' \
             > "$APPDIR/AppRun"
           chmod +x "$APPDIR/AppRun"
 
           # Desktop entry (AppImage spec: Exec= is just the binary name)
           # Note: AppImage .desktop filename must match the icon basename, so we
-          # keep 'heimdallr.desktop' here (not the reverse-DNS used for system installs).
+          # keep 'heimdallm.desktop' here (not the reverse-DNS used for system installs).
           printf '%s\n' \
             '[Desktop Entry]' \
-            'Name=Heimdallr' \
+            'Name=Heimdallm' \
             'Comment=AI-powered GitHub PR review agent' \
-            'Exec=heimdallr' \
-            'Icon=heimdallr' \
+            'Exec=heimdallm' \
+            'Icon=heimdallm' \
             'Type=Application' \
             'Categories=Development;' \
-            'StartupWMClass=com.theburrowhub.heimdallr' \
+            'StartupWMClass=com.theburrowhub.heimdallm' \
             'StartupNotify=true' \
-            > "$APPDIR/heimdallr.desktop"
+            > "$APPDIR/heimdallm.desktop"
 
           # Icon named after the desktop file (required by AppImage spec)
-          cp flutter_app/assets/icon.png "$APPDIR/heimdallr.png"
+          cp flutter_app/assets/icon.png "$APPDIR/heimdallm.png"
 
           # Download appimagetool
           wget -q \
@@ -222,23 +222,23 @@ jobs:
 
           # Build (APPIMAGE_EXTRACT_AND_RUN=1 avoids FUSE requirement in CI)
           APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 \
-            ./appimagetool "$APPDIR" "dist/Heimdallr-${VERSION}-x86_64.AppImage"
+            ./appimagetool "$APPDIR" "dist/Heimdallm-${VERSION}-x86_64.AppImage"
 
-          ls -lh "dist/Heimdallr-${VERSION}-x86_64.AppImage"
-          echo "APPIMAGE_PATH=dist/Heimdallr-${VERSION}-x86_64.AppImage" >> "$GITHUB_ENV"
+          ls -lh "dist/Heimdallm-${VERSION}-x86_64.AppImage"
+          echo "APPIMAGE_PATH=dist/Heimdallm-${VERSION}-x86_64.AppImage" >> "$GITHUB_ENV"
 
       # ── Publish ──────────────────────────────────────────────────────────────
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Heimdallr-linux-${{ env.VERSION }}
+          name: Heimdallm-linux-${{ env.VERSION }}
           path: dist/
           retention-days: 90
 
       - name: Create/Update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Heimdallr v${{ env.VERSION }}
+          name: Heimdallm v${{ env.VERSION }}
           tag_name: ${{ github.ref_name }}
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
@@ -251,7 +251,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
-    name: Build Heimdallr.dmg
+    name: Build Heimdallm.dmg
     runs-on: macos-14
 
     steps:
@@ -314,33 +314,33 @@ jobs:
           echo "✓ Found bundle: $APP"
 
           # Verify daemon binary was compiled
-          if [ ! -f "daemon/bin/heimdallr" ]; then
-            echo "❌ daemon/bin/heimdallr not found"
+          if [ ! -f "daemon/bin/heimdallm" ]; then
+            echo "❌ daemon/bin/heimdallm not found"
             exit 1
           fi
 
-          # Embed daemon as 'heimdalld' — MUST differ from Flutter's 'Heimdallr'
-          # because macOS APFS is case-insensitive: heimdallr == Heimdallr,
+          # Embed daemon as 'heimdalld' — MUST differ from Flutter's 'Heimdallm'
+          # because macOS APFS is case-insensitive: heimdallm == Heimdallm,
           # which would silently overwrite the Flutter binary with the daemon.
-          cp "daemon/bin/heimdallr" "$APP/Contents/MacOS/heimdalld"
+          cp "daemon/bin/heimdallm" "$APP/Contents/MacOS/heimdalld"
           chmod +x "$APP/Contents/MacOS/heimdalld"
 
           echo "Bundle contents after embedding:"
           ls -lh "$APP/Contents/MacOS/"
 
           # Verify both binaries are present and distinct
-          if [ ! -f "$APP/Contents/MacOS/Heimdallr" ]; then
-            echo "❌ Flutter binary Heimdallr missing"
+          if [ ! -f "$APP/Contents/MacOS/Heimdallm" ]; then
+            echo "❌ Flutter binary Heimdallm missing"
             exit 1
           fi
           if [ ! -f "$APP/Contents/MacOS/heimdalld" ]; then
             echo "❌ Daemon binary heimdalld missing"
             exit 1
           fi
-          FLUTTER_SIZE=$(stat -f%z "$APP/Contents/MacOS/Heimdallr")
+          FLUTTER_SIZE=$(stat -f%z "$APP/Contents/MacOS/Heimdallm")
           DAEMON_SIZE=$(stat -f%z "$APP/Contents/MacOS/heimdalld")
           if [ "$FLUTTER_SIZE" -eq "$DAEMON_SIZE" ] && \
-             cmp -s "$APP/Contents/MacOS/Heimdallr" "$APP/Contents/MacOS/heimdalld"; then
+             cmp -s "$APP/Contents/MacOS/Heimdallm" "$APP/Contents/MacOS/heimdalld"; then
             echo "❌ Both binaries are identical — case collision detected!"
             exit 1
           fi
@@ -381,16 +381,16 @@ jobs:
         run: |
           APP="${APP}"
           VERSION="${GITHUB_REF_NAME}"
-          DMG="dist/Heimdallr-${VERSION}.dmg"
+          DMG="dist/Heimdallm-${VERSION}.dmg"
           mkdir -p dist
 
           CREATE_DMG_ARGS=(
-            --volname "Heimdallr ${VERSION}"
+            --volname "Heimdallm ${VERSION}"
             --window-pos 200 120
             --window-size 660 400
             --icon-size 128
-            --icon "Heimdallr.app" 165 185
-            --hide-extension "Heimdallr.app"
+            --icon "Heimdallm.app" 165 185
+            --hide-extension "Heimdallm.app"
             --app-drop-link 495 185
           )
 
@@ -409,14 +409,14 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Heimdallr-${{ env.VERSION }}
+          name: Heimdallm-${{ env.VERSION }}
           path: ${{ env.DMG_PATH }}
           retention-days: 90
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Heimdallr ${{ env.VERSION }}
+          name: Heimdallm ${{ env.VERSION }}
           tag_name: ${{ github.ref_name }}
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/Dockerfile.linux-verify
+++ b/Dockerfile.linux-verify
@@ -7,7 +7,7 @@
 #   daemon build → flutter build linux --release → verify output artifacts
 #
 # Usage:
-#   docker build -f Dockerfile.linux-verify -t heimdallr-verify .
+#   docker build -f Dockerfile.linux-verify -t heimdallm-verify .
 #   (or simply: make verify-linux)
 
 FROM ubuntu:22.04
@@ -59,7 +59,7 @@ RUN cd daemon && make build
 RUN cd flutter_app && flutter build linux --release
 
 # 6. Verify output artifacts exist
-RUN test -f daemon/bin/heimdallr \
+RUN test -f daemon/bin/heimdallm \
     && test -d flutter_app/build/linux/x64/release/bundle \
-    && test -f flutter_app/build/linux/x64/release/bundle/heimdallr \
+    && test -f flutter_app/build/linux/x64/release/bundle/heimdallm \
     && echo "✓  All output artifacts verified"

--- a/LLM-HOW-TO-INSTALL.md
+++ b/LLM-HOW-TO-INSTALL.md
@@ -1,6 +1,6 @@
-# LLM How-To: Install or Update Heimdallr
+# LLM How-To: Install or Update Heimdallm
 
-Step-by-step guide for Claude Code or any AI agent to install Heimdallr on macOS or Linux.
+Step-by-step guide for Claude Code or any AI agent to install Heimdallm on macOS or Linux.
 
 - **macOS**: steps 1–5 below (DMG installer)
 - **Linux**: jump to [Linux installation](#linux-installation)
@@ -10,11 +10,11 @@ Step-by-step guide for Claude Code or any AI agent to install Heimdallr on macOS
 ## 1. Get the latest version
 
 ```bash
-VERSION=$(gh release view --repo theburrowhub/heimdallr --json tagName -q '.tagName')
-DOWNLOAD_URL=$(gh release view --repo theburrowhub/heimdallr --json assets \
+VERSION=$(gh release view --repo theburrowhub/heimdallm --json tagName -q '.tagName')
+DOWNLOAD_URL=$(gh release view --repo theburrowhub/heimdallm --json assets \
   -q '.assets[] | select(.name | endswith(".dmg")) | .browserDownloadUrl')
 
-echo "Installing Heimdallr $VERSION"
+echo "Installing Heimdallm $VERSION"
 ```
 
 ---
@@ -23,17 +23,17 @@ echo "Installing Heimdallr $VERSION"
 
 ```bash
 # Download
-curl -L "$DOWNLOAD_URL" -o "/tmp/Heimdallr.dmg" --progress-bar
+curl -L "$DOWNLOAD_URL" -o "/tmp/Heimdallm.dmg" --progress-bar
 
 # Mount
-hdiutil attach /tmp/Heimdallr.dmg -nobrowse -quiet
+hdiutil attach /tmp/Heimdallm.dmg -nobrowse -quiet
 sleep 2
 
 # Find the app inside the mounted volume
-APP_SRC=$(find /Volumes -name "Heimdallr.app" 2>/dev/null | head -1)
+APP_SRC=$(find /Volumes -name "Heimdallm.app" 2>/dev/null | head -1)
 
 # Verify the bundle has both binaries before installing
-FLUTTER_BIN="$APP_SRC/Contents/MacOS/Heimdallr"
+FLUTTER_BIN="$APP_SRC/Contents/MacOS/Heimdallm"
 DAEMON_BIN="$APP_SRC/Contents/MacOS/heimdalld"
 
 if [ ! -f "$FLUTTER_BIN" ] || [ ! -f "$DAEMON_BIN" ]; then
@@ -49,9 +49,9 @@ fi
 echo "✓ Bundle looks good ($(ls -lh "$DAEMON_BIN" | awk '{print $5}') daemon, $(ls -lh "$FLUTTER_BIN" | awk '{print $5}') launcher)"
 
 # Install
-pkill -9 -f Heimdallr 2>/dev/null; sleep 1
-rm -rf /Applications/Heimdallr.app
-cp -R "$APP_SRC" /Applications/Heimdallr.app
+pkill -9 -f Heimdallm 2>/dev/null; sleep 1
+rm -rf /Applications/Heimdallm.app
+cp -R "$APP_SRC" /Applications/Heimdallm.app
 echo "✓ Installed to /Applications"
 ```
 
@@ -62,7 +62,7 @@ echo "✓ Installed to /Applications"
 macOS blocks apps not signed by Apple by default. This one-time command removes that restriction:
 
 ```bash
-xattr -cr /Applications/Heimdallr.app
+xattr -cr /Applications/Heimdallm.app
 echo "✓ macOS restriction removed"
 ```
 
@@ -71,27 +71,27 @@ echo "✓ macOS restriction removed"
 ## 4. Launch
 
 ```bash
-open /Applications/Heimdallr.app
+open /Applications/Heimdallm.app
 sleep 5
 
 # Confirm it started (should be exactly 1)
-echo "Instances running: $(pgrep -c Heimdallr 2>/dev/null || echo 0)"
+echo "Instances running: $(pgrep -c Heimdallm 2>/dev/null || echo 0)"
 
 # Confirm the background service is up
 curl -s http://localhost:7842/health
 # Expected: {"status":"ok"}
 ```
 
-On first launch Heimdallr detects your `gh` token automatically and sets itself up.
+On first launch Heimdallm detects your `gh` token automatically and sets itself up.
 
 ---
 
 ## 5. Cleanup
 
 ```bash
-HEIMDALLR_DEV=$(mount | grep -i "Heimdallr" | awk '{print $1}' | head -1)
-[ -n "$HEIMDALLR_DEV" ] && hdiutil detach "$HEIMDALLR_DEV" 2>/dev/null
-rm -f /tmp/Heimdallr.dmg
+HEIMDALLM_DEV=$(mount | grep -i "Heimdallm" | awk '{print $1}' | head -1)
+[ -n "$HEIMDALLM_DEV" ] && hdiutil detach "$HEIMDALLM_DEV" 2>/dev/null
+rm -f /tmp/Heimdallm.dmg
 ```
 
 ---
@@ -101,46 +101,46 @@ rm -f /tmp/Heimdallr.dmg
 ### 1. Get the latest version
 
 ```bash
-VERSION=$(gh release view --repo theburrowhub/heimdallr --json tagName -q '.tagName')
-echo "Installing Heimdallr $VERSION"
+VERSION=$(gh release view --repo theburrowhub/heimdallm --json tagName -q '.tagName')
+echo "Installing Heimdallm $VERSION"
 ```
 
 ### 2. Download and install for your distro
 
 **Ubuntu / Debian / Mint / Pop!_OS (.deb):**
 ```bash
-curl -L "$(gh release view --repo theburrowhub/heimdallr --json assets \
+curl -L "$(gh release view --repo theburrowhub/heimdallm --json assets \
   -q '.assets[] | select(.name | endswith(".deb")) | .browserDownloadUrl')" \
-  -o /tmp/heimdallr.deb
-sudo dpkg -i /tmp/heimdallr.deb
+  -o /tmp/heimdallm.deb
+sudo dpkg -i /tmp/heimdallm.deb
 sudo apt-get install -f -y   # install any missing dependencies
 ```
 
 **Fedora / RHEL / openSUSE (.rpm):**
 ```bash
-curl -L "$(gh release view --repo theburrowhub/heimdallr --json assets \
+curl -L "$(gh release view --repo theburrowhub/heimdallm --json assets \
   -q '.assets[] | select(.name | endswith(".rpm")) | .browserDownloadUrl')" \
-  -o /tmp/heimdallr.rpm
-sudo rpm -i /tmp/heimdallr.rpm
+  -o /tmp/heimdallm.rpm
+sudo rpm -i /tmp/heimdallm.rpm
 ```
 
 **Any distro (AppImage):**
 ```bash
-APPIMAGE_URL=$(gh release view --repo theburrowhub/heimdallr --json assets \
+APPIMAGE_URL=$(gh release view --repo theburrowhub/heimdallm --json assets \
   -q '.assets[] | select(.name | endswith(".AppImage")) | .browserDownloadUrl')
-curl -L "$APPIMAGE_URL" -o ~/bin/Heimdallr.AppImage
-chmod +x ~/bin/Heimdallr.AppImage
+curl -L "$APPIMAGE_URL" -o ~/bin/Heimdallm.AppImage
+chmod +x ~/bin/Heimdallm.AppImage
 ```
 
 ### 3. Launch
 
 ```bash
 # .deb/.rpm — binary is in PATH
-heimdallr &
+heimdallm &
 sleep 5
 
 # AppImage
-~/bin/Heimdallr.AppImage &
+~/bin/Heimdallm.AppImage &
 sleep 5
 
 # Confirm daemon is responding
@@ -151,7 +151,7 @@ curl -s http://localhost:7842/health
 ### 4. Cleanup
 
 ```bash
-rm -f /tmp/heimdallr.deb /tmp/heimdallr.rpm
+rm -f /tmp/heimdallm.deb /tmp/heimdallm.rpm
 ```
 
 ### Troubleshooting (Linux)
@@ -163,7 +163,7 @@ sudo apt-get install -f -y
 Installs `libgtk-3-0`, `libayatana-appindicator3-1`, `libnotify4`, `libsecret-1-0`.
 
 **Token not detected**
-Heimdallr detects credentials in this order: `gh auth token` → GNOME/KDE Keyring (`secret-tool`) → `~/.config/heimdallr/.token` → `GITHUB_TOKEN` env var. Run `gh auth login` if none are configured.
+Heimdallm detects credentials in this order: `gh auth token` → GNOME/KDE Keyring (`secret-tool`) → `~/.config/heimdallm/.token` → `GITHUB_TOKEN` env var. Run `gh auth login` if none are configured.
 
 **AppImage won't run**
 ```bash
@@ -176,23 +176,23 @@ sudo apt-get install -y libfuse2   # Ubuntu 22.04+
 
 **Hundreds of instances spawn immediately**
 ```bash
-pkill -9 -f Heimdallr
+pkill -9 -f Heimdallm
 ```
 The bundle is corrupt — both binaries were the same file. Step 2 guards against this; if it happened anyway, re-download.
 
 **"Operation not permitted" / app killed on launch**
-Step 3 was skipped or ran on the DMG volume (read-only). Re-run it on `/Applications/Heimdallr.app`.
+Step 3 was skipped or ran on the DMG volume (read-only). Re-run it on `/Applications/Heimdallm.app`.
 
 **App opens and closes immediately**
 Run from Terminal to see errors:
 ```bash
-/Applications/Heimdallr.app/Contents/MacOS/Heimdallr 2>&1 &
-sleep 4 && pgrep Heimdallr
+/Applications/Heimdallm.app/Contents/MacOS/Heimdallm 2>&1 &
+sleep 4 && pgrep Heimdallm
 ```
 
 **Daemon not responding after 10 seconds**
 ```bash
-/Applications/Heimdallr.app/Contents/MacOS/heimdalld &
+/Applications/Heimdallm.app/Contents/MacOS/heimdalld &
 sleep 2 && curl -s http://localhost:7842/health
 ```
 If it exits, there's no config yet — the app creates it on first launch.
@@ -201,4 +201,4 @@ If it exits, there's no config yet — the app creates it on first launch.
 
 ## Updating
 
-Repeat from step 1. Config (`~/.config/heimdallr/`) and history (`~/.local/share/heimdallr/`) are preserved.
+Repeat from step 1. Config (`~/.config/heimdallm/`) and history (`~/.local/share/heimdallm/`) are preserved.

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # ── Platform detection ─────────────────────────────────────────────────────────
 OS := $(shell uname -s)
 
-DAEMON_BIN  := $(shell pwd)/daemon/bin/heimdallr
+DAEMON_BIN  := $(shell pwd)/daemon/bin/heimdallm
 
 ifeq ($(OS),Darwin)
   FLUTTER_DEVICE   := macos
   FLUTTER_BUILD    := flutter_app/build/macos/Build/Products
-  APP_BUNDLE       := $(FLUTTER_BUILD)/Release/Heimdallr.app
+  APP_BUNDLE       := $(FLUTTER_BUILD)/Release/Heimdallm.app
   # Detect local Developer ID Application certificate automatically
   SIGNING_IDENTITY ?= $(shell security find-identity -v -p codesigning 2>/dev/null \
 	| grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/')
@@ -40,8 +40,8 @@ test:
 # make dev-stop    — stop the running daemon
 
 dev: build-daemon dev-stop
-	@echo "▶  Lanzando Heimdallr..."
-	cd flutter_app && HEIMDALLR_DAEMON_PATH=$(DAEMON_BIN) flutter run -d $(FLUTTER_DEVICE)
+	@echo "▶  Lanzando Heimdallm..."
+	cd flutter_app && HEIMDALLM_DAEMON_PATH=$(DAEMON_BIN) flutter run -d $(FLUTTER_DEVICE)
 
 dev-daemon: build-daemon dev-stop
 	@echo "▶  Daemon en http://localhost:7842 (Ctrl-C para parar)"
@@ -49,7 +49,7 @@ dev-daemon: build-daemon dev-stop
 
 dev-stop:
 	@pkill -f "$(DAEMON_BIN)" 2>/dev/null && echo "↓  Daemon parado" || true
-	@UI_PID_FILE="$$HOME/.local/share/heimdallr/ui.pid"; \
+	@UI_PID_FILE="$$HOME/.local/share/heimdallm/ui.pid"; \
 	 if [ -f "$$UI_PID_FILE" ]; then \
 	   UI_PID=$$(cat "$$UI_PID_FILE"); \
 	   kill "$$UI_PID" 2>/dev/null && echo "↓  UI parada (PID $$UI_PID)" || true; \
@@ -69,7 +69,7 @@ dev-stop:
 #   - Apple Developer Program membership
 #   - Developer ID Application certificate installed in Keychain
 #   - App-specific password stored in Keychain:
-#       xcrun notarytool store-credentials "heimdallr-notary" \
+#       xcrun notarytool store-credentials "heimdallm-notary" \
 #         --apple-id YOUR@EMAIL.COM --team-id TEAMID --password APP_SPECIFIC_PWD
 #   - gh CLI authenticated: gh auth login
 
@@ -84,7 +84,7 @@ VERSION ?= $(shell \
 release-local: _check-macos _check-signing _check-gh build-daemon
 	@echo ""
 	@echo "╔══════════════════════════════════════════════╗"
-	@echo "║  Heimdallr local release                     ║"
+	@echo "║  Heimdallm local release                     ║"
 	@echo "╠══════════════════════════════════════════════╣"
 	@echo "║  Version  : $(VERSION)"
 	@echo "║  Identity : $(SIGNING_IDENTITY)"
@@ -124,22 +124,22 @@ release-local: _check-macos _check-signing _check-gh build-daemon
 	@command -v create-dmg >/dev/null || (echo "Installing create-dmg..."; brew install create-dmg)
 	mkdir -p dist
 	$(eval DMG_ARGS := \
-	  --volname "Heimdallr $(VERSION)" \
+	  --volname "Heimdallm $(VERSION)" \
 	  --window-pos 200 120 --window-size 660 400 \
 	  --icon-size 128 \
-	  --icon "Heimdallr.app" 165 185 \
-	  --hide-extension "Heimdallr.app" \
+	  --icon "Heimdallm.app" 165 185 \
+	  --hide-extension "Heimdallm.app" \
 	  --app-drop-link 495 185)
 	$(if $(wildcard assets/dmg-background.png), \
 	  $(eval DMG_ARGS := --background assets/dmg-background.png $(DMG_ARGS)))
-	create-dmg $(DMG_ARGS) "dist/Heimdallr-$(VERSION).dmg" "$(APP_BUNDLE)"
+	create-dmg $(DMG_ARGS) "dist/Heimdallm-$(VERSION).dmg" "$(APP_BUNDLE)"
 
 	# ── 6. Notarize DMG ───────────────────────────────────────────────────────
 	@echo "▶  Submitting for notarization (this takes a few minutes)..."
-	xcrun notarytool submit "dist/Heimdallr-$(VERSION).dmg" \
-	  --keychain-profile "heimdallr-notary" \
+	xcrun notarytool submit "dist/Heimdallm-$(VERSION).dmg" \
+	  --keychain-profile "heimdallm-notary" \
 	  --wait
-	xcrun stapler staple "dist/Heimdallr-$(VERSION).dmg"
+	xcrun stapler staple "dist/Heimdallm-$(VERSION).dmg"
 	@echo "✓  Notarization complete"
 
 	# ── 7. Create git tag ─────────────────────────────────────────────────────
@@ -150,12 +150,12 @@ release-local: _check-macos _check-signing _check-gh build-daemon
 	# ── 8. Publish GitHub release ─────────────────────────────────────────────
 	@echo "▶  Publishing GitHub release..."
 	gh release create "$(VERSION)" \
-	  "dist/Heimdallr-$(VERSION).dmg" \
-	  --title "Heimdallr $(VERSION)" \
+	  "dist/Heimdallm-$(VERSION).dmg" \
+	  --title "Heimdallm $(VERSION)" \
 	  --generate-notes \
 	  --verify-tag
 	@echo ""
-	@echo "✅  Released Heimdallr $(VERSION)"
+	@echo "✅  Released Heimdallm $(VERSION)"
 	@echo "    https://github.com/$$(gh repo view --json nameWithOwner -q .nameWithOwner)/releases/tag/$(VERSION)"
 
 # ── Guards ────────────────────────────────────────────────────────────────────
@@ -197,10 +197,10 @@ package-macos: _check-macos build-daemon build-app
 	codesign --force --deep --sign - "$(APP_BUNDLE)"
 	mkdir -p dist
 	hdiutil create \
-	  -volname "Heimdallr" \
+	  -volname "Heimdallm" \
 	  -srcfolder "$(APP_BUNDLE)" \
 	  -ov -format UDZO \
-	  "dist/Heimdallr.dmg"
+	  "dist/Heimdallm.dmg"
 
 # ── Docker-based Linux build verification ─────────────────────────────────────
 #
@@ -216,7 +216,7 @@ package-macos: _check-macos build-daemon build-app
 verify-linux:
 	@command -v docker >/dev/null || { echo "❌  Docker is required. Install it from https://docs.docker.com/get-docker/"; exit 1; }
 	@echo "▶  Building Linux verification image (this may take a few minutes on first run)..."
-	docker build -f Dockerfile.linux-verify -t heimdallr-verify .
+	docker build -f Dockerfile.linux-verify -t heimdallm-verify .
 	@echo ""
 	@echo "✅  Linux build verification passed"
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Heimdallr
+# Heimdallm
 
 > AI-powered GitHub PR review agent for macOS and Linux — reviews your pull requests automatically using Claude, Gemini or Codex, posts the review directly to GitHub, and keeps you informed via native notifications.
 
-![Heimdallr dashboard](assets/icon.png)
+![Heimdallm dashboard](assets/icon.png)
 
 ---
 
 ## What it does
 
-Heimdallr runs silently in your menu bar. It watches the GitHub PRs where you're requested as a reviewer, runs an AI code review on each one, and submits the review back to GitHub — no copy-pasting, no manual prompting.
+Heimdallm runs silently in your menu bar. It watches the GitHub PRs where you're requested as a reviewer, runs an AI code review on each one, and submits the review back to GitHub — no copy-pasting, no manual prompting.
 
 - **Automatic reviews** — polls `review-requested:@me` on GitHub and submits reviews as your GitHub account
 - **Configurable prompts** — general review, security audit, performance, architecture, or your own custom instructions with `{diff}` `{title}` `{author}` placeholders
@@ -23,43 +23,43 @@ Heimdallr runs silently in your menu bar. It watches the GitHub PRs where you're
 
 ### macOS (DMG)
 
-1. Download `Heimdallr-vX.Y.Z.dmg` from [Releases](https://github.com/theburrowhub/heimdallr/releases)
-2. Open the DMG and drag **Heimdallr** to **Applications**
+1. Download `Heimdallm-vX.Y.Z.dmg` from [Releases](https://github.com/theburrowhub/heimdallm/releases)
+2. Open the DMG and drag **Heimdallm** to **Applications**
 3. Open Terminal and run once:
    ```bash
-   xattr -cr /Applications/Heimdallr.app
+   xattr -cr /Applications/Heimdallm.app
    ```
-4. Double-click Heimdallr in Applications
+4. Double-click Heimdallm in Applications
 
 > **Requires**: macOS 13+ (Apple Silicon or Intel), `gh` CLI authenticated (`gh auth login`).
 
 ### Linux
 
-Download from [Releases](https://github.com/theburrowhub/heimdallr/releases) and install for your distro:
+Download from [Releases](https://github.com/theburrowhub/heimdallm/releases) and install for your distro:
 
 | Package | Distros | Command |
 |---------|---------|---------|
-| `.deb` | Ubuntu, Debian, Mint, Pop!\_OS | `sudo dpkg -i heimdallr_X.Y.Z_amd64.deb` |
-| `.rpm` | Fedora, RHEL, openSUSE | `sudo rpm -i heimdallr-X.Y.Z-1.x86_64.rpm` |
-| `.AppImage` | Arch, NixOS, any distro | `chmod +x Heimdallr-X.Y.Z-x86_64.AppImage && ./Heimdallr-X.Y.Z-x86_64.AppImage` |
+| `.deb` | Ubuntu, Debian, Mint, Pop!\_OS | `sudo dpkg -i heimdallm_X.Y.Z_amd64.deb` |
+| `.rpm` | Fedora, RHEL, openSUSE | `sudo rpm -i heimdallm-X.Y.Z-1.x86_64.rpm` |
+| `.AppImage` | Arch, NixOS, any distro | `chmod +x Heimdallm-X.Y.Z-x86_64.AppImage && ./Heimdallm-X.Y.Z-x86_64.AppImage` |
 
-Installs to `/opt/heimdallr/` with a desktop entry and `/usr/bin/heimdallr` symlink.
+Installs to `/opt/heimdallm/` with a desktop entry and `/usr/bin/heimdallm` symlink.
 
-> **Requires**: `gh` CLI authenticated (`gh auth login`). Token stored via GNOME Keyring / KDE Wallet (`secret-tool`), or `~/.config/heimdallr/.token` as fallback.
+> **Requires**: `gh` CLI authenticated (`gh auth login`). Token stored via GNOME Keyring / KDE Wallet (`secret-tool`), or `~/.config/heimdallm/.token` as fallback.
 
 ### Automated install (for agents / scripts)
 
 See [LLM-HOW-TO-INSTALL.md](LLM-HOW-TO-INSTALL.md) for a step-by-step guide suitable for Claude Code, shell scripts, or any automation tool.
 
-On first launch Heimdallr detects your `gh` CLI token automatically and sets itself up.
+On first launch Heimdallm detects your `gh` CLI token automatically and sets itself up.
 
 ---
 
 ## Architecture
 
 ```
-Heimdallr.app/
-├── Heimdallr          ← Flutter macOS UI
+Heimdallm.app/
+├── Heimdallm          ← Flutter macOS UI
 └── heimdalld          ← Go daemon (background service)
 ```
 
@@ -86,13 +86,13 @@ Flutter app  ←→  HTTP/SSE  ←→  heimdalld  ←→  GitHub API
 
 ```bash
 # Clone
-git clone https://github.com/theburrowhub/heimdallr && cd heimdallr
+git clone https://github.com/theburrowhub/heimdallm && cd heimdallm
 
 # Run (builds daemon + launches app in debug mode)
 make dev
 ```
 
-`make dev` compiles the daemon, embeds it, and launches the Flutter app with `HEIMDALLR_DAEMON_PATH` pointing to the local binary. On first run the app detects your `gh` token and creates `~/.config/heimdallr/config.toml`.
+`make dev` compiles the daemon, embeds it, and launches the Flutter app with `HEIMDALLM_DAEMON_PATH` pointing to the local binary. On first run the app detects your `gh` token and creates `~/.config/heimdallm/config.toml`.
 
 ### Other targets
 
@@ -106,7 +106,7 @@ make release-local # Build signed + notarized DMG and publish GitHub release
 ### Project structure
 
 ```
-heimdallr/
+heimdallm/
 ├── daemon/                  Go background service
 │   └── internal/
 │       ├── github/          GitHub API client (PRs, diffs, submit reviews)

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,5 +1,5 @@
-BINARY = bin/heimdallr
-CMD    = ./cmd/heimdallr
+BINARY = bin/heimdallm
+CMD    = ./cmd/heimdallm
 
 .PHONY: build test test-race lint clean dev
 

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -15,17 +15,17 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/heimdallr/daemon/internal/config"
-	"github.com/heimdallr/daemon/internal/executor"
-	gh "github.com/heimdallr/daemon/internal/github"
-	"github.com/heimdallr/daemon/internal/keychain"
-	"github.com/heimdallr/daemon/internal/notify"
-	"github.com/heimdallr/daemon/internal/pipeline"
-	"github.com/heimdallr/daemon/internal/scheduler"
-	"github.com/heimdallr/daemon/internal/server"
-	"github.com/heimdallr/daemon/internal/sse"
-	"github.com/heimdallr/daemon/internal/store"
-	"github.com/heimdallr/daemon/launchagent"
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/executor"
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/keychain"
+	"github.com/heimdallm/daemon/internal/notify"
+	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/scheduler"
+	"github.com/heimdallm/daemon/internal/server"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
+	"github.com/heimdallm/daemon/launchagent"
 )
 
 func main() {
@@ -62,7 +62,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	dbPath := filepath.Join(dataDir(), "heimdallr.db")
+	dbPath := filepath.Join(dataDir(), "heimdallm.db")
 	s, err := store.Open(dbPath)
 	if err != nil {
 		slog.Error("store open failed", "err", err)
@@ -82,7 +82,7 @@ func main() {
 	exec := executor.New()
 
 	// Load or create the per-daemon API token.  All mutating HTTP endpoints
-	// require this token in X-Heimdallr-Token (security issue #3).
+	// require this token in X-Heimdallm-Token (security issue #3).
 	apiToken, err := loadOrCreateAPIToken(dataDir())
 	if err != nil {
 		slog.Error("could not create API token — refusing to start without authentication", "err", err)
@@ -436,7 +436,7 @@ func setupLogging() {
 
 func dataDir() string {
 	home, _ := os.UserHomeDir()
-	dir := filepath.Join(home, ".local", "share", "heimdallr")
+	dir := filepath.Join(home, ".local", "share", "heimdallm")
 	os.MkdirAll(dir, 0700)
 	return dir
 }

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -1,4 +1,4 @@
-module github.com/heimdallr/daemon
+module github.com/heimdallm/daemon
 
 go 1.21
 

--- a/daemon/integration_test.go
+++ b/daemon/integration_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/heimdallr/daemon/internal/executor"
-	gh "github.com/heimdallr/daemon/internal/github"
-	"github.com/heimdallr/daemon/internal/pipeline"
-	"github.com/heimdallr/daemon/internal/server"
-	"github.com/heimdallr/daemon/internal/sse"
-	"github.com/heimdallr/daemon/internal/store"
+	"github.com/heimdallm/daemon/internal/executor"
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/server"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
 )
 
 func fakeGHServer(t *testing.T) *httptest.Server {

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
-	"github.com/heimdallr/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/executor"
 )
 
 var validIntervals = map[string]bool{
@@ -152,8 +152,8 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// DefaultPath returns ~/.config/heimdallr/config.toml
+// DefaultPath returns ~/.config/heimdallm/config.toml
 func DefaultPath() string {
 	home, _ := os.UserHomeDir()
-	return home + "/.config/heimdallr/config.toml"
+	return home + "/.config/heimdallm/config.toml"
 }

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/heimdallr/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/config"
 )
 
 func TestLoad_Defaults(t *testing.T) {

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -89,7 +89,7 @@ func (e *Executor) Detect(primary, fallback string) (string, error) {
 	return "", fmt.Errorf("executor: no AI CLI available (tried %q, %q)", primary, fallback)
 }
 
-// allowedCLIs is the strict allowlist of AI CLI names Heimdallr supports.
+// allowedCLIs is the strict allowlist of AI CLI names Heimdallm supports.
 // Any value not in this set is rejected before reaching resolveCLIPath,
 // preventing shell injection via a crafted ai.primary / ai.fallback config value.
 var allowedCLIs = map[string]struct{}{
@@ -100,7 +100,7 @@ var allowedCLIs = map[string]struct{}{
 
 // allowedPermissionModes is the strict allowlist for the --permission-mode flag.
 // "bypassPermissions" is intentionally excluded — it grants unrestricted filesystem
-// access and must never be passed to the claude CLI from Heimdallr config.
+// access and must never be passed to the claude CLI from Heimdallm config.
 var allowedPermissionModes = map[string]struct{}{
 	"default":     {},
 	"auto":        {},
@@ -249,7 +249,7 @@ var dangerousSegments = []string{
 	"/.ssh",            // SSH private keys, host keys, authorized_keys
 	"/.gnupg",          // GPG keys, trust database
 	"/.aws",            // AWS access keys, credentials files
-	"/.config/heimdallr", // Heimdallr daemon config (auth tokens, etc)
+	"/.config/heimdallm", // Heimdallm daemon config (auth tokens, etc)
 	"/.kube",           // Kubernetes credentials (service account tokens, certs)
 	"/.docker",         // Docker registry auth (config.json with credentials)
 	"/.netrc",          // FTP/HTTP plaintext credentials

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/heimdallr/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/executor"
 )
 
 func TestDetect(t *testing.T) {

--- a/daemon/internal/executor/prompt_test.go
+++ b/daemon/internal/executor/prompt_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/heimdallr/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/executor"
 )
 
 func TestBuildPromptFromTemplate_CommentsSubstituted(t *testing.T) {

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	gh "github.com/heimdallr/daemon/internal/github"
+	gh "github.com/heimdallm/daemon/internal/github"
 )
 
 func TestFetchPRs(t *testing.T) {

--- a/daemon/internal/keychain/keychain.go
+++ b/daemon/internal/keychain/keychain.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const service = "heimdallr"
+const service = "heimdallm"
 const account = "github-token"
 
 // Get retrieves the GitHub token from macOS Keychain.

--- a/daemon/internal/notify/notify.go
+++ b/daemon/internal/notify/notify.go
@@ -8,7 +8,7 @@ func New() *Notifier { return &Notifier{} }
 
 // Notify logs the notification. OS-level notifications are handled by the
 // Flutter app via SSE events so the daemon never calls osascript directly
-// (osascript associates notifications with Script Editor, not Heimdallr).
+// (osascript associates notifications with Script Editor, not Heimdallm).
 func (n *Notifier) Notify(title, message string) {
 	slog.Info("notify", "title", title, "message", message)
 }

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/heimdallr/daemon/internal/executor"
-	"github.com/heimdallr/daemon/internal/github"
-	"github.com/heimdallr/daemon/internal/store"
+	"github.com/heimdallm/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/store"
 )
 
 // DiffFetcher retrieves the diff for a pull request.
@@ -330,7 +330,7 @@ func buildIssueComment(issue executor.Issue) string {
 			sb.WriteString(fmt.Sprintf(" line %d", issue.Line))
 		}
 	}
-	sb.WriteString("\n\n---\n*Posted by Heimdallr AI Review*")
+	sb.WriteString("\n\n---\n*Posted by Heimdallm AI Review*")
 	return sb.String()
 }
 
@@ -338,7 +338,7 @@ func buildIssueComment(issue executor.Issue) string {
 // Individual issues are already posted as separate comments; this is the formal review summary.
 func buildMultiSummaryBody(r *executor.ReviewResult) string {
 	var sb strings.Builder
-	sb.WriteString("## 🤖 Heimdallr AI Review — Summary\n\n")
+	sb.WriteString("## 🤖 Heimdallm AI Review — Summary\n\n")
 	sb.WriteString(r.Summary)
 	sb.WriteString("\n\n")
 	if len(r.Issues) > 0 {
@@ -351,7 +351,7 @@ func buildMultiSummaryBody(r *executor.ReviewResult) string {
 		}
 		sb.WriteString("\n")
 	}
-	sb.WriteString(fmt.Sprintf("---\n*Severity: **%s** · Reviewed by Heimdallr*",
+	sb.WriteString(fmt.Sprintf("---\n*Severity: **%s** · Reviewed by Heimdallm*",
 		strings.ToUpper(r.Severity)))
 	return sb.String()
 }
@@ -359,7 +359,7 @@ func buildMultiSummaryBody(r *executor.ReviewResult) string {
 // buildGitHubBody formats the AI review as a GitHub-flavored markdown review body.
 func buildGitHubBody(r *executor.ReviewResult) string {
 	var sb strings.Builder
-	sb.WriteString("## 🤖 Heimdallr AI Review\n\n")
+	sb.WriteString("## 🤖 Heimdallm AI Review\n\n")
 	sb.WriteString(r.Summary)
 	sb.WriteString("\n\n")
 
@@ -387,12 +387,12 @@ func buildGitHubBody(r *executor.ReviewResult) string {
 	}
 
 	sb.WriteString(fmt.Sprintf("---\n*Severity: **%s** · Reviewed by %s*",
-		strings.ToUpper(r.Severity), "Heimdallr"))
+		strings.ToUpper(r.Severity), "Heimdallm"))
 	return sb.String()
 }
 
 // severityToEvent maps severity to a GitHub review event type.
-// Only high-severity issues block a PR — Heimdallr must not be a blocker
+// Only high-severity issues block a PR — Heimdallm must not be a blocker
 // for medium/low issues. Those are left as informational comments with an APPROVE.
 func severityToEvent(severity string, _ int) string {
 	if severity == "high" {

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/heimdallr/daemon/internal/executor"
-	"github.com/heimdallr/daemon/internal/github"
-	"github.com/heimdallr/daemon/internal/pipeline"
-	"github.com/heimdallr/daemon/internal/store"
+	"github.com/heimdallm/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/store"
 )
 
 type fakeGH struct {

--- a/daemon/internal/scheduler/scheduler_test.go
+++ b/daemon/internal/scheduler/scheduler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/heimdallr/daemon/internal/scheduler"
+	"github.com/heimdallm/daemon/internal/scheduler"
 )
 
 func TestScheduler_Ticks(t *testing.T) {

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -17,10 +17,10 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/heimdallr/daemon/internal/executor"
-	"github.com/heimdallr/daemon/internal/pipeline"
-	"github.com/heimdallr/daemon/internal/sse"
-	"github.com/heimdallr/daemon/internal/store"
+	"github.com/heimdallm/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
 )
 
 // Server holds the HTTP router, SSE broker, store, and optional pipeline.
@@ -89,7 +89,7 @@ var sensitiveGETPaths = []string{
 }
 
 // authMiddleware rejects:
-//   - POST/PUT/PATCH/DELETE requests without a valid X-Heimdallr-Token header.
+//   - POST/PUT/PATCH/DELETE requests without a valid X-Heimdallm-Token header.
 //   - GET requests to /config or /agents without a valid token (these endpoints
 //     return local directory paths, CLI flags, and agent configs that should not
 //     be readable by arbitrary browser tabs — see security issue #3).
@@ -109,7 +109,7 @@ func (srv *Server) authMiddleware(next http.Handler) http.Handler {
 				}
 			}
 			if needsAuth {
-				token := r.Header.Get("X-Heimdallr-Token")
+				token := r.Header.Get("X-Heimdallm-Token")
 				// Constant-time comparison to prevent timing attacks.
 				if !hmac.Equal([]byte(token), []byte(srv.apiToken)) {
 					http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
@@ -518,18 +518,18 @@ func (srv *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 }
 
 // daemonLogPath returns the platform-specific path to the daemon stderr log.
-// macOS: ~/Library/Logs/heimdallr/heimdallr-daemon-error.log (LaunchAgent convention)
-// Linux/other: $XDG_STATE_HOME/heimdallr/heimdallr.log (fallback ~/.local/share/heimdallr/heimdallr.log)
+// macOS: ~/Library/Logs/heimdallm/heimdallm-daemon-error.log (LaunchAgent convention)
+// Linux/other: $XDG_STATE_HOME/heimdallm/heimdallm.log (fallback ~/.local/share/heimdallm/heimdallm.log)
 func daemonLogPath() string {
 	home, _ := os.UserHomeDir()
 	switch runtime.GOOS {
 	case "darwin":
-		return filepath.Join(home, "Library", "Logs", "heimdallr", "heimdallr-daemon-error.log")
+		return filepath.Join(home, "Library", "Logs", "heimdallm", "heimdallm-daemon-error.log")
 	default:
 		if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
-			return filepath.Join(xdg, "heimdallr", "heimdallr.log")
+			return filepath.Join(xdg, "heimdallm", "heimdallm.log")
 		}
-		return filepath.Join(home, ".local", "share", "heimdallr", "heimdallr.log")
+		return filepath.Join(home, ".local", "share", "heimdallm", "heimdallm.log")
 	}
 }
 

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/heimdallr/daemon/internal/server"
-	"github.com/heimdallr/daemon/internal/sse"
-	"github.com/heimdallr/daemon/internal/store"
+	"github.com/heimdallm/daemon/internal/server"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
 )
 
 func setupServer(t *testing.T) (*server.Server, *store.Store) {
@@ -130,7 +130,7 @@ func TestHandlerLogsStream_WithToken(t *testing.T) {
 	defer cancel()
 
 	req := httptest.NewRequest("GET", "/logs/stream", nil).WithContext(ctx)
-	req.Header.Set("X-Heimdallr-Token", "secret-token")
+	req.Header.Set("X-Heimdallm-Token", "secret-token")
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
@@ -159,7 +159,7 @@ func TestPublicEndpointsRequireAuthWhenTokenSet(t *testing.T) {
 
 		// With valid token → not 401
 		req2 := httptest.NewRequest("GET", path, nil)
-		req2.Header.Set("X-Heimdallr-Token", "secret-token")
+		req2.Header.Set("X-Heimdallm-Token", "secret-token")
 		w2 := httptest.NewRecorder()
 		srv.Router().ServeHTTP(w2, req2)
 		if w2.Code == http.StatusUnauthorized {
@@ -203,7 +203,7 @@ func TestHandlerTriggerReviewRateLimit(t *testing.T) {
 	// Fire 2 concurrent reviews — should succeed
 	for i := 1; i <= 2; i++ {
 		req := httptest.NewRequest("POST", fmt.Sprintf("/prs/%d/review", i), nil)
-		req.Header.Set("X-Heimdallr-Token", token)
+		req.Header.Set("X-Heimdallm-Token", token)
 		w := httptest.NewRecorder()
 		srv.Router().ServeHTTP(w, req)
 		if w.Code != http.StatusAccepted {
@@ -216,7 +216,7 @@ func TestHandlerTriggerReviewRateLimit(t *testing.T) {
 
 	// Third review should be rejected with 429
 	req := httptest.NewRequest("POST", "/prs/3/review", nil)
-	req.Header.Set("X-Heimdallr-Token", token)
+	req.Header.Set("X-Heimdallm-Token", token)
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 	if w.Code != http.StatusTooManyRequests {
@@ -281,7 +281,7 @@ func TestHandlerPutConfigValueValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest("PUT", "/config",
 				strings.NewReader(tc.body))
-			req.Header.Set("X-Heimdallr-Token", "secret-token")
+			req.Header.Set("X-Heimdallm-Token", "secret-token")
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
 			srv.Router().ServeHTTP(w, req)

--- a/daemon/internal/sse/broker_test.go
+++ b/daemon/internal/sse/broker_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/heimdallr/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/sse"
 )
 
 func TestBroker_PublishAndReceive(t *testing.T) {

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/heimdallr/daemon/internal/store"
+	"github.com/heimdallm/daemon/internal/store"
 )
 
 func newTestStore(t *testing.T) *store.Store {

--- a/daemon/launchagent/plist.go
+++ b/daemon/launchagent/plist.go
@@ -8,14 +8,14 @@ import (
 	"text/template"
 )
 
-const plistName = "com.heimdallr.daemon.plist"
+const plistName = "com.heimdallm.daemon.plist"
 
 var plistTemplate = template.Must(template.New("plist").Parse(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Label</key>
-	<string>com.heimdallr.daemon</string>
+	<string>com.heimdallm.daemon</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>{{.BinaryPath}}</string>
@@ -25,9 +25,9 @@ var plistTemplate = template.Must(template.New("plist").Parse(`<?xml version="1.
 	<key>KeepAlive</key>
 	<true/>
 	<key>StandardOutPath</key>
-	<string>{{.LogDir}}/heimdallr-daemon.log</string>
+	<string>{{.LogDir}}/heimdallm-daemon.log</string>
 	<key>StandardErrorPath</key>
-	<string>{{.LogDir}}/heimdallr-daemon-error.log</string>
+	<string>{{.LogDir}}/heimdallm-daemon-error.log</string>
 </dict>
 </plist>
 `))
@@ -46,7 +46,7 @@ func Install(binaryPath string) error {
 	if err != nil {
 		return err
 	}
-	logDir := filepath.Join(home, "Library", "Logs", "heimdallr")
+	logDir := filepath.Join(home, "Library", "Logs", "heimdallm")
 	if err := os.MkdirAll(logDir, 0700); err != nil {
 		return fmt.Errorf("launchagent: mkdir logs: %w", err)
 	}

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Heimdallr — AI-powered GitHub PR Reviews for macOS &amp; Linux</title>
-  <meta name="description" content="Heimdallr watches your GitHub pull requests and automatically runs AI code reviews using Claude, Gemini or Codex — then posts the review directly to GitHub. Available for macOS and Linux.">
-  <meta property="og:title" content="Heimdallr">
+  <title>Heimdallm — AI-powered GitHub PR Reviews for macOS &amp; Linux</title>
+  <meta name="description" content="Heimdallm watches your GitHub pull requests and automatically runs AI code reviews using Claude, Gemini or Codex — then posts the review directly to GitHub. Available for macOS and Linux.">
+  <meta property="og:title" content="Heimdallm">
   <meta property="og:description" content="AI-powered GitHub PR reviews for macOS and Linux. Runs in your menu bar. Reviews automatically. Posts to GitHub.">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -311,11 +311,11 @@
 
 <!-- Nav -->
 <nav>
-  <div class="logo"><span>🛡️</span> Heimdallr</div>
+  <div class="logo"><span>🛡️</span> Heimdallm</div>
   <a href="#features">Features</a>
   <a href="#prompts">Prompts</a>
   <a href="#install">Install</a>
-  <a href="https://github.com/theburrowhub/heimdallr" class="cta">GitHub →</a>
+  <a href="https://github.com/theburrowhub/heimdallm" class="cta">GitHub →</a>
 </nav>
 
 <!-- Hero -->
@@ -323,14 +323,14 @@
   <div class="hero-badge">⚡ macOS &amp; Linux · Free · Open Source</div>
   <h1>Your PRs, <em>reviewed automatically</em>.<br>Posted to GitHub.</h1>
   <p>
-    Heimdallr runs silently in your menu bar, watches your GitHub review requests,
+    Heimdallm runs silently in your menu bar, watches your GitHub review requests,
     and submits AI-generated code reviews — powered by Claude, Gemini or Codex.
   </p>
   <div class="hero-actions">
-    <a href="https://github.com/theburrowhub/heimdallr/releases/latest" class="btn btn-primary">
+    <a href="https://github.com/theburrowhub/heimdallm/releases/latest" class="btn btn-primary">
       ⬇️ Download
     </a>
-    <a href="https://github.com/theburrowhub/heimdallr" class="btn btn-secondary">
+    <a href="https://github.com/theburrowhub/heimdallm" class="btn btn-secondary">
       View on GitHub
     </a>
   </div>
@@ -340,7 +340,7 @@
 <div class="flow">
   <div class="flow-step"><span class="flow-icon">🔔</span><strong>PR arrives</strong><p>Someone requests your review on GitHub</p></div>
   <div class="flow-arrow">→</div>
-  <div class="flow-step"><span class="flow-icon">🤖</span><strong>AI reviews</strong><p>Heimdallr fetches the diff and runs your AI agent</p></div>
+  <div class="flow-step"><span class="flow-icon">🤖</span><strong>AI reviews</strong><p>Heimdallm fetches the diff and runs your AI agent</p></div>
   <div class="flow-arrow">→</div>
   <div class="flow-step"><span class="flow-icon">📝</span><strong>Posted to GitHub</strong><p>Review submitted as your account with severity rating</p></div>
   <div class="flow-arrow">→</div>
@@ -352,7 +352,7 @@
   <div class="section-inner">
     <div class="section-label">Features</div>
     <h2>Everything you need. Nothing you don't.</h2>
-    <p>Heimdallr is a small, focused tool that does one thing well.</p>
+    <p>Heimdallm is a small, focused tool that does one thing well.</p>
     <div class="grid">
       <div class="card">
         <div class="card-icon">🔍</div>
@@ -403,8 +403,8 @@
       <div class="review-header">
         <div class="avatar">🤖</div>
         <div class="meta">
-          <strong>Heimdallr AI Review</strong>
-          <span>reviewed just now via heimdallr · Reviewed by claude</span>
+          <strong>Heimdallm AI Review</strong>
+          <span>reviewed just now via heimdallm · Reviewed by claude</span>
         </div>
         <span class="badge">HIGH</span>
       </div>
@@ -464,14 +464,14 @@
           <div>
             <h4>Download</h4>
             <p>Grab the latest DMG from GitHub Releases.</p>
-            <a href="https://github.com/theburrowhub/heimdallr/releases/latest" class="btn btn-primary" style="margin-top:.75rem; font-size:.85rem; padding:.5rem 1rem;">⬇️ Download .dmg</a>
+            <a href="https://github.com/theburrowhub/heimdallm/releases/latest" class="btn btn-primary" style="margin-top:.75rem; font-size:.85rem; padding:.5rem 1rem;">⬇️ Download .dmg</a>
           </div>
         </div>
         <div class="install-step">
           <div class="step-num">2</div>
           <div>
             <h4>Drag to Applications</h4>
-            <p>Open the DMG and drag Heimdallr to the Applications folder.</p>
+            <p>Open the DMG and drag Heimdallm to the Applications folder.</p>
           </div>
         </div>
         <div class="install-step">
@@ -479,7 +479,7 @@
           <div>
             <h4>Remove quarantine</h4>
             <p>Run once in Terminal — macOS security requirement for unsigned apps:</p>
-            <pre class="inline-code">xattr -cr /Applications/Heimdallr.app</pre>
+            <pre class="inline-code">xattr -cr /Applications/Heimdallm.app</pre>
           </div>
         </div>
       </div>
@@ -493,14 +493,14 @@
           <div class="step-num">1</div>
           <div>
             <h4>Download .deb</h4>
-            <a href="https://github.com/theburrowhub/heimdallr/releases/latest" class="btn btn-primary" style="margin-top:.75rem; font-size:.85rem; padding:.5rem 1rem;">⬇️ Download .deb</a>
+            <a href="https://github.com/theburrowhub/heimdallm/releases/latest" class="btn btn-primary" style="margin-top:.75rem; font-size:.85rem; padding:.5rem 1rem;">⬇️ Download .deb</a>
           </div>
         </div>
         <div class="install-step">
           <div class="step-num">2</div>
           <div>
             <h4>Install</h4>
-            <pre class="inline-code">sudo dpkg -i heimdallr_*.deb
+            <pre class="inline-code">sudo dpkg -i heimdallm_*.deb
 sudo apt-get install -f -y</pre>
           </div>
         </div>
@@ -508,12 +508,12 @@ sudo apt-get install -f -y</pre>
           <div class="step-num">3</div>
           <div>
             <h4>Launch</h4>
-            <pre class="inline-code">heimdallr</pre>
+            <pre class="inline-code">heimdallm</pre>
             <p style="margin-top:.4rem;">Or find it in your application launcher.</p>
           </div>
         </div>
       </div>
-      <p style="margin-top:1.5rem; color:var(--muted); font-size:.875rem;">Installs to <code>/opt/heimdallr/</code> · Dependencies: libgtk-3, libayatana-appindicator, libsecret · Token via GNOME Keyring or <code>gh auth token</code></p>
+      <p style="margin-top:1.5rem; color:var(--muted); font-size:.875rem;">Installs to <code>/opt/heimdallm/</code> · Dependencies: libgtk-3, libayatana-appindicator, libsecret · Token via GNOME Keyring or <code>gh auth token</code></p>
     </div>
 
     <!-- Fedora/RHEL -->
@@ -523,25 +523,25 @@ sudo apt-get install -f -y</pre>
           <div class="step-num">1</div>
           <div>
             <h4>Download .rpm</h4>
-            <a href="https://github.com/theburrowhub/heimdallr/releases/latest" class="btn btn-primary" style="margin-top:.75rem; font-size:.85rem; padding:.5rem 1rem;">⬇️ Download .rpm</a>
+            <a href="https://github.com/theburrowhub/heimdallm/releases/latest" class="btn btn-primary" style="margin-top:.75rem; font-size:.85rem; padding:.5rem 1rem;">⬇️ Download .rpm</a>
           </div>
         </div>
         <div class="install-step">
           <div class="step-num">2</div>
           <div>
             <h4>Install</h4>
-            <pre class="inline-code">sudo rpm -i heimdallr-*.x86_64.rpm</pre>
+            <pre class="inline-code">sudo rpm -i heimdallm-*.x86_64.rpm</pre>
           </div>
         </div>
         <div class="install-step">
           <div class="step-num">3</div>
           <div>
             <h4>Launch</h4>
-            <pre class="inline-code">heimdallr</pre>
+            <pre class="inline-code">heimdallm</pre>
           </div>
         </div>
       </div>
-      <p style="margin-top:1.5rem; color:var(--muted); font-size:.875rem;">Installs to <code>/opt/heimdallr/</code> · Dependencies: gtk3, libnotify, libsecret · Token via KDE Wallet or <code>gh auth token</code></p>
+      <p style="margin-top:1.5rem; color:var(--muted); font-size:.875rem;">Installs to <code>/opt/heimdallm/</code> · Dependencies: gtk3, libnotify, libsecret · Token via KDE Wallet or <code>gh auth token</code></p>
     </div>
 
     <!-- AppImage -->
@@ -551,26 +551,26 @@ sudo apt-get install -f -y</pre>
           <div class="step-num">1</div>
           <div>
             <h4>Download AppImage</h4>
-            <a href="https://github.com/theburrowhub/heimdallr/releases/latest" class="btn btn-primary" style="margin-top:.75rem; font-size:.85rem; padding:.5rem 1rem;">⬇️ Download .AppImage</a>
+            <a href="https://github.com/theburrowhub/heimdallm/releases/latest" class="btn btn-primary" style="margin-top:.75rem; font-size:.85rem; padding:.5rem 1rem;">⬇️ Download .AppImage</a>
           </div>
         </div>
         <div class="install-step">
           <div class="step-num">2</div>
           <div>
             <h4>Make executable</h4>
-            <pre class="inline-code">chmod +x Heimdallr-*.AppImage</pre>
+            <pre class="inline-code">chmod +x Heimdallm-*.AppImage</pre>
           </div>
         </div>
         <div class="install-step">
           <div class="step-num">3</div>
           <div>
             <h4>Run</h4>
-            <pre class="inline-code">./Heimdallr-*.AppImage</pre>
+            <pre class="inline-code">./Heimdallm-*.AppImage</pre>
             <p style="margin-top:.4rem;">No installation needed. Works on Arch, NixOS, and any distro.</p>
           </div>
         </div>
       </div>
-      <p style="margin-top:1.5rem; color:var(--muted); font-size:.875rem;">Self-contained · No system dependencies · Token via <code>gh auth token</code> or <code>~/.config/heimdallr/.token</code></p>
+      <p style="margin-top:1.5rem; color:var(--muted); font-size:.875rem;">Self-contained · No system dependencies · Token via <code>gh auth token</code> or <code>~/.config/heimdallm/.token</code></p>
     </div>
   </div>
 </section>
@@ -601,10 +601,10 @@ sudo apt-get install -f -y</pre>
 <!-- Footer -->
 <footer>
   <p>
-    <strong>Heimdallr</strong> is open source under the MIT license.<br>
-    <a href="https://github.com/theburrowhub/heimdallr">GitHub</a> ·
-    <a href="https://github.com/theburrowhub/heimdallr/releases">Releases</a> ·
-    <a href="https://github.com/theburrowhub/heimdallr/issues">Issues</a>
+    <strong>Heimdallm</strong> is open source under the MIT license.<br>
+    <a href="https://github.com/theburrowhub/heimdallm">GitHub</a> ·
+    <a href="https://github.com/theburrowhub/heimdallm/releases">Releases</a> ·
+    <a href="https://github.com/theburrowhub/heimdallm/issues">Issues</a>
   </p>
 </footer>
 

--- a/docs/superpowers/plans/2026-04-06-pr-comments-context.md
+++ b/docs/superpowers/plans/2026-04-06-pr-comments-context.md
@@ -297,7 +297,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/heimdallr/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/executor"
 )
 
 func TestBuildPromptFromTemplate_CommentsSubstituted(t *testing.T) {

--- a/docs/superpowers/specs/2026-04-06-pr-comments-context-design.md
+++ b/docs/superpowers/specs/2026-04-06-pr-comments-context-design.md
@@ -5,7 +5,7 @@
 
 ## Problem
 
-Heimdallr reviews PRs using only the diff, title, and author. It ignores existing comments from other reviewers and the PR author, which often contain critical context: questions, clarifications, decisions already made, and prior feedback. This leads to redundant or uninformed reviews.
+Heimdallm reviews PRs using only the diff, title, and author. It ignores existing comments from other reviewers and the PR author, which often contain critical context: questions, clarifications, decisions already made, and prior feedback. This leads to redundant or uninformed reviews.
 
 ## Goal
 

--- a/docs/superpowers/specs/2026-04-16-heimdallm-v2-design.md
+++ b/docs/superpowers/specs/2026-04-16-heimdallm-v2-design.md
@@ -5,14 +5,14 @@
 
 ## Visión
 
-Heimdallm (Heimdall + LLM) es la evolución del proyecto Heimdallr. Unifica el repo desktop (`auto-pr`) y el repo Docker (`heimdallr-docker`) en un único monorepo, añade tracking y procesamiento automático de issues con LLM, y ofrece una interfaz web como alternativa a la Flutter app.
+Heimdallm (Heimdall + LLM) es la evolución del proyecto Heimdallm. Unifica el repo desktop (`auto-pr`) y el repo Docker (`heimdallm-docker`) en un único monorepo, añade tracking y procesamiento automático de issues con LLM, y ofrece una interfaz web como alternativa a la Flutter app.
 
 ---
 
 ## Fase 1: Rename + Consolidación de Repos
 
 ### Objetivo
-Renombrar el repo existente `theburrowhub/auto-pr` → `theburrowhub/heimdallm` (GitHub preserva historial, issues, PRs y redirige URLs) y fusionar `heimdallr-docker` en él como subdirectorio `docker/`.
+Renombrar el repo existente `theburrowhub/auto-pr` → `theburrowhub/heimdallm` (GitHub preserva historial, issues, PRs y redirige URLs) y fusionar `heimdallm-docker` en él como subdirectorio `docker/`.
 
 ### Estructura del monorepo
 
@@ -21,7 +21,7 @@ heimdallm/
 ├── daemon/           # Go daemon — binario renombrado a heimdallm
 ├── flutter_app/      # Desktop UI (macOS/Linux) — sin cambios funcionales
 ├── web_ui/           # NUEVO: SvelteKit web dashboard
-├── docker/           # Contenido fusionado de heimdallr-docker
+├── docker/           # Contenido fusionado de heimdallm-docker
 │   ├── Dockerfile
 │   ├── docker-compose.yml
 │   └── .env.example
@@ -33,21 +33,21 @@ heimdallm/
 
 | Artefacto | Antes | Después |
 |-----------|-------|---------|
-| Módulo Go | `github.com/heimdallr/daemon` | `github.com/heimdallm/daemon` |
-| Binario | `heimdallr` | `heimdallm` |
-| Config dir | `~/.config/heimdallr/` | `~/.config/heimdallm/` |
-| Data dir | `~/.local/share/heimdallr/` | `~/.local/share/heimdallm/` |
-| LaunchAgent | `com.heimdallr.daemon.plist` | `com.heimdallm.daemon.plist` |
-| Token header HTTP | `X-Heimdallr-Token` | `X-Heimdallm-Token` |
-| Env vars | `HEIMDALLR_*` | `HEIMDALLM_*` |
-| Docker image | `heimdallr/daemon` | `heimdallm/daemon` |
+| Módulo Go | `github.com/heimdallm/daemon` | `github.com/heimdallm/daemon` |
+| Binario | `heimdallm` | `heimdallm` |
+| Config dir | `~/.config/heimdallm/` | `~/.config/heimdallm/` |
+| Data dir | `~/.local/share/heimdallm/` | `~/.local/share/heimdallm/` |
+| LaunchAgent | `com.heimdallm.daemon.plist` | `com.heimdallm.daemon.plist` |
+| Token header HTTP | `X-Heimdallm-Token` | `X-Heimdallm-Token` |
+| Env vars | `HEIMDALLM_*` | `HEIMDALLM_*` |
+| Docker image | `heimdallm/daemon` | `heimdallm/daemon` |
 | SSE broker events | sin cambio de formato | sin cambio de formato |
 
-### Migración de heimdallr-docker
+### Migración de heimdallm-docker
 - GitHub: `Settings → Rename` en `auto-pr` → `heimdallm`
-- El contenido de `heimdallr-docker` se incorpora en `docker/` vía `git subtree add` para preservar su historial de commits
+- El contenido de `heimdallm-docker` se incorpora en `docker/` vía `git subtree add` para preservar su historial de commits
 - Los paths de config, Dockerfile, docker-compose y `.env.example` se actualizan al nuevo naming
-- Una vez fusionado y verificado, `heimdallr-docker` se archiva (no se borra, para preservar historial de issues/PRs externos)
+- Una vez fusionado y verificado, `heimdallm-docker` se archiva (no se borra, para preservar historial de issues/PRs externos)
 
 ### Criterios de éxito
 - `go build ./...` y `go test ./...` pasan con el nuevo module path

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -26,7 +26,7 @@ class ApiClient {
     if (_cachedToken != null) return _cachedToken;
     final home = Platform.environment['HOME'] ?? '';
     if (home.isEmpty) return null;
-    final file = File('$home/.local/share/heimdallr/api_token');
+    final file = File('$home/.local/share/heimdallm/api_token');
     if (await file.exists()) {
       _cachedToken = (await file.readAsString()).trim();
     }
@@ -34,12 +34,12 @@ class ApiClient {
   }
 
   /// Headers for mutating requests (POST/PUT/DELETE).
-  /// Includes X-Heimdallr-Token to satisfy the auth middleware (issue #3).
+  /// Includes X-Heimdallm-Token to satisfy the auth middleware (issue #3).
   Future<Map<String, String>> _authHeaders() async {
     final token = await _apiToken();
     return {
       'Content-Type': 'application/json',
-      if (token != null && token.isNotEmpty) 'X-Heimdallr-Token': token,
+      if (token != null && token.isNotEmpty) 'X-Heimdallm-Token': token,
     };
   }
 

--- a/flutter_app/lib/core/api/sse_client.dart
+++ b/flutter_app/lib/core/api/sse_client.dart
@@ -55,7 +55,7 @@ class SseClient {
   Future<String?> _loadToken() async {
     try {
       final home = Platform.environment['HOME'] ?? '';
-      final file = File('$home/.local/share/heimdallr/api_token');
+      final file = File('$home/.local/share/heimdallm/api_token');
       if (await file.exists()) return (await file.readAsString()).trim();
     } catch (_) {}
     return null;
@@ -71,7 +71,7 @@ class SseClient {
       request.headers['Cache-Control'] = 'no-cache';
       final token = await _loadToken();
       if (token != null && token.isNotEmpty) {
-        request.headers['X-Heimdallr-Token'] = token;
+        request.headers['X-Heimdallm-Token'] = token;
       }
       final response = await _httpClient.send(request);
 

--- a/flutter_app/lib/core/daemon/daemon_lifecycle.dart
+++ b/flutter_app/lib/core/daemon/daemon_lifecycle.dart
@@ -40,15 +40,15 @@ class DaemonLifecycle {
   /// Returns the daemon binary path, or null if not found.
   ///
   /// Priority:
-  ///   1. HEIMDALLR_DAEMON_PATH env var  (set by `make dev`)
+  ///   1. HEIMDALLM_DAEMON_PATH env var  (set by `make dev`)
   ///   2. 'heimdalld' next to the Flutter binary  (production .app bundle)
   ///
-  /// IMPORTANT: 'heimdallr' is NOT used as a fallback because on macOS APFS
-  /// (case-insensitive) 'heimdallr' resolves to 'Heimdallr' — the Flutter app
+  /// IMPORTANT: 'heimdallm' is NOT used as a fallback because on macOS APFS
+  /// (case-insensitive) 'heimdallm' resolves to 'Heimdallm' — the Flutter app
   /// binary itself. Using it as a spawn target creates an infinite fork bomb.
   static String? defaultBinaryPath() {
     // 1. Explicit override (make dev)
-    final envPath = Platform.environment['HEIMDALLR_DAEMON_PATH'];
+    final envPath = Platform.environment['HEIMDALLM_DAEMON_PATH'];
     if (envPath != null && envPath.isNotEmpty) {
       return File(envPath).existsSync() ? envPath : null;
     }

--- a/flutter_app/lib/core/setup/first_run_setup.dart
+++ b/flutter_app/lib/core/setup/first_run_setup.dart
@@ -5,7 +5,7 @@ import 'gh_cli.dart';
 /// Handles first-run setup: writes config file to disk and stores
 /// the GitHub token in macOS Keychain via the `security` CLI.
 class FirstRunSetup {
-  static const _keychainService = 'heimdallr';
+  static const _keychainService = 'heimdallm';
   static const _keychainAccount = 'github-token';
 
   // ── Token ────────────────────────────────────────────────────────────────
@@ -36,7 +36,7 @@ class FirstRunSetup {
   /// Stores the GitHub token in the platform credential store.
   /// macOS: Keychain via `security` CLI.
   /// Linux: GNOME/KDE secret service via `secret-tool`; falls back to
-  ///        `~/.config/heimdallr/.token` (chmod 600) when secret-tool is unavailable.
+  ///        `~/.config/heimdallm/.token` (chmod 600) when secret-tool is unavailable.
   static Future<void> storeToken(String token) async {
     if (Platform.isMacOS) {
       await _storeTokenMacOS(token);
@@ -88,7 +88,7 @@ class FirstRunSetup {
     try {
       final proc = await Process.start('secret-tool', [
         'store',
-        '--label=Heimdallr GitHub Token',
+        '--label=Heimdallm GitHub Token',
         'service', _keychainService,
         'account', _keychainAccount,
       ]);
@@ -122,11 +122,11 @@ class FirstRunSetup {
     return _readTokenFile();
   }
 
-  // ── Linux file fallback (~/.config/heimdallr/.token, chmod 600) ──────────
+  // ── Linux file fallback (~/.config/heimdallm/.token, chmod 600) ──────────
 
   static String _tokenFilePath() {
     final home = Platform.environment['HOME'] ?? '';
-    return '$home/.config/heimdallr/.token';
+    return '$home/.config/heimdallm/.token';
   }
 
   static Future<void> _writeTokenFile(String token) async {
@@ -149,16 +149,16 @@ class FirstRunSetup {
 
   // ── Config file ──────────────────────────────────────────────────────────
 
-  /// Writes the daemon config file to ~/.config/heimdallr/config.toml
+  /// Writes the daemon config file to ~/.config/heimdallm/config.toml
   static Future<void> writeConfig(AppConfig config) async {
     final home = Platform.environment['HOME'] ?? '';
     if (home.isEmpty) throw Exception('HOME environment variable not set');
 
-    final dir = Directory('$home/.config/heimdallr');
+    final dir = Directory('$home/.config/heimdallm');
     await dir.create(recursive: true);
 
     final content = _buildToml(config);
-    await File('$home/.config/heimdallr/config.toml').writeAsString(content);
+    await File('$home/.config/heimdallm/config.toml').writeAsString(content);
   }
 
   /// Escapes backslashes, double-quotes, and newline characters in a
@@ -248,6 +248,6 @@ class FirstRunSetup {
   /// Returns true if a config file already exists.
   static Future<bool> configExists() async {
     final home = Platform.environment['HOME'] ?? '';
-    return File('$home/.config/heimdallr/config.toml').exists();
+    return File('$home/.config/heimdallm/config.toml').exists();
   }
 }

--- a/flutter_app/lib/core/tray/tray_menu.dart
+++ b/flutter_app/lib/core/tray/tray_menu.dart
@@ -88,7 +88,7 @@ class TrayMenu with TrayListener {
     }
 
     // ── App controls ────────────────────────────────────────────────────
-    items.add(MenuItem(key: 'open', label: 'Open Heimdallr'));
+    items.add(MenuItem(key: 'open', label: 'Open Heimdallm'));
     items.add(MenuItem.separator());
     items.add(MenuItem(key: 'quit', label: 'Quit'));
 
@@ -107,7 +107,7 @@ class TrayMenu with TrayListener {
         MenuItem(key: 'pr_title_${pr.id}', label: pr.title, disabled: true),
         _info(pr.repo),
         MenuItem.separator(),
-        MenuItem(key: 'open_pr_${pr.id}', label: 'Open in Heimdallr'),
+        MenuItem(key: 'open_pr_${pr.id}', label: 'Open in Heimdallm'),
         MenuItem(key: 'view_${pr.id}',    label: 'View on GitHub'),
         MenuItem.separator(),
         MenuItem(key: 'review_${pr.id}',  label: 'Review Now'),

--- a/flutter_app/lib/features/agents/agents_screen.dart
+++ b/flutter_app/lib/features/agents/agents_screen.dart
@@ -447,7 +447,7 @@ class _PromptEditorDialogState extends State<_PromptEditorDialog>
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         const Text(
-                          'Describe what to look for. Heimdallr will inject these '
+                          'Describe what to look for. Heimdallm will inject these '
                           'instructions into its default review template.',
                           style: TextStyle(fontSize: 12, color: Colors.grey),
                         ),

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -57,7 +57,7 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
       // Invalidate the cached token so the ApiClient re-reads it on the next request.
       ref.read(apiClientProvider).clearTokenCache();
 
-      // 2. Write config to ~/.config/heimdallr/config.toml
+      // 2. Write config to ~/.config/heimdallm/config.toml
       await FirstRunSetup.writeConfig(config);
 
       // 3. Launch daemon
@@ -72,7 +72,7 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
 
       if (!await api.checkHealth()) {
         throw Exception(
-          'Heimdallr could not start. Check the app installation.',
+          'Heimdallm could not start. Check the app installation.',
         );
       }
 

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -390,7 +390,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             ? const SizedBox(width: 16, height: 16,
                 child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
             : const Icon(Icons.rocket_launch),
-        label: Text(isLoading ? 'Starting…' : 'Save and start Heimdallr'),
+        label: Text(isLoading ? 'Starting…' : 'Save and start Heimdallm'),
         onPressed: isLoading ? null : () async {
           final updated = _buildConfig(base);
           final token = _tokenController.text.trim();
@@ -440,7 +440,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         Icon(Icons.info_outline, color: Colors.orange.shade700),
         const SizedBox(width: 8),
         const Expanded(
-          child: Text('Heimdallr is not running. Configure and tap "Save and start".'),
+          child: Text('Heimdallm is not running. Configure and tap "Save and start".'),
         ),
       ]),
     ),

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -19,7 +19,7 @@ class DashboardScreen extends ConsumerWidget {
       length: 5,
       child: Scaffold(
         appBar: AppBar(
-          title: const Text('Heimdallr'),
+          title: const Text('Heimdallm'),
           actions: [
             IconButton(
               icon: const Icon(Icons.article_outlined),
@@ -184,7 +184,7 @@ class _ReviewsTabState extends ConsumerState<_ReviewsTab> {
         children: [
           const Icon(Icons.wifi_off, size: 48, color: Colors.grey),
           const SizedBox(height: 12),
-          const Text('Could not reach the Heimdallr daemon.',
+          const Text('Could not reach the Heimdallm daemon.',
               style: TextStyle(fontWeight: FontWeight.w600)),
           const SizedBox(height: 4),
           const Text('Go to Settings to configure and start it.',

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -22,7 +22,7 @@ GoRouter get appRouter => _appRouter;
 /// and returns false so this new process can exit cleanly.
 Future<bool> _ensureSingleInstance() async {
   final home = Platform.environment['HOME'] ?? '';
-  final dir  = Directory('$home/.local/share/heimdallr');
+  final dir  = Directory('$home/.local/share/heimdallm');
   await dir.create(recursive: true);
   final pidFile = File('${dir.path}/ui.pid');
 
@@ -33,7 +33,7 @@ Future<bool> _ensureSingleInstance() async {
       final check = await Process.run('kill', ['-0', '$existing']);
       if (check.exitCode == 0) {
         // Another instance is running — signal it to show its window, then exit.
-        debugPrint('Another Heimdallr instance is running (PID $existing), signalling it.');
+        debugPrint('Another Heimdallm instance is running (PID $existing), signalling it.');
         await Process.run('kill', ['-USR1', '$existing']);
         return false;
       }
@@ -87,7 +87,7 @@ void main() async {
   }
 
   try {
-    await localNotifier.setup(appName: 'Heimdallr');
+    await localNotifier.setup(appName: 'Heimdallm');
   } catch (e) {
     debugPrint('local_notifier init failed: $e');
   }
@@ -101,7 +101,7 @@ Future<void> _setupWindow() async {
   const options = WindowOptions(
     size: Size(1200, 720),
     minimumSize: Size(900, 520),
-    title: 'Heimdallr',
+    title: 'Heimdallm',
     titleBarStyle: TitleBarStyle.normal,
   );
 
@@ -110,7 +110,7 @@ Future<void> _setupWindow() async {
   // the callback as a belt-and-suspenders measure.
   await windowManager.setSize(const Size(1200, 720));
   await windowManager.setMinimumSize(const Size(900, 520));
-  await windowManager.setTitle('Heimdallr');
+  await windowManager.setTitle('Heimdallm');
   await windowManager.show();
   await windowManager.focus();
 
@@ -127,7 +127,7 @@ Future<void> _setupTray() async {
   );
   // Initial minimal menu until data loads
   await trayManager.setContextMenu(Menu(items: [
-    MenuItem(key: 'open', label: 'Open Heimdallr'),
+    MenuItem(key: 'open', label: 'Open Heimdallm'),
     MenuItem.separator(),
     MenuItem(key: 'quit', label: 'Quit'),
   ]));
@@ -234,17 +234,17 @@ class _BootstrapAppState extends State<_BootstrapApp> with WindowListener {
     if (binaryPath == null) {
       _setError(
         title: 'Daemon binary not found',
-        details: 'Heimdallr could not locate its background service.\n'
+        details: 'Heimdallm could not locate its background service.\n'
             'This usually means the installation is incomplete.',
         hint: 'If you installed from a DMG, open Terminal and run:\n'
-            'xattr -cr /Applications/Heimdallr.app\n'
+            'xattr -cr /Applications/Heimdallm.app\n'
             'then relaunch the app.',
       );
       return;
     }
 
     // ── 5. Launch daemon ──────────────────────────────────────────────────
-    _setStatus('Starting Heimdallr…');
+    _setStatus('Starting Heimdallm…');
     try {
       // Use detached mode so the daemon process outlives the Flutter process.
       // This ensures reviews in progress survive window hides and dev restarts.
@@ -253,14 +253,14 @@ class _BootstrapAppState extends State<_BootstrapApp> with WindowListener {
       _setError(
         title: 'Could not start daemon',
         details: e.toString(),
-        hint: 'Check that Heimdallr has permission to run sub-processes.\n'
-            'Try: xattr -cr /Applications/Heimdallr.app',
+        hint: 'Check that Heimdallm has permission to run sub-processes.\n'
+            'Try: xattr -cr /Applications/Heimdallm.app',
       );
       return;
     }
 
     // ── 6. Wait for daemon to become healthy ──────────────────────────────
-    _setStatus('Waiting for Heimdallr…');
+    _setStatus('Waiting for Heimdallm…');
     await _waitForHealth(api, retryBinary: binaryPath);
   }
 
@@ -279,9 +279,9 @@ class _BootstrapAppState extends State<_BootstrapApp> with WindowListener {
         if (daemonRestarts >= maxDaemonRestarts) {
           _setError(
             title: 'Daemon failed to start',
-            details: 'Heimdallr could not start after $maxDaemonRestarts attempts.',
+            details: 'Heimdallm could not start after $maxDaemonRestarts attempts.',
             hint: 'Try restarting the app. If the problem persists, check your installation:\n'
-                'xattr -cr /Applications/Heimdallr.app',
+                'xattr -cr /Applications/Heimdallm.app',
           );
           return;
         }
@@ -316,7 +316,7 @@ class _BootstrapAppState extends State<_BootstrapApp> with WindowListener {
   @override
   Widget build(BuildContext context) {
     if (_destination != null) {
-      return HeimdallrApp(router: widget.appRouter, initialLocation: _destination!);
+      return HeimdallmApp(router: widget.appRouter, initialLocation: _destination!);
     }
     if (_errorTitle != null) {
       return _ErrorApp(
@@ -360,7 +360,7 @@ class _SplashApp extends StatelessWidget {
               Image.asset('assets/icon.png', width: 96, height: 96,
                   errorBuilder: (_, __, ___) => const Icon(Icons.shield, size: 96)),
               const SizedBox(height: 24),
-              const Text('Heimdallr',
+              const Text('Heimdallm',
                   style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold)),
               const SizedBox(height: 20),
               const SizedBox(
@@ -466,15 +466,15 @@ class _ErrorApp extends StatelessWidget {
   }
 }
 
-class HeimdallrApp extends StatelessWidget {
+class HeimdallmApp extends StatelessWidget {
   final String initialLocation;
   final GoRouter? router;
-  const HeimdallrApp({super.key, this.initialLocation = '/', this.router});
+  const HeimdallmApp({super.key, this.initialLocation = '/', this.router});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
-      title: 'Heimdallr',
+      title: 'Heimdallm',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF0969DA)),

--- a/flutter_app/linux/CMakeLists.txt
+++ b/flutter_app/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "heimdallr")
+set(BINARY_NAME "heimdallm")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.theburrowhub.heimdallr")
+set(APPLICATION_ID "com.theburrowhub.heimdallm")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/flutter_app/macos/Runner/Configs/AppInfo.xcconfig
+++ b/flutter_app/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = Heimdallr
+PRODUCT_NAME = Heimdallm
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.theburrowhub.heimdallr
+PRODUCT_BUNDLE_IDENTIFIER = com.theburrowhub.heimdallm
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2026 theburrowhub. All rights reserved.

--- a/flutter_app/macos/Runner/DebugProfile.entitlements
+++ b/flutter_app/macos/Runner/DebugProfile.entitlements
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- Sandbox disabled: Heimdallr spawns the daemon, runs gh/security/bash -->
+	<!-- Sandbox disabled: Heimdallm spawns the daemon, runs gh/security/bash -->
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
 	<key>com.apple.security.cs.allow-jit</key>

--- a/flutter_app/macos/Runner/Release.entitlements
+++ b/flutter_app/macos/Runner/Release.entitlements
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- Sandbox disabled: Heimdallr spawns the daemon, runs gh/security/bash -->
+	<!-- Sandbox disabled: Heimdallm spawns the daemon, runs gh/security/bash -->
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
 	<key>com.apple.security.network.client</key>

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,4 +1,4 @@
-name: heimdallr
+name: heimdallm
 description: GitHub PR Auto-Review Desktop App
 version: 1.0.0+1
 

--- a/flutter_app/test/core/api_client_test.dart
+++ b/flutter_app/test/core/api_client_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
-import 'package:heimdallr/core/api/api_client.dart';
+import 'package:heimdallm/core/api/api_client.dart';
 
 void main() {
   group('ApiClient', () {

--- a/flutter_app/test/core/sse_client_test.dart
+++ b/flutter_app/test/core/sse_client_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:heimdallr/core/api/sse_client.dart';
+import 'package:heimdallm/core/api/sse_client.dart';
 
 void main() {
   test('SseEvent parses type and data', () {

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -3,11 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:heimdallr/core/api/api_client.dart';
-import 'package:heimdallr/core/models/config_model.dart';
-import 'package:heimdallr/features/config/config_providers.dart';
-import 'package:heimdallr/features/config/config_screen.dart';
-import 'package:heimdallr/features/dashboard/dashboard_providers.dart';
+import 'package:heimdallm/core/api/api_client.dart';
+import 'package:heimdallm/core/models/config_model.dart';
+import 'package:heimdallm/features/config/config_providers.dart';
+import 'package:heimdallm/features/config/config_screen.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
 
 class MockApiClient extends Mock implements ApiClient {}
 

--- a/flutter_app/test/features/dashboard_test.dart
+++ b/flutter_app/test/features/dashboard_test.dart
@@ -3,9 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:heimdallr/core/models/pr.dart';
-import 'package:heimdallr/features/dashboard/dashboard_providers.dart';
-import 'package:heimdallr/features/dashboard/dashboard_screen.dart';
+import 'package:heimdallm/core/models/pr.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
+import 'package:heimdallm/features/dashboard/dashboard_screen.dart';
 
 void main() {
   testWidgets('DashboardScreen shows PR title', (tester) async {

--- a/flutter_app/test/features/pr_detail_test.dart
+++ b/flutter_app/test/features/pr_detail_test.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:heimdallr/core/models/pr.dart';
-import 'package:heimdallr/core/models/review.dart';
-import 'package:heimdallr/features/dashboard/dashboard_providers.dart';
-import 'package:heimdallr/features/pr_detail/pr_detail_providers.dart';
-import 'package:heimdallr/features/pr_detail/pr_detail_screen.dart';
+import 'package:heimdallm/core/models/pr.dart';
+import 'package:heimdallm/core/models/review.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
+import 'package:heimdallm/features/pr_detail/pr_detail_providers.dart';
+import 'package:heimdallm/features/pr_detail/pr_detail_screen.dart';
 
 void main() {
   testWidgets('PRDetailScreen shows review summary', (tester) async {

--- a/flutter_app/test/shared/severity_badge_test.dart
+++ b/flutter_app/test/shared/severity_badge_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:heimdallr/shared/widgets/severity_badge.dart';
+import 'package:heimdallm/shared/widgets/severity_badge.dart';
 
 void main() {
   testWidgets('SeverityBadge shows correct color for high', (tester) async {


### PR DESCRIPTION
## Summary

- Renames all occurrences of `heimdallr` → `heimdallm` across 50 files (Go daemon, Flutter app, CI, docs)
- Updates Go module path, binary names, config/data directories, HTTP headers, env vars, LaunchAgent plist, bundle identifiers, keychain service, and UI strings
- Preserves `heimdalld` daemon binary name (APFS case-sensitivity workaround)

### Artifacts renamed

| Artifact | Before | After |
|----------|--------|-------|
| Go module | `github.com/heimdallr/daemon` | `github.com/heimdallm/daemon` |
| Binary | `bin/heimdallr` | `bin/heimdallm` |
| Config dir | `~/.config/heimdallr/` | `~/.config/heimdallm/` |
| Data dir | `~/.local/share/heimdallr/` | `~/.local/share/heimdallm/` |
| LaunchAgent | `com.heimdallr.daemon.plist` | `com.heimdallm.daemon.plist` |
| HTTP header | `X-Heimdallr-Token` | `X-Heimdallm-Token` |
| Env vars | `HEIMDALLR_*` | `HEIMDALLM_*` |
| Flutter package | `heimdallr` | `heimdallm` |
| Bundle ID | `com.theburrowhub.heimdallr` | `com.theburrowhub.heimdallm` |

Closes #22

## Test plan

- [x] `go build ./...` passes with new module path
- [x] `go test -race ./...` passes (8/8 packages)
- [x] `flutter analyze` — no issues found
- [x] `flutter test` — 15/15 tests pass
- [x] Binary builds as `bin/heimdallm`
- [x] Verify GitHub repo rename (Settings → Rename) preserves redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)