### PR TITLE
feat: auto-discover repositories by GitHub topic tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ curl http://localhost:7842/health
 
 The Docker image is published to `ghcr.io/theburrowhub/heimdallm:latest` on every release. See [`docker/.env.example`](docker/.env.example) for all configuration options.
 
+#### Auto-discovery by topic
+
+Instead of maintaining a static repo list, tag your repos with a GitHub topic and Heimdallm discovers them automatically:
+
+```bash
+# In docker/.env:
+HEIMDALLM_DISCOVERY_TOPIC=heimdallm-review
+HEIMDALLM_DISCOVERY_ORGS=your-org
+```
+
+Repos tagged with the topic are merged with `HEIMDALLM_REPOSITORIES`. Repos in `non_monitored` are always excluded. See [issue #39](https://github.com/theburrowhub/heimdallm/issues/39) for details.
+
 ### Automated install (for agents / scripts)
 
 See [LLM-HOW-TO-INSTALL.md](LLM-HOW-TO-INSTALL.md) for a step-by-step guide suitable for Claude Code, shell scripts, or any automation tool.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/discovery"
 	"github.com/heimdallm/daemon/internal/executor"
 	gh "github.com/heimdallm/daemon/internal/github"
 	"github.com/heimdallm/daemon/internal/keychain"
@@ -98,9 +99,11 @@ func main() {
 	p := pipeline.New(s, ghClient, exec, &notifyWithSSE{notifier: notifier})
 	srv := server.New(s, broker, p, apiToken)
 
-	// cfgMu protects cfg and sched so reload is safe from any goroutine.
+	// cfgMu protects cfg, sched, disc, and discSched so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
 	var sched *scheduler.Scheduler
+	var disc *discovery.Engine
+	var discSched *scheduler.Scheduler
 
 	// reviewMu prevents concurrent pipeline runs for the same GitHub PR ID.
 	// Key: pr.ID (GitHub PR ID), Value: true while being reviewed.
@@ -184,8 +187,13 @@ func main() {
 
 	makePollFn := func(c *config.Config) func() {
 		return func() {
+			var repos []string
 			cfgMu.Lock()
-			repos := c.GitHub.Repositories
+			if disc != nil {
+				repos = disc.Repos()
+			} else {
+				repos = c.GitHub.Repositories
+			}
 			cfgMu.Unlock()
 
 			// Fetch all review-requested PRs without a repo filter — adding many
@@ -249,6 +257,20 @@ func main() {
 
 	cfgMu.Lock()
 	sched = startScheduler(cfg)
+	// Start topic-based repo discovery if configured.
+	if cfg.GitHub.DiscoveryTopic != "" {
+		disc = discovery.New(
+			ghClient,
+			cfg.GitHub.DiscoveryTopic,
+			cfg.GitHub.DiscoveryOrgs,
+			cfg.GitHub.Repositories,
+			cfg.GitHub.NonMonitored,
+		)
+		// Run initial discovery synchronously so the first poll has discovered repos.
+		disc.Run()
+		discSched = scheduler.New(parsePollInterval(cfg.GitHub.DiscoveryInterval), disc.Run)
+		discSched.Start()
+	}
 	cfgMu.Unlock()
 
 	// Capture the scheduler pointer under mutex so the deferred Stop is safe
@@ -259,11 +281,20 @@ func main() {
 		cfgMu.Unlock()
 		sc.Stop()
 	}()
+	defer func() {
+		cfgMu.Lock()
+		ds := discSched
+		cfgMu.Unlock()
+		if ds != nil {
+			ds.Stop()
+		}
+	}()
 
 	// Expose live config for GET /config
 	srv.SetConfigFn(func() map[string]any {
 		cfgMu.Lock()
 		c := cfg
+		d := disc
 		cfgMu.Unlock()
 		repoOverrides := make(map[string]map[string]string)
 		for repo, ai := range c.AI.Repos {
@@ -289,18 +320,25 @@ func main() {
 				"no_session_persistence":   ac.NoSessionPersistence,
 			}
 		}
-		return map[string]any{
-			"server_port":    c.Server.Port,
-			"poll_interval":  c.GitHub.PollInterval,
-			"repositories":   c.GitHub.Repositories,
-			"non_monitored":  c.GitHub.NonMonitored,
-			"ai_primary":     c.AI.Primary,
-			"ai_fallback":    c.AI.Fallback,
-			"review_mode":    c.AI.ReviewMode,
-			"retention_days": c.Retention.MaxDays,
-			"repo_overrides": repoOverrides,
-			"agent_configs":  agentConfigs,
+		result := map[string]any{
+			"server_port":        c.Server.Port,
+			"poll_interval":      c.GitHub.PollInterval,
+			"repositories":       c.GitHub.Repositories,
+			"non_monitored":      c.GitHub.NonMonitored,
+			"discovery_topic":    c.GitHub.DiscoveryTopic,
+			"discovery_orgs":     c.GitHub.DiscoveryOrgs,
+			"discovery_interval": c.GitHub.DiscoveryInterval,
+			"ai_primary":         c.AI.Primary,
+			"ai_fallback":        c.AI.Fallback,
+			"review_mode":        c.AI.ReviewMode,
+			"retention_days":     c.Retention.MaxDays,
+			"repo_overrides":     repoOverrides,
+			"agent_configs":      agentConfigs,
 		}
+		if d != nil {
+			result["effective_repositories"] = d.Repos()
+		}
+		return result
 	})
 
 	// Cache authenticated username for GET /me.
@@ -336,12 +374,33 @@ func main() {
 		cfgMu.Lock()
 		cfg = newCfg
 		oldSched := sched
+		oldDiscSched := discSched
 		sched = startScheduler(newCfg)
+
+		// Recreate or stop discovery engine based on new config.
+		if newCfg.GitHub.DiscoveryTopic != "" {
+			disc = discovery.New(
+				ghClient,
+				newCfg.GitHub.DiscoveryTopic,
+				newCfg.GitHub.DiscoveryOrgs,
+				newCfg.GitHub.Repositories,
+				newCfg.GitHub.NonMonitored,
+			)
+			disc.Run()
+			discSched = scheduler.New(parsePollInterval(newCfg.GitHub.DiscoveryInterval), disc.Run)
+			discSched.Start()
+		} else {
+			disc = nil
+			discSched = nil
+		}
 		cfgMu.Unlock()
 
-		// Stop the old scheduler outside the lock to avoid holding the mutex
+		// Stop the old schedulers outside the lock to avoid holding the mutex
 		// during a potentially blocking Stop call.
 		oldSched.Stop()
+		if oldDiscSched != nil {
+			oldDiscSched.Stop()
+		}
 
 		// Run first poll immediately with new config
 		go makePollFn(newCfg)()

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -13,7 +14,7 @@ import (
 )
 
 var validIntervals = map[string]bool{
-	"1m": true, "5m": true, "30m": true, "1h": true,
+	"1m": true, "5m": true, "15m": true, "30m": true, "1h": true,
 }
 
 type Config struct {
@@ -34,7 +35,10 @@ type GitHubConfig struct {
 	// NonMonitored tracks repos the user knows about but has disabled auto-review for.
 	// The daemon never polls these; they are stored here only so the Flutter UI can
 	// remember and display them after a restart.
-	NonMonitored []string `toml:"non_monitored"`
+	NonMonitored      []string `toml:"non_monitored"`
+	DiscoveryTopic    string   `toml:"discovery_topic"`    // GitHub topic tag for auto-discovery
+	DiscoveryOrgs     []string `toml:"discovery_orgs"`     // orgs to search (empty = infer from Repositories)
+	DiscoveryInterval string   `toml:"discovery_interval"` // how often to run discovery (default: 15m)
 }
 
 // CLIAgentConfig holds per-CLI execution settings (model, flags, prompt override).
@@ -121,6 +125,9 @@ func (c *Config) applyDefaults() {
 	if c.AI.ReviewMode == "" {
 		c.AI.ReviewMode = "single"
 	}
+	if c.GitHub.DiscoveryInterval == "" {
+		c.GitHub.DiscoveryInterval = "15m"
+	}
 }
 
 // applyEnvOverrides applies HEIMDALLM_* environment variable overrides.
@@ -163,6 +170,35 @@ func (c *Config) applyEnvOverrides() {
 			c.Retention.MaxDays = d
 		}
 	}
+	if v := os.Getenv("HEIMDALLM_DISCOVERY_TOPIC"); v != "" {
+		c.GitHub.DiscoveryTopic = v
+	}
+	if v := os.Getenv("HEIMDALLM_DISCOVERY_ORGS"); v != "" {
+		orgs := strings.Split(v, ",")
+		cleaned := make([]string, 0, len(orgs))
+		for _, o := range orgs {
+			if s := strings.TrimSpace(o); s != "" {
+				cleaned = append(cleaned, s)
+			}
+		}
+		if len(cleaned) > 0 {
+			c.GitHub.DiscoveryOrgs = cleaned
+		}
+	}
+	if v := os.Getenv("HEIMDALLM_DISCOVERY_INTERVAL"); v != "" {
+		c.GitHub.DiscoveryInterval = v
+	}
+}
+
+// topicPattern matches valid GitHub topic tags: lowercase alphanumeric and hyphens, max 50 chars.
+var topicPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,49}$`)
+
+// ValidateTopic checks that a GitHub topic tag is valid.
+func ValidateTopic(topic string) error {
+	if !topicPattern.MatchString(topic) {
+		return fmt.Errorf("invalid topic %q: must be lowercase alphanumeric/hyphens, 1-50 chars", topic)
+	}
+	return nil
 }
 
 // Validate checks that required fields are present and values are valid.
@@ -171,7 +207,19 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("config: ai.primary is required")
 	}
 	if c.GitHub.PollInterval != "" && !validIntervals[c.GitHub.PollInterval] {
-		return fmt.Errorf("config: invalid poll_interval %q (valid: 1m, 5m, 30m, 1h)", c.GitHub.PollInterval)
+		return fmt.Errorf("config: invalid poll_interval %q (valid: 1m, 5m, 15m, 30m, 1h)", c.GitHub.PollInterval)
+	}
+	// Validate discovery config.
+	if c.GitHub.DiscoveryTopic != "" {
+		if err := ValidateTopic(c.GitHub.DiscoveryTopic); err != nil {
+			return fmt.Errorf("config: discovery_topic: %w", err)
+		}
+		if len(c.GitHub.DiscoveryOrgs) == 0 && len(c.GitHub.Repositories) == 0 {
+			return fmt.Errorf("config: discovery_topic is set but no organizations can be inferred (set discovery_orgs or add at least one repo to repositories)")
+		}
+	}
+	if c.GitHub.DiscoveryInterval != "" && !validIntervals[c.GitHub.DiscoveryInterval] {
+		return fmt.Errorf("config: invalid discovery_interval %q (valid: 1m, 5m, 15m, 30m, 1h)", c.GitHub.DiscoveryInterval)
 	}
 	// Validate per-CLI agent configs: permission_mode and approval_mode must be in their allowlists.
 	for name, a := range c.AI.Agents {

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -158,7 +158,7 @@ func TestValidate_InvalidPollInterval(t *testing.T) {
 }
 
 func TestValidate_AllValidIntervals(t *testing.T) {
-	for _, interval := range []string{"1m", "5m", "30m", "1h"} {
+	for _, interval := range []string{"1m", "5m", "15m", "30m", "1h"} {
 		cfg := &Config{AI: AIConfig{Primary: "claude"}, GitHub: GitHubConfig{PollInterval: interval}}
 		if err := cfg.Validate(); err != nil {
 			t.Errorf("Validate() with interval %q = %v", interval, err)
@@ -385,5 +385,90 @@ func TestLoadOrCreate_FailsWithoutPrimary(t *testing.T) {
 	_, err := LoadOrCreate(path)
 	if err == nil {
 		t.Error("LoadOrCreate without ai.primary should fail")
+	}
+}
+
+// ── Discovery config ────────────────────────────────────────────────────────
+
+func TestApplyDefaults_DiscoveryInterval(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	if cfg.GitHub.DiscoveryInterval != "15m" {
+		t.Errorf("DiscoveryInterval = %q, want %q", cfg.GitHub.DiscoveryInterval, "15m")
+	}
+}
+
+func TestApplyEnvOverrides_Discovery(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+
+	t.Setenv("HEIMDALLM_DISCOVERY_TOPIC", "heimdallm-review")
+	t.Setenv("HEIMDALLM_DISCOVERY_ORGS", "freepik-company, theburrowhub")
+	t.Setenv("HEIMDALLM_DISCOVERY_INTERVAL", "30m")
+
+	cfg.applyEnvOverrides()
+
+	if cfg.GitHub.DiscoveryTopic != "heimdallm-review" {
+		t.Errorf("DiscoveryTopic = %q, want %q", cfg.GitHub.DiscoveryTopic, "heimdallm-review")
+	}
+	if len(cfg.GitHub.DiscoveryOrgs) != 2 {
+		t.Fatalf("DiscoveryOrgs = %v, want 2 items", cfg.GitHub.DiscoveryOrgs)
+	}
+	if cfg.GitHub.DiscoveryOrgs[0] != "freepik-company" {
+		t.Errorf("DiscoveryOrgs[0] = %q, want %q", cfg.GitHub.DiscoveryOrgs[0], "freepik-company")
+	}
+	if cfg.GitHub.DiscoveryInterval != "30m" {
+		t.Errorf("DiscoveryInterval = %q, want %q", cfg.GitHub.DiscoveryInterval, "30m")
+	}
+}
+
+func TestValidateTopic_Valid(t *testing.T) {
+	for _, topic := range []string{"heimdallm-review", "code-review", "a", "my-topic-123"} {
+		if err := ValidateTopic(topic); err != nil {
+			t.Errorf("ValidateTopic(%q) = %v, want nil", topic, err)
+		}
+	}
+}
+
+func TestValidateTopic_Invalid(t *testing.T) {
+	for _, topic := range []string{"", "UPPERCASE", "has spaces", "special!", "has_underscore", "-starts-with-hyphen"} {
+		if err := ValidateTopic(topic); err == nil {
+			t.Errorf("ValidateTopic(%q) = nil, want error", topic)
+		}
+	}
+}
+
+func TestValidate_DiscoveryTopicWithoutOrgsOrRepos(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.AI.Primary = "claude"
+	cfg.GitHub.DiscoveryTopic = "heimdallm-review"
+	// No DiscoveryOrgs and no Repositories
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate() = nil, want error for discovery_topic without orgs or repos")
+	}
+}
+
+func TestValidate_DiscoveryTopicWithStaticRepos(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.AI.Primary = "claude"
+	cfg.GitHub.DiscoveryTopic = "heimdallm-review"
+	cfg.GitHub.Repositories = []string{"freepik-company/some-repo"}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil (orgs inferred from repos)", err)
+	}
+}
+
+func TestValidate_DiscoveryIntervalInvalid(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.AI.Primary = "claude"
+	cfg.GitHub.DiscoveryInterval = "7m"
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate() = nil, want error for invalid discovery_interval")
 	}
 }

--- a/daemon/internal/discovery/discovery.go
+++ b/daemon/internal/discovery/discovery.go
@@ -1,0 +1,116 @@
+// Package discovery manages automatic repository discovery via GitHub topic tags.
+package discovery
+
+import (
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// RepoSearcher is the interface for fetching repos by topic. Satisfied by github.Client.
+type RepoSearcher interface {
+	FetchReposByTopic(topic string, orgs []string) ([]string, error)
+}
+
+// Engine manages topic-based repo discovery and merging with static repos.
+type Engine struct {
+	searcher     RepoSearcher
+	topic        string
+	orgs         []string
+	staticRepos  []string
+	nonMonitored map[string]struct{}
+
+	mu               sync.RWMutex
+	cachedDiscovered []string
+	lastCount        int
+}
+
+// New creates a discovery engine. If orgs is empty, orgs are inferred from staticRepos.
+func New(searcher RepoSearcher, topic string, orgs, staticRepos, nonMonitored []string) *Engine {
+	inferredOrgs := orgs
+	if len(inferredOrgs) == 0 {
+		inferredOrgs = inferOrgs(staticRepos)
+	}
+	nm := make(map[string]struct{}, len(nonMonitored))
+	for _, r := range nonMonitored {
+		nm[r] = struct{}{}
+	}
+	return &Engine{
+		searcher:     searcher,
+		topic:        topic,
+		orgs:         inferredOrgs,
+		staticRepos:  staticRepos,
+		nonMonitored: nm,
+	}
+}
+
+// inferOrgs extracts unique org prefixes from "org/repo" strings.
+func inferOrgs(repos []string) []string {
+	set := make(map[string]struct{})
+	for _, r := range repos {
+		if idx := strings.IndexByte(r, '/'); idx > 0 {
+			set[r[:idx]] = struct{}{}
+		}
+	}
+	orgs := make([]string, 0, len(set))
+	for o := range set {
+		orgs = append(orgs, o)
+	}
+	sort.Strings(orgs)
+	return orgs
+}
+
+// Run executes one discovery cycle: fetch repos by topic, cache the result.
+// On API failure, the previous cached list is preserved.
+// Thread-safe — called by the discovery scheduler.
+func (e *Engine) Run() {
+	repos, err := e.searcher.FetchReposByTopic(e.topic, e.orgs)
+	if err != nil {
+		slog.Warn("discovery: API call failed, keeping cached list", "err", err)
+		return
+	}
+
+	e.mu.Lock()
+	prev := e.lastCount
+	e.cachedDiscovered = repos
+	e.lastCount = len(repos)
+	e.mu.Unlock()
+
+	slog.Info("discovery: cycle complete", "discovered", len(repos), "previous", prev)
+	if prev > 0 && len(repos) < prev {
+		// Build list of missing repos for the warning
+		current := make(map[string]struct{}, len(repos))
+		for _, r := range repos {
+			current[r] = struct{}{}
+		}
+		slog.Warn("discovery: repo count decreased", "previous", prev, "current", len(repos))
+	}
+}
+
+// Repos returns the current effective repo list: (static UNION cached_discovered) MINUS non_monitored.
+// Thread-safe — called by the poll function on every tick.
+func (e *Engine) Repos() []string {
+	e.mu.RLock()
+	discovered := e.cachedDiscovered
+	e.mu.RUnlock()
+
+	set := make(map[string]struct{}, len(e.staticRepos)+len(discovered))
+	for _, r := range e.staticRepos {
+		set[r] = struct{}{}
+	}
+	for _, r := range discovered {
+		set[r] = struct{}{}
+	}
+	// Apply non_monitored blacklist
+	for r := range e.nonMonitored {
+		delete(set, r)
+	}
+
+	result := make([]string, 0, len(set))
+	for r := range set {
+		result = append(result, r)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/daemon/internal/discovery/discovery_test.go
+++ b/daemon/internal/discovery/discovery_test.go
@@ -1,0 +1,116 @@
+package discovery
+
+import (
+	"errors"
+	"testing"
+)
+
+type mockSearcher struct {
+	repos []string
+	err   error
+}
+
+func (m *mockSearcher) FetchReposByTopic(topic string, orgs []string) ([]string, error) {
+	return m.repos, m.err
+}
+
+func TestEngine_MergeStaticAndDiscovered(t *testing.T) {
+	searcher := &mockSearcher{repos: []string{"org/discovered-1", "org/discovered-2"}}
+	e := New(searcher, "review", []string{"org"}, []string{"org/static-1"}, nil)
+	e.Run()
+
+	repos := e.Repos()
+	if len(repos) != 3 {
+		t.Fatalf("Repos() = %v, want 3 items", repos)
+	}
+	// Should be sorted
+	expected := []string{"org/discovered-1", "org/discovered-2", "org/static-1"}
+	for i, r := range repos {
+		if r != expected[i] {
+			t.Errorf("Repos()[%d] = %q, want %q", i, r, expected[i])
+		}
+	}
+}
+
+func TestEngine_NonMonitoredBlacklist(t *testing.T) {
+	searcher := &mockSearcher{repos: []string{"org/discovered-1", "org/blacklisted"}}
+	e := New(searcher, "review", []string{"org"},
+		[]string{"org/static-1", "org/also-blacklisted"},
+		[]string{"org/blacklisted", "org/also-blacklisted"})
+	e.Run()
+
+	repos := e.Repos()
+	if len(repos) != 2 {
+		t.Fatalf("Repos() = %v, want 2 items", repos)
+	}
+	for _, r := range repos {
+		if r == "org/blacklisted" || r == "org/also-blacklisted" {
+			t.Errorf("Repos() contains blacklisted repo %q", r)
+		}
+	}
+}
+
+func TestEngine_InferOrgsFromStaticRepos(t *testing.T) {
+	searcher := &mockSearcher{repos: []string{"freepik/repo-a"}}
+	e := New(searcher, "review", nil, // empty orgs — should infer
+		[]string{"freepik/repo-1", "theburrowhub/repo-2"}, nil)
+
+	if len(e.orgs) != 2 {
+		t.Fatalf("orgs = %v, want 2 inferred orgs", e.orgs)
+	}
+	// Sorted
+	if e.orgs[0] != "freepik" || e.orgs[1] != "theburrowhub" {
+		t.Errorf("orgs = %v, want [freepik theburrowhub]", e.orgs)
+	}
+}
+
+func TestEngine_CacheOnAPIFailure(t *testing.T) {
+	searcher := &mockSearcher{repos: []string{"org/repo-1", "org/repo-2"}}
+	e := New(searcher, "review", []string{"org"}, nil, nil)
+	e.Run() // First run succeeds
+
+	// Now make it fail
+	searcher.repos = nil
+	searcher.err = errors.New("API error")
+	e.Run() // Should keep cached
+
+	repos := e.Repos()
+	if len(repos) != 2 {
+		t.Fatalf("Repos() after API failure = %v, want 2 cached items", repos)
+	}
+}
+
+func TestEngine_Deduplication(t *testing.T) {
+	searcher := &mockSearcher{repos: []string{"org/repo-1", "org/repo-2"}}
+	e := New(searcher, "review", []string{"org"},
+		[]string{"org/repo-1", "org/repo-3"}, // repo-1 overlaps
+		nil)
+	e.Run()
+
+	repos := e.Repos()
+	if len(repos) != 3 {
+		t.Fatalf("Repos() = %v, want 3 deduplicated items", repos)
+	}
+}
+
+func TestEngine_NoDiscoveryBeforeRun(t *testing.T) {
+	searcher := &mockSearcher{repos: []string{"org/discovered"}}
+	e := New(searcher, "review", []string{"org"}, []string{"org/static"}, nil)
+	// Don't call Run()
+
+	repos := e.Repos()
+	if len(repos) != 1 || repos[0] != "org/static" {
+		t.Errorf("Repos() before Run() = %v, want [org/static]", repos)
+	}
+}
+
+func TestEngine_EmptyStaticAndDiscovered(t *testing.T) {
+	searcher := &mockSearcher{repos: []string{}}
+	e := New(searcher, "review", []string{"org"}, nil, nil)
+	e.Run()
+
+	repos := e.Repos()
+	if len(repos) != 0 {
+		t.Errorf("Repos() = %v, want empty", repos)
+	}
+}

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -346,6 +346,49 @@ func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error)
 	return comments, nil
 }
 
+// FetchReposByTopic searches for repositories with the given topic in the specified orgs.
+// Returns deduplicated "org/repo" strings, sorted alphabetically.
+func (c *Client) FetchReposByTopic(topic string, orgs []string) ([]string, error) {
+	set := make(map[string]struct{})
+	for _, org := range orgs {
+		query := url.QueryEscape(fmt.Sprintf("topic:%s org:%s", topic, org))
+		path := fmt.Sprintf("/search/repositories?q=%s&per_page=100", query)
+		resp, err := c.do("GET", path, "application/vnd.github+json")
+		if err != nil {
+			return nil, fmt.Errorf("github: search repos by topic: %w", err)
+		}
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			errBody := string(body)
+			if len(errBody) > maxErrBodyLen {
+				errBody = errBody[:maxErrBodyLen]
+			}
+			return nil, fmt.Errorf("github: search repos: %s (body: %s)", resp.Status, errBody)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("github: read search response: %w", err)
+		}
+		var result struct {
+			Items []struct {
+				FullName string `json:"full_name"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, fmt.Errorf("github: parse search response: %w", err)
+		}
+		for _, item := range result.Items {
+			set[item.FullName] = struct{}{}
+		}
+	}
+	repos := make([]string, 0, len(set))
+	for r := range set {
+		repos = append(repos, r)
+	}
+	sort.Strings(repos)
+	return repos, nil
+}
+
 func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) {
 	path := fmt.Sprintf("/repos/%s/issues/%d/comments", repo, number)
 	resp, err := c.do("GET", path, "application/vnd.github+json")

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -140,3 +140,75 @@ func TestFetchComments_APIError(t *testing.T) {
 		t.Fatal("expected error for 404 response, got nil")
 	}
 }
+
+func TestFetchReposByTopic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := map[string]any{
+			"items": []map[string]any{
+				{"full_name": "myorg/repo-a"},
+				{"full_name": "myorg/repo-b"},
+			},
+		}
+		json.NewEncoder(w).Encode(result)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchReposByTopic("heimdallr", []string{"myorg"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(got))
+	}
+	if got[0] != "myorg/repo-a" || got[1] != "myorg/repo-b" {
+		t.Errorf("unexpected repos: %v", got)
+	}
+}
+
+func TestFetchReposByTopic_MultipleOrgs(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var items []map[string]any
+		if calls == 1 {
+			items = []map[string]any{
+				{"full_name": "org1/shared-repo"},
+				{"full_name": "org1/unique-repo"},
+			}
+		} else {
+			items = []map[string]any{
+				{"full_name": "org2/other-repo"},
+				{"full_name": "org1/shared-repo"}, // duplicate
+			}
+		}
+		json.NewEncoder(w).Encode(map[string]any{"items": items})
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchReposByTopic("heimdallr", []string{"org1", "org2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 deduplicated repos, got %d: %v", len(got), got)
+	}
+	// Results should be sorted alphabetically
+	if got[0] != "org1/shared-repo" || got[1] != "org1/unique-repo" || got[2] != "org2/other-repo" {
+		t.Errorf("unexpected order or repos: %v", got)
+	}
+}
+
+func TestFetchReposByTopic_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Internal Server Error"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	_, err := client.FetchReposByTopic("heimdallr", []string{"myorg"})
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+}

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/heimdallm/daemon/internal/config"
 	"github.com/heimdallm/daemon/internal/executor"
 	"github.com/heimdallm/daemon/internal/pipeline"
 	"github.com/heimdallm/daemon/internal/sse"
