### PR TITLE
feat(issues): review_only triage pipeline + fetcher

### DIFF
--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -496,14 +496,38 @@ func enrichEnvWithLoginPath() []string {
 // markdown code fences, prose surrounding the JSON object) and returns the
 // inner JSON bytes. Exported so downstream pipelines (issue triage, etc.)
 // can reuse the same cleanup without duplicating it.
+//
+// Known limitation: the function scans from the first '{' to the last '}',
+// which is not a balanced-brace parser. If an LLM emits multiple top-level
+// JSON objects the result will not be valid JSON and the caller's
+// json.Unmarshal will surface the error. Our prompts explicitly ask for a
+// single JSON object, so this has not been a problem in practice — but
+// worth noting before somebody feeds this bytes from a different source.
 func StripToJSON(data []byte) []byte {
 	s := strings.TrimSpace(string(data))
+
+	// Peel a leading code fence if present. Look for an explicit closing
+	// fence rather than assuming the last line is the fence — if the LLM
+	// appends trailing prose after the fence, the naive approach would keep
+	// that prose inside the JSON slice.
 	if strings.HasPrefix(s, "```") {
 		lines := strings.Split(s, "\n")
-		if len(lines) > 2 {
-			s = strings.Join(lines[1:len(lines)-1], "\n")
+		closeIdx := -1
+		for i := 1; i < len(lines); i++ {
+			if strings.HasPrefix(lines[i], "```") {
+				closeIdx = i
+				break
+			}
+		}
+		switch {
+		case closeIdx > 0:
+			s = strings.Join(lines[1:closeIdx], "\n")
+		case len(lines) > 1:
+			// No closing fence at all — strip just the opening line.
+			s = strings.Join(lines[1:], "\n")
 		}
 	}
+
 	start := strings.Index(s, "{")
 	end := strings.LastIndex(s, "}")
 	if start >= 0 && end > start {

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -328,8 +328,23 @@ func ValidateWorkDir(dir string) error {
 	return nil
 }
 
-// Execute runs the AI CLI with the given prompt and options, returning the parsed result.
+// Execute runs the AI CLI with the given prompt and options, returning the
+// parsed PR review result. Callers that need a different output schema (e.g.
+// the issue-tracking pipeline) should use ExecuteRaw + StripToJSON instead of
+// re-implementing the subprocess plumbing.
 func (e *Executor) Execute(cli, prompt string, opts ExecOptions) (*ReviewResult, error) {
+	raw, err := e.ExecuteRaw(cli, prompt, opts)
+	if err != nil {
+		return nil, err
+	}
+	return parseResult(raw)
+}
+
+// ExecuteRaw runs the AI CLI and returns stdout unchanged. Used by pipelines
+// that parse a schema other than ReviewResult (issue triage, auto_implement
+// output, etc.). Callers should pass the bytes through StripToJSON before
+// json.Unmarshal — CLIs routinely wrap JSON in code fences or surrounding text.
+func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), executionTimeout)
 	defer cancel()
 
@@ -370,7 +385,7 @@ func (e *Executor) Execute(cli, prompt string, opts ExecOptions) (*ReviewResult,
 		return nil, fmt.Errorf("executor: run %s: %w (output: %s)", cli, err, errDetail)
 	}
 
-	return parseResult(stdout.Bytes())
+	return stdout.Bytes(), nil
 }
 
 // buildArgs constructs the CLI argument list based on the CLI name and options.
@@ -477,26 +492,31 @@ func enrichEnvWithLoginPath() []string {
 	return loginPathEnv
 }
 
-func parseResult(data []byte) (*ReviewResult, error) {
+// StripToJSON strips common LLM output wrappers (leading/trailing whitespace,
+// markdown code fences, prose surrounding the JSON object) and returns the
+// inner JSON bytes. Exported so downstream pipelines (issue triage, etc.)
+// can reuse the same cleanup without duplicating it.
+func StripToJSON(data []byte) []byte {
 	s := strings.TrimSpace(string(data))
-	// Strip potential markdown code fences
 	if strings.HasPrefix(s, "```") {
 		lines := strings.Split(s, "\n")
 		if len(lines) > 2 {
 			s = strings.Join(lines[1:len(lines)-1], "\n")
 		}
 	}
-
-	// Find first { to last } in case there's surrounding text
 	start := strings.Index(s, "{")
 	end := strings.LastIndex(s, "}")
 	if start >= 0 && end > start {
 		s = s[start : end+1]
 	}
+	return []byte(s)
+}
 
+func parseResult(data []byte) (*ReviewResult, error) {
+	clean := StripToJSON(data)
 	var result ReviewResult
-	if err := json.Unmarshal([]byte(s), &result); err != nil {
-		return nil, fmt.Errorf("executor: parse JSON result: %w (raw: %.200s)", err, s)
+	if err := json.Unmarshal(clean, &result); err != nil {
+		return nil, fmt.Errorf("executor: parse JSON result: %w (raw: %.200s)", err, clean)
 	}
 	if result.Severity == "" {
 		result.Severity = "low"

--- a/daemon/internal/executor/strip_to_json_test.go
+++ b/daemon/internal/executor/strip_to_json_test.go
@@ -1,0 +1,99 @@
+package executor_test
+
+import (
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/executor"
+)
+
+func TestStripToJSON_PlainObject(t *testing.T) {
+	in := []byte(`{"a":1}`)
+	got := string(executor.StripToJSON(in))
+	if got != `{"a":1}` {
+		t.Errorf("got %q, want %q", got, `{"a":1}`)
+	}
+}
+
+func TestStripToJSON_TrimsWhitespace(t *testing.T) {
+	in := []byte("   \n  {\"a\":1}  \n\n  ")
+	got := string(executor.StripToJSON(in))
+	if got != `{"a":1}` {
+		t.Errorf("got %q, want %q", got, `{"a":1}`)
+	}
+}
+
+func TestStripToJSON_MarkdownFence(t *testing.T) {
+	in := []byte("```json\n{\"a\":1}\n```")
+	got := string(executor.StripToJSON(in))
+	if got != `{"a":1}` {
+		t.Errorf("got %q, want %q", got, `{"a":1}`)
+	}
+}
+
+func TestStripToJSON_FenceWithTrailingProse(t *testing.T) {
+	// Regression: before the explicit closing-fence scan this case left the
+	// trailing prose inside the JSON slice, which only survived by accident
+	// because the final '}' was still the last brace.
+	in := []byte("```json\n{\"a\":1}\n```\nthanks, hope that helps!")
+	got := string(executor.StripToJSON(in))
+	if got != `{"a":1}` {
+		t.Errorf("got %q, want %q", got, `{"a":1}`)
+	}
+}
+
+func TestStripToJSON_FenceWithoutClosing(t *testing.T) {
+	// LLM forgets to close the fence — still recover what we can.
+	in := []byte("```json\n{\"a\":1}")
+	got := string(executor.StripToJSON(in))
+	if got != `{"a":1}` {
+		t.Errorf("got %q, want %q", got, `{"a":1}`)
+	}
+}
+
+func TestStripToJSON_ProseAroundObject(t *testing.T) {
+	in := []byte("Here is my triage:\n{\"severity\":\"low\"}\nHope it helps.")
+	got := string(executor.StripToJSON(in))
+	if got != `{"severity":"low"}` {
+		t.Errorf("got %q, want %q", got, `{"severity":"low"}`)
+	}
+}
+
+func TestStripToJSON_NestedObjectsKeepOutermost(t *testing.T) {
+	in := []byte(`{"triage":{"severity":"high"},"summary":"x"}`)
+	got := string(executor.StripToJSON(in))
+	if got != `{"triage":{"severity":"high"},"summary":"x"}` {
+		t.Errorf("got %q (nested braces changed the slice)", got)
+	}
+}
+
+func TestStripToJSON_NoBracesReturnsUnchanged(t *testing.T) {
+	// No JSON at all — return what we have so the caller's Unmarshal
+	// surfaces a descriptive error. Nothing to strip here.
+	in := []byte("not json at all")
+	got := string(executor.StripToJSON(in))
+	if got != "not json at all" {
+		t.Errorf("got %q, want input back", got)
+	}
+}
+
+func TestStripToJSON_Empty(t *testing.T) {
+	if got := string(executor.StripToJSON(nil)); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+	if got := string(executor.StripToJSON([]byte(""))); got != "" {
+		t.Errorf("empty input should produce empty output, got %q", got)
+	}
+}
+
+func TestStripToJSON_MultipleObjectsKnownLimitation(t *testing.T) {
+	// Documented limitation: StripToJSON scans from the first '{' to the
+	// LAST '}'. When the LLM returns two top-level objects the result is
+	// not valid JSON — the caller's Unmarshal must surface that cleanly.
+	// Pinning the behaviour here prevents a silent change that would be
+	// hard to catch in production.
+	in := []byte(`{"a":1}{"b":2}`)
+	got := string(executor.StripToJSON(in))
+	if got != `{"a":1}{"b":2}` {
+		t.Errorf("got %q (documented limitation: outer-slice behaviour)", got)
+	}
+}

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -12,10 +12,15 @@ import (
 	"github.com/heimdallm/daemon/internal/store"
 )
 
-// recomputeGrace absorbs the small updated_at bump GitHub applies when the
+// RecomputeGrace absorbs the small updated_at bump GitHub applies when the
 // daemon posts its own comment. Without it, every triage would immediately
-// re-trigger itself on the next poll. Mirrors the 30 s grace used for PRs.
-const recomputeGrace = 30 * time.Second
+// re-trigger itself on the next poll.
+//
+// The PR pipeline in main.go currently duplicates this 30 s window inline.
+// When #28 wires issues into the poll cycle it should import this constant
+// and route the PR check through it too, so the two grace windows can't
+// drift apart unnoticed.
+const RecomputeGrace = 30 * time.Second
 
 // IssuesFetcher is the subset of github.Client that fetches classified
 // issues. Kept as an interface so the fetcher can be tested without an HTTP
@@ -77,13 +82,16 @@ func (f *Fetcher) ProcessRepo(repo string, cfg config.IssueTrackingConfig, authU
 
 	processed := 0
 	for _, issue := range issues {
+		// A dedup lookup error intentionally falls through to "treat as
+		// unprocessed" so a flaky store never stops the pipeline from running;
+		// the explicit if / else if makes that control flow obvious.
 		skip, reason, err := f.alreadyProcessed(issue)
 		if err != nil {
 			slog.Warn("issues fetcher: dedup check failed, treating as unprocessed",
 				"repo", repo, "number", issue.Number, "err", err)
-		}
-		if skip {
-			slog.Debug("issues fetcher: skipping issue", "repo", repo, "number", issue.Number, "reason", reason)
+		} else if skip {
+			slog.Debug("issues fetcher: skipping issue",
+				"repo", repo, "number", issue.Number, "reason", reason)
 			continue
 		}
 
@@ -127,7 +135,7 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 		return false, "", err
 	}
 
-	cutoff := latest.CreatedAt.Add(recomputeGrace)
+	cutoff := latest.CreatedAt.Add(RecomputeGrace)
 	if !issue.UpdatedAt.After(cutoff) {
 		return true, "no new activity since last review", nil
 	}

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -1,0 +1,135 @@
+package issues
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// recomputeGrace absorbs the small updated_at bump GitHub applies when the
+// daemon posts its own comment. Without it, every triage would immediately
+// re-trigger itself on the next poll. Mirrors the 30 s grace used for PRs.
+const recomputeGrace = 30 * time.Second
+
+// IssuesFetcher is the subset of github.Client that fetches classified
+// issues. Kept as an interface so the fetcher can be tested without an HTTP
+// server standing in.
+type IssuesFetcher interface {
+	FetchIssues(repo string, cfg config.IssueTrackingConfig, authenticatedUser string) ([]*github.Issue, error)
+}
+
+// PipelineRunner is the subset of *Pipeline the fetcher uses.
+type PipelineRunner interface {
+	Run(issue *github.Issue, opts RunOptions) (*store.IssueReview, error)
+}
+
+// issueDedupStore is the store slice needed to decide whether an issue has
+// already been processed with no new activity since.
+type issueDedupStore interface {
+	GetIssueByGithubID(githubID int64) (*store.Issue, error)
+	LatestIssueReview(issueID int64) (*store.IssueReview, error)
+}
+
+// OptionsFn lets the caller map each classified issue to its RunOptions.
+// In production main.go resolves per-repo AI config here; tests can return a
+// constant.
+type OptionsFn func(issue *github.Issue) RunOptions
+
+// Fetcher orchestrates: fetch issues for a repo, skip those already processed
+// without new activity, dispatch the rest to the pipeline.
+type Fetcher struct {
+	client   IssuesFetcher
+	store    issueDedupStore
+	pipeline PipelineRunner
+}
+
+// NewFetcher wires the orchestrator. All dependencies are interfaces so
+// tests inject lightweight fakes.
+func NewFetcher(client IssuesFetcher, s issueDedupStore, p PipelineRunner) *Fetcher {
+	return &Fetcher{client: client, store: s, pipeline: p}
+}
+
+// ProcessRepo fetches every eligible issue for one repo and dispatches it to
+// the pipeline. Returns the number of issues actually handed off and a
+// non-nil error only when the fetch itself failed — per-issue pipeline
+// failures are logged and counted but do not abort the run.
+//
+// When cfg.Enabled is false this is a no-op; the caller does not have to
+// guard the call.
+func (f *Fetcher) ProcessRepo(repo string, cfg config.IssueTrackingConfig, authUser string, optsFor OptionsFn) (int, error) {
+	if !cfg.Enabled {
+		return 0, nil
+	}
+	if optsFor == nil {
+		return 0, fmt.Errorf("issues fetcher: nil OptionsFn")
+	}
+
+	issues, err := f.client.FetchIssues(repo, cfg, authUser)
+	if err != nil {
+		return 0, fmt.Errorf("issues fetcher: fetch %s: %w", repo, err)
+	}
+
+	processed := 0
+	for _, issue := range issues {
+		skip, reason, err := f.alreadyProcessed(issue)
+		if err != nil {
+			slog.Warn("issues fetcher: dedup check failed, treating as unprocessed",
+				"repo", repo, "number", issue.Number, "err", err)
+		}
+		if skip {
+			slog.Debug("issues fetcher: skipping issue", "repo", repo, "number", issue.Number, "reason", reason)
+			continue
+		}
+
+		if _, runErr := f.pipeline.Run(issue, optsFor(issue)); runErr != nil {
+			slog.Error("issues fetcher: pipeline run failed",
+				"repo", repo, "number", issue.Number, "err", runErr)
+			continue
+		}
+		processed++
+	}
+	return processed, nil
+}
+
+// alreadyProcessed reports whether the issue can be skipped because:
+//   - it was dismissed by the user, or
+//   - it was already reviewed and has no new activity (UpdatedAt ≤ last
+//     review + grace window).
+//
+// The err return signals a lookup failure — the caller logs it and proceeds
+// as if the issue were unprocessed, so a flaky store never stops the
+// pipeline from running.
+func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
+	row, err := f.store.GetIssueByGithubID(issue.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// First time we see this issue — process it.
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	if row.Dismissed {
+		return true, "dismissed", nil
+	}
+
+	latest, err := f.store.LatestIssueReview(row.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Known issue, never reviewed — process it.
+			return false, "", nil
+		}
+		return false, "", err
+	}
+
+	cutoff := latest.CreatedAt.Add(recomputeGrace)
+	if !issue.UpdatedAt.After(cutoff) {
+		return true, "no new activity since last review", nil
+	}
+	return false, "", nil
+}

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -1,0 +1,237 @@
+package issues_test
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/issues"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// ── fetcher-only fakes ───────────────────────────────────────────────────────
+
+type fakeClient struct {
+	issues []*github.Issue
+	err    error
+}
+
+func (c *fakeClient) FetchIssues(repo string, cfg config.IssueTrackingConfig, authenticatedUser string) ([]*github.Issue, error) {
+	return c.issues, c.err
+}
+
+type dedupEntry struct {
+	row     *store.Issue
+	review  *store.IssueReview
+	rowErr  error
+	revErr  error
+}
+
+type fakeDedup struct {
+	byGithubID map[int64]dedupEntry
+}
+
+func (d *fakeDedup) GetIssueByGithubID(githubID int64) (*store.Issue, error) {
+	e, ok := d.byGithubID[githubID]
+	if !ok {
+		return nil, sql.ErrNoRows
+	}
+	if e.rowErr != nil {
+		return nil, e.rowErr
+	}
+	return e.row, nil
+}
+
+func (d *fakeDedup) LatestIssueReview(issueID int64) (*store.IssueReview, error) {
+	for _, e := range d.byGithubID {
+		if e.row != nil && e.row.ID == issueID {
+			if e.revErr != nil {
+				return nil, e.revErr
+			}
+			if e.review == nil {
+				return nil, sql.ErrNoRows
+			}
+			return e.review, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
+type fakePipeline struct {
+	calls  []int // issue.Number for each Run call
+	runErr error
+}
+
+func (f *fakePipeline) Run(issue *github.Issue, opts issues.RunOptions) (*store.IssueReview, error) {
+	f.calls = append(f.calls, issue.Number)
+	if f.runErr != nil {
+		return nil, f.runErr
+	}
+	return &store.IssueReview{IssueID: int64(issue.Number), ActionTaken: string(config.IssueModeReviewOnly)}, nil
+}
+
+func noOpts(_ *github.Issue) issues.RunOptions { return issues.RunOptions{} }
+
+func fixture(number int, updated time.Time) *github.Issue {
+	return &github.Issue{
+		ID:        int64(1000 + number),
+		Number:    number,
+		Repo:      "org/repo",
+		UpdatedAt: updated,
+		Mode:      config.IssueModeReviewOnly,
+	}
+}
+
+func enabledCfg() config.IssueTrackingConfig {
+	return config.IssueTrackingConfig{Enabled: true}
+}
+
+// ── behaviour ────────────────────────────────────────────────────────────────
+
+func TestFetcher_NoOpWhenDisabled(t *testing.T) {
+	client := &fakeClient{issues: []*github.Issue{fixture(1, time.Now())}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(client, &fakeDedup{}, p)
+
+	processed, err := f.ProcessRepo("org/repo", config.IssueTrackingConfig{Enabled: false}, "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 0 || len(p.calls) != 0 {
+		t.Errorf("expected no-op when disabled, got processed=%d calls=%v", processed, p.calls)
+	}
+}
+
+func TestFetcher_NilOptionsFnIsError(t *testing.T) {
+	f := issues.NewFetcher(&fakeClient{}, &fakeDedup{}, &fakePipeline{})
+	_, err := f.ProcessRepo("org/repo", enabledCfg(), "alice", nil)
+	if err == nil {
+		t.Fatal("expected error for nil OptionsFn")
+	}
+}
+
+func TestFetcher_FetchErrorIsFatalForThisRun(t *testing.T) {
+	client := &fakeClient{err: errors.New("github down")}
+	f := issues.NewFetcher(client, &fakeDedup{}, &fakePipeline{})
+
+	_, err := f.ProcessRepo("org/repo", enabledCfg(), "alice", noOpts)
+	if err == nil {
+		t.Fatal("expected fetch error to surface")
+	}
+}
+
+func TestFetcher_DispatchesUnprocessedIssues(t *testing.T) {
+	client := &fakeClient{issues: []*github.Issue{fixture(1, time.Now()), fixture(2, time.Now())}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(client, &fakeDedup{byGithubID: map[int64]dedupEntry{}}, p)
+
+	processed, err := f.ProcessRepo("org/repo", enabledCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 2 || len(p.calls) != 2 {
+		t.Errorf("expected 2 dispatches, got processed=%d calls=%v", processed, p.calls)
+	}
+}
+
+func TestFetcher_SkipsDismissedIssues(t *testing.T) {
+	issue := fixture(1, time.Now())
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {row: &store.Issue{ID: 10, GithubID: issue.ID, Dismissed: true}},
+	}}
+	client := &fakeClient{issues: []*github.Issue{issue}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(client, dedup, p)
+
+	processed, _ := f.ProcessRepo("org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 0 || len(p.calls) != 0 {
+		t.Errorf("dismissed issue should be skipped, got processed=%d calls=%v", processed, p.calls)
+	}
+}
+
+func TestFetcher_SkipsIssueAlreadyReviewedWithoutNewActivity(t *testing.T) {
+	reviewedAt := time.Now().Add(-1 * time.Hour)
+	issue := fixture(1, reviewedAt.Add(5*time.Second)) // within 30s grace
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row:    &store.Issue{ID: 10, GithubID: issue.ID},
+			review: &store.IssueReview{IssueID: 10, CreatedAt: reviewedAt},
+		},
+	}}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, &fakePipeline{})
+
+	processed, _ := f.ProcessRepo("org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 0 {
+		t.Errorf("issue within grace window should be skipped, got processed=%d", processed)
+	}
+}
+
+func TestFetcher_RerunsIssueWithNewActivityAfterGrace(t *testing.T) {
+	reviewedAt := time.Now().Add(-1 * time.Hour)
+	issue := fixture(1, reviewedAt.Add(5*time.Minute)) // well past the 30s grace
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row:    &store.Issue{ID: 10, GithubID: issue.ID},
+			review: &store.IssueReview{IssueID: 10, CreatedAt: reviewedAt},
+		},
+	}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, p)
+
+	processed, _ := f.ProcessRepo("org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 1 {
+		t.Errorf("new activity past grace should re-run, got processed=%d calls=%v", processed, p.calls)
+	}
+}
+
+func TestFetcher_RunsFirstTimeIssueKnownButNeverReviewed(t *testing.T) {
+	issue := fixture(1, time.Now())
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {row: &store.Issue{ID: 10, GithubID: issue.ID}}, // no review yet
+	}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, p)
+
+	processed, _ := f.ProcessRepo("org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 1 {
+		t.Errorf("issue known but never reviewed must run, got processed=%d", processed)
+	}
+}
+
+func TestFetcher_PipelineErrorIsLoggedNotPropagated(t *testing.T) {
+	// One issue makes Run return an error; the second should still run so a
+	// single flaky issue does not block the rest of the repo.
+	issue1 := fixture(1, time.Now())
+	issue2 := fixture(2, time.Now())
+	client := &fakeClient{issues: []*github.Issue{issue1, issue2}}
+	p := &fakePipeline{runErr: errors.New("LLM timeout")}
+	f := issues.NewFetcher(client, &fakeDedup{byGithubID: map[int64]dedupEntry{}}, p)
+
+	processed, err := f.ProcessRepo("org/repo", enabledCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("per-issue failure must not abort ProcessRepo, got %v", err)
+	}
+	if processed != 0 {
+		t.Errorf("expected 0 successes when every run fails, got %d", processed)
+	}
+	if len(p.calls) != 2 {
+		t.Errorf("both issues must be attempted, got %v", p.calls)
+	}
+}
+
+func TestFetcher_DedupLookupErrorTreatedAsUnprocessed(t *testing.T) {
+	issue := fixture(1, time.Now())
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {rowErr: errors.New("store unavailable")},
+	}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, p)
+
+	processed, _ := f.ProcessRepo("org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 1 {
+		t.Errorf("flaky store must not block the pipeline, got processed=%d", processed)
+	}
+}

