### PR TITLE
feat(issues): GitHub client — FetchIssues with classification & priority sort

### DIFF
--- a/daemon/internal/github/fetch_issues.go
+++ b/daemon/internal/github/fetch_issues.go
@@ -1,0 +1,229 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/heimdallm/daemon/internal/config"
+)
+
+// maxIssuePages bounds how many pages we consume per repo on a single
+// FetchIssues call — a hard safety net against runaway pagination. At
+// per_page=100 this caps the result at 1000 open issues per repo, which
+// is plenty for the review pipeline and prevents a malformed response
+// from looping forever.
+const maxIssuePages = 10
+
+// FetchIssues returns the open issues for a repo after applying the filters
+// and classification rules in cfg, sorted by processing priority.
+//
+// Behaviour:
+//
+//  1. Fetches `GET /repos/{repo}/issues?state=open` (REST, not Search API —
+//     5000 req/h authenticated vs. 30 req/min). The endpoint returns both
+//     issues and PRs; we drop PRs by inspecting the `pull_request` field.
+//
+//  2. Assigns each remaining issue an IssueMode via cfg.Classify. Issues
+//     that classify as ignore are dropped unconditionally — this covers
+//     both explicit skip_labels and "no labels matched + default_action =
+//     ignore". The label dimension is therefore filtered before filter_mode
+//     is applied to the remaining dimensions (org + assignee).
+//
+//  3. Applies organizations and assignees filters. filter_mode decides how
+//     they combine: "exclusive" = all active dimensions must pass (AND);
+//     "inclusive" = at least one active dimension must pass (OR). A
+//     dimension is "active" only when its configured list is non-empty.
+//
+//  4. Sorts: issues assigned to authenticatedUser first, then the rest;
+//     within each group review_only before develop (review is cheap, develop
+//     is expensive, so it clears the queue faster); within each mode oldest
+//     first so long-pending issues move forward.
+//
+// The store-level "skip already processed without new activity" check is
+// intentionally not here — it needs the local store and belongs to the
+// pipeline caller (#26 onward).
+func (c *Client) FetchIssues(repo string, cfg config.IssueTrackingConfig, authenticatedUser string) ([]*Issue, error) {
+	if repo == "" {
+		return nil, fmt.Errorf("github: FetchIssues: empty repo")
+	}
+
+	var kept []*Issue
+	for page := 1; page <= maxIssuePages; page++ {
+		batch, err := c.fetchIssuesPage(repo, page)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, issue := range batch {
+			issue.Repo = repo
+			if issue.IsPullRequest() {
+				continue
+			}
+			mode := cfg.Classify(issue.LabelNames())
+			if mode == config.IssueModeIgnore {
+				continue
+			}
+			if !issueMatchesFilters(issue, repo, cfg) {
+				continue
+			}
+			issue.Mode = mode
+			kept = append(kept, issue)
+		}
+
+		if len(batch) < 100 {
+			break
+		}
+		if page == maxIssuePages {
+			slog.Warn("github: FetchIssues page cap reached", "repo", repo, "cap", maxIssuePages)
+		}
+	}
+
+	sortIssuesByPriority(kept, authenticatedUser)
+	return kept, nil
+}
+
+func (c *Client) fetchIssuesPage(repo string, page int) ([]*Issue, error) {
+	params := url.Values{}
+	params.Set("state", "open")
+	params.Set("per_page", "100")
+	params.Set("page", strconv.Itoa(page))
+
+	path := fmt.Sprintf("/repos/%s/issues?%s", repo, params.Encode())
+	resp, err := c.do("GET", path, "application/vnd.github+json")
+	if err != nil {
+		return nil, fmt.Errorf("github: fetch issues (%s page %d): %w", repo, page, err)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody := string(body)
+		if len(errBody) > maxErrBodyLen {
+			errBody = errBody[:maxErrBodyLen]
+		}
+		return nil, fmt.Errorf("github: fetch issues (%s page %d): status %d: %s", repo, page, resp.StatusCode, errBody)
+	}
+
+	var batch []*Issue
+	if err := json.Unmarshal(body, &batch); err != nil {
+		return nil, fmt.Errorf("github: decode issues (%s page %d): %w", repo, page, err)
+	}
+	return batch, nil
+}
+
+// issueMatchesFilters applies organizations + assignees + filter_mode.
+// The label dimension is handled up-stream (cfg.Classify + ignore short-
+// circuit), so by the time we get here the issue is known to be
+// review_only or develop.
+func issueMatchesFilters(issue *Issue, repo string, cfg config.IssueTrackingConfig) bool {
+	orgActive := len(cfg.Organizations) > 0
+	assigneeActive := len(cfg.Assignees) > 0
+
+	orgPass := !orgActive || repoBelongsToOrg(repo, cfg.Organizations)
+	assigneePass := !assigneeActive || hasAnyAssignee(issue.AssigneeLogins(), cfg.Assignees)
+
+	// No active filters → include.
+	if !orgActive && !assigneeActive {
+		return true
+	}
+
+	if cfg.FilterMode == config.FilterModeInclusive {
+		// OR: at least one active dimension passes.
+		if orgActive && orgPass {
+			return true
+		}
+		if assigneeActive && assigneePass {
+			return true
+		}
+		return false
+	}
+
+	// Default / exclusive: AND across active dimensions.
+	if orgActive && !orgPass {
+		return false
+	}
+	if assigneeActive && !assigneePass {
+		return false
+	}
+	return true
+}
+
+// repoBelongsToOrg reports whether "org/name" has an owner in the org list.
+// Comparison is case-insensitive to match how GitHub treats org slugs in the
+// UI; the API preserves case on the way out.
+func repoBelongsToOrg(repo string, orgs []string) bool {
+	slash := strings.IndexByte(repo, '/')
+	if slash <= 0 {
+		return false
+	}
+	owner := strings.ToLower(repo[:slash])
+	for _, o := range orgs {
+		if strings.EqualFold(strings.TrimSpace(o), owner) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasAnyAssignee reports whether any entry in got is also in want. Empty
+// got never matches — an issue with no assignees never satisfies an active
+// assignee filter.
+func hasAnyAssignee(got, want []string) bool {
+	if len(got) == 0 || len(want) == 0 {
+		return false
+	}
+	wantSet := make(map[string]struct{}, len(want))
+	for _, w := range want {
+		wantSet[strings.ToLower(strings.TrimSpace(w))] = struct{}{}
+	}
+	for _, g := range got {
+		if _, ok := wantSet[strings.ToLower(strings.TrimSpace(g))]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// sortIssuesByPriority applies the ordering described in FetchIssues:
+//
+//	1) assigned-to-authenticatedUser before everyone else
+//	2) review_only before develop (review is cheap, clears the queue faster)
+//	3) oldest first
+//
+// sort.SliceStable keeps the GitHub response order within otherwise-equal
+// issues (GitHub returns newest-updated first), making the tertiary
+// CreatedAt tiebreaker deterministic.
+func sortIssuesByPriority(issues []*Issue, authenticatedUser string) {
+	authLower := strings.ToLower(strings.TrimSpace(authenticatedUser))
+	isMine := func(i *Issue) bool {
+		if authLower == "" {
+			return false
+		}
+		for _, a := range i.Assignees {
+			if strings.ToLower(a.Login) == authLower {
+				return true
+			}
+		}
+		return false
+	}
+	sort.SliceStable(issues, func(i, j int) bool {
+		a, b := issues[i], issues[j]
+		am, bm := isMine(a), isMine(b)
+		if am != bm {
+			return am // mine first
+		}
+		aDev := a.Mode == config.IssueModeDevelop
+		bDev := b.Mode == config.IssueModeDevelop
+		if aDev != bDev {
+			return !aDev // review_only (develop=false) first
+		}
+		return a.CreatedAt.Before(b.CreatedAt) // older first
+	})
+}

--- a/daemon/internal/github/fetch_issues.go
+++ b/daemon/internal/github/fetch_issues.go
@@ -14,11 +14,17 @@ import (
 	"github.com/heimdallm/daemon/internal/config"
 )
 
+// issuesPerPage is the per_page query size used when walking the issues
+// endpoint. It is referenced both in the query string and in the "last
+// page" check so that changing one without the other cannot silently break
+// pagination.
+const issuesPerPage = 100
+
 // maxIssuePages bounds how many pages we consume per repo on a single
 // FetchIssues call — a hard safety net against runaway pagination. At
-// per_page=100 this caps the result at 1000 open issues per repo, which
-// is plenty for the review pipeline and prevents a malformed response
-// from looping forever.
+// issuesPerPage=100 this caps the result at 1000 open issues per repo,
+// which is plenty for the review pipeline and prevents a malformed
+// response from looping forever.
 const maxIssuePages = 10
 
 // FetchIssues returns the open issues for a repo after applying the filters
@@ -77,7 +83,7 @@ func (c *Client) FetchIssues(repo string, cfg config.IssueTrackingConfig, authen
 			kept = append(kept, issue)
 		}
 
-		if len(batch) < 100 {
+		if len(batch) < issuesPerPage {
 			break
 		}
 		if page == maxIssuePages {
@@ -92,7 +98,7 @@ func (c *Client) FetchIssues(repo string, cfg config.IssueTrackingConfig, authen
 func (c *Client) fetchIssuesPage(repo string, page int) ([]*Issue, error) {
 	params := url.Values{}
 	params.Set("state", "open")
-	params.Set("per_page", "100")
+	params.Set("per_page", strconv.Itoa(issuesPerPage))
 	params.Set("page", strconv.Itoa(page))
 
 	path := fmt.Sprintf("/repos/%s/issues?%s", repo, params.Encode())
@@ -100,8 +106,14 @@ func (c *Client) fetchIssuesPage(repo string, page int) ([]*Issue, error) {
 	if err != nil {
 		return nil, fmt.Errorf("github: fetch issues (%s page %d): %w", repo, page, err)
 	}
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	// Surface I/O errors explicitly — a short read would otherwise slip into
+	// json.Unmarshal and produce a misleading "decode issues" error that
+	// masks the real network failure.
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	resp.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("github: read issues body (%s page %d): %w", repo, page, readErr)
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		errBody := string(body)
@@ -163,7 +175,7 @@ func repoBelongsToOrg(repo string, orgs []string) bool {
 	if slash <= 0 {
 		return false
 	}
-	owner := strings.ToLower(repo[:slash])
+	owner := repo[:slash]
 	for _, o := range orgs {
 		if strings.EqualFold(strings.TrimSpace(o), owner) {
 			return true

--- a/daemon/internal/github/fetch_issues_test.go
+++ b/daemon/internal/github/fetch_issues_test.go
@@ -383,6 +383,43 @@ func TestFetchIssues_Pagination(t *testing.T) {
 	}
 }
 
+func TestFetchIssues_PaginationCapBounded(t *testing.T) {
+	// Server that always returns a full page of issues. FetchIssues should
+	// stop at its internal max-pages cap and return the accumulated results
+	// without error instead of looping forever.
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		// Each page returns 100 unique issues so IDs don't collide.
+		items := make([]map[string]any, 100)
+		for i := range items {
+			id := int64(page*100 + i)
+			items[i] = issueFixture{
+				ID: id, Number: int(id),
+				Labels:    []string{"bug"},
+				CreatedAt: time.Now(),
+			}.marshal()
+		}
+		_ = json.NewEncoder(w).Encode(items)
+	}))
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	got, err := client.FetchIssues("org/repo", baseCfg(), "")
+	if err != nil {
+		t.Fatalf("cap should not surface an error, got %v", err)
+	}
+	// Never exceed the cap × issuesPerPage.
+	if len(got) > 10*100 {
+		t.Errorf("result exceeded cap: got %d issues", len(got))
+	}
+	// Never issue more requests than the cap.
+	if c := atomic.LoadInt32(&calls); c > 10 {
+		t.Errorf("requests exceeded cap: got %d", c)
+	}
+}
+
 func TestFetchIssues_PaginationStopsAtPartialPage(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/github/fetch_issues_test.go
+++ b/daemon/internal/github/fetch_issues_test.go
@@ -1,0 +1,449 @@
+package github_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+type issueFixture struct {
+	ID          int64
+	Number      int
+	Title       string
+	Labels      []string
+	Assignees   []string
+	CreatedAt   time.Time
+	IsPR        bool
+}
+
+func (f issueFixture) marshal() map[string]any {
+	labels := make([]map[string]string, len(f.Labels))
+	for i, l := range f.Labels {
+		labels[i] = map[string]string{"name": l}
+	}
+	assignees := make([]map[string]string, len(f.Assignees))
+	for i, a := range f.Assignees {
+		assignees[i] = map[string]string{"login": a}
+	}
+	body := map[string]any{
+		"id":         f.ID,
+		"number":     f.Number,
+		"title":      f.Title,
+		"state":      "open",
+		"labels":     labels,
+		"assignees":  assignees,
+		"user":       map[string]string{"login": "author"},
+		"html_url":   fmt.Sprintf("https://github.com/org/repo/issues/%d", f.Number),
+		"created_at": f.CreatedAt.UTC().Format(time.RFC3339),
+		"updated_at": f.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if f.IsPR {
+		body["pull_request"] = map[string]string{"url": "…"}
+	}
+	return body
+}
+
+func issuesPageServer(t *testing.T, pages map[int][]issueFixture) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/repos/") || !strings.HasSuffix(r.URL.Path, "/issues") {
+			http.NotFound(w, r)
+			return
+		}
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		fixtures, ok := pages[page]
+		if !ok {
+			_ = json.NewEncoder(w).Encode([]any{})
+			return
+		}
+		out := make([]map[string]any, len(fixtures))
+		for i, f := range fixtures {
+			out[i] = f.marshal()
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+}
+
+func baseCfg() config.IssueTrackingConfig {
+	return config.IssueTrackingConfig{
+		Enabled:          true,
+		FilterMode:       config.FilterModeExclusive,
+		DevelopLabels:    []string{"bug", "enhancement"},
+		ReviewOnlyLabels: []string{"question"},
+		SkipLabels:       []string{"wontfix"},
+		DefaultAction:    string(config.IssueModeIgnore),
+	}
+}
+
+// ── basic classification / filtering ─────────────────────────────────────────
+
+func TestFetchIssues_DropsPullRequests(t *testing.T) {
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 1, Number: 1, Title: "real issue", Labels: []string{"bug"}, CreatedAt: time.Now()},
+			{ID: 2, Number: 2, Title: "this is a PR", Labels: []string{"bug"}, CreatedAt: time.Now(), IsPR: true},
+		},
+	})
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchIssues("org/repo", baseCfg(), "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 issue (PR filtered), got %d", len(got))
+	}
+	if got[0].Title != "real issue" {
+		t.Errorf("wrong record kept: %q", got[0].Title)
+	}
+}
+
+func TestFetchIssues_SkipLabelsWinOverEverything(t *testing.T) {
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 10, Number: 10, Title: "closed by policy", Labels: []string{"wontfix", "bug"}, CreatedAt: time.Now()},
+			{ID: 11, Number: 11, Title: "ok", Labels: []string{"bug"}, CreatedAt: time.Now()},
+		},
+	})
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchIssues("org/repo", baseCfg(), "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Number != 11 {
+		t.Errorf("expected only #11, got %+v", got)
+	}
+}
+
+func TestFetchIssues_DefaultActionIgnoreDropsUntaggedIssues(t *testing.T) {
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 20, Number: 20, Title: "no label", Labels: nil, CreatedAt: time.Now()},
+		},
+	})
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchIssues("org/repo", baseCfg(), "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected default_action=ignore to drop untagged issue, got %d", len(got))
+	}
+}
+
+func TestFetchIssues_DefaultActionReviewOnlyKeepsUntaggedIssues(t *testing.T) {
+	cfg := baseCfg()
+	cfg.DefaultAction = string(config.IssueModeReviewOnly)
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 30, Number: 30, Title: "no label", Labels: nil, CreatedAt: time.Now()},
+		},
+	})
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchIssues("org/repo", cfg, "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Mode != config.IssueModeReviewOnly {
+		t.Errorf("expected 1 review_only issue, got %+v", got)
+	}
+}
+
+func TestFetchIssues_AssignsModeFromClassifier(t *testing.T) {
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 40, Number: 40, Title: "dev", Labels: []string{"bug"}, CreatedAt: time.Now()},
+			{ID: 41, Number: 41, Title: "review", Labels: []string{"question"}, CreatedAt: time.Now()},
+		},
+	})
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, _ := client.FetchIssues("org/repo", baseCfg(), "")
+	modes := map[int]config.IssueMode{}
+	for _, i := range got {
+		modes[i.Number] = i.Mode
+	}
+	if modes[40] != config.IssueModeDevelop {
+		t.Errorf("#40 should be develop, got %q", modes[40])
+	}
+	if modes[41] != config.IssueModeReviewOnly {
+		t.Errorf("#41 should be review_only, got %q", modes[41])
+	}
+}
+
+// ── dimension filters ────────────────────────────────────────────────────────
+
+func TestFetchIssues_OrganizationsFilter(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Organizations = []string{"wanted-org"}
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {{ID: 50, Number: 50, Title: "x", Labels: []string{"bug"}, CreatedAt: time.Now()}},
+	})
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	got, _ := client.FetchIssues("wanted-org/repo", cfg, "")
+	if len(got) != 1 {
+		t.Errorf("expected issue kept for wanted-org, got %d", len(got))
+	}
+	got, _ = client.FetchIssues("other-org/repo", cfg, "")
+	if len(got) != 0 {
+		t.Errorf("expected issue dropped for other-org, got %d", len(got))
+	}
+}
+
+func TestFetchIssues_OrganizationsFilter_CaseInsensitive(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Organizations = []string{"Freepik-Company"}
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {{ID: 51, Number: 51, Title: "x", Labels: []string{"bug"}, CreatedAt: time.Now()}},
+	})
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	got, _ := client.FetchIssues("freepik-company/repo", cfg, "")
+	if len(got) != 1 {
+		t.Errorf("case-insensitive org match expected, got %d", len(got))
+	}
+}
+
+func TestFetchIssues_AssigneesFilter(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Assignees = []string{"alice"}
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 60, Number: 60, Title: "alice's", Assignees: []string{"alice"}, Labels: []string{"bug"}, CreatedAt: time.Now()},
+			{ID: 61, Number: 61, Title: "bob's", Assignees: []string{"bob"}, Labels: []string{"bug"}, CreatedAt: time.Now()},
+			{ID: 62, Number: 62, Title: "unassigned", Labels: []string{"bug"}, CreatedAt: time.Now()},
+		},
+	})
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	got, _ := client.FetchIssues("org/repo", cfg, "")
+	if len(got) != 1 || got[0].Number != 60 {
+		t.Errorf("expected only alice's issue, got %+v", got)
+	}
+}
+
+// ── filter_mode ──────────────────────────────────────────────────────────────
+
+func TestFetchIssues_FilterModeExclusive_AllMustPass(t *testing.T) {
+	cfg := baseCfg()
+	cfg.FilterMode = config.FilterModeExclusive
+	cfg.Organizations = []string{"wanted-org"}
+	cfg.Assignees = []string{"alice"}
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 70, Number: 70, Assignees: []string{"alice"}, Labels: []string{"bug"}, CreatedAt: time.Now()},
+			{ID: 71, Number: 71, Assignees: []string{"bob"}, Labels: []string{"bug"}, CreatedAt: time.Now()}, // wrong assignee
+		},
+	})
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	got, _ := client.FetchIssues("wanted-org/repo", cfg, "")
+	if len(got) != 1 || got[0].Number != 70 {
+		t.Errorf("exclusive: only #70 should pass (all filters match), got %+v", got)
+	}
+
+	got, _ = client.FetchIssues("other-org/repo", cfg, "")
+	if len(got) != 0 {
+		t.Errorf("exclusive: no issue should pass when org filter fails, got %d", len(got))
+	}
+}
+
+func TestFetchIssues_FilterModeInclusive_AtLeastOneDimensionPasses(t *testing.T) {
+	cfg := baseCfg()
+	cfg.FilterMode = config.FilterModeInclusive
+	cfg.Organizations = []string{"wanted-org"}
+	cfg.Assignees = []string{"alice"}
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 80, Number: 80, Assignees: []string{"bob"}, Labels: []string{"bug"}, CreatedAt: time.Now()}, // org matches (we'll fetch via wanted-org)
+			{ID: 81, Number: 81, Assignees: []string{"alice"}, Labels: []string{"bug"}, CreatedAt: time.Now()}, // assignee matches even in other-org
+		},
+	})
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	// Fetched from wanted-org — org passes, so both issues are kept.
+	got, _ := client.FetchIssues("wanted-org/repo", cfg, "")
+	if len(got) != 2 {
+		t.Errorf("inclusive + org matches: expected 2 issues, got %d", len(got))
+	}
+
+	// Fetched from other-org — org fails, assignee decides.
+	got, _ = client.FetchIssues("other-org/repo", cfg, "")
+	if len(got) != 1 || got[0].Number != 81 {
+		t.Errorf("inclusive + only assignee matches: expected #81 only, got %+v", got)
+	}
+}
+
+// ── sort ─────────────────────────────────────────────────────────────────────
+
+func TestFetchIssues_SortsAssignedUserBeforeOthers(t *testing.T) {
+	old := time.Now().Add(-48 * time.Hour)
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 90, Number: 90, Labels: []string{"bug"}, CreatedAt: old},
+			{ID: 91, Number: 91, Assignees: []string{"alice"}, Labels: []string{"bug"}, CreatedAt: time.Now()},
+		},
+	})
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	got, _ := client.FetchIssues("org/repo", baseCfg(), "alice")
+	if len(got) != 2 || got[0].Number != 91 {
+		t.Errorf("issues assigned to authenticated user must come first, got %+v", got)
+	}
+}
+
+func TestFetchIssues_SortsReviewOnlyBeforeDevelop(t *testing.T) {
+	t0 := time.Now()
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 100, Number: 100, Labels: []string{"bug"}, CreatedAt: t0.Add(-1 * time.Hour)}, // develop, older
+			{ID: 101, Number: 101, Labels: []string{"question"}, CreatedAt: t0},                // review_only, newer
+		},
+	})
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	got, _ := client.FetchIssues("org/repo", baseCfg(), "")
+	if len(got) != 2 || got[0].Number != 101 {
+		t.Errorf("review_only must sort before develop, got %+v", got)
+	}
+}
+
+func TestFetchIssues_SortsOldestFirstWithinMode(t *testing.T) {
+	t0 := time.Now()
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 110, Number: 110, Labels: []string{"bug"}, CreatedAt: t0},
+			{ID: 111, Number: 111, Labels: []string{"bug"}, CreatedAt: t0.Add(-24 * time.Hour)},
+			{ID: 112, Number: 112, Labels: []string{"bug"}, CreatedAt: t0.Add(-72 * time.Hour)},
+		},
+	})
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	got, _ := client.FetchIssues("org/repo", baseCfg(), "")
+	if len(got) != 3 {
+		t.Fatalf("expected 3 issues, got %d", len(got))
+	}
+	if got[0].Number != 112 || got[1].Number != 111 || got[2].Number != 110 {
+		t.Errorf("expected oldest first, got %d → %d → %d", got[0].Number, got[1].Number, got[2].Number)
+	}
+}
+
+// ── pagination ───────────────────────────────────────────────────────────────
+
+func TestFetchIssues_Pagination(t *testing.T) {
+	t0 := time.Now()
+	page1 := make([]issueFixture, 100)
+	for i := range page1 {
+		page1[i] = issueFixture{
+			ID: int64(200 + i), Number: 200 + i,
+			Labels: []string{"bug"}, CreatedAt: t0,
+		}
+	}
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: page1,
+		2: {{ID: 300, Number: 300, Labels: []string{"bug"}, CreatedAt: t0}},
+	})
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	got, err := client.FetchIssues("org/repo", baseCfg(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 101 {
+		t.Errorf("expected 101 issues across 2 pages, got %d", len(got))
+	}
+}
+
+func TestFetchIssues_PaginationStopsAtPartialPage(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page != 1 {
+			t.Errorf("unexpected fetch of page %d (first page was partial)", page)
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			issueFixture{ID: 400, Number: 400, Labels: []string{"bug"}, CreatedAt: time.Now()}.marshal(),
+		})
+	}))
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	_, err := client.FetchIssues("org/repo", baseCfg(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected 1 HTTP call for partial page, got %d", got)
+	}
+}
+
+// ── error surfaces ───────────────────────────────────────────────────────────
+
+func TestFetchIssues_EmptyRepoReturnsError(t *testing.T) {
+	client := gh.NewClient("fake")
+	_, err := client.FetchIssues("", baseCfg(), "")
+	if err == nil {
+		t.Fatal("expected error for empty repo, got nil")
+	}
+}
+
+func TestFetchIssues_HTTPErrorSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	_, err := client.FetchIssues("org/repo", baseCfg(), "")
+	if err == nil {
+		t.Fatal("expected error on 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should surface status code, got: %v", err)
+	}
+}
+
+func TestFetchIssues_InvalidJSONSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	_, err := client.FetchIssues("org/repo", baseCfg(), "")
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+}