@@ -291,13 +292,16 @@ func (srv *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 // to write via PUT /config. Any key outside this set is rejected with HTTP 400
 // to prevent arbitrary data injection into the configs table (security issue #4).
 var validConfigKeys = map[string]struct{}{
-	"server_port":    {},
-	"poll_interval":  {},
-	"repositories":   {},
-	"ai_primary":     {},
-	"ai_fallback":    {},
-	"review_mode":    {},
-	"retention_days": {},
+	"server_port":        {},
+	"poll_interval":      {},
+	"repositories":       {},
+	"ai_primary":         {},
+	"ai_fallback":        {},
+	"review_mode":        {},
+	"retention_days":     {},
+	"discovery_topic":    {},
+	"discovery_orgs":     {},
+	"discovery_interval": {},
 }
 
 // validPollIntervals is the allowlist of permitted poll_interval values.
@@ -312,6 +316,15 @@ var validPollIntervals = map[string]struct{}{
 var validReviewModes = map[string]struct{}{
 	"single": {},
 	"multi":  {},
+}
+
+// validDiscoveryIntervals is the allowlist of permitted discovery_interval values.
+var validDiscoveryIntervals = map[string]struct{}{
+	"1m":  {},
+	"5m":  {},
+	"15m": {},
+	"30m": {},
+	"1h":  {},
 }
 
 func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
@@ -363,6 +376,32 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		if _, valid := validReviewModes[s]; !valid {
 			http.Error(w, "review_mode must be one of: single, multi", http.StatusBadRequest)
 			return
+		}
+	}
+	if v, ok := body["discovery_topic"]; ok {
+		s, isStr := v.(string)
+		if !isStr {
+			http.Error(w, "discovery_topic must be a string", http.StatusBadRequest)
+			return
+		}
+		if s != "" {
+			if err := config.ValidateTopic(s); err != nil {
+				http.Error(w, fmt.Sprintf("invalid discovery_topic: %v", err), http.StatusBadRequest)
+				return
+			}
+		}
+	}
+	if v, ok := body["discovery_interval"]; ok {
+		s, isStr := v.(string)
+		if !isStr {
+			http.Error(w, "discovery_interval must be a string", http.StatusBadRequest)
+			return
+		}
+		if s != "" {
+			if _, valid := validDiscoveryIntervals[s]; !valid {
+				http.Error(w, "discovery_interval must be one of: 1m, 5m, 15m, 30m, 1h", http.StatusBadRequest)
+				return
+			}
 		}
 	}
 

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -275,6 +275,26 @@ func TestHandlerPutConfigValueValidation(t *testing.T) {
 			body:       `{"review_mode":"batch"}`,
 			wantStatus: http.StatusBadRequest,
 		},
+		{
+			name:       "valid discovery_topic heimdallm-review",
+			body:       `{"discovery_topic":"heimdallm-review"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid discovery_topic uppercase",
+			body:       `{"discovery_topic":"Heimdallm-Review"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "valid discovery_interval 15m",
+			body:       `{"discovery_interval":"15m"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid discovery_interval 10m",
+			body:       `{"discovery_interval":"10m"}`,
+			wantStatus: http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range cases {

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -70,3 +70,15 @@ HEIMDALLM_RETENTION_DAYS=90
 
 # Server port (change if 7842 conflicts)
 HEIMDALLM_PORT=7842
+
+# ── Topic-based repository discovery ────────────────────────────────────────
+# Automatically discover repos by GitHub topic tag (e.g. "heimdallm-review").
+# Repos with this topic are merged with HEIMDALLM_REPOSITORIES.
+# HEIMDALLM_DISCOVERY_TOPIC=heimdallm-review
+
+# Organizations to search for topics (comma-separated).
+# If empty, orgs are inferred from HEIMDALLM_REPOSITORIES.
+# HEIMDALLM_DISCOVERY_ORGS=freepik-company,theburrowhub
+
+# How often to refresh discovered repos (valid: 1m, 5m, 15m, 30m, 1h)
+HEIMDALLM_DISCOVERY_INTERVAL=15m

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -9,6 +9,11 @@ bind_addr = "0.0.0.0"
 [github]
 poll_interval = "5m"
 repositories = ["org/repo1", "org/repo2"]
+# Topic-based auto-discovery (optional)
+# Repos tagged with this topic are automatically monitored.
+# discovery_topic = "heimdallm-review"
+# discovery_orgs = ["freepik-company", "theburrowhub"]
+# discovery_interval = "15m"
 
 [ai]
 # Available: claude, gemini, codex, opencode


### PR DESCRIPTION
Closes #39

## Summary

- Add topic-based auto-discovery: repos tagged with a configurable GitHub topic are automatically monitored
- Discovery runs on a separate interval (default 15m) independent of PR polling
- Discovered repos merged with static `HEIMDALLM_REPOSITORIES`, minus `non_monitored` (absolute blacklist)
- If discovery API fails, last cached list is preserved
- Warning logged when discovered repo count decreases between cycles
- Zero behavioral change when `discovery_topic` is not configured

## Configuration

```toml
[github]
discovery_topic = "heimdallm-review"
discovery_orgs = ["freepik-company"]
discovery_interval = "15m"
```

Or via env vars: `HEIMDALLM_DISCOVERY_TOPIC`, `HEIMDALLM_DISCOVERY_ORGS`, `HEIMDALLM_DISCOVERY_INTERVAL`

## Commits

1. **config** — `DiscoveryTopic`, `DiscoveryOrgs`, `DiscoveryInterval` fields + env vars + topic format validation
2. **github** — `FetchReposByTopic()` method using GitHub Search API
3. **discovery** — New `daemon/internal/discovery/` package with Engine (cache, merge, blacklist, org inference)
4. **main** — Wire discovery engine, dual schedulers, reload handling, `effective_repositories` in GET /config
5. **server** — Discovery keys in PUT /config with validation
6. **docs** — `.env.example`, `config.example.toml`, README

## Test plan

- [ ] Config tests: defaults, env overrides, topic validation (valid/invalid), orphan topic detection
- [ ] GitHub client tests: FetchReposByTopic with mock HTTP (single org, multi org, API error)
- [ ] Discovery engine tests: merge, blacklist, dedup, cache on failure, org inference, pre-run state
- [ ] Server tests: PUT /config accepts/rejects discovery config values
- [ ] `go build ./cmd/heimdallm` compiles
- [ ] Without `discovery_topic`: behavior identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)