### PR TITLE
feat(discovery): auto-discover repos by GitHub topic tag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS.md
+
+Instructions for AI coding agents (Claude Code, Cursor, Copilot, …) and human
+collaborators working on this repo. These rules override the agent's default
+workflow — follow them exactly.
+
+## Go tests must run in Docker
+
+**Always use `make test-docker` for the Go daemon test suite.**
+
+```bash
+make test-docker
+# narrow down to specific packages/tests:
+make test-docker GO_TEST_ARGS="-run TestDiscovery ./internal/discovery/..."
+```
+
+### Why this is non-negotiable
+
+`go test` compiles a transient binary named `<pkg>.test` in
+`/var/folders/.../go-build/` (macOS) or `/tmp/go-build...` (Linux), then runs
+it. These tests:
+
+- open random local ports via `httptest.NewServer`,
+- send HTTP requests with `Authorization: Bearer <token>` headers,
+- exit within milliseconds.
+
+That signature matches heuristics used by corporate EDR agents
+(Elastic Security, CrowdStrike, SentinelOne, Defender for Endpoint, …).
+The EDR will kill the process mid-test — surfaced to the user as
+`signal: killed` — and send a **malware alert** to the security team, who
+will then open a ticket with the developer. **This has already happened
+once in this repo (2026-04-17).** We do not want to do it again.
+
+Running the tests inside a Docker container means the ephemeral binaries
+live in the container's tmpfs, not the host filesystem. The host EDR never
+sees them.
+
+### What `make test-docker` guarantees
+
+Hardening details are inlined in the Makefile target. Summary:
+
+| Concern | Guarantee |
+|---|---|
+| Image | Official `golang:1.21-alpine`, **pinned by SHA256 digest** (not a mutable tag) |
+| Host filesystem access | Single mount: repo at `/src`, **read-only** (`:ro`) |
+| Build cache | Redirected to `/tmp/heimdallm-gocache/` — does not touch `~/.cache` or `~/go` |
+| Privileges | Runs as invoking user (`--user $(id -u):$(id -g)`) — no root in the container |
+| Container persistence | `--rm` — destroyed on exit, no `*.test` artefacts on the host |
+| Network | Default bridge (needed for `go mod download` on first run) |
+| Ports | None exposed |
+
+If IT/Security asks how we run Go tests on their laptops, point them at
+this section and the `test-docker` target.
+
+## When `go test` on the host is OK
+
+Never, on a corporate laptop with an EDR, unless Security has explicitly
+whitelisted `$GOCACHE` and `/var/folders/.../go-build/`. Raising a ticket
+for that exception is preferable to bypassing the rule.
+
+On personal machines, CI runners, or Docker-in-Docker sandboxes, `go test`
+directly is fine. The CI workflow (`.github/workflows/tests.yml`) runs on
+`macos-14` GitHub Actions runners and uses `setup-go` natively — that
+environment has no EDR.
+
+## Flutter tests
+
+Flutter tests do not trip EDR heuristics (Dart VM, no ephemeral native
+binaries). Run them normally:
+
+```bash
+cd flutter_app && flutter test
+# or combined with Go tests (note: `make test` runs Go on the host):
+make test
+```
+
+**Prefer `make test-docker && cd flutter_app && flutter test`** over
+`make test` on EDR-protected endpoints.
+
+## Conventional commits
+
+`release-please` reads commit prefixes to bump semver and generate the
+changelog. Stick to: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`,
+`ci:`, `test:`. A `feat!:` or trailer `BREAKING CHANGE:` forces a major
+bump.
+
+## Do not
+
+- Run `go test` / `go build` on the host on a corporate laptop with EDR.
+- Stage `.DS_Store` in commits.
+- Push directly to `main` — always open a PR.
+- Skip hooks (`--no-verify`) without an explicit user instruction.
+- Invent a different Docker image/tag for tests — the pinned digest in the
+  Makefile is the canonical one. Bump it deliberately, in its own commit,
+  when upgrading Go.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ else
   APP_BUNDLE       := $(FLUTTER_BUILD)/bundle
 endif
 
-.PHONY: build-daemon build-app test dev dev-daemon dev-stop \
+.PHONY: build-daemon build-app test test-docker dev dev-daemon dev-stop \
         release-local package-macos install-service verify-linux clean
 
 # ── Build ─────────────────────────────────────────────────────────────────────
@@ -32,6 +32,47 @@ build-app:
 test:
 	cd daemon && make test
 	cd flutter_app && flutter test
+
+# ── Sandboxed Go tests (EDR-safe) ─────────────────────────────────────────────
+#
+# Runs `go vet` + `go test` for the daemon inside an official Go container,
+# so corporate EDR agents (Elastic Security, CrowdStrike, SentinelOne, …)
+# never see ephemeral *.test binaries appearing in /var/folders/.../go-build/.
+#
+# Hardening (share with IT/Security if asked):
+#   - Image pinned by SHA256 digest (GO_DOCKER_IMAGE below)
+#   - Repo mounted READ-ONLY (:ro) — container cannot modify sources
+#   - Go cache redirected to /tmp/heimdallm-gocache on the host
+#     (never touches ~/.cache/go-build or ~/go/pkg/mod)
+#   - Runs as the invoking user (--user $(id -u):$(id -g)), no root in container
+#   - --rm → container and its tmpfs are destroyed on exit
+#   - No ports exposed, no host env vars forwarded
+#
+# AI AGENTS: this is the default for Go tests on this repo. Do not run
+# `go test` directly on the host unless explicitly asked. See AGENTS.md.
+#
+# Usage:
+#   make test-docker
+#   make test-docker GO_TEST_ARGS="-run TestFoo ./internal/config/..."
+
+GO_DOCKER_IMAGE ?= golang:1.21-alpine@sha256:2414035b086e3c42b99654c8b26e6f5b1b1598080d65fd03c7f499552ff4dc94
+GO_TEST_ARGS    ?= -timeout 60s -count=1 ./...
+
+test-docker:
+	@command -v docker >/dev/null || { echo "❌  Docker is required. Install from https://docs.docker.com/get-docker/"; exit 1; }
+	@mkdir -p /tmp/heimdallm-gocache /tmp/heimdallm-home
+	@echo "▶  Running Go vet + tests inside $(GO_DOCKER_IMAGE)"
+	docker run --rm \
+	  --user "$(shell id -u):$(shell id -g)" \
+	  -v "$(shell pwd):/src:ro" \
+	  -v "/tmp/heimdallm-gocache:/tmp/.cache" \
+	  -v "/tmp/heimdallm-home:/tmp/home" \
+	  -w /src/daemon \
+	  -e HOME=/tmp/home \
+	  -e GOCACHE=/tmp/.cache/go-build \
+	  -e GOMODCACHE=/tmp/.cache/gomod \
+	  $(GO_DOCKER_IMAGE) \
+	  sh -c "go vet ./... && go test $(GO_TEST_ARGS)"
 
 # ── Local development ─────────────────────────────────────────────────────────
 #

--- a/README.md
+++ b/README.md
@@ -138,11 +138,19 @@ make dev
 ### Other targets
 
 ```bash
