### PR TITLE
feat(issues): SQLite schema + config surface for issue tracking

### DIFF
--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -81,10 +81,14 @@ const (
 	IssueModeReviewOnly IssueMode = "review_only"
 )
 
-// FilterMode combines the org / assignee / label filters.
+// FilterMode names how the org / assignee / label filters are combined.
+// Keeping it as a named type (mirrors IssueMode) lets validation surface type
+// mismatches at compile time rather than as a runtime string compare.
+type FilterMode string
+
 const (
-	FilterModeExclusive = "exclusive" // AND
-	FilterModeInclusive = "inclusive" // OR
+	FilterModeExclusive FilterMode = "exclusive" // AND
+	FilterModeInclusive FilterMode = "inclusive" // OR
 )
 
 // IssueTrackingConfig is the `[github.issue_tracking]` section.
@@ -102,7 +106,7 @@ type IssueTrackingConfig struct {
 	// FilterMode decides how the org / assignee / label dimensions are
 	// combined ("exclusive" = AND, "inclusive" = OR). Applied by the
 	// pipeline; not consulted by Classify itself.
-	FilterMode string `toml:"filter_mode"`
+	FilterMode FilterMode `toml:"filter_mode"`
 
 	// Organizations limits processing to issues belonging to these orgs.
 	// Empty = no org filter.
@@ -330,7 +334,7 @@ func (c *Config) applyIssueTrackingEnv() {
 		}
 	}
 	if v := os.Getenv("HEIMDALLM_ISSUE_FILTER_MODE"); v != "" {
-		c.GitHub.IssueTracking.FilterMode = v
+		c.GitHub.IssueTracking.FilterMode = FilterMode(v)
 	}
 	if v := os.Getenv("HEIMDALLM_ISSUE_DEFAULT_ACTION"); v != "" {
 		c.GitHub.IssueTracking.DefaultAction = v

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -62,6 +62,106 @@ type GitHubConfig struct {
 	// rate limit (30 req/min authenticated). Defaults to "15m" when discovery
 	// is enabled. Accepts any Go time.ParseDuration value.
 	DiscoveryInterval string `toml:"discovery_interval"`
+
+	// IssueTracking turns the issue-tracking pipeline (fase-2) on and off and
+	// governs how issues are filtered and classified. The pipeline itself
+	// lives in downstream issues (#25 onward); this struct is the
+	// configuration surface only.
+	IssueTracking IssueTrackingConfig `toml:"issue_tracking"`
+}
+
+// IssueMode is the processing mode assigned to an issue after label
+// classification. Used by the pipeline (#26/#27) to pick review_only vs.
+// auto_implement vs. skip. Exported so downstream packages can reuse it.
+type IssueMode string
+
+const (
+	IssueModeIgnore     IssueMode = "ignore"
+	IssueModeDevelop    IssueMode = "develop"
+	IssueModeReviewOnly IssueMode = "review_only"
+)
+
+// FilterMode combines the org / assignee / label filters.
+const (
+	FilterModeExclusive = "exclusive" // AND
+	FilterModeInclusive = "inclusive" // OR
+)
+
+// IssueTrackingConfig is the `[github.issue_tracking]` section.
+//
+// Classification precedence (applied in Classify):
+//
+//	skip_labels  >  review_only_labels  >  develop_labels  >  default_action
+//
+// An issue that carries a label present in multiple lists resolves to the
+// highest-precedence match. This is a fail-safe ordering: when in doubt,
+// review before developing, and skip before either.
+type IssueTrackingConfig struct {
+	Enabled bool `toml:"enabled"`
+
+	// FilterMode decides how the org / assignee / label dimensions are
+	// combined ("exclusive" = AND, "inclusive" = OR). Applied by the
+	// pipeline; not consulted by Classify itself.
+	FilterMode string `toml:"filter_mode"`
+
+	// Organizations limits processing to issues belonging to these orgs.
+	// Empty = no org filter.
+	Organizations []string `toml:"organizations"`
+
+	// Assignees limits processing to issues assigned to these GitHub users.
+	// Empty = no assignee filter.
+	Assignees []string `toml:"assignees"`
+
+	// DevelopLabels are labels that mark an issue as "please implement".
+	DevelopLabels []string `toml:"develop_labels"`
+
+	// ReviewOnlyLabels are labels that mark an issue as "please analyse and
+	// comment only". Takes precedence over DevelopLabels when both are
+	// present on the same issue — fail-safe default.
+	ReviewOnlyLabels []string `toml:"review_only_labels"`
+
+	// SkipLabels are labels that opt an issue out of processing entirely.
+	// Highest precedence.
+	SkipLabels []string `toml:"skip_labels"`
+
+	// DefaultAction is applied when an issue carries no label from any of
+	// the three lists above. Must be "ignore" or "review_only".
+	DefaultAction string `toml:"default_action"`
+}
+
+// Classify returns the processing mode for an issue given its labels.
+// Matching is case-insensitive to match the way GitHub displays labels; the
+// underlying labels API is case-preserving but the UI is not, so users
+// routinely mix "Bug" and "bug" in practice.
+func (c IssueTrackingConfig) Classify(labels []string) IssueMode {
+	set := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		set[strings.ToLower(strings.TrimSpace(l))] = struct{}{}
+	}
+	if labelSetIntersects(set, c.SkipLabels) {
+		return IssueModeIgnore
+	}
+	if labelSetIntersects(set, c.ReviewOnlyLabels) {
+		return IssueModeReviewOnly
+	}
+	if labelSetIntersects(set, c.DevelopLabels) {
+		return IssueModeDevelop
+	}
+	switch strings.ToLower(c.DefaultAction) {
+	case "review_only":
+		return IssueModeReviewOnly
+	default:
+		return IssueModeIgnore
+	}
+}
+
+func labelSetIntersects(set map[string]struct{}, list []string) bool {
+	for _, l := range list {
+		if _, ok := set[strings.ToLower(strings.TrimSpace(l))]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // CLIAgentConfig holds per-CLI execution settings (model, flags, prompt override).
@@ -145,6 +245,12 @@ func (c *Config) applyDefaults() {
 	if c.GitHub.DiscoveryTopic != "" && c.GitHub.DiscoveryInterval == "" {
 		c.GitHub.DiscoveryInterval = "15m"
 	}
+	if c.GitHub.IssueTracking.FilterMode == "" {
+		c.GitHub.IssueTracking.FilterMode = FilterModeExclusive
+	}
+	if c.GitHub.IssueTracking.DefaultAction == "" {
+		c.GitHub.IssueTracking.DefaultAction = string(IssueModeIgnore)
+	}
 	if c.Retention.MaxDays == 0 {
 		c.Retention.MaxDays = 90
 	}
@@ -211,6 +317,61 @@ func (c *Config) applyEnvOverrides() {
 	if v := os.Getenv("HEIMDALLM_DISCOVERY_INTERVAL"); v != "" {
 		c.GitHub.DiscoveryInterval = v
 	}
+	c.applyIssueTrackingEnv()
+}
+
+// applyIssueTrackingEnv maps HEIMDALLM_ISSUE_* env vars into IssueTrackingConfig.
+// CSV lists only overwrite the TOML value when at least one non-blank entry is
+// present, matching the behaviour of HEIMDALLM_REPOSITORIES.
+func (c *Config) applyIssueTrackingEnv() {
+	if v := os.Getenv("HEIMDALLM_ISSUE_TRACKING_ENABLED"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			c.GitHub.IssueTracking.Enabled = b
+		}
+	}
+	if v := os.Getenv("HEIMDALLM_ISSUE_FILTER_MODE"); v != "" {
+		c.GitHub.IssueTracking.FilterMode = v
+	}
+	if v := os.Getenv("HEIMDALLM_ISSUE_DEFAULT_ACTION"); v != "" {
+		c.GitHub.IssueTracking.DefaultAction = v
+	}
+	if list, ok := csvEnv("HEIMDALLM_ISSUE_ORGANIZATIONS"); ok {
+		c.GitHub.IssueTracking.Organizations = list
+	}
+	if list, ok := csvEnv("HEIMDALLM_ISSUE_ASSIGNEES"); ok {
+		c.GitHub.IssueTracking.Assignees = list
+	}
+	if list, ok := csvEnv("HEIMDALLM_ISSUE_DEVELOP_LABELS"); ok {
+		c.GitHub.IssueTracking.DevelopLabels = list
+	}
+	if list, ok := csvEnv("HEIMDALLM_ISSUE_REVIEW_ONLY_LABELS"); ok {
+		c.GitHub.IssueTracking.ReviewOnlyLabels = list
+	}
+	if list, ok := csvEnv("HEIMDALLM_ISSUE_SKIP_LABELS"); ok {
+		c.GitHub.IssueTracking.SkipLabels = list
+	}
+}
+
+// csvEnv parses a comma-separated env var into a trimmed, non-empty list.
+// Returns ok=false when the env var is unset OR contains only blanks, so the
+// caller can preserve any existing TOML value (same contract as the
+// HEIMDALLM_REPOSITORIES override).
+func csvEnv(name string) ([]string, bool) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return nil, false
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
 }
 
 // Validate checks that required fields are present and values are valid.
@@ -232,6 +393,34 @@ func (c *Config) Validate() error {
 	}
 	if err := c.validateDiscovery(); err != nil {
 		return err
+	}
+	if err := c.validateIssueTracking(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateIssueTracking enforces the small set of invariants the pipeline
+// relies on: filter_mode and default_action must be from a known set. Labels
+// themselves are free-form strings — intentionally — because GitHub allows
+// almost anything in a label and we do not want to reject legitimate values.
+// Silent fallbacks in applyDefaults mean the user almost never sees these
+// errors; they exist so an explicit typo like filter_mode = "excluive" fails
+// fast instead of defaulting silently.
+func (c *Config) validateIssueTracking() error {
+	it := c.GitHub.IssueTracking
+	if !it.Enabled {
+		return nil
+	}
+	switch it.FilterMode {
+	case FilterModeExclusive, FilterModeInclusive:
+	default:
+		return fmt.Errorf("config: github.issue_tracking.filter_mode %q is invalid (must be %q or %q)", it.FilterMode, FilterModeExclusive, FilterModeInclusive)
+	}
+	switch IssueMode(it.DefaultAction) {
+	case IssueModeIgnore, IssueModeReviewOnly:
+	default:
+		return fmt.Errorf("config: github.issue_tracking.default_action %q is invalid (must be %q or %q)", it.DefaultAction, IssueModeIgnore, IssueModeReviewOnly)
 	}
 	return nil
 }

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -383,6 +383,220 @@ func TestValidate_DiscoveryOrgsValid(t *testing.T) {
 	}
 }
 
+// ── Issue tracking ───────────────────────────────────────────────────────────
+
+func TestApplyDefaults_IssueTracking(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+
+	if cfg.GitHub.IssueTracking.FilterMode != FilterModeExclusive {
+		t.Errorf("FilterMode = %q, want default %q", cfg.GitHub.IssueTracking.FilterMode, FilterModeExclusive)
+	}
+	if cfg.GitHub.IssueTracking.DefaultAction != string(IssueModeIgnore) {
+		t.Errorf("DefaultAction = %q, want default %q", cfg.GitHub.IssueTracking.DefaultAction, IssueModeIgnore)
+	}
+	if cfg.GitHub.IssueTracking.Enabled {
+		t.Error("Enabled should default to false")
+	}
+}
+
+func TestApplyDefaults_IssueTrackingPreservesExisting(t *testing.T) {
+	cfg := &Config{}
+	cfg.GitHub.IssueTracking.FilterMode = FilterModeInclusive
+	cfg.GitHub.IssueTracking.DefaultAction = string(IssueModeReviewOnly)
+	cfg.applyDefaults()
+
+	if cfg.GitHub.IssueTracking.FilterMode != FilterModeInclusive {
+		t.Errorf("FilterMode overwritten: %q", cfg.GitHub.IssueTracking.FilterMode)
+	}
+	if cfg.GitHub.IssueTracking.DefaultAction != string(IssueModeReviewOnly) {
+		t.Errorf("DefaultAction overwritten: %q", cfg.GitHub.IssueTracking.DefaultAction)
+	}
+}
+
+func TestApplyEnvOverrides_IssueTracking(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+
+	t.Setenv("HEIMDALLM_ISSUE_TRACKING_ENABLED", "true")
+	t.Setenv("HEIMDALLM_ISSUE_FILTER_MODE", "inclusive")
+	t.Setenv("HEIMDALLM_ISSUE_DEFAULT_ACTION", "review_only")
+	t.Setenv("HEIMDALLM_ISSUE_ORGANIZATIONS", "freepik-company, theburrowhub")
+	t.Setenv("HEIMDALLM_ISSUE_ASSIGNEES", "sergiotejon")
+	t.Setenv("HEIMDALLM_ISSUE_DEVELOP_LABELS", "enhancement,feature, bug")
+	t.Setenv("HEIMDALLM_ISSUE_REVIEW_ONLY_LABELS", "question,discussion")
+	t.Setenv("HEIMDALLM_ISSUE_SKIP_LABELS", "wontfix")
+
+	cfg.applyEnvOverrides()
+
+	it := cfg.GitHub.IssueTracking
+	if !it.Enabled {
+		t.Error("Enabled should be true")
+	}
+	if it.FilterMode != FilterModeInclusive {
+		t.Errorf("FilterMode = %q", it.FilterMode)
+	}
+	if it.DefaultAction != string(IssueModeReviewOnly) {
+		t.Errorf("DefaultAction = %q", it.DefaultAction)
+	}
+	if len(it.Organizations) != 2 || it.Organizations[1] != "theburrowhub" {
+		t.Errorf("Organizations = %v", it.Organizations)
+	}
+	if len(it.Assignees) != 1 || it.Assignees[0] != "sergiotejon" {
+		t.Errorf("Assignees = %v", it.Assignees)
+	}
+	if len(it.DevelopLabels) != 3 || it.DevelopLabels[2] != "bug" {
+		t.Errorf("DevelopLabels = %v", it.DevelopLabels)
+	}
+	if len(it.ReviewOnlyLabels) != 2 {
+		t.Errorf("ReviewOnlyLabels = %v", it.ReviewOnlyLabels)
+	}
+	if len(it.SkipLabels) != 1 {
+		t.Errorf("SkipLabels = %v", it.SkipLabels)
+	}
+}
+
+func TestApplyEnvOverrides_IssueTracking_BlankCSVPreservesExisting(t *testing.T) {
+	cfg := &Config{}
+	cfg.GitHub.IssueTracking.DevelopLabels = []string{"existing"}
+
+	t.Setenv("HEIMDALLM_ISSUE_DEVELOP_LABELS", "  ,  ,  ")
+	cfg.applyEnvOverrides()
+
+	if len(cfg.GitHub.IssueTracking.DevelopLabels) != 1 || cfg.GitHub.IssueTracking.DevelopLabels[0] != "existing" {
+		t.Errorf("expected existing value to be preserved, got %v", cfg.GitHub.IssueTracking.DevelopLabels)
+	}
+}
+
+func TestValidate_IssueTrackingDisabledSkipsChecks(t *testing.T) {
+	cfg := &Config{
+		AI: AIConfig{Primary: "claude"},
+		GitHub: GitHubConfig{
+			IssueTracking: IssueTrackingConfig{
+				Enabled:       false,
+				FilterMode:    "nonsense",
+				DefaultAction: "also nonsense",
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("disabled issue_tracking should skip validation, got: %v", err)
+	}
+}
+
+func TestValidate_IssueTrackingInvalidFilterMode(t *testing.T) {
+	cfg := &Config{
+		AI: AIConfig{Primary: "claude"},
+		GitHub: GitHubConfig{
+			IssueTracking: IssueTrackingConfig{
+				Enabled:       true,
+				FilterMode:    "excluive",
+				DefaultAction: string(IssueModeIgnore),
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid filter_mode")
+	}
+	if !strings.Contains(err.Error(), "filter_mode") {
+		t.Errorf("error should mention filter_mode, got: %v", err)
+	}
+}
+
+func TestValidate_IssueTrackingInvalidDefaultAction(t *testing.T) {
+	cfg := &Config{
+		AI: AIConfig{Primary: "claude"},
+		GitHub: GitHubConfig{
+			IssueTracking: IssueTrackingConfig{
+				Enabled:       true,
+				FilterMode:    FilterModeExclusive,
+				DefaultAction: "auto_implement",
+			},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid default_action")
+	}
+	if !strings.Contains(err.Error(), "default_action") {
+		t.Errorf("error should mention default_action, got: %v", err)
+	}
+}
+
+func TestValidate_IssueTrackingEnabledDefaultsPassValidation(t *testing.T) {
+	cfg := &Config{AI: AIConfig{Primary: "claude"}}
+	cfg.GitHub.IssueTracking.Enabled = true
+	cfg.applyDefaults() // fills FilterMode + DefaultAction
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("applyDefaults + Enabled should pass validation, got: %v", err)
+	}
+}
+
+// ── Issue classification ─────────────────────────────────────────────────────
+
+func TestClassify_Precedence(t *testing.T) {
+	cfg := IssueTrackingConfig{
+		SkipLabels:       []string{"wontfix"},
+		ReviewOnlyLabels: []string{"question", "discussion"},
+		DevelopLabels:    []string{"bug", "enhancement"},
+		DefaultAction:    string(IssueModeIgnore),
+	}
+	cases := []struct {
+		name   string
+		labels []string
+		want   IssueMode
+	}{
+		{"skip wins over review_only + develop", []string{"wontfix", "question", "bug"}, IssueModeIgnore},
+		{"review_only wins over develop", []string{"question", "bug"}, IssueModeReviewOnly},
+		{"develop only", []string{"bug"}, IssueModeDevelop},
+		{"unrelated labels fall back to default_action=ignore", []string{"help-wanted"}, IssueModeIgnore},
+		{"no labels fall back to default_action=ignore", nil, IssueModeIgnore},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cfg.Classify(tc.labels); got != tc.want {
+				t.Errorf("Classify(%v) = %q, want %q", tc.labels, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassify_CaseInsensitive(t *testing.T) {
+	cfg := IssueTrackingConfig{
+		ReviewOnlyLabels: []string{"Question"},
+		DevelopLabels:    []string{"BUG"},
+		DefaultAction:    string(IssueModeIgnore),
+	}
+	if got := cfg.Classify([]string{"bug"}); got != IssueModeDevelop {
+		t.Errorf("Classify(bug) = %q, want develop (case-insensitive)", got)
+	}
+	if got := cfg.Classify([]string{"QUESTION"}); got != IssueModeReviewOnly {
+		t.Errorf("Classify(QUESTION) = %q, want review_only", got)
+	}
+}
+
+func TestClassify_DefaultActionReviewOnly(t *testing.T) {
+	cfg := IssueTrackingConfig{
+		DevelopLabels: []string{"bug"},
+		DefaultAction: string(IssueModeReviewOnly),
+	}
+	if got := cfg.Classify([]string{"help-wanted"}); got != IssueModeReviewOnly {
+		t.Errorf("Classify unrelated label = %q, want review_only (default_action)", got)
+	}
+}
+
+func TestClassify_TrimsWhitespace(t *testing.T) {
+	cfg := IssueTrackingConfig{
+		DevelopLabels: []string{"  bug  "},
+		DefaultAction: string(IssueModeIgnore),
+	}
+	if got := cfg.Classify([]string{"bug"}); got != IssueModeDevelop {
+		t.Errorf("Classify should trim whitespace in configured labels, got %q", got)
+	}
+}
+
 // ── AIForRepo ────────────────────────────────────────────────────────────────
 
 func TestAIForRepo_GlobalFallback(t *testing.T) {

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -474,7 +474,7 @@ func TestValidate_IssueTrackingDisabledSkipsChecks(t *testing.T) {
 		GitHub: GitHubConfig{
 			IssueTracking: IssueTrackingConfig{
 				Enabled:       false,
-				FilterMode:    "nonsense",
+				FilterMode:    FilterMode("nonsense"),
 				DefaultAction: "also nonsense",
 			},
 		},
@@ -490,7 +490,7 @@ func TestValidate_IssueTrackingInvalidFilterMode(t *testing.T) {
 		GitHub: GitHubConfig{
 			IssueTracking: IssueTrackingConfig{
 				Enabled:       true,
-				FilterMode:    "excluive",
+				FilterMode:    FilterMode("excluive"),
 				DefaultAction: string(IssueModeIgnore),
 			},
 		},

--- a/daemon/internal/store/issues.go
+++ b/daemon/internal/store/issues.go
@@ -1,0 +1,224 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// Issue mirrors a GitHub issue stored locally for the issue-tracking pipeline.
+// `Assignees` and `Labels` are the raw JSON strings (`[]` when empty) kept
+// alongside the row — the pipeline (#26/#27) unmarshals them on demand, so
+// we do not round-trip through a slice in the store layer.
+type Issue struct {
+	ID        int64     `json:"id"`
+	GithubID  int64     `json:"github_id"`
+	Repo      string    `json:"repo"`
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	Body      string    `json:"body"`
+	Author    string    `json:"author"`
+	Assignees string    `json:"assignees"` // JSON array
+	Labels    string    `json:"labels"`    // JSON array
+	State     string    `json:"state"`
+	CreatedAt time.Time `json:"created_at"`
+	FetchedAt time.Time `json:"fetched_at"`
+	Dismissed bool      `json:"dismissed"`
+}
+
+// IssueReview is the record of one run of the issue pipeline against an issue.
+// `ActionTaken` is "review_only" or "auto_implement" (the pipeline falls back
+// to review_only when auto_implement is configured but local_dir is unset —
+// see #26). `PRCreated` stores the GitHub PR number when auto_implement opened
+// one, or zero otherwise.
+type IssueReview struct {
+	ID          int64     `json:"id"`
+	IssueID     int64     `json:"issue_id"`
+	CLIUsed     string    `json:"cli_used"`
+	Summary     string    `json:"summary"`
+	Triage      string    `json:"triage"`      // JSON object {severity, category, ...}
+	Suggestions string    `json:"suggestions"` // JSON array
+	ActionTaken string    `json:"action_taken"`
+	PRCreated   int       `json:"pr_created"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// UpsertIssue inserts or updates an issue keyed on github_id. The dismissed
+// flag is intentionally not part of the UPDATE clause so a user's dismiss
+// choice survives the next poll — same pattern as UpsertPR.
+func (s *Store) UpsertIssue(i *Issue) (int64, error) {
+	if i.Assignees == "" {
+		i.Assignees = "[]"
+	}
+	if i.Labels == "" {
+		i.Labels = "[]"
+	}
+	res, err := s.db.Exec(`
+		INSERT INTO issues (github_id, repo, number, title, body, author, assignees, labels, state, created_at, fetched_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(github_id) DO UPDATE SET
+			repo=excluded.repo, number=excluded.number, title=excluded.title,
+			body=excluded.body, author=excluded.author, assignees=excluded.assignees,
+			labels=excluded.labels, state=excluded.state,
+			created_at=excluded.created_at, fetched_at=excluded.fetched_at
+	`, i.GithubID, i.Repo, i.Number, i.Title, i.Body, i.Author, i.Assignees, i.Labels, i.State,
+		i.CreatedAt.UTC().Format(sqliteTimeFormat),
+		i.FetchedAt.UTC().Format(sqliteTimeFormat),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("store: upsert issue: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil || id == 0 {
+		// UPDATE path — resolve the row id via the natural key.
+		row := s.db.QueryRow("SELECT id FROM issues WHERE github_id = ?", i.GithubID)
+		if scanErr := row.Scan(&id); scanErr != nil {
+			return 0, fmt.Errorf("store: upsert issue fallback select: %w", scanErr)
+		}
+	}
+	return id, nil
+}
+
+// GetIssue retrieves an issue by its local row ID.
+func (s *Store) GetIssue(id int64) (*Issue, error) {
+	row := s.db.QueryRow(
+		`SELECT id, github_id, repo, number, title, body, author, assignees, labels,
+		        state, created_at, fetched_at, dismissed FROM issues WHERE id = ?`, id,
+	)
+	return scanIssue(row)
+}
+
+// GetIssueByGithubID retrieves an issue by its GitHub ID (the natural key).
+func (s *Store) GetIssueByGithubID(githubID int64) (*Issue, error) {
+	row := s.db.QueryRow(
+		`SELECT id, github_id, repo, number, title, body, author, assignees, labels,
+		        state, created_at, fetched_at, dismissed FROM issues WHERE github_id = ?`, githubID,
+	)
+	return scanIssue(row)
+}
+
+// ListIssues returns all non-dismissed issues ordered by fetched_at descending.
+func (s *Store) ListIssues() ([]*Issue, error) {
+	rows, err := s.db.Query(
+		`SELECT id, github_id, repo, number, title, body, author, assignees, labels,
+		        state, created_at, fetched_at, dismissed FROM issues
+		 WHERE dismissed = 0 ORDER BY fetched_at DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list issues: %w", err)
+	}
+	defer rows.Close()
+	var issues []*Issue
+	for rows.Next() {
+		i, err := scanIssue(rows)
+		if err != nil {
+			return nil, err
+		}
+		issues = append(issues, i)
+	}
+	return issues, rows.Err()
+}
+
+// DismissIssue hides an issue from the dashboard and opts it out of future
+// pipeline runs until the user undismisses it.
+func (s *Store) DismissIssue(id int64) error {
+	_, err := s.db.Exec("UPDATE issues SET dismissed = 1 WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("store: dismiss issue %d: %w", id, err)
+	}
+	return nil
+}
+
+// UndismissIssue restores a previously dismissed issue.
+func (s *Store) UndismissIssue(id int64) error {
+	_, err := s.db.Exec("UPDATE issues SET dismissed = 0 WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("store: undismiss issue %d: %w", id, err)
+	}
+	return nil
+}
+
+// InsertIssueReview stores a single pipeline run's result.
+func (s *Store) InsertIssueReview(r *IssueReview) (int64, error) {
+	if r.Suggestions == "" {
+		r.Suggestions = "[]"
+	}
+	if r.ActionTaken == "" {
+		r.ActionTaken = "review_only"
+	}
+	res, err := s.db.Exec(`
+		INSERT INTO issue_reviews (issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, r.IssueID, r.CLIUsed, r.Summary, r.Triage, r.Suggestions, r.ActionTaken, r.PRCreated,
+		r.CreatedAt.UTC().Format(sqliteTimeFormat),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("store: insert issue review: %w", err)
+	}
+	return res.LastInsertId()
+}
+
+// ListIssueReviews returns every review for an issue, newest first.
+func (s *Store) ListIssueReviews(issueID int64) ([]*IssueReview, error) {
+	rows, err := s.db.Query(
+		`SELECT id, issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at
+		 FROM issue_reviews WHERE issue_id = ? ORDER BY created_at DESC`,
+		issueID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list issue reviews: %w", err)
+	}
+	defer rows.Close()
+	var reviews []*IssueReview
+	for rows.Next() {
+		r, err := scanIssueReview(rows)
+		if err != nil {
+			return nil, err
+		}
+		reviews = append(reviews, r)
+	}
+	return reviews, rows.Err()
+}
+
+// LatestIssueReview returns the most recent review for an issue, or
+// sql.ErrNoRows if none exists yet.
+func (s *Store) LatestIssueReview(issueID int64) (*IssueReview, error) {
+	row := s.db.QueryRow(
+		`SELECT id, issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at
+		 FROM issue_reviews WHERE issue_id = ? ORDER BY created_at DESC LIMIT 1`,
+		issueID,
+	)
+	return scanIssueReview(row)
+}
+
+func scanIssue(s scanner) (*Issue, error) {
+	var i Issue
+	var createdAt, fetchedAt string
+	var dismissed int
+	if err := s.Scan(&i.ID, &i.GithubID, &i.Repo, &i.Number, &i.Title, &i.Body,
+		&i.Author, &i.Assignees, &i.Labels, &i.State, &createdAt, &fetchedAt, &dismissed); err != nil {
+		return nil, fmt.Errorf("store: scan issue: %w", err)
+	}
+	var err error
+	if i.CreatedAt, err = time.Parse(sqliteTimeFormat, createdAt); err != nil {
+		return nil, fmt.Errorf("store: parse issue created_at %q: %w", createdAt, err)
+	}
+	if i.FetchedAt, err = time.Parse(sqliteTimeFormat, fetchedAt); err != nil {
+		return nil, fmt.Errorf("store: parse issue fetched_at %q: %w", fetchedAt, err)
+	}
+	i.Dismissed = dismissed != 0
+	return &i, nil
+}
+
+func scanIssueReview(s scanner) (*IssueReview, error) {
+	var r IssueReview
+	var createdAt string
+	if err := s.Scan(&r.ID, &r.IssueID, &r.CLIUsed, &r.Summary, &r.Triage,
+		&r.Suggestions, &r.ActionTaken, &r.PRCreated, &createdAt); err != nil {
+		return nil, fmt.Errorf("store: scan issue review: %w", err)
+	}
+	var err error
+	if r.CreatedAt, err = time.Parse(sqliteTimeFormat, createdAt); err != nil {
+		return nil, fmt.Errorf("store: parse issue review created_at %q: %w", createdAt, err)
+	}
+	return &r, nil
+}

--- a/daemon/internal/store/issues.go
+++ b/daemon/internal/store/issues.go
@@ -67,9 +67,12 @@ func (s *Store) UpsertIssue(i *Issue) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("store: upsert issue: %w", err)
 	}
+	// LastInsertId returns 0 on the UPDATE path with modernc.org/sqlite (the
+	// driver this project uses). Other SQLite drivers may report the existing
+	// row id instead — the fallback SELECT below handles either case so this
+	// code is portable if the driver ever changes.
 	id, err := res.LastInsertId()
 	if err != nil || id == 0 {
-		// UPDATE path — resolve the row id via the natural key.
 		row := s.db.QueryRow("SELECT id FROM issues WHERE github_id = ?", i.GithubID)
 		if scanErr := row.Scan(&id); scanErr != nil {
 			return 0, fmt.Errorf("store: upsert issue fallback select: %w", scanErr)
@@ -138,7 +141,13 @@ func (s *Store) UndismissIssue(id int64) error {
 }
 
 // InsertIssueReview stores a single pipeline run's result.
+// Empty Triage / Suggestions are normalised to valid JSON (`{}` / `[]`) so
+// downstream consumers can `json.Unmarshal` them without guarding against
+// the empty-string case.
 func (s *Store) InsertIssueReview(r *IssueReview) (int64, error) {
+	if r.Triage == "" {
+		r.Triage = "{}"
+	}
 	if r.Suggestions == "" {
 		r.Suggestions = "[]"
 	}

--- a/daemon/internal/store/issues_test.go
+++ b/daemon/internal/store/issues_test.go
@@ -207,11 +207,12 @@ func TestIssueReview_InsertDefaults(t *testing.T) {
 	s := newTestStore(t)
 	issueID, _ := s.UpsertIssue(newIssue(210, 24))
 
+	// All JSON-typed fields left blank on purpose — the store should normalise
+	// them to valid-JSON defaults so json.Unmarshal downstream doesn't choke.
 	rev := &store.IssueReview{
 		IssueID:   issueID,
 		CLIUsed:   "claude",
 		Summary:   "no suggestions yet",
-		Triage:    `{}`,
 		CreatedAt: time.Now(),
 	}
 	_, err := s.InsertIssueReview(rev)
@@ -220,6 +221,9 @@ func TestIssueReview_InsertDefaults(t *testing.T) {
 	}
 
 	got, _ := s.LatestIssueReview(issueID)
+	if got.Triage != "{}" {
+		t.Errorf("triage default mismatch: %q", got.Triage)
+	}
 	if got.Suggestions != "[]" {
 		t.Errorf("suggestions default mismatch: %q", got.Suggestions)
 	}

--- a/daemon/internal/store/issues_test.go
+++ b/daemon/internal/store/issues_test.go
@@ -1,0 +1,284 @@
+package store_test
+
+import (
+	"errors"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+func newIssue(githubID int64, number int) *store.Issue {
+	return &store.Issue{
+		GithubID:  githubID,
+		Repo:      "org/repo",
+		Number:    number,
+		Title:     "Bug in main",
+		Body:      "reproduce by running foo",
+		Author:    "alice",
+		Assignees: `["bob"]`,
+		Labels:    `["bug","priority:high"]`,
+		State:     "open",
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+		FetchedAt: time.Now().UTC().Truncate(time.Second),
+	}
+}
+
+func TestIssue_UpsertAndGet(t *testing.T) {
+	s := newTestStore(t)
+	i := newIssue(201, 15)
+
+	id, err := s.UpsertIssue(i)
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("expected non-zero id")
+	}
+
+	got, err := s.GetIssue(id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != i.Title {
+		t.Errorf("title mismatch: got %q want %q", got.Title, i.Title)
+	}
+	if got.Labels != i.Labels {
+		t.Errorf("labels JSON mismatch: got %q want %q", got.Labels, i.Labels)
+	}
+	if got.Dismissed {
+		t.Error("new issue should not be dismissed")
+	}
+}
+
+func TestIssue_UpsertDefaultsJSONArrays(t *testing.T) {
+	s := newTestStore(t)
+	i := newIssue(202, 16)
+	i.Assignees = ""
+	i.Labels = ""
+
+	id, err := s.UpsertIssue(i)
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, _ := s.GetIssue(id)
+	if got.Assignees != "[]" || got.Labels != "[]" {
+		t.Errorf("expected [] defaults, got assignees=%q labels=%q", got.Assignees, got.Labels)
+	}
+}
+
+func TestIssue_UpsertIsIdempotentByGithubID(t *testing.T) {
+	s := newTestStore(t)
+	i := newIssue(203, 17)
+
+	first, err := s.UpsertIssue(i)
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+
+	// Update the same GitHub issue with a new title.
+	i.Title = "Bug in main (edited)"
+	second, err := s.UpsertIssue(i)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if first != second {
+		t.Fatalf("expected same row id on re-upsert, got %d vs %d", first, second)
+	}
+	got, _ := s.GetIssue(first)
+	if got.Title != "Bug in main (edited)" {
+		t.Errorf("title not updated on re-upsert: %q", got.Title)
+	}
+}
+
+func TestIssue_UpsertPreservesDismissed(t *testing.T) {
+	s := newTestStore(t)
+	i := newIssue(204, 18)
+
+	id, _ := s.UpsertIssue(i)
+	if err := s.DismissIssue(id); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+
+	// Re-upserting the same issue (as the poll loop would) must keep
+	// dismissed = true. Regression-guarded to match UpsertPR semantics.
+	if _, err := s.UpsertIssue(i); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	got, _ := s.GetIssue(id)
+	if !got.Dismissed {
+		t.Error("dismiss flag was lost on re-upsert")
+	}
+}
+
+func TestIssue_GetByGithubID(t *testing.T) {
+	s := newTestStore(t)
+	i := newIssue(205, 19)
+	_, _ = s.UpsertIssue(i)
+
+	got, err := s.GetIssueByGithubID(205)
+	if err != nil {
+		t.Fatalf("get by github id: %v", err)
+	}
+	if got.Number != 19 {
+		t.Errorf("number mismatch: %d", got.Number)
+	}
+}
+
+func TestIssue_GetByGithubID_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.GetIssueByGithubID(999999)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows for missing issue, got: %v", err)
+	}
+}
+
+func TestIssue_ListHidesDismissed(t *testing.T) {
+	s := newTestStore(t)
+	id1, _ := s.UpsertIssue(newIssue(206, 20))
+	id2, _ := s.UpsertIssue(newIssue(207, 21))
+
+	if err := s.DismissIssue(id2); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+
+	list, err := s.ListIssues()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 issue (dismissed hidden), got %d", len(list))
+	}
+	if list[0].ID != id1 {
+		t.Errorf("expected id1=%d in list, got %d", id1, list[0].ID)
+	}
+}
+
+func TestIssue_Undismiss(t *testing.T) {
+	s := newTestStore(t)
+	id, _ := s.UpsertIssue(newIssue(208, 22))
+
+	_ = s.DismissIssue(id)
+	if err := s.UndismissIssue(id); err != nil {
+		t.Fatalf("undismiss: %v", err)
+	}
+	got, _ := s.GetIssue(id)
+	if got.Dismissed {
+		t.Error("expected undismissed")
+	}
+}
+
+func TestIssueReview_InsertAndList(t *testing.T) {
+	s := newTestStore(t)
+	issueID, _ := s.UpsertIssue(newIssue(209, 23))
+
+	rev := &store.IssueReview{
+		IssueID:     issueID,
+		CLIUsed:     "claude",
+		Summary:     "looks like a config bug",
+		Triage:      `{"severity":"medium","category":"config"}`,
+		Suggestions: `["document the flag","add a validation step"]`,
+		ActionTaken: "review_only",
+		PRCreated:   0,
+		CreatedAt:   time.Now().UTC().Truncate(time.Second),
+	}
+	revID, err := s.InsertIssueReview(rev)
+	if err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+	if revID == 0 {
+		t.Fatal("expected non-zero review id")
+	}
+
+	reviews, err := s.ListIssueReviews(issueID)
+	if err != nil {
+		t.Fatalf("list reviews: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("expected 1 review, got %d", len(reviews))
+	}
+	if reviews[0].Triage != rev.Triage {
+		t.Errorf("triage mismatch: %q", reviews[0].Triage)
+	}
+}
+
+func TestIssueReview_InsertDefaults(t *testing.T) {
+	s := newTestStore(t)
+	issueID, _ := s.UpsertIssue(newIssue(210, 24))
+
+	rev := &store.IssueReview{
+		IssueID:   issueID,
+		CLIUsed:   "claude",
+		Summary:   "no suggestions yet",
+		Triage:    `{}`,
+		CreatedAt: time.Now(),
+	}
+	_, err := s.InsertIssueReview(rev)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	got, _ := s.LatestIssueReview(issueID)
+	if got.Suggestions != "[]" {
+		t.Errorf("suggestions default mismatch: %q", got.Suggestions)
+	}
+	if got.ActionTaken != "review_only" {
+		t.Errorf("action_taken default mismatch: %q", got.ActionTaken)
+	}
+}
+
+func TestIssueReview_LatestReturnsNewest(t *testing.T) {
+	s := newTestStore(t)
+	issueID, _ := s.UpsertIssue(newIssue(211, 25))
+	t0 := time.Now().UTC().Truncate(time.Second)
+
+	older := &store.IssueReview{IssueID: issueID, CLIUsed: "claude", Summary: "first", Triage: "{}", CreatedAt: t0.Add(-time.Hour)}
+	newer := &store.IssueReview{IssueID: issueID, CLIUsed: "claude", Summary: "second", Triage: "{}", CreatedAt: t0}
+
+	_, _ = s.InsertIssueReview(older)
+	_, _ = s.InsertIssueReview(newer)
+
+	got, err := s.LatestIssueReview(issueID)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	if got.Summary != "second" {
+		t.Errorf("expected newest review 'second', got %q", got.Summary)
+	}
+}
+
+func TestIssueReview_LatestReturnsErrNoRowsWhenNone(t *testing.T) {
+	s := newTestStore(t)
+	issueID, _ := s.UpsertIssue(newIssue(212, 26))
+
+	_, err := s.LatestIssueReview(issueID)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows, got: %v", err)
+	}
+}
+
+func TestIssues_SchemaMigrationIdempotent(t *testing.T) {
+	// Opening the same path twice re-runs the schema; CREATE IF NOT EXISTS
+	// should make this a no-op. Regression guard for the migration story.
+	path := t.TempDir() + "/heimdallm.db"
+	s1, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	s1.Close()
+	s2, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	defer s2.Close()
+
+	// Write + read through issues should work on the second open.
+	id, err := s2.UpsertIssue(newIssue(213, 27))
+	if err != nil {
+		t.Fatalf("upsert after re-open: %v", err)
+	}
+	if _, err := s2.GetIssue(id); err != nil {
+		t.Fatalf("get after re-open: %v", err)
+	}
+}

--- a/daemon/internal/store/prs.go
+++ b/daemon/internal/store/prs.go
@@ -38,8 +38,11 @@ func (s *Store) UpsertPR(pr *PR) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("store: upsert pr: %w", err)
 	}
+	// LastInsertId returns 0 on the UPDATE path with modernc.org/sqlite (the
+	// driver this project uses). Other SQLite drivers may report the existing
+	// row id instead — the fallback SELECT below handles either case so this
+	// code is portable if the driver ever changes.
 	id, err := res.LastInsertId()
-	// LastInsertId returns 0 on UPDATE (conflict path) — fall back to a SELECT.
 	if err != nil || id == 0 {
 		row := s.db.QueryRow("SELECT id FROM prs WHERE github_id = ?", pr.GithubID)
 		if scanErr := row.Scan(&id); scanErr != nil {

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -62,6 +62,38 @@ CREATE TABLE IF NOT EXISTS agents (
   is_default   INTEGER NOT NULL DEFAULT 0,
   created_at DATETIME NOT NULL
 );
+
+-- Issue tracking pipeline (#24). The assignees and labels columns hold JSON
+-- arrays of strings so we do not have to create a separate join table just
+-- for display; the issue_reviews downstream consumers treat the whole row
+-- as one record.
+CREATE TABLE IF NOT EXISTS issues (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  github_id   INTEGER UNIQUE NOT NULL,
+  repo        TEXT NOT NULL,
+  number      INTEGER NOT NULL,
+  title       TEXT NOT NULL,
+  body        TEXT NOT NULL DEFAULT '',
+  author      TEXT NOT NULL,
+  assignees   TEXT NOT NULL DEFAULT '[]',
+  labels      TEXT NOT NULL DEFAULT '[]',
+  state       TEXT NOT NULL,
+  created_at  DATETIME NOT NULL,
+  fetched_at  DATETIME NOT NULL,
+  dismissed   INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS issue_reviews (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  issue_id     INTEGER NOT NULL REFERENCES issues(id),
+  cli_used     TEXT NOT NULL,
+  summary      TEXT NOT NULL,
+  triage       TEXT NOT NULL,
+  suggestions  TEXT NOT NULL DEFAULT '[]',
+  action_taken TEXT NOT NULL DEFAULT 'review_only',
+  pr_created   INTEGER NOT NULL DEFAULT 0,
+  created_at   DATETIME NOT NULL
+);
 `
 
 // Open opens (or creates) a SQLite database at dsn and applies the schema.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -32,6 +32,20 @@ HEIMDALLM_REPOSITORIES=
 # Defaults to 15m when HEIMDALLM_DISCOVERY_TOPIC is set.
 # HEIMDALLM_DISCOVERY_INTERVAL=15m
 
+# ── Issue tracking pipeline (optional, fase-2) ──────────────────────────────
+# Enables the daemon to fetch, classify and process GitHub issues in the
+# monitored repos. Label classification precedence:
+#   skip_labels  >  review_only_labels  >  develop_labels  >  default_action
+#
+# HEIMDALLM_ISSUE_TRACKING_ENABLED=false
+# HEIMDALLM_ISSUE_FILTER_MODE=exclusive          # "exclusive" | "inclusive"
+# HEIMDALLM_ISSUE_DEFAULT_ACTION=ignore          # "ignore" | "review_only"
+# HEIMDALLM_ISSUE_ORGANIZATIONS=your-org
+# HEIMDALLM_ISSUE_ASSIGNEES=your-username
+# HEIMDALLM_ISSUE_DEVELOP_LABELS=enhancement,feature,bug
+# HEIMDALLM_ISSUE_REVIEW_ONLY_LABELS=question,discussion,analysis
+# HEIMDALLM_ISSUE_SKIP_LABELS=wontfix,duplicate,invalid
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # AI CLI AUTHENTICATION
 # Set the key(s) for whichever CLI you configured as primary/fallback.

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -19,6 +19,24 @@ repositories = ["org/repo1", "org/repo2"]
 # discovery_orgs     = ["your-org", "your-other-org"]   # required when discovery_topic is set
 # discovery_interval = "15m"                             # any Go duration; defaults to 15m
 
+# Issue tracking pipeline (fase-2).
+# When enabled, the daemon fetches open issues from the monitored repos,
+# classifies them by label, and — depending on the mode — posts an AI
+# review comment (review_only) or opens an implementation PR
+# (auto_implement). Label classification precedence:
+#
+#   skip_labels  >  review_only_labels  >  develop_labels  >  default_action
+#
+# [github.issue_tracking]
+# enabled             = false
+# filter_mode         = "exclusive"              # "exclusive" (AND) | "inclusive" (OR)
+# default_action      = "ignore"                 # "ignore" | "review_only"
+# organizations       = ["your-org"]             # empty = any org in repositories
+# assignees           = ["your-username"]        # empty = any assignee (or unassigned)
+# develop_labels      = ["enhancement", "feature", "bug"]
+# review_only_labels  = ["question", "discussion", "analysis"]
+# skip_labels         = ["wontfix", "duplicate", "invalid"]
+
 [ai]
 # Available: claude, gemini, codex, opencode
 primary = "claude"


### PR DESCRIPTION
## Summary

First building block of the fase-2 issue-tracking pipeline (#24). Ships the **storage schema** and the **full configuration surface**, ready for #25 (`FetchIssues`) and downstream pipeline work. Nothing about fetching, classifying or acting on issues at runtime — this PR deliberately does **not** touch the GitHub client, the pipeline or `main.go`. Scope is acotado on purpose so reviews of #25/#26/#27 can focus on logic without mixing storage/config changes.

## What's in

### `[github.issue_tracking]` config (TOML + `HEIMDALLM_ISSUE_*` env vars)

All the fields agreed in the #24 thread:
- `enabled`
- `filter_mode` — `exclusive` (AND) | `inclusive` (OR)
- `default_action` — `ignore` | `review_only`, applied when an issue carries no label from any configured list
- `organizations`, `assignees` — org and assignee filters
- `develop_labels`, `review_only_labels`, `skip_labels`

**Defaults** (applied by `applyDefaults`):
- `filter_mode = exclusive`
- `default_action = ignore` (no noise on untriaged issues, matching the feedback on #24)

**Classification precedence** (exported as `(IssueTrackingConfig).Classify(labels) IssueMode`):

```
skip_labels  >  review_only_labels  >  develop_labels  >  default_action
```

Case-insensitive, trimmed — handles the common "Bug" vs "bug" mixup. Result is the exported `IssueMode` (`ignore`/`develop`/`review_only`) so #25/#26 can reuse the same constants.

**Validation** rejects typos in `filter_mode` and `default_action` **only when `enabled=true`**, so an opt-out config does not need to fill those fields in. Labels are intentionally free-form.

**Env vars** use the same CSV contract as `HEIMDALLM_REPOSITORIES`: a blank-only value (`"  ,  ,  "`) preserves the existing TOML value instead of wiping it.

### Storage (`daemon/internal/store/issues.go`)

New tables with the exact SQL from the #24 description:

- `issues` — `assignees` and `labels` are JSON strings (`[]` default) alongside the row, as specified.
- `issue_reviews` — `action_taken` and `pr_created` for tracking whether a run actually opened a PR.

CRUD mirrors the PR store:
- `UpsertIssue` preserves the user's `dismissed` flag across re-polls.
- `ListIssues` hides dismissed rows.
- `LatestIssueReview` returns `sql.ErrNoRows` when there are none yet (useful for the \"first run since last review\" check the pipeline will need).
- Schema is idempotent (`CREATE IF NOT EXISTS`), regression test included.

### Docs

- `docker/config.example.toml` — commented `[github.issue_tracking]` block.
- `docker/.env.example` — all `HEIMDALLM_ISSUE_*` vars.

## What's out (handled in downstream issues)

- `FetchIssues` + `organizations` / `assignees` / `filter_mode` enforcement → #25.
- `review_only` pipeline → #26.
- `auto_implement` pipeline (branch + PR) → #27.
- Polling integration + HTTP endpoints → #28.
- UI (Flutter / web) → #29 / #31.

## Tests

All new, including:
- defaults + env var overrides (incl. blank-CSV preservation),
- `Classify` precedence + case-insensitivity + `default_action=review_only` variant + whitespace trimming,
- validation: disabled skips, invalid `filter_mode`, invalid `default_action`, enabled+defaults passes,
- store: insert/get/upsert/list-hides-dismissed/undismiss, JSON defaults, upsert keeps `dismissed`, `LatestIssueReview` newest + `sql.ErrNoRows`, **schema migration idempotent across re-opens**.

Run inside the pinned Docker sandbox (`make test-docker`, added in #41 — required on Elastic-Security-protected laptops):

```
ok  github.com/heimdallm/daemon/internal/config
ok  github.com/heimdallm/daemon/internal/discovery
ok  github.com/heimdallm/daemon/internal/executor
ok  github.com/heimdallm/daemon/internal/github
ok  github.com/heimdallm/daemon/internal/pipeline
ok  github.com/heimdallm/daemon/internal/scheduler
ok  github.com/heimdallm/daemon/internal/server
ok  github.com/heimdallm/daemon/internal/sse
ok  github.com/heimdallm/daemon/internal/store
```

## Test plan

- [ ] CI green (GitHub Actions macos-14 + flutter).
- [ ] Manual: start the daemon with \`HEIMDALLM_ISSUE_TRACKING_ENABLED=true\`, confirm the tables \`issues\` / \`issue_reviews\` appear in the SQLite DB and the config is picked up at runtime.
- [ ] Manual: toggle \`filter_mode=excluive\` (typo) and confirm the daemon refuses to start with a clear error.

Closes #24