### PR TITLE
fix(discovery): add non_monitored blacklist, org inference, and count drop warning

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -195,7 +195,7 @@ func main() {
 			static := c.GitHub.Repositories
 			cfgMu.Unlock()
 			// Merge static list with repos discovered via topic tag (empty when disabled).
-			repos := discovery.MergeRepos(static, discoverySvc.Discovered())
+			repos := discovery.MergeRepos(static, discoverySvc.Discovered(), c.GitHub.NonMonitored)
 
 			// Fetch all review-requested PRs without a repo filter — adding many
 			// repo: terms to the Search API query can exceed its length limit and
@@ -267,6 +267,9 @@ func main() {
 		ctx, cancel := context.WithCancel(context.Background())
 		topic := c.GitHub.DiscoveryTopic
 		orgs := append([]string(nil), c.GitHub.DiscoveryOrgs...)
+		if len(orgs) == 0 {
+			orgs = discovery.InferOrgs(c.GitHub.Repositories)
+		}
 		go discoverySvc.Run(ctx, interval, topic, orgs)
 		slog.Info("discovery: loop started", "topic", topic, "orgs", orgs, "interval", interval)
 		return cancel

--- a/daemon/internal/discovery/discovery.go
+++ b/daemon/internal/discovery/discovery.go
@@ -11,6 +11,8 @@ package discovery
 import (
 	"context"
 	"log/slog"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -27,10 +29,11 @@ type ReposFetcher interface {
 type Service struct {
 	fetcher ReposFetcher
 
-	mu      sync.RWMutex
-	cache   []string
-	lastErr error
-	lastAt  time.Time
+	mu        sync.RWMutex
+	cache     []string
+	lastErr   error
+	lastAt    time.Time
+	lastCount int
 }
 
 // NewService wires a fetcher into a discovery service.
@@ -75,7 +78,13 @@ func (s *Service) Refresh(topic string, orgs []string) error {
 	// previous list; a partial outage returns (some, err) and we update with
 	// what we have.
 	if len(repos) > 0 {
+		prev := s.lastCount
 		s.cache = repos
+		s.lastCount = len(repos)
+		if prev > 0 && len(repos) < prev {
+			slog.Warn("discovery: repo count decreased",
+				"previous", prev, "current", len(repos))
+		}
 	} else if err != nil {
 		slog.Warn("discovery: refresh failed, keeping previous cache",
 			"cached", len(s.cache), "err", err)
@@ -118,14 +127,24 @@ func (s *Service) Run(ctx context.Context, interval time.Duration, topic string,
 // MergeRepos returns the union of static and discovered repositories,
 // preserving the order of static entries (stable for config-driven overrides)
 // and appending discovered entries that are not already present.
-func MergeRepos(static, discovered []string) []string {
+// Repos listed in nonMonitored are excluded unconditionally (absolute blacklist).
+func MergeRepos(static, discovered, nonMonitored []string) []string {
 	if len(static) == 0 && len(discovered) == 0 {
 		return nil
+	}
+	blacklist := make(map[string]struct{}, len(nonMonitored))
+	for _, r := range nonMonitored {
+		if r != "" {
+			blacklist[r] = struct{}{}
+		}
 	}
 	seen := make(map[string]struct{}, len(static)+len(discovered))
 	out := make([]string, 0, len(static)+len(discovered))
 	for _, r := range static {
 		if r == "" {
+			continue
+		}
+		if _, blocked := blacklist[r]; blocked {
 			continue
 		}
 		if _, dup := seen[r]; dup {
@@ -138,11 +157,34 @@ func MergeRepos(static, discovered []string) []string {
 		if r == "" {
 			continue
 		}
+		if _, blocked := blacklist[r]; blocked {
+			continue
+		}
 		if _, dup := seen[r]; dup {
 			continue
 		}
 		seen[r] = struct{}{}
 		out = append(out, r)
 	}
+	if len(out) == 0 {
+		return nil
+	}
 	return out
+}
+
+// InferOrgs extracts unique organization prefixes from "org/repo" strings.
+// Returns sorted, deduplicated org names. Used when discovery_orgs is empty.
+func InferOrgs(repos []string) []string {
+	set := make(map[string]struct{})
+	for _, r := range repos {
+		if idx := strings.IndexByte(r, '/'); idx > 0 {
+			set[r[:idx]] = struct{}{}
+		}
+	}
+	orgs := make([]string, 0, len(set))
+	for o := range set {
+		orgs = append(orgs, o)
+	}
+	sort.Strings(orgs)
+	return orgs
 }

--- a/daemon/internal/discovery/discovery_test.go
+++ b/daemon/internal/discovery/discovery_test.go
@@ -45,6 +45,7 @@ func TestMergeRepos_PreservesStaticOrderAndDeduplicates(t *testing.T) {
 	out := discovery.MergeRepos(
 		[]string{"org/static1", "org/shared"},
 		[]string{"org/shared", "org/discovered1", "org/discovered2"},
+		nil,
 	)
 	want := []string{"org/static1", "org/shared", "org/discovered1", "org/discovered2"}
 	if len(out) != len(want) {
@@ -58,29 +59,65 @@ func TestMergeRepos_PreservesStaticOrderAndDeduplicates(t *testing.T) {
 }
 
 func TestMergeRepos_BothEmpty(t *testing.T) {
-	if got := discovery.MergeRepos(nil, nil); got != nil {
-		t.Errorf("MergeRepos(nil, nil) = %v, want nil", got)
+	if got := discovery.MergeRepos(nil, nil, nil); got != nil {
+		t.Errorf("MergeRepos(nil, nil, nil) = %v, want nil", got)
 	}
 }
 
 func TestMergeRepos_OnlyStatic(t *testing.T) {
-	got := discovery.MergeRepos([]string{"a", "b"}, nil)
+	got := discovery.MergeRepos([]string{"a", "b"}, nil, nil)
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
 		t.Errorf("got %v", got)
 	}
 }
 
 func TestMergeRepos_OnlyDiscovered(t *testing.T) {
-	got := discovery.MergeRepos(nil, []string{"a", "b"})
+	got := discovery.MergeRepos(nil, []string{"a", "b"}, nil)
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
 		t.Errorf("got %v", got)
 	}
 }
 
 func TestMergeRepos_IgnoresEmptyStrings(t *testing.T) {
-	got := discovery.MergeRepos([]string{"", "a", ""}, []string{"", "b"})
+	got := discovery.MergeRepos([]string{"", "a", ""}, []string{"", "b"}, nil)
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
 		t.Errorf("got %v", got)
+	}
+}
+
+func TestMergeRepos_NonMonitored(t *testing.T) {
+	got := discovery.MergeRepos(
+		[]string{"org/static1", "org/blocked"},
+		[]string{"org/discovered1", "org/blocked2"},
+		[]string{"org/blocked", "org/blocked2"},
+	)
+	want := []string{"org/static1", "org/discovered1"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// ── InferOrgs ───────────────────────────────────────────────────────────────
+
+func TestInferOrgs(t *testing.T) {
+	got := discovery.InferOrgs([]string{
+		"freepik-company/repo-a",
+		"theburrowhub/repo-b",
+		"freepik-company/repo-c",
+	})
+	want := []string{"freepik-company", "theburrowhub"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }
 


### PR DESCRIPTION
Refs #39

## Summary

Addresses 3 gaps in the discovery implementation (merged via #41) that were identified during parallel development:

1. **`non_monitored` as absolute blacklist** — `MergeRepos` now accepts a `nonMonitored` parameter. Repos in this list are excluded from the final set regardless of whether they come from static config or topic discovery.

2. **Org inference from static repos** — New `InferOrgs()` function extracts org prefixes from `HEIMDALLM_REPOSITORIES` when `discovery_orgs` is empty. Reduces configuration friction.

3. **Count drop warning** — `Refresh()` now logs a warning when the number of discovered repos decreases between cycles, helping detect repos that silently lost their topic tag.

## Changes

- `daemon/internal/discovery/discovery.go` — `MergeRepos` gains `nonMonitored` param; new `InferOrgs` function; `lastCount` tracking in `Refresh`
- `daemon/internal/discovery/discovery_test.go` — `TestMergeRepos_NonMonitored`, `TestInferOrgs`; all existing calls updated
- `daemon/cmd/heimdallm/main.go` — Passes `c.GitHub.NonMonitored` to `MergeRepos`; uses `InferOrgs` fallback in `startDiscovery`

## Test plan

- [ ] `go test ./internal/discovery/ -v` — all tests pass including 2 new
- [ ] `go test ./... -timeout 60s` — no regressions
- [ ] Without `non_monitored` set: behavior unchanged (nil passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)