-make test          # Run Go + Flutter test suites
+make test          # Run Go + Flutter test suites on the host
+make test-docker   # Run Go tests inside a pinned Docker image (EDR-safe)
 make dev-daemon    # Run daemon only (debug API at localhost:7842)
 make dev-stop      # Stop the running daemon
 make release-local # Build signed + notarized DMG and publish GitHub release
 ```
+
+> **Working on a laptop with corporate EDR (Elastic Security, CrowdStrike, …)?**
+> Use `make test-docker` instead of `make test` for the Go suite. `go test`
+> compiles ephemeral `*.test` binaries that EDR heuristics flag as malware;
+> running inside Docker keeps those artefacts in the container's tmpfs.
+> See [`AGENTS.md`](AGENTS.md) for the full rationale and the hardening
+> details to share with your security team.
 
 ### Project structure
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ curl http://localhost:7842/health
 
 The Docker image is published to `ghcr.io/theburrowhub/heimdallm:latest` on every release. See [`docker/.env.example`](docker/.env.example) for all configuration options.
 
+#### Auto-discover repositories by topic
+
+Instead of listing every repository in `HEIMDALLM_REPOSITORIES`, you can tag
+the repos you want Heimdallm to watch with a GitHub **topic** and let the
+daemon discover them:
+
+```bash
+HEIMDALLM_DISCOVERY_TOPIC=heimdallm-review
+HEIMDALLM_DISCOVERY_ORGS=your-org,your-other-org   # required
+HEIMDALLM_DISCOVERY_INTERVAL=15m                    # optional, defaults to 15m
+```
+
+Any non-archived repo inside one of the listed orgs that carries the topic is
+merged into the monitored set on each discovery cycle. Transient Search API
+errors fall back to the last known-good list, so an outage never empties the
+set silently. The static `HEIMDALLM_REPOSITORIES` list keeps working — the
+two sources are merged (deduplicated) at poll time.
+
 ### Automated install (for agents / scripts)
 
 See [LLM-HOW-TO-INSTALL.md](LLM-HOW-TO-INSTALL.md) for a step-by-step guide suitable for Claude Code, shell scripts, or any automation tool.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/discovery"
 	"github.com/heimdallm/daemon/internal/executor"
 	gh "github.com/heimdallm/daemon/internal/github"
 	"github.com/heimdallm/daemon/internal/keychain"
@@ -98,9 +99,15 @@ func main() {
 	p := pipeline.New(s, ghClient, exec, &notifyWithSSE{notifier: notifier})
 	srv := server.New(s, broker, p, apiToken)
 
-	// cfgMu protects cfg and sched so reload is safe from any goroutine.
+	// cfgMu protects cfg, sched and the discovery loop so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
 	var sched *scheduler.Scheduler
+
+	// discoverySvc holds the discovered repo cache; it is nil when topic-based
+	// discovery is disabled. discoveryCancel stops the background loop so reload
+	// can restart it with fresh config.
+	discoverySvc := discovery.NewService(ghClient)
+	var discoveryCancel context.CancelFunc
 
 	// reviewMu prevents concurrent pipeline runs for the same GitHub PR ID.
 	// Key: pr.ID (GitHub PR ID), Value: true while being reviewed.
@@ -185,8 +192,10 @@ func main() {
 	makePollFn := func(c *config.Config) func() {
 		return func() {
 			cfgMu.Lock()
-			repos := c.GitHub.Repositories
+			static := c.GitHub.Repositories
 			cfgMu.Unlock()
+			// Merge static list with repos discovered via topic tag (empty when disabled).
+			repos := discovery.MergeRepos(static, discoverySvc.Discovered())
 
 			// Fetch all review-requested PRs without a repo filter — adding many
 			// repo: terms to the Search API query can exceed its length limit and
@@ -247,8 +256,25 @@ func main() {
 		return sc
 	}
 
+	// startDiscovery spawns the discovery loop when discovery_topic is configured.
+	// It returns a cancel func for the running loop, or nil when discovery is off.
+	// Must be called with cfgMu held so the caller can swap cancel funcs atomically.
+	startDiscovery := func(c *config.Config) context.CancelFunc {
+		if c.GitHub.DiscoveryTopic == "" {
+			return nil
+		}
+		interval := parseDiscoveryInterval(c.GitHub.DiscoveryInterval)
+		ctx, cancel := context.WithCancel(context.Background())
+		topic := c.GitHub.DiscoveryTopic
+		orgs := append([]string(nil), c.GitHub.DiscoveryOrgs...)
+		go discoverySvc.Run(ctx, interval, topic, orgs)
+		slog.Info("discovery: loop started", "topic", topic, "orgs", orgs, "interval", interval)
+		return cancel
+	}
+
 	cfgMu.Lock()
 	sched = startScheduler(cfg)
+	discoveryCancel = startDiscovery(cfg)
 	cfgMu.Unlock()
 
 	// Capture the scheduler pointer under mutex so the deferred Stop is safe
@@ -256,8 +282,12 @@ func main() {
 	defer func() {
 		cfgMu.Lock()
 		sc := sched
+		dc := discoveryCancel
 		cfgMu.Unlock()
 		sc.Stop()
+		if dc != nil {
+			dc()
+		}
 	}()
 
 	// Expose live config for GET /config
@@ -327,7 +357,9 @@ func main() {
 		return login, err
 	})
 
-	// Wire the reload callback: re-read config from disk, restart scheduler.
+	// Wire the reload callback: re-read config from disk, restart scheduler
+	// and the discovery loop so changes to discovery_topic / orgs / interval
+	// take effect without a daemon restart.
 	srv.SetReloadFn(func() error {
 		newCfg, err := config.Load(cfgPath)
 		if err != nil {
@@ -336,12 +368,17 @@ func main() {
 		cfgMu.Lock()
 		cfg = newCfg
 		oldSched := sched
+		oldDiscoveryCancel := discoveryCancel
 		sched = startScheduler(newCfg)
+		discoveryCancel = startDiscovery(newCfg)
 		cfgMu.Unlock()
 
-		// Stop the old scheduler outside the lock to avoid holding the mutex
+		// Stop the old workers outside the lock to avoid holding the mutex
 		// during a potentially blocking Stop call.
 		oldSched.Stop()
+		if oldDiscoveryCancel != nil {
+			oldDiscoveryCancel()
+		}
 
 		// Run first poll immediately with new config
 		go makePollFn(newCfg)()
@@ -473,6 +510,17 @@ func parsePollInterval(s string) time.Duration {
 	d, err := time.ParseDuration(s)
 	if err != nil || d <= 0 {
 		return 5 * time.Minute
+	}
+	return d
+}
+
+// parseDiscoveryInterval falls back to 15m when the value is empty or invalid.
+// Config.Validate rejects invalid durations before we reach here, so the
+// fallback only covers the unset-in-TOML-but-topic-defaulted case.
+func parseDiscoveryInterval(s string) time.Duration {
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 15 * time.Minute
 	}
 	return d
 }

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -365,20 +365,29 @@ func main() {
 		if err != nil {
 			return fmt.Errorf("reload: %w", err)
 		}
+
 		cfgMu.Lock()
-		cfg = newCfg
 		oldSched := sched
 		oldDiscoveryCancel := discoveryCancel
+		cfgMu.Unlock()
+
+		// Stop the old discovery loop BEFORE starting the new one. The Search
+		// API rate limit (30 req/min) is tight enough that running two loops
+		// in parallel — even briefly during reload — risks throttling the
+		// daemon.
+		if oldDiscoveryCancel != nil {
+			oldDiscoveryCancel()
+		}
+
+		cfgMu.Lock()
+		cfg = newCfg
 		sched = startScheduler(newCfg)
 		discoveryCancel = startDiscovery(newCfg)
 		cfgMu.Unlock()
 
-		// Stop the old workers outside the lock to avoid holding the mutex
-		// during a potentially blocking Stop call.
+		// Scheduler overlap is pre-existing behaviour and tolerated; Stop is
+		// idempotent and safe to call outside the lock.
 		oldSched.Stop()
-		if oldDiscoveryCancel != nil {
-			oldDiscoveryCancel()
-		}
 
 		// Run first poll immediately with new config
 		go makePollFn(newCfg)()

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -5,8 +5,10 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/heimdallm/daemon/internal/executor"
@@ -15,6 +17,11 @@ import (
 var validIntervals = map[string]bool{
 	"1m": true, "5m": true, "30m": true, "1h": true,
 }
+
+// githubTopicPattern enforces GitHub's topic rules: lowercase letters, digits
+// and hyphens, starting with a letter or digit, up to 50 characters total.
+// See https://docs.github.com/repositories/classifying-your-repository-with-topics
+var githubTopicPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,49}$`)
 
 type Config struct {
 	Server    ServerConfig    `toml:"server"`
@@ -35,6 +42,19 @@ type GitHubConfig struct {
 	// The daemon never polls these; they are stored here only so the Flutter UI can
 	// remember and display them after a restart.
 	NonMonitored []string `toml:"non_monitored"`
+
+	// DiscoveryTopic, when set, enables automatic repository discovery based on
+	// a GitHub topic tag (e.g. "heimdallm-review"). Discovered repos are merged
+	// with Repositories at poll time. Empty = discovery disabled.
+	DiscoveryTopic string `toml:"discovery_topic"`
+	// DiscoveryOrgs limits topic-based discovery to specific organisations.
+	// Required when DiscoveryTopic is set (prevents scanning all of GitHub).
+	DiscoveryOrgs []string `toml:"discovery_orgs"`
+	// DiscoveryInterval controls how often the discovery query is refreshed.
+	// Independent from PollInterval because the Search API has a stricter
+	// rate limit (30 req/min authenticated). Defaults to "15m" when discovery
+	// is enabled. Accepts any Go time.ParseDuration value.
+	DiscoveryInterval string `toml:"discovery_interval"`
 }
 
 // CLIAgentConfig holds per-CLI execution settings (model, flags, prompt override).
@@ -115,6 +135,9 @@ func (c *Config) applyDefaults() {
 	if c.GitHub.PollInterval == "" {
 		c.GitHub.PollInterval = "5m"
 	}
+	if c.GitHub.DiscoveryTopic != "" && c.GitHub.DiscoveryInterval == "" {
+		c.GitHub.DiscoveryInterval = "15m"
+	}
 	if c.Retention.MaxDays == 0 {
 		c.Retention.MaxDays = 90
 	}
@@ -163,6 +186,24 @@ func (c *Config) applyEnvOverrides() {
 			c.Retention.MaxDays = d
 		}
 	}
+	if v := os.Getenv("HEIMDALLM_DISCOVERY_TOPIC"); v != "" {
+		c.GitHub.DiscoveryTopic = v
+	}
+	if v := os.Getenv("HEIMDALLM_DISCOVERY_ORGS"); v != "" {
+		orgs := strings.Split(v, ",")
+		cleaned := make([]string, 0, len(orgs))
+		for _, o := range orgs {
+			if s := strings.TrimSpace(o); s != "" {
+				cleaned = append(cleaned, s)
+			}
+		}
+		if len(cleaned) > 0 {
+			c.GitHub.DiscoveryOrgs = cleaned
+		}
+	}
+	if v := os.Getenv("HEIMDALLM_DISCOVERY_INTERVAL"); v != "" {
+		c.GitHub.DiscoveryInterval = v
+	}
 }
 
 // Validate checks that required fields are present and values are valid.