--- a/daemon/internal/github/models.go
+++ b/daemon/internal/github/models.go
@@ -3,10 +3,70 @@ package github
 import (
 	"strings"
 	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
 )
 
 type User struct {
 	Login string `json:"login"`
+}
+
+// Label is a GitHub label stripped down to the field the pipeline needs.
+type Label struct {
+	Name string `json:"name"`
+}
+
+// Issue mirrors a GitHub issue filtered and classified by FetchIssues.
+//
+// The JSON field `pull_request` on the wire distinguishes issues from PRs
+// when using the `GET /repos/{owner}/{repo}/issues` endpoint (which returns
+// both). `PullRequest` is a probe field — when non-nil the record is a PR
+// and FetchIssues drops it. We do not unmarshal its contents.
+//
+// `Mode` is populated client-side by FetchIssues after running the
+// config-driven label classifier so downstream consumers (the pipeline in
+// #26 / #27) don't need to re-apply the precedence rules.
+type Issue struct {
+	ID          int64            `json:"id"`
+	Number      int              `json:"number"`
+	Title       string           `json:"title"`
+	Body        string           `json:"body"`
+	HTMLURL     string           `json:"html_url"`
+	User        User             `json:"user"`
+	Assignees   []User           `json:"assignees"`
+	Labels      []Label          `json:"labels"`
+	State       string           `json:"state"`
+	CreatedAt   time.Time        `json:"created_at"`
+	UpdatedAt   time.Time        `json:"updated_at"`
+	PullRequest *struct{}        `json:"pull_request,omitempty"`
+	Repo        string           `json:"-"`
+	Mode        config.IssueMode `json:"-"`
+}
+
+// IsPullRequest reports whether the record returned by the issues endpoint is
+// actually a pull request. The issues API returns both; the pipeline only
+// wants plain issues.
+func (i *Issue) IsPullRequest() bool {
+	return i.PullRequest != nil
+}
+
+// LabelNames extracts label names as a plain string slice for use with
+// IssueTrackingConfig.Classify and for logging / storage.
+func (i *Issue) LabelNames() []string {
+	out := make([]string, len(i.Labels))
+	for idx, l := range i.Labels {
+		out[idx] = l.Name
+	}
+	return out
+}
+
+// AssigneeLogins returns the logins assigned to the issue (may be empty).
+func (i *Issue) AssigneeLogins() []string {
+	out := make([]string, len(i.Assignees))
+	for idx, a := range i.Assignees {
+		out[idx] = a.Login
+	}
+	return out
 }
 
 type Repo struct {


### PR DESCRIPTION
## Summary

Second step of the fase-2 issue-tracking pipeline (#25). Adds the GitHub client surface the downstream pipeline (#26 onward) needs. No UI, no storage writes, no polling integration — those live in later issues.

## What's in

### `FetchIssues(repo, cfg, authenticatedUser) ([]*Issue, error)` (`internal/github/fetch_issues.go`)

- Hits REST `GET /repos/{owner}/{repo}/issues?state=open` (5000 req/h auth) instead of Search API (30 req/min) — same decision as the #24 comment thread.
- Paginated at `per_page=100` with a hard cap of 10 pages per repo (up to 1000 open issues) so a malformed response cannot loop forever.
- The endpoint returns both issues and PRs; we drop PRs via the `pull_request` probe field.

### Classification

Each kept issue goes through `IssueTrackingConfig.Classify` (exported in #42) and is stamped with a `Mode` (`develop` / `review_only`) so #26 / #27 do not re-apply the precedence rules.

Importantly, the label dimension short-circuits **before** `filter_mode` is evaluated:

- `skip_labels` → dropped.
- No label matches + `default_action = ignore` → dropped.
- No label matches + `default_action = review_only` → kept as `review_only`.

This matters for `filter_mode = inclusive`: an issue without a useful label can **never** sneak in through the org or assignee branch, which would leave it with `Mode = ignore` and confuse the pipeline.

### Dimension filters (org + assignee, combined by `filter_mode`)

| Mode | Rule |
|---|---|
| `exclusive` (AND) | every active dimension must pass |
| `inclusive` (OR) | at least one active dimension must pass |

- An empty list (`Organizations: []` or `Assignees: []`) is **not active** and neither counts toward nor against a match — mirrors how the existing \`Repositories\` filter behaves.
- Org comparison is case-insensitive (`Freepik-Company` vs `freepik-company` match) because GitHub preserves case on the API while the UI lowercases.

### Priority sort

Produced with `sort.SliceStable` so GitHub's response order is the natural tiebreaker:

1. Issues assigned to `authenticatedUser` before everyone else.
2. `review_only` before `develop` (cheap work clears the queue faster).
3. Oldest first, so long-pending issues keep moving.

### Model additions (`internal/github/models.go`)

- `Label` (just `Name`).
- `Issue` with all the fields the pipeline needs plus `PullRequest *struct{}` probe and unexported `Repo` / `Mode` fields populated client-side.
- `IsPullRequest()`, `LabelNames()`, `AssigneeLogins()` helpers so downstream code doesn't have to walk the sub-structs.

## What's out (handled elsewhere)

- **Skip already processed without new activity** — requires the store, belongs in the pipeline (#26).
- `review_only` pipeline (#26), `auto_implement` (#27), polling + HTTP endpoints (#28), UI (#29 / #31 / #32 / #33).
- No changes to `main.go`, store, or config beyond what #24 already merged.

## Tests

All httptest-backed, running in the Docker sandbox (\`make test-docker\`):

- PR records dropped.
- `skip_labels` win over everything; `default_action=ignore` drops untagged; `default_action=review_only` keeps them.
- `Mode` assignment for develop / review_only labels.
- `organizations` filter + case-insensitive variant.
- `assignees` filter.
- `filter_mode` exclusive vs. inclusive edge cases (e.g. org match but wrong assignee, vice versa).
- Sort: authenticated-user first, review_only before develop, oldest first within a mode.
- Pagination: multi-page assembly + early stop on partial page.
- Error paths: empty repo, 404, decode error.

Suite in Docker:

```
ok  github.com/heimdallm/daemon/internal/config
ok  github.com/heimdallm/daemon/internal/discovery
ok  github.com/heimdallm/daemon/internal/executor
ok  github.com/heimdallm/daemon/internal/github
ok  github.com/heimdallm/daemon/internal/pipeline
ok  github.com/heimdallm/daemon/internal/scheduler
ok  github.com/heimdallm/daemon/internal/server
ok  github.com/heimdallm/daemon/internal/sse
ok  github.com/heimdallm/daemon/internal/store
```

## Test plan

- [ ] CI green on GitHub Actions.
- [ ] Manual: enable issue tracking on a scratch repo, add one issue with \`bug\`, one with \`wontfix\`, one untagged. Confirm FetchIssues returns exactly one (the bug) classified as \`develop\`.
- [ ] Manual: flip \`filter_mode\` between \`exclusive\` and \`inclusive\` with conflicting org/assignee filters; confirm behaviour matches the table in this PR.

Closes #25