### PR TITLE
docs: update documentation post-consolidation and rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+> **Note:** Versions 0.1.0–0.1.3 were originally published under [`theburrowhub/heimdallr-docker`](https://github.com/theburrowhub/heimdallr-docker) (now archived). The project was unified into this repository and renamed to Heimdallm in v0.1.1.
+
 ## [0.1.1](https://github.com/theburrowhub/heimdallm/compare/v0.1.0...v0.1.1) (2026-04-16)
 
 

--- a/LLM-HOW-TO-INSTALL.md
+++ b/LLM-HOW-TO-INSTALL.md
@@ -163,7 +163,11 @@ sudo apt-get install -f -y
 Installs `libgtk-3-0`, `libayatana-appindicator3-1`, `libnotify4`, `libsecret-1-0`.
 
 **Token not detected**
-Heimdallm detects credentials in this order: `gh auth token` → GNOME/KDE Keyring (`secret-tool`) → `~/.config/heimdallm/.token` → `GITHUB_TOKEN` env var. Run `gh auth login` if none are configured.
+
+**Token resolution order:**
+- **macOS**: Keychain → `GITHUB_TOKEN` env var → `~/.config/heimdallm/.token`
+- **Linux**: `GITHUB_TOKEN` env var → `~/.config/heimdallm/.token`
+- **Docker**: `GITHUB_TOKEN` env var → `/config/.token` mount → `~/.config/heimdallm/.token`
 
 **AppImage won't run**
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## What it does
 
-Heimdallm runs silently in your menu bar. It watches the GitHub PRs where you're requested as a reviewer, runs an AI code review on each one, and submits the review back to GitHub — no copy-pasting, no manual prompting.
+Heimdallm runs silently in your menu bar. It watches the GitHub PRs where you're requested as a reviewer, runs an AI code review using Claude, Gemini, Codex, or OpenCode, and submits the review back to GitHub — no copy-pasting, no manual prompting.
 
 - **Automatic reviews** — polls `review-requested:@me` on GitHub and submits reviews as your GitHub account
 - **Configurable prompts** — general review, security audit, performance, architecture, or your own custom instructions with `{diff}` `{title}` `{author}` placeholders
@@ -16,6 +16,7 @@ Heimdallm runs silently in your menu bar. It watches the GitHub PRs where you're
 - **Per-repo overrides** — different AI agent, prompt, and feedback mode per repository
 - **Severity gating** — only `high` severity triggers `REQUEST_CHANGES`; everything else approves with informational notes
 - **Native desktop** — menu bar icon (macOS), system notifications, dark mode, no Electron
+- **Docker mode** — runs headless as a Docker container for server/CI deployments
 
 ---
 
@@ -47,6 +48,26 @@ Installs to `/opt/heimdallm/` with a desktop entry and `/usr/bin/heimdallm` syml
 
 > **Requires**: `gh` CLI authenticated (`gh auth login`). Token stored via GNOME Keyring / KDE Wallet (`secret-tool`), or `~/.config/heimdallm/.token` as fallback.
 
+### Docker
+
+For headless/server deployment, Heimdallm runs as a Docker container with all four AI CLIs bundled.
+
+```bash
+# 1. Set up configuration
+cd docker
+cp .env.example .env
+# Edit .env — set GITHUB_TOKEN, HEIMDALLM_REPOSITORIES, and AI API key(s)
+
+# 2. Start the service
+docker compose up -d
+
+# 3. Verify
+curl http://localhost:7842/health
+# {"status":"ok"}
+```
+
+The Docker image is published to `ghcr.io/theburrowhub/heimdallm:latest` on every release. See [`docker/.env.example`](docker/.env.example) for all configuration options.
+
 ### Automated install (for agents / scripts)
 
 See [LLM-HOW-TO-INSTALL.md](LLM-HOW-TO-INSTALL.md) for a step-by-step guide suitable for Claude Code, shell scripts, or any automation tool.
@@ -70,6 +91,8 @@ Flutter app  ←→  HTTP/SSE  ←→  heimdalld  ←→  GitHub API
                                      ↓
                               claude / gemini / codex CLI
 ```
+
+In **Docker mode**, the daemon runs standalone without the Flutter UI. Configuration is via environment variables (`HEIMDALLM_*`) or a mounted `config.toml`.
 
 ---
 
@@ -124,10 +147,17 @@ heimdallm/
 │       └── core/
 │           ├── api/         HTTP + SSE client
 │           └── setup/       First-run setup, token detection
+├── docker/                  Docker deployment
+│   ├── Dockerfile           Multi-stage build (Go + Node.js + 4 AI CLIs)
+│   ├── docker-compose.yml   Production deployment
+│   ├── .env.example         Environment variable reference
+│   └── scripts/             Local test runner (smoke/github/e2e)
 ├── .github/workflows/
 │   ├── tests.yml            CI: Go + Flutter tests on PR/main
 │   ├── build.yml            CI: build + release on version tags
-│   └── tag.yml              Manual: compute semver tag from conventional commits
+│   ├── tag.yml              Manual: compute semver tag from conventional commits
+│   ├── docker-publish.yml   CI: Docker build validation on PRs
+│   └── release.yml          CI: release-please + Docker push to GHCR
 └── Makefile
 ```
 
@@ -149,6 +179,8 @@ The `tag.yml` workflow analyses commits since the last tag:
 - `fix:`, `refactor:`, etc. → patch bump
 
 Pushing the tag triggers `build.yml`, which builds, signs, notarizes (if Developer ID configured), and publishes the DMG to GitHub Releases.
+
+Alternatively, **release-please** (via `release.yml`) automates this: it reads conventional commits, opens a Release PR with changelog, and on merge creates the tag + GitHub Release. This also triggers the Docker image build and push to `ghcr.io/theburrowhub/heimdallm`.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -320,7 +320,7 @@
 
 <!-- Hero -->
 <section class="hero">
-  <div class="hero-badge">⚡ macOS &amp; Linux · Free · Open Source</div>
+  <div class="hero-badge">⚡ macOS · Linux · Docker · Free · Open Source</div>
   <h1>Your PRs, <em>reviewed automatically</em>.<br>Posted to GitHub.</h1>
   <p>
     Heimdallm runs silently in your menu bar, watches your GitHub review requests,
@@ -383,6 +383,11 @@
         <div class="card-icon">💬</div>
         <h3>Feedback modes</h3>
         <p><em>Single</em>: one consolidated review comment. <em>Multi</em>: one comment per issue + summary. Configurable globally or per repo.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">🐳</div>
+        <h3>Docker deployment</h3>
+        <p>Run headless on any server. Pre-built image with Claude, Gemini, Codex and OpenCode bundled. Configure via environment variables.</p>
       </div>
       <div class="card">
         <div class="card-icon">🖥️</div>
@@ -454,6 +459,7 @@
       <button class="os-tab" onclick="showOS('linux-deb',this)">🐧 Ubuntu / Debian</button>
       <button class="os-tab" onclick="showOS('linux-rpm',this)">🎩 Fedora / RHEL</button>
       <button class="os-tab" onclick="showOS('linux-appimage',this)">📦 AppImage (universal)</button>
+      <button class="os-tab" onclick="showOS('docker',this)">🐳 Docker</button>
     </div>
 
     <!-- macOS -->
@@ -571,6 +577,35 @@ sudo apt-get install -f -y</pre>
         </div>
       </div>
       <p style="margin-top:1.5rem; color:var(--muted); font-size:.875rem;">Self-contained · No system dependencies · Token via <code>gh auth token</code> or <code>~/.config/heimdallm/.token</code></p>
+    </div>
+
+    <!-- Docker -->
+    <div id="os-docker" class="os-panel" style="display:none">
+      <div class="install-steps">
+        <div class="install-step">
+          <div class="step-num">1</div>
+          <div>
+            <h4>Configure</h4>
+            <pre class="inline-code">cd docker && cp .env.example .env
+# Edit .env with your tokens</pre>
+          </div>
+        </div>
+        <div class="install-step">
+          <div class="step-num">2</div>
+          <div>
+            <h4>Start</h4>
+            <pre class="inline-code">docker compose up -d</pre>
+          </div>
+        </div>
+        <div class="install-step">
+          <div class="step-num">3</div>
+          <div>
+            <h4>Verify</h4>
+            <pre class="inline-code">curl http://localhost:7842/health</pre>
+          </div>
+        </div>
+      </div>
+      <p style="margin-top:1.5rem; color:var(--muted); font-size:.875rem;">Image: <code>ghcr.io/theburrowhub/heimdallm:latest</code> · ~2.4 GB · Runs as non-root · Built-in health check</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Closes #34

## Summary

- Add Docker deployment section to README with quickstart
- Document universal token resolution order (macOS: Keychain > env > file, Linux/Docker: env > file)
- Add provenance note to CHANGELOG for entries imported from `heimdallr-docker`
- Add Docker tab, card, and install panel to landing page (`docs/index.html`)
- Document `opencode` as 4th AI CLI throughout

## Test plan

- [ ] `grep -ri heimdallr --exclude-dir=.git` returns only CHANGELOG historical entries
- [ ] Landing page renders Docker tab correctly
- [ ] README Docker quickstart commands are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)