@@ -180,6 +221,35 @@ func (c *Config) Validate() error {
 		}
 		if err := executor.ValidateApprovalMode(a.ApprovalMode); err != nil {
 			return fmt.Errorf("config: agents[%s].approval_mode: %w", name, err)
+		}
+	}
+	if err := c.validateDiscovery(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateDiscovery enforces the rules for topic-based repository discovery.
+// Topic must follow GitHub's topic format, at least one org is required when
+// discovery is enabled (to bound the Search API scope), and the interval must
+// be parseable as a positive duration.
+func (c *Config) validateDiscovery() error {
+	if c.GitHub.DiscoveryTopic == "" {
+		return nil
+	}
+	if !githubTopicPattern.MatchString(c.GitHub.DiscoveryTopic) {
+		return fmt.Errorf("config: github.discovery_topic %q is invalid (must match GitHub topic format: lowercase letters, digits and hyphens, up to 50 chars)", c.GitHub.DiscoveryTopic)
+	}
+	if len(c.GitHub.DiscoveryOrgs) == 0 {
+		return fmt.Errorf("config: github.discovery_orgs must list at least one organisation when discovery_topic is set")
+	}
+	if c.GitHub.DiscoveryInterval != "" {
+		d, err := time.ParseDuration(c.GitHub.DiscoveryInterval)
+		if err != nil {
+			return fmt.Errorf("config: github.discovery_interval %q is invalid: %w", c.GitHub.DiscoveryInterval, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("config: github.discovery_interval %q must be positive", c.GitHub.DiscoveryInterval)
 		}
 	}
 	return nil

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -23,6 +23,13 @@ var validIntervals = map[string]bool{
 // See https://docs.github.com/repositories/classifying-your-repository-with-topics
 var githubTopicPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,49}$`)
 
+// githubOrgPattern matches the GitHub org/user slug format: alphanumeric plus
+// internal hyphens, 1–39 characters, not starting or ending with a hyphen.
+// Validating this defensively prevents injection into the Search API query
+// (e.g. a value like "evil-org archived:false org:other" being interpolated
+// verbatim into the `q=` parameter).
+var githubOrgPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$`)
+
 type Config struct {
 	Server    ServerConfig    `toml:"server"`
 	GitHub    GitHubConfig    `toml:"github"`
@@ -242,6 +249,11 @@ func (c *Config) validateDiscovery() error {
 	}
 	if len(c.GitHub.DiscoveryOrgs) == 0 {
 		return fmt.Errorf("config: github.discovery_orgs must list at least one organisation when discovery_topic is set")
+	}
+	for _, org := range c.GitHub.DiscoveryOrgs {
+		if !githubOrgPattern.MatchString(org) {
+			return fmt.Errorf("config: github.discovery_orgs entry %q is invalid (must match GitHub org/user slug: 1–39 alphanumerics plus internal hyphens)", org)
+		}
 	}
 	if c.GitHub.DiscoveryInterval != "" {
 		d, err := time.ParseDuration(c.GitHub.DiscoveryInterval)

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -162,6 +163,165 @@ func TestValidate_AllValidIntervals(t *testing.T) {
 		cfg := &Config{AI: AIConfig{Primary: "claude"}, GitHub: GitHubConfig{PollInterval: interval}}
 		if err := cfg.Validate(); err != nil {
 			t.Errorf("Validate() with interval %q = %v", interval, err)
+		}
+	}
+}
+
+// ── Topic-based discovery ────────────────────────────────────────────────────
+
+func TestApplyDefaults_DiscoveryIntervalWhenTopicSet(t *testing.T) {
+	cfg := &Config{}
+	cfg.GitHub.DiscoveryTopic = "heimdallm-review"
+	cfg.applyDefaults()
+
+	if cfg.GitHub.DiscoveryInterval != "15m" {
+		t.Errorf("DiscoveryInterval = %q, want default %q", cfg.GitHub.DiscoveryInterval, "15m")
+	}
+}
+
+func TestApplyDefaults_NoDiscoveryIntervalWhenTopicUnset(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+
+	if cfg.GitHub.DiscoveryInterval != "" {
+		t.Errorf("DiscoveryInterval = %q, want empty when topic unset", cfg.GitHub.DiscoveryInterval)
+	}
+}
+
+func TestApplyDefaults_PreservesDiscoveryInterval(t *testing.T) {
+	cfg := &Config{}
+	cfg.GitHub.DiscoveryTopic = "heimdallm-review"
+	cfg.GitHub.DiscoveryInterval = "30m"
+	cfg.applyDefaults()
+
+	if cfg.GitHub.DiscoveryInterval != "30m" {
+		t.Errorf("DiscoveryInterval overwritten: %q", cfg.GitHub.DiscoveryInterval)
+	}
+}
+
+func TestApplyEnvOverrides_Discovery(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+
+	t.Setenv("HEIMDALLM_DISCOVERY_TOPIC", "heimdallm-review")
+	t.Setenv("HEIMDALLM_DISCOVERY_ORGS", "freepik-company, theburrowhub ,  ")
+	t.Setenv("HEIMDALLM_DISCOVERY_INTERVAL", "10m")
+
+	cfg.applyEnvOverrides()
+
+	if cfg.GitHub.DiscoveryTopic != "heimdallm-review" {
+		t.Errorf("DiscoveryTopic = %q", cfg.GitHub.DiscoveryTopic)
+	}
+	if len(cfg.GitHub.DiscoveryOrgs) != 2 {
+		t.Fatalf("DiscoveryOrgs = %v, want 2 entries", cfg.GitHub.DiscoveryOrgs)
+	}
+	if cfg.GitHub.DiscoveryOrgs[0] != "freepik-company" || cfg.GitHub.DiscoveryOrgs[1] != "theburrowhub" {
+		t.Errorf("DiscoveryOrgs = %v", cfg.GitHub.DiscoveryOrgs)
+	}
+	if cfg.GitHub.DiscoveryInterval != "10m" {
+		t.Errorf("DiscoveryInterval = %q", cfg.GitHub.DiscoveryInterval)
+	}
+}
+
+func TestApplyEnvOverrides_DiscoveryOrgs_AllBlankPreservesExisting(t *testing.T) {
+	cfg := &Config{}
+	cfg.GitHub.DiscoveryOrgs = []string{"existing-org"}
+
+	t.Setenv("HEIMDALLM_DISCOVERY_ORGS", "  ,  ,  ")
+	cfg.applyEnvOverrides()
+
+	if len(cfg.GitHub.DiscoveryOrgs) != 1 || cfg.GitHub.DiscoveryOrgs[0] != "existing-org" {
+		t.Errorf("DiscoveryOrgs should keep the existing value when env is all blank, got %v", cfg.GitHub.DiscoveryOrgs)
+	}
+}
+
+func TestValidate_DiscoveryDisabled(t *testing.T) {
+	cfg := &Config{AI: AIConfig{Primary: "claude"}}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() with no discovery = %v", err)
+	}
+}
+
+func TestValidate_DiscoveryTopicRequiresOrgs(t *testing.T) {
+	cfg := &Config{
+		AI:     AIConfig{Primary: "claude"},
+		GitHub: GitHubConfig{DiscoveryTopic: "heimdallm-review"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() with discovery_topic but no orgs = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "discovery_orgs") {
+		t.Errorf("error should mention discovery_orgs, got: %v", err)
+	}
+}
+
+func TestValidate_DiscoveryTopicInvalidFormat(t *testing.T) {
+	cases := []struct {
+		name  string
+		topic string
+	}{
+		{"uppercase", "Heimdallm-Review"},
+		{"starts with hyphen", "-heimdallm"},
+		{"contains space", "heimdallm review"},
+		{"too long", strings.Repeat("a", 51)},
+		{"underscore", "heimdallm_review"},
+		{"empty after hyphen", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.topic == "" {
+				t.Skip("empty topic disables discovery; covered elsewhere")
+			}
+			cfg := &Config{
+				AI: AIConfig{Primary: "claude"},
+				GitHub: GitHubConfig{
+					DiscoveryTopic: tc.topic,
+					DiscoveryOrgs:  []string{"some-org"},
+				},
+			}
+			if err := cfg.Validate(); err == nil {
+				t.Errorf("Validate(topic=%q) = nil, want error", tc.topic)
+			}
+		})
+	}
+}
+
+func TestValidate_DiscoveryTopicValidFormats(t *testing.T) {
+	cases := []string{
+		"heimdallm-review",
+		"a",
+		"123",
+		"a-b-c-d",
+		strings.Repeat("a", 50),
+	}
+	for _, topic := range cases {
+		cfg := &Config{
+			AI: AIConfig{Primary: "claude"},
+			GitHub: GitHubConfig{
+				DiscoveryTopic: topic,
+				DiscoveryOrgs:  []string{"some-org"},
+			},
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate(topic=%q) = %v, want nil", topic, err)
+		}
+	}
+}
+
+func TestValidate_DiscoveryIntervalInvalid(t *testing.T) {
+	cases := []string{"not-a-duration", "-5m", "0"}
+	for _, interval := range cases {
+		cfg := &Config{
+			AI: AIConfig{Primary: "claude"},
+			GitHub: GitHubConfig{
+				DiscoveryTopic:    "heimdallm-review",
+				DiscoveryOrgs:     []string{"some-org"},
+				DiscoveryInterval: interval,
+			},
+		}
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("Validate(interval=%q) = nil, want error", interval)
 		}
 	}
 }

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -326,6 +326,63 @@ func TestValidate_DiscoveryIntervalInvalid(t *testing.T) {
 	}
 }
 