--- a/daemon/internal/issues/integration_test.go
+++ b/daemon/internal/issues/integration_test.go
@@ -1,0 +1,119 @@
+package issues_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/issues"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// Integration test that wires a real *store.Store to both the Fetcher and a
+// real *Pipeline, with fakes only for the network-facing edges (GitHub and
+// the CLI executor). Covers the end-to-end flow the reviewers wanted an
+// integration-level guard on.
+func TestIntegration_FetcherDrivesPipelineEndToEnd(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	// Two issues: one plain review_only, one classified develop but without a
+	// working directory — the pipeline must downgrade it to review_only and
+	// both should still end up triaged.
+	now := time.Now().UTC().Truncate(time.Second)
+	reviewOnly := &github.Issue{
+		ID: 1001, Number: 1, Repo: "org/repo",
+		Title: "Needs triage", Body: "Please look at this.",
+		State: "open", User: github.User{Login: "reporter"},
+		Labels:    []github.Label{{Name: "question"}},
+		Assignees: []github.User{},
+		CreatedAt: now, UpdatedAt: now,
+		Mode: config.IssueModeReviewOnly,
+	}
+	developFallback := &github.Issue{
+		ID: 1002, Number: 2, Repo: "org/repo",
+		Title: "Fix crash", Body: "Null pointer in auth.",
+		State: "open", User: github.User{Login: "reporter"},
+		Labels:    []github.Label{{Name: "bug"}},
+		Assignees: []github.User{},
+		CreatedAt: now, UpdatedAt: now,
+		Mode: config.IssueModeDevelop, // no WorkDir in RunOptions → fallback
+	}
+
+	client := &fakeClient{issues: []*github.Issue{reviewOnly, developFallback}}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(validResult)}
+	broker := &fakeBroker{}
+
+	pipe := issues.New(s, gh, exec, broker, nil)
+	fetcher := issues.NewFetcher(client, s, pipe)
+
+	processed, err := fetcher.ProcessRepo(
+		"org/repo",
+		config.IssueTrackingConfig{Enabled: true},
+		"reporter",
+		func(_ *github.Issue) issues.RunOptions { return issues.RunOptions{Primary: "claude"} },
+	)
+	if err != nil {
+		t.Fatalf("ProcessRepo: %v", err)
+	}
+	if processed != 2 {
+		t.Fatalf("expected both issues processed (fallback preserves processing), got %d", processed)
+	}
+
+	// Store has both issues + both reviews.
+	list, err := s.ListIssues()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 issues in store, got %d", len(list))
+	}
+	for _, row := range list {
+		latest, err := s.LatestIssueReview(row.ID)
+		if err != nil {
+			t.Fatalf("latest review for issue %d: %v", row.ID, err)
+		}
+		if latest.ActionTaken != string(config.IssueModeReviewOnly) {
+			t.Errorf("issue %d action_taken=%q, want review_only (incl. fallback)",
+				row.Number, latest.ActionTaken)
+		}
+	}
+
+	// Both comments landed on GitHub.
+	if len(gh.postCalls) != 2 {
+		t.Errorf("expected 2 PostComment calls, got %d", len(gh.postCalls))
+	}
+
+	// Second pass immediately after: the grace window should skip both.
+	processed2, err := fetcher.ProcessRepo(
+		"org/repo",
+		config.IssueTrackingConfig{Enabled: true},
+		"reporter",
+		func(_ *github.Issue) issues.RunOptions { return issues.RunOptions{Primary: "claude"} },
+	)
+	if err != nil {
+		t.Fatalf("second ProcessRepo: %v", err)
+	}
+	if processed2 != 0 {
+		t.Errorf("dedup: expected 0 re-processed within grace, got %d", processed2)
+	}
+	if len(gh.postCalls) != 2 {
+		t.Errorf("dedup: expected no new PostComment calls, got %d total", len(gh.postCalls))
+	}
+}
+
+func TestIntegration_RecomputeGraceIsExportedForMainPipeline(t *testing.T) {
+	// The constant is exported specifically so main.go in #28 can align the
+	// PR pipeline's grace window with the issue fetcher's. Locking the value
+	// (and its exported status) here prevents an accidental private rename
+	// from silently drifting the two pipelines apart.
+	if issues.RecomputeGrace != 30*time.Second {
+		t.Errorf("RecomputeGrace changed to %v — confirm with the PR pipeline's grace value in main.go before updating",
+			issues.RecomputeGrace)
+	}
+}

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -1,0 +1,359 @@
+// Package issues hosts the fase-2 issue-tracking pipeline — one step per
+// issue triage plus a fetcher that orchestrates batches of issues from a
+// repo. This pipeline runs the review_only mode (LLM triage + GitHub
+// comment). The auto_implement mode lives in a sibling file shipped with
+// issue #27.
+package issues
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// IssueCommenter posts a comment on an issue. Same method GitHub exposes for
+// PR comments — both routes share `/repos/{owner}/{repo}/issues/{n}/comments`.
+type IssueCommenter interface {
+	PostComment(repo string, number int, body string) error
+}
+
+// IssueCommentFetcher fetches the existing discussion for an issue so the
+// triage LLM can take prior context into account.
+type IssueCommentFetcher interface {
+	FetchComments(repo string, number int) ([]github.Comment, error)
+}
+
+// CLIExecutor runs an AI CLI. The pipeline uses ExecuteRaw because the
+// triage schema (Triage object) differs from the PR-review schema.
+type CLIExecutor interface {
+	Detect(primary, fallback string) (string, error)
+	ExecuteRaw(cli, prompt string, opts executor.ExecOptions) ([]byte, error)
+}
+
+// Publisher is the subset of sse.Broker used for emitting events.
+type Publisher interface {
+	Publish(e sse.Event)
+}
+
+// Notifier sends desktop / system notifications.
+type Notifier interface {
+	Notify(title, message string)
+}
+
+// Triage is the structured triage block returned by the LLM.
+type Triage struct {
+	Severity          string `json:"severity"`
+	Category          string `json:"category"`
+	SuggestedAssignee string `json:"suggested_assignee"`
+}
+
+// IssueReviewResult is the parsed LLM output for a triage run. Mirrors the
+// schema advertised in the prompt template.
+type IssueReviewResult struct {
+	Summary     string   `json:"summary"`
+	Triage      Triage   `json:"triage"`
+	Suggestions []string `json:"suggestions"`
+	Severity    string   `json:"severity"`
+}
+
+// RunOptions carries per-execution settings derived from global + repo +
+// agent config by the caller.
+type RunOptions struct {
+	Primary  string
+	Fallback string
+	// LocalDir comes from the repo-level AI config. When empty, the develop
+	// mode is unsafe (no working tree to read) and the pipeline falls back to
+	// review_only — see the FetchIssues / config contract in #24 / #25.
+	LocalDir string
+	ExecOpts executor.ExecOptions
+}
+
+// Pipeline runs a single issue triage end-to-end.
+type Pipeline struct {
+	store    issueStore
+	gh       issueGitHub
+	executor CLIExecutor
+	broker   Publisher
+	notify   Notifier
+}
+
+// issueStore is the subset of *store.Store the pipeline needs. Kept narrow
+// so tests can substitute a fake without bringing in SQLite.
+type issueStore interface {
+	UpsertIssue(i *store.Issue) (int64, error)
+	InsertIssueReview(r *store.IssueReview) (int64, error)
+}
+
+type issueGitHub interface {
+	IssueCommenter
+	IssueCommentFetcher
+}
+
+// New wires the pipeline. All dependencies are interfaces so tests can
+// inject fakes.
+func New(s issueStore, gh issueGitHub, exec CLIExecutor, broker Publisher, n Notifier) *Pipeline {
+	return &Pipeline{store: s, gh: gh, executor: exec, broker: broker, notify: n}
+}
+
+// Run processes one classified issue and returns the persisted review. The
+// returned IssueReview's ActionTaken reflects the mode that actually ran —
+// in particular, a develop-classified issue that loses its local_dir is
+// persisted as "review_only" so the audit trail matches behaviour.
+func (p *Pipeline) Run(issue *github.Issue, opts RunOptions) (*store.IssueReview, error) {
+	if issue == nil {
+		return nil, fmt.Errorf("issues pipeline: nil issue")
+	}
+
+	// 1. Determine the effective mode. If the caller asked for develop but
+	// there is no local_dir to hand the CLI, degrade to review_only instead
+	// of failing — safer for operators and matches the acceptance criterion
+	// in #26.
+	effective := issue.Mode
+	if effective == config.IssueModeDevelop && strings.TrimSpace(opts.LocalDir) == "" {
+		slog.Warn("issues pipeline: develop mode requires local_dir, downgrading to review_only",
+			"repo", issue.Repo, "issue", issue.Number)
+		effective = config.IssueModeReviewOnly
+	}
+	// This pipeline implements review_only only. auto_implement (when
+	// effective == develop) is the subject of issue #27; protect against it
+	// being invoked here accidentally.
+	if effective != config.IssueModeReviewOnly {
+		return nil, fmt.Errorf("issues pipeline: mode %q is not supported here (auto_implement lives in #27)", effective)
+	}
+
+	// 2. Persist the issue row (or update an existing one). Dismiss-preserving
+	// upsert semantics are already guaranteed by store.UpsertIssue.
+	storeIssue, err := issueToStore(issue)
+	if err != nil {
+		return nil, err
+	}
+	issueID, err := p.store.UpsertIssue(storeIssue)
+	if err != nil {
+		return nil, fmt.Errorf("issues pipeline: upsert issue: %w", err)
+	}
+
+	p.publish(sse.EventIssueDetected, map[string]any{
+		"issue_id": issueID, "number": issue.Number, "repo": issue.Repo,
+	})
+	p.publish(sse.EventIssueReviewStarted, map[string]any{
+		"issue_id": issueID, "number": issue.Number, "repo": issue.Repo,
+	})
+	if p.notify != nil {
+		p.notify.Notify("Issue Triage Started", fmt.Sprintf("%s #%d", issue.Repo, issue.Number))
+	}
+
+	// 3. Pull existing discussion as additional context. Failure is
+	// non-fatal — the triage still runs with title + body alone.
+	comments, err := p.gh.FetchComments(issue.Repo, issue.Number)
+	if err != nil {
+		slog.Warn("issues pipeline: failed to fetch comments, proceeding without", "err", err)
+		comments = nil
+	}
+
+	// 4. Build prompt + run the CLI.
+	prompt := BuildPrompt(PromptContext{
+		Repo:        issue.Repo,
+		Number:      issue.Number,
+		Title:       issue.Title,
+		Author:      issue.User.Login,
+		Labels:      issue.LabelNames(),
+		Body:        issue.Body,
+		Comments:    comments,
+		HasLocalDir: opts.ExecOpts.WorkDir != "",
+	})
+
+	cli, err := p.executor.Detect(opts.Primary, opts.Fallback)
+	if err != nil {
+		p.publishError(issueID, issue, fmt.Errorf("detect CLI: %w", err))
+		return nil, fmt.Errorf("issues pipeline: detect CLI: %w", err)
+	}
+
+	raw, err := p.executor.ExecuteRaw(cli, prompt, opts.ExecOpts)
+	if err != nil {
+		p.publishError(issueID, issue, fmt.Errorf("execute %s: %w", cli, err))
+		return nil, fmt.Errorf("issues pipeline: execute %s: %w", cli, err)
+	}
+
+	result, err := parseIssueResult(raw)
+	if err != nil {
+		p.publishError(issueID, issue, err)
+		return nil, fmt.Errorf("issues pipeline: parse result: %w", err)
+	}
+
+	// 5. Build + post the Markdown comment. PostComment failure is not
+	// fatal — the review is still persisted locally with a zero pr_created
+	// so operators can re-drive it manually without losing the LLM output.
+	body := BuildMarkdownComment(result)
+	postErr := p.gh.PostComment(issue.Repo, issue.Number, body)
+	if postErr != nil {
+		slog.Warn("issues pipeline: PostComment failed, review will be stored locally only",
+			"repo", issue.Repo, "number", issue.Number, "err", postErr)
+	}
+
+	// 6. Persist the review.
+	triageJSON, err := json.Marshal(result.Triage)
+	if err != nil {
+		return nil, fmt.Errorf("issues pipeline: marshal triage: %w", err)
+	}
+	suggestionsJSON, err := json.Marshal(result.Suggestions)
+	if err != nil {
+		return nil, fmt.Errorf("issues pipeline: marshal suggestions: %w", err)
+	}
+	rev := &store.IssueReview{
+		IssueID:     issueID,
+		CLIUsed:     cli,
+		Summary:     result.Summary,
+		Triage:      string(triageJSON),
+		Suggestions: string(suggestionsJSON),
+		ActionTaken: string(config.IssueModeReviewOnly),
+		CreatedAt:   time.Now().UTC(),
+	}
+	revID, err := p.store.InsertIssueReview(rev)
+	if err != nil {
+		return nil, fmt.Errorf("issues pipeline: store review: %w", err)
+	}
+	rev.ID = revID
+
+	p.publish(sse.EventIssueReviewCompleted, map[string]any{
+		"issue_id": issueID, "number": issue.Number, "repo": issue.Repo,
+		"severity": result.Severity, "post_ok": postErr == nil,
+	})
+	if p.notify != nil {
+		p.notify.Notify("Issue Triage Complete",
+			fmt.Sprintf("%s #%d — severity: %s", issue.Repo, issue.Number, result.Severity))
+	}
+
+	slog.Info("issues pipeline: triage complete",
+		"repo", issue.Repo, "number", issue.Number,
+		"severity", result.Severity, "posted", postErr == nil)
+
+	return rev, nil
+}
+
+// publish emits an SSE event with a pre-built data map. Swallowed if
+// broker is nil (tests that don't care about SSE).
+func (p *Pipeline) publish(eventType string, data map[string]any) {
+	if p.broker == nil {
+		return
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+	p.broker.Publish(sse.Event{Type: eventType, Data: string(b)})
+}
+
+// publishError emits an issue_review_error event with issue context + reason.
+func (p *Pipeline) publishError(issueID int64, issue *github.Issue, err error) {
+	p.publish(sse.EventIssueReviewError, map[string]any{
+		"issue_id": issueID, "number": issue.Number, "repo": issue.Repo,
+		"error": err.Error(),
+	})
+}
+
+// parseIssueResult strips LLM wrappers and unmarshals the triage JSON.
+// A missing `severity` at top level falls back to the triage block's value
+// (and ultimately to "low") so downstream consumers never see empty.
+func parseIssueResult(data []byte) (*IssueReviewResult, error) {
+	clean := executor.StripToJSON(data)
+	var r IssueReviewResult
+	if err := json.Unmarshal(clean, &r); err != nil {
+		return nil, fmt.Errorf("issues pipeline: parse JSON: %w (raw: %.200s)", err, clean)
+	}
+	if r.Severity == "" {
+		r.Severity = r.Triage.Severity
+	}
+	if r.Severity == "" {
+		r.Severity = "low"
+	}
+	return &r, nil
+}
+
+// issueToStore converts the github.Issue wire shape into the store row. The
+// store keeps assignees and labels as JSON arrays (`[]` when empty), matching
+// the schema introduced in #24.
+func issueToStore(i *github.Issue) (*store.Issue, error) {
+	assignees := i.AssigneeLogins()
+	if assignees == nil {
+		assignees = []string{}
+	}
+	labels := i.LabelNames()
+	if labels == nil {
+		labels = []string{}
+	}
+	assigneesJSON, err := json.Marshal(assignees)
+	if err != nil {
+		return nil, fmt.Errorf("issues pipeline: marshal assignees: %w", err)
+	}
+	labelsJSON, err := json.Marshal(labels)
+	if err != nil {
+		return nil, fmt.Errorf("issues pipeline: marshal labels: %w", err)
+	}
+	return &store.Issue{
+		GithubID:  i.ID,
+		Repo:      i.Repo,
+		Number:    i.Number,
+		Title:     i.Title,
+		Body:      i.Body,
+		Author:    i.User.Login,
+		Assignees: string(assigneesJSON),
+		Labels:    string(labelsJSON),
+		State:     i.State,
+		CreatedAt: i.CreatedAt,
+		FetchedAt: time.Now().UTC(),
+	}, nil
+}
+
+// BuildMarkdownComment renders the triage result as the comment body posted
+// to GitHub. Kept stable and human-readable because it lands under the user's
+// nose on every triaged issue; changes should be deliberate.
+func BuildMarkdownComment(r *IssueReviewResult) string {
+	sev := strings.ToUpper(r.Severity)
+	icon := "🟡"
+	switch r.Severity {
+	case "critical":
+		icon = "🛑"
+	case "high":
+		icon = "🔴"
+	case "medium":
+		icon = "⚠️"
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("## %s Heimdallm triage — %s\n\n", icon, sev))
+	if r.Summary != "" {
+		sb.WriteString(r.Summary)
+		sb.WriteString("\n\n")
+	}
+
+	sb.WriteString("### Classification\n\n")
+	if r.Triage.Category != "" {
+		sb.WriteString(fmt.Sprintf("- **Category:** %s\n", r.Triage.Category))
+	}
+	if r.Triage.Severity != "" {
+		sb.WriteString(fmt.Sprintf("- **Suggested severity:** %s\n", r.Triage.Severity))
+	}
+	if r.Triage.SuggestedAssignee != "" {
+		sb.WriteString(fmt.Sprintf("- **Suggested assignee:** @%s\n", r.Triage.SuggestedAssignee))
+	}
+	sb.WriteString("\n")
+
+	if len(r.Suggestions) > 0 {
+		sb.WriteString("### Next steps\n\n")
+		for _, s := range r.Suggestions {
+			sb.WriteString("- " + s + "\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("---\n*review_only mode · reviewed by Heimdallm*")
+	return sb.String()
+}

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -66,13 +66,17 @@ type IssueReviewResult struct {
 
 // RunOptions carries per-execution settings derived from global + repo +
 // agent config by the caller.
+//
+// The working directory — the repo-level `local_dir` in config.toml — is
+// passed as `ExecOpts.WorkDir`. That single field drives both the mode
+// downgrade (develop → review_only when absent) and the prompt context, so
+// they can never disagree. Callers mapping from `config.RepoAI.LocalDir`
+// assign it directly to `ExecOpts.WorkDir`; do not add a separate field
+// here (we had one in PR #44 review drafts — it caused exactly the
+// inconsistency the reviewers flagged).
 type RunOptions struct {
 	Primary  string
 	Fallback string
-	// LocalDir comes from the repo-level AI config. When empty, the develop
-	// mode is unsafe (no working tree to read) and the pipeline falls back to
-	// review_only — see the FetchIssues / config contract in #24 / #25.
-	LocalDir string
 	ExecOpts executor.ExecOptions
 }
 
@@ -113,20 +117,29 @@ func (p *Pipeline) Run(issue *github.Issue, opts RunOptions) (*store.IssueReview
 	}
 
 	// 1. Determine the effective mode. If the caller asked for develop but
-	// there is no local_dir to hand the CLI, degrade to review_only instead
-	// of failing — safer for operators and matches the acceptance criterion
-	// in #26.
+	// there is no working directory to hand the CLI, degrade to review_only
+	// instead of failing — safer for operators and matches the acceptance
+	// criterion in #26. `ExecOpts.WorkDir` is the single source of truth for
+	// "is there a local checkout"; Run does not consult any other field.
+	workDir := strings.TrimSpace(opts.ExecOpts.WorkDir)
 	effective := issue.Mode
-	if effective == config.IssueModeDevelop && strings.TrimSpace(opts.LocalDir) == "" {
+	if effective == config.IssueModeDevelop && workDir == "" {
 		slog.Warn("issues pipeline: develop mode requires local_dir, downgrading to review_only",
 			"repo", issue.Repo, "issue", issue.Number)
 		effective = config.IssueModeReviewOnly
 	}
-	// This pipeline implements review_only only. auto_implement (when
-	// effective == develop) is the subject of issue #27; protect against it
-	// being invoked here accidentally.
+	// Reject anything that does not resolve to review_only with a specific
+	// message so the log tells operators exactly why the pipeline refused.
+	// `ignore` should never reach this code (the fetcher filters it out) —
+	// if it somehow does, surface that as its own error rather than the
+	// auto_implement one.
+	if effective == config.IssueModeIgnore {
+		return nil, fmt.Errorf("issues pipeline: refusing an ignore-classified issue (fetcher should have filtered it out)")
+	}
 	if effective != config.IssueModeReviewOnly {
-		return nil, fmt.Errorf("issues pipeline: mode %q is not supported here (auto_implement lives in #27)", effective)
+		// Only possibility left: develop mode WITH a working directory,
+		// which is the auto_implement path owned by #27.
+		return nil, fmt.Errorf("issues pipeline: develop mode with local_dir belongs to the auto_implement path in #27")
 	}
 
 	// 2. Persist the issue row (or update an existing one). Dismiss-preserving
@@ -158,7 +171,8 @@ func (p *Pipeline) Run(issue *github.Issue, opts RunOptions) (*store.IssueReview
 		comments = nil
 	}
 
-	// 4. Build prompt + run the CLI.
+	// 4. Build prompt + run the CLI. HasLocalDir mirrors workDir above so
+	// the LLM hears the same story as the mode-selection logic.
 	prompt := BuildPrompt(PromptContext{
 		Repo:        issue.Repo,
 		Number:      issue.Number,
@@ -167,7 +181,7 @@ func (p *Pipeline) Run(issue *github.Issue, opts RunOptions) (*store.IssueReview
 		Labels:      issue.LabelNames(),
 		Body:        issue.Body,
 		Comments:    comments,
-		HasLocalDir: opts.ExecOpts.WorkDir != "",
+		HasLocalDir: workDir != "",
 	})
 
 	cli, err := p.executor.Detect(opts.Primary, opts.Fallback)
@@ -280,6 +294,13 @@ func parseIssueResult(data []byte) (*IssueReviewResult, error) {
 // issueToStore converts the github.Issue wire shape into the store row. The
 // store keeps assignees and labels as JSON arrays (`[]` when empty), matching
 // the schema introduced in #24.
+//
+// The issue's processing mode (review_only vs develop) is intentionally not
+// part of store.Issue — the issues table captures the issue itself, while
+// the mode of *each triage run* lives on issue_reviews.action_taken. That
+// separation lets a single issue accumulate multiple reviews across mode
+// changes (e.g. initial review_only → later auto_implement in #27) without
+// losing the history.
 func issueToStore(i *github.Issue) (*store.Issue, error) {
 	assignees := i.AssigneeLogins()
 	if assignees == nil {
@@ -342,7 +363,10 @@ func BuildMarkdownComment(r *IssueReviewResult) string {
 		sb.WriteString(fmt.Sprintf("- **Suggested severity:** %s\n", r.Triage.Severity))
 	}
 	if r.Triage.SuggestedAssignee != "" {
-		sb.WriteString(fmt.Sprintf("- **Suggested assignee:** @%s\n", r.Triage.SuggestedAssignee))
+		// Strip any leading '@' the LLM may have included so the template
+		// does not render a double '@@alice' that pings nobody.
+		assignee := strings.TrimLeft(r.Triage.SuggestedAssignee, "@")
+		sb.WriteString(fmt.Sprintf("- **Suggested assignee:** @%s\n", assignee))
 	}
 	sb.WriteString("\n")
 

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -1,0 +1,413 @@
+package issues_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/issues"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// ── fakes ────────────────────────────────────────────────────────────────────
+
+type fakeStore struct {
+	upserts      []*store.Issue
+	reviews      []*store.IssueReview
+	nextIssueID  int64
+	nextReviewID int64
+	upsertErr    error
+	insertErr    error
+}
+
+func (f *fakeStore) UpsertIssue(i *store.Issue) (int64, error) {
+	if f.upsertErr != nil {
+		return 0, f.upsertErr
+	}
+	f.nextIssueID++
+	copy := *i
+	copy.ID = f.nextIssueID
+	f.upserts = append(f.upserts, &copy)
+	return f.nextIssueID, nil
+}
+
+func (f *fakeStore) InsertIssueReview(r *store.IssueReview) (int64, error) {
+	if f.insertErr != nil {
+		return 0, f.insertErr
+	}
+	f.nextReviewID++
+	copy := *r
+	copy.ID = f.nextReviewID
+	f.reviews = append(f.reviews, &copy)
+	return f.nextReviewID, nil
+}
+
+type fakeGH struct {
+	postCalls     []postCall
+	commentsByKey map[string][]github.Comment
+	postErr       error
+	commentsErr   error
+}
+
+type postCall struct {
+	Repo   string
+	Number int
+	Body   string
+}
+
+func (f *fakeGH) PostComment(repo string, number int, body string) error {
+	f.postCalls = append(f.postCalls, postCall{Repo: repo, Number: number, Body: body})
+	return f.postErr
+}
+
+func (f *fakeGH) FetchComments(repo string, number int) ([]github.Comment, error) {
+	if f.commentsErr != nil {
+		return nil, f.commentsErr
+	}
+	return f.commentsByKey[fmt.Sprintf("%s#%d", repo, number)], nil
+}
+
+type fakeExec struct {
+	detectCLI  string
+	detectErr  error
+	rawOutput  []byte
+	rawErr     error
+	lastPrompt string
+	lastOpts   executor.ExecOptions
+	lastCLI    string
+}
+
+func (f *fakeExec) Detect(primary, fallback string) (string, error) {
+	if f.detectErr != nil {
+		return "", f.detectErr
+	}
+	if f.detectCLI == "" {
+		return primary, nil
+	}
+	return f.detectCLI, nil
+}
+
+func (f *fakeExec) ExecuteRaw(cli, prompt string, opts executor.ExecOptions) ([]byte, error) {
+	f.lastCLI = cli
+	f.lastPrompt = prompt
+	f.lastOpts = opts
+	if f.rawErr != nil {
+		return nil, f.rawErr
+	}
+	return f.rawOutput, nil
+}
+
+type fakeBroker struct {
+	mu     sync.Mutex
+	events []sse.Event
+}
+
+func (b *fakeBroker) Publish(e sse.Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.events = append(b.events, e)
+}
+
+func (b *fakeBroker) types() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.events))
+	for i, e := range b.events {
+		out[i] = e.Type
+	}
+	return out
+}
+
+type fakeNotifier struct {
+	calls []string
+}
+
+func (n *fakeNotifier) Notify(title, message string) {
+	n.calls = append(n.calls, title+": "+message)
+}
+
+// validResult is a sample JSON triage payload returned by the fake executor.
+const validResult = `
+{
+  "summary": "User cannot log in after upgrade.",
+  "triage": {
+    "severity": "high",
+    "category": "bug",
+    "suggested_assignee": "alice"
+  },
+  "suggestions": ["reproduce locally", "check auth migration"],
+  "severity": "high"
+}
+`
+
+func newIssue(mode config.IssueMode) *github.Issue {
+	return &github.Issue{
+		ID:        12345,
+		Number:    7,
+		Title:     "Login broken",
+		Body:      "After upgrade, login fails with 500.",
+		Repo:      "org/repo",
+		State:     "open",
+		User:      github.User{Login: "reporter"},
+		Labels:    []github.Label{{Name: "bug"}},
+		Assignees: []github.User{{Login: "alice"}},
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+		UpdatedAt: time.Now(),
+		Mode:      mode,
+	}
+}
+
+// ── happy path ───────────────────────────────────────────────────────────────
+
+func TestPipeline_RunHappyPath(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(validResult)}
+	broker := &fakeBroker{}
+	notify := &fakeNotifier{}
+	p := issues.New(s, gh, exec, broker, notify)
+
+	issue := newIssue(config.IssueModeReviewOnly)
+	rev, err := p.Run(issue, issues.RunOptions{Primary: "claude"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev == nil {
+		t.Fatal("nil review returned")
+	}
+
+	// Issue upserted once with JSON-encoded labels/assignees.
+	if len(s.upserts) != 1 {
+		t.Fatalf("expected 1 upsert, got %d", len(s.upserts))
+	}
+	up := s.upserts[0]
+	var labels []string
+	_ = json.Unmarshal([]byte(up.Labels), &labels)
+	if len(labels) != 1 || labels[0] != "bug" {
+		t.Errorf("labels JSON wrong: %q", up.Labels)
+	}
+	var assignees []string
+	_ = json.Unmarshal([]byte(up.Assignees), &assignees)
+	if len(assignees) != 1 || assignees[0] != "alice" {
+		t.Errorf("assignees JSON wrong: %q", up.Assignees)
+	}
+
+	// Comment posted to GitHub.
+	if len(gh.postCalls) != 1 || gh.postCalls[0].Number != 7 {
+		t.Fatalf("expected 1 PostComment on #7, got %+v", gh.postCalls)
+	}
+	if !strings.Contains(gh.postCalls[0].Body, "Heimdallm triage") {
+		t.Errorf("body missing heading: %q", gh.postCalls[0].Body)
+	}
+	if !strings.Contains(gh.postCalls[0].Body, "reproduce locally") {
+		t.Errorf("body missing suggestion: %q", gh.postCalls[0].Body)
+	}
+
+	// Review persisted with action_taken=review_only.
+	if len(s.reviews) != 1 {
+		t.Fatalf("expected 1 review stored, got %d", len(s.reviews))
+	}
+	storedRev := s.reviews[0]
+	if storedRev.ActionTaken != string(config.IssueModeReviewOnly) {
+		t.Errorf("action_taken=%q, want review_only", storedRev.ActionTaken)
+	}
+	if !strings.Contains(storedRev.Triage, `"category":"bug"`) {
+		t.Errorf("triage JSON not persisted correctly: %q", storedRev.Triage)
+	}
+	if !strings.Contains(storedRev.Suggestions, "reproduce locally") {
+		t.Errorf("suggestions JSON missing: %q", storedRev.Suggestions)
+	}
+
+	// SSE sequence: detected → started → completed.
+	types := broker.types()
+	want := []string{sse.EventIssueDetected, sse.EventIssueReviewStarted, sse.EventIssueReviewCompleted}
+	if !stringsEqual(types, want) {
+		t.Errorf("SSE sequence = %v, want %v", types, want)
+	}
+
+	if len(notify.calls) != 2 {
+		t.Errorf("expected 2 notifications (start + complete), got %d", len(notify.calls))
+	}
+}
+
+// ── fallback: develop without local_dir → review_only ────────────────────────
+
+func TestPipeline_DevelopFallsBackToReviewOnlyWithoutLocalDir(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(validResult)}
+	p := issues.New(s, gh, exec, &fakeBroker{}, nil)
+
+	issue := newIssue(config.IssueModeDevelop)
+	rev, err := p.Run(issue, issues.RunOptions{Primary: "claude", LocalDir: ""})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev.ActionTaken != string(config.IssueModeReviewOnly) {
+		t.Errorf("fallback should store action_taken=review_only, got %q", rev.ActionTaken)
+	}
+	if len(gh.postCalls) != 1 {
+		t.Errorf("fallback should still post a review_only comment, got %d calls", len(gh.postCalls))
+	}
+}
+
+func TestPipeline_DevelopWithLocalDirIsNotYetSupportedHere(t *testing.T) {
+	// #27 owns the auto_implement path. Until that lands, the review_only
+	// pipeline must refuse rather than silently behaving like review_only when
+	// a working tree IS available.
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{}
+	p := issues.New(s, gh, exec, nil, nil)
+
+	issue := newIssue(config.IssueModeDevelop)
+	_, err := p.Run(issue, issues.RunOptions{Primary: "claude", LocalDir: "/tmp/repo"})
+	if err == nil {
+		t.Fatal("expected error for develop+local_dir until #27 lands")
+	}
+	if !strings.Contains(err.Error(), "auto_implement") {
+		t.Errorf("error should point at auto_implement/#27, got: %v", err)
+	}
+}
+
+// ── robustness: LLM output, comments, postcomment ────────────────────────────
+
+func TestPipeline_HandlesMarkdownWrappedJSON(t *testing.T) {
+	wrapped := "```json\n" + validResult + "\n```\nextra trailing text"
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(wrapped)}
+	p := issues.New(s, gh, exec, nil, nil)
+
+	rev, err := p.Run(newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev.Summary == "" {
+		t.Errorf("summary not parsed out of wrapped JSON")
+	}
+}
+
+func TestPipeline_MissingTopSeverityFallsBackToTriage(t *testing.T) {
+	noTopSeverity := `
+	{ "summary": "x",
+	  "triage": {"severity":"medium","category":"bug","suggested_assignee":""},
+	  "suggestions": []
+	}`
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(noTopSeverity)}
+	broker := &fakeBroker{}
+	p := issues.New(s, gh, exec, broker, nil)
+
+	_, err := p.Run(newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// completion event carries severity; check it is not empty.
+	evts := broker.events
+	if len(evts) == 0 {
+		t.Fatal("no SSE events emitted")
+	}
+	last := evts[len(evts)-1]
+	if !strings.Contains(last.Data, `"severity":"medium"`) {
+		t.Errorf("completion event should carry inherited severity, got %q", last.Data)
+	}
+}
+
+func TestPipeline_PostCommentErrorDoesNotAbort(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{postErr: errors.New("rate limited")}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(validResult)}
+	broker := &fakeBroker{}
+	p := issues.New(s, gh, exec, broker, nil)
+
+	_, err := p.Run(newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude"})
+	if err != nil {
+		t.Fatalf("PostComment errors must not abort the pipeline, got: %v", err)
+	}
+	if len(s.reviews) != 1 {
+		t.Errorf("review should still be persisted locally, got %d", len(s.reviews))
+	}
+	// completion event should carry post_ok=false.
+	last := broker.events[len(broker.events)-1]
+	if !strings.Contains(last.Data, `"post_ok":false`) {
+		t.Errorf("completion event should flag post_ok=false, got %q", last.Data)
+	}
+}
+
+func TestPipeline_FetchCommentsErrorIsNonFatal(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{commentsErr: errors.New("comments API broken")}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(validResult)}
+	p := issues.New(s, gh, exec, nil, nil)
+
+	if _, err := p.Run(newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("comment fetch failure must not abort, got: %v", err)
+	}
+}
+
+// ── error paths → SSE issue_review_error ────────────────────────────────────
+
+func TestPipeline_CLIDetectFailureEmitsErrorEvent(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectErr: errors.New("no CLI available")}
+	broker := &fakeBroker{}
+	p := issues.New(s, gh, exec, broker, nil)
+
+	_, err := p.Run(newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude"})
+	if err == nil {
+		t.Fatal("expected error for CLI detect failure")
+	}
+	types := broker.types()
+	if types[len(types)-1] != sse.EventIssueReviewError {
+		t.Errorf("expected error SSE as last event, got %v", types)
+	}
+}
+
+func TestPipeline_BadJSONEmitsErrorEvent(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("not json at all")}
+	broker := &fakeBroker{}
+	p := issues.New(s, gh, exec, broker, nil)
+
+	_, err := p.Run(newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude"})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	types := broker.types()
+	if types[len(types)-1] != sse.EventIssueReviewError {
+		t.Errorf("expected issue_review_error, got %v", types)
+	}
+}
+
+func TestPipeline_NilIssueIsRejected(t *testing.T) {
+	p := issues.New(&fakeStore{}, &fakeGH{}, &fakeExec{}, nil, nil)
+	if _, err := p.Run(nil, issues.RunOptions{}); err == nil {
+		t.Fatal("expected error for nil issue")
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func stringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -247,7 +247,8 @@ func TestPipeline_DevelopFallsBackToReviewOnlyWithoutLocalDir(t *testing.T) {
 	p := issues.New(s, gh, exec, &fakeBroker{}, nil)
 
 	issue := newIssue(config.IssueModeDevelop)
-	rev, err := p.Run(issue, issues.RunOptions{Primary: "claude", LocalDir: ""})
+	// WorkDir zero → no working tree → downgrade to review_only.
+	rev, err := p.Run(issue, issues.RunOptions{Primary: "claude"})
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -256,6 +257,11 @@ func TestPipeline_DevelopFallsBackToReviewOnlyWithoutLocalDir(t *testing.T) {
 	}
 	if len(gh.postCalls) != 1 {
 		t.Errorf("fallback should still post a review_only comment, got %d calls", len(gh.postCalls))
+	}
+	// Prompt context must match the mode-selection logic: no working
+	// directory means the LLM should not be told to read a repo.
+	if strings.Contains(exec.lastPrompt, "read access to the repository") {
+		t.Errorf("prompt leaks local-dir instruction when there is no WorkDir")
 	}
 }
 
@@ -269,12 +275,65 @@ func TestPipeline_DevelopWithLocalDirIsNotYetSupportedHere(t *testing.T) {
 	p := issues.New(s, gh, exec, nil, nil)
 
 	issue := newIssue(config.IssueModeDevelop)
-	_, err := p.Run(issue, issues.RunOptions{Primary: "claude", LocalDir: "/tmp/repo"})
+	_, err := p.Run(issue, issues.RunOptions{
+		Primary:  "claude",
+		ExecOpts: executor.ExecOptions{WorkDir: "/tmp/repo"},
+	})
 	if err == nil {
 		t.Fatal("expected error for develop+local_dir until #27 lands")
 	}
 	if !strings.Contains(err.Error(), "auto_implement") {
 		t.Errorf("error should point at auto_implement/#27, got: %v", err)
+	}
+}
+
+func TestPipeline_IgnoreModeRejectedWithItsOwnError(t *testing.T) {
+	// The fetcher normally filters ignore-classified issues out, but the
+	// pipeline must surface a specific error (not the auto_implement one)
+	// if one ever sneaks in. Regression guard for Muriano's review feedback.
+	s := &fakeStore{}
+	p := issues.New(s, &fakeGH{}, &fakeExec{}, nil, nil)
+
+	issue := newIssue(config.IssueModeIgnore)
+	_, err := p.Run(issue, issues.RunOptions{Primary: "claude"})
+	if err == nil {
+		t.Fatal("expected error for ignore-classified issue")
+	}
+	if strings.Contains(err.Error(), "auto_implement") {
+		t.Errorf("ignore-classified issue should not mention auto_implement, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "ignore") {
+		t.Errorf("error should mention the ignore mode, got: %v", err)
+	}
+}
+
+func TestPipeline_StripsLeadingAtInSuggestedAssignee(t *testing.T) {
+	// If the LLM happens to include '@' in SuggestedAssignee the Markdown
+	// template must still render a single '@alice', not '@@alice'.
+	raw := `
+	{
+	  "summary": "bug",
+	  "triage": {"severity":"low","category":"bug","suggested_assignee":"@alice"},
+	  "suggestions": [],
+	  "severity": "low"
+	}`
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(raw)}
+	p := issues.New(s, gh, exec, nil, nil)
+
+	if _, err := p.Run(newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(gh.postCalls) != 1 {
+		t.Fatalf("expected 1 PostComment, got %d", len(gh.postCalls))
+	}
+	body := gh.postCalls[0].Body
+	if strings.Contains(body, "@@alice") {
+		t.Errorf("body has double @@alice: %q", body)
+	}
+	if !strings.Contains(body, "@alice") {
+		t.Errorf("body missing single @alice mention: %q", body)
 	}
 }
 

--- a/daemon/internal/issues/prompt.go
+++ b/daemon/internal/issues/prompt.go
@@ -1,0 +1,99 @@
+package issues
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/heimdallm/daemon/internal/github"
+)
+
+// maxBodyBytes bounds the issue body we send to the LLM. Long issue bodies
+// mostly contain copy-pasted stack traces or log dumps that waste tokens; the
+// first few KB carry the signal the triage actually needs.
+const maxBodyBytes = 8 * 1024
+
+// maxCommentsBytes caps the formatted comment thread so a chatty issue cannot
+// push the prompt past the CLI's context window.
+const maxCommentsBytes = 8 * 1024
+
+// PromptContext is the data the triage template substitutes into the prompt.
+type PromptContext struct {
+	Repo        string
+	Number      int
+	Title       string
+	Author      string
+	Labels      []string
+	Body        string
+	Comments    []github.Comment
+	HasLocalDir bool // when true, the LLM can read the repo for deeper context
+}
+
+// BuildPrompt formats the LLM prompt for a review_only triage run. The output
+// schema is fixed — the daemon parses it back into IssueReviewResult — so the
+// prompt ends with a strict JSON-only instruction.
+func BuildPrompt(ctx PromptContext) string {
+	var sb strings.Builder
+
+	sb.WriteString("You are Heimdallm, an engineering assistant triaging a GitHub issue.\n")
+	sb.WriteString("Read the issue below and produce a short, actionable triage report.\n\n")
+
+	sb.WriteString(fmt.Sprintf("Repository: %s\n", ctx.Repo))
+	sb.WriteString(fmt.Sprintf("Issue: #%d — %s\n", ctx.Number, ctx.Title))
+	sb.WriteString(fmt.Sprintf("Author: @%s\n", ctx.Author))
+	if len(ctx.Labels) > 0 {
+		sb.WriteString("Labels: " + strings.Join(ctx.Labels, ", ") + "\n")
+	}
+	if ctx.HasLocalDir {
+		sb.WriteString("You have read access to the repository checked out at the working directory — consult the code when it helps the triage.\n")
+	}
+	sb.WriteString("\n")
+
+	body := strings.TrimSpace(ctx.Body)
+	if body == "" {
+		body = "(empty issue body)"
+	}
+	if len(body) > maxBodyBytes {
+		body = body[:maxBodyBytes] + "\n... (truncated)"
+	}
+	sb.WriteString("<issue_body>\n")
+	sb.WriteString(body)
+	sb.WriteString("\n</issue_body>\n\n")
+
+	if comments := formatComments(ctx.Comments); comments != "" {
+		sb.WriteString(comments)
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("Return a single JSON object, and nothing else, with this exact shape:\n")
+	sb.WriteString("{\n")
+	sb.WriteString(`  "summary": "2–4 sentence recap of what the issue is actually asking for",` + "\n")
+	sb.WriteString(`  "triage": {` + "\n")
+	sb.WriteString(`    "severity": "low|medium|high|critical",` + "\n")
+	sb.WriteString(`    "category": "one of: bug, feature, question, docs, infra, other",` + "\n")
+	sb.WriteString(`    "suggested_assignee": "github-login or empty string"` + "\n")
+	sb.WriteString("  },\n")
+	sb.WriteString(`  "suggestions": ["concrete next step", "another one"],` + "\n")
+	sb.WriteString(`  "severity": "low|medium|high|critical"` + "\n")
+	sb.WriteString("}\n")
+	sb.WriteString("If unsure about a field, use a conservative default. Do not wrap the JSON in prose or code fences.\n")
+
+	return sb.String()
+}
+
+// formatComments renders the comment thread as a prompt section, trimming to
+// the configured byte cap. Empty input returns empty string so the prompt
+// does not show an empty "Existing discussion:" header.
+func formatComments(comments []github.Comment) string {
+	if len(comments) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(comments))
+	for _, c := range comments {
+		lines = append(lines, fmt.Sprintf("@%s: %s", c.Author, strings.TrimSpace(c.Body)))
+	}
+	joined := strings.Join(lines, "\n---\n")
+	if len(joined) > maxCommentsBytes {
+		joined = joined[:maxCommentsBytes] + "\n... (truncated)"
+	}
+	return "Existing discussion:\n<issue_comments>\n" + joined + "\n</issue_comments>"
+}

--- a/daemon/internal/sse/broker.go
+++ b/daemon/internal/sse/broker.go
@@ -8,6 +8,13 @@ const (
 	EventReviewStarted   = "review_started"
 	EventReviewCompleted = "review_completed"
 	EventReviewError     = "review_error"
+
+	// Issue tracking pipeline (#26 onward).
+	EventIssueDetected        = "issue_detected"
+	EventIssueReviewStarted   = "issue_review_started"
+	EventIssueReviewCompleted = "issue_review_completed"
+	EventIssueImplemented     = "issue_implemented" // reserved for #27 (auto_implement PR created)
+	EventIssueReviewError     = "issue_review_error"
 )
 
 // maxSubscribers limits the number of concurrent SSE connections to prevent


### PR DESCRIPTION
## Summary

Third step of the fase-2 issue-tracking pipeline (#26). Ships the full \`review_only\` triage flow — LLM triage → Markdown comment → store persistence → SSE events — plus the \`Fetcher\` orchestrator that walks the classified issues of a repo and dispatches them to the pipeline. Integration with the poll cycle and HTTP endpoints is intentionally **not** here; that lives in #28.

## New package: \`internal/issues\`

### \`prompt.go\`

Builds the LLM prompt for triage. Title + labels + body (capped at 8 KB) + discussion thread (capped at 8 KB) + a strict JSON schema:

\`\`\`json
{
  \"summary\": \"2–4 sentence recap\",
  \"triage\": {
    \"severity\": \"low|medium|high|critical\",
    \"category\": \"bug|feature|question|docs|infra|other\",
    \"suggested_assignee\": \"github-login or empty\"
  },
  \"suggestions\": [\"...\"],
  \"severity\": \"low|medium|high|critical\"
}
\`\`\`

The prompt advertises the working directory only when one is actually set, so the LLM is not told to read a repo it can't see.

### \`pipeline.go\`

\`Pipeline.Run(issue, opts)\` does, in order:

1. **Resolve effective mode.** If the caller passes an issue classified as \`develop\` but has **no \`local_dir\`** configured, the pipeline **downgrades to \`review_only\`** with a warning log. The persisted \`action_taken\` reflects the mode that actually ran — audits stay honest (AC from #26). A \`develop\` issue **with** a \`local_dir\` is an explicit error: that is #27's job and must not silently behave like \`review_only\` when a working tree is available.
2. **UpsertIssue** (the dismissed flag survives upserts thanks to #24's contract).
3. SSE \`issue_detected\` → \`issue_review_started\`.
4. Best-effort \`FetchComments\` for extra context (failure is logged and we proceed).
5. Detect CLI → \`ExecuteRaw\` → \`StripToJSON\` → \`IssueReviewResult\`.
6. Build the Markdown comment and \`PostComment\`. **\`PostComment\` failure is non-fatal:** the review is persisted locally and the completion event carries \`post_ok=false\` so operators can re-drive the comment manually.
7. Persist the \`IssueReview\` (JSON-encoded triage + suggestions) and emit \`issue_review_completed\` — or \`issue_review_error\` on the error paths.

### \`fetcher.go\`

\`Fetcher.ProcessRepo(repo, cfg, authUser, optsFor)\`:

- **No-op** when \`cfg.Enabled = false\`, so callers don't have to guard.
- Fetches via \`*github.Client.FetchIssues\` (from #25).
- **Skips dismissed** issues and **issues already reviewed without new activity** (30 s grace, same value the PR pipeline uses).
- Dispatches the rest to the pipeline, resolving per-issue \`RunOptions\` through the \`OptionsFn\` callback — main.go in #28 will plug per-repo AI config here.
- **Per-issue failures are logged, not propagated** — one flaky issue doesn't abort the run.

All dependencies are small interfaces; tests inject fakes without touching SQLite or the network.

## Ancillary changes

- **\`executor.ExecuteRaw(cli, prompt, opts) ([]byte, error)\`** — returns stdout unchanged, so pipelines with a different schema (issues here, \`auto_implement\` in #27) don't have to re-implement subprocess plumbing. \`Execute\` is refactored to compose \`ExecuteRaw\` + \`parseResult\`; existing callers are unaffected.
- **\`executor.StripToJSON\`** — exported helper that peels markdown code fences and prose around a JSON object. Reused by the issue pipeline's parser.
- **\`sse\` new events**: \`issue_detected\`, \`issue_review_started\`, \`issue_review_completed\`, \`issue_implemented\` (reserved for #27), \`issue_review_error\`.

## What's out (handled in downstream issues)

- Integration with the poll cycle, HTTP endpoints for issues, reload-aware wiring → **#28**.
- \`auto_implement\` mode (branch + PR creation) → **#27**.
- UI (Flutter / web) → **#29 / #31 / #32 / #33**.
- No changes to \`main.go\`.

## Tests

All run in the Docker sandbox (\`make test-docker\`, mandatory on EDR-protected laptops).

### \`pipeline_test.go\`

- Happy path: upsert, JSON-encoded labels / assignees, single comment posted, review persisted with \`action_taken=review_only\`, SSE sequence \`detected → started → completed\`, notifier invoked twice.
- \`develop\` without \`local_dir\` → falls back to \`review_only\`, review still posted, \`action_taken\` correct.
- \`develop\` with \`local_dir\` → explicit error pointing at #27.
- Markdown-wrapped JSON output handled correctly.
- Missing top-level \`severity\` falls back to \`triage.severity\` in the completion event.
- \`PostComment\` rate limit → pipeline succeeds, review persisted, \`post_ok=false\` in the event.
- \`FetchComments\` failure → pipeline still runs (best-effort).
- CLI detect failure → \`issue_review_error\` emitted.
- Bad JSON → \`issue_review_error\` emitted.
- Nil issue → rejected.

### \`fetcher_test.go\`

- Disabled = no-op.
- Nil \`OptionsFn\` → rejected.
- Fetch error surfaces.
- Unseen issues dispatched.
- Dismissed rows skipped.
- Recently reviewed rows within the 30 s grace → skipped.
- New activity past grace → re-run.
- Known-but-never-reviewed rows → run.
- Pipeline errors logged and counted but never abort the loop.
- Flaky store errors treated as \"not yet processed\" so the pipeline isn't blocked on transient DB issues.

### Docker sandbox suite

\`\`\`
ok  github.com/heimdallm/daemon/internal/config
ok  github.com/heimdallm/daemon/internal/discovery
ok  github.com/heimdallm/daemon/internal/executor
ok  github.com/heimdallm/daemon/internal/github
ok  github.com/heimdallm/daemon/internal/issues
ok  github.com/heimdallm/daemon/internal/pipeline
ok  github.com/heimdallm/daemon/internal/scheduler
ok  github.com/heimdallm/daemon/internal/server
ok  github.com/heimdallm/daemon/internal/sse
ok  github.com/heimdallm/daemon/internal/store
\`\`\`

## Test plan

- [ ] CI green on GitHub Actions.
- [ ] Manual: stub a repo, set the issue-tracking env vars (see \`docker/.env.example\`), enable the pipeline, and verify a tagged \`question\` issue gets a comment posted within one cycle.
- [ ] Manual: label a monitored issue \`wontfix\`, confirm no comment appears (skip-labels precedence).
- [ ] Manual: dismiss an issue via the store and confirm subsequent cycles skip it silently.

Closes #26