+func TestValidate_DiscoveryOrgsInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		org  string
+	}{
+		{"contains space", "freepik company"},
+		{"contains slash", "org/subpath"},
+		{"search qualifier injection", "evil archived:false org:other"},
+		{"starts with hyphen", "-freepik"},
+		{"ends with hyphen", "freepik-"},
+		{"contains underscore", "free_pik"},
+		{"too long", strings.Repeat("a", 40)},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				AI: AIConfig{Primary: "claude"},
+				GitHub: GitHubConfig{
+					DiscoveryTopic: "heimdallm-review",
+					DiscoveryOrgs:  []string{"valid-org", tc.org},
+				},
+			}
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate(org=%q) = nil, want error", tc.org)
+			}
+			if !strings.Contains(err.Error(), "discovery_orgs") {
+				t.Errorf("error should mention discovery_orgs, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_DiscoveryOrgsValid(t *testing.T) {
+	cases := []string{
+		"freepik-company",
+		"theburrowhub",
+		"a",
+		"A1",
+		"1a",
+		strings.Repeat("a", 39),
+	}
+	for _, org := range cases {
+		cfg := &Config{
+			AI: AIConfig{Primary: "claude"},
+			GitHub: GitHubConfig{
+				DiscoveryTopic: "heimdallm-review",
+				DiscoveryOrgs:  []string{org},
+			},
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate(org=%q) = %v, want nil", org, err)
+		}
+	}
+}
+
 // ── AIForRepo ────────────────────────────────────────────────────────────────
 
 func TestAIForRepo_GlobalFallback(t *testing.T) {

--- a/daemon/internal/discovery/discovery.go
+++ b/daemon/internal/discovery/discovery.go
@@ -1,0 +1,148 @@
+// Package discovery automatically discovers GitHub repositories by topic tag.
+// The static repository list in config is augmented with whatever the Search
+// API returns for `topic:<tag> org:<org>` across the configured orgs.
+//
+// The service keeps an in-memory cache that is only replaced on a successful
+// refresh: transient API errors (rate limiting, 5xx) never wipe the last
+// known-good list, so an outage cannot silently stop the daemon from polling
+// previously discovered repos.
+package discovery
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// ReposFetcher is the subset of the GitHub client used for discovery.
+// It is an interface so tests can swap in a fake without an HTTP server.
+type ReposFetcher interface {
+	FetchReposByTopic(topic string, orgs []string) ([]string, error)
+}
+
+// Service runs a background loop that refreshes the list of repositories
+// that carry the configured topic tag. Callers read the current list with
+// Discovered(); the merge with the static list happens at the call site.
+type Service struct {
+	fetcher ReposFetcher
+
+	mu      sync.RWMutex
+	cache   []string
+	lastErr error
+	lastAt  time.Time
+}
+
+// NewService wires a fetcher into a discovery service.
+func NewService(fetcher ReposFetcher) *Service {
+	return &Service{fetcher: fetcher}
+}
+
+// Discovered returns a copy of the most recent successful discovery list.
+// The slice is safe for the caller to mutate.
+func (s *Service) Discovered() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.cache) == 0 {
+		return nil
+	}
+	out := make([]string, len(s.cache))
+	copy(out, s.cache)
+	return out
+}
+
+// LastError returns the most recent refresh error, or nil on success.
+func (s *Service) LastError() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastErr
+}
+
+// Refresh performs a single discovery query and updates the cache on success.
+// On full failure the cache is preserved — degrade to previously known list.
+// Partial failures (some orgs OK, others not) update the cache with what was
+// returned and also record the error, so the caller can log it.
+func (s *Service) Refresh(topic string, orgs []string) error {
+	repos, err := s.fetcher.FetchReposByTopic(topic, orgs)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastErr = err
+	s.lastAt = time.Now()
+
+	// Only overwrite the cache if we got at least one repo back. This is the
+	// key safety property: a total outage returns (nil, err) and we keep the
+	// previous list; a partial outage returns (some, err) and we update with
+	// what we have.
+	if len(repos) > 0 {
+		s.cache = repos
+	} else if err != nil {
+		slog.Warn("discovery: refresh failed, keeping previous cache",
+			"cached", len(s.cache), "err", err)
+	}
+	return err
+}
+
+// Run blocks until ctx is cancelled, refreshing the cache every interval.
+// The first refresh happens immediately; subsequent refreshes wait for the
+// full interval. Errors are logged but never stop the loop.
+func (s *Service) Run(ctx context.Context, interval time.Duration, topic string, orgs []string) {
+	if interval <= 0 {
+		slog.Warn("discovery: non-positive interval, loop disabled", "interval", interval)
+		return
+	}
+	if err := s.Refresh(topic, orgs); err != nil {
+		slog.Warn("discovery: initial refresh failed", "err", err)
+	} else {
+		slog.Info("discovery: initial refresh",
+			"topic", topic, "orgs", orgs, "count", len(s.Discovered()))
+	}
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := s.Refresh(topic, orgs); err != nil {
+				slog.Warn("discovery: refresh failed", "err", err)
+				continue
+			}
+			slog.Info("discovery: refreshed",
+				"topic", topic, "orgs", orgs, "count", len(s.Discovered()))
+		}
+	}
+}
+
+// MergeRepos returns the union of static and discovered repositories,
+// preserving the order of static entries (stable for config-driven overrides)
+// and appending discovered entries that are not already present.
+func MergeRepos(static, discovered []string) []string {
+	if len(static) == 0 && len(discovered) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(static)+len(discovered))
+	out := make([]string, 0, len(static)+len(discovered))
+	for _, r := range static {
+		if r == "" {
+			continue
+		}
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		seen[r] = struct{}{}
+		out = append(out, r)
+	}
+	for _, r := range discovered {
+		if r == "" {
+			continue
+		}
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		seen[r] = struct{}{}
+		out = append(out, r)
+	}
+	return out
+}

--- a/daemon/internal/discovery/discovery_test.go
+++ b/daemon/internal/discovery/discovery_test.go
@@ -1,0 +1,237 @@
+package discovery_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/discovery"
+)
+
+type fakeFetcher struct {
+	mu     sync.Mutex
+	calls  int32
+	repos  []string
+	err    error
+	onCall func(call int32)
+}
+
+func (f *fakeFetcher) FetchReposByTopic(topic string, orgs []string) ([]string, error) {
+	n := atomic.AddInt32(&f.calls, 1)
+	if f.onCall != nil {
+		f.onCall(n)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Return copies so callers can mutate safely.
+	out := make([]string, len(f.repos))
+	copy(out, f.repos)
+	return out, f.err
+}
+
+func (f *fakeFetcher) set(repos []string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.repos = repos
+	f.err = err
+}
+
+// ── MergeRepos ───────────────────────────────────────────────────────────────
+
+func TestMergeRepos_PreservesStaticOrderAndDeduplicates(t *testing.T) {
+	out := discovery.MergeRepos(
+		[]string{"org/static1", "org/shared"},
+		[]string{"org/shared", "org/discovered1", "org/discovered2"},
+	)
+	want := []string{"org/static1", "org/shared", "org/discovered1", "org/discovered2"}
+	if len(out) != len(want) {
+		t.Fatalf("got %v, want %v", out, want)
+	}
+	for i := range want {
+		if out[i] != want[i] {
+			t.Errorf("out[%d] = %q, want %q", i, out[i], want[i])
+		}
+	}
+}
+
+func TestMergeRepos_BothEmpty(t *testing.T) {
+	if got := discovery.MergeRepos(nil, nil); got != nil {
+		t.Errorf("MergeRepos(nil, nil) = %v, want nil", got)
+	}
+}
+
+func TestMergeRepos_OnlyStatic(t *testing.T) {
+	got := discovery.MergeRepos([]string{"a", "b"}, nil)
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestMergeRepos_OnlyDiscovered(t *testing.T) {
+	got := discovery.MergeRepos(nil, []string{"a", "b"})
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestMergeRepos_IgnoresEmptyStrings(t *testing.T) {
+	got := discovery.MergeRepos([]string{"", "a", ""}, []string{"", "b"})
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("got %v", got)
+	}
+}
+
+// ── Service.Refresh ──────────────────────────────────────────────────────────
+
+func TestService_Refresh_Success(t *testing.T) {
+	f := &fakeFetcher{repos: []string{"org/a", "org/b"}}
+	s := discovery.NewService(f)
+
+	if err := s.Refresh("topic", []string{"org"}); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	got := s.Discovered()
+	if len(got) != 2 || got[0] != "org/a" || got[1] != "org/b" {
+		t.Errorf("got %v", got)
+	}
+	if s.LastError() != nil {
+		t.Errorf("LastError = %v, want nil", s.LastError())
+	}
+}
+
+func TestService_Refresh_TotalFailurePreservesCache(t *testing.T) {
+	f := &fakeFetcher{repos: []string{"org/a"}}
+	s := discovery.NewService(f)
+	if err := s.Refresh("t", []string{"o"}); err != nil {
+		t.Fatalf("seed refresh: %v", err)
+	}
+
+	// Simulate a total failure: API returns no repos and an error.
+	f.set(nil, errors.New("rate limit"))
+	if err := s.Refresh("t", []string{"o"}); err == nil {
+		t.Fatal("expected error on total failure")
+	}
+
+	got := s.Discovered()
+	if len(got) != 1 || got[0] != "org/a" {
+		t.Errorf("cache should be preserved on total failure, got %v", got)
+	}
+	if s.LastError() == nil {
+		t.Error("LastError should reflect the failure")
+	}
+}
+
+func TestService_Refresh_PartialFailureUpdatesWithWhatWeGot(t *testing.T) {
+	f := &fakeFetcher{repos: []string{"org/a"}}
+	s := discovery.NewService(f)
+	if err := s.Refresh("t", []string{"o"}); err != nil {
+		t.Fatalf("seed refresh: %v", err)
+	}
+
+	// Partial failure: API returns a different result + an error.
+	f.set([]string{"org/a", "org/b"}, errors.New("one org failed"))
+	err := s.Refresh("t", []string{"o"})
+	if err == nil {
+		t.Fatal("expected error on partial failure")
+	}
+
+	got := s.Discovered()
+	if len(got) != 2 || got[0] != "org/a" || got[1] != "org/b" {
+		t.Errorf("cache should reflect partial result, got %v", got)
+	}
+}
+
+func TestService_Discovered_ReturnsCopy(t *testing.T) {
+	f := &fakeFetcher{repos: []string{"org/a"}}
+	s := discovery.NewService(f)
+	if err := s.Refresh("t", []string{"o"}); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	got := s.Discovered()
+	got[0] = "mutated"
+
+	got2 := s.Discovered()
+	if got2[0] != "org/a" {
+		t.Errorf("callers must not be able to mutate the cache through Discovered(); got %v", got2)
+	}
+}
+
+// ── Service.Run ──────────────────────────────────────────────────────────────
+
+func TestService_Run_RefreshesOnTick(t *testing.T) {
+	called := make(chan struct{}, 4)
+	f := &fakeFetcher{
+		repos: []string{"org/a"},
+		onCall: func(n int32) {
+			select {
+			case called <- struct{}{}:
+			default:
+			}
+		},
+	}
+	s := discovery.NewService(f)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go s.Run(ctx, 20*time.Millisecond, "topic", []string{"org"})
+
+	// First call should be immediate.
+	select {
+	case <-called:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for initial refresh")
+	}
+	// Second call must come from the ticker.
+	select {
+	case <-called:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for ticker refresh")
+	}
+}
+
+func TestService_Run_StopsOnContextCancel(t *testing.T) {
+	f := &fakeFetcher{repos: []string{"org/a"}}
+	s := discovery.NewService(f)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx, 10*time.Millisecond, "t", []string{"o"})
+		close(done)
+	}()
+
+	// Let it tick a few times then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Run did not return within 1s of cancel")
+	}
+}
+
+func TestService_Run_ZeroIntervalReturns(t *testing.T) {
+	f := &fakeFetcher{repos: []string{"org/a"}}
+	s := discovery.NewService(f)
+
+	done := make(chan struct{})
+	go func() {
+		s.Run(context.Background(), 0, "t", []string{"o"})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Run should return immediately when interval is zero")
+	}
+	if atomic.LoadInt32(&f.calls) != 0 {
+		t.Errorf("expected no API calls on zero interval, got %d", f.calls)
+	}
+}

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -250,8 +251,9 @@ const maxDiscoveryPages = 10
 // return an empty slice without calling the API.
 //
 // Each org is queried independently so one failing org does not wipe the
-// others — a partial result is returned alongside a joined error describing
-// which orgs failed. Results are deduplicated across orgs.
+// others — a partial result is returned alongside a joined error (see
+// errors.Join) describing which orgs failed. Results are deduplicated across
+// orgs.
 func (c *Client) FetchReposByTopic(topic string, orgs []string) ([]string, error) {
 	if topic == "" || len(orgs) == 0 {
 		return nil, nil
@@ -259,12 +261,12 @@ func (c *Client) FetchReposByTopic(topic string, orgs []string) ([]string, error
 
 	seen := make(map[string]struct{})
 	var repos []string
-	var errs []string
+	var errs []error
 
 	for _, org := range orgs {
 		found, err := c.fetchReposForOrg(topic, org)
 		if err != nil {
-			errs = append(errs, fmt.Sprintf("%s: %v", org, err))
+			errs = append(errs, fmt.Errorf("%s: %w", org, err))
 			continue
 		}
 		for _, r := range found {
@@ -280,7 +282,7 @@ func (c *Client) FetchReposByTopic(topic string, orgs []string) ([]string, error
 	sort.Strings(repos)
 
 	if len(errs) > 0 {
-		return repos, fmt.Errorf("github: discovery errors: %s", strings.Join(errs, "; "))
+		return repos, fmt.Errorf("github: discovery errors: %w", errors.Join(errs...))
 	}
 	return repos, nil
 }
@@ -291,6 +293,7 @@ func (c *Client) fetchReposForOrg(topic, org string) ([]string, error) {
 	query := fmt.Sprintf("topic:%s org:%s archived:false", topic, org)
 
 	var repos []string
+	totalFetched := 0
 	for page := 1; page <= maxDiscoveryPages; page++ {
 		params := url.Values{}
 		params.Set("q", query)
@@ -330,9 +333,13 @@ func (c *Client) fetchReposForOrg(topic, org string) ([]string, error) {
 			}
 			repos = append(repos, it.FullName)
 		}
+		totalFetched += len(result.Items)
 
-		// Search API returns at most per_page items; fewer means we reached the end.
-		if len(result.Items) < 100 {
+		// Stop when the page is partial (no more items upstream) OR when we
+		// have already consumed the advertised total. The second check avoids
+		// an extra empty request when total_count is an exact multiple of
+		// per_page.
+		if len(result.Items) < 100 || totalFetched >= result.TotalCount {
 			break
 		}
 	}

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -237,6 +238,105 @@ func (c *Client) PostComment(repo string, number int, body string) error {
 		return fmt.Errorf("github: post comment: status %d: %s", resp.StatusCode, errBody)
 	}
 	return nil
+}
+
+// maxDiscoveryPages bounds the number of Search API pages consumed per org.
+// GitHub caps search results at 1000 entries (10 pages × 100 per_page); we stop
+// there to avoid endless pagination in the unlikely event of a malformed response.
+const maxDiscoveryPages = 10
+
+// FetchReposByTopic returns the full_names of non-archived, non-disabled repos
+// that carry the given topic in any of the provided orgs. Empty topic or orgs
+// return an empty slice without calling the API.
+//
+// Each org is queried independently so one failing org does not wipe the
+// others — a partial result is returned alongside a joined error describing
+// which orgs failed. Results are deduplicated across orgs.
+func (c *Client) FetchReposByTopic(topic string, orgs []string) ([]string, error) {
+	if topic == "" || len(orgs) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	var repos []string
+	var errs []string
+
+	for _, org := range orgs {
+		found, err := c.fetchReposForOrg(topic, org)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", org, err))
+			continue
+		}
+		for _, r := range found {
+			if _, dup := seen[r]; dup {
+				continue
+			}
+			seen[r] = struct{}{}
+			repos = append(repos, r)
+		}
+	}
+
+	// Deterministic order makes the result easy to compare in tests and logs.
+	sort.Strings(repos)
+
+	if len(errs) > 0 {
+		return repos, fmt.Errorf("github: discovery errors: %s", strings.Join(errs, "; "))
+	}
+	return repos, nil
+}
+
+func (c *Client) fetchReposForOrg(topic, org string) ([]string, error) {
+	// archived:false and fork filtering is handled post-fetch because Search API
+	// does not honour the `fork:` qualifier reliably alongside `topic:`.
+	query := fmt.Sprintf("topic:%s org:%s archived:false", topic, org)
+
+	var repos []string
+	for page := 1; page <= maxDiscoveryPages; page++ {
+		params := url.Values{}
+		params.Set("q", query)
+		params.Set("per_page", "100")
+		params.Set("page", strconv.Itoa(page))
+
+		resp, err := c.do("GET", "/search/repositories?"+params.Encode(), "application/vnd.github+json")
+		if err != nil {
+			return nil, fmt.Errorf("search repositories: %w", err)
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			errBody := string(body)
+			if len(errBody) > maxErrBodyLen {
+				errBody = errBody[:maxErrBodyLen]
+			}
+			return nil, fmt.Errorf("search repositories: status %d: %s", resp.StatusCode, errBody)
+		}
+
+		var result struct {
+			TotalCount int `json:"total_count"`
+			Items      []struct {
+				FullName string `json:"full_name"`
+				Archived bool   `json:"archived"`
+				Disabled bool   `json:"disabled"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, fmt.Errorf("decode repositories: %w", err)
+		}
+
+		for _, it := range result.Items {
+			if it.Archived || it.Disabled || it.FullName == "" {
+				continue
+			}
+			repos = append(repos, it.FullName)
+		}
+
+		// Search API returns at most per_page items; fewer means we reached the end.
+		if len(result.Items) < 100 {
+			break
+		}
+	}
+	return repos, nil
 }
 
 // FetchDiff returns the unified diff for a PR.

--- a/daemon/internal/github/discovery_test.go
+++ b/daemon/internal/github/discovery_test.go
@@ -1,0 +1,215 @@
+package github_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+type repoItem struct {
+	FullName string `json:"full_name"`
+	Archived bool   `json:"archived"`
+	Disabled bool   `json:"disabled"`
+}
+
+func searchResponse(items []repoItem) []byte {
+	body := map[string]any{
+		"total_count": len(items),
+		"items":       items,
+	}
+	data, _ := json.Marshal(body)
+	return data
+}
+
+func TestFetchReposByTopic_EmptyArgsReturnNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("should not call API when args are empty, got %s", r.URL.String())
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+
+	if got, err := client.FetchReposByTopic("", []string{"org"}); err != nil || got != nil {
+		t.Errorf("empty topic: got %v, %v", got, err)
+	}
+	if got, err := client.FetchReposByTopic("topic", nil); err != nil || got != nil {
+		t.Errorf("empty orgs: got %v, %v", got, err)
+	}
+}
+
+func TestFetchReposByTopic_SingleOrg(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search/repositories" {
+			http.NotFound(w, r)
+			return
+		}
+		q := r.URL.Query().Get("q")
+		if !strings.Contains(q, "topic:heimdallm-review") {
+			t.Errorf("query missing topic filter: %q", q)
+		}
+		if !strings.Contains(q, "org:freepik-company") {
+			t.Errorf("query missing org filter: %q", q)
+		}
+		if !strings.Contains(q, "archived:false") {
+			t.Errorf("query missing archived:false: %q", q)
+		}
+		w.Write(searchResponse([]repoItem{
+			{FullName: "freepik-company/ai-platform"},
+			{FullName: "freepik-company/design-system"},
+		}))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchReposByTopic("heimdallm-review", []string{"freepik-company"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"freepik-company/ai-platform", "freepik-company/design-system"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFetchReposByTopic_MultipleOrgsDeduped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		switch {
+		case strings.Contains(q, "org:orgA"):
+			w.Write(searchResponse([]repoItem{
+				{FullName: "orgA/repo1"},
+				{FullName: "shared/common"},
+			}))
+		case strings.Contains(q, "org:orgB"):
+			w.Write(searchResponse([]repoItem{
+				{FullName: "shared/common"},
+				{FullName: "orgB/repo2"},
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchReposByTopic("topic", []string{"orgA", "orgB"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"orgA/repo1", "orgB/repo2", "shared/common"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v, want %v (sorted + deduped)", got, want)
+	}
+}
+
+func TestFetchReposByTopic_FiltersArchivedAndDisabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(searchResponse([]repoItem{
+			{FullName: "org/alive"},
+			{FullName: "org/archived", Archived: true},
+			{FullName: "org/disabled", Disabled: true},
+			{FullName: "", Archived: false},
+		}))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchReposByTopic("topic", []string{"org"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "org/alive" {
+		t.Errorf("filters failed, got %v", got)
+	}
+}
+
+func TestFetchReposByTopic_Pagination(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		switch page {
+		case 1:
+			items := make([]repoItem, 100)
+			for i := range items {
+				items[i] = repoItem{FullName: fmt.Sprintf("org/repo-%03d", i)}
+			}
+			w.Write(searchResponse(items))
+		case 2:
+			w.Write(searchResponse([]repoItem{
+				{FullName: "org/repo-final"},
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchReposByTopic("topic", []string{"org"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 101 {
+		t.Errorf("expected 101 repos after pagination, got %d", len(got))
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Errorf("expected 2 API calls for pagination, got %d", calls)
+	}
+}
+
+func TestFetchReposByTopic_PartialFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q, _ := url.QueryUnescape(r.URL.Query().Get("q"))
+		switch {
+		case strings.Contains(q, "org:healthy"):
+			w.Write(searchResponse([]repoItem{{FullName: "healthy/repo"}}))
+		case strings.Contains(q, "org:broken"):
+			http.Error(w, `{"message":"rate limit exceeded"}`, http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchReposByTopic("topic", []string{"healthy", "broken"})
+	if err == nil {
+		t.Fatal("expected partial failure error, got nil")
+	}
+	if !strings.Contains(err.Error(), "broken") {
+		t.Errorf("error should mention failing org, got: %v", err)
+	}
+	if len(got) != 1 || got[0] != "healthy/repo" {
+		t.Errorf("expected partial result %v, got %v", []string{"healthy/repo"}, got)
+	}
+}
+
+func TestFetchReposByTopic_AllOrgsFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"forbidden"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchReposByTopic("topic", []string{"a", "b"})
+	if err == nil {
+		t.Fatal("expected error when all orgs fail, got nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %v", got)
+	}
+}

--- a/daemon/internal/github/discovery_test.go
+++ b/daemon/internal/github/discovery_test.go
@@ -21,8 +21,12 @@ type repoItem struct {
 }
 
 func searchResponse(items []repoItem) []byte {
+	return searchResponseWithTotal(items, len(items))
+}
+
+func searchResponseWithTotal(items []repoItem, total int) []byte {
 	body := map[string]any{
-		"total_count": len(items),
+		"total_count": total,
 		"items":       items,
 	}
 	data, _ := json.Marshal(body)
@@ -147,11 +151,12 @@ func TestFetchReposByTopic_Pagination(t *testing.T) {
 			for i := range items {
 				items[i] = repoItem{FullName: fmt.Sprintf("org/repo-%03d", i)}
 			}
-			w.Write(searchResponse(items))
+			// total_count=101 signals a second page upstream.
+			w.Write(searchResponseWithTotal(items, 101))
 		case 2:
-			w.Write(searchResponse([]repoItem{
+			w.Write(searchResponseWithTotal([]repoItem{
 				{FullName: "org/repo-final"},
-			}))
+			}, 101))
 		default:
 			http.NotFound(w, r)
 		}
@@ -168,6 +173,39 @@ func TestFetchReposByTopic_Pagination(t *testing.T) {
 	}
 	if atomic.LoadInt32(&calls) != 2 {
 		t.Errorf("expected 2 API calls for pagination, got %d", calls)
+	}
+}
+
+func TestFetchReposByTopic_PaginationStopsAtTotalCount(t *testing.T) {
+	// Regression: when total_count is an exact multiple of per_page (100),
+	// the loop used to make one extra request that returned 0 items.
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page != 1 {
+			t.Errorf("unexpected second request on page %d — loop should have stopped", page)
+			http.NotFound(w, r)
+			return
+		}
+		items := make([]repoItem, 100)
+		for i := range items {
+			items[i] = repoItem{FullName: fmt.Sprintf("org/repo-%03d", i)}
+		}
+		w.Write(searchResponse(items))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchReposByTopic("topic", []string{"org"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 100 {
+		t.Errorf("expected 100 repos, got %d", len(got))
+	}
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Errorf("expected exactly 1 API call (total == 100 == per_page), got %d", calls)
 	}
 }
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -13,7 +13,24 @@ GITHUB_TOKEN=ghp_your_token_here
 HEIMDALLM_AI_PRIMARY=claude
 
 # Comma-separated list of repos to monitor (e.g. "org/repo1,org/repo2")
+# Optional when HEIMDALLM_DISCOVERY_TOPIC is set (discovered repos are merged
+# into this list on every discovery cycle).
 HEIMDALLM_REPOSITORIES=
+
+# ── Topic-based auto-discovery (optional) ───────────────────────────────────
+# When set, any public or private repo inside HEIMDALLM_DISCOVERY_ORGS that
+# carries this GitHub topic is automatically monitored. Topics must follow
+# GitHub's format: lowercase letters, digits and hyphens, up to 50 chars.
+# See https://docs.github.com/repositories/classifying-your-repository-with-topics
+# HEIMDALLM_DISCOVERY_TOPIC=heimdallm-review
+
+# Required when HEIMDALLM_DISCOVERY_TOPIC is set. Comma-separated GitHub orgs
+# to scan. Bounds the Search API scope (prevents scanning all of GitHub).
+# HEIMDALLM_DISCOVERY_ORGS=your-org,your-other-org
+
+# How often the discovery list is refreshed. Any Go duration (e.g. 10m, 1h).
+# Defaults to 15m when HEIMDALLM_DISCOVERY_TOPIC is set.
+# HEIMDALLM_DISCOVERY_INTERVAL=15m
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # AI CLI AUTHENTICATION

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -10,6 +10,15 @@ bind_addr = "0.0.0.0"
 poll_interval = "5m"
 repositories = ["org/repo1", "org/repo2"]
 
+# Topic-based auto-discovery (optional).
+# When discovery_topic is set, any repo inside discovery_orgs that carries the
+# topic is automatically monitored alongside the static list above. The merged
+# list is refreshed every discovery_interval. See:
+# https://docs.github.com/repositories/classifying-your-repository-with-topics
+# discovery_topic    = "heimdallm-review"
+# discovery_orgs     = ["your-org", "your-other-org"]   # required when discovery_topic is set
+# discovery_interval = "15m"                             # any Go duration; defaults to 15m
+
 [ai]
 # Available: claude, gemini, codex, opencode
 primary = "claude"


### PR DESCRIPTION
## Summary

Implements #39. Opt-in repository auto-discovery: tag a repo on GitHub with a configured **topic** and Heimdallm starts monitoring it — no more manual `HEIMDALLM_REPOSITORIES` updates every time a team adds a repo.

- New config: `discovery_topic`, `discovery_orgs`, `discovery_interval` (TOML + env vars `HEIMDALLM_DISCOVERY_*`).
- The discovered list is merged with the static `repositories` list at poll time; the static list still works and takes precedence in ordering.
- Runs on its own `discovery_interval` loop (default `15m`) — independent from the PR poll, so the stricter Search API rate limit (30 req/min) can't starve the PR pipeline.
- Reload picks up changes to topic/orgs/interval and restarts the loop without restarting the daemon.

## Design decisions

- **`discovery_orgs` is mandatory when `discovery_topic` is set.** Avoids accidentally scanning all of GitHub if someone sets the topic without thinking about scope. Fails fast at config validation.
- **Topic format validated** against GitHub's rules (lowercase, digits, hyphens, ≤50 chars) to prevent silent 422s from the API.
- **Graceful degradation:** if the Search API fails (rate limit, 5xx, network), the last known-good cache is preserved — an outage never silently empties the monitored set. Partial failures update with what we got and still surface the error in logs.
- **Per-org queries** so one failing org does not poison the others. Results are deduplicated and sorted deterministically.
- **Service-style separation:** discovery lives in its own `internal/discovery` package, decoupled from the GitHub client via a small `ReposFetcher` interface → trivial to unit-test without an HTTP server.

## Tests

New tests covering:

- **Config validation** — topic format, orgs required, interval parsing, env var overrides.
- **GitHub client** `FetchReposByTopic` — single/multi-org, dedup, archived/disabled filtering, pagination (>100 repos), partial and total failures.
- **Discovery service** — cache preserved on total failure, partial failure updates, `Discovered()` returns a copy (no external mutation), ticker loop, context cancellation, zero-interval guard.
- **`MergeRepos`** helper — static ordering preserved, dedup, empty cases.

All new and existing tests pass:
```
ok  github.com/heimdallm/daemon/internal/config
ok  github.com/heimdallm/daemon/internal/discovery
ok  github.com/heimdallm/daemon/internal/github
```
(The pre-existing `TestDetect_Fallback` failure in `internal/executor` is environment-dependent and unrelated — reproduces on `main`.)

## Docs updated

- `README.md` — new "Auto-discover repositories by topic" subsection.
- `docker/.env.example` — all three `HEIMDALLM_DISCOVERY_*` vars documented.
- `docker/config.example.toml` — commented TOML example.

## Test plan

- [ ] `go test ./...` in CI (should be green on whatever runner doesn't have stray CLI binaries in PATH).
- [ ] Manual: set `HEIMDALLM_DISCOVERY_TOPIC=heimdallm-review` + `HEIMDALLM_DISCOVERY_ORGS=theburrowhub` on a dev daemon, tag one repo, confirm it appears in the poll loop within `discovery_interval`.
- [ ] Manual: revoke the token mid-discovery and confirm the cached list is preserved (log should say `discovery: refresh failed, keeping previous cache`).
- [ ] Manual: edit `config.toml` to toggle discovery on/off, hit `POST /reload`, confirm the loop starts/stops.

Closes #39