### PR TITLE
feat(web_ui): scaffold SvelteKit + API/SSE clients (#30)

### DIFF
--- a/docs/superpowers/plans/2026-04-17-web-ui-routes.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-routes.md
@@ -1,0 +1,2398 @@
+# Web UI Routes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the five SvelteKit routes specified in issue #31 (`/`, `/prs`, `/prs/{id}`, `/issues`, `/issues/{id}`) on top of the #30 scaffold, plus the Fase-2 type-parity fixes inherited from PR #60.
+
+**Architecture:** All routes are client-rendered on top of the scaffold's SvelteKit + Svelte 5 runes + Tailwind + typed API client. SSE events drive refresh-counter stores that re-run `$effect`-based fetchers. Shared tiles, badges, and filter UI live in `src/lib/components/`. URL query params hold filter state for shareability.
+
+**Tech Stack:** SvelteKit 2, Svelte 5 (runes), TypeScript, TailwindCSS 4, vitest + jsdom (unit tests), adapter-node (prod). Node 22 LTS.
+
+**Design spec:** `docs/superpowers/specs/2026-04-17-web-ui-routes-design.md`
+**Depends on:** PR #60 (`feat/web-ui-scaffold`, open at time of writing)
+
+---
+
+## Task 0: Branch setup
+
+**Files:**
+- No file changes; environment setup only
+
+- [ ] **Step 1: Fetch and verify scaffold branch**
+
+```bash
+cd /home/vbueno/Desarrollo/workspaces/heimdallm-002
+git fetch origin feat/web-ui-scaffold
+git log origin/feat/web-ui-scaffold --oneline -5
+```
+
+Expected: a list of `feat(web_ui): ...` commits ending with `09604c4 fix(web_ui): share single SSE connection via layout context`.
+
+- [ ] **Step 2: Create the stacked branch**
+
+```bash
+git checkout -b feat/web-ui-routes origin/feat/web-ui-scaffold
+```
+
+Expected: `Switched to a new branch 'feat/web-ui-routes'`. Working tree now contains `web_ui/`.
+
+- [ ] **Step 3: Install dependencies**
+
+```bash
+cd web_ui && npm ci
+```
+
+Expected: install completes without errors. Node version ≥ 22 (check with `node --version` if it fails).
+
+- [ ] **Step 4: Verify scaffold is green before we change anything**
+
+```bash
+cd web_ui
+npm run check
+npm test
+npm run lint
+npm run build
+```
+
+Expected: all four pass (scaffold baseline: 0 check errors, 15 tests passing, lint clean, `build/` generated).
+
+If anything fails at this step, stop and fix the scaffold before proceeding — you do not want to debug scaffold regressions while implementing routes.
+
+- [ ] **Step 5: Commit checkpoint (branch exists, nothing else changed)**
+
+Nothing to commit yet — this is a read-only verification task. Move to Task 1.
+
+---
+
+## Task 1: Expand SseEventType union in types.ts
+
+**Files:**
+- Modify: `web_ui/src/lib/types.ts` (the `SseEventType` line)
+
+- [ ] **Step 1: Open types.ts and locate the SSE event type union**
+
+Read `web_ui/src/lib/types.ts`. Find:
+
+```ts
+export type SseEventType = 'pr_detected' | 'review_started' | 'review_completed' | 'review_error';
+```
+
+- [ ] **Step 2: Replace with the full union**
+
+```ts
+// SSE event types emitted by the daemon's sse.Broker. Must match the
+// constants in daemon/internal/sse/broker.go exactly or listeners in
+// sse.ts won't fire.
+export type SseEventType =
+  | 'pr_detected'
+  | 'review_started'
+  | 'review_completed'
+  | 'review_error'
+  | 'issue_detected'
+  | 'issue_review_started'
+  | 'issue_review_completed'
+  | 'issue_review_error';
+```
+
+- [ ] **Step 3: Run the type-checker**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors. No downstream code references these names yet, so adding them is safe.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/lib/types.ts
+git commit -m "feat(web_ui): add issue SSE event types"
+```
+
+---
+
+## Task 2: Register issue events in sse.ts
+
+**Files:**
+- Modify: `web_ui/src/lib/sse.ts:4-9` (the `KNOWN_EVENT_TYPES` constant)
+- Test: `web_ui/src/tests/sse.test.ts`
+
+- [ ] **Step 1: Write failing tests first**
+
+Append to `web_ui/src/tests/sse.test.ts` inside the existing `describe('connectEvents', () => { ... })` block (before the final closing brace of the describe):
+
+```ts
+it('parses and emits issue_detected events', () => {
+  const { events } = connectEvents();
+  MockEventSource.instances[0].fireOpen();
+  MockEventSource.instances[0].emit('issue_detected', JSON.stringify({ issue_id: 42 }));
+  const last = get(events);
+  expect(last).toEqual({ type: 'issue_detected', data: { issue_id: 42 } });
+});
+
+it('parses and emits issue_review_started events', () => {
+  const { events } = connectEvents();
+  MockEventSource.instances[0].fireOpen();
+  MockEventSource.instances[0].emit('issue_review_started', JSON.stringify({ issue_id: 7 }));
+  expect(get(events)).toEqual({ type: 'issue_review_started', data: { issue_id: 7 } });
+});
+
+it('parses and emits issue_review_completed events', () => {
+  const { events } = connectEvents();
+  MockEventSource.instances[0].fireOpen();
+  MockEventSource.instances[0].emit('issue_review_completed', JSON.stringify({ issue_id: 7 }));
+  expect(get(events)).toEqual({ type: 'issue_review_completed', data: { issue_id: 7 } });
+});
+
+it('parses and emits issue_review_error events', () => {
+  const { events } = connectEvents();
+  MockEventSource.instances[0].fireOpen();
+  MockEventSource.instances[0].emit('issue_review_error', JSON.stringify({ issue_id: 7, error: 'nope' }));
+  expect(get(events)).toEqual({ type: 'issue_review_error', data: { issue_id: 7, error: 'nope' } });
+});
+```
+
+- [ ] **Step 2: Run tests — expect the 4 new ones to fail**
+
+```bash
+cd web_ui && npx vitest run src/tests/sse.test.ts
+```
+
+Expected: 4 new tests fail (events never emit because `KNOWN_EVENT_TYPES` doesn't include them). Scaffold's existing sse tests still pass.
+
+- [ ] **Step 3: Update `KNOWN_EVENT_TYPES` in sse.ts**
+
+Edit `web_ui/src/lib/sse.ts`. Replace:
+
+```ts
+const KNOWN_EVENT_TYPES: SseEventType[] = [
+  'pr_detected',
+  'review_started',
+  'review_completed',
+  'review_error'
+];
+```
+
+with:
+
+```ts
+const KNOWN_EVENT_TYPES: SseEventType[] = [
+  'pr_detected',
+  'review_started',
+  'review_completed',
+  'review_error',
+  'issue_detected',
+  'issue_review_started',
+  'issue_review_completed',
+  'issue_review_error'
+];
+```
+
+- [ ] **Step 4: Run tests — expect all to pass**
+
+```bash
+cd web_ui && npx vitest run src/tests/sse.test.ts
+```
+
+Expected: all passing (scaffold 4 + new 4 = 8).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web_ui/src/lib/sse.ts web_ui/src/tests/sse.test.ts
+git commit -m "feat(web_ui): register issue SSE events in KNOWN_EVENT_TYPES"
+```
+
+---
+
+## Task 3: Add `parseIssue` for wire-format unwrapping
+
+**Files:**
+- Modify: `web_ui/src/lib/api.ts` (add helper; apply in `fetchIssues`, `fetchIssue`)
+- Test: `web_ui/src/tests/api.test.ts`
+
+**Context:** The daemon's `store.Issue` persists `assignees` and `labels` as JSON strings. The issue-tracking-UI spec (`docs/superpowers/specs/2026-04-17-issue-tracking-ui-design.md` §2.4) states the daemon handler unwraps them before serializing. We add a client-side `parseIssue` that is **tolerant of both** shapes (string or array) so a daemon that hasn't unwrapped yet still works, and so array-shaped responses are passed through untouched.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `web_ui/src/tests/api.test.ts` inside the existing `describe('api.ts', () => { ... })` block:
+
+```ts
+it('fetchIssues unwraps JSON-string assignees and labels', async () => {
+  fetchMock.mockResolvedValue(
+    okJson([
+      {
+        id: 1,
+        github_id: 100,
+        repo: 'o/r',
+        number: 1,
+        title: 't',
+        body: 'b',
+        author: 'a',
+        assignees: '["alice","bob"]',
+        labels: '["bug","auto_implement"]',
+        state: 'open',
+        created_at: '2026-04-17T00:00:00Z',
+        fetched_at: '2026-04-17T00:00:01Z',
+        dismissed: false
+      }
+    ])
+  );
+  const issues = await fetchIssues();
+  expect(issues[0].assignees).toEqual(['alice', 'bob']);
+  expect(issues[0].labels).toEqual(['bug', 'auto_implement']);
+});
+
+it('fetchIssues passes through already-array assignees and labels', async () => {
+  fetchMock.mockResolvedValue(
+    okJson([
+      {
+        id: 1,
+        assignees: ['alice'],
+        labels: ['bug'],
+        // remaining fields elided — parseIssue must not fail on partial input
+      }
+    ])
+  );
+  const issues = await fetchIssues();
+  expect(issues[0].assignees).toEqual(['alice']);
+  expect(issues[0].labels).toEqual(['bug']);
+});
+
+it('fetchIssue unwraps the same fields on the nested issue and its latest_review', async () => {
+  fetchMock.mockResolvedValue(
+    okJson({
+      issue: {
+        id: 1,
+        assignees: '[]',
+        labels: '["review_only"]',
+        latest_review: {
+          id: 9,
+          issue_id: 1,
+          triage: '{"severity":"high"}',
+          suggestions: '["do the thing"]'
+        }
+      },
+      reviews: [
+        {
+          id: 9,
+          issue_id: 1,
+          triage: '{"severity":"high"}',
+          suggestions: '["do the thing"]'
+        }
+      ]
+    })
+  );
+  const detail = await fetchIssue(1);
+  expect(detail.issue.assignees).toEqual([]);
+  expect(detail.issue.labels).toEqual(['review_only']);
+  expect(detail.reviews[0].triage).toEqual({ severity: 'high' });
+  expect(detail.reviews[0].suggestions).toEqual(['do the thing']);
+});
+```
+
+Also, at the top of `api.test.ts` extend the import line to include the issue fetchers:
+
+```ts
+import { ApiError, fetchIssue, fetchIssues, fetchPR, fetchPRs, fetchStats, triggerReview, upsertAgent } from '../lib/api.js';
+```
+
+- [ ] **Step 2: Run tests — expect the 3 new ones to fail**
+
+```bash
+cd web_ui && npx vitest run src/tests/api.test.ts
+```
+
+Expected: 3 new tests fail (fields remain as strings or objects).
+
+- [ ] **Step 3: Add `parseIssue` and `parseIssueReview` helpers in api.ts**
+
+In `web_ui/src/lib/api.ts`, just after the existing `parsePR` function, add:
+
+```ts
+// The daemon's issue review stores `triage` and `suggestions` as JSON-encoded
+// strings; the issue itself stores `assignees` and `labels` the same way.
+// Handlers may or may not unwrap them depending on version. These helpers
+// accept both shapes (string or already-parsed) so callers always receive
+// typed values.
+
+function parseMaybeJson<T>(raw: unknown, fallback: T): T {
+  if (typeof raw === 'string') {
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  }
+  if (raw == null) return fallback;
+  return raw as T;
+}
+
+function parseIssueReview(raw: unknown): IssueReview {
+  const r = { ...(raw as Record<string, unknown>) };
+  r.triage = parseMaybeJson(r.triage, {});
+  r.suggestions = parseMaybeJson(r.suggestions, []);
+  return r as unknown as IssueReview;
+}
+
+function parseIssue(raw: unknown): Issue {
+  const i = { ...(raw as Record<string, unknown>) };
+  i.assignees = parseMaybeJson<string[]>(i.assignees, []);
+  i.labels = parseMaybeJson<string[]>(i.labels, []);
+  if (i.latest_review) i.latest_review = parseIssueReview(i.latest_review);
+  return i as unknown as Issue;
+}
+```
+
+- [ ] **Step 4: Apply in `fetchIssues` and `fetchIssue`**
+
+Replace:
+
+```ts
+export function fetchIssues(): Promise<Issue[]> {
+  return request<Issue[]>('GET', '/api/issues');
+}
+
+export function fetchIssue(id: number): Promise<IssueDetail> {
+  return request<IssueDetail>('GET', `/api/issues/${id}`);
+}
+```
+
+with:
+
+```ts
+export async function fetchIssues(): Promise<Issue[]> {
+  const raws = await request<unknown[]>('GET', '/api/issues');
+  return raws.map(parseIssue);
+}
+
+export async function fetchIssue(id: number): Promise<IssueDetail> {
+  const raw = await request<{ issue: unknown; reviews?: unknown[] }>('GET', `/api/issues/${id}`);
+  return {
+    issue: parseIssue(raw.issue),
+    reviews: (raw.reviews ?? []).map(parseIssueReview)
+  };
+}
+```
+
+- [ ] **Step 5: Run tests — expect all to pass**
+
+```bash
+cd web_ui && npx vitest run src/tests/api.test.ts
+```
+
+Expected: all passing (scaffold 6 + new 3 = 9).
+
+- [ ] **Step 6: Run the full type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web_ui/src/lib/api.ts web_ui/src/tests/api.test.ts
+git commit -m "feat(web_ui): parse issue wire-format JSON strings client-side"
+```
+
+---
+
+## Task 4: Extend stores.ts with refresh counters and reviewing sets
+
+**Files:**
+- Modify: `web_ui/src/lib/stores.ts`
+
+- [ ] **Step 1: Append to stores.ts**
+
+Append to `web_ui/src/lib/stores.ts`:
+
+```ts
+// Refresh counters — incrementing these forces list fetchers to re-run.
+// Used by the SSE bridge (see sseBridge.ts) and by any page that needs
+// to invalidate after a mutation.
+export const prListRefresh = writable(0);
+export const issueListRefresh = writable(0);
+
+// In-flight review trackers. A PR id is present while a review is
+// running, so tiles and buttons can show a spinner.
+export const reviewingPRs = writable<Set<number>>(new Set());
+export const reviewingIssues = writable<Set<number>>(new Set());
+```
+
+- [ ] **Step 2: Run type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web_ui/src/lib/stores.ts
+git commit -m "feat(web_ui): add refresh counters and reviewing sets"
+```
+
+---
+
+## Task 5: Create `sseBridge.ts` with TDD
+
+**Files:**
+- Create: `web_ui/src/lib/sseBridge.ts`
+- Test: `web_ui/src/tests/stores.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `web_ui/src/tests/stores.test.ts`:
+
+```ts
+import { get, writable } from 'svelte/store';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  issueListRefresh,
+  prListRefresh,
+  reviewingIssues,
+  reviewingPRs
+} from '../lib/stores.js';
+import { initSseBridge } from '../lib/sseBridge.js';
+import type { SseEvent } from '../lib/types.js';
+
+function makeEvents() {
+  return writable<SseEvent | null>(null);
+}
+
+beforeEach(() => {
+  prListRefresh.set(0);
+  issueListRefresh.set(0);
+  reviewingPRs.set(new Set());
+  reviewingIssues.set(new Set());
+});
+
+describe('initSseBridge', () => {
+  it('increments prListRefresh on pr_detected', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set({ type: 'pr_detected', data: {} });
+    expect(get(prListRefresh)).toBe(1);
+  });
+
+  it('adds pr_id to reviewingPRs on review_started', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set({ type: 'review_started', data: { pr_id: 42 } });
+    expect(get(reviewingPRs).has(42)).toBe(true);
+  });
+
+  it('removes pr_id and bumps prListRefresh on review_completed', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set({ type: 'review_started', data: { pr_id: 42 } });
+    events.set({ type: 'review_completed', data: { pr_id: 42 } });
+    expect(get(reviewingPRs).has(42)).toBe(false);
+    expect(get(prListRefresh)).toBe(1);
+  });
+
+  it('removes pr_id without bumping on review_error', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set({ type: 'review_started', data: { pr_id: 42 } });
+    events.set({ type: 'review_error', data: { pr_id: 42 } });
+    expect(get(reviewingPRs).has(42)).toBe(false);
+    expect(get(prListRefresh)).toBe(0);
+  });
+
+  it('handles all four issue review events symmetrically', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set({ type: 'issue_detected', data: {} });
+    expect(get(issueListRefresh)).toBe(1);
+
+    events.set({ type: 'issue_review_started', data: { issue_id: 7 } });
+    expect(get(reviewingIssues).has(7)).toBe(true);
+
+    events.set({ type: 'issue_review_completed', data: { issue_id: 7 } });
+    expect(get(reviewingIssues).has(7)).toBe(false);
+    expect(get(issueListRefresh)).toBe(2);
+
+    events.set({ type: 'issue_review_started', data: { issue_id: 8 } });
+    events.set({ type: 'issue_review_error', data: { issue_id: 8 } });
+    expect(get(reviewingIssues).has(8)).toBe(false);
+  });
+
+  it('bumps both refresh counters and clears reviewingIssues on issue_implemented', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+
+    // Simulate the auto_implement sequence: started → implemented (no
+    // review_completed in between — that's the daemon's actual behavior).
+    events.set({ type: 'issue_review_started', data: { issue_id: 7 } });
+    expect(get(reviewingIssues).has(7)).toBe(true);
+
+    events.set({
+      type: 'issue_implemented',
+      data: { issue_id: 7, number: 42, repo: 'o/r', pr_created: 99, branch: 'auto/fix-42' }
+    });
+    expect(get(reviewingIssues).has(7)).toBe(false);
+    expect(get(issueListRefresh)).toBe(1);
+    expect(get(prListRefresh)).toBe(1);
+  });
+
+  it('ignores a null event (no crash, no state change)', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set(null);
+    expect(get(prListRefresh)).toBe(0);
+    expect(get(issueListRefresh)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect import to fail**
+
+```bash
+cd web_ui && npx vitest run src/tests/stores.test.ts
+```
+
+Expected: failure on import of `sseBridge.js` (file does not exist).
+
+- [ ] **Step 3: Create `sseBridge.ts`**
+
+Create `web_ui/src/lib/sseBridge.ts`:
+
+```ts
+import type { Readable } from 'svelte/store';
+import {
+  issueListRefresh,
+  prListRefresh,
+  reviewingIssues,
+  reviewingPRs
+} from './stores.js';
+import type { SseEvent } from './types.js';
+
+function withSet(
+  store: typeof reviewingPRs,
+  mutate: (s: Set<number>) => void
+): void {
+  store.update((s) => {
+    const next = new Set(s);
+    mutate(next);
+    return next;
+  });
+}
+
+export function initSseBridge(events: Readable<SseEvent | null>): () => void {
+  return events.subscribe((e) => {
+    if (!e) return;
+    const data = (e.data ?? {}) as { pr_id?: number; issue_id?: number };
+    switch (e.type) {
+      case 'pr_detected':
+        prListRefresh.update((n) => n + 1);
+        break;
+      case 'review_started':
+        if (typeof data.pr_id === 'number') withSet(reviewingPRs, (s) => s.add(data.pr_id!));
+        break;
+      case 'review_completed':
+        if (typeof data.pr_id === 'number') withSet(reviewingPRs, (s) => s.delete(data.pr_id!));
+        prListRefresh.update((n) => n + 1);
+        break;
+      case 'review_error':
+        if (typeof data.pr_id === 'number') withSet(reviewingPRs, (s) => s.delete(data.pr_id!));
+        break;
+      case 'issue_detected':
+        issueListRefresh.update((n) => n + 1);
+        break;
+      case 'issue_review_started':
+        if (typeof data.issue_id === 'number') withSet(reviewingIssues, (s) => s.add(data.issue_id!));
+        break;
+      case 'issue_review_completed':
+        if (typeof data.issue_id === 'number') withSet(reviewingIssues, (s) => s.delete(data.issue_id!));
+        issueListRefresh.update((n) => n + 1);
+        break;
+      case 'issue_review_error':
+        if (typeof data.issue_id === 'number') withSet(reviewingIssues, (s) => s.delete(data.issue_id!));
+        break;
+      case 'issue_implemented':
+        // New issue→PR link. The daemon emits this instead of
+        // `issue_review_completed` for the auto_implement success path, so
+        // we must also clear the in-flight marker or the tile's
+        // "reviewing…" chip would never go away.
+        if (typeof data.issue_id === 'number')
+          withSet(reviewingIssues, (s) => s.delete(data.issue_id!));
+        issueListRefresh.update((n) => n + 1);
+        prListRefresh.update((n) => n + 1);
+        break;
+    }
+  });
+}
+```
+
+> **Note on scaffold evolution:** The design spec originally listed 8 SSE event types. After the design was written, the scaffold's commit `147e992` added a 9th event `issue_implemented` (emitted when `auto_implement` creates a PR, payload `{issue_id, number, repo, pr_created, branch}`). The bridge handles it by bumping both refresh counters AND clearing the in-flight `reviewingIssues` marker, because the auto_implement success path emits `issue_implemented` instead of `issue_review_completed` — so without the explicit clear, the tile's "reviewing…" spinner would never disappear.
+
+- [ ] **Step 4: Run tests — expect all to pass**
+
+```bash
+cd web_ui && npx vitest run src/tests/stores.test.ts
+```
+
+Expected: 6 tests passing.
+
+- [ ] **Step 5: Run full type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web_ui/src/lib/sseBridge.ts web_ui/src/tests/stores.test.ts
+git commit -m "feat(web_ui): SSE bridge translates daemon events to store effects"
+```
+
+---
+
+## Task 6: Wire `initSseBridge` into the layout
+
+**Files:**
+- Modify: `web_ui/src/routes/+layout.svelte`
+
+- [ ] **Step 1: Add the import and call**
+
+In `web_ui/src/routes/+layout.svelte`, locate the existing `<script>` imports and the `onMount` block.
+
+Add to the imports:
+
+```ts
+import { initSseBridge } from '$lib/sseBridge.js';
+```
+
+Inside `onMount`, add a local unsubscriber after the existing `connUnsub` line and before the closing brace:
+
+```ts
+let bridgeUnsub: (() => void) | undefined;
+
+onMount(() => {
+  if (!browser) return;
+  sse = connectEvents();
+  connUnsub = sse.connected.subscribe((v) => connected.set(v));
+  bridgeUnsub = initSseBridge(sse.events);
+});
+```
+
+Also update `onDestroy`:
+
+```ts
+onDestroy(() => {
+  bridgeUnsub?.();
+  connUnsub?.();
+  sse?.close();
+});
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Smoke test the dev server**
+
+```bash
+cd web_ui && npm run dev
+```
+
+Open `http://localhost:5173`. Expected: page renders (stats cards may 502 without daemon — OK). No JS errors in browser console.
+
+Stop the dev server (`Ctrl-C`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/routes/+layout.svelte
+git commit -m "feat(web_ui): wire SSE bridge into layout"
+```
+
+---
+
+## Task 7: `severity.ts` utility module
+
+**Files:**
+- Create: `web_ui/src/lib/severity.ts`
+- Test: `web_ui/src/tests/severity.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `web_ui/src/tests/severity.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { severityClass, severityOrder } from '../lib/severity.js';
+
+describe('severityClass', () => {
+  it('returns red classes for critical', () => {
+    expect(severityClass('critical')).toBe('bg-red-100 text-red-700');
+  });
+  it('returns orange classes for high', () => {
+    expect(severityClass('high')).toBe('bg-orange-100 text-orange-700');
+  });
+  it('returns amber classes for medium', () => {
+    expect(severityClass('medium')).toBe('bg-amber-100 text-amber-700');
+  });
+  it('returns gray classes for low and for unknown', () => {
+    expect(severityClass('low')).toBe('bg-gray-100 text-gray-600');
+    expect(severityClass('whatever')).toBe('bg-gray-100 text-gray-600');
+    expect(severityClass('')).toBe('bg-gray-100 text-gray-600');
+  });
+  it('is case-insensitive', () => {
+    expect(severityClass('HIGH')).toBe('bg-orange-100 text-orange-700');
+    expect(severityClass('Critical')).toBe('bg-red-100 text-red-700');
+  });
+});
+
+describe('severityOrder', () => {
+  it('ranks critical highest, unknown lowest', () => {
+    const sorted = ['low', 'critical', 'medium', 'unknown', 'high'].sort(
+      (a, b) => severityOrder(b) - severityOrder(a)
+    );
+    expect(sorted).toEqual(['critical', 'high', 'medium', 'low', 'unknown']);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect import failure**
+
+```bash
+cd web_ui && npx vitest run src/tests/severity.test.ts
+```
+
+Expected: failure on import (module does not exist).
+
+- [ ] **Step 3: Create `severity.ts`**
+
+Create `web_ui/src/lib/severity.ts`:
+
+```ts
+const CLASSES: Record<string, string> = {
+  critical: 'bg-red-100 text-red-700',
+  high: 'bg-orange-100 text-orange-700',
+  medium: 'bg-amber-100 text-amber-700',
+  low: 'bg-gray-100 text-gray-600'
+};
+
+const ORDER: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1
+};
+
+export function severityClass(sev: string): string {
+  return CLASSES[sev.toLowerCase()] ?? 'bg-gray-100 text-gray-600';
+}
+
+export function severityOrder(sev: string): number {
+  return ORDER[sev.toLowerCase()] ?? 0;
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+cd web_ui && npx vitest run src/tests/severity.test.ts
+```
+
+Expected: all 6 assertions across 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web_ui/src/lib/severity.ts web_ui/src/tests/severity.test.ts
+git commit -m "feat(web_ui): severity class and ordering utility"
+```
+
+---
+
+## Task 8: `persisted.ts` — localStorage-backed writables
+
+**Files:**
+- Create: `web_ui/src/lib/persisted.ts`
+- Test: `web_ui/src/tests/persisted.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `web_ui/src/tests/persisted.test.ts`:
+
+```ts
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { persistedBoolean, persistedString } from '../lib/persisted.js';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('persistedBoolean', () => {
+  it('uses default when key is absent', () => {
+    const s = persistedBoolean('key1', true);
+    expect(get(s)).toBe(true);
+  });
+
+  it('reads existing value from localStorage', () => {
+    localStorage.setItem('key2', 'false');
+    const s = persistedBoolean('key2', true);
+    expect(get(s)).toBe(false);
+  });
+
+  it('persists on write', () => {
+    const s = persistedBoolean('key3', true);
+    s.set(false);
+    expect(localStorage.getItem('key3')).toBe('false');
+  });
+
+  it('tolerates malformed stored value by falling back to default', () => {
+    localStorage.setItem('key4', 'not a bool');
+    const s = persistedBoolean('key4', true);
+    expect(get(s)).toBe(true);
+  });
+});
+
+describe('persistedString', () => {
+  it('uses default when key is absent', () => {
+    const s = persistedString('sk1', 'newest');
+    expect(get(s)).toBe('newest');
+  });
+
+  it('persists on write', () => {
+    const s = persistedString('sk2', 'newest');
+    s.set('priority');
+    expect(localStorage.getItem('sk2')).toBe('priority');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect import failure**
+
+```bash
+cd web_ui && npx vitest run src/tests/persisted.test.ts
+```
+
+Expected: failure (module does not exist).
+
+- [ ] **Step 3: Create `persisted.ts`**
+
+Create `web_ui/src/lib/persisted.ts`:
+
+```ts
+import { writable, type Writable } from 'svelte/store';
+
+// SSR-safe. Returns a writable<boolean> backed by localStorage under `key`.
+// On first read, if localStorage has a stored value it is parsed; otherwise
+// `initial` is used. On every write, the new value is persisted.
+export function persistedBoolean(key: string, initial: boolean): Writable<boolean> {
+  const start = read(key, initial, (raw) => (raw === 'true' ? true : raw === 'false' ? false : null));
+  const store = writable<boolean>(start);
+  store.subscribe((v) => write(key, String(v)));
+  return store;
+}
+
+export function persistedString(key: string, initial: string): Writable<string> {
+  const start = read(key, initial, (raw) => raw);
+  const store = writable<string>(start);
+  store.subscribe((v) => write(key, v));
+  return store;
+}
+
+function read<T>(key: string, fallback: T, parse: (raw: string) => T | null): T {
+  if (typeof localStorage === 'undefined') return fallback;
+  const raw = localStorage.getItem(key);
+  if (raw == null) return fallback;
+  const parsed = parse(raw);
+  return parsed == null ? fallback : parsed;
+}
+
+function write(key: string, value: string): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(key, value);
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+cd web_ui && npx vitest run src/tests/persisted.test.ts
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web_ui/src/lib/persisted.ts web_ui/src/tests/persisted.test.ts
+git commit -m "feat(web_ui): localStorage-backed persisted stores"
+```
+
+---
+
+## Task 9: `SeverityBadge.svelte`
+
+**Files:**
+- Create: `web_ui/src/lib/components/SeverityBadge.svelte`
+
+- [ ] **Step 1: Create the component**
+
+Create `web_ui/src/lib/components/SeverityBadge.svelte`:
+
+```svelte
+<script lang="ts">
+  import { severityClass } from '$lib/severity.js';
+
+  let { severity }: { severity: string | null | undefined } = $props();
+
+  const label = $derived((severity ?? 'none').toUpperCase());
+  const cls = $derived(
+    severity ? severityClass(severity) : 'bg-gray-100 text-gray-500'
+  );
+</script>
+
+<span class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {cls}">
+  {label}
+</span>
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web_ui/src/lib/components/SeverityBadge.svelte
+git commit -m "feat(web_ui): SeverityBadge component"
+```
+
+---
+
+## Task 10: `CollapseHeader.svelte`
+
+**Files:**
+- Create: `web_ui/src/lib/components/CollapseHeader.svelte`
+
+- [ ] **Step 1: Create the component**
+
+Create `web_ui/src/lib/components/CollapseHeader.svelte`:
+
+```svelte
+<script lang="ts">
+  interface Props {
+    title: string;
+    count: number;
+    expanded: boolean;
+    onToggle: () => void;
+  }
+
+  let { title, count, expanded, onToggle }: Props = $props();
+</script>
+
+<button
+  type="button"
+  onclick={onToggle}
+  class="flex w-full items-center gap-2 border-b border-gray-200 bg-gray-50 px-4 py-2 text-left hover:bg-gray-100"
+  aria-expanded={expanded}
+>
+  <svg
+    class="h-4 w-4 shrink-0 text-gray-500 transition-transform {expanded ? 'rotate-90' : ''}"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+  </svg>
+  <span class="text-sm font-semibold text-gray-700">{title}</span>
+  <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-600">{count}</span>
+</button>
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web_ui/src/lib/components/CollapseHeader.svelte
+git commit -m "feat(web_ui): CollapseHeader component"
+```
+
+---
+
+## Task 11: `PRTile.svelte`
+
+**Files:**
+- Create: `web_ui/src/lib/components/PRTile.svelte`
+
+- [ ] **Step 1: Create the component**
+
+Create `web_ui/src/lib/components/PRTile.svelte`:
+
+```svelte
+<script lang="ts">
+  import { reviewingPRs } from '$lib/stores.js';
+  import type { PR } from '$lib/types.js';
+  import SeverityBadge from './SeverityBadge.svelte';
+
+  let { pr }: { pr: PR } = $props();
+
+  const isReviewing = $derived($reviewingPRs.has(pr.id));
+  const severity = $derived(pr.latest_review?.severity ?? null);
+</script>
+
+<a
+  href="/prs/{pr.id}"
+  class="block border-b border-gray-100 px-4 py-3 hover:bg-gray-50"
+>
+  <div class="flex items-start gap-3">
+    <div class="min-w-0 flex-1">
+      <p class="truncate text-sm font-medium text-gray-900">{pr.title}</p>
+      <p class="mt-0.5 truncate text-xs text-gray-500">
+        <span class="font-mono">{pr.repo}</span>
+        · #{pr.number}
+        · {pr.author}
+      </p>
+    </div>
+    <div class="flex shrink-0 items-center gap-2">
+      {#if isReviewing}
+        <span class="text-xs text-indigo-600" data-testid="reviewing-spinner">reviewing…</span>
+      {/if}
+      <SeverityBadge {severity} />
+    </div>
+  </div>
+</a>
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web_ui/src/lib/components/PRTile.svelte
+git commit -m "feat(web_ui): PRTile component"
+```
+
+---
+
+## Task 12: `IssueTile.svelte`
+
+**Files:**
+- Create: `web_ui/src/lib/components/IssueTile.svelte`
+
+- [ ] **Step 1: Create the component**
+
+Create `web_ui/src/lib/components/IssueTile.svelte`:
+
+```svelte
+<script lang="ts">
+  import { reviewingIssues } from '$lib/stores.js';
+  import type { Issue } from '$lib/types.js';
+  import SeverityBadge from './SeverityBadge.svelte';
+
+  let { issue }: { issue: Issue } = $props();
+
+  const isReviewing = $derived($reviewingIssues.has(issue.id));
+
+  const triage = $derived(issue.latest_review?.triage as { severity?: string } | undefined);
+  const severity = $derived(triage?.severity ?? null);
+
+  const mode = $derived.by(() => {
+    if (issue.labels.includes('auto_implement')) return 'auto_implement' as const;
+    if (issue.labels.includes('review_only')) return 'review_only' as const;
+    return null;
+  });
+</script>
+
+<a
+  href="/issues/{issue.id}"
+  class="block border-b border-gray-100 px-4 py-3 hover:bg-gray-50"
+>
+  <div class="flex items-start gap-3">
+    <div class="min-w-0 flex-1">
+      <p class="truncate text-sm font-medium text-gray-900">{issue.title}</p>
+      <p class="mt-0.5 truncate text-xs text-gray-500">
+        <span class="font-mono">{issue.repo}</span>
+        · #{issue.number}
+        · {issue.author}
+      </p>
+      {#if mode}
+        <span
+          class="mt-1 inline-flex rounded px-1.5 py-0.5 text-[10px] font-medium
+          {mode === 'auto_implement'
+            ? 'bg-indigo-100 text-indigo-700'
+            : 'bg-blue-100 text-blue-700'}"
+        >
+          {mode}
+        </span>
+      {/if}
+    </div>
+    <div class="flex shrink-0 items-center gap-2">
+      {#if isReviewing}
+        <span class="text-xs text-indigo-600">reviewing…</span>
+      {/if}
+      {#if severity}
+        <SeverityBadge {severity} />
+      {:else}
+        <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+          PENDING
+        </span>
+      {/if}
+    </div>
+  </div>
+</a>
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web_ui/src/lib/components/IssueTile.svelte
+git commit -m "feat(web_ui): IssueTile component"
+```
+
+---
+
+## Task 13: `FilterBar.svelte`
+
+**Files:**
+- Create: `web_ui/src/lib/components/FilterBar.svelte`
+
+- [ ] **Step 1: Create the component**
+
+Create `web_ui/src/lib/components/FilterBar.svelte`:
+
+```svelte
+<script lang="ts">
+  interface Filters {
+    repo: string;
+    severity: string;
+    // One of state (PRs) or mode (issues).
+    state?: string;
+    mode?: string;
+  }
+
+  interface Props {
+    filters: Filters;
+    repos: string[];          // unique repos available in current dataset
+    variant: 'pr' | 'issue';
+    onChange: (next: Filters) => void;
+  }
+
+  let { filters, repos, variant, onChange }: Props = $props();
+
+  const severities = ['any', 'critical', 'high', 'medium', 'low'];
+  const prStates = ['open', 'closed', 'all'];
+  const issueModes = ['all', 'auto_implement', 'review_only'];
+
+  function update(field: keyof Filters, value: string): void {
+    onChange({ ...filters, [field]: value });
+  }
+</script>
+
+<div class="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+  <label class="flex items-center gap-1 text-xs text-gray-600">
+    <span>Repo:</span>
+    <select
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      value={filters.repo}
+      onchange={(e) => update('repo', (e.currentTarget as HTMLSelectElement).value)}
+    >
+      <option value="">any</option>
+      {#each repos as repo (repo)}
+        <option value={repo}>{repo}</option>
+      {/each}
+    </select>
+  </label>
+
+  <label class="flex items-center gap-1 text-xs text-gray-600">
+    <span>Severity:</span>
+    <select
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      value={filters.severity || 'any'}
+      onchange={(e) => update('severity', (e.currentTarget as HTMLSelectElement).value)}
+    >
+      {#each severities as s (s)}
+        <option value={s}>{s}</option>
+      {/each}
+    </select>
+  </label>
+
+  {#if variant === 'pr'}
+    <label class="flex items-center gap-1 text-xs text-gray-600">
+      <span>State:</span>
+      <select
+        class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+        value={filters.state ?? 'open'}
+        onchange={(e) => update('state', (e.currentTarget as HTMLSelectElement).value)}
+      >
+        {#each prStates as s (s)}
+          <option value={s}>{s}</option>
+        {/each}
+      </select>
+    </label>
+  {:else}
+    <label class="flex items-center gap-1 text-xs text-gray-600">
+      <span>Mode:</span>
+      <select
+        class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+        value={filters.mode ?? 'all'}
+        onchange={(e) => update('mode', (e.currentTarget as HTMLSelectElement).value)}
+      >
+        {#each issueModes as m (m)}
+          <option value={m}>{m}</option>
+        {/each}
+      </select>
+    </label>
+  {/if}
+</div>
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web_ui/src/lib/components/FilterBar.svelte
+git commit -m "feat(web_ui): FilterBar component with PR/issue variants"
+```
+
+---
+
+## Task 14: `ReviewCard.svelte`
+
+**Files:**
+- Create: `web_ui/src/lib/components/ReviewCard.svelte`
+
+- [ ] **Step 1: Create the component**
+
+Create `web_ui/src/lib/components/ReviewCard.svelte`:
+
+```svelte
+<script lang="ts">
+  import type { IssueReview, Review } from '$lib/types.js';
+  import SeverityBadge from './SeverityBadge.svelte';
+
+  interface Props {
+    review: Review | IssueReview;
+    variant: 'pr' | 'issue';
+  }
+
+  let { review, variant }: Props = $props();
+
+  const asPR = $derived(variant === 'pr' ? (review as Review) : null);
+  const asIssue = $derived(variant === 'issue' ? (review as IssueReview) : null);
+
+  const triage = $derived(asIssue?.triage as {
+    severity?: string;
+    category?: string;
+    suggested_assignee?: string;
+  } | undefined);
+</script>
+
+<article class="mb-3 rounded-md border border-gray-200 bg-white p-4">
+  <header class="mb-2 flex items-center justify-between gap-2">
+    <div class="flex items-center gap-2">
+      {#if asPR}
+        <SeverityBadge severity={asPR.severity} />
+      {:else if triage?.severity}
+        <SeverityBadge severity={triage.severity} />
+      {/if}
+      <span class="text-xs text-gray-500">{review.cli_used}</span>
+    </div>
+    <time class="text-xs text-gray-400" datetime={review.created_at}>
+      {new Date(review.created_at).toLocaleString()}
+    </time>
+  </header>
+
+  {#if review.summary}
+    <p class="text-sm text-gray-800">{review.summary}</p>
+  {/if}
+
+  {#if asPR && asPR.issues.length > 0}
+    <section class="mt-3">
+      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">
+        Findings ({asPR.issues.length})
+      </h4>
+      <ul class="mt-1 space-y-1 text-sm">
+        {#each asPR.issues as f (f.file + f.line + f.description)}
+          <li class="flex items-start gap-2">
+            <SeverityBadge severity={f.severity} />
+            <span class="font-mono text-xs text-gray-500">{f.file}:{f.line}</span>
+            <span class="text-gray-800">{f.description}</span>
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+
+  {#if asIssue && triage}
+    <section class="mt-3 rounded bg-gray-50 p-2 text-xs text-gray-700">
+      {#if triage.severity}<div><strong>Severity:</strong> {triage.severity}</div>{/if}
+      {#if triage.category}<div><strong>Category:</strong> {triage.category}</div>{/if}
+      {#if triage.suggested_assignee}<div><strong>Suggested assignee:</strong> {triage.suggested_assignee}</div>{/if}
+    </section>
+  {/if}
+
+  {#if review.suggestions && review.suggestions.length > 0}
+    <section class="mt-3">
+      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Suggestions</h4>
+      <ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-gray-800">
+        {#each review.suggestions as s, i (i)}
+          <li>{typeof s === 'string' ? s : JSON.stringify(s)}</li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+
+  {#if asIssue && asIssue.action_taken === 'auto_implement' && asIssue.pr_created > 0}
+    <p class="mt-3 text-xs">
+      <a href="/prs/{asIssue.pr_created}" class="text-indigo-600 hover:underline">
+        View created PR →
+      </a>
+    </p>
+  {/if}
+</article>
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web_ui/src/lib/components/ReviewCard.svelte
+git commit -m "feat(web_ui): ReviewCard component with PR/issue variants"
+```
+
+---
+
+## Task 15: Extract `ConnectionPill` and `StatsCards` from the scaffold landing page
+
+**Files:**
+- Create: `web_ui/src/lib/components/ConnectionPill.svelte`
+- Create: `web_ui/src/lib/components/StatsCards.svelte`
+
+- [ ] **Step 1: Create `ConnectionPill.svelte`**
+
+Create `web_ui/src/lib/components/ConnectionPill.svelte`:
+
+```svelte
+<script lang="ts">
+  import { getContext } from 'svelte';
+  import type { Readable } from 'svelte/store';
+
+  const connected = getContext<Readable<boolean>>('sse-connected');
+
+  const cls = $derived(
+    $connected ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
+  );
+  const label = $derived($connected ? 'connected' : 'disconnected');
+</script>
+
+<span class="rounded-full px-2 py-0.5 text-xs font-medium {cls}" data-testid="sse-pill">
+  {label}
+</span>
+```
+
+- [ ] **Step 2: Create `StatsCards.svelte`**
+
+Create `web_ui/src/lib/components/StatsCards.svelte`:
+
+```svelte
+<script lang="ts">
+  import type { Stats } from '$lib/types.js';
+
+  let { stats }: { stats: Stats | null } = $props();
+
+  const cells = $derived([
+    { label: 'Total reviews', value: stats?.total_reviews },
+    { label: 'Avg findings / review', value: stats?.avg_issues_per_review?.toFixed(1) },
+    { label: 'Median time (s)', value: stats?.review_timing?.median_seconds?.toFixed(1) },
+    { label: 'High-severity', value: stats?.by_severity?.HIGH ?? 0 }
+  ]);
+</script>
+
+<section class="grid grid-cols-2 gap-4 md:grid-cols-4">
+  {#each cells as cell (cell.label)}
+    <div class="rounded-lg border border-gray-200 bg-white p-4">
+      <dt class="text-xs uppercase tracking-wide text-gray-500">{cell.label}</dt>
+      <dd class="mt-1 text-2xl font-semibold">{cell.value ?? '—'}</dd>
+    </div>
+  {/each}
+</section>
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/lib/components/ConnectionPill.svelte web_ui/src/lib/components/StatsCards.svelte
+git commit -m "feat(web_ui): extract ConnectionPill and StatsCards components"
+```
+
+---
+
+## Task 16: `/prs` — PR list page
+
+**Files:**
+- Create: `web_ui/src/routes/prs/+page.svelte`
+
+- [ ] **Step 1: Create the page**
+
+Create `web_ui/src/routes/prs/+page.svelte`:
+
+```svelte
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import FilterBar from '$lib/components/FilterBar.svelte';
+  import PRTile from '$lib/components/PRTile.svelte';
+  import { fetchPRs } from '$lib/api.js';
+  import { severityOrder } from '$lib/severity.js';
+  import { prListRefresh, reviewingPRs } from '$lib/stores.js';
+  import type { PR } from '$lib/types.js';
+
+  let prs = $state<PR[]>([]);
+  let err = $state<string | null>(null);
+  let loading = $state(true);
+
+  $effect(() => {
+    $prListRefresh; // re-run on SSE-driven bump
+    if (!browser) return;
+    loading = true;
+    fetchPRs()
+      .then((r) => {
+        prs = r;
+        err = null;
+      })
+      .catch((e) => {
+        err = e instanceof Error ? e.message : String(e);
+      })
+      .finally(() => (loading = false));
+  });
+
+  const repo     = $derived($page.url.searchParams.get('repo') ?? '');
+  const severity = $derived($page.url.searchParams.get('severity') ?? 'any');
+  const state    = $derived($page.url.searchParams.get('state') ?? 'open');
+
+  const repos = $derived(Array.from(new Set(prs.map((p) => p.repo))).sort());
+
+  const filtered = $derived.by(() => {
+    const list = prs.filter((p) => {
+      if (repo && p.repo !== repo) return false;
+      if (state !== 'all' && p.state !== state) return false;
+      if (severity !== 'any') {
+        const s = p.latest_review?.severity?.toLowerCase() ?? '';
+        if (s !== severity) return false;
+      }
+      return true;
+    });
+    return list.sort(
+      (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+    );
+  });
+
+  function applyFilters(next: { repo: string; severity: string; state?: string }): void {
+    const params = new URLSearchParams();
+    if (next.repo) params.set('repo', next.repo);
+    if (next.severity && next.severity !== 'any') params.set('severity', next.severity);
+    if (next.state && next.state !== 'open') params.set('state', next.state);
+    const qs = params.toString();
+    goto(qs ? `/prs?${qs}` : '/prs', { keepFocus: true, replaceState: true, noScroll: true });
+  }
+</script>
+
+<section class="flex items-center gap-3">
+  <h1 class="text-2xl font-bold">PR Reviews</h1>
+  {#if $reviewingPRs.size > 0}
+    <span class="text-xs text-indigo-600">{$reviewingPRs.size} reviewing…</span>
+  {/if}
+</section>
+
+<FilterBar
+  filters={{ repo, severity, state }}
+  repos={repos}
+  variant="pr"
+  onChange={applyFilters}
+/>
+
+{#if err}
+  <p class="text-sm text-red-600">Could not load PRs: {err}</p>
+{:else if loading && prs.length === 0}
+  <p class="text-sm text-gray-500">Loading…</p>
+{:else if filtered.length === 0}
+  <p class="text-sm text-gray-500">No PRs match the current filters.</p>
+{:else}
+  <div class="overflow-hidden rounded-md border border-gray-200 bg-white">
+    {#each filtered as pr (pr.id)}
+      <PRTile {pr} />
+    {/each}
+  </div>
+{/if}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors. If it reports unused `severityOrder`, that's because we didn't use it on this page (PRs sort by `updated_at`, not severity). Remove the import:
+
+```ts
+// Remove: import { severityOrder } from '$lib/severity.js';
+```
+
+Re-run `npm run check` — expected: 0 errors.
+
+- [ ] **Step 3: Dev-server smoke test**
+
+```bash
+cd web_ui && npm run dev
+```
+
+Visit `http://localhost:5173/prs` — expected: "No PRs match the current filters" (if no daemon) or a list (with daemon).
+
+Stop the dev server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/routes/prs/+page.svelte
+git commit -m "feat(web_ui): /prs list with URL-driven filters"
+```
+
+---
+
+## Task 17: `/prs/[id]` — PR detail page
+
+**Files:**
+- Create: `web_ui/src/routes/prs/[id]/+page.svelte`
+
+- [ ] **Step 1: Create the page**
+
+Create `web_ui/src/routes/prs/[id]/+page.svelte`:
+
+```svelte
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import ReviewCard from '$lib/components/ReviewCard.svelte';
+  import { dismissPR, fetchPR, triggerReview, undismissPR } from '$lib/api.js';
+  import { prListRefresh, reviewingPRs } from '$lib/stores.js';
+  import type { PR, Review } from '$lib/types.js';
+
+  const id = $derived(Number($page.params.id));
+
+  let pr = $state<PR | null>(null);
+  let reviews = $state<Review[]>([]);
+  let err = $state<string | null>(null);
+  let busy = $state(false);
+
+  $effect(() => {
+    $prListRefresh;
+    if (!browser || !Number.isFinite(id)) return;
+    fetchPR(id)
+      .then((d) => {
+        pr = d.pr;
+        reviews = d.reviews;
+        err = null;
+      })
+      .catch((e) => {
+        err = e instanceof Error ? e.message : String(e);
+      });
+  });
+
+  const reviewing = $derived($reviewingPRs.has(id));
+
+  async function onReview(): Promise<void> {
+    if (!pr) return;
+    busy = true;
+    try {
+      // Optimistic: mark reviewing before SSE confirms.
+      reviewingPRs.update((s) => new Set(s).add(id));
+      await triggerReview(id);
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+      reviewingPRs.update((s) => {
+        const n = new Set(s);
+        n.delete(id);
+        return n;
+      });
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function onDismissToggle(): Promise<void> {
+    if (!pr) return;
+    busy = true;
+    try {
+      if (pr.dismissed) {
+        await undismissPR(id);
+        prListRefresh.update((n) => n + 1);
+      } else {
+        await dismissPR(id);
+        // Dismissed PRs disappear from /prs; navigate back.
+        goto('/prs');
+        return;
+      }
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+{#if err && !pr}
+  <p class="text-sm text-red-600">Could not load PR: {err}</p>
+{:else if !pr}
+  <p class="text-sm text-gray-500">Loading…</p>
+{:else}
+  <article>
+    <header class="mb-4 rounded-md border border-gray-200 bg-white p-4">
+      <h1 class="text-xl font-bold">{pr.title}</h1>
+      <p class="mt-1 text-sm text-gray-500">
+        <span class="font-mono">{pr.repo}</span>
+        · #{pr.number}
+        · {pr.author}
+        · <span class="capitalize">{pr.state}</span>
+      </p>
+      <p class="mt-2 text-xs">
+        <a href={pr.url} class="text-indigo-600 hover:underline" target="_blank" rel="noreferrer">
+          View on GitHub →
+        </a>
+      </p>
+    </header>
+
+    <div class="mb-4 flex items-center gap-2">
+      <button
+        type="button"
+        class="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        onclick={onReview}
+        disabled={busy || reviewing}
+      >
+        {reviewing ? 'Reviewing…' : 'Review now'}
+      </button>
+      <button
+        type="button"
+        class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        onclick={onDismissToggle}
+        disabled={busy}
+      >
+        {pr.dismissed ? 'Undismiss' : 'Dismiss'}
+      </button>
+      {#if err}
+        <span class="text-xs text-red-600">{err}</span>
+      {/if}
+    </div>
+
+    <section>
+      <h2 class="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        Review history ({reviews.length})
+      </h2>
+      {#if reviews.length === 0}
+        <p class="text-sm text-gray-500">No reviews yet.</p>
+      {:else}
+        {#each reviews as r (r.id)}
+          <ReviewCard review={r} variant="pr" />
+        {/each}
+      {/if}
+    </section>
+  </article>
+{/if}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Dev-server smoke test**
+
+```bash
+cd web_ui && npm run dev
+```
+
+Visit `http://localhost:5173/prs/1` — expected: "Could not load PR" (no daemon) or the PR detail (with daemon).
+
+Stop the dev server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/routes/prs/[id]/+page.svelte
+git commit -m "feat(web_ui): /prs/[id] detail page with actions"
+```
+
+---
+
+## Task 18: `/issues` — Issue list page
+
+**Files:**
+- Create: `web_ui/src/routes/issues/+page.svelte`
+
+- [ ] **Step 1: Create the page**
+
+Create `web_ui/src/routes/issues/+page.svelte`:
+
+```svelte
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import FilterBar from '$lib/components/FilterBar.svelte';
+  import IssueTile from '$lib/components/IssueTile.svelte';
+  import { fetchIssues } from '$lib/api.js';
+  import { issueListRefresh, reviewingIssues } from '$lib/stores.js';
+  import type { Issue } from '$lib/types.js';
+
+  let issues = $state<Issue[]>([]);
+  let err = $state<string | null>(null);
+  let loading = $state(true);
+
+  $effect(() => {
+    $issueListRefresh;
+    if (!browser) return;
+    loading = true;
+    fetchIssues()
+      .then((r) => {
+        issues = r;
+        err = null;
+      })
+      .catch((e) => (err = e instanceof Error ? e.message : String(e)))
+      .finally(() => (loading = false));
+  });
+
+  const repo     = $derived($page.url.searchParams.get('repo') ?? '');
+  const severity = $derived($page.url.searchParams.get('severity') ?? 'any');
+  const mode     = $derived($page.url.searchParams.get('mode') ?? 'all');
+
+  const repos = $derived(Array.from(new Set(issues.map((i) => i.repo))).sort());
+
+  const filtered = $derived.by(() => {
+    const list = issues.filter((i) => {
+      if (i.dismissed) return false;
+      if (repo && i.repo !== repo) return false;
+      if (severity !== 'any') {
+        const triage = i.latest_review?.triage as { severity?: string } | undefined;
+        const s = triage?.severity?.toLowerCase() ?? '';
+        if (s !== severity) return false;
+      }
+      if (mode !== 'all') {
+        if (!i.labels.includes(mode)) return false;
+      }
+      return true;
+    });
+    return list.sort((a, b) => {
+      const ta = new Date(a.fetched_at).getTime();
+      const tb = new Date(b.fetched_at).getTime();
+      return tb - ta;
+    });
+  });
+
+  function applyFilters(next: { repo: string; severity: string; mode?: string }): void {
+    const params = new URLSearchParams();
+    if (next.repo) params.set('repo', next.repo);
+    if (next.severity && next.severity !== 'any') params.set('severity', next.severity);
+    if (next.mode && next.mode !== 'all') params.set('mode', next.mode);
+    const qs = params.toString();
+    goto(qs ? `/issues?${qs}` : '/issues', { keepFocus: true, replaceState: true, noScroll: true });
+  }
+</script>
+
+<section class="flex items-center gap-3">
+  <h1 class="text-2xl font-bold">Issues</h1>
+  {#if $reviewingIssues.size > 0}
+    <span class="text-xs text-indigo-600">{$reviewingIssues.size} reviewing…</span>
+  {/if}
+</section>
+
+<FilterBar
+  filters={{ repo, severity, mode }}
+  repos={repos}
+  variant="issue"
+  onChange={applyFilters}
+/>
+
+{#if err}
+  <p class="text-sm text-red-600">Could not load issues: {err}</p>
+{:else if loading && issues.length === 0}
+  <p class="text-sm text-gray-500">Loading…</p>
+{:else if filtered.length === 0}
+  <p class="text-sm text-gray-500">No issues match the current filters.</p>
+{:else}
+  <div class="overflow-hidden rounded-md border border-gray-200 bg-white">
+    {#each filtered as issue (issue.id)}
+      <IssueTile {issue} />
+    {/each}
+  </div>
+{/if}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Dev-server smoke test**
+
+```bash
+cd web_ui && npm run dev
+```
+
+Visit `http://localhost:5173/issues` — expected: no crash, loading state, then "No issues match…" (without daemon) or list (with daemon).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/routes/issues/+page.svelte
+git commit -m "feat(web_ui): /issues list with URL-driven filters"
+```
+
+---
+
+## Task 19: `/issues/[id]` — Issue detail page
+
+**Files:**
+- Create: `web_ui/src/routes/issues/[id]/+page.svelte`
+
+- [ ] **Step 1: Create the page**
+
+Create `web_ui/src/routes/issues/[id]/+page.svelte`:
+
+```svelte
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import ReviewCard from '$lib/components/ReviewCard.svelte';
+  import {
+    dismissIssue,
+    fetchIssue,
+    triggerIssueReview,
+    undismissIssue
+  } from '$lib/api.js';
+  import { issueListRefresh, reviewingIssues } from '$lib/stores.js';
+  import type { Issue, IssueReview } from '$lib/types.js';
+
+  const id = $derived(Number($page.params.id));
+
+  let issue = $state<Issue | null>(null);
+  let reviews = $state<IssueReview[]>([]);
+  let err = $state<string | null>(null);
+  let busy = $state(false);
+
+  $effect(() => {
+    $issueListRefresh;
+    if (!browser || !Number.isFinite(id)) return;
+    fetchIssue(id)
+      .then((d) => {
+        issue = d.issue;
+        reviews = d.reviews;
+        err = null;
+      })
+      .catch((e) => (err = e instanceof Error ? e.message : String(e)));
+  });
+
+  const reviewing = $derived($reviewingIssues.has(id));
+
+  const autoImplementPR = $derived(
+    reviews.find((r) => r.action_taken === 'auto_implement' && r.pr_created > 0)?.pr_created
+  );
+
+  async function onReview(): Promise<void> {
+    if (!issue) return;
+    busy = true;
+    try {
+      reviewingIssues.update((s) => new Set(s).add(id));
+      await triggerIssueReview(id);
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+      reviewingIssues.update((s) => {
+        const n = new Set(s);
+        n.delete(id);
+        return n;
+      });
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function onDismissToggle(): Promise<void> {
+    if (!issue) return;
+    busy = true;
+    try {
+      if (issue.dismissed) {
+        await undismissIssue(id);
+        issueListRefresh.update((n) => n + 1);
+      } else {
+        await dismissIssue(id);
+        goto('/issues');
+        return;
+      }
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+{#if err && !issue}
+  <p class="text-sm text-red-600">Could not load issue: {err}</p>
+{:else if !issue}
+  <p class="text-sm text-gray-500">Loading…</p>
+{:else}
+  <article>
+    <header class="mb-4 rounded-md border border-gray-200 bg-white p-4">
+      <h1 class="text-xl font-bold">{issue.title}</h1>
+      <p class="mt-1 text-sm text-gray-500">
+        <span class="font-mono">{issue.repo}</span>
+        · #{issue.number}
+        · {issue.author}
+        · <span class="capitalize">{issue.state}</span>
+      </p>
+      {#if issue.labels.length > 0}
+        <ul class="mt-2 flex flex-wrap gap-1">
+          {#each issue.labels as l (l)}
+            <li class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-700">
+              {l}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+      {#if issue.assignees.length > 0}
+        <p class="mt-2 text-xs text-gray-500">
+          Assignees: {issue.assignees.join(', ')}
+        </p>
+      {/if}
+      <p class="mt-2 text-xs">
+        <a
+          href="https://github.com/{issue.repo}/issues/{issue.number}"
+          class="text-indigo-600 hover:underline"
+          target="_blank"
+          rel="noreferrer"
+        >
+          View on GitHub →
+        </a>
+      </p>
+      {#if autoImplementPR}
+        <p class="mt-2 text-xs">
+          <a href="/prs/{autoImplementPR}" class="text-indigo-600 hover:underline">
+            View created PR →
+          </a>
+        </p>
+      {/if}
+    </header>
+
+    <div class="mb-4 flex items-center gap-2">
+      <button
+        type="button"
+        class="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        onclick={onReview}
+        disabled={busy || reviewing}
+      >
+        {reviewing ? 'Reviewing…' : 'Review now'}
+      </button>
+      <button
+        type="button"
+        class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        onclick={onDismissToggle}
+        disabled={busy}
+      >
+        {issue.dismissed ? 'Undismiss' : 'Dismiss'}
+      </button>
+      {#if err}
+        <span class="text-xs text-red-600">{err}</span>
+      {/if}
+    </div>
+
+    <section>
+      <h2 class="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        Review history ({reviews.length})
+      </h2>
+      {#if reviews.length === 0}
+        <p class="text-sm text-gray-500">No reviews yet.</p>
+      {:else}
+        {#each reviews as r (r.id)}
+          <ReviewCard review={r} variant="issue" />
+        {/each}
+      {/if}
+    </section>
+  </article>
+{/if}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Dev-server smoke test**
+
+```bash
+cd web_ui && npm run dev
+```
+
+Visit `http://localhost:5173/issues/1` — expected: no crash.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/routes/issues/[id]/+page.svelte
+git commit -m "feat(web_ui): /issues/[id] detail page with actions"
+```
+
+---
+
+## Task 20: `/` — Dashboard page (replace scaffold placeholder)
+
+**Files:**
+- Modify: `web_ui/src/routes/+page.svelte` (full rewrite)
+
+- [ ] **Step 1: Replace the entire file**
+
+Overwrite `web_ui/src/routes/+page.svelte` with:
+
+```svelte
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import CollapseHeader from '$lib/components/CollapseHeader.svelte';
+  import ConnectionPill from '$lib/components/ConnectionPill.svelte';
+  import IssueTile from '$lib/components/IssueTile.svelte';
+  import PRTile from '$lib/components/PRTile.svelte';
+  import StatsCards from '$lib/components/StatsCards.svelte';
+  import { fetchIssues, fetchMe, fetchPRs, fetchStats } from '$lib/api.js';
+  import { persistedBoolean, persistedString } from '$lib/persisted.js';
+  import { severityOrder } from '$lib/severity.js';
+  import { issueListRefresh, prListRefresh } from '$lib/stores.js';
+  import type { Issue, PR, Stats } from '$lib/types.js';
+
+  let prs = $state<PR[]>([]);
+  let issues = $state<Issue[]>([]);
+  let stats = $state<Stats | null>(null);
+  let me = $state<string>('');
+  let err = $state<string | null>(null);
+
+  $effect(() => {
+    $prListRefresh;
+    if (!browser) return;
+    fetchPRs().then((r) => (prs = r)).catch((e) => (err = String(e)));
+    fetchStats().then((r) => (stats = r)).catch(() => {});
+  });
+
+  $effect(() => {
+    $issueListRefresh;
+    if (!browser) return;
+    fetchIssues().then((r) => (issues = r)).catch(() => {});
+  });
+
+  $effect(() => {
+    if (!browser) return;
+    fetchMe().then((r) => (me = r.login)).catch(() => {});
+  });
+
+  const sort = persistedString('dashboard.sort', 'priority');
+  const reviewsExpanded = persistedBoolean('dashboard.reviewsExpanded', true);
+  const prsExpanded = persistedBoolean('dashboard.prsExpanded', true);
+  const issuesExpanded = persistedBoolean('dashboard.issuesExpanded', true);
+
+  function byUpdated(a: PR, b: PR): number {
+    return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+  }
+  function byPriority(a: PR, b: PR): number {
+    const d = severityOrder(b.latest_review?.severity ?? '') - severityOrder(a.latest_review?.severity ?? '');
+    return d !== 0 ? d : byUpdated(a, b);
+  }
+
+  const sorter = $derived($sort === 'priority' ? byPriority : byUpdated);
+
+  const meLower = $derived(me.toLowerCase());
+
+  const myReviews = $derived(
+    prs
+      .filter((p) => !p.dismissed && p.author.toLowerCase() !== meLower)
+      .sort(sorter)
+  );
+  const myPRs = $derived(
+    prs
+      .filter((p) => !p.dismissed && p.author.toLowerCase() === meLower)
+      .sort(sorter)
+  );
+  const trackedIssues = $derived(issues.filter((i) => !i.dismissed));
+
+  const empty = $derived(prs.length === 0 && issues.length === 0);
+</script>
+
+<section class="mb-6 flex items-center gap-3">
+  <h1 class="text-3xl font-bold">Dashboard</h1>
+  <ConnectionPill />
+</section>
+
+<StatsCards {stats} />
+
+<section class="mt-6 mb-3 flex items-center gap-2">
+  <span class="text-xs text-gray-500">Sort:</span>
+  <button
+    type="button"
+    class="rounded px-2 py-1 text-xs font-medium {$sort === 'priority'
+      ? 'bg-indigo-100 text-indigo-700'
+      : 'text-gray-600 hover:bg-gray-100'}"
+    onclick={() => sort.set('priority')}
+  >
+    Priority
+  </button>
+  <button
+    type="button"
+    class="rounded px-2 py-1 text-xs font-medium {$sort === 'newest'
+      ? 'bg-indigo-100 text-indigo-700'
+      : 'text-gray-600 hover:bg-gray-100'}"
+    onclick={() => sort.set('newest')}
+  >
+    Newest
+  </button>
+</section>
+
+{#if err}
+  <p class="text-sm text-red-600">Could not load: {err}</p>
+{:else if empty}
+  <p class="mt-6 text-center text-sm text-gray-500">No activity yet.</p>
+{:else}
+  <div class="overflow-hidden rounded-md border border-gray-200 bg-white">
+    {#if myReviews.length > 0}
+      <CollapseHeader
+        title="My Reviews"
+        count={myReviews.length}
+        expanded={$reviewsExpanded}
+        onToggle={() => reviewsExpanded.update((v) => !v)}
+      />
+      {#if $reviewsExpanded}
+        {#each myReviews as pr (pr.id)}
+          <PRTile {pr} />
+        {/each}
+      {/if}
+    {/if}
+
+    {#if myPRs.length > 0}
+      <CollapseHeader
+        title="My PRs"
+        count={myPRs.length}
+        expanded={$prsExpanded}
+        onToggle={() => prsExpanded.update((v) => !v)}
+      />
+      {#if $prsExpanded}
+        {#each myPRs as pr (pr.id)}
+          <PRTile {pr} />
+        {/each}
+      {/if}
+    {/if}
+
+    {#if trackedIssues.length > 0}
+      <CollapseHeader
+        title="Tracked Issues"
+        count={trackedIssues.length}
+        expanded={$issuesExpanded}
+        onToggle={() => issuesExpanded.update((v) => !v)}
+      />
+      {#if $issuesExpanded}
+        {#each trackedIssues as issue (issue.id)}
+          <IssueTile {issue} />
+        {/each}
+      {/if}
+    {/if}
+  </div>
+{/if}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Dev-server smoke test**
+
+```bash
+cd web_ui && npm run dev
+```
+
+Visit `http://localhost:5173/` — expected: Dashboard header with connection pill, stats cards (may be `—` without daemon), sort toggle; sections only render when data exists.
+
+Stop the dev server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/routes/+page.svelte
+git commit -m "feat(web_ui): / Dashboard with sections, sort, and persisted state"
+```
+
+---
+
+## Task 21: Full verification pass
+
+**Files:**
+- No new code; run all checks.
+
+- [ ] **Step 1: Lint**
+
+```bash
+cd web_ui && npm run lint
+```
+
+Expected: clean. If prettier flags formatting, run `npm run format` and re-commit:
+
+```bash
+npm run format
+git add -A
+git commit -m "style(web_ui): apply prettier"
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 3: Unit tests**
+
+```bash
+cd web_ui && npm test
+```
+
+Expected: all passing — scaffold baseline (15) + Task 2 (+4) + Task 3 (+3) + Task 5 (+6) + Task 7 (+6) + Task 8 (+6) = **40 tests**. If the exact count differs, check whether the per-task tests landed as planned.
+
+- [ ] **Step 4: Production build**
+
+```bash
+cd web_ui && npm run build
+```
+
+Expected: `build/handler.js` generated, no errors.
+
+- [ ] **Step 5: Docker build (sanity)**
+
+```bash
+cd web_ui && docker build -t heimdallm-web:routes .
+```
+
+Expected: image built, same size band as the scaffold (~160 MB).
+
+- [ ] **Step 6: Manual test plan against live daemon**
+
+Prereqs: a running heimdallm daemon with at least one PR and one issue tracked.
+
+Run the web UI dev server against it:
+
+```bash
+cd web_ui && HEIMDALLM_API_URL=http://localhost:7842 npm run dev
+```
+
+Then verify each acceptance row in `docs/superpowers/specs/2026-04-17-web-ui-routes-design.md` §8 "Manual test plan". Keep notes; anything that fails goes back to the relevant task.
+
+- [ ] **Step 7: Commit anything discovered in Step 6 fix-ups**
+
+If any manual findings required code changes, commit them with clear messages (one per fix) before opening the PR.
+
+---
+
+## Self-review
+
+**Spec coverage** (each design-spec section → tasks):
+
+| Spec section | Tasks |
+|---|---|
+| §1 Dependency strategy | Task 0 (branch setup) |
+| §2 Inherited follow-ups | Task 1, 2, 3 |
+| §3 Architecture overview | Tasks 4, 5, 6 establish the store/bridge pattern; Tasks 16–20 use it |
+| §4 Stores & SSE bridge | Task 4 (stores), Task 5 (bridge), Task 6 (wiring) |
+| §5.1 `/` Dashboard | Task 20 |
+| §5.2 `/prs` list | Task 16 |
+| §5.3 `/prs/{id}` detail | Task 17 |
+| §5.4 `/issues` list | Task 18 |
+| §5.5 `/issues/{id}` detail | Task 19 |
+| §6 Shared components | Tasks 9–15 |
+| §7 Types & SSE updates | Tasks 1, 2, 3 |
+| §8 Testing | TDD throughout Tasks 2, 3, 5, 7, 8; manual plan in Task 21 |
+
+**Placeholder scan:** No `TBD`, no `TODO`, no "add error handling" / "similar to" / "write tests for the above" — every step has explicit code, paths, and expected outcomes.
+
+**Type consistency:**
+- `parseIssue`, `parseIssueReview`, `parseMaybeJson` — names stable across Task 3 and usage sites.
+- `initSseBridge` — stable across Task 5 and Task 6.
+- `prListRefresh`, `issueListRefresh`, `reviewingPRs`, `reviewingIssues` — stable across stores.ts, sseBridge.ts, and every page.
+- `severityClass`, `severityOrder` — stable across Task 7 and Task 20.
+- `persistedBoolean`, `persistedString` — stable across Task 8 and Task 20.
+- Component props: `pr: PR`, `issue: Issue`, `stats: Stats | null`, `severity: string | null | undefined` consistent across components.
+
+**Scope check:** One branch, one PR, ~22 tasks. Well-bounded. No sub-project decomposition needed.

--- a/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
@@ -644,11 +644,6 @@ export async function loadToken(): Promise<string | null> {
   }
   return cached;
 }
-
-/** Resets the in-memory cache. For tests only. */
-export function __resetTokenCache(): void {
-  cached = undefined;
-}
 ```
 
 - [ ] **Step 4: Run tests — confirm they pass**

--- a/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
@@ -1476,6 +1476,7 @@ Top nav bar, login display, auth-error banner, SSE connection initiated on mount
         <li>
           <a
             href={item.href}
+            aria-current={$page.url.pathname === item.href ? 'page' : undefined}
             class="hover:text-indigo-600 {$page.url.pathname === item.href
               ? 'text-indigo-600 font-medium'
               : 'text-gray-600'}"

--- a/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
@@ -684,18 +684,14 @@ Forwards any HTTP method + path to the daemon, injects `X-Heimdallm-Token`, stre
 import { loadToken } from '$lib/server/token.js';
 import { error, type RequestHandler } from '@sveltejs/kit';
 
-const DAEMON_URL = process.env.HEIMDALLM_API_URL ?? 'http://127.0.0.1:7842';
+const DAEMON_URL = (process.env.HEIMDALLM_API_URL ?? 'http://127.0.0.1:7842').replace(/\/+$/, '');
 
 const handle: RequestHandler = async ({ params, request, url, fetch: _fetch }) => {
   const token = await loadToken();
   if (!token) {
-    error(
-      503,
-      JSON.stringify({
-        message:
-          'daemon token missing: set HEIMDALLM_API_TOKEN or mount /data/api_token'
-      })
-    );
+    error(503, {
+      message: 'daemon token missing: set HEIMDALLM_API_TOKEN or mount /data/api_token'
+    });
   }
 
   const target = new URL(`${DAEMON_URL}/${params.path ?? ''}`);
@@ -775,12 +771,12 @@ Opens an upstream streaming fetch to the daemon's `/events`, pipes the `Readable
 import { loadToken } from '$lib/server/token.js';
 import { error, type RequestHandler } from '@sveltejs/kit';
 
-const DAEMON_URL = process.env.HEIMDALLM_API_URL ?? 'http://127.0.0.1:7842';
+const DAEMON_URL = (process.env.HEIMDALLM_API_URL ?? 'http://127.0.0.1:7842').replace(/\/+$/, '');
 
 export const GET: RequestHandler = async ({ request }) => {
   const token = await loadToken();
   if (!token) {
-    error(503, 'daemon token missing');
+    error(503, { message: 'daemon token missing' });
   }
 
   const upstream = await fetch(`${DAEMON_URL}/events`, {

--- a/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
@@ -776,7 +776,9 @@ const DAEMON_URL = (process.env.HEIMDALLM_API_URL ?? 'http://127.0.0.1:7842').re
 export const GET: RequestHandler = async ({ request }) => {
   const token = await loadToken();
   if (!token) {
-    error(503, { message: 'daemon token missing' });
+    error(503, {
+      message: 'daemon token missing: set HEIMDALLM_API_TOKEN or mount /data/api_token'
+    });
   }
 
   const upstream = await fetch(`${DAEMON_URL}/events`, {
@@ -788,7 +790,7 @@ export const GET: RequestHandler = async ({ request }) => {
   });
 
   if (!upstream.ok || !upstream.body) {
-    error(upstream.status || 502, `daemon /events failed: ${upstream.status}`);
+    error(upstream.status ?? 502, { message: `daemon /events failed: ${upstream.status}` });
   }
 
   return new Response(upstream.body, {

--- a/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
@@ -910,8 +910,11 @@ describe('api.ts', () => {
   });
 
   it('triggerReview throws ApiError on 500', async () => {
-    fetchMock.mockResolvedValue(new Response('boom', { status: 500, statusText: 'Server Error' }));
+    const make500 = () =>
+      new Response('boom', { status: 500, statusText: 'Server Error' });
+    fetchMock.mockResolvedValueOnce(make500());
     await expect(triggerReview(7)).rejects.toBeInstanceOf(ApiError);
+    fetchMock.mockResolvedValueOnce(make500());
     await expect(triggerReview(7)).rejects.toMatchObject({
       status: 500,
       path: '/api/prs/7/review'

--- a/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
@@ -1175,7 +1175,7 @@ Wraps native `EventSource` into two Svelte stores: `events` (a readable of every
 
 ```ts
 import { get } from 'svelte/store';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { connectEvents } from '../lib/sse.js';
 
 type Listener = (e: MessageEvent) => void;
@@ -1226,6 +1226,10 @@ beforeEach(() => {
   vi.stubGlobal('EventSource', MockEventSource);
 });
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe('connectEvents', () => {
   it('opens EventSource at /events', () => {
     connectEvents();
@@ -1259,11 +1263,14 @@ describe('connectEvents', () => {
     expect(get(handle.connected)).toBe(false);
   });
 
-  it('close() calls EventSource.close()', () => {
+  it('close() calls EventSource.close() and sets connected to false', () => {
     const handle = connectEvents();
     const es = MockEventSource.instances[0];
+    es.fireOpen();
+    expect(get(handle.connected)).toBe(true);
     handle.close();
     expect(es.closed).toBe(true);
+    expect(get(handle.connected)).toBe(false);
   });
 });
 ```

--- a/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
@@ -131,7 +131,7 @@ export default defineConfig({
     "sourceMap": true,
     "strict": true,
     "moduleResolution": "bundler",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   }
 }
 ```

--- a/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
@@ -1,0 +1,1780 @@
+# Web UI Scaffold Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Scaffold the SvelteKit `web_ui/` project with a server-side proxy to the daemon, typed API/SSE clients, a minimal layout + landing page, and a Dockerfile — satisfying all acceptance criteria of [issue #30](https://github.com/theburrowhub/heimdallm/issues/30).
+
+**Architecture:** SvelteKit 2.x with `@sveltejs/adapter-node`. Browser talks only to same-origin SvelteKit endpoints; a catch-all proxy `/api/[...path]` and a dedicated `/events` SSE passthrough inject `X-Heimdallm-Token` when forwarding to the daemon. The token lives in `src/lib/server/` — never ships to the browser. Native `EventSource` handles SSE because the connection is same-origin.
+
+**Tech Stack:** SvelteKit 2.x, Svelte 5 (runes), TypeScript 5.x, Vite 5.x, TailwindCSS 4, `@sveltejs/adapter-node`, Vitest 2.x, Node 22 LTS.
+
+**Reference:** [Design spec](../specs/2026-04-17-web-ui-scaffold-design.md)
+
+**Conventions used in this plan:**
+- All paths are relative to the repo root (`/home/vbueno/Desarrollo/workspaces/heimdallm-001/`).
+- Every step is atomic (2–5 minutes). Run verification after each.
+- Commits use conventional-commit prefixes (`feat`, `chore`, etc.) because the repo uses release-please.
+- Per `AGENTS.md`, Go tests are not involved here — this is pure Node/TS work.
+
+---
+
+## Task 1: Bootstrap `web_ui/` with package.json, configs, and a placeholder route
+
+**Files:**
+- Create: `web_ui/package.json`
+- Create: `web_ui/svelte.config.js`
+- Create: `web_ui/vite.config.ts`
+- Create: `web_ui/tsconfig.json`
+- Create: `web_ui/.gitignore`
+- Create: `web_ui/.npmrc`
+- Create: `web_ui/.prettierrc`
+- Create: `web_ui/.prettierignore`
+- Create: `web_ui/eslint.config.js`
+- Create: `web_ui/src/app.d.ts`
+- Create: `web_ui/src/app.html`
+- Create: `web_ui/src/routes/+page.svelte`
+- Create: `web_ui/static/.gitkeep`
+
+- [ ] **Step 1: Create `web_ui/package.json`**
+
+```json
+{
+  "name": "heimdallm-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "prettier --check . && eslint .",
+    "format": "prettier --write ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.15.0",
+    "@sveltejs/adapter-node": "^5.2.0",
+    "@sveltejs/kit": "^2.15.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@tailwindcss/vite": "^4.0.0",
+    "@types/node": "^22.10.0",
+    "eslint": "^9.15.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-svelte": "^2.46.0",
+    "globals": "^15.12.0",
+    "jsdom": "^25.0.0",
+    "prettier": "^3.4.0",
+    "prettier-plugin-svelte": "^3.3.0",
+    "svelte": "^5.15.0",
+    "svelte-check": "^4.1.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.6.0",
+    "typescript-eslint": "^8.15.0",
+    "vite": "^5.4.0",
+    "vitest": "^2.1.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create `web_ui/svelte.config.js`**
+
+```js
+import adapter from '@sveltejs/adapter-node';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter()
+  }
+};
+
+export default config;
+```
+
+- [ ] **Step 3: Create `web_ui/vite.config.ts`**
+
+```ts
+import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tailwindcss(), sveltekit()],
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'jsdom',
+    globals: true
+  }
+});
+```
+
+- [ ] **Step 4: Create `web_ui/tsconfig.json`**
+
+```json
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler",
+    "types": ["vitest/globals"]
+  }
+}
+```
+
+- [ ] **Step 5: Create `web_ui/.gitignore`**
+
+```
+node_modules
+/build
+/.svelte-kit
+/package
+.env
+.env.*
+!.env.example
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+.DS_Store
+```
+
+- [ ] **Step 6: Create `web_ui/.npmrc`**
+
+```
+engine-strict=true
+```
+
+- [ ] **Step 7: Create `web_ui/.prettierrc`**
+
+```json
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 100,
+  "plugins": ["prettier-plugin-svelte"],
+  "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+}
+```
+
+- [ ] **Step 8: Create `web_ui/.prettierignore`**
+
+```
+.svelte-kit/
+build/
+node_modules/
+package-lock.json
+```
+
+- [ ] **Step 9: Create `web_ui/eslint.config.js`**
+
+```js
+import prettier from 'eslint-config-prettier';
+import js from '@eslint/js';
+import svelte from 'eslint-plugin-svelte';
+import globals from 'globals';
+import ts from 'typescript-eslint';
+
+export default ts.config(
+  js.configs.recommended,
+  ...ts.configs.recommended,
+  ...svelte.configs['flat/recommended'],
+  prettier,
+  ...svelte.configs['flat/prettier'],
+  {
+    languageOptions: {
+      globals: { ...globals.browser, ...globals.node }
+    }
+  },
+  {
+    files: ['**/*.svelte'],
+    languageOptions: { parserOptions: { parser: ts.parser } }
+  },
+  { ignores: ['build/', '.svelte-kit/', 'node_modules/'] }
+);
+```
+
+- [ ] **Step 10: Create `web_ui/src/app.d.ts`**
+
+```ts
+// See https://kit.svelte.dev/docs/types#app
+declare global {
+  namespace App {
+    interface Locals {
+      login: string | null;
+    }
+    // interface PageData {}
+    // interface PageState {}
+    // interface Platform {}
+    interface Error {
+      message: string;
+    }
+  }
+}
+
+export {};
+```
+
+- [ ] **Step 11: Create `web_ui/src/app.html`**
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Heimdallm</title>
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover" class="min-h-screen bg-white text-gray-900 antialiased">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>
+```
+
+- [ ] **Step 12: Create `web_ui/src/routes/+page.svelte` (placeholder)**
+
+```svelte
+<h1>Heimdallm scaffold OK</h1>
+```
+
+- [ ] **Step 13: Create `web_ui/static/.gitkeep`** (empty file — just `touch web_ui/static/.gitkeep`)
+
+- [ ] **Step 14: Install dependencies**
+
+```bash
+cd web_ui && npm install
+```
+
+Expected: downloads packages, creates `node_modules/` and `package-lock.json`. If it fails on `engine-strict` it means the local Node is <22 — install Node 22 LTS via nvm/fnm first.
+
+- [ ] **Step 15: Verify dev server boots**
+
+```bash
+cd web_ui && npm run dev -- --port 5173 &
+sleep 3
+curl -s http://127.0.0.1:5173/ | grep -q "Heimdallm scaffold OK" && echo OK || echo FAIL
+kill %1
+```
+
+Expected: `OK`.
+
+- [ ] **Step 16: Verify production build**
+
+```bash
+cd web_ui && npm run build
+```
+
+Expected: exits 0, produces `web_ui/build/` directory with a `handler.js`.
+
+- [ ] **Step 17: Commit**
+
+```bash
+git add web_ui/
+git commit -m "chore(web_ui): bootstrap SvelteKit project scaffold"
+```
+
+---
+
+## Task 2: Add TailwindCSS v4 and verify dev server renders styled content
+
+**Files:**
+- Create: `web_ui/src/app.css`
+- Modify: `web_ui/src/routes/+page.svelte`
+
+Tailwind CSS v4 is already installed as part of Task 1 and wired as a Vite plugin. This task adds the stylesheet import and confirms utility classes work end-to-end.
+
+- [ ] **Step 1: Create `web_ui/src/app.css`**
+
+```css
+@import 'tailwindcss';
+
+:root {
+  color-scheme: light dark;
+}
+
+html,
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+}
+```
+
+- [ ] **Step 2: Update `web_ui/src/routes/+page.svelte` to import the stylesheet and use utility classes**
+
+```svelte
+<script lang="ts">
+  import '../app.css';
+</script>
+
+<main class="mx-auto max-w-3xl p-8">
+  <h1 class="text-3xl font-bold text-indigo-600">Heimdallm scaffold OK</h1>
+  <p class="mt-2 text-sm text-gray-500">Tailwind is wired.</p>
+</main>
+```
+
+- [ ] **Step 3: Verify dev server shows styled content**
+
+```bash
+cd web_ui && npm run dev -- --port 5173 &
+sleep 3
+curl -s http://127.0.0.1:5173/ | grep -q 'text-indigo-600' && echo OK || echo FAIL
+kill %1
+```
+
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/app.css web_ui/src/routes/+page.svelte
+git commit -m "chore(web_ui): integrate TailwindCSS v4"
+```
+
+---
+
+## Task 3: Define TypeScript types in `src/lib/types.ts`
+
+**Files:**
+- Create: `web_ui/src/lib/types.ts`
+
+The types below mirror the Dart models in `flutter_app/lib/core/models/`. Note:
+- The Dart codebase uses `Issue` for "code finding" (file/line/severity). In TS we rename that to **`ReviewFinding`** so `Issue` can mean "GitHub issue" per the Fase-2 design spec — a naming collision we resolve in favour of the Fase-2 semantic.
+- Field names keep the daemon's snake_case wire format. Callers convert to camelCase only at the UI layer.
+
+- [ ] **Step 1: Create `web_ui/src/lib/types.ts`**
+
+```ts
+// Wire-format types mirroring the daemon's JSON responses.
+// Field names intentionally use snake_case to match the wire format.
+
+export interface ReviewFinding {
+  file: string;
+  line: number;
+  description: string;
+  severity: string;
+}
+
+export interface Review {
+  id: number;
+  pr_id: number;
+  cli_used: string;
+  summary: string;
+  issues: ReviewFinding[];
+  suggestions: string[];
+  severity: string;
+  created_at: string;
+}
+
+export interface PR {
+  id: number;
+  github_id: number;
+  repo: string;
+  number: number;
+  title: string;
+  author: string;
+  url: string;
+  state: string;
+  updated_at: string;
+  dismissed: boolean;
+  latest_review?: Review | null;
+}
+
+export interface PRDetail {
+  pr: PR;
+  reviews: Review[];
+}
+
+// Fase-2 GitHub issue tracking (daemon endpoints not yet implemented).
+export interface Issue {
+  id: number;
+  github_id: number;
+  repo: string;
+  number: number;
+  title: string;
+  body: string;
+  author: string;
+  assignees: string[];
+  labels: string[];
+  state: string;
+  created_at: string;
+  fetched_at: string;
+  dismissed: boolean;
+  latest_review?: IssueReview | null;
+}
+
+export interface IssueReview {
+  id: number;
+  issue_id: number;
+  cli_used: string;
+  summary: string;
+  triage: unknown;
+  suggestions: unknown[];
+  action_taken: 'review_only' | 'auto_implement';
+  pr_created: number;
+  created_at: string;
+}
+
+export interface IssueDetail {
+  issue: Issue;
+  reviews: IssueReview[];
+}
+
+// Agent == ReviewPrompt in the Dart codebase.
+export interface Agent {
+  id: string;
+  name: string;
+  focus: string;
+  instructions: string;
+  prompt: string;
+  cli_flags: string;
+  is_default: boolean;
+}
+
+export interface Stats {
+  total_prs?: number;
+  open_issues?: number;
+  reviews_today?: number;
+  uptime_seconds?: number;
+  [key: string]: unknown;
+}
+
+export interface Me {
+  login: string;
+}
+
+// Config is deliberately loose — the shape is large and the daemon owns
+// validation. Typed access happens at the Config-page level in a later PR.
+export type Config = Record<string, unknown>;
+
+// SSE event types emitted by the daemon.
+export type SseEventType =
+  | 'pr_updated'
+  | 'issue_updated'
+  | 'config_reloaded'
+  | 'log'
+  | 'message';
+
+export interface SseEvent<T = unknown> {
+  type: SseEventType;
+  data: T;
+}
+```
+
+- [ ] **Step 2: Verify types compile**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: `0 errors, 0 warnings`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web_ui/src/lib/types.ts
+git commit -m "feat(web_ui): define TypeScript types mirroring daemon wire format"
+```
+
+---
+
+## Task 4: Server-side token loader with tests (TDD)
+
+**Files:**
+- Create: `web_ui/src/lib/server/token.ts`
+- Create: `web_ui/src/tests/token.test.ts`
+
+Precedence: `HEIMDALLM_API_TOKEN` env var wins over `HEIMDALLM_API_TOKEN_FILE` (default `/data/api_token`). Cached after first successful read so we don't hit the filesystem on every request.
+
+- [ ] **Step 1: Write failing tests at `web_ui/src/tests/token.test.ts`**
+
+```ts
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readFileMock = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: unknown[]) => readFileMock(...args)
+}));
+
+const originalEnv = { ...process.env };
+
+beforeEach(async () => {
+  vi.resetModules();
+  readFileMock.mockReset();
+  process.env = { ...originalEnv };
+  delete process.env.HEIMDALLM_API_TOKEN;
+  delete process.env.HEIMDALLM_API_TOKEN_FILE;
+});
+
+describe('loadToken', () => {
+  it('returns env var when set and non-empty', async () => {
+    process.env.HEIMDALLM_API_TOKEN = 'env-token';
+    readFileMock.mockResolvedValue('file-token\n');
+    const { loadToken } = await import('../lib/server/token.js');
+    expect(await loadToken()).toBe('env-token');
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to file when env var missing, trimming trailing newline', async () => {
+    readFileMock.mockResolvedValue('file-token\n');
+    const { loadToken } = await import('../lib/server/token.js');
+    expect(await loadToken()).toBe('file-token');
+    expect(readFileMock).toHaveBeenCalledWith('/data/api_token', 'utf-8');
+  });
+
+  it('caches the resolved token across calls', async () => {
+    readFileMock.mockResolvedValue('file-token\n');
+    const { loadToken } = await import('../lib/server/token.js');
+    expect(await loadToken()).toBe('file-token');
+    expect(await loadToken()).toBe('file-token');
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when neither env nor file yields a token', async () => {
+    readFileMock.mockRejectedValue(new Error('ENOENT'));
+    const { loadToken } = await import('../lib/server/token.js');
+    expect(await loadToken()).toBeNull();
+  });
+
+  it('uses HEIMDALLM_API_TOKEN_FILE override when set', async () => {
+    process.env.HEIMDALLM_API_TOKEN_FILE = '/run/secrets/token';
+    readFileMock.mockResolvedValue('secret\n');
+    const { loadToken } = await import('../lib/server/token.js');
+    expect(await loadToken()).toBe('secret');
+    expect(readFileMock).toHaveBeenCalledWith('/run/secrets/token', 'utf-8');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm they fail because the module doesn't exist**
+
+```bash
+cd web_ui && npm test -- src/tests/token.test.ts
+```
+
+Expected: FAIL with `Cannot find module '../lib/server/token.js'` (or similar).
+
+- [ ] **Step 3: Implement `web_ui/src/lib/server/token.ts`**
+
+```ts
+import { readFile } from 'node:fs/promises';
+
+let cached: string | null | undefined;
+
+export async function loadToken(): Promise<string | null> {
+  if (cached !== undefined) return cached;
+
+  const envToken = process.env.HEIMDALLM_API_TOKEN;
+  if (envToken && envToken.trim().length > 0) {
+    cached = envToken.trim();
+    return cached;
+  }
+
+  const path = process.env.HEIMDALLM_API_TOKEN_FILE ?? '/data/api_token';
+  try {
+    const contents = await readFile(path, 'utf-8');
+    const trimmed = contents.trim();
+    cached = trimmed.length > 0 ? trimmed : null;
+  } catch {
+    cached = null;
+  }
+  return cached;
+}
+
+/** Resets the in-memory cache. For tests only. */
+export function __resetTokenCache(): void {
+  cached = undefined;
+}
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+cd web_ui && npm test -- src/tests/token.test.ts
+```
+
+Expected: 5 passing tests.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web_ui/src/lib/server/ web_ui/src/tests/token.test.ts
+git commit -m "feat(web_ui): add server-side token loader with env/file precedence"
+```
+
+---
+
+## Task 5: API catch-all proxy (`/api/[...path]`)
+
+**Files:**
+- Create: `web_ui/src/routes/api/[...path]/+server.ts`
+
+Forwards any HTTP method + path to the daemon, injects `X-Heimdallm-Token`, streams the response body back unchanged. No JSON parsing, no validation. If the token is missing, returns 503 with a clear JSON error.
+
+- [ ] **Step 1: Create `web_ui/src/routes/api/[...path]/+server.ts`**
+
+```ts
+import { loadToken } from '$lib/server/token.js';
+import { error, type RequestHandler } from '@sveltejs/kit';
+
+const DAEMON_URL = process.env.HEIMDALLM_API_URL ?? 'http://127.0.0.1:7842';
+
+const handle: RequestHandler = async ({ params, request, url, fetch: _fetch }) => {
+  const token = await loadToken();
+  if (!token) {
+    error(
+      503,
+      JSON.stringify({
+        message:
+          'daemon token missing: set HEIMDALLM_API_TOKEN or mount /data/api_token'
+      })
+    );
+  }
+
+  const target = new URL(`${DAEMON_URL}/${params.path ?? ''}`);
+  target.search = url.search;
+
+  const headers = new Headers();
+  const contentType = request.headers.get('content-type');
+  if (contentType) headers.set('content-type', contentType);
+  headers.set('X-Heimdallm-Token', token);
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    signal: request.signal,
+    // @ts-expect-error duplex is required by Node fetch when streaming a body
+    duplex: 'half'
+  };
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    init.body = request.body;
+  }
+
+  const upstream = await fetch(target, init);
+
+  const respHeaders = new Headers();
+  const upstreamCt = upstream.headers.get('content-type');
+  if (upstreamCt) respHeaders.set('content-type', upstreamCt);
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: respHeaders
+  });
+};
+
+export const GET = handle;
+export const POST = handle;
+export const PUT = handle;
+export const DELETE = handle;
+export const PATCH = handle;
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: `0 errors`. (The `@ts-expect-error` on `duplex` is required because `RequestInit` lib types don't include `duplex` yet.)
+
+- [ ] **Step 3: Verify build still passes**
+
+```bash
+cd web_ui && npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/routes/api/
+git commit -m "feat(web_ui): add catch-all /api proxy to daemon"
+```
+
+---
+
+## Task 6: SSE passthrough proxy (`/events`)
+
+**Files:**
+- Create: `web_ui/src/routes/events/+server.ts`
+
+Opens an upstream streaming fetch to the daemon's `/events`, pipes the `ReadableStream` back to the browser with `text/event-stream` headers. Browser disconnect aborts the upstream via `request.signal`.
+
+- [ ] **Step 1: Create `web_ui/src/routes/events/+server.ts`**
+
+```ts
+import { loadToken } from '$lib/server/token.js';
+import { error, type RequestHandler } from '@sveltejs/kit';
+
+const DAEMON_URL = process.env.HEIMDALLM_API_URL ?? 'http://127.0.0.1:7842';
+
+export const GET: RequestHandler = async ({ request }) => {
+  const token = await loadToken();
+  if (!token) {
+    error(503, 'daemon token missing');
+  }
+
+  const upstream = await fetch(`${DAEMON_URL}/events`, {
+    headers: {
+      Accept: 'text/event-stream',
+      'X-Heimdallm-Token': token
+    },
+    signal: request.signal
+  });
+
+  if (!upstream.ok || !upstream.body) {
+    error(upstream.status || 502, `daemon /events failed: ${upstream.status}`);
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive'
+    }
+  });
+};
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 3: Verify build passes**
+
+```bash
+cd web_ui && npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/routes/events/
+git commit -m "feat(web_ui): add /events SSE passthrough to daemon"
+```
+
+---
+
+## Task 7: HTTP client `src/lib/api.ts` with tests (TDD)
+
+**Files:**
+- Create: `web_ui/src/lib/api.ts`
+- Create: `web_ui/src/tests/api.test.ts`
+
+One `request()` helper does all HTTP work. Each typed method delegates with the right verb/path. `ApiError` exposes `{ status, statusText, path, message }`. All browser requests hit `/api/<daemon-path>` — same-origin, token injected by the proxy.
+
+- [ ] **Step 1: Write failing tests at `web_ui/src/tests/api.test.ts`**
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, fetchPRs, fetchStats, triggerReview, upsertAgent } from '../lib/api.js';
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function okJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+describe('api.ts', () => {
+  it('fetchPRs GETs /api/prs and returns a typed array', async () => {
+    fetchMock.mockResolvedValue(okJson([{ id: 1, number: 42, title: 't' }]));
+    const prs = await fetchPRs();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/prs',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(prs).toHaveLength(1);
+    expect(prs[0].id).toBe(1);
+  });
+
+  it('triggerReview POSTs and resolves on 202', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
+    await expect(triggerReview(7)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/prs/7/review',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('triggerReview throws ApiError on 500', async () => {
+    fetchMock.mockResolvedValue(new Response('boom', { status: 500, statusText: 'Server Error' }));
+    await expect(triggerReview(7)).rejects.toBeInstanceOf(ApiError);
+    await expect(triggerReview(7)).rejects.toMatchObject({
+      status: 500,
+      path: '/api/prs/7/review'
+    });
+  });
+
+  it('upsertAgent POSTs JSON body with correct content-type', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    await upsertAgent({
+      id: 'a',
+      name: 'A',
+      focus: 'general',
+      instructions: '',
+      prompt: '',
+      cli_flags: '',
+      is_default: false
+    });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init.body as string)).toMatchObject({ id: 'a', name: 'A' });
+  });
+
+  it('fetchStats returns parsed JSON object', async () => {
+    fetchMock.mockResolvedValue(okJson({ total_prs: 3, uptime_seconds: 99 }));
+    const stats = await fetchStats();
+    expect(stats.total_prs).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd web_ui && npm test -- src/tests/api.test.ts
+```
+
+Expected: FAIL with `Cannot find module '../lib/api.js'`.
+
+- [ ] **Step 3: Implement `web_ui/src/lib/api.ts`**
+
+```ts
+import type {
+  Agent,
+  Config,
+  Issue,
+  IssueDetail,
+  Me,
+  PR,
+  PRDetail,
+  Stats
+} from './types.js';
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly path: string,
+    message?: string
+  ) {
+    super(message ?? `${path} failed: ${status} ${statusText}`);
+    this.name = 'ApiError';
+  }
+}
+
+type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+async function request<T>(
+  method: Method,
+  path: string,
+  body?: unknown,
+  { expectEmpty = false }: { expectEmpty?: boolean } = {}
+): Promise<T> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { 'Content-Type': 'application/json' };
+    init.body = JSON.stringify(body);
+  }
+  const resp = await fetch(path, init);
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new ApiError(resp.status, resp.statusText, path, text || undefined);
+  }
+  if (expectEmpty || resp.status === 202 || resp.status === 204) {
+    return undefined as T;
+  }
+  return (await resp.json()) as T;
+}
+
+// ─── Health ─────────────────────────────────────────────────────────────
+export function checkHealth(): Promise<boolean> {
+  return fetch('/api/health')
+    .then((r) => r.ok)
+    .catch(() => false);
+}
+
+// ─── PRs ────────────────────────────────────────────────────────────────
+export function fetchPRs(): Promise<PR[]> {
+  return request<PR[]>('GET', '/api/prs');
+}
+
+export function fetchPR(id: number): Promise<PRDetail> {
+  return request<PRDetail>('GET', `/api/prs/${id}`);
+}
+
+export function triggerReview(id: number): Promise<void> {
+  return request<void>('POST', `/api/prs/${id}/review`, undefined, { expectEmpty: true });
+}
+
+export function dismissPR(id: number): Promise<void> {
+  return request<void>('POST', `/api/prs/${id}/dismiss`, undefined, { expectEmpty: true });
+}
+
+export function undismissPR(id: number): Promise<void> {
+  return request<void>('POST', `/api/prs/${id}/undismiss`, undefined, { expectEmpty: true });
+}
+
+// ─── Issues (Fase 2 — daemon endpoints arrive in #25–#28) ───────────────
+export function fetchIssues(): Promise<Issue[]> {
+  return request<Issue[]>('GET', '/api/issues');
+}
+
+export function fetchIssue(id: number): Promise<IssueDetail> {
+  return request<IssueDetail>('GET', `/api/issues/${id}`);
+}
+
+export function triggerIssueReview(id: number): Promise<void> {
+  return request<void>('POST', `/api/issues/${id}/review`, undefined, { expectEmpty: true });
+}
+
+export function dismissIssue(id: number): Promise<void> {
+  return request<void>('POST', `/api/issues/${id}/dismiss`, undefined, { expectEmpty: true });
+}
+
+export function undismissIssue(id: number): Promise<void> {
+  return request<void>('POST', `/api/issues/${id}/undismiss`, undefined, { expectEmpty: true });
+}
+
+// ─── Config ─────────────────────────────────────────────────────────────
+export function fetchConfig(): Promise<Config> {
+  return request<Config>('GET', '/api/config');
+}
+
+export function updateConfig(config: Config): Promise<void> {
+  return request<void>('PUT', '/api/config', config, { expectEmpty: true });
+}
+
+export function reloadConfig(): Promise<void> {
+  return request<void>('POST', '/api/reload', undefined, { expectEmpty: true });
+}
+
+// ─── Agents ─────────────────────────────────────────────────────────────
+export function fetchAgents(): Promise<Agent[]> {
+  return request<Agent[]>('GET', '/api/agents');
+}
+
+export function upsertAgent(agent: Agent): Promise<void> {
+  return request<void>('POST', '/api/agents', agent, { expectEmpty: true });
+}
+
+export function deleteAgent(id: string): Promise<void> {
+  return request<void>('DELETE', `/api/agents/${id}`, undefined, { expectEmpty: true });
+}
+
+// ─── Identity & stats ───────────────────────────────────────────────────
+export function fetchMe(): Promise<Me> {
+  return request<Me>('GET', '/api/me');
+}
+
+export function fetchStats(): Promise<Stats> {
+  return request<Stats>('GET', '/api/stats');
+}
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+cd web_ui && npm test -- src/tests/api.test.ts
+```
+
+Expected: 5 passing tests.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web_ui/src/lib/api.ts web_ui/src/tests/api.test.ts
+git commit -m "feat(web_ui): typed API client mirroring api_client.dart"
+```
+
+---
+
+## Task 8: SSE wrapper `src/lib/sse.ts` with tests (TDD)
+
+**Files:**
+- Create: `web_ui/src/lib/sse.ts`
+- Create: `web_ui/src/tests/sse.test.ts`
+
+Wraps native `EventSource` into two Svelte stores: `events` (a readable of every parsed event) and `connected` (a readable boolean reflecting readyState). Exposes `close()` for teardown.
+
+- [ ] **Step 1: Write failing tests at `web_ui/src/tests/sse.test.ts`**
+
+```ts
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { connectEvents } from '../lib/sse.js';
+
+type Listener = (e: MessageEvent) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  url: string;
+  readyState = MockEventSource.CONNECTING;
+  onopen: ((e: Event) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  closed = false;
+  listeners: Record<string, Listener[]> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: Listener): void {
+    (this.listeners[type] ||= []).push(cb);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = MockEventSource.CLOSED;
+  }
+
+  // test helpers
+  emit(type: string, data: string): void {
+    const ev = new MessageEvent(type, { data });
+    this.listeners[type]?.forEach((cb) => cb(ev));
+  }
+  fireOpen(): void {
+    this.readyState = MockEventSource.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+  fireError(): void {
+    this.onerror?.(new Event('error'));
+  }
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  vi.stubGlobal('EventSource', MockEventSource);
+});
+
+describe('connectEvents', () => {
+  it('opens EventSource at /events', () => {
+    connectEvents();
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe('/events');
+  });
+
+  it('pushes typed events into the events store', () => {
+    const handle = connectEvents();
+    const es = MockEventSource.instances[0];
+    const received: unknown[] = [];
+    const unsub = handle.events.subscribe((e) => {
+      if (e) received.push(e);
+    });
+    es.emit('pr_updated', JSON.stringify({ id: 1 }));
+    es.emit('log', '"hello"');
+    unsub();
+    expect(received).toEqual([
+      { type: 'pr_updated', data: { id: 1 } },
+      { type: 'log', data: 'hello' }
+    ]);
+  });
+
+  it('connected store reflects open/error transitions', () => {
+    const handle = connectEvents();
+    const es = MockEventSource.instances[0];
+    expect(get(handle.connected)).toBe(false);
+    es.fireOpen();
+    expect(get(handle.connected)).toBe(true);
+    es.fireError();
+    expect(get(handle.connected)).toBe(false);
+  });
+
+  it('close() calls EventSource.close()', () => {
+    const handle = connectEvents();
+    const es = MockEventSource.instances[0];
+    handle.close();
+    expect(es.closed).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd web_ui && npm test -- src/tests/sse.test.ts
+```
+
+Expected: FAIL with `Cannot find module '../lib/sse.js'`.
+
+- [ ] **Step 3: Implement `web_ui/src/lib/sse.ts`**
+
+```ts
+import { readable, writable, type Readable } from 'svelte/store';
+import type { SseEvent, SseEventType } from './types.js';
+
+const KNOWN_EVENT_TYPES: SseEventType[] = [
+  'pr_updated',
+  'issue_updated',
+  'config_reloaded',
+  'log',
+  'message'
+];
+
+export interface EventsHandle {
+  events: Readable<SseEvent | null>;
+  connected: Readable<boolean>;
+  close: () => void;
+}
+
+function parse(data: string): unknown {
+  try {
+    return JSON.parse(data);
+  } catch {
+    return data;
+  }
+}
+
+export function connectEvents(path = '/events'): EventsHandle {
+  const connected = writable(false);
+  let emit: ((e: SseEvent) => void) | undefined;
+  const events = readable<SseEvent | null>(null, (set) => {
+    emit = (e) => set(e);
+    return () => {
+      emit = undefined;
+    };
+  });
+
+  const source = new EventSource(path);
+
+  source.onopen = () => connected.set(true);
+  source.onerror = () => connected.set(false);
+
+  for (const type of KNOWN_EVENT_TYPES) {
+    source.addEventListener(type, (ev) => {
+      const msg = ev as MessageEvent;
+      emit?.({ type, data: parse(msg.data) });
+    });
+  }
+
+  return {
+    events,
+    connected,
+    close: () => {
+      source.close();
+      connected.set(false);
+    }
+  };
+}
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+cd web_ui && npm test -- src/tests/sse.test.ts
+```
+
+Expected: 4 passing tests.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web_ui/src/lib/sse.ts web_ui/src/tests/sse.test.ts
+git commit -m "feat(web_ui): SSE wrapper exposing events and connected stores"
+```
+
+---
+
+## Task 9: Auth store and `+layout.ts` loader
+
+**Files:**
+- Create: `web_ui/src/lib/stores.ts`
+- Create: `web_ui/src/routes/+layout.ts`
+
+Auth is best-effort: if `/api/me` succeeds we store the login; if it fails we surface a friendly message via `authError`. The landing page reads from this store; future pages (#31/#32) will too.
+
+- [ ] **Step 1: Create `web_ui/src/lib/stores.ts`**
+
+```ts
+import { writable } from 'svelte/store';
+
+export interface AuthState {
+  login: string | null;
+  authError: string | null;
+  ready: boolean;
+}
+
+export const auth = writable<AuthState>({ login: null, authError: null, ready: false });
+```
+
+- [ ] **Step 2: Create `web_ui/src/routes/+layout.ts`**
+
+```ts
+import { fetchMe } from '$lib/api.js';
+import { auth } from '$lib/stores.js';
+import type { LayoutLoad } from './$types.js';
+
+export const ssr = false; // browser-only — auth state + SSE live in the client
+
+export const load: LayoutLoad = async () => {
+  try {
+    const me = await fetchMe();
+    auth.set({ login: me.login ?? null, authError: null, ready: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'daemon unreachable';
+    auth.set({ login: null, authError: message, ready: true });
+  }
+  return {};
+};
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: `0 errors`. (SvelteKit generates `./$types.js` during `svelte-kit sync` — the `check` script runs that first.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/lib/stores.ts web_ui/src/routes/+layout.ts
+git commit -m "feat(web_ui): auth store + layout loader calling /api/me"
+```
+
+---
+
+## Task 10: Layout shell (`+layout.svelte`)
+
+**Files:**
+- Create: `web_ui/src/routes/+layout.svelte`
+
+Top nav bar, login display, auth-error banner, SSE connection initiated on mount and torn down on destroy. Nav links point at routes #31/#32 will add — they'll 404 until then, which is intentional.
+
+- [ ] **Step 1: Create `web_ui/src/routes/+layout.svelte`**
+
+```svelte
+<script lang="ts">
+  import '../app.css';
+  import { browser } from '$app/environment';
+  import { page } from '$app/stores';
+  import { connectEvents, type EventsHandle } from '$lib/sse.js';
+  import { auth } from '$lib/stores.js';
+  import { onDestroy, onMount } from 'svelte';
+
+  let { children } = $props();
+
+  let sse: EventsHandle | undefined;
+
+  onMount(() => {
+    if (browser) sse = connectEvents();
+  });
+
+  onDestroy(() => {
+    sse?.close();
+  });
+
+  const navItems = [
+    { href: '/', label: 'Dashboard' },
+    { href: '/prs', label: 'PRs' },
+    { href: '/issues', label: 'Issues' },
+    { href: '/agents', label: 'Agents' },
+    { href: '/config', label: 'Config' },
+    { href: '/logs', label: 'Logs' }
+  ];
+</script>
+
+<header class="border-b border-gray-200 bg-white">
+  <nav class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-3">
+    <a href="/" class="text-lg font-semibold tracking-tight">Heimdallm</a>
+    <ul class="flex items-center gap-4 text-sm">
+      {#each navItems as item (item.href)}
+        <li>
+          <a
+            href={item.href}
+            class="hover:text-indigo-600 {$page.url.pathname === item.href
+              ? 'text-indigo-600 font-medium'
+              : 'text-gray-600'}"
+          >
+            {item.label}
+          </a>
+        </li>
+      {/each}
+    </ul>
+    <span class="text-sm text-gray-500" data-testid="login">
+      {$auth.login ?? '—'}
+    </span>
+  </nav>
+</header>
+
+{#if $auth.authError}
+  <div class="border-b border-red-200 bg-red-50 px-6 py-2 text-sm text-red-700">
+    Daemon unreachable — check <code>HEIMDALLM_API_URL</code>. ({$auth.authError})
+  </div>
+{/if}
+
+<main class="mx-auto max-w-6xl px-6 py-8">
+  {@render children()}
+</main>
+```
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 3: Run build**
+
+```bash
+cd web_ui && npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Smoke-test in dev (without a daemon, auth banner should appear)**
+
+```bash
+cd web_ui && npm run dev -- --port 5173 &
+sleep 3
+curl -s http://127.0.0.1:5173/ | grep -q 'Heimdallm' && echo OK || echo FAIL
+kill %1
+```
+
+Expected: `OK` (the banner will be absent in SSR because `ssr = false`, but the nav shell will render).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web_ui/src/routes/+layout.svelte
+git commit -m "feat(web_ui): layout shell with nav, auth banner, and SSE init"
+```
+
+---
+
+## Task 11: Landing page (`+page.svelte`) with SSE indicator and stats
+
+**Files:**
+- Replace contents of: `web_ui/src/routes/+page.svelte`
+
+Demonstrates end-to-end wiring: hits `/api/stats` and shows the resulting key numbers, plus a live connection pill driven by the SSE `connected` store.
+
+- [ ] **Step 1: Replace `web_ui/src/routes/+page.svelte`**
+
+```svelte
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { fetchStats } from '$lib/api.js';
+  import { connectEvents } from '$lib/sse.js';
+  import type { Stats } from '$lib/types.js';
+  import { onDestroy, onMount } from 'svelte';
+
+  let stats = $state<Stats | null>(null);
+  let statsError = $state<string | null>(null);
+  let sseHandle = $state<ReturnType<typeof connectEvents> | null>(null);
+  let connected = $state(false);
+  let connUnsub: (() => void) | undefined;
+
+  onMount(async () => {
+    if (!browser) return;
+    sseHandle = connectEvents();
+    connUnsub = sseHandle.connected.subscribe((v) => (connected = v));
+    try {
+      stats = await fetchStats();
+    } catch (e) {
+      statsError = e instanceof Error ? e.message : String(e);
+    }
+  });
+
+  onDestroy(() => {
+    connUnsub?.();
+    sseHandle?.close();
+  });
+
+  const pillClass = $derived(
+    connected
+      ? 'bg-green-100 text-green-700'
+      : 'bg-amber-100 text-amber-700'
+  );
+  const pillLabel = $derived(connected ? 'connected' : 'disconnected');
+</script>
+
+<section class="flex items-center gap-3">
+  <h1 class="text-3xl font-bold">Heimdallm</h1>
+  <span class="rounded-full px-2 py-0.5 text-xs font-medium {pillClass}" data-testid="sse-pill">
+    {pillLabel}
+  </span>
+</section>
+
+<p class="mt-1 text-sm text-gray-500">v0.1 scaffold — dashboard lands in #31.</p>
+
+<section class="mt-8 grid grid-cols-2 gap-4 md:grid-cols-4">
+  {#each [
+    { label: 'Total PRs', value: stats?.total_prs },
+    { label: 'Open issues', value: stats?.open_issues },
+    { label: 'Reviews today', value: stats?.reviews_today },
+    { label: 'Uptime (s)', value: stats?.uptime_seconds }
+  ] as cell (cell.label)}
+    <div class="rounded-lg border border-gray-200 bg-white p-4">
+      <dt class="text-xs uppercase tracking-wide text-gray-500">{cell.label}</dt>
+      <dd class="mt-1 text-2xl font-semibold">
+        {cell.value ?? '—'}
+      </dd>
+    </div>
+  {/each}
+</section>
+
+{#if statsError}
+  <p class="mt-4 text-sm text-red-600">Could not load stats: {statsError}</p>
+{/if}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+cd web_ui && npm run check
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 3: Run build**
+
+```bash
+cd web_ui && npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web_ui/src/routes/+page.svelte
+git commit -m "feat(web_ui): landing page with SSE indicator and stats cards"
+```
+
+---
+
+## Task 12: `.env.example` and `README.md`
+
+**Files:**
+- Create: `web_ui/.env.example`
+- Create: `web_ui/README.md`
+
+- [ ] **Step 1: Create `web_ui/.env.example`**
+
+```
+# URL of the running heimdallm daemon. In docker-compose, set to
+# http://daemon:7842 (internal service hostname).
+HEIMDALLM_API_URL=http://127.0.0.1:7842
+
+# API token. Leave unset to read from HEIMDALLM_API_TOKEN_FILE instead.
+# HEIMDALLM_API_TOKEN=
+
+# Path to the token file. Defaults to /data/api_token. For local dev,
+# point at ~/.local/share/heimdallm/api_token.
+# HEIMDALLM_API_TOKEN_FILE=/data/api_token
+```
+
+- [ ] **Step 2: Create `web_ui/README.md`**
+
+```markdown
+# Heimdallm Web UI
+
+SvelteKit dashboard — a browser-based alternative to the Flutter desktop app.
+
+See the [design spec](../docs/superpowers/specs/2026-04-17-web-ui-scaffold-design.md) for the architecture.
+
+## Local development
+
+Prereqs: Node 22 LTS, a running heimdallm daemon on `127.0.0.1:7842` with a token at `~/.local/share/heimdallm/api_token`.
+
+```bash
+cd web_ui
+cp .env.example .env
+# point HEIMDALLM_API_TOKEN_FILE at your local token file, e.g.:
+echo "HEIMDALLM_API_TOKEN_FILE=$HOME/.local/share/heimdallm/api_token" >> .env
+
+npm install
+npm run dev
+```
+
+Open http://127.0.0.1:5173.
+
+## Scripts
+
+- `npm run dev` — Vite dev server with HMR.
+- `npm run build` — production build (adapter-node output in `build/`).
+- `npm run preview` — preview the production build.
+- `npm run check` — type-check with svelte-check.
+- `npm test` — unit tests (Vitest).
+- `npm run lint` / `npm run format` — prettier + eslint.
+
+## Architecture at a glance
+
+```
+Browser ── /api/* ── SvelteKit server ── daemon :7842
+        └─ /events ─┘                    (X-Heimdallm-Token injected server-side)
+```
+
+The token lives in `src/lib/server/token.ts` and never ships to the browser. Same-origin SSE means we use native `EventSource` without polyfills.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web_ui/.env.example web_ui/README.md
+git commit -m "docs(web_ui): add .env.example and README quickstart"
+```
+
+---
+
+## Task 13: Dockerfile + `.dockerignore`
+
+**Files:**
+- Create: `web_ui/Dockerfile`
+- Create: `web_ui/.dockerignore`
+
+Multi-stage build: `node:22-alpine` build stage runs `npm ci` + `npm run build`; runtime stage copies only `build/`, `package.json`, and production `node_modules`. Final image runs as the unprivileged `node` user on port 3000. docker-compose wiring lives in issue #33.
+
+- [ ] **Step 1: Create `web_ui/.dockerignore`**
+
+```
+node_modules
+build
+.svelte-kit
+.git
+.env
+.env.*
+!.env.example
+*.log
+.DS_Store
+```
+
+- [ ] **Step 2: Create `web_ui/Dockerfile`**
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+
+# ─── Build stage ────────────────────────────────────────────────────────
+FROM node:22-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build && npm prune --omit=dev
+
+# ─── Runtime stage ──────────────────────────────────────────────────────
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOST=0.0.0.0
+
+COPY --from=build /app/build ./build
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
+
+USER node
+EXPOSE 3000
+CMD ["node", "build"]
+```
+
+- [ ] **Step 3: Verify the image builds**
+
+```bash
+cd web_ui && docker build -t heimdallm-web:dev .
+```
+
+Expected: image builds successfully.
+
+- [ ] **Step 4: Smoke-run the image (no daemon required for boot — the app serves the shell; `/api/me` will 503 without a token)**
+
+```bash
+docker run --rm -d --name heimdallm-web-smoke -p 3000:3000 heimdallm-web:dev
+sleep 3
+curl -s http://127.0.0.1:3000/ | grep -q 'Heimdallm' && echo OK || echo FAIL
+docker stop heimdallm-web-smoke
+```
+
+Expected: `OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web_ui/Dockerfile web_ui/.dockerignore
+git commit -m "feat(web_ui): add Dockerfile for standalone container build"
+```
+
+---
+
+## Task 14: Final verification against acceptance criteria
+
+- [ ] **Step 1: Run the full check suite**
+
+```bash
+cd web_ui && npm run check && npm test && npm run build
+```
+
+Expected:
+- `svelte-check` reports 0 errors, 0 warnings.
+- Vitest: all tests pass (5 in `token.test.ts` + 5 in `api.test.ts` + 4 in `sse.test.ts` = 14).
+- Build succeeds and produces `build/`.
+
+- [ ] **Step 2: Confirm the dev server works end-to-end with a real daemon**
+
+Only runnable if you have the daemon running locally.
+
+```bash
+cd web_ui
+echo "HEIMDALLM_API_TOKEN_FILE=$HOME/.local/share/heimdallm/api_token" > .env
+npm run dev -- --port 5173 &
+sleep 3
+# expect the login name of the authenticated user in the response
+curl -s http://127.0.0.1:5173/api/me
+# expect an event-stream response (will hang — use timeout)
+timeout 3 curl -sN http://127.0.0.1:5173/events | head -n 5 || true
+kill %1
+```
+
+Expected: `/api/me` returns `{"login":"..."}`; `/events` emits at least a `:` comment line or an actual event.
+
+- [ ] **Step 3: Map each AC in issue #30 to evidence**
+
+Paste into the PR description:
+
+| AC | Evidence |
+|---|---|
+| `npm run build` sin errores | Task 14 step 1 build passes |
+| `npm run dev` levanta el servidor | Task 14 step 2 dev server serves `/` |
+| `api.ts` tipado correctamente y conecta al daemon | `src/lib/api.ts` + `src/tests/api.test.ts` + Task 14 step 2 `/api/me` call |
+| SSE recibe y parsea eventos correctamente | `src/lib/sse.ts` + `src/tests/sse.test.ts` + Task 14 step 2 `/events` curl |
+| Token leído automáticamente | `src/lib/server/token.ts` + `src/tests/token.test.ts` (5 tests) |
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+# branch name convention from existing repo: <scope>/<short-slug>
+git checkout -b feat/web-ui-scaffold
+git push -u origin feat/web-ui-scaffold
+gh pr create --title "feat(web_ui): scaffold SvelteKit + API/SSE clients (#30)" \
+  --body "$(cat <<'EOF'
+Closes #30. Implements the foundational scaffold from
+`docs/superpowers/specs/2026-04-17-web-ui-scaffold-design.md`.
+
+## Summary
+
+- SvelteKit 2 + Svelte 5 + Tailwind v4 + adapter-node.
+- Server-side proxy: `/api/[...path]` catch-all + `/events` SSE passthrough.
+- `src/lib/server/token.ts` reads `HEIMDALLM_API_TOKEN` env var or `/data/api_token`.
+- `src/lib/api.ts` — typed client mirroring `api_client.dart` plus Fase-2 methods.
+- `src/lib/sse.ts` — native-EventSource wrapper exposing Svelte stores.
+- Landing page at `/` with connection indicator + stats cards.
+- Dockerfile (standalone; docker-compose wiring is #33).
+
+## Test plan
+
+- [x] `npm run check` — 0 errors
+- [x] `npm test` — 14 passing
+- [x] `npm run build` — produces `build/`
+- [x] `docker build` — succeeds
+- [ ] Manual: `/api/me` returns login with daemon running
+- [ ] Manual: `/events` streams events
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR opened; URL returned by `gh pr create`.
+
+- [ ] **Step 5: Mark #30 complete**
+
+Once the PR merges, #30 closes automatically via the `Closes #30` in the PR body.
+
+---
+
+## Self-review checklist (plan author)
+
+1. **Spec coverage** — every section of `2026-04-17-web-ui-scaffold-design.md` has a task:
+   - Architecture → Tasks 5, 6
+   - File layout → Task 1 (skeleton), Tasks 3–11 (files)
+   - Key interfaces → Tasks 3, 4, 5, 6, 7, 8
+   - Layout behaviour → Tasks 9, 10, 11
+   - TailwindCSS → Task 2
+   - Testing → Tasks 4, 7, 8
+   - Tooling → Task 1
+   - Dockerfile → Task 13
+   - AC mapping → Task 14
+   - Out-of-scope items are deliberately absent (no Issues route, no docker-compose).
+2. **No placeholders** — no TBD/TODO; every code block is concrete.
+3. **Type consistency** — `Agent`, `Stats`, `Me`, `PR`, `Review`, `Issue`, `SseEvent` defined in Task 3 are used verbatim in Tasks 7, 8, 10, 11.
+4. **Ambiguity** — `ReviewFinding` vs `Issue` naming divergence from Dart is called out explicitly in Task 3.

--- a/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
@@ -357,15 +357,21 @@ git commit -m "chore(web_ui): integrate TailwindCSS v4"
 **Files:**
 - Create: `web_ui/src/lib/types.ts`
 
-The types below mirror the Dart models in `flutter_app/lib/core/models/`. Note:
-- The Dart codebase uses `Issue` for "code finding" (file/line/severity). In TS we rename that to **`ReviewFinding`** so `Issue` can mean "GitHub issue" per the Fase-2 design spec — a naming collision we resolve in favour of the Fase-2 semantic.
-- Field names keep the daemon's snake_case wire format. Callers convert to camelCase only at the UI layer.
+The types below mirror the **daemon's wire format** (Go structs in `daemon/internal/store/*.go` and `daemon/internal/sse/broker.go`), not the Dart models. Most fields match Dart's models, but a few don't — see inline comments. Specifically:
+- The Dart codebase uses `Issue` for "code finding" (file/line/severity). In TS we rename that to **`ReviewFinding`** so `Issue` can mean "GitHub issue" per the Fase-2 design spec.
+- `Review.issues` and `Review.suggestions` arrive from the daemon as **JSON-encoded strings** (stored in TEXT columns), not arrays. `api.ts` parses them — see Task 7.
+- Field names keep snake_case to match the wire format. UI components convert to camelCase only at display time if needed.
 
 - [ ] **Step 1: Create `web_ui/src/lib/types.ts`**
 
 ```ts
 // Wire-format types mirroring the daemon's JSON responses.
 // Field names intentionally use snake_case to match the wire format.
+//
+// The Dart code-finding type (file/line/severity) is called `Issue` in
+// flutter_app/lib/core/models/issue.dart. We rename it to `ReviewFinding`
+// here so `Issue` can denote the Fase-2 GitHub-issue domain type without
+// collision.
 
 export interface ReviewFinding {
   file: string;
@@ -374,6 +380,11 @@ export interface ReviewFinding {
   severity: string;
 }
 
+// The daemon stores issues/suggestions as JSON-encoded strings in TEXT
+// columns (see daemon/internal/store/reviews.go: `Issues string json:"issues"`),
+// so the wire format is `"[{...}]"` — a string, not an array. api.ts is
+// responsible for parsing these strings into typed arrays before returning
+// Reviews to callers. The Dart api_client does the same in _parseReviewMap.
 export interface Review {
   id: number;
   pr_id: number;
@@ -383,6 +394,7 @@ export interface Review {
   suggestions: string[];
   severity: string;
   created_at: string;
+  github_review_id: number; // 0 = not yet published to GitHub
 }
 
 export interface PR {
@@ -395,6 +407,7 @@ export interface PR {
   url: string;
   state: string;
   updated_at: string;
+  fetched_at: string;
   dismissed: boolean;
   latest_review?: Review | null;
 }
@@ -404,7 +417,8 @@ export interface PRDetail {
   reviews: Review[];
 }
 
-// Fase-2 GitHub issue tracking (daemon endpoints not yet implemented).
+// Fase-2 GitHub issue tracking (daemon endpoints not yet implemented;
+// shape follows docs/superpowers/specs/2026-04-16-heimdallm-v2-design.md).
 export interface Issue {
   id: number;
   github_id: number;
@@ -439,23 +453,49 @@ export interface IssueDetail {
   reviews: IssueReview[];
 }
 
-// Agent == ReviewPrompt in the Dart codebase.
+// Agent mirrors daemon/internal/store/agents.go. The daemon's Agent
+// includes `cli` (claude | gemini | codex) and `created_at` in addition
+// to the fields Dart's ReviewPrompt exposes.
 export interface Agent {
   id: string;
   name: string;
-  focus: string;
-  instructions: string;
+  cli: string;
   prompt: string;
+  instructions: string;
   cli_flags: string;
   is_default: boolean;
+  created_at: string;
+}
+
+// Stats mirrors daemon/internal/store/store.go Stats struct.
+export interface RepoCount {
+  repo: string;
+  count: number;
+}
+
+export interface DayCount {
+  day: string;
+  count: number;
+}
+
+export interface ReviewTimingStats {
+  median_seconds: number;
+  min_seconds: number;
+  max_seconds: number;
+  bucket_fast: number;       // < 30 s
+  bucket_medium: number;     // 30–120 s
+  bucket_slow: number;       // 120–300 s
+  bucket_very_slow: number;  // > 300 s
 }
 
 export interface Stats {
-  total_prs?: number;
-  open_issues?: number;
-  reviews_today?: number;
-  uptime_seconds?: number;
-  [key: string]: unknown;
+  total_reviews: number;
+  by_severity: Record<string, number>;
+  by_cli: Record<string, number>;
+  top_repos: RepoCount[];
+  reviews_last_7_days: DayCount[];
+  avg_issues_per_review: number;
+  review_timing: ReviewTimingStats;
 }
 
 export interface Me {
@@ -466,13 +506,14 @@ export interface Me {
 // validation. Typed access happens at the Config-page level in a later PR.
 export type Config = Record<string, unknown>;
 
-// SSE event types emitted by the daemon.
+// SSE event types emitted by the daemon's sse.Broker. Must match the
+// constants in daemon/internal/sse/broker.go exactly or listeners in
+// sse.ts won't fire.
 export type SseEventType =
-  | 'pr_updated'
-  | 'issue_updated'
-  | 'config_reloaded'
-  | 'log'
-  | 'message';
+  | 'pr_detected'
+  | 'review_started'
+  | 'review_completed'
+  | 'review_error';
 
 export interface SseEvent<T = unknown> {
   type: SseEventType;
@@ -803,11 +844,13 @@ git commit -m "feat(web_ui): add /events SSE passthrough to daemon"
 
 One `request()` helper does all HTTP work. Each typed method delegates with the right verb/path. `ApiError` exposes `{ status, statusText, path, message }`. All browser requests hit `/api/<daemon-path>` — same-origin, token injected by the proxy.
 
+The daemon serialises `Review.issues` / `Review.suggestions` as JSON-encoded strings (not arrays). `api.ts` parses them transparently via a private `parseReview` helper so callers always get typed arrays — same behaviour as Dart's `_parseReviewMap`.
+
 - [ ] **Step 1: Write failing tests at `web_ui/src/tests/api.test.ts`**
 
 ```ts
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ApiError, fetchPRs, fetchStats, triggerReview, upsertAgent } from '../lib/api.js';
+import { ApiError, fetchPR, fetchPRs, fetchStats, triggerReview, upsertAgent } from '../lib/api.js';
 
 const fetchMock = vi.fn();
 
@@ -839,6 +882,31 @@ describe('api.ts', () => {
     expect(prs[0].id).toBe(1);
   });
 
+  it('fetchPR parses stringified issues/suggestions in latest_review', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({
+        pr: {
+          id: 1,
+          latest_review: {
+            id: 9,
+            issues: '[{"file":"a.go","line":1,"description":"x","severity":"LOW"}]',
+            suggestions: '["do the thing"]'
+          }
+        },
+        reviews: [
+          { id: 9, issues: '[]', suggestions: '[]' }
+        ]
+      })
+    );
+    const detail = await fetchPR(1);
+    expect(detail.pr.latest_review!.issues).toEqual([
+      { file: 'a.go', line: 1, description: 'x', severity: 'LOW' }
+    ]);
+    expect(detail.pr.latest_review!.suggestions).toEqual(['do the thing']);
+    expect(detail.reviews[0].issues).toEqual([]);
+    expect(detail.reviews[0].suggestions).toEqual([]);
+  });
+
   it('triggerReview POSTs and resolves on 202', async () => {
     fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
     await expect(triggerReview(7)).resolves.toBeUndefined();
@@ -862,22 +930,43 @@ describe('api.ts', () => {
     await upsertAgent({
       id: 'a',
       name: 'A',
-      focus: 'general',
-      instructions: '',
+      cli: 'claude',
       prompt: '',
+      instructions: 'Review carefully.',
       cli_flags: '',
-      is_default: false
+      is_default: false,
+      created_at: '2026-04-17T00:00:00Z'
     });
     const [, init] = fetchMock.mock.calls[0];
     expect(init.method).toBe('POST');
     expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
-    expect(JSON.parse(init.body as string)).toMatchObject({ id: 'a', name: 'A' });
+    expect(JSON.parse(init.body as string)).toMatchObject({ id: 'a', name: 'A', cli: 'claude' });
   });
 
   it('fetchStats returns parsed JSON object', async () => {
-    fetchMock.mockResolvedValue(okJson({ total_prs: 3, uptime_seconds: 99 }));
+    fetchMock.mockResolvedValue(
+      okJson({
+        total_reviews: 3,
+        by_severity: { HIGH: 1 },
+        by_cli: {},
+        top_repos: [],
+        reviews_last_7_days: [],
+        avg_issues_per_review: 1.5,
+        review_timing: {
+          median_seconds: 42,
+          min_seconds: 10,
+          max_seconds: 90,
+          bucket_fast: 1,
+          bucket_medium: 1,
+          bucket_slow: 1,
+          bucket_very_slow: 0
+        }
+      })
+    );
     const stats = await fetchStats();
-    expect(stats.total_prs).toBe(3);
+    expect(stats.total_reviews).toBe(3);
+    expect(stats.avg_issues_per_review).toBe(1.5);
+    expect(stats.review_timing.median_seconds).toBe(42);
   });
 });
 ```
@@ -901,6 +990,7 @@ import type {
   Me,
   PR,
   PRDetail,
+  Review,
   Stats
 } from './types.js';
 
@@ -940,6 +1030,28 @@ async function request<T>(
   return (await resp.json()) as T;
 }
 
+// The daemon stores issues/suggestions as JSON-encoded strings; this helper
+// parses them so callers always get typed arrays. Mirrors Dart's
+// _parseReviewMap in flutter_app/lib/core/api/api_client.dart.
+function parseReview(raw: unknown): Review {
+  const r = { ...(raw as Record<string, unknown>) };
+  if (typeof r.issues === 'string') {
+    r.issues = r.issues ? JSON.parse(r.issues as string) : [];
+  }
+  r.issues ??= [];
+  if (typeof r.suggestions === 'string') {
+    r.suggestions = r.suggestions ? JSON.parse(r.suggestions as string) : [];
+  }
+  r.suggestions ??= [];
+  return r as unknown as Review;
+}
+
+function parsePR(raw: unknown): PR {
+  const pr = { ...(raw as Record<string, unknown>) };
+  if (pr.latest_review) pr.latest_review = parseReview(pr.latest_review);
+  return pr as unknown as PR;
+}
+
 // ─── Health ─────────────────────────────────────────────────────────────
 export function checkHealth(): Promise<boolean> {
   return fetch('/api/health')
@@ -948,12 +1060,17 @@ export function checkHealth(): Promise<boolean> {
 }
 
 // ─── PRs ────────────────────────────────────────────────────────────────
-export function fetchPRs(): Promise<PR[]> {
-  return request<PR[]>('GET', '/api/prs');
+export async function fetchPRs(): Promise<PR[]> {
+  const raws = await request<unknown[]>('GET', '/api/prs');
+  return raws.map(parsePR);
 }
 
-export function fetchPR(id: number): Promise<PRDetail> {
-  return request<PRDetail>('GET', `/api/prs/${id}`);
+export async function fetchPR(id: number): Promise<PRDetail> {
+  const raw = await request<{ pr: unknown; reviews?: unknown[] }>('GET', `/api/prs/${id}`);
+  return {
+    pr: parsePR(raw.pr),
+    reviews: (raw.reviews ?? []).map(parseReview)
+  };
 }
 
 export function triggerReview(id: number): Promise<void> {
@@ -1127,12 +1244,12 @@ describe('connectEvents', () => {
     const unsub = handle.events.subscribe((e) => {
       if (e) received.push(e);
     });
-    es.emit('pr_updated', JSON.stringify({ id: 1 }));
-    es.emit('log', '"hello"');
+    es.emit('pr_detected', JSON.stringify({ id: 1 }));
+    es.emit('review_completed', '{"pr_id":1}');
     unsub();
     expect(received).toEqual([
-      { type: 'pr_updated', data: { id: 1 } },
-      { type: 'log', data: 'hello' }
+      { type: 'pr_detected', data: { id: 1 } },
+      { type: 'review_completed', data: { pr_id: 1 } }
     ]);
   });
 
@@ -1170,11 +1287,10 @@ import { readable, writable, type Readable } from 'svelte/store';
 import type { SseEvent, SseEventType } from './types.js';
 
 const KNOWN_EVENT_TYPES: SseEventType[] = [
-  'pr_updated',
-  'issue_updated',
-  'config_reloaded',
-  'log',
-  'message'
+  'pr_detected',
+  'review_started',
+  'review_completed',
+  'review_error'
 ];
 
 export interface EventsHandle {
@@ -1477,10 +1593,10 @@ Demonstrates end-to-end wiring: hits `/api/stats` and shows the resulting key nu
 
 <section class="mt-8 grid grid-cols-2 gap-4 md:grid-cols-4">
   {#each [
-    { label: 'Total PRs', value: stats?.total_prs },
-    { label: 'Open issues', value: stats?.open_issues },
-    { label: 'Reviews today', value: stats?.reviews_today },
-    { label: 'Uptime (s)', value: stats?.uptime_seconds }
+    { label: 'Total reviews', value: stats?.total_reviews },
+    { label: 'Avg findings / review', value: stats?.avg_issues_per_review?.toFixed(1) },
+    { label: 'Median time (s)', value: stats?.review_timing?.median_seconds?.toFixed(1) },
+    { label: 'High-severity', value: stats?.by_severity?.HIGH ?? 0 }
   ] as cell (cell.label)}
     <div class="rounded-lg border border-gray-200 bg-white p-4">
       <dt class="text-xs uppercase tracking-wide text-gray-500">{cell.label}</dt>
@@ -1686,7 +1802,7 @@ cd web_ui && npm run check && npm test && npm run build
 
 Expected:
 - `svelte-check` reports 0 errors, 0 warnings.
-- Vitest: all tests pass (5 in `token.test.ts` + 5 in `api.test.ts` + 4 in `sse.test.ts` = 14).
+- Vitest: all tests pass (5 in `token.test.ts` + 6 in `api.test.ts` + 4 in `sse.test.ts` = 15).
 - Build succeeds and produces `build/`.
 
 - [ ] **Step 2: Confirm the dev server works end-to-end with a real daemon**
@@ -1743,7 +1859,7 @@ Closes #30. Implements the foundational scaffold from
 ## Test plan
 
 - [x] `npm run check` — 0 errors
-- [x] `npm test` — 14 passing
+- [x] `npm test` — 15 passing
 - [x] `npm run build` — produces `build/`
 - [x] `docker build` — succeeds
 - [ ] Manual: `/api/me` returns login with daemon running

--- a/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
+++ b/docs/superpowers/plans/2026-04-17-web-ui-scaffold.md
@@ -6,7 +6,7 @@
 
 **Architecture:** SvelteKit 2.x with `@sveltejs/adapter-node`. Browser talks only to same-origin SvelteKit endpoints; a catch-all proxy `/api/[...path]` and a dedicated `/events` SSE passthrough inject `X-Heimdallm-Token` when forwarding to the daemon. The token lives in `src/lib/server/` — never ships to the browser. Native `EventSource` handles SSE because the connection is same-origin.
 
-**Tech Stack:** SvelteKit 2.x, Svelte 5 (runes), TypeScript 5.x, Vite 5.x, TailwindCSS 4, `@sveltejs/adapter-node`, Vitest 2.x, Node 22 LTS.
+**Tech Stack:** SvelteKit 2.x, Svelte 5 (runes), TypeScript 5.x, Vite 6.x, TailwindCSS 4, `@sveltejs/adapter-node`, Vitest 3.x, Node 22 LTS.
 
 **Reference:** [Design spec](../specs/2026-04-17-web-ui-scaffold-design.md)
 
@@ -76,8 +76,8 @@
     "tailwindcss": "^4.0.0",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.15.0",
-    "vite": "^5.4.0",
-    "vitest": "^2.1.0"
+    "vite": "^6.0.0",
+    "vitest": "^3.0.0"
   }
 }
 ```

--- a/docs/superpowers/specs/2026-04-17-web-ui-routes-design.md
+++ b/docs/superpowers/specs/2026-04-17-web-ui-routes-design.md
@@ -1,0 +1,307 @@
+# Web UI Routes — Design Spec
+
+**Date**: 2026-04-17
+**Issue**: [#31](https://github.com/theburrowhub/heimdallm/issues/31) — *feat: web UI — rutas Dashboard, PRs e Issues*
+**Depends on**: [#30](https://github.com/theburrowhub/heimdallm/issues/30) → [PR #60](https://github.com/theburrowhub/heimdallm/pull/60) (`feat/web-ui-scaffold`, open)
+**Scope**: Five SvelteKit routes (`/`, `/prs`, `/prs/{id}`, `/issues`, `/issues/{id}`) on top of the #30 scaffold, plus the Fase-2 type-parity fixes #60 explicitly defers to #31.
+
+---
+
+## 1. Dependency strategy
+
+PR #60 is open at the time of this spec. Rather than wait for it to merge or duplicate the scaffold, this work **stacks on top of #60**:
+
+- Branch: `feat/web-ui-routes` (name subject to final naming convention), forked from `origin/feat/web-ui-scaffold`.
+- GitHub PR base: `feat/web-ui-scaffold` — keeps the #31 diff focused on #31's work only.
+- When #60 merges to `main`, GitHub retargets the PR automatically. If retargeting fails, a single `git rebase origin/main` resolves it.
+
+This matches the stacked-PR pattern the repo already uses (e.g. PR #59 based on PR #56).
+
+## 2. Inherited follow-ups from #60
+
+PR #60's description explicitly defers these to #31:
+
+1. **Fase-2 type parity**:
+   - `types.ts` currently models `Issue.assignees` / `Issue.labels` as `string[]`, but the daemon serializes them as JSON-encoded strings on the wire (same shape Dart handles with `_parseReviewMap` for review findings). Either parse client-side in `api.ts`, or — preferred — confirm the daemon's issue handler already unwraps them (per the issue-tracking-UI spec, §2.4 decision: "Parse in the daemon handler"). Implementation step should verify the daemon's actual wire output and adjust.
+   - `SseEventType` union omits `issue_detected`, `issue_review_started`, `issue_review_completed`, `issue_review_error`. Add them.
+2. **`sse.ts` `KNOWN_EVENT_TYPES`** — register the four new issue events so the `EventSource` listener fires.
+
+These changes are pre-requisites for the Dashboard's unified feed and the `/issues` routes; folding them into #31 avoids a preliminary "tighten types" PR.
+
+## 3. Architecture overview
+
+All routes are **client-rendered**. No SvelteKit `load` functions, no SSR beyond what the adapter-node default provides. This matches the scaffold's `/+page.svelte` pattern (`onMount → fetchStats()`) and avoids introducing SSR to an auth-gated internal tool where SSR offers no user benefit.
+
+Data flow:
+
+```
+ ┌─────────────────────────────────────────────────────┐
+ │  +layout.svelte                                      │
+ │    connectEvents() → EventSource → events store      │
+ │    initSseBridge(events) → store effects (below)     │
+ └─────────────────────────────────────────────────────┘
+                    │
+                    ▼
+ ┌──────────────────────────────┐         ┌───────────────────────┐
+ │  stores.ts                   │◀────────│  SSE bridge           │
+ │    prListRefresh: writable   │  bumps  │  pr_detected → +1     │
+ │    issueListRefresh          │         │  review_started → add │
+ │    reviewingPRs: Set<number> │         │  review_completed →   │
+ │    reviewingIssues           │         │    delete + bump      │
+ └──────────────────────────────┘         │  review_error → del   │
+                    │                     │  (issue equivalents)  │
+                    ▼                     └───────────────────────┘
+ ┌──────────────────────────────────────────────────────────────┐
+ │  Route +page.svelte                                            │
+ │    $effect(() => { $prListRefresh; fetchPRs().then(...) })     │
+ └──────────────────────────────────────────────────────────────┘
+```
+
+The refresh-counter pattern mirrors Flutter's `prListRefreshProvider` (see `flutter_app/lib/features/dashboard/dashboard_providers.dart`) so Svelte and Dart implementations stay conceptually aligned.
+
+## 4. Stores & SSE bridge
+
+Extend `src/lib/stores.ts` (scaffold already has `auth`):
+
+```ts
+export const prListRefresh = writable(0);
+export const issueListRefresh = writable(0);
+export const reviewingPRs = writable<Set<number>>(new Set());
+export const reviewingIssues = writable<Set<number>>(new Set());
+```
+
+New file `src/lib/sseBridge.ts`:
+
+```ts
+export function initSseBridge(events: Readable<SseEvent | null>) {
+  events.subscribe((e) => {
+    if (!e) return;
+    switch (e.type) {
+      case 'pr_detected':        prListRefresh.update(n => n + 1); break;
+      case 'review_started':     reviewingPRs.update(s => { s.add(e.data.pr_id); return new Set(s); }); break;
+      case 'review_completed':   reviewingPRs.update(s => { s.delete(e.data.pr_id); return new Set(s); });
+                                 prListRefresh.update(n => n + 1); break;
+      case 'review_error':       reviewingPRs.update(s => { s.delete(e.data.pr_id); return new Set(s); }); break;
+      case 'issue_detected':     issueListRefresh.update(n => n + 1); break;
+      case 'issue_review_started':   reviewingIssues.update(s => { s.add(e.data.issue_id); return new Set(s); }); break;
+      case 'issue_review_completed': reviewingIssues.update(s => { s.delete(e.data.issue_id); return new Set(s); });
+                                     issueListRefresh.update(n => n + 1); break;
+      case 'issue_review_error':     reviewingIssues.update(s => { s.delete(e.data.issue_id); return new Set(s); }); break;
+    }
+  });
+}
+```
+
+Called once from `+layout.svelte`:
+
+```svelte
+onMount(() => {
+  sse = connectEvents();
+  connUnsub = sse.connected.subscribe(v => connected.set(v));
+  initSseBridge(sse.events);
+});
+```
+
+Per-route fetch idiom (Svelte 5 runes):
+
+```svelte
+<script lang="ts">
+  import { prListRefresh } from '$lib/stores';
+  let prs = $state<PR[]>([]);
+  let err = $state<string | null>(null);
+  $effect(() => {
+    $prListRefresh;
+    fetchPRs().then(r => prs = r).catch(e => err = String(e));
+  });
+</script>
+```
+
+## 5. Routes
+
+### 5.1 `/` — Dashboard
+
+File: `src/routes/+page.svelte` (replaces scaffold placeholder).
+
+**Vertical layout:**
+
+1. **Header row** — `<h1>Dashboard</h1>` + `<ConnectionPill />`.
+2. **Stats band** — four cards (`total_reviews`, `avg_issues_per_review`, `review_timing.median_seconds`, high-severity count from `by_severity.HIGH`). Extracted to `<StatsCards stats={stats} />`.
+3. **Sort toggle** — "Priority" / "Newest" pill pair. Choice stored in `dashboardSort` (localStorage-backed, default `priority`).
+4. **Three collapsible sections**:
+   - **My Reviews** — `prs.filter(p => p.author.toLowerCase() !== me.login.toLowerCase() && !p.dismissed)`
+   - **My PRs** — `prs.filter(p => p.author.toLowerCase() === me.login.toLowerCase() && !p.dismissed)`
+   - **Tracked Issues** — `issues.filter(i => !i.dismissed)`
+
+   Each uses `<CollapseHeader title count expanded onToggle />` followed by the tile list when expanded. Expansion state per section persisted via localStorage keys `dashboard.reviewsExpanded`, `.prsExpanded`, `.issuesExpanded` (default `true`).
+5. **Empty state** — "No activity yet" centered when both lists are empty.
+
+**Sort semantics** (matching Flutter):
+
+- *Priority*: primary sort by `latest_review?.severity` (critical → high → medium → low → none), tiebreak by `updated_at` desc.
+- *Newest*: `updated_at` desc.
+
+**Data**: `fetchPRs()`, `fetchIssues()`, `fetchStats()`, `fetchMe()`. All four re-run on their respective refresh-counter bumps (stats doesn't strictly need a counter; it re-runs on `prListRefresh` bumps as a proxy).
+
+### 5.2 `/prs` — PR list
+
+File: `src/routes/prs/+page.svelte`.
+
+- **Filters** read from `$page.url.searchParams`: `repo`, `severity`, `state` (default `open`, options `open|closed|all`).
+- **Filter UI** in `<FilterBar />`:
+  - `repo` — select populated from the unique set of `pr.repo` in the fetched list.
+  - `severity` — select with enum `[critical, high, medium, low, any]`.
+  - `state` — select `[open, closed, all]`.
+  - Changing a value calls `goto('?' + params.toString(), { keepFocus: true, replaceState: true })`.
+- **List**: `<PRTile pr={pr} />` rows, sorted `updated_at` desc. Dismissed PRs are hidden (filtered by the daemon handler by default).
+- **Click tile** → `goto('/prs/{id}')`.
+- **Reviewing indicator**: small spinner next to page title when `$reviewingPRs.size > 0`.
+
+### 5.3 `/prs/{id}` — PR detail
+
+File: `src/routes/prs/[id]/+page.svelte`.
+
+Single-column layout (no two-panel; see Q5 rationale):
+
+1. **Metadata card**: title → repo · `#number` · author · state chip · labels chips · `<a>` to GitHub.
+2. **Action bar**: `"Review now"` button + `"Dismiss"` / `"Undismiss"` button (depending on `dismissed`). Buttons show inline spinner when `$reviewingPRs.has(id)`.
+3. **Review history**: vertical list of `<ReviewCard variant="pr" review={r} />`. Card shows summary, severity badge, findings (collapsible if >5), suggestions list, relative timestamp.
+
+**Actions**:
+
+- *Review now* → optimistic `reviewingPRs.add(id)` → `triggerReview(id)` → SSE `review_started` (already added, no-op) → `review_completed` clears the set and bumps `prListRefresh`, causing the review history to refetch.
+- *Dismiss* → `dismissPR(id)` → on success, `goto('/prs')` (back to list).
+- *Undismiss* → `undismissPR(id)` → refetch detail.
+
+**Data**: `fetchPR(id)` → `{ pr, reviews }`. Re-runs on `$prListRefresh` bump.
+
+### 5.4 `/issues` — Issue list
+
+File: `src/routes/issues/+page.svelte`.
+
+- **Filters** via query params: `repo`, `severity`, `mode` (values `review_only | auto_implement | all`, default `all`).
+- **`mode` filter** derives from the issue's `labels` array — presence of `auto_implement` or `review_only` label. No wire-format change needed.
+- **List**: `<IssueTile issue={issue} />` rows. Default sort: `updated_at` desc if present, fall back to `fetched_at` desc.
+- **Tile content**: title · repo · `#number` · author · labels chips (with `auto_implement` / `review_only` visually distinguished — colored left-border or dedicated chip style) · severity badge from `latest_review?.triage.severity` or `PENDING`.
+
+### 5.5 `/issues/{id}` — Issue detail
+
+File: `src/routes/issues/[id]/+page.svelte`.
+
+Same single-column structure as `/prs/{id}`:
+
+1. **Metadata card**: title · repo · `#number` · author · labels chips · assignees · state chip · GitHub link. **Conditional "View created PR"** link: shown when any review has `action_taken === 'auto_implement'` and `pr_created > 0`; links to `/prs/{pr_created}`.
+2. **Action bar**: `"Review now"` + `"Dismiss"` / `"Undismiss"`.
+3. **Review history**: `<ReviewCard variant="issue" review={r} />`. Card shows summary, triage block (severity / category / suggested_assignee), suggestions list.
+
+**Data**: `fetchIssue(id)` → `{ issue, reviews }`. Re-runs on `$issueListRefresh` bump.
+
+## 6. Shared components
+
+All in `src/lib/components/`:
+
+| Component | Used by | Key props |
+|---|---|---|
+| `PRTile.svelte` | `/prs`, Dashboard (My Reviews, My PRs) | `pr: PR` |
+| `IssueTile.svelte` | `/issues`, Dashboard (Tracked Issues) | `issue: Issue` |
+| `SeverityBadge.svelte` | tiles, review cards | `severity: string` |
+| `CollapseHeader.svelte` | Dashboard sections | `title`, `count`, `expanded`, `onToggle` |
+| `FilterBar.svelte` | `/prs`, `/issues` | `filters`, `onChange`, `variant: 'pr' \| 'issue'` |
+| `ConnectionPill.svelte` | `+layout`, `/` | uses `sse-connected` context |
+| `StatsCards.svelte` | `/` | `stats: Stats` |
+| `ReviewCard.svelte` | both detail pages | `review`, `variant: 'pr' \| 'issue'` |
+
+Two utility modules:
+
+- `src/lib/severity.ts` — `severityClass(severity): string` maps `critical → red-600 / red-100 bg`, `high → orange-600 / orange-100 bg`, `medium → amber-600 / amber-100 bg`, `low → gray-500 / gray-100 bg`, falls back to gray for unknowns.
+- `src/lib/persisted.ts` — `persistedBoolean(key, default)` and `persistedString(key, default)` writable stores backed by `localStorage`, SSR-safe (no access during server render).
+
+## 7. Types & SSE updates
+
+Modify `src/lib/types.ts`:
+
+```ts
+export type SseEventType =
+  | 'pr_detected' | 'review_started' | 'review_completed' | 'review_error'
+  | 'issue_detected' | 'issue_review_started' | 'issue_review_completed' | 'issue_review_error';
+```
+
+Issue `assignees`/`labels` — implementation step verifies daemon wire format (the issue-tracking-UI spec §2.4 says daemon unwraps JSON strings; confirm this is live in main). If the daemon ships strings, add `parseIssue` in `api.ts` mirroring `parseReview`.
+
+Modify `src/lib/sse.ts`:
+
+```ts
+const KNOWN_EVENT_TYPES: SseEventType[] = [
+  'pr_detected', 'review_started', 'review_completed', 'review_error',
+  'issue_detected', 'issue_review_started', 'issue_review_completed', 'issue_review_error'
+];
+```
+
+## 8. Testing
+
+Continue the scaffold's **vitest-only** pattern. No Playwright or Svelte Testing Library in this PR.
+
+| File | Tests added | Covers |
+|---|---:|---|
+| `src/tests/api.test.ts` | +3 | `parseIssue` unwraps JSON-string `assignees`/`labels`; accepts already-arrays; `fetchIssues` applies it over the list. |
+| `src/tests/sse.test.ts` | +4 | Each issue event parses and emits on the `events` store. |
+| `src/tests/stores.test.ts` (new) | ~6 | `initSseBridge` wires every event type correctly (counter bumps + set mutations + error paths). |
+| `src/tests/severity.test.ts` (new) | ~2 | Known severities return known classes; unknown falls back. |
+| `src/tests/persisted.test.ts` (new) | ~3 | Default when absent, persists on write, parses existing value, SSR-safe. |
+
+**Total net new: ~18 unit tests** on top of the scaffold's 15.
+
+**Manual test plan** (PR description):
+
+- [ ] `cd web_ui && npm run check` — 0 errors / 0 warnings
+- [ ] `cd web_ui && npm test` — all passing
+- [ ] `cd web_ui && npm run lint` — clean
+- [ ] `cd web_ui && npm run build` — adapter-node output in `build/`
+- [ ] Live daemon: `/` shows three collapsible sections with real PRs/issues; sort toggle and collapsed state persist across reload.
+- [ ] `/prs?repo=foo&severity=high&state=open` filters the list; clearing a filter restores; URL changes are back-buttonable.
+- [ ] `/prs/{id}`: "Review now" triggers a review; tile spinner clears on SSE `review_completed`; "Dismiss" removes from `/prs` list; "Undismiss" on detail page restores it.
+- [ ] `/issues` + `/issues/{id}`: same acceptance as PRs; "View created PR" link appears when a review has `action_taken === 'auto_implement'` and `pr_created > 0`.
+- [ ] SSE disconnect / reconnect: layout auth banner toggles correctly.
+
+## 9. Files changed summary
+
+**New files (18):**
+
+- `src/lib/components/{PRTile,IssueTile,SeverityBadge,CollapseHeader,FilterBar,ConnectionPill,StatsCards,ReviewCard}.svelte`
+- `src/lib/{severity,persisted,sseBridge}.ts`
+- `src/routes/prs/+page.svelte`
+- `src/routes/prs/[id]/+page.svelte`
+- `src/routes/issues/+page.svelte`
+- `src/routes/issues/[id]/+page.svelte`
+- `src/tests/{stores,severity,persisted}.test.ts`
+
+**Modified files (8):**
+
+- `src/lib/types.ts` — expand `SseEventType`; adjust `Issue` if daemon ships JSON strings.
+- `src/lib/api.ts` — add `parseIssue`, apply in issue fetchers.
+- `src/lib/sse.ts` — expand `KNOWN_EVENT_TYPES`.
+- `src/lib/stores.ts` — add 4 stores.
+- `src/routes/+layout.svelte` — call `initSseBridge(sse.events)` after `connectEvents()`.
+- `src/routes/+page.svelte` — replace placeholder with real Dashboard.
+- `src/tests/api.test.ts` — +3 tests.
+- `src/tests/sse.test.ts` — +4 tests.
+
+**Unchanged (explicitly):** `src/lib/server/token.ts`, `src/routes/api/[...path]/+server.ts`, `src/routes/events/+server.ts`, `Dockerfile`, `package.json`, `svelte.config.js`, `vite.config.ts`, `eslint.config.js`.
+
+## 10. Out of scope
+
+- `/agents`, `/config`, `/logs` routes (→ #32 or later).
+- Dark mode / theming.
+- Mobile breakpoints below ~640px.
+- docker-compose integration (→ #33).
+- SvelteKit `load`-based SSR.
+- Component-level tests (Svelte Testing Library / happy-dom) — a scaffold-level decision.
+- Inline per-row Review / Dismiss buttons on list pages — detail-page-only per issue scope.
+
+## 11. Acceptance criteria mapping
+
+| Issue #31 AC | Evidence |
+|---|---|
+| Todas las rutas renderizan datos reales del daemon | `$effect` hooks call `fetchPRs`/`fetchIssues`/`fetchPR`/`fetchIssue`/`fetchStats` in every `+page.svelte`. |
+| Actualizaciones en tiempo real via SSE sin recargar la página | `initSseBridge` + refresh-counter stores; list pages depend on counters in `$effect`. |
+| Responsive (funciona en ventana de browser estándar) | Single-column detail layouts + Tailwind's default responsive grid on the stats band; tested at common desktop widths. Mobile-below-640px explicitly deferred. |
+| Depende de: #30 | PR stacked on `feat/web-ui-scaffold`; Fase-2 type follow-ups inherited and resolved in this PR. |

--- a/docs/superpowers/specs/2026-04-17-web-ui-scaffold-design.md
+++ b/docs/superpowers/specs/2026-04-17-web-ui-scaffold-design.md
@@ -1,0 +1,317 @@
+# Web UI Scaffold — Design Spec
+
+**Fecha:** 2026-04-17
+**Estado:** Aprobado
+**Issue:** [#30](https://github.com/theburrowhub/heimdallm/issues/30) — `feat: scaffold SvelteKit + API/SSE clients`
+**Fase:** 3 (Web UI)
+**Autor:** brainstorm session con vbuenog
+
+## Contexto
+
+Este es el primer PR de la Fase 3 del plan [Heimdallm v2](./2026-04-16-heimdallm-v2-design.md). Crea la estructura base del web UI (`web_ui/`) y los clientes HTTP y SSE sobre los que se construirán los PRs siguientes:
+
+- #31 — rutas Dashboard, PRs, Issues
+- #32 — rutas Config, Agents, Logs
+- #33 — Docker + docker-compose + setup automático de token
+
+El daemon ya existe y expone sus endpoints actuales en `:7842`. Los endpoints de issue-tracking (Fase 2, issues #24–#29) aún no están implementados pero se incluirán en el cliente TS desde el primer día para desbloquear trabajo paralelo.
+
+## Decisiones arquitectónicas
+
+### Server-side proxy vs direct browser → daemon
+
+**Elegido: server-side proxy.** El navegador habla con endpoints de SvelteKit (`/api/*`, `/events`); el servidor SvelteKit guarda el token y reenvía al daemon añadiendo el header `X-Heimdallm-Token`.
+
+Razones:
+- El daemon tiene CORS restrictivo (fix #4); un proxy same-origin evita tener que añadir un allowlist en el daemon.
+- En docker-compose, `http://daemon:7842` solo es resoluble desde dentro de la red de containers — el navegador no puede alcanzarlo directamente.
+- El token nunca llega al navegador, no se almacena en `localStorage`/memoria del cliente.
+- `EventSource` nativo del navegador funciona sin polyfill porque la conexión es same-origin (no necesita headers personalizados hacia el servidor SvelteKit; SvelteKit inyecta el token al reenviar al daemon).
+
+Consecuencia de diseño: no necesitamos portar el parser SSE de `sse_client.dart` — `EventSource` nativo parsea y reconecta automáticamente.
+
+### Patrón del proxy: catch-all
+
+**Elegido: un único handler catch-all** en `src/routes/api/[...path]/+server.ts` que reenvía cualquier método+path al daemon, más un handler dedicado `src/routes/events/+server.ts` para el stream SSE.
+
+Razones:
+- El proxy no tiene lógica de negocio — auth y validación viven en el daemon.
+- `api.ts` sigue siendo la única fuente de verdad sobre el contrato de endpoints.
+- Añadir nuevos endpoints del daemon no requiere tocar el proxy.
+
+### Cobertura de endpoints en `api.ts`
+
+**Elegido: incluir los métodos de Fase 2 desde ya**, aunque devuelvan 404 hasta que el daemon los implemente en issues #25–#28.
+
+Razones:
+- Desbloquea trabajo paralelo en #31 (ruta Issues) antes de que Fase 2 termine.
+- El tipado queda congelado y revisable de una vez.
+- Los tests de `api.ts` mockean `fetch`, así que no dependen del estado del daemon.
+
+### Tipos TS
+
+**Elegido: `interface`/`type` escritos a mano** en `src/lib/types.ts`, espejando los modelos Dart. Sin validación en runtime (ni Zod ni similar).
+
+Razones:
+- Mantener paridad con cómo maneja tipos el lado Dart.
+- Evitar dependencia adicional en el scaffold.
+- El daemon ya valida los campos sensibles.
+
+### Layout shell
+
+**Elegido: shell mínimo + landing con indicador de estado.** Nav bar con links a las seis secciones (los que no existan harán 404 hasta #31/#32), comprobación de autenticación vía `/api/me`, conexión SSE en `onMount`, y una landing en `/` que muestra versión + estado de conexión + `fetchStats()`.
+
+Razones:
+- `npm run dev` arranca una app navegable que prueba la wiring end-to-end.
+- No invade el trabajo de #31/#32 (no crea rutas stub para secciones futuras).
+- Satisface los criterios de aceptación de #30 de forma verificable visualmente.
+
+### Testing
+
+**Elegido: vitest con tests unitarios para `api.ts`, `sse.ts` y `lib/server/token.ts`.** Sin Playwright, sin tests de los proxies.
+
+Razones:
+- Los proxies son forwarders de bytes sin lógica — no aportan valor al mockear.
+- Los clientes y la carga de token son donde pueden meterse bugs sutiles.
+- E2E llega naturalmente con los PRs de rutas (#31/#32).
+
+## Arquitectura
+
+```
+Browser (Svelte 5 app, same-origin, :5173 dev / :3000 docker)
+    │
+    │  fetch("/api/…")          new EventSource("/events")
+    ▼
+SvelteKit server (adapter-node)
+    • HEIMDALLM_API_TOKEN en memoria (nunca enviado al navegador)
+    • Catch-all proxy: src/routes/api/[...path]/+server.ts
+    • SSE passthrough: src/routes/events/+server.ts
+    │
+    │  http://$HEIMDALLM_API_URL/… con header X-Heimdallm-Token
+    ▼
+Heimdallm daemon (:7842) — no cambia
+```
+
+Propiedades clave:
+- Token nunca sale del servidor SvelteKit.
+- Todo same-origin desde la óptica del navegador — sin CORS, sin cookies, sin polyfills.
+- Proxy fino; el daemon sigue siendo la fuente de verdad para auth, validación y lógica de negocio.
+- `adapter-node` porque tenemos server endpoints; corre como HTTP server Node en el container.
+
+## Estructura de archivos
+
+```
+web_ui/
+├── package.json                # scripts npm, dependencias
+├── svelte.config.js            # @sveltejs/adapter-node
+├── vite.config.ts              # vite + tailwind v4 plugin + config vitest
+├── tsconfig.json
+├── .env.example                # HEIMDALLM_API_URL, HEIMDALLM_API_TOKEN
+├── Dockerfile                  # multi-stage: build → node:22-alpine runtime
+├── .dockerignore
+├── README.md                   # dev quickstart
+├── static/
+│   └── favicon.png
+└── src/
+    ├── app.d.ts
+    ├── app.html
+    ├── app.css                 # directivas tailwind + estilos base
+    ├── lib/
+    │   ├── api.ts              # cliente tipado — todos los métodos de #30
+    │   ├── sse.ts              # EventSource nativo → Svelte stores
+    │   ├── types.ts            # interfaces TS espejo de los modelos Dart
+    │   ├── stores.ts           # auth store ({ login, ready, error })
+    │   └── server/
+    │       └── token.ts        # server-only: env var o /data/api_token
+    ├── routes/
+    │   ├── +layout.svelte      # nav, auth check, init SSE
+    │   ├── +layout.ts          # carga /api/me en el mount
+    │   ├── +page.svelte        # landing: heading + indicador de SSE
+    │   ├── api/
+    │   │   └── [...path]/+server.ts   # proxy catch-all al daemon
+    │   └── events/+server.ts           # passthrough del stream SSE
+    └── tests/
+        ├── api.test.ts         # fetch mockeado; verifica métodos + errores
+        ├── sse.test.ts         # verifica wiring de EventSource y stores
+        └── token.test.ts       # precedencia env vs fichero
+```
+
+Notas:
+- `src/lib/server/**` es una convención de SvelteKit — esos módulos solo pueden importarse desde código server-only, impidiendo que el token llegue al bundle del navegador.
+- `stores.ts` expone un store de auth populado por `+layout.ts`; evita prop-drilling de `login` en cada página futura.
+- `.env.example` contiene `HEIMDALLM_API_URL=http://127.0.0.1:7842` para que `npm run dev` funcione out-of-the-box contra un daemon local.
+
+## Interfaces clave
+
+### `src/lib/server/token.ts`
+
+```ts
+export async function loadToken(): Promise<string | null>
+```
+
+Orden de resolución (cacheado en una variable a nivel de módulo tras la primera llamada exitosa):
+1. `process.env.HEIMDALLM_API_TOKEN` si está definido y no vacío.
+2. Contenido de `/data/api_token` (path sobreescribible via `HEIMDALLM_API_TOKEN_FILE`), trimmed.
+3. Si ninguno está disponible → `null`; el proxy responderá 503 con un mensaje claro para que la UI pueda mostrar "daemon token missing".
+
+### `src/routes/api/[...path]/+server.ts` — catch-all proxy
+
+- Exporta handlers `GET`, `POST`, `PUT`, `DELETE`.
+- Construye `${HEIMDALLM_API_URL}/${params.path}` preservando la query string.
+- Reenvía método, body (streamed, sin buffering) y `Content-Type`.
+- Añade `X-Heimdallm-Token` desde `loadToken()`.
+- Devuelve la respuesta del daemon verbatim (status + body streamed).
+- Sin parseo JSON, sin validación — bytes in, bytes out.
+
+### `src/routes/events/+server.ts` — SSE passthrough
+
+- Abre `fetch(${HEIMDALLM_API_URL}/events, { headers: { Accept: 'text/event-stream', 'X-Heimdallm-Token': token }, signal: request.signal })`.
+- Devuelve `new Response(upstream.body, { headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive' } })`.
+- Si el navegador se desconecta, `request.signal` aborta el fetch upstream.
+- Si el daemon se desconecta, el `EventSource` nativo del navegador reconecta automáticamente.
+
+### `src/lib/api.ts` — cliente del navegador
+
+- Base URL relativa (`/api`). Sin lógica de token — la inyecta el proxy server-side.
+- Helper privado `request(method, path, body?)`: hace `fetch`, lanza `ApiError` en non-2xx, devuelve JSON parseado (o `void` en 202/204).
+- Métodos tipados (mínimo listado en #30 más `undismissPR`, `checkHealth` de `api_client.dart` y `undismissIssue` por simetría):
+
+  ```
+  checkHealth, fetchPRs, fetchPR, triggerReview, dismissPR, undismissPR,
+  fetchIssues, fetchIssue, triggerIssueReview, dismissIssue, undismissIssue,
+  fetchConfig, updateConfig, reloadConfig,
+  fetchAgents, upsertAgent, deleteAgent,
+  fetchMe, fetchStats
+  ```
+
+- `ApiError` class con `{ status, statusText, path, message }`, alineado con `ApiException` de Dart.
+
+### `src/lib/sse.ts` — wrapper SSE del navegador
+
+`EventSource` nativo con stores Svelte 5:
+
+```ts
+export function connectEvents(): {
+  events: Readable<SseEvent>;     // emite en cada evento tipado
+  connected: Readable<boolean>;   // refleja EventSource.readyState
+  close(): void;
+}
+```
+
+- Suscribe a tipos de evento del daemon (`pr_updated`, `issue_updated`, `config_reloaded`, `log`, …) via `addEventListener`.
+- Estado de conexión derivado de `onopen`/`onerror`.
+- `+layout.svelte` llama a `connectEvents()` una vez, en el mount, dentro de un bloque browser-only (`if (browser)`), y guarda el handle para teardown en `onDestroy`.
+
+### `src/lib/types.ts`
+
+Interfaces TS escritas a mano espejando los modelos Dart (`PR`, `Review`, `Issue`, `Agent`, `Config`, `Stats`, `SseEvent`, …). Los nombres de campos coinciden con el wire format JSON (snake_case donde el daemon emite snake_case).
+
+## Comportamiento del layout
+
+### `+layout.ts`
+
+- Carga `/api/me` una vez por sesión (solo en navegación client-side).
+- Devuelve `{ login: string | null, authError: string | null }` al resto de páginas.
+
+### `+layout.svelte`
+
+- Shell fino: nav bar arriba + `<slot />`.
+- Nav: wordmark "Heimdallm" a la izquierda; seis links a la derecha — Dashboard (`/`), PRs (`/prs`), Issues (`/issues`), Agents (`/agents`), Config (`/config`), Logs (`/logs`). Los no-root harán 404 hasta que #31/#32 los creen; el nav los renderiza igualmente.
+- Item más a la derecha: login de GitHub del usuario autenticado (desde el auth store), o "—" mientras carga.
+- En el mount (solo en el navegador): abre `connectEvents()` y guarda el handle en un store; cierra en `onDestroy`.
+- Si `authError` está seteado, renderiza un banner rojo encima del contenido: "Daemon unreachable — check `HEIMDALLM_API_URL`" (sin modal, sin botón de retry; recargar la página para reintentar).
+
+### `+page.svelte` (landing en `/`)
+
+- Heading grande: **Heimdallm**.
+- Una línea con la versión (desde `package.json`).
+- Pill pequeña al lado del heading con el estado SSE:
+  - verde + "connected" cuando `EventSource.readyState === OPEN`,
+  - ámbar + "connecting…" cuando `CONNECTING`,
+  - rojo + "disconnected" cuando `CLOSED`.
+- Abajo: tabla de cuatro celdas con los resultados de `fetchStats()` — total PRs, open issues (mostrará "—" hasta que Fase 2 esté lista), reviews today, uptime. Esta es la página "prueba de que la wiring funciona"; probablemente será reemplazada por un dashboard más rico en #31.
+
+## Estilos
+
+**TailwindCSS 4** vía el plugin Vite (`@tailwindcss/vite`, más simple que el PostCSS dance de v3). Utility-first sin custom theme en este scaffold — los defaults se ven limpios. `app.css` mínimo: `@import "tailwindcss";` más un par de tweaks base (stack de system font, `color-scheme: dark light`).
+
+Sin librería de componentes, sin tokens personalizados, sin toggle dark-mode. Scope de diseño limitado — #31/#32 pueden introducir eso si lo necesitan.
+
+## Testing
+
+**vitest** con ~10 tests totales:
+
+- `tests/api.test.ts` (fetch mockeado via `vi.fn()`):
+  - `fetchPRs` hace GET a `/api/prs`, parsea JSON array, devuelve lista tipada.
+  - `triggerReview` POST y resuelve en 202; lanza `ApiError` en 500.
+  - `upsertAgent` envía body JSON con `Content-Type` correcto.
+  - `ApiError` carga `{ status, path }`.
+- `tests/sse.test.ts` (constructor `EventSource` mockeado):
+  - Wrapper abre `/events`, registra listeners para cada tipo de evento conocido, empuja al store `events`.
+  - Store `connected` alterna `true`/`false` con `onopen`/`onerror`.
+  - `close()` llama a `EventSource.close()` y limpia subscripciones.
+- `tests/token.test.ts` (fs y `process.env` mockeados):
+  - Env var gana sobre fichero.
+  - Fichero leído cuando env falta; trim de newline final.
+  - Cacheado tras la primera lectura exitosa.
+
+Sin tests de los proxies — son forwarders de bytes sin lógica. La cobertura end-to-end llega con Fase 2/3.
+
+## Tooling
+
+- Package manager: **npm** (la AC de #30 pide explícitamente `npm run build`/`npm run dev`).
+- Node: **22.x LTS**, pinneado en `package.json` `engines` y en el Dockerfile.
+- Svelte **5** (runes), SvelteKit **2.x**, TypeScript **5.x**, Vite **5.x**, TailwindCSS **4**.
+- Lint/format: **prettier + eslint** con la config por defecto de SvelteKit — sin reglas custom en este PR.
+- Scripts en `package.json`: `dev`, `build`, `preview`, `test`, `lint`, `format`, `check` (svelte-check).
+
+## Dockerfile
+
+Multi-stage:
+1. Stage build (`node:22-alpine`): `npm ci`, `npm run build` → produce `build/` (output de adapter-node).
+2. Stage runtime (`node:22-alpine`): copia `build/`, `package.json`, `node_modules` (solo prod), expone `3000`, `CMD ["node", "build"]`.
+
+Usuario no-root (`node`), `USER node`. `HEIMDALLM_API_URL` y `HEIMDALLM_API_TOKEN[_FILE]` leídos del entorno en runtime. Imagen bajo ~200 MB.
+
+El wiring completo de docker-compose (dependencia del servicio daemon, volumen montado para `/data/api_token`, helper `make setup`) vive en #33. Este Dockerfile basta para `docker build` y `docker run` el web UI standalone, apuntando a un daemon existente via `HEIMDALLM_API_URL`.
+
+## Mapeo de criterios de aceptación
+
+| AC de #30 | Satisfecho por |
+|---|---|
+| `npm run build` sin errores | build de adapter-node en CI; `svelte-check` limpio |
+| `npm run dev` levanta el servidor de desarrollo | dev server de Vite en `:5173` proxy-ando al daemon local |
+| `api.ts` tipado correctamente y conecta al daemon | `src/lib/api.ts` con métodos tipados + `src/lib/types.ts`; proxy via `/api/*` |
+| SSE recibe y parsea eventos correctamente | `EventSource` nativo sobre el proxy `/events`; wrapper `src/lib/sse.ts` + test |
+| Token leído automáticamente del volumen o env var | `src/lib/server/token.ts` con precedencia env → fichero + test |
+
+## Fuera de alcance (deferred explícitamente)
+
+- **Rutas más allá de `/`.** Dashboard completo, PRs, Issues, Agents, Config, Logs se ponen en #31/#32.
+- **Integración docker-compose + `make setup`.** Issue #33.
+- **Endpoints de issue-tracking del daemon.** Fase 2, issues #24–#29. `api.ts` define los métodos; harán 404 hasta que el backend los implemente.
+- **UI de autenticación.** El token vive en env/volumen; sin pantalla de login, sin UI de rotación.
+- **Workflow de CI para `web_ui/`.** Este PR solo necesita que el scaffold pase build local; añadir un job de GitHub Actions para `web_ui/` puede seguir (trackeado por separado si no se incluye).
+- **Dark mode / theming / design tokens personalizados.** Solo Tailwind por defecto.
+
+## Riesgos y trade-offs aceptados
+
+- **Svelte 5 runes** son el default actual pero relativamente nuevos — el equipo los adopta aquí por primera vez. Los docs y el ecosistema están sólidos; sin blockers esperados.
+- **Métodos de Fase 2 en `api.ts`** harán 404 en runtime hasta que #25–#28 aterricen. Decisión deliberada: desbloquear trabajo paralelo > preocupación por código muerto.
+- **Server proxy añade un hop**; para un dashboard en `localhost`, el coste de latencia es despreciable.
+
+## Orden de implementación sugerido
+
+1. Scaffolding base: `npm create svelte@latest`, configurar adapter-node, tsconfig, package.json, vite.config con plugin de Tailwind.
+2. `src/lib/types.ts` — modelos espejo de Dart.
+3. `src/lib/server/token.ts` + `tests/token.test.ts`.
+4. Proxies: `src/routes/api/[...path]/+server.ts` y `src/routes/events/+server.ts`.
+5. `src/lib/api.ts` + `tests/api.test.ts`.
+6. `src/lib/sse.ts` + `tests/sse.test.ts`.
+7. `src/lib/stores.ts`, `+layout.ts`, `+layout.svelte`.
+8. `+page.svelte` con el indicador de estado y tabla de stats.
+9. Dockerfile + `.dockerignore`.
+10. README (quickstart de dev).
+11. Verificación: `npm run build`, `npm run dev`, `npm test`, `npm run check`.
+
+Cada paso es verificable localmente antes de pasar al siguiente.

--- a/web_ui/.dockerignore
+++ b/web_ui/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+build
+.svelte-kit
+.git
+.env
+.env.*
+!.env.example
+*.log
+.DS_Store

--- a/web_ui/.env.example
+++ b/web_ui/.env.example
@@ -1,0 +1,10 @@
+# URL of the running heimdallm daemon. In docker-compose, set to
+# http://daemon:7842 (internal service hostname).
+HEIMDALLM_API_URL=http://127.0.0.1:7842
+
+# API token. Leave unset to read from HEIMDALLM_API_TOKEN_FILE instead.
+# HEIMDALLM_API_TOKEN=
+
+# Path to the token file. Defaults to /data/api_token. For local dev,
+# point at ~/.local/share/heimdallm/api_token.
+# HEIMDALLM_API_TOKEN_FILE=/data/api_token

--- a/web_ui/.gitignore
+++ b/web_ui/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+/build
+/.svelte-kit
+/package
+.env
+.env.*
+!.env.example
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+.DS_Store

--- a/web_ui/.npmrc
+++ b/web_ui/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/web_ui/.prettierignore
+++ b/web_ui/.prettierignore
@@ -1,0 +1,4 @@
+.svelte-kit/
+build/
+node_modules/
+package-lock.json

--- a/web_ui/.prettierrc
+++ b/web_ui/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 100,
+  "plugins": ["prettier-plugin-svelte"],
+  "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+}

--- a/web_ui/Dockerfile
+++ b/web_ui/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.7
+
+# ─── Build stage ────────────────────────────────────────────────────────
+FROM node:22-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build && npm prune --omit=dev
+
+# ─── Runtime stage ──────────────────────────────────────────────────────
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOST=0.0.0.0
+
+COPY --from=build /app/build ./build
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
+
+USER node
+EXPOSE 3000
+CMD ["node", "build"]

--- a/web_ui/Dockerfile
+++ b/web_ui/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # ─── Build stage ────────────────────────────────────────────────────────
-FROM node:22-alpine AS build
+FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -11,7 +11,7 @@ COPY . .
 RUN npm run build && npm prune --omit=dev
 
 # ─── Runtime stage ──────────────────────────────────────────────────────
-FROM node:22-alpine AS runtime
+FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000

--- a/web_ui/README.md
+++ b/web_ui/README.md
@@ -1,0 +1,39 @@
+# Heimdallm Web UI
+
+SvelteKit dashboard — a browser-based alternative to the Flutter desktop app.
+
+See the [design spec](../docs/superpowers/specs/2026-04-17-web-ui-scaffold-design.md) for the architecture.
+
+## Local development
+
+Prereqs: Node 22 LTS, a running heimdallm daemon on `127.0.0.1:7842` with a token at `~/.local/share/heimdallm/api_token`.
+
+```bash
+cd web_ui
+cp .env.example .env
+# point HEIMDALLM_API_TOKEN_FILE at your local token file, e.g.:
+echo "HEIMDALLM_API_TOKEN_FILE=$HOME/.local/share/heimdallm/api_token" >> .env
+
+npm install
+npm run dev
+```
+
+Open http://127.0.0.1:5173.
+
+## Scripts
+
+- `npm run dev` — Vite dev server with HMR.
+- `npm run build` — production build (adapter-node output in `build/`).
+- `npm run preview` — preview the production build.
+- `npm run check` — type-check with svelte-check.
+- `npm test` — unit tests (Vitest).
+- `npm run lint` / `npm run format` — prettier + eslint.
+
+## Architecture at a glance
+
+```
+Browser ── /api/* ── SvelteKit server ── daemon :7842
+        └─ /events ─┘                    (X-Heimdallm-Token injected server-side)
+```
+
+The token lives in `src/lib/server/token.ts` and never ships to the browser. Same-origin SSE means we use native `EventSource` without polyfills.

--- a/web_ui/README.md
+++ b/web_ui/README.md
@@ -37,3 +37,13 @@ Browser ── /api/* ── SvelteKit server ── daemon :7842
 ```
 
 The token lives in `src/lib/server/token.ts` and never ships to the browser. Same-origin SSE means we use native `EventSource` without polyfills.
+
+## Token rotation
+
+The server caches the daemon API token in memory after the first successful read. If the daemon rotates the token on disk at runtime, the web container keeps the old value until restart:
+
+```bash
+docker compose restart web
+```
+
+This is deliberate — reloading the token on every request would hit the filesystem unnecessarily. If token rotation becomes common, add a TTL to `src/lib/server/token.ts`.

--- a/web_ui/eslint.config.js
+++ b/web_ui/eslint.config.js
@@ -1,0 +1,23 @@
+import prettier from 'eslint-config-prettier';
+import js from '@eslint/js';
+import svelte from 'eslint-plugin-svelte';
+import globals from 'globals';
+import ts from 'typescript-eslint';
+
+export default ts.config(
+  js.configs.recommended,
+  ...ts.configs.recommended,
+  ...svelte.configs['flat/recommended'],
+  prettier,
+  ...svelte.configs['flat/prettier'],
+  {
+    languageOptions: {
+      globals: { ...globals.browser, ...globals.node }
+    }
+  },
+  {
+    files: ['**/*.svelte'],
+    languageOptions: { parserOptions: { parser: ts.parser } }
+  },
+  { ignores: ['build/', '.svelte-kit/', 'node_modules/'] }
+);

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -1,0 +1,5344 @@
+{
+  "name": "heimdallm-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "heimdallm-web",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@eslint/js": "^9.15.0",
+        "@sveltejs/adapter-node": "^5.2.0",
+        "@sveltejs/kit": "^2.15.0",
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "@tailwindcss/vite": "^4.0.0",
+        "@types/node": "^22.10.0",
+        "eslint": "^9.15.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-svelte": "^2.46.0",
+        "globals": "^15.12.0",
+        "jsdom": "^25.0.0",
+        "prettier": "^3.4.0",
+        "prettier-plugin-svelte": "^3.3.0",
+        "svelte": "^5.15.0",
+        "svelte-check": "^4.1.0",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^5.6.0",
+        "typescript-eslint": "^8.15.0",
+        "vite": "^6.0.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.2.tgz",
+      "integrity": "sha512-S/ggWH1LU7jTyi9DxZOKyxpVd4hF/OZ0JrEbeLjXk/DFXwRny0tjD2c992zOUYQobLrVkRVMDdmHP16HKP7GRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
+      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/adapter-node": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.4.tgz",
+      "integrity": "sha512-45X92CXW+2J8ZUzPv3eLlKWEzINKiiGeFWTjyER4ZN4sGgNoaoeSkCY/QYNxHpPXy71QPsctwccBo9jJs0ySPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-commonjs": "^29.0.0",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.0",
+        "rollup": "^4.59.0"
+      },
+      "peerDependencies": {
+        "@sveltejs/kit": "^2.4.0"
+      }
+    },
+    "node_modules/@sveltejs/kit": {
+      "version": "2.57.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.57.1.tgz",
+      "integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@types/cookie": "^0.6.0",
+        "acorn": "^8.14.1",
+        "cookie": "^0.6.0",
+        "devalue": "^5.6.4",
+        "esm-env": "^1.2.2",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.5",
+        "mrmime": "^2.0.0",
+        "set-cookie-parser": "^3.0.0",
+        "sirv": "^3.0.0"
+      },
+      "bin": {
+        "svelte-kit": "svelte-kit.js"
+      },
+      "engines": {
+        "node": ">=18.13"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0",
+        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": "^5.3.3 || ^6.0.0",
+        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+        "debug": "^4.4.1",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.17",
+        "vitefu": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
+      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-svelte": {
+      "version": "2.46.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.46.1.tgz",
+      "integrity": "sha512-7xYr2o4NID/f9OEYMqxsEQsCsj4KaMy4q5sANaKkAb6/QeCjYFxRmDm2S3YC3A3pl1kyPZ/syOx/i7LcWYSbIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "eslint-compat-utils": "^0.5.1",
+        "esutils": "^2.0.3",
+        "known-css-properties": "^0.35.0",
+        "postcss": "^8.4.38",
+        "postcss-load-config": "^3.1.4",
+        "postcss-safe-parser": "^6.0.0",
+        "postcss-selector-parser": "^6.1.0",
+        "semver": "^7.6.2",
+        "svelte-eslint-parser": "^0.43.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0-0 || ^9.0.0-0",
+        "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrap": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
+      "integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/known-css-properties": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
+      "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^2.0.5",
+        "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+      "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.29"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.1.tgz",
+      "integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.55.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.4.tgz",
+      "integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.6.4",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.4",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.6.tgz",
+      "integrity": "sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/svelte-eslint-parser": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.43.0.tgz",
+      "integrity": "sha512-GpU52uPKKcVnh8tKN5P4UZpJ/fUDndmq7wfsvoVXsyP+aY0anol7Yqo01fyrlaWGMFfm4av5DyrjlaXdLRJvGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "postcss": "^8.4.39",
+        "postcss-scss": "^4.0.9"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/svelte-eslint-parser/node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/svelte-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/svelte-eslint-parser/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/svelte/node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -10,6 +10,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
+    "start": "node build",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "test": "vitest run",

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "heimdallm-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "prettier --check . && eslint .",
+    "format": "prettier --write ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.15.0",
+    "@sveltejs/adapter-node": "^5.2.0",
+    "@sveltejs/kit": "^2.15.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@tailwindcss/vite": "^4.0.0",
+    "@types/node": "^22.10.0",
+    "eslint": "^9.15.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-svelte": "^2.46.0",
+    "globals": "^15.12.0",
+    "jsdom": "^25.0.0",
+    "prettier": "^3.4.0",
+    "prettier-plugin-svelte": "^3.3.0",
+    "svelte": "^5.15.0",
+    "svelte-check": "^4.1.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.6.0",
+    "typescript-eslint": "^8.15.0",
+    "vite": "^6.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/web_ui/src/app.css
+++ b/web_ui/src/app.css
@@ -1,0 +1,15 @@
+@import 'tailwindcss';
+
+:root {
+  color-scheme: light dark;
+}
+
+html,
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+}

--- a/web_ui/src/app.d.ts
+++ b/web_ui/src/app.d.ts
@@ -1,0 +1,16 @@
+// See https://kit.svelte.dev/docs/types#app
+declare global {
+  namespace App {
+    interface Locals {
+      login: string | null;
+    }
+    // interface PageData {}
+    // interface PageState {}
+    // interface Platform {}
+    interface Error {
+      message: string;
+    }
+  }
+}
+
+export {};

--- a/web_ui/src/app.d.ts
+++ b/web_ui/src/app.d.ts
@@ -1,9 +1,7 @@
 // See https://kit.svelte.dev/docs/types#app
 declare global {
   namespace App {
-    interface Locals {
-      login: string | null;
-    }
+    // interface Locals {}
     // interface PageData {}
     // interface PageState {}
     // interface Platform {}

--- a/web_ui/src/app.html
+++ b/web_ui/src/app.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Heimdallm</title>
     %sveltekit.head%

--- a/web_ui/src/app.html
+++ b/web_ui/src/app.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Heimdallm</title>
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover" class="min-h-screen bg-white text-gray-900 antialiased">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/web_ui/src/lib/api.ts
+++ b/web_ui/src/lib/api.ts
@@ -1,0 +1,158 @@
+import type {
+  Agent,
+  Config,
+  Issue,
+  IssueDetail,
+  Me,
+  PR,
+  PRDetail,
+  Review,
+  Stats
+} from './types.js';
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly path: string,
+    message?: string
+  ) {
+    super(message ?? `${path} failed: ${status} ${statusText}`);
+    this.name = 'ApiError';
+  }
+}
+
+type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+async function request<T>(
+  method: Method,
+  path: string,
+  body?: unknown,
+  { expectEmpty = false }: { expectEmpty?: boolean } = {}
+): Promise<T> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { 'Content-Type': 'application/json' };
+    init.body = JSON.stringify(body);
+  }
+  const resp = await fetch(path, init);
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new ApiError(resp.status, resp.statusText, path, text || undefined);
+  }
+  if (expectEmpty || resp.status === 202 || resp.status === 204) {
+    return undefined as T;
+  }
+  return (await resp.json()) as T;
+}
+
+// The daemon stores issues/suggestions as JSON-encoded strings; this helper
+// parses them so callers always get typed arrays. Mirrors Dart's
+// _parseReviewMap in flutter_app/lib/core/api/api_client.dart.
+function parseReview(raw: unknown): Review {
+  const r = { ...(raw as Record<string, unknown>) };
+  if (typeof r.issues === 'string') {
+    r.issues = r.issues ? JSON.parse(r.issues as string) : [];
+  }
+  r.issues ??= [];
+  if (typeof r.suggestions === 'string') {
+    r.suggestions = r.suggestions ? JSON.parse(r.suggestions as string) : [];
+  }
+  r.suggestions ??= [];
+  return r as unknown as Review;
+}
+
+function parsePR(raw: unknown): PR {
+  const pr = { ...(raw as Record<string, unknown>) };
+  if (pr.latest_review) pr.latest_review = parseReview(pr.latest_review);
+  return pr as unknown as PR;
+}
+
+// ─── Health ─────────────────────────────────────────────────────────────
+export function checkHealth(): Promise<boolean> {
+  return fetch('/api/health')
+    .then((r) => r.ok)
+    .catch(() => false);
+}
+
+// ─── PRs ────────────────────────────────────────────────────────────────
+export async function fetchPRs(): Promise<PR[]> {
+  const raws = await request<unknown[]>('GET', '/api/prs');
+  return raws.map(parsePR);
+}
+
+export async function fetchPR(id: number): Promise<PRDetail> {
+  const raw = await request<{ pr: unknown; reviews?: unknown[] }>('GET', `/api/prs/${id}`);
+  return {
+    pr: parsePR(raw.pr),
+    reviews: (raw.reviews ?? []).map(parseReview)
+  };
+}
+
+export function triggerReview(id: number): Promise<void> {
+  return request<void>('POST', `/api/prs/${id}/review`, undefined, { expectEmpty: true });
+}
+
+export function dismissPR(id: number): Promise<void> {
+  return request<void>('POST', `/api/prs/${id}/dismiss`, undefined, { expectEmpty: true });
+}
+
+export function undismissPR(id: number): Promise<void> {
+  return request<void>('POST', `/api/prs/${id}/undismiss`, undefined, { expectEmpty: true });
+}
+
+// ─── Issues (Fase 2 — daemon endpoints arrive in #25–#28) ───────────────
+export function fetchIssues(): Promise<Issue[]> {
+  return request<Issue[]>('GET', '/api/issues');
+}
+
+export function fetchIssue(id: number): Promise<IssueDetail> {
+  return request<IssueDetail>('GET', `/api/issues/${id}`);
+}
+
+export function triggerIssueReview(id: number): Promise<void> {
+  return request<void>('POST', `/api/issues/${id}/review`, undefined, { expectEmpty: true });
+}
+
+export function dismissIssue(id: number): Promise<void> {
+  return request<void>('POST', `/api/issues/${id}/dismiss`, undefined, { expectEmpty: true });
+}
+
+export function undismissIssue(id: number): Promise<void> {
+  return request<void>('POST', `/api/issues/${id}/undismiss`, undefined, { expectEmpty: true });
+}
+
+// ─── Config ─────────────────────────────────────────────────────────────
+export function fetchConfig(): Promise<Config> {
+  return request<Config>('GET', '/api/config');
+}
+
+export function updateConfig(config: Config): Promise<void> {
+  return request<void>('PUT', '/api/config', config, { expectEmpty: true });
+}
+
+export function reloadConfig(): Promise<void> {
+  return request<void>('POST', '/api/reload', undefined, { expectEmpty: true });
+}
+
+// ─── Agents ─────────────────────────────────────────────────────────────
+export function fetchAgents(): Promise<Agent[]> {
+  return request<Agent[]>('GET', '/api/agents');
+}
+
+export function upsertAgent(agent: Agent): Promise<void> {
+  return request<void>('POST', '/api/agents', agent, { expectEmpty: true });
+}
+
+export function deleteAgent(id: string): Promise<void> {
+  return request<void>('DELETE', `/api/agents/${id}`, undefined, { expectEmpty: true });
+}
+
+// ─── Identity & stats ───────────────────────────────────────────────────
+export function fetchMe(): Promise<Me> {
+  return request<Me>('GET', '/api/me');
+}
+
+export function fetchStats(): Promise<Stats> {
+  return request<Stats>('GET', '/api/stats');
+}

--- a/web_ui/src/lib/api.ts
+++ b/web_ui/src/lib/api.ts
@@ -9,7 +9,6 @@ import type {
   PR,
   PRDetail,
   Review,
-  ReviewFinding,
   Stats
 } from './types.js';
 
@@ -67,13 +66,13 @@ function safeParse<T>(raw: string, fallback: T): T {
 function parseReview(raw: unknown): Review {
   const r = { ...(raw as Record<string, unknown>) };
   if (typeof r.issues === 'string') {
-    r.issues = r.issues ? safeParse<ReviewFinding[]>(r.issues, []) : [];
+    r.issues = r.issues ? safeParse<unknown[]>(r.issues, []) : [];
   }
-  r.issues ??= [];
+  if (!Array.isArray(r.issues)) r.issues = [];
   if (typeof r.suggestions === 'string') {
-    r.suggestions = r.suggestions ? safeParse<string[]>(r.suggestions, []) : [];
+    r.suggestions = r.suggestions ? safeParse<unknown[]>(r.suggestions, []) : [];
   }
-  r.suggestions ??= [];
+  if (!Array.isArray(r.suggestions)) r.suggestions = [];
   return r as unknown as Review;
 }
 
@@ -88,11 +87,13 @@ function parseIssueReview(raw: unknown): IssueReview {
   if (typeof r.triage === 'string') {
     r.triage = r.triage ? safeParse<IssueTriage>(r.triage, {}) : {};
   }
-  r.triage ??= {};
-  if (typeof r.suggestions === 'string') {
-    r.suggestions = r.suggestions ? safeParse<string[]>(r.suggestions, []) : [];
+  if (r.triage == null || typeof r.triage !== 'object' || Array.isArray(r.triage)) {
+    r.triage = {};
   }
-  r.suggestions ??= [];
+  if (typeof r.suggestions === 'string') {
+    r.suggestions = r.suggestions ? safeParse<unknown[]>(r.suggestions, []) : [];
+  }
+  if (!Array.isArray(r.suggestions)) r.suggestions = [];
   return r as unknown as IssueReview;
 }
 
@@ -101,13 +102,28 @@ function parseIssue(raw: unknown): Issue {
   if (typeof i.assignees === 'string') {
     i.assignees = i.assignees ? safeParse<string[]>(i.assignees, []) : [];
   }
-  i.assignees ??= [];
+  if (!Array.isArray(i.assignees)) i.assignees = [];
   if (typeof i.labels === 'string') {
     i.labels = i.labels ? safeParse<string[]>(i.labels, []) : [];
   }
-  i.labels ??= [];
+  if (!Array.isArray(i.labels)) i.labels = [];
   if (i.latest_review) i.latest_review = parseIssueReview(i.latest_review);
   return i as unknown as Issue;
+}
+
+// Daemon's `by_severity` map uses whatever case the SQL GROUP BY returned —
+// which is lowercase in practice (pipelines store "high"/"medium"/"low"/"critical").
+// Normalize to uppercase here so consumers can index with a stable canonical form.
+function parseStats(raw: unknown): Stats {
+  const s = { ...(raw as Record<string, unknown>) };
+  const rawBy = (s.by_severity ?? {}) as Record<string, number>;
+  const normalized: Record<string, number> = {};
+  for (const [k, v] of Object.entries(rawBy)) {
+    const key = k.toUpperCase();
+    normalized[key] = (normalized[key] ?? 0) + v;
+  }
+  s.by_severity = normalized;
+  return s as unknown as Stats;
 }
 
 // ─── Health ─────────────────────────────────────────────────────────────
@@ -200,6 +216,7 @@ export function fetchMe(): Promise<Me> {
   return request<Me>('GET', '/api/me');
 }
 
-export function fetchStats(): Promise<Stats> {
-  return request<Stats>('GET', '/api/stats');
+export async function fetchStats(): Promise<Stats> {
+  const raw = await request<unknown>('GET', '/api/stats');
+  return parseStats(raw);
 }

--- a/web_ui/src/lib/api.ts
+++ b/web_ui/src/lib/api.ts
@@ -3,6 +3,8 @@ import type {
   Config,
   Issue,
   IssueDetail,
+  IssueReview,
+  IssueTriage,
   Me,
   PR,
   PRDetail,
@@ -81,6 +83,33 @@ function parsePR(raw: unknown): PR {
   return pr as unknown as PR;
 }
 
+function parseIssueReview(raw: unknown): IssueReview {
+  const r = { ...(raw as Record<string, unknown>) };
+  if (typeof r.triage === 'string') {
+    r.triage = r.triage ? safeParse<IssueTriage>(r.triage, {}) : {};
+  }
+  r.triage ??= {};
+  if (typeof r.suggestions === 'string') {
+    r.suggestions = r.suggestions ? safeParse<string[]>(r.suggestions, []) : [];
+  }
+  r.suggestions ??= [];
+  return r as unknown as IssueReview;
+}
+
+function parseIssue(raw: unknown): Issue {
+  const i = { ...(raw as Record<string, unknown>) };
+  if (typeof i.assignees === 'string') {
+    i.assignees = i.assignees ? safeParse<string[]>(i.assignees, []) : [];
+  }
+  i.assignees ??= [];
+  if (typeof i.labels === 'string') {
+    i.labels = i.labels ? safeParse<string[]>(i.labels, []) : [];
+  }
+  i.labels ??= [];
+  if (i.latest_review) i.latest_review = parseIssueReview(i.latest_review);
+  return i as unknown as Issue;
+}
+
 // ─── Health ─────────────────────────────────────────────────────────────
 export function checkHealth(): Promise<boolean> {
   return fetch('/api/health')
@@ -115,12 +144,17 @@ export function undismissPR(id: number): Promise<void> {
 }
 
 // ─── Issues (Fase 2 — daemon endpoints arrive in #25–#28) ───────────────
-export function fetchIssues(): Promise<Issue[]> {
-  return request<Issue[]>('GET', '/api/issues');
+export async function fetchIssues(): Promise<Issue[]> {
+  const raws = await request<unknown[]>('GET', '/api/issues');
+  return raws.map(parseIssue);
 }
 
-export function fetchIssue(id: number): Promise<IssueDetail> {
-  return request<IssueDetail>('GET', `/api/issues/${id}`);
+export async function fetchIssue(id: number): Promise<IssueDetail> {
+  const raw = await request<{ issue: unknown; reviews?: unknown[] }>('GET', `/api/issues/${id}`);
+  return {
+    issue: parseIssue(raw.issue),
+    reviews: (raw.reviews ?? []).map(parseIssueReview)
+  };
 }
 
 export function triggerIssueReview(id: number): Promise<void> {

--- a/web_ui/src/lib/api.ts
+++ b/web_ui/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   PR,
   PRDetail,
   Review,
+  ReviewFinding,
   Stats
 } from './types.js';
 
@@ -43,7 +44,19 @@ async function request<T>(
   if (expectEmpty || resp.status === 202 || resp.status === 204) {
     return undefined as T;
   }
+  // Defensive: a 200 with empty body would throw on .json() — treat as undefined.
+  if (resp.headers.get('content-length') === '0') {
+    return undefined as T;
+  }
   return (await resp.json()) as T;
+}
+
+function safeParse<T>(raw: string, fallback: T): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
 }
 
 // The daemon stores issues/suggestions as JSON-encoded strings; this helper
@@ -52,11 +65,11 @@ async function request<T>(
 function parseReview(raw: unknown): Review {
   const r = { ...(raw as Record<string, unknown>) };
   if (typeof r.issues === 'string') {
-    r.issues = r.issues ? JSON.parse(r.issues as string) : [];
+    r.issues = r.issues ? safeParse<ReviewFinding[]>(r.issues, []) : [];
   }
   r.issues ??= [];
   if (typeof r.suggestions === 'string') {
-    r.suggestions = r.suggestions ? JSON.parse(r.suggestions as string) : [];
+    r.suggestions = r.suggestions ? safeParse<string[]>(r.suggestions, []) : [];
   }
   r.suggestions ??= [];
   return r as unknown as Review;

--- a/web_ui/src/lib/components/CollapseHeader.svelte
+++ b/web_ui/src/lib/components/CollapseHeader.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  interface Props {
+    title: string;
+    count: number;
+    expanded: boolean;
+    onToggle: () => void;
+  }
+
+  let { title, count, expanded, onToggle }: Props = $props();
+</script>
+
+<button
+  type="button"
+  onclick={onToggle}
+  class="flex w-full items-center gap-2 border-b border-gray-200 bg-gray-50 px-4 py-2 text-left hover:bg-gray-100"
+  aria-expanded={expanded}
+>
+  <svg
+    class="h-4 w-4 shrink-0 text-gray-500 transition-transform {expanded ? 'rotate-90' : ''}"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+      clip-rule="evenodd"
+    />
+  </svg>
+  <span class="text-sm font-semibold text-gray-700">{title}</span>
+  <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-600">{count}</span>
+</button>

--- a/web_ui/src/lib/components/ConnectionPill.svelte
+++ b/web_ui/src/lib/components/ConnectionPill.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { getContext } from 'svelte';
+  import type { Readable } from 'svelte/store';
+
+  const connected = getContext<Readable<boolean>>('sse-connected');
+
+  const cls = $derived($connected ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700');
+  const label = $derived($connected ? 'connected' : 'disconnected');
+</script>
+
+<span class="rounded-full px-2 py-0.5 text-xs font-medium {cls}" data-testid="sse-pill">
+  {label}
+</span>

--- a/web_ui/src/lib/components/IssueFilterBar.svelte
+++ b/web_ui/src/lib/components/IssueFilterBar.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  interface Filters {
+    repo: string;
+    severity: string;
+    mode: string;
+  }
+
+  interface Props {
+    filters: Filters;
+    repos: string[];
+    onChange: (next: Filters) => void;
+  }
+
+  let { filters, repos, onChange }: Props = $props();
+
+  const severities = ['any', 'critical', 'high', 'medium', 'low'];
+  const modes = ['all', 'auto_implement', 'review_only'];
+
+  function update(field: keyof Filters, value: string): void {
+    onChange({ ...filters, [field]: value });
+  }
+</script>
+
+<div
+  class="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-gray-200 bg-gray-50 p-3"
+>
+  <label class="flex items-center gap-1 text-xs text-gray-600">
+    <span>Repo:</span>
+    <select
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      value={filters.repo}
+      onchange={(e) => update('repo', (e.currentTarget as HTMLSelectElement).value)}
+    >
+      <option value="">any</option>
+      {#each repos as repo (repo)}
+        <option value={repo}>{repo}</option>
+      {/each}
+    </select>
+  </label>
+
+  <label class="flex items-center gap-1 text-xs text-gray-600">
+    <span>Severity:</span>
+    <select
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      value={filters.severity || 'any'}
+      onchange={(e) => update('severity', (e.currentTarget as HTMLSelectElement).value)}
+    >
+      {#each severities as s (s)}
+        <option value={s}>{s}</option>
+      {/each}
+    </select>
+  </label>
+
+  <label class="flex items-center gap-1 text-xs text-gray-600">
+    <span>Mode:</span>
+    <select
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      value={filters.mode ?? 'all'}
+      onchange={(e) => update('mode', (e.currentTarget as HTMLSelectElement).value)}
+    >
+      {#each modes as m (m)}
+        <option value={m}>{m}</option>
+      {/each}
+    </select>
+  </label>
+</div>

--- a/web_ui/src/lib/components/IssueReviewCard.svelte
+++ b/web_ui/src/lib/components/IssueReviewCard.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import type { IssueReview } from '$lib/types.js';
+  import SeverityBadge from './SeverityBadge.svelte';
+
+  let { review }: { review: IssueReview } = $props();
+
+  const triage = $derived(review.triage);
+</script>
+
+<article class="mb-3 rounded-md border border-gray-200 bg-white p-4">
+  <header class="mb-2 flex items-center justify-between gap-2">
+    <div class="flex items-center gap-2">
+      {#if triage.severity}
+        <SeverityBadge severity={triage.severity} />
+      {/if}
+      <span class="text-xs text-gray-500">{review.cli_used}</span>
+    </div>
+    <time class="text-xs text-gray-400" datetime={review.created_at}>
+      {new Date(review.created_at).toLocaleString()}
+    </time>
+  </header>
+
+  {#if review.summary}
+    <p class="text-sm text-gray-800">{review.summary}</p>
+  {/if}
+
+  <section class="mt-3 rounded bg-gray-50 p-2 text-xs text-gray-700">
+    {#if triage.severity}<div><strong>Severity:</strong> {triage.severity}</div>{/if}
+    {#if triage.category}<div><strong>Category:</strong> {triage.category}</div>{/if}
+    {#if typeof triage.suggested_assignee === 'string' && triage.suggested_assignee}
+      <div><strong>Suggested assignee:</strong> {triage.suggested_assignee}</div>
+    {/if}
+  </section>
+
+  {#if review.suggestions.length > 0}
+    <section class="mt-3">
+      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Suggestions</h4>
+      <ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-gray-800">
+        {#each review.suggestions as s, i (i)}
+          <li>{typeof s === 'string' ? s : JSON.stringify(s)}</li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+
+  {#if review.action_taken === 'auto_implement' && review.pr_created > 0}
+    <p class="mt-3 text-xs">
+      <a href="/prs/{review.pr_created}" class="text-indigo-600 hover:underline">
+        View created PR →
+      </a>
+    </p>
+  {/if}
+</article>

--- a/web_ui/src/lib/components/IssueTile.svelte
+++ b/web_ui/src/lib/components/IssueTile.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { reviewingIssues } from '$lib/stores.js';
+  import type { Issue } from '$lib/types.js';
+  import SeverityBadge from './SeverityBadge.svelte';
+
+  let { issue }: { issue: Issue } = $props();
+
+  const isReviewing = $derived($reviewingIssues.has(issue.id));
+
+  const triage = $derived(issue.latest_review?.triage as { severity?: string } | undefined);
+  const severity = $derived(triage?.severity ?? null);
+
+  const mode = $derived.by(() => {
+    if (issue.labels.includes('auto_implement')) return 'auto_implement' as const;
+    if (issue.labels.includes('review_only')) return 'review_only' as const;
+    return null;
+  });
+</script>
+
+<a href="/issues/{issue.id}" class="block border-b border-gray-100 px-4 py-3 hover:bg-gray-50">
+  <div class="flex items-start gap-3">
+    <div class="min-w-0 flex-1">
+      <p class="truncate text-sm font-medium text-gray-900">{issue.title}</p>
+      <p class="mt-0.5 truncate text-xs text-gray-500">
+        <span class="font-mono">{issue.repo}</span>
+        · #{issue.number}
+        · {issue.author}
+      </p>
+      {#if mode}
+        <span
+          class="mt-1 inline-flex rounded px-1.5 py-0.5 text-[10px] font-medium
+          {mode === 'auto_implement'
+            ? 'bg-indigo-100 text-indigo-700'
+            : 'bg-blue-100 text-blue-700'}"
+        >
+          {mode}
+        </span>
+      {/if}
+    </div>
+    <div class="flex shrink-0 items-center gap-2">
+      {#if isReviewing}
+        <span class="text-xs text-indigo-600">reviewing…</span>
+      {/if}
+      {#if severity}
+        <SeverityBadge {severity} />
+      {:else}
+        <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+          PENDING
+        </span>
+      {/if}
+    </div>
+  </div>
+</a>

--- a/web_ui/src/lib/components/PRFilterBar.svelte
+++ b/web_ui/src/lib/components/PRFilterBar.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  interface Filters {
+    repo: string;
+    severity: string;
+    state: string;
+  }
+
+  interface Props {
+    filters: Filters;
+    repos: string[];
+    onChange: (next: Filters) => void;
+  }
+
+  let { filters, repos, onChange }: Props = $props();
+
+  const severities = ['any', 'critical', 'high', 'medium', 'low'];
+  const states = ['open', 'closed', 'all'];
+
+  function update(field: keyof Filters, value: string): void {
+    onChange({ ...filters, [field]: value });
+  }
+</script>
+
+<div
+  class="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-gray-200 bg-gray-50 p-3"
+>
+  <label class="flex items-center gap-1 text-xs text-gray-600">
+    <span>Repo:</span>
+    <select
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      value={filters.repo}
+      onchange={(e) => update('repo', (e.currentTarget as HTMLSelectElement).value)}
+    >
+      <option value="">any</option>
+      {#each repos as repo (repo)}
+        <option value={repo}>{repo}</option>
+      {/each}
+    </select>
+  </label>
+
+  <label class="flex items-center gap-1 text-xs text-gray-600">
+    <span>Severity:</span>
+    <select
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      value={filters.severity || 'any'}
+      onchange={(e) => update('severity', (e.currentTarget as HTMLSelectElement).value)}
+    >
+      {#each severities as s (s)}
+        <option value={s}>{s}</option>
+      {/each}
+    </select>
+  </label>
+
+  <label class="flex items-center gap-1 text-xs text-gray-600">
+    <span>State:</span>
+    <select
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      value={filters.state ?? 'open'}
+      onchange={(e) => update('state', (e.currentTarget as HTMLSelectElement).value)}
+    >
+      {#each states as s (s)}
+        <option value={s}>{s}</option>
+      {/each}
+    </select>
+  </label>
+</div>

--- a/web_ui/src/lib/components/PRReviewCard.svelte
+++ b/web_ui/src/lib/components/PRReviewCard.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import type { Review } from '$lib/types.js';
+  import SeverityBadge from './SeverityBadge.svelte';
+
+  let { review }: { review: Review } = $props();
+</script>
+
+<article class="mb-3 rounded-md border border-gray-200 bg-white p-4">
+  <header class="mb-2 flex items-center justify-between gap-2">
+    <div class="flex items-center gap-2">
+      <SeverityBadge severity={review.severity} />
+      <span class="text-xs text-gray-500">{review.cli_used}</span>
+    </div>
+    <time class="text-xs text-gray-400" datetime={review.created_at}>
+      {new Date(review.created_at).toLocaleString()}
+    </time>
+  </header>
+
+  {#if review.summary}
+    <p class="text-sm text-gray-800">{review.summary}</p>
+  {/if}
+
+  {#if review.issues.length > 0}
+    <section class="mt-3">
+      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">
+        Findings ({review.issues.length})
+      </h4>
+      <ul class="mt-1 space-y-1 text-sm">
+        {#each review.issues as f (f.file + f.line + f.description)}
+          <li class="flex items-start gap-2">
+            <SeverityBadge severity={f.severity} />
+            <span class="font-mono text-xs text-gray-500">{f.file}:{f.line}</span>
+            <span class="text-gray-800">{f.description}</span>
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+
+  {#if review.suggestions.length > 0}
+    <section class="mt-3">
+      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Suggestions</h4>
+      <ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-gray-800">
+        {#each review.suggestions as s, i (i)}
+          <li>{typeof s === 'string' ? s : JSON.stringify(s)}</li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+</article>

--- a/web_ui/src/lib/components/PRTile.svelte
+++ b/web_ui/src/lib/components/PRTile.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { reviewingPRs } from '$lib/stores.js';
+  import type { PR } from '$lib/types.js';
+  import SeverityBadge from './SeverityBadge.svelte';
+
+  let { pr }: { pr: PR } = $props();
+
+  const isReviewing = $derived($reviewingPRs.has(pr.id));
+  const severity = $derived(pr.latest_review?.severity ?? null);
+</script>
+
+<a href="/prs/{pr.id}" class="block border-b border-gray-100 px-4 py-3 hover:bg-gray-50">
+  <div class="flex items-start gap-3">
+    <div class="min-w-0 flex-1">
+      <p class="truncate text-sm font-medium text-gray-900">{pr.title}</p>
+      <p class="mt-0.5 truncate text-xs text-gray-500">
+        <span class="font-mono">{pr.repo}</span>
+        · #{pr.number}
+        · {pr.author}
+      </p>
+    </div>
+    <div class="flex shrink-0 items-center gap-2">
+      {#if isReviewing}
+        <span class="text-xs text-indigo-600" data-testid="reviewing-spinner">reviewing…</span>
+      {/if}
+      <SeverityBadge {severity} />
+    </div>
+  </div>
+</a>

--- a/web_ui/src/lib/components/SeverityBadge.svelte
+++ b/web_ui/src/lib/components/SeverityBadge.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { severityClass } from '$lib/severity.js';
+
+  let { severity }: { severity: string | null | undefined } = $props();
+
+  const label = $derived((severity ?? 'none').toUpperCase());
+  const cls = $derived(severity ? severityClass(severity) : 'bg-gray-100 text-gray-500');
+</script>
+
+<span class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {cls}">
+  {label}
+</span>

--- a/web_ui/src/lib/components/StatsCards.svelte
+++ b/web_ui/src/lib/components/StatsCards.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { Stats } from '$lib/types.js';
+
+  let { stats }: { stats: Stats | null } = $props();
+
+  const cells = $derived([
+    { label: 'Total reviews', value: stats?.total_reviews },
+    { label: 'Avg findings / review', value: stats?.avg_issues_per_review?.toFixed(1) },
+    { label: 'Median time (s)', value: stats?.review_timing?.median_seconds?.toFixed(1) },
+    { label: 'High-severity', value: stats?.by_severity?.HIGH ?? 0 }
+  ]);
+</script>
+
+<section class="grid grid-cols-2 gap-4 md:grid-cols-4">
+  {#each cells as cell (cell.label)}
+    <div class="rounded-lg border border-gray-200 bg-white p-4">
+      <dt class="text-xs uppercase tracking-wide text-gray-500">{cell.label}</dt>
+      <dd class="mt-1 text-2xl font-semibold">{cell.value ?? '—'}</dd>
+    </div>
+  {/each}
+</section>

--- a/web_ui/src/lib/filters.ts
+++ b/web_ui/src/lib/filters.ts
@@ -1,0 +1,41 @@
+import type { Issue, IssueTriage, PR } from './types.js';
+
+export interface PRFilter {
+  repo: string; // "" = any
+  severity: string; // "any" or a severity name
+  state: string; // "open" | "closed" | "all"
+}
+
+export interface IssueFilter {
+  repo: string; // "" = any
+  severity: string; // "any" or a severity name
+  mode: string; // "all" | "auto_implement" | "review_only"
+}
+
+export function filterPRs(prs: PR[], f: PRFilter): PR[] {
+  return prs.filter((p) => {
+    if (f.repo && p.repo !== f.repo) return false;
+    if (f.state !== 'all' && p.state?.toLowerCase() !== f.state) return false;
+    if (f.severity !== 'any') {
+      const s = p.latest_review?.severity?.toLowerCase() ?? '';
+      if (s !== f.severity) return false;
+    }
+    return true;
+  });
+}
+
+export function filterIssues(issues: Issue[], f: IssueFilter): Issue[] {
+  return issues.filter((i) => {
+    if (i.dismissed) return false;
+    if (f.repo && i.repo !== f.repo) return false;
+    if (f.severity !== 'any') {
+      const triage = i.latest_review?.triage as IssueTriage | undefined;
+      const s = triage?.severity?.toLowerCase() ?? '';
+      if (s !== f.severity) return false;
+    }
+    if (f.mode !== 'all') {
+      if (!i.labels.includes(f.mode)) return false;
+    }
+    return true;
+  });
+}

--- a/web_ui/src/lib/persisted.ts
+++ b/web_ui/src/lib/persisted.ts
@@ -1,0 +1,47 @@
+import { writable, type Writable } from 'svelte/store';
+
+function subscribeWithSkip<T>(store: Writable<T>, onChange: (v: T) => void): void {
+  // Svelte's `writable.subscribe` fires synchronously with the current value —
+  // that first callback is a no-op write for persisted stores. Skip it so a
+  // cold start doesn't perform a redundant localStorage write on every boot.
+  let first = true;
+  store.subscribe((v) => {
+    if (first) {
+      first = false;
+      return;
+    }
+    onChange(v);
+  });
+}
+
+// SSR-safe. Returns a writable<boolean> backed by localStorage under `key`.
+// On first read, if localStorage has a stored value it is parsed; otherwise
+// `initial` is used. On every write, the new value is persisted.
+export function persistedBoolean(key: string, initial: boolean): Writable<boolean> {
+  const start = read(key, initial, (raw) =>
+    raw === 'true' ? true : raw === 'false' ? false : null
+  );
+  const store = writable<boolean>(start);
+  subscribeWithSkip(store, (v) => write(key, String(v)));
+  return store;
+}
+
+export function persistedString(key: string, initial: string): Writable<string> {
+  const start = read<string>(key, initial, (raw) => raw);
+  const store = writable<string>(start);
+  subscribeWithSkip(store, (v) => write(key, v));
+  return store;
+}
+
+function read<T>(key: string, fallback: T, parse: (raw: string) => T | null): T {
+  if (typeof localStorage === 'undefined') return fallback;
+  const raw = localStorage.getItem(key);
+  if (raw == null) return fallback;
+  const parsed = parse(raw);
+  return parsed == null ? fallback : parsed;
+}
+
+function write(key: string, value: string): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(key, value);
+}

--- a/web_ui/src/lib/server/token.ts
+++ b/web_ui/src/lib/server/token.ts
@@ -1,0 +1,23 @@
+import { readFile } from 'node:fs/promises';
+
+let cached: string | null | undefined;
+
+export async function loadToken(): Promise<string | null> {
+  if (cached !== undefined) return cached;
+
+  const envToken = process.env.HEIMDALLM_API_TOKEN;
+  if (envToken && envToken.trim().length > 0) {
+    cached = envToken.trim();
+    return cached;
+  }
+
+  const path = process.env.HEIMDALLM_API_TOKEN_FILE ?? '/data/api_token';
+  try {
+    const contents = await readFile(path, 'utf-8');
+    const trimmed = contents.trim();
+    cached = trimmed.length > 0 ? trimmed : null;
+  } catch {
+    cached = null;
+  }
+  return cached;
+}

--- a/web_ui/src/lib/severity.ts
+++ b/web_ui/src/lib/severity.ts
@@ -1,0 +1,21 @@
+const CLASSES: Record<string, string> = {
+  critical: 'bg-red-100 text-red-700',
+  high: 'bg-orange-100 text-orange-700',
+  medium: 'bg-amber-100 text-amber-700',
+  low: 'bg-gray-100 text-gray-600'
+};
+
+const ORDER: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1
+};
+
+export function severityClass(sev: string): string {
+  return CLASSES[sev.toLowerCase()] ?? 'bg-gray-100 text-gray-600';
+}
+
+export function severityOrder(sev: string): number {
+  return ORDER[sev.toLowerCase()] ?? 0;
+}

--- a/web_ui/src/lib/sort.ts
+++ b/web_ui/src/lib/sort.ts
@@ -1,0 +1,28 @@
+import { severityOrder } from './severity.js';
+import type { PR } from './types.js';
+
+// Parses an ISO date to epoch millis, returning 0 for empty/malformed input
+// so sorts are stable and predictable even if the daemon serves partial data.
+function timestamp(value: string | undefined): number {
+  if (!value) return 0;
+  const t = new Date(value).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+export function byUpdated(a: PR, b: PR): number {
+  return timestamp(b.updated_at) - timestamp(a.updated_at);
+}
+
+export function byPriority(a: PR, b: PR): number {
+  const d =
+    severityOrder(b.latest_review?.severity ?? '') - severityOrder(a.latest_review?.severity ?? '');
+  return d !== 0 ? d : byUpdated(a, b);
+}
+
+// Generic descending-by-date comparator factory. Used for issues where the
+// only sort key is `fetched_at` (issues have no `updated_at` on the wire).
+export function desc<T extends object>(field: keyof T): (a: T, b: T) => number {
+  return (a, b) =>
+    timestamp(String((b[field] as string | undefined) ?? '')) -
+    timestamp(String((a[field] as string | undefined) ?? ''));
+}

--- a/web_ui/src/lib/sse.ts
+++ b/web_ui/src/lib/sse.ts
@@ -8,6 +8,14 @@ const KNOWN_EVENT_TYPES: SseEventType[] = [
   'review_error'
 ];
 
+// Native EventSource auto-reconnects only after a 200 response. Our proxy
+// can legitimately respond 502/503 (daemon unreachable / token missing),
+// and at that point the browser gives up permanently. This module adds a
+// manual retry loop with capped exponential backoff so the UI recovers
+// once the daemon comes back.
+const INITIAL_RETRY_MS = 2_000;
+const MAX_RETRY_MS = 60_000;
+
 export interface EventsHandle {
   events: Readable<SseEvent | null>;
   connected: Readable<boolean>;
@@ -32,23 +40,51 @@ export function connectEvents(path = '/events'): EventsHandle {
     };
   });
 
-  const source = new EventSource(path);
+  let source: EventSource | undefined;
+  let retryMs = INITIAL_RETRY_MS;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let closed = false;
 
-  source.onopen = () => connected.set(true);
-  source.onerror = () => connected.set(false);
+  const open = (): void => {
+    if (closed) return;
+    source = new EventSource(path);
 
-  for (const type of KNOWN_EVENT_TYPES) {
-    source.addEventListener(type, (ev) => {
-      const msg = ev as MessageEvent;
-      emit?.({ type, data: parse(msg.data) });
-    });
-  }
+    source.onopen = () => {
+      retryMs = INITIAL_RETRY_MS;
+      connected.set(true);
+    };
+
+    source.onerror = () => {
+      connected.set(false);
+      // EventSource will auto-reconnect on its own for 200-terminated streams.
+      // For non-200 initial responses the browser stops retrying and moves
+      // readyState to CLOSED. Detect that and retry manually with backoff.
+      if (source?.readyState === EventSource.CLOSED) {
+        source.close();
+        source = undefined;
+        retryTimer = setTimeout(open, retryMs);
+        retryMs = Math.min(retryMs * 2, MAX_RETRY_MS);
+      }
+    };
+
+    for (const type of KNOWN_EVENT_TYPES) {
+      source.addEventListener(type, (ev) => {
+        const msg = ev as MessageEvent;
+        emit?.({ type, data: parse(msg.data) });
+      });
+    }
+  };
+
+  open();
 
   return {
     events,
     connected,
     close: () => {
-      source.close();
+      closed = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      source?.close();
+      source = undefined;
       connected.set(false);
     }
   };

--- a/web_ui/src/lib/sse.ts
+++ b/web_ui/src/lib/sse.ts
@@ -5,7 +5,12 @@ const KNOWN_EVENT_TYPES: SseEventType[] = [
   'pr_detected',
   'review_started',
   'review_completed',
-  'review_error'
+  'review_error',
+  'issue_detected',
+  'issue_review_started',
+  'issue_review_completed',
+  'issue_review_error',
+  'issue_implemented'
 ];
 
 // Native EventSource auto-reconnects only after a 200 response. Our proxy

--- a/web_ui/src/lib/sse.ts
+++ b/web_ui/src/lib/sse.ts
@@ -1,0 +1,55 @@
+import { readable, writable, type Readable } from 'svelte/store';
+import type { SseEvent, SseEventType } from './types.js';
+
+const KNOWN_EVENT_TYPES: SseEventType[] = [
+  'pr_detected',
+  'review_started',
+  'review_completed',
+  'review_error'
+];
+
+export interface EventsHandle {
+  events: Readable<SseEvent | null>;
+  connected: Readable<boolean>;
+  close: () => void;
+}
+
+function parse(data: string): unknown {
+  try {
+    return JSON.parse(data);
+  } catch {
+    return data;
+  }
+}
+
+export function connectEvents(path = '/events'): EventsHandle {
+  const connected = writable(false);
+  let emit: ((e: SseEvent) => void) | undefined;
+  const events = readable<SseEvent | null>(null, (set) => {
+    emit = (e) => set(e);
+    return () => {
+      emit = undefined;
+    };
+  });
+
+  const source = new EventSource(path);
+
+  source.onopen = () => connected.set(true);
+  source.onerror = () => connected.set(false);
+
+  for (const type of KNOWN_EVENT_TYPES) {
+    source.addEventListener(type, (ev) => {
+      const msg = ev as MessageEvent;
+      emit?.({ type, data: parse(msg.data) });
+    });
+  }
+
+  return {
+    events,
+    connected,
+    close: () => {
+      source.close();
+      connected.set(false);
+    }
+  };
+}

--- a/web_ui/src/lib/sseBridge.ts
+++ b/web_ui/src/lib/sseBridge.ts
@@ -1,0 +1,88 @@
+import type { Readable } from 'svelte/store';
+import { issueListRefresh, prListRefresh, reviewingIssues, reviewingPRs } from './stores.js';
+import type { SseEvent } from './types.js';
+
+// Clears the in-flight review sets whenever the SSE connection transitions
+// from disconnected to connected. Rationale: if the daemon emitted
+// `review_completed` or `issue_review_completed` while we were offline, we
+// won't know — and the tile would otherwise show "reviewing…" forever.
+// Accepts brief UI inaccuracy (an active review appears not-in-flight until
+// the daemon re-emits `review_started`) in exchange for eventual consistency.
+//
+// Does NOT sweep on the very first emission to avoid clearing a legitimate
+// in-flight set populated by an optimistic client-side update before the
+// first SSE connection even opens.
+export function watchReconnectAndSweep(connected: Readable<boolean>): () => void {
+  let seen = false;
+  let previous = false;
+  return connected.subscribe((now) => {
+    if (!seen) {
+      seen = true;
+      previous = now;
+      return;
+    }
+    if (now && !previous) {
+      reviewingPRs.set(new Set());
+      reviewingIssues.set(new Set());
+    }
+    previous = now;
+  });
+}
+
+type SetStore = typeof reviewingPRs;
+
+function mutateSet(store: SetStore, mutate: (s: Set<number>) => void): void {
+  store.update((s) => {
+    const next = new Set(s);
+    mutate(next);
+    return next;
+  });
+}
+
+export function initSseBridge(events: Readable<SseEvent | null>): () => void {
+  return events.subscribe((e) => {
+    if (!e) return;
+    const data = (e.data ?? {}) as { pr_id?: number; issue_id?: number };
+    switch (e.type) {
+      case 'pr_detected':
+        prListRefresh.update((n) => n + 1);
+        break;
+      case 'review_started':
+        if (typeof data.pr_id === 'number') mutateSet(reviewingPRs, (s) => s.add(data.pr_id!));
+        break;
+      case 'review_completed':
+        if (typeof data.pr_id === 'number') mutateSet(reviewingPRs, (s) => s.delete(data.pr_id!));
+        prListRefresh.update((n) => n + 1);
+        break;
+      case 'review_error':
+        if (typeof data.pr_id === 'number') mutateSet(reviewingPRs, (s) => s.delete(data.pr_id!));
+        break;
+      case 'issue_detected':
+        issueListRefresh.update((n) => n + 1);
+        break;
+      case 'issue_review_started':
+        if (typeof data.issue_id === 'number')
+          mutateSet(reviewingIssues, (s) => s.add(data.issue_id!));
+        break;
+      case 'issue_review_completed':
+        if (typeof data.issue_id === 'number')
+          mutateSet(reviewingIssues, (s) => s.delete(data.issue_id!));
+        issueListRefresh.update((n) => n + 1);
+        break;
+      case 'issue_review_error':
+        if (typeof data.issue_id === 'number')
+          mutateSet(reviewingIssues, (s) => s.delete(data.issue_id!));
+        break;
+      case 'issue_implemented':
+        // New issue→PR link. The daemon emits this instead of
+        // `issue_review_completed` for the auto_implement success path, so
+        // we must also clear the in-flight marker or the tile's
+        // "reviewing…" chip would never go away.
+        if (typeof data.issue_id === 'number')
+          mutateSet(reviewingIssues, (s) => s.delete(data.issue_id!));
+        issueListRefresh.update((n) => n + 1);
+        prListRefresh.update((n) => n + 1);
+        break;
+    }
+  });
+}

--- a/web_ui/src/lib/stores.ts
+++ b/web_ui/src/lib/stores.ts
@@ -7,3 +7,14 @@ export interface AuthState {
 }
 
 export const auth = writable<AuthState>({ login: null, authError: null, ready: false });
+
+// Refresh counters — incrementing these forces list fetchers to re-run.
+// Used by the SSE bridge (see sseBridge.ts) and by any page that needs
+// to invalidate after a mutation.
+export const prListRefresh = writable(0);
+export const issueListRefresh = writable(0);
+
+// In-flight review trackers. A PR id is present while a review is
+// running, so tiles and buttons can show a spinner.
+export const reviewingPRs = writable<Set<number>>(new Set());
+export const reviewingIssues = writable<Set<number>>(new Set());

--- a/web_ui/src/lib/stores.ts
+++ b/web_ui/src/lib/stores.ts
@@ -1,0 +1,9 @@
+import { writable } from 'svelte/store';
+
+export interface AuthState {
+  login: string | null;
+  authError: string | null;
+  ready: boolean;
+}
+
+export const auth = writable<AuthState>({ login: null, authError: null, ready: false });

--- a/web_ui/src/lib/types.ts
+++ b/web_ui/src/lib/types.ts
@@ -115,10 +115,10 @@ export interface ReviewTimingStats {
   median_seconds: number;
   min_seconds: number;
   max_seconds: number;
-  bucket_fast: number;       // < 30 s
-  bucket_medium: number;     // 30–120 s
-  bucket_slow: number;       // 120–300 s
-  bucket_very_slow: number;  // > 300 s
+  bucket_fast: number; // < 30 s
+  bucket_medium: number; // 30–120 s
+  bucket_slow: number; // 120–300 s
+  bucket_very_slow: number; // > 300 s
 }
 
 export interface Stats {
@@ -142,11 +142,7 @@ export type Config = Record<string, unknown>;
 // SSE event types emitted by the daemon's sse.Broker. Must match the
 // constants in daemon/internal/sse/broker.go exactly or listeners in
 // sse.ts won't fire.
-export type SseEventType =
-  | 'pr_detected'
-  | 'review_started'
-  | 'review_completed'
-  | 'review_error';
+export type SseEventType = 'pr_detected' | 'review_started' | 'review_completed' | 'review_error';
 
 export interface SseEvent<T = unknown> {
   type: SseEventType;

--- a/web_ui/src/lib/types.ts
+++ b/web_ui/src/lib/types.ts
@@ -112,6 +112,8 @@ export interface DayCount {
 }
 
 export interface ReviewTimingStats {
+  sample_count: number;
+  avg_seconds: number;
   median_seconds: number;
   min_seconds: number;
   max_seconds: number;

--- a/web_ui/src/lib/types.ts
+++ b/web_ui/src/lib/types.ts
@@ -1,0 +1,154 @@
+// Wire-format types mirroring the daemon's JSON responses.
+// Field names intentionally use snake_case to match the wire format.
+//
+// The Dart code-finding type (file/line/severity) is called `Issue` in
+// flutter_app/lib/core/models/issue.dart. We rename it to `ReviewFinding`
+// here so `Issue` can denote the Fase-2 GitHub-issue domain type without
+// collision.
+
+export interface ReviewFinding {
+  file: string;
+  line: number;
+  description: string;
+  severity: string;
+}
+
+// The daemon stores issues/suggestions as JSON-encoded strings in TEXT
+// columns (see daemon/internal/store/reviews.go: `Issues string json:"issues"`),
+// so the wire format is `"[{...}]"` — a string, not an array. api.ts is
+// responsible for parsing these strings into typed arrays before returning
+// Reviews to callers. The Dart api_client does the same in _parseReviewMap.
+export interface Review {
+  id: number;
+  pr_id: number;
+  cli_used: string;
+  summary: string;
+  issues: ReviewFinding[];
+  suggestions: string[];
+  severity: string;
+  created_at: string;
+  github_review_id: number; // 0 = not yet published to GitHub
+}
+
+export interface PR {
+  id: number;
+  github_id: number;
+  repo: string;
+  number: number;
+  title: string;
+  author: string;
+  url: string;
+  state: string;
+  updated_at: string;
+  fetched_at: string;
+  dismissed: boolean;
+  latest_review?: Review | null;
+}
+
+export interface PRDetail {
+  pr: PR;
+  reviews: Review[];
+}
+
+// Fase-2 GitHub issue tracking (daemon endpoints not yet implemented;
+// shape follows docs/superpowers/specs/2026-04-16-heimdallm-v2-design.md).
+export interface Issue {
+  id: number;
+  github_id: number;
+  repo: string;
+  number: number;
+  title: string;
+  body: string;
+  author: string;
+  assignees: string[];
+  labels: string[];
+  state: string;
+  created_at: string;
+  fetched_at: string;
+  dismissed: boolean;
+  latest_review?: IssueReview | null;
+}
+
+export interface IssueReview {
+  id: number;
+  issue_id: number;
+  cli_used: string;
+  summary: string;
+  triage: unknown;
+  suggestions: unknown[];
+  action_taken: 'review_only' | 'auto_implement';
+  pr_created: number;
+  created_at: string;
+}
+
+export interface IssueDetail {
+  issue: Issue;
+  reviews: IssueReview[];
+}
+
+// Agent mirrors daemon/internal/store/agents.go. The daemon's Agent
+// includes `cli` (claude | gemini | codex) and `created_at` in addition
+// to the fields Dart's ReviewPrompt exposes.
+export interface Agent {
+  id: string;
+  name: string;
+  cli: string;
+  prompt: string;
+  instructions: string;
+  cli_flags: string;
+  is_default: boolean;
+  created_at: string;
+}
+
+// Stats mirrors daemon/internal/store/store.go Stats struct.
+export interface RepoCount {
+  repo: string;
+  count: number;
+}
+
+export interface DayCount {
+  day: string;
+  count: number;
+}
+
+export interface ReviewTimingStats {
+  median_seconds: number;
+  min_seconds: number;
+  max_seconds: number;
+  bucket_fast: number;       // < 30 s
+  bucket_medium: number;     // 30–120 s
+  bucket_slow: number;       // 120–300 s
+  bucket_very_slow: number;  // > 300 s
+}
+
+export interface Stats {
+  total_reviews: number;
+  by_severity: Record<string, number>;
+  by_cli: Record<string, number>;
+  top_repos: RepoCount[];
+  reviews_last_7_days: DayCount[];
+  avg_issues_per_review: number;
+  review_timing: ReviewTimingStats;
+}
+
+export interface Me {
+  login: string;
+}
+
+// Config is deliberately loose — the shape is large and the daemon owns
+// validation. Typed access happens at the Config-page level in a later PR.
+export type Config = Record<string, unknown>;
+
+// SSE event types emitted by the daemon's sse.Broker. Must match the
+// constants in daemon/internal/sse/broker.go exactly or listeners in
+// sse.ts won't fire.
+export type SseEventType =
+  | 'pr_detected'
+  | 'review_started'
+  | 'review_completed'
+  | 'review_error';
+
+export interface SseEvent<T = unknown> {
+  type: SseEventType;
+  data: T;
+}

--- a/web_ui/src/lib/types.ts
+++ b/web_ui/src/lib/types.ts
@@ -50,8 +50,9 @@ export interface PRDetail {
   reviews: Review[];
 }
 
-// Fase-2 GitHub issue tracking (daemon endpoints not yet implemented;
-// shape follows docs/superpowers/specs/2026-04-16-heimdallm-v2-design.md).
+// Fase-2 GitHub issue tracking. Shape mirrors daemon/internal/store/issues.go.
+// assignees/labels are JSON-encoded strings on the wire — api.ts parseIssue
+// decodes them into typed arrays (mirroring the parseReview pattern).
 export interface Issue {
   id: number;
   github_id: number;
@@ -69,13 +70,22 @@ export interface Issue {
   latest_review?: IssueReview | null;
 }
 
+// IssueReview mirrors daemon/internal/store/issues.go. triage and suggestions
+// arrive as JSON-encoded strings on the wire; api.ts parseIssueReview decodes
+// them before returning typed objects to callers.
+export interface IssueTriage {
+  severity?: string;
+  category?: string;
+  [key: string]: unknown;
+}
+
 export interface IssueReview {
   id: number;
   issue_id: number;
   cli_used: string;
   summary: string;
-  triage: unknown;
-  suggestions: unknown[];
+  triage: IssueTriage;
+  suggestions: string[];
   action_taken: 'review_only' | 'auto_implement';
   pr_created: number;
   created_at: string;
@@ -144,7 +154,16 @@ export type Config = Record<string, unknown>;
 // SSE event types emitted by the daemon's sse.Broker. Must match the
 // constants in daemon/internal/sse/broker.go exactly or listeners in
 // sse.ts won't fire.
-export type SseEventType = 'pr_detected' | 'review_started' | 'review_completed' | 'review_error';
+export type SseEventType =
+  | 'pr_detected'
+  | 'review_started'
+  | 'review_completed'
+  | 'review_error'
+  | 'issue_detected'
+  | 'issue_review_started'
+  | 'issue_review_completed'
+  | 'issue_review_error'
+  | 'issue_implemented';
 
 export interface SseEvent<T = unknown> {
   type: SseEventType;

--- a/web_ui/src/routes/+layout.svelte
+++ b/web_ui/src/routes/+layout.svelte
@@ -4,17 +4,27 @@
   import { page } from '$app/stores';
   import { connectEvents, type EventsHandle } from '$lib/sse.js';
   import { auth } from '$lib/stores.js';
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy, onMount, setContext } from 'svelte';
+  import { writable, type Readable } from 'svelte/store';
 
   let { children } = $props();
 
+  // Shared connection state. Populated by onMount; exposed to child pages
+  // via context so they don't open their own EventSource.
+  const connected = writable(false);
+  setContext<Readable<boolean>>('sse-connected', { subscribe: connected.subscribe });
+
   let sse: EventsHandle | undefined;
+  let connUnsub: (() => void) | undefined;
 
   onMount(() => {
-    if (browser) sse = connectEvents();
+    if (!browser) return;
+    sse = connectEvents();
+    connUnsub = sse.connected.subscribe((v) => connected.set(v));
   });
 
   onDestroy(() => {
+    connUnsub?.();
     sse?.close();
   });
 

--- a/web_ui/src/routes/+layout.svelte
+++ b/web_ui/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
   import { browser } from '$app/environment';
   import { page } from '$app/stores';
   import { connectEvents, type EventsHandle } from '$lib/sse.js';
+  import { initSseBridge, watchReconnectAndSweep } from '$lib/sseBridge.js';
   import { auth } from '$lib/stores.js';
   import { onDestroy, onMount, setContext } from 'svelte';
   import { writable, type Readable } from 'svelte/store';
@@ -16,14 +17,20 @@
 
   let sse: EventsHandle | undefined;
   let connUnsub: (() => void) | undefined;
+  let bridgeUnsub: (() => void) | undefined;
+  let reconnectUnsub: (() => void) | undefined;
 
   onMount(() => {
     if (!browser) return;
     sse = connectEvents();
     connUnsub = sse.connected.subscribe((v) => connected.set(v));
+    bridgeUnsub = initSseBridge(sse.events);
+    reconnectUnsub = watchReconnectAndSweep(sse.connected);
   });
 
   onDestroy(() => {
+    reconnectUnsub?.();
+    bridgeUnsub?.();
     connUnsub?.();
     sse?.close();
   });

--- a/web_ui/src/routes/+layout.svelte
+++ b/web_ui/src/routes/+layout.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import '../app.css';
+  import { browser } from '$app/environment';
+  import { page } from '$app/stores';
+  import { connectEvents, type EventsHandle } from '$lib/sse.js';
+  import { auth } from '$lib/stores.js';
+  import { onDestroy, onMount } from 'svelte';
+
+  let { children } = $props();
+
+  let sse: EventsHandle | undefined;
+
+  onMount(() => {
+    if (browser) sse = connectEvents();
+  });
+
+  onDestroy(() => {
+    sse?.close();
+  });
+
+  const navItems = [
+    { href: '/', label: 'Dashboard' },
+    { href: '/prs', label: 'PRs' },
+    { href: '/issues', label: 'Issues' },
+    { href: '/agents', label: 'Agents' },
+    { href: '/config', label: 'Config' },
+    { href: '/logs', label: 'Logs' }
+  ];
+</script>
+
+<header class="border-b border-gray-200 bg-white">
+  <nav class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-3">
+    <a href="/" class="text-lg font-semibold tracking-tight">Heimdallm</a>
+    <ul class="flex items-center gap-4 text-sm">
+      {#each navItems as item (item.href)}
+        <li>
+          <a
+            href={item.href}
+            aria-current={$page.url.pathname === item.href ? 'page' : undefined}
+            class="hover:text-indigo-600 {$page.url.pathname === item.href
+              ? 'text-indigo-600 font-medium'
+              : 'text-gray-600'}"
+          >
+            {item.label}
+          </a>
+        </li>
+      {/each}
+    </ul>
+    <span class="text-sm text-gray-500" data-testid="login">
+      {$auth.login ?? '—'}
+    </span>
+  </nav>
+</header>
+
+{#if $auth.authError}
+  <div class="border-b border-red-200 bg-red-50 px-6 py-2 text-sm text-red-700">
+    Daemon unreachable — check <code>HEIMDALLM_API_URL</code>. ({$auth.authError})
+  </div>
+{/if}
+
+<main class="mx-auto max-w-6xl px-6 py-8">
+  {@render children()}
+</main>

--- a/web_ui/src/routes/+layout.ts
+++ b/web_ui/src/routes/+layout.ts
@@ -1,0 +1,16 @@
+import { fetchMe } from '$lib/api.js';
+import { auth } from '$lib/stores.js';
+import type { LayoutLoad } from './$types.js';
+
+export const ssr = false; // browser-only — auth state + SSE live in the client
+
+export const load: LayoutLoad = async () => {
+  try {
+    const me = await fetchMe();
+    auth.set({ login: me.login ?? null, authError: null, ready: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'daemon unreachable';
+    auth.set({ login: null, authError: message, ready: true });
+  }
+  return {};
+};

--- a/web_ui/src/routes/+layout.ts
+++ b/web_ui/src/routes/+layout.ts
@@ -7,7 +7,7 @@ export const ssr = false; // browser-only — auth state + SSE live in the clien
 export const load: LayoutLoad = async () => {
   try {
     const me = await fetchMe();
-    auth.set({ login: me.login ?? null, authError: null, ready: true });
+    auth.set({ login: me.login, authError: null, ready: true });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'daemon unreachable';
     auth.set({ login: null, authError: message, ready: true });

--- a/web_ui/src/routes/+page.svelte
+++ b/web_ui/src/routes/+page.svelte
@@ -1,0 +1,1 @@
+<h1>Heimdallm scaffold OK</h1>

--- a/web_ui/src/routes/+page.svelte
+++ b/web_ui/src/routes/+page.svelte
@@ -35,7 +35,7 @@
 <p class="mt-1 text-sm text-gray-500">v0.1 scaffold — dashboard lands in #31.</p>
 
 <section class="mt-8 grid grid-cols-2 gap-4 md:grid-cols-4">
-  {#each [{ label: 'Total reviews', value: stats?.total_reviews }, { label: 'Avg findings / review', value: stats?.avg_issues_per_review?.toFixed(1) }, { label: 'Median time (s)', value: stats?.review_timing?.median_seconds?.toFixed(1) }, { label: 'High-severity', value: stats?.by_severity?.HIGH ?? 0 }] as cell (cell.label)}
+  {#each [{ label: 'Total reviews', value: stats?.total_reviews }, { label: 'Avg findings / review', value: stats?.avg_issues_per_review?.toFixed(1) }, { label: 'Median time (s)', value: stats?.review_timing?.median_seconds?.toFixed(1) }, { label: 'High-severity', value: stats?.by_severity?.HIGH ?? stats?.by_severity?.high ?? stats?.by_severity?.High ?? 0 }] as cell (cell.label)}
     <div class="rounded-lg border border-gray-200 bg-white p-4">
       <dt class="text-xs uppercase tracking-wide text-gray-500">{cell.label}</dt>
       <dd class="mt-1 text-2xl font-semibold">

--- a/web_ui/src/routes/+page.svelte
+++ b/web_ui/src/routes/+page.svelte
@@ -28,9 +28,7 @@
   });
 
   const pillClass = $derived(
-    connected
-      ? 'bg-green-100 text-green-700'
-      : 'bg-amber-100 text-amber-700'
+    connected ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
   );
   const pillLabel = $derived(connected ? 'connected' : 'disconnected');
 </script>
@@ -45,12 +43,7 @@
 <p class="mt-1 text-sm text-gray-500">v0.1 scaffold — dashboard lands in #31.</p>
 
 <section class="mt-8 grid grid-cols-2 gap-4 md:grid-cols-4">
-  {#each [
-    { label: 'Total reviews', value: stats?.total_reviews },
-    { label: 'Avg findings / review', value: stats?.avg_issues_per_review?.toFixed(1) },
-    { label: 'Median time (s)', value: stats?.review_timing?.median_seconds?.toFixed(1) },
-    { label: 'High-severity', value: stats?.by_severity?.HIGH ?? 0 }
-  ] as cell (cell.label)}
+  {#each [{ label: 'Total reviews', value: stats?.total_reviews }, { label: 'Avg findings / review', value: stats?.avg_issues_per_review?.toFixed(1) }, { label: 'Median time (s)', value: stats?.review_timing?.median_seconds?.toFixed(1) }, { label: 'High-severity', value: stats?.by_severity?.HIGH ?? 0 }] as cell (cell.label)}
     <div class="rounded-lg border border-gray-200 bg-white p-4">
       <dt class="text-xs uppercase tracking-wide text-gray-500">{cell.label}</dt>
       <dd class="mt-1 text-2xl font-semibold">

--- a/web_ui/src/routes/+page.svelte
+++ b/web_ui/src/routes/+page.svelte
@@ -1,1 +1,8 @@
-<h1>Heimdallm scaffold OK</h1>
+<script lang="ts">
+  import '../app.css';
+</script>
+
+<main class="mx-auto max-w-3xl p-8">
+  <h1 class="text-3xl font-bold text-indigo-600">Heimdallm scaffold OK</h1>
+  <p class="mt-2 text-sm text-gray-500">Tailwind is wired.</p>
+</main>

--- a/web_ui/src/routes/+page.svelte
+++ b/web_ui/src/routes/+page.svelte
@@ -1,20 +1,17 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import { fetchStats } from '$lib/api.js';
-  import { connectEvents } from '$lib/sse.js';
   import type { Stats } from '$lib/types.js';
-  import { onDestroy, onMount } from 'svelte';
+  import { getContext, onMount } from 'svelte';
+  import type { Readable } from 'svelte/store';
+
+  const connected = getContext<Readable<boolean>>('sse-connected');
 
   let stats = $state<Stats | null>(null);
   let statsError = $state<string | null>(null);
-  let sseHandle = $state<ReturnType<typeof connectEvents> | null>(null);
-  let connected = $state(false);
-  let connUnsub: (() => void) | undefined;
 
   onMount(async () => {
     if (!browser) return;
-    sseHandle = connectEvents();
-    connUnsub = sseHandle.connected.subscribe((v) => (connected = v));
     try {
       stats = await fetchStats();
     } catch (e) {
@@ -22,15 +19,10 @@
     }
   });
 
-  onDestroy(() => {
-    connUnsub?.();
-    sseHandle?.close();
-  });
-
   const pillClass = $derived(
-    connected ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
+    $connected ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
   );
-  const pillLabel = $derived(connected ? 'connected' : 'disconnected');
+  const pillLabel = $derived($connected ? 'connected' : 'disconnected');
 </script>
 
 <section class="flex items-center gap-3">

--- a/web_ui/src/routes/+page.svelte
+++ b/web_ui/src/routes/+page.svelte
@@ -1,8 +1,65 @@
 <script lang="ts">
-  import '../app.css';
+  import { browser } from '$app/environment';
+  import { fetchStats } from '$lib/api.js';
+  import { connectEvents } from '$lib/sse.js';
+  import type { Stats } from '$lib/types.js';
+  import { onDestroy, onMount } from 'svelte';
+
+  let stats = $state<Stats | null>(null);
+  let statsError = $state<string | null>(null);
+  let sseHandle = $state<ReturnType<typeof connectEvents> | null>(null);
+  let connected = $state(false);
+  let connUnsub: (() => void) | undefined;
+
+  onMount(async () => {
+    if (!browser) return;
+    sseHandle = connectEvents();
+    connUnsub = sseHandle.connected.subscribe((v) => (connected = v));
+    try {
+      stats = await fetchStats();
+    } catch (e) {
+      statsError = e instanceof Error ? e.message : String(e);
+    }
+  });
+
+  onDestroy(() => {
+    connUnsub?.();
+    sseHandle?.close();
+  });
+
+  const pillClass = $derived(
+    connected
+      ? 'bg-green-100 text-green-700'
+      : 'bg-amber-100 text-amber-700'
+  );
+  const pillLabel = $derived(connected ? 'connected' : 'disconnected');
 </script>
 
-<main class="mx-auto max-w-3xl p-8">
-  <h1 class="text-3xl font-bold text-indigo-600">Heimdallm scaffold OK</h1>
-  <p class="mt-2 text-sm text-gray-500">Tailwind is wired.</p>
-</main>
+<section class="flex items-center gap-3">
+  <h1 class="text-3xl font-bold">Heimdallm</h1>
+  <span class="rounded-full px-2 py-0.5 text-xs font-medium {pillClass}" data-testid="sse-pill">
+    {pillLabel}
+  </span>
+</section>
+
+<p class="mt-1 text-sm text-gray-500">v0.1 scaffold — dashboard lands in #31.</p>
+
+<section class="mt-8 grid grid-cols-2 gap-4 md:grid-cols-4">
+  {#each [
+    { label: 'Total reviews', value: stats?.total_reviews },
+    { label: 'Avg findings / review', value: stats?.avg_issues_per_review?.toFixed(1) },
+    { label: 'Median time (s)', value: stats?.review_timing?.median_seconds?.toFixed(1) },
+    { label: 'High-severity', value: stats?.by_severity?.HIGH ?? 0 }
+  ] as cell (cell.label)}
+    <div class="rounded-lg border border-gray-200 bg-white p-4">
+      <dt class="text-xs uppercase tracking-wide text-gray-500">{cell.label}</dt>
+      <dd class="mt-1 text-2xl font-semibold">
+        {cell.value ?? '—'}
+      </dd>
+    </div>
+  {/each}
+</section>
+
+{#if statsError}
+  <p class="mt-4 text-sm text-red-600">Could not load stats: {statsError}</p>
+{/if}

--- a/web_ui/src/routes/+page.svelte
+++ b/web_ui/src/routes/+page.svelte
@@ -1,50 +1,156 @@
 <script lang="ts">
   import { browser } from '$app/environment';
-  import { fetchStats } from '$lib/api.js';
-  import type { Stats } from '$lib/types.js';
-  import { getContext, onMount } from 'svelte';
-  import type { Readable } from 'svelte/store';
+  import CollapseHeader from '$lib/components/CollapseHeader.svelte';
+  import ConnectionPill from '$lib/components/ConnectionPill.svelte';
+  import IssueTile from '$lib/components/IssueTile.svelte';
+  import PRTile from '$lib/components/PRTile.svelte';
+  import StatsCards from '$lib/components/StatsCards.svelte';
+  import { fetchIssues, fetchPRs, fetchStats } from '$lib/api.js';
+  import { persistedBoolean, persistedString } from '$lib/persisted.js';
+  import { byPriority, byUpdated } from '$lib/sort.js';
+  import { auth, issueListRefresh, prListRefresh } from '$lib/stores.js';
+  import type { Issue, PR, Stats } from '$lib/types.js';
 
-  const connected = getContext<Readable<boolean>>('sse-connected');
+  let prs: PR[] = $state([]);
+  let issues: Issue[] = $state([]);
+  let stats: Stats | null = $state(null);
+  let err: string | null = $state(null);
+  let prsLoading = $state(true);
+  let issuesLoading = $state(true);
 
-  let stats = $state<Stats | null>(null);
-  let statsError = $state<string | null>(null);
-
-  onMount(async () => {
+  $effect(() => {
+    void $prListRefresh;
     if (!browser) return;
-    try {
-      stats = await fetchStats();
-    } catch (e) {
-      statsError = e instanceof Error ? e.message : String(e);
-    }
+    prsLoading = true;
+    fetchPRs()
+      .then((r) => (prs = r))
+      .catch((e: unknown) => (err = e instanceof Error ? e.message : String(e)))
+      .finally(() => (prsLoading = false));
+    fetchStats()
+      .then((r) => (stats = r))
+      .catch(() => {});
   });
 
-  const pillClass = $derived(
-    $connected ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
+  $effect(() => {
+    void $issueListRefresh;
+    if (!browser) return;
+    issuesLoading = true;
+    fetchIssues()
+      .then((r) => (issues = r))
+      .catch(() => {})
+      .finally(() => (issuesLoading = false));
+  });
+
+  const loading = $derived(prsLoading || issuesLoading);
+
+  const sort = persistedString('dashboard.sort', 'priority');
+  const reviewsExpanded = persistedBoolean('dashboard.reviewsExpanded', true);
+  const prsExpanded = persistedBoolean('dashboard.prsExpanded', true);
+  const issuesExpanded = persistedBoolean('dashboard.issuesExpanded', true);
+
+  const sorter: (a: PR, b: PR) => number = $derived($sort === 'priority' ? byPriority : byUpdated);
+
+  const meLower = $derived(($auth.login ?? '').toLowerCase());
+  const hasLogin = $derived(meLower !== '');
+
+  const activePRs: PR[] = $derived(prs.filter((p) => !p.dismissed));
+
+  // When login is unknown (fetchMe failed / daemon has no meFn), fall back
+  // to a single "PRs" bucket so the dashboard isn't silently wrong.
+  const myReviews: PR[] = $derived(
+    hasLogin
+      ? activePRs.filter((p) => p.author.toLowerCase() !== meLower).sort(sorter)
+      : activePRs.sort(sorter)
   );
-  const pillLabel = $derived($connected ? 'connected' : 'disconnected');
+  const myPRs: PR[] = $derived(
+    hasLogin ? activePRs.filter((p) => p.author.toLowerCase() === meLower).sort(sorter) : []
+  );
+  const trackedIssues: Issue[] = $derived(issues.filter((i) => !i.dismissed));
+
+  const empty = $derived(
+    myReviews.length === 0 && myPRs.length === 0 && trackedIssues.length === 0
+  );
 </script>
 
-<section class="flex items-center gap-3">
-  <h1 class="text-3xl font-bold">Heimdallm</h1>
-  <span class="rounded-full px-2 py-0.5 text-xs font-medium {pillClass}" data-testid="sse-pill">
-    {pillLabel}
-  </span>
+<section class="mb-6 flex items-center gap-3">
+  <h1 class="text-3xl font-bold">Dashboard</h1>
+  <ConnectionPill />
 </section>
 
-<p class="mt-1 text-sm text-gray-500">v0.1 scaffold — dashboard lands in #31.</p>
+<StatsCards {stats} />
 
-<section class="mt-8 grid grid-cols-2 gap-4 md:grid-cols-4">
-  {#each [{ label: 'Total reviews', value: stats?.total_reviews }, { label: 'Avg findings / review', value: stats?.avg_issues_per_review?.toFixed(1) }, { label: 'Median time (s)', value: stats?.review_timing?.median_seconds?.toFixed(1) }, { label: 'High-severity', value: stats?.by_severity?.HIGH ?? stats?.by_severity?.high ?? stats?.by_severity?.High ?? 0 }] as cell (cell.label)}
-    <div class="rounded-lg border border-gray-200 bg-white p-4">
-      <dt class="text-xs uppercase tracking-wide text-gray-500">{cell.label}</dt>
-      <dd class="mt-1 text-2xl font-semibold">
-        {cell.value ?? '—'}
-      </dd>
-    </div>
-  {/each}
+<section class="mt-6 mb-3 flex items-center gap-2">
+  <span class="text-xs text-gray-500">Sort:</span>
+  <button
+    type="button"
+    aria-pressed={$sort === 'priority'}
+    class="rounded px-2 py-1 text-xs font-medium {$sort === 'priority'
+      ? 'bg-indigo-100 text-indigo-700'
+      : 'text-gray-600 hover:bg-gray-100'}"
+    onclick={() => sort.set('priority')}
+  >
+    Priority
+  </button>
+  <button
+    type="button"
+    aria-pressed={$sort === 'newest'}
+    class="rounded px-2 py-1 text-xs font-medium {$sort === 'newest'
+      ? 'bg-indigo-100 text-indigo-700'
+      : 'text-gray-600 hover:bg-gray-100'}"
+    onclick={() => sort.set('newest')}
+  >
+    Newest
+  </button>
 </section>
 
-{#if statsError}
-  <p class="mt-4 text-sm text-red-600">Could not load stats: {statsError}</p>
+{#if err}
+  <p class="text-sm text-red-600">Could not load PRs: {err}</p>
+{:else if loading && prs.length === 0 && issues.length === 0}
+  <p class="mt-6 text-center text-sm text-gray-500">Loading…</p>
+{:else if empty}
+  <p class="mt-6 text-center text-sm text-gray-500">No activity yet.</p>
+{:else}
+  <div class="overflow-hidden rounded-md border border-gray-200 bg-white">
+    {#if myReviews.length > 0}
+      <CollapseHeader
+        title={hasLogin ? 'My Reviews' : 'Pull Requests'}
+        count={myReviews.length}
+        expanded={$reviewsExpanded}
+        onToggle={() => reviewsExpanded.update((v) => !v)}
+      />
+      {#if $reviewsExpanded}
+        {#each myReviews as pr (pr.id)}
+          <PRTile {pr} />
+        {/each}
+      {/if}
+    {/if}
+
+    {#if myPRs.length > 0}
+      <CollapseHeader
+        title="My PRs"
+        count={myPRs.length}
+        expanded={$prsExpanded}
+        onToggle={() => prsExpanded.update((v) => !v)}
+      />
+      {#if $prsExpanded}
+        {#each myPRs as pr (pr.id)}
+          <PRTile {pr} />
+        {/each}
+      {/if}
+    {/if}
+
+    {#if trackedIssues.length > 0}
+      <CollapseHeader
+        title="Tracked Issues"
+        count={trackedIssues.length}
+        expanded={$issuesExpanded}
+        onToggle={() => issuesExpanded.update((v) => !v)}
+      />
+      {#if $issuesExpanded}
+        {#each trackedIssues as issue (issue.id)}
+          <IssueTile {issue} />
+        {/each}
+      {/if}
+    {/if}
+  </div>
 {/if}

--- a/web_ui/src/routes/api/[...path]/+server.ts
+++ b/web_ui/src/routes/api/[...path]/+server.ts
@@ -3,7 +3,7 @@ import { error, type RequestHandler } from '@sveltejs/kit';
 
 const DAEMON_URL = (process.env.HEIMDALLM_API_URL ?? 'http://127.0.0.1:7842').replace(/\/+$/, '');
 
-const handle: RequestHandler = async ({ params, request, url, fetch: _fetch }) => {
+const handle: RequestHandler = async ({ params, request, url }) => {
   const token = await loadToken();
   if (!token) {
     error(503, {

--- a/web_ui/src/routes/api/[...path]/+server.ts
+++ b/web_ui/src/routes/api/[...path]/+server.ts
@@ -30,7 +30,13 @@ const handle: RequestHandler = async ({ params, request, url, fetch: _fetch }) =
     init.body = request.body;
   }
 
-  const upstream = await fetch(target, init);
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, init);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    error(502, { message: `daemon unreachable at ${DAEMON_URL}: ${msg}` });
+  }
 
   const respHeaders = new Headers();
   const upstreamCt = upstream.headers.get('content-type');

--- a/web_ui/src/routes/api/[...path]/+server.ts
+++ b/web_ui/src/routes/api/[...path]/+server.ts
@@ -53,4 +53,3 @@ export const GET = handle;
 export const POST = handle;
 export const PUT = handle;
 export const DELETE = handle;
-export const PATCH = handle;

--- a/web_ui/src/routes/api/[...path]/+server.ts
+++ b/web_ui/src/routes/api/[...path]/+server.ts
@@ -1,0 +1,50 @@
+import { loadToken } from '$lib/server/token.js';
+import { error, type RequestHandler } from '@sveltejs/kit';
+
+const DAEMON_URL = (process.env.HEIMDALLM_API_URL ?? 'http://127.0.0.1:7842').replace(/\/+$/, '');
+
+const handle: RequestHandler = async ({ params, request, url, fetch: _fetch }) => {
+  const token = await loadToken();
+  if (!token) {
+    error(503, {
+      message: 'daemon token missing: set HEIMDALLM_API_TOKEN or mount /data/api_token'
+    });
+  }
+
+  const target = new URL(`${DAEMON_URL}/${params.path ?? ''}`);
+  target.search = url.search;
+
+  const headers = new Headers();
+  const contentType = request.headers.get('content-type');
+  if (contentType) headers.set('content-type', contentType);
+  headers.set('X-Heimdallm-Token', token);
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    signal: request.signal,
+    // @ts-expect-error duplex is required by Node fetch when streaming a body
+    duplex: 'half'
+  };
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    init.body = request.body;
+  }
+
+  const upstream = await fetch(target, init);
+
+  const respHeaders = new Headers();
+  const upstreamCt = upstream.headers.get('content-type');
+  if (upstreamCt) respHeaders.set('content-type', upstreamCt);
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: respHeaders
+  });
+};
+
+export const GET = handle;
+export const POST = handle;
+export const PUT = handle;
+export const DELETE = handle;
+export const PATCH = handle;

--- a/web_ui/src/routes/events/+server.ts
+++ b/web_ui/src/routes/events/+server.ts
@@ -11,13 +11,19 @@ export const GET: RequestHandler = async ({ request }) => {
     });
   }
 
-  const upstream = await fetch(`${DAEMON_URL}/events`, {
-    headers: {
-      Accept: 'text/event-stream',
-      'X-Heimdallm-Token': token
-    },
-    signal: request.signal
-  });
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${DAEMON_URL}/events`, {
+      headers: {
+        Accept: 'text/event-stream',
+        'X-Heimdallm-Token': token
+      },
+      signal: request.signal
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    error(502, { message: `daemon unreachable at ${DAEMON_URL}: ${msg}` });
+  }
 
   if (!upstream.ok || !upstream.body) {
     error(upstream.status ?? 502, { message: `daemon /events failed: ${upstream.status}` });

--- a/web_ui/src/routes/events/+server.ts
+++ b/web_ui/src/routes/events/+server.ts
@@ -1,0 +1,34 @@
+import { loadToken } from '$lib/server/token.js';
+import { error, type RequestHandler } from '@sveltejs/kit';
+
+const DAEMON_URL = (process.env.HEIMDALLM_API_URL ?? 'http://127.0.0.1:7842').replace(/\/+$/, '');
+
+export const GET: RequestHandler = async ({ request }) => {
+  const token = await loadToken();
+  if (!token) {
+    error(503, {
+      message: 'daemon token missing: set HEIMDALLM_API_TOKEN or mount /data/api_token'
+    });
+  }
+
+  const upstream = await fetch(`${DAEMON_URL}/events`, {
+    headers: {
+      Accept: 'text/event-stream',
+      'X-Heimdallm-Token': token
+    },
+    signal: request.signal
+  });
+
+  if (!upstream.ok || !upstream.body) {
+    error(upstream.status ?? 502, { message: `daemon /events failed: ${upstream.status}` });
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive'
+    }
+  });
+};

--- a/web_ui/src/routes/issues/+page.svelte
+++ b/web_ui/src/routes/issues/+page.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import IssueFilterBar from '$lib/components/IssueFilterBar.svelte';
+  import IssueTile from '$lib/components/IssueTile.svelte';
+  import { fetchIssues } from '$lib/api.js';
+  import { filterIssues } from '$lib/filters.js';
+  import { desc } from '$lib/sort.js';
+  import { issueListRefresh, reviewingIssues } from '$lib/stores.js';
+  import type { Issue } from '$lib/types.js';
+
+  let issues: Issue[] = $state([]);
+  let err: string | null = $state(null);
+  let loading = $state(true);
+
+  $effect(() => {
+    void $issueListRefresh;
+    if (!browser) return;
+    loading = true;
+    fetchIssues()
+      .then((r) => {
+        issues = r;
+        err = null;
+      })
+      .catch((e: unknown) => (err = e instanceof Error ? e.message : String(e)))
+      .finally(() => (loading = false));
+  });
+
+  const repo = $derived($page.url.searchParams.get('repo') ?? '');
+  const severity = $derived($page.url.searchParams.get('severity') ?? 'any');
+  const mode = $derived($page.url.searchParams.get('mode') ?? 'all');
+
+  const repos: string[] = $derived(Array.from(new Set(issues.map((i: Issue) => i.repo))).sort());
+
+  const filtered = $derived.by<Issue[]>(() =>
+    filterIssues(issues, { repo, severity, mode }).slice().sort(desc<Issue>('fetched_at'))
+  );
+
+  function applyFilters(next: { repo: string; severity: string; mode?: string }): void {
+    const params = new URLSearchParams();
+    if (next.repo) params.set('repo', next.repo);
+    if (next.severity && next.severity !== 'any') params.set('severity', next.severity);
+    if (next.mode && next.mode !== 'all') params.set('mode', next.mode);
+    const qs = params.toString();
+    goto(qs ? `/issues?${qs}` : '/issues', { keepFocus: true, replaceState: true, noScroll: true });
+  }
+</script>
+
+<section class="flex items-center gap-3">
+  <h1 class="text-2xl font-bold">Issues</h1>
+  {#if $reviewingIssues.size > 0}
+    <span class="text-xs text-indigo-600">{$reviewingIssues.size} reviewing…</span>
+  {/if}
+</section>
+
+<IssueFilterBar filters={{ repo, severity, mode }} {repos} onChange={applyFilters} />
+
+{#if err}
+  <p class="text-sm text-red-600">Could not load issues: {err}</p>
+{:else if loading && issues.length === 0}
+  <p class="text-sm text-gray-500">Loading…</p>
+{:else if filtered.length === 0}
+  <p class="text-sm text-gray-500">No issues match the current filters.</p>
+{:else}
+  <div class="overflow-hidden rounded-md border border-gray-200 bg-white">
+    {#each filtered as issue (issue.id)}
+      <IssueTile {issue} />
+    {/each}
+  </div>
+{/if}

--- a/web_ui/src/routes/issues/[id]/+page.svelte
+++ b/web_ui/src/routes/issues/[id]/+page.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import IssueReviewCard from '$lib/components/IssueReviewCard.svelte';
+  import { dismissIssue, fetchIssue, triggerIssueReview, undismissIssue } from '$lib/api.js';
+  import { issueListRefresh, reviewingIssues } from '$lib/stores.js';
+  import type { Issue, IssueReview } from '$lib/types.js';
+
+  const id = $derived(Number($page.params.id));
+
+  let issue: Issue | null = $state(null);
+  let reviews: IssueReview[] = $state([]);
+  let err: string | null = $state(null);
+  let busy = $state(false);
+
+  $effect(() => {
+    void $issueListRefresh;
+    if (!browser || !Number.isFinite(id)) return;
+    // Clear stale state so the loading branch renders on id change.
+    issue = null;
+    reviews = [];
+    err = null;
+    fetchIssue(id)
+      .then((d) => {
+        issue = d.issue;
+        reviews = d.reviews;
+        err = null;
+      })
+      .catch((e: unknown) => (err = e instanceof Error ? e.message : String(e)));
+  });
+
+  const reviewing = $derived($reviewingIssues.has(id));
+
+  const autoImplementPR: number | undefined = $derived(
+    reviews
+      .filter((r) => r.action_taken === 'auto_implement' && r.pr_created > 0)
+      .slice()
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())[0]
+      ?.pr_created
+  );
+
+  async function onReview(): Promise<void> {
+    if (!issue) return;
+    busy = true;
+    try {
+      reviewingIssues.update((s) => new Set(s).add(id));
+      await triggerIssueReview(id);
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+      reviewingIssues.update((s) => {
+        const n = new Set(s);
+        n.delete(id);
+        return n;
+      });
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function onDismissToggle(): Promise<void> {
+    if (!issue) return;
+    busy = true;
+    try {
+      if (issue.dismissed) {
+        await undismissIssue(id);
+        issueListRefresh.update((n) => n + 1);
+      } else {
+        await dismissIssue(id);
+        // Dismissed issues disappear from /issues; navigate back.
+        // No early return — let `finally` reset `busy` even if goto rejects.
+        void goto('/issues');
+      }
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+{#if err && !issue}
+  <p class="text-sm text-red-600">Could not load issue: {err}</p>
+{:else if !issue}
+  <p class="text-sm text-gray-500">Loading…</p>
+{:else}
+  <article>
+    <header class="mb-4 rounded-md border border-gray-200 bg-white p-4">
+      <h1 class="text-xl font-bold">{issue.title}</h1>
+      <p class="mt-1 text-sm text-gray-500">
+        <span class="font-mono">{issue.repo}</span>
+        · #{issue.number}
+        · {issue.author}
+        · <span class="capitalize">{issue.state}</span>
+      </p>
+      {#if issue.labels.length > 0}
+        <ul class="mt-2 flex flex-wrap gap-1">
+          {#each issue.labels as l (l)}
+            <li class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-700">
+              {l}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+      {#if issue.assignees.length > 0}
+        <p class="mt-2 text-xs text-gray-500">
+          Assignees: {issue.assignees.join(', ')}
+        </p>
+      {/if}
+      <p class="mt-2 text-xs">
+        <a
+          href="https://github.com/{issue.repo}/issues/{issue.number}"
+          class="text-indigo-600 hover:underline"
+          target="_blank"
+          rel="noreferrer"
+        >
+          View on GitHub →
+        </a>
+      </p>
+      {#if autoImplementPR}
+        <p class="mt-2 text-xs">
+          <a href="/prs/{autoImplementPR}" class="text-indigo-600 hover:underline">
+            View created PR →
+          </a>
+        </p>
+      {/if}
+    </header>
+
+    <div class="mb-4 flex items-center gap-2">
+      <button
+        type="button"
+        class="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        onclick={onReview}
+        disabled={busy || reviewing}
+      >
+        {reviewing ? 'Reviewing…' : 'Review now'}
+      </button>
+      <button
+        type="button"
+        class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        onclick={onDismissToggle}
+        disabled={busy}
+      >
+        {issue.dismissed ? 'Undismiss' : 'Dismiss'}
+      </button>
+      {#if err}
+        <span class="text-xs text-red-600">{err}</span>
+      {/if}
+    </div>
+
+    <section>
+      <h2 class="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        Review history ({reviews.length})
+      </h2>
+      {#if reviews.length === 0}
+        <p class="text-sm text-gray-500">No reviews yet.</p>
+      {:else}
+        {#each reviews as r (r.id)}
+          <IssueReviewCard review={r} />
+        {/each}
+      {/if}
+    </section>
+  </article>
+{/if}

--- a/web_ui/src/routes/prs/+page.svelte
+++ b/web_ui/src/routes/prs/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import PRFilterBar from '$lib/components/PRFilterBar.svelte';
+  import PRTile from '$lib/components/PRTile.svelte';
+  import { fetchPRs } from '$lib/api.js';
+  import { filterPRs } from '$lib/filters.js';
+  import { byUpdated } from '$lib/sort.js';
+  import { prListRefresh, reviewingPRs } from '$lib/stores.js';
+  import type { PR } from '$lib/types.js';
+
+  let prs: PR[] = $state([]);
+  let err: string | null = $state(null);
+  let loading: boolean = $state(true);
+
+  $effect(() => {
+    void $prListRefresh; // re-run on SSE-driven bump
+    if (!browser) return;
+    loading = true;
+    fetchPRs()
+      .then((r) => {
+        prs = r;
+        err = null;
+      })
+      .catch((e) => {
+        err = e instanceof Error ? e.message : String(e);
+      })
+      .finally(() => (loading = false));
+  });
+
+  const repo = $derived($page.url.searchParams.get('repo') ?? '');
+  const severity = $derived($page.url.searchParams.get('severity') ?? 'any');
+  const prState = $derived($page.url.searchParams.get('state') ?? 'open');
+
+  const repos: string[] = $derived(Array.from(new Set(prs.map((p: PR) => p.repo))).sort());
+
+  const filtered = $derived.by<PR[]>(() =>
+    filterPRs(prs, { repo, severity, state: prState }).slice().sort(byUpdated)
+  );
+
+  function applyFilters(next: { repo: string; severity: string; state?: string }): void {
+    const params = new URLSearchParams();
+    if (next.repo) params.set('repo', next.repo);
+    if (next.severity && next.severity !== 'any') params.set('severity', next.severity);
+    if (next.state && next.state !== 'open') params.set('state', next.state);
+    const qs = params.toString();
+    goto(qs ? `/prs?${qs}` : '/prs', { keepFocus: true, replaceState: true, noScroll: true });
+  }
+</script>
+
+<section class="flex items-center gap-3">
+  <h1 class="text-2xl font-bold">PR Reviews</h1>
+  {#if $reviewingPRs.size > 0}
+    <span class="text-xs text-indigo-600">{$reviewingPRs.size} reviewing…</span>
+  {/if}
+</section>
+
+<PRFilterBar filters={{ repo, severity, state: prState }} {repos} onChange={applyFilters} />
+
+{#if err}
+  <p class="text-sm text-red-600">Could not load PRs: {err}</p>
+{:else if loading && prs.length === 0}
+  <p class="text-sm text-gray-500">Loading…</p>
+{:else if filtered.length === 0}
+  <p class="text-sm text-gray-500">No PRs match the current filters.</p>
+{:else}
+  <div class="overflow-hidden rounded-md border border-gray-200 bg-white">
+    {#each filtered as pr (pr.id)}
+      <PRTile {pr} />
+    {/each}
+  </div>
+{/if}

--- a/web_ui/src/routes/prs/[id]/+page.svelte
+++ b/web_ui/src/routes/prs/[id]/+page.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import PRReviewCard from '$lib/components/PRReviewCard.svelte';
+  import { dismissPR, fetchPR, triggerReview, undismissPR } from '$lib/api.js';
+  import { prListRefresh, reviewingPRs } from '$lib/stores.js';
+  import type { PR, Review } from '$lib/types.js';
+
+  const id = $derived(Number($page.params.id));
+
+  let pr: PR | null = $state(null);
+  let reviews: Review[] = $state([]);
+  let err: string | null = $state(null);
+  let busy: boolean = $state(false);
+
+  $effect(() => {
+    void $prListRefresh; // re-run on SSE-driven bump
+    if (!browser || !Number.isFinite(id)) return;
+    pr = null;
+    reviews = [];
+    err = null;
+    fetchPR(id)
+      .then((d) => {
+        pr = d.pr;
+        reviews = d.reviews;
+        err = null;
+      })
+      .catch((e) => {
+        err = e instanceof Error ? e.message : String(e);
+      });
+  });
+
+  const reviewing = $derived($reviewingPRs.has(id));
+
+  async function onReview(): Promise<void> {
+    if (!pr) return;
+    busy = true;
+    try {
+      // Optimistic: mark reviewing before SSE confirms.
+      reviewingPRs.update((s) => new Set(s).add(id));
+      await triggerReview(id);
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+      reviewingPRs.update((s) => {
+        const n = new Set(s);
+        n.delete(id);
+        return n;
+      });
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function onDismissToggle(): Promise<void> {
+    if (!pr) return;
+    busy = true;
+    try {
+      if (pr.dismissed) {
+        await undismissPR(id);
+        prListRefresh.update((n) => n + 1);
+      } else {
+        await dismissPR(id);
+        // Dismissed PRs disappear from /prs; navigate back.
+        // Let the `finally` block run so `busy` is reset even if goto rejects.
+        void goto('/prs');
+      }
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+{#if err && !pr}
+  <p class="text-sm text-red-600">Could not load PR: {err}</p>
+{:else if !pr}
+  <p class="text-sm text-gray-500">Loading…</p>
+{:else}
+  <article>
+    <header class="mb-4 rounded-md border border-gray-200 bg-white p-4">
+      <h1 class="text-xl font-bold">{pr.title}</h1>
+      <p class="mt-1 text-sm text-gray-500">
+        <span class="font-mono">{pr.repo}</span>
+        · #{pr.number}
+        · {pr.author}
+        · <span class="capitalize">{pr.state}</span>
+      </p>
+      <p class="mt-2 text-xs">
+        <a href={pr.url} class="text-indigo-600 hover:underline" target="_blank" rel="noreferrer">
+          View on GitHub →
+        </a>
+      </p>
+    </header>
+
+    <div class="mb-4 flex items-center gap-2">
+      <button
+        type="button"
+        class="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        onclick={onReview}
+        disabled={busy || reviewing}
+      >
+        {reviewing ? 'Reviewing…' : 'Review now'}
+      </button>
+      <button
+        type="button"
+        class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        onclick={onDismissToggle}
+        disabled={busy}
+      >
+        {pr.dismissed ? 'Undismiss' : 'Dismiss'}
+      </button>
+      {#if err}
+        <span class="text-xs text-red-600">{err}</span>
+      {/if}
+    </div>
+
+    <section>
+      <h2 class="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        Review history ({reviews.length})
+      </h2>
+      {#if reviews.length === 0}
+        <p class="text-sm text-gray-500">No reviews yet.</p>
+      {:else}
+        {#each reviews as r (r.id)}
+          <PRReviewCard review={r} />
+        {/each}
+      {/if}
+    </section>
+  </article>
+{/if}

--- a/web_ui/src/tests/api.test.ts
+++ b/web_ui/src/tests/api.test.ts
@@ -99,6 +99,8 @@ describe('api.ts', () => {
         reviews_last_7_days: [],
         avg_issues_per_review: 1.5,
         review_timing: {
+          sample_count: 3,
+          avg_seconds: 50,
           median_seconds: 42,
           min_seconds: 10,
           max_seconds: 90,

--- a/web_ui/src/tests/api.test.ts
+++ b/web_ui/src/tests/api.test.ts
@@ -23,10 +23,7 @@ describe('api.ts', () => {
   it('fetchPRs GETs /api/prs and returns a typed array', async () => {
     fetchMock.mockResolvedValue(okJson([{ id: 1, number: 42, title: 't' }]));
     const prs = await fetchPRs();
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/prs',
-      expect.objectContaining({ method: 'GET' })
-    );
+    expect(fetchMock).toHaveBeenCalledWith('/api/prs', expect.objectContaining({ method: 'GET' }));
     expect(prs).toHaveLength(1);
     expect(prs[0].id).toBe(1);
   });
@@ -42,9 +39,7 @@ describe('api.ts', () => {
             suggestions: '["do the thing"]'
           }
         },
-        reviews: [
-          { id: 9, issues: '[]', suggestions: '[]' }
-        ]
+        reviews: [{ id: 9, issues: '[]', suggestions: '[]' }]
       })
     );
     const detail = await fetchPR(1);
@@ -66,8 +61,7 @@ describe('api.ts', () => {
   });
 
   it('triggerReview throws ApiError on 500', async () => {
-    const make500 = () =>
-      new Response('boom', { status: 500, statusText: 'Server Error' });
+    const make500 = () => new Response('boom', { status: 500, statusText: 'Server Error' });
     fetchMock.mockResolvedValueOnce(make500());
     await expect(triggerReview(7)).rejects.toBeInstanceOf(ApiError);
     fetchMock.mockResolvedValueOnce(make500());

--- a/web_ui/src/tests/api.test.ts
+++ b/web_ui/src/tests/api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ApiError,
   fetchIssue,
+  fetchIssues,
   fetchPR,
   fetchPRs,
   fetchStats,
@@ -123,6 +124,105 @@ describe('api.ts', () => {
     expect(stats.total_reviews).toBe(3);
     expect(stats.avg_issues_per_review).toBe(1.5);
     expect(stats.review_timing.median_seconds).toBe(42);
+  });
+
+  it('fetchStats normalizes by_severity keys to uppercase (handles lowercase daemon output)', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({
+        total_reviews: 10,
+        by_severity: { high: 3, low: 5, medium: 2 },
+        by_cli: {},
+        top_repos: [],
+        reviews_last_7_days: [],
+        avg_issues_per_review: 1.0,
+        review_timing: {
+          sample_count: 0,
+          avg_seconds: 0,
+          median_seconds: 0,
+          min_seconds: 0,
+          max_seconds: 0,
+          bucket_fast: 0,
+          bucket_medium: 0,
+          bucket_slow: 0,
+          bucket_very_slow: 0
+        }
+      })
+    );
+    const stats = await fetchStats();
+    expect(stats.by_severity.HIGH).toBe(3);
+    expect(stats.by_severity.LOW).toBe(5);
+    expect(stats.by_severity.MEDIUM).toBe(2);
+  });
+
+  it('fetchStats folds mixed-case keys into a single uppercase bucket', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({
+        total_reviews: 5,
+        by_severity: { high: 2, HIGH: 1, High: 1 },
+        by_cli: {},
+        top_repos: [],
+        reviews_last_7_days: [],
+        avg_issues_per_review: 0,
+        review_timing: {
+          sample_count: 0,
+          avg_seconds: 0,
+          median_seconds: 0,
+          min_seconds: 0,
+          max_seconds: 0,
+          bucket_fast: 0,
+          bucket_medium: 0,
+          bucket_slow: 0,
+          bucket_very_slow: 0
+        }
+      })
+    );
+    const stats = await fetchStats();
+    expect(stats.by_severity.HIGH).toBe(4);
+  });
+
+  it('fetchIssues degrades gracefully when labels is not an array or string', async () => {
+    fetchMock.mockResolvedValue(
+      okJson([
+        { id: 1, labels: null, assignees: 42 },
+        { id: 2, labels: { not: 'an array' }, assignees: [] }
+      ])
+    );
+    const issues = await fetchIssues();
+    expect(issues[0].labels).toEqual([]);
+    expect(issues[0].assignees).toEqual([]);
+    expect(issues[1].labels).toEqual([]);
+    expect(issues[1].assignees).toEqual([]);
+  });
+
+  it('fetchIssue degrades gracefully when triage is not a plain object', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({
+        issue: { id: 1, labels: [], assignees: [] },
+        reviews: [
+          { id: 9, triage: null, suggestions: null },
+          { id: 10, triage: ['array', 'not', 'object'], suggestions: 'not-json-or-array' }
+        ]
+      })
+    );
+    const detail = await fetchIssue(1);
+    expect(detail.reviews[0].triage).toEqual({});
+    expect(detail.reviews[0].suggestions).toEqual([]);
+    expect(detail.reviews[1].triage).toEqual({});
+    expect(detail.reviews[1].suggestions).toEqual([]);
+  });
+
+  it('fetchPR degrades gracefully when review issues/suggestions are malformed', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({
+        pr: { id: 1, latest_review: { id: 9, issues: null, suggestions: 42 } },
+        reviews: [{ id: 9, issues: {}, suggestions: null }]
+      })
+    );
+    const detail = await fetchPR(1);
+    expect(detail.pr.latest_review!.issues).toEqual([]);
+    expect(detail.pr.latest_review!.suggestions).toEqual([]);
+    expect(detail.reviews[0].issues).toEqual([]);
+    expect(detail.reviews[0].suggestions).toEqual([]);
   });
 
   it('fetchIssue parses stringified assignees/labels/triage/suggestions', async () => {

--- a/web_ui/src/tests/api.test.ts
+++ b/web_ui/src/tests/api.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, fetchPR, fetchPRs, fetchStats, triggerReview, upsertAgent } from '../lib/api.js';
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function okJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+describe('api.ts', () => {
+  it('fetchPRs GETs /api/prs and returns a typed array', async () => {
+    fetchMock.mockResolvedValue(okJson([{ id: 1, number: 42, title: 't' }]));
+    const prs = await fetchPRs();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/prs',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(prs).toHaveLength(1);
+    expect(prs[0].id).toBe(1);
+  });
+
+  it('fetchPR parses stringified issues/suggestions in latest_review', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({
+        pr: {
+          id: 1,
+          latest_review: {
+            id: 9,
+            issues: '[{"file":"a.go","line":1,"description":"x","severity":"LOW"}]',
+            suggestions: '["do the thing"]'
+          }
+        },
+        reviews: [
+          { id: 9, issues: '[]', suggestions: '[]' }
+        ]
+      })
+    );
+    const detail = await fetchPR(1);
+    expect(detail.pr.latest_review!.issues).toEqual([
+      { file: 'a.go', line: 1, description: 'x', severity: 'LOW' }
+    ]);
+    expect(detail.pr.latest_review!.suggestions).toEqual(['do the thing']);
+    expect(detail.reviews[0].issues).toEqual([]);
+    expect(detail.reviews[0].suggestions).toEqual([]);
+  });
+
+  it('triggerReview POSTs and resolves on 202', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
+    await expect(triggerReview(7)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/prs/7/review',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('triggerReview throws ApiError on 500', async () => {
+    const make500 = () =>
+      new Response('boom', { status: 500, statusText: 'Server Error' });
+    fetchMock.mockResolvedValueOnce(make500());
+    await expect(triggerReview(7)).rejects.toBeInstanceOf(ApiError);
+    fetchMock.mockResolvedValueOnce(make500());
+    await expect(triggerReview(7)).rejects.toMatchObject({
+      status: 500,
+      path: '/api/prs/7/review'
+    });
+  });
+
+  it('upsertAgent POSTs JSON body with correct content-type', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    await upsertAgent({
+      id: 'a',
+      name: 'A',
+      cli: 'claude',
+      prompt: '',
+      instructions: 'Review carefully.',
+      cli_flags: '',
+      is_default: false,
+      created_at: '2026-04-17T00:00:00Z'
+    });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init.body as string)).toMatchObject({ id: 'a', name: 'A', cli: 'claude' });
+  });
+
+  it('fetchStats returns parsed JSON object', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({
+        total_reviews: 3,
+        by_severity: { HIGH: 1 },
+        by_cli: {},
+        top_repos: [],
+        reviews_last_7_days: [],
+        avg_issues_per_review: 1.5,
+        review_timing: {
+          median_seconds: 42,
+          min_seconds: 10,
+          max_seconds: 90,
+          bucket_fast: 1,
+          bucket_medium: 1,
+          bucket_slow: 1,
+          bucket_very_slow: 0
+        }
+      })
+    );
+    const stats = await fetchStats();
+    expect(stats.total_reviews).toBe(3);
+    expect(stats.avg_issues_per_review).toBe(1.5);
+    expect(stats.review_timing.median_seconds).toBe(42);
+  });
+});

--- a/web_ui/src/tests/api.test.ts
+++ b/web_ui/src/tests/api.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ApiError, fetchPR, fetchPRs, fetchStats, triggerReview, upsertAgent } from '../lib/api.js';
+import {
+  ApiError,
+  fetchIssue,
+  fetchPR,
+  fetchPRs,
+  fetchStats,
+  triggerReview,
+  upsertAgent
+} from '../lib/api.js';
 
 const fetchMock = vi.fn();
 
@@ -115,5 +123,36 @@ describe('api.ts', () => {
     expect(stats.total_reviews).toBe(3);
     expect(stats.avg_issues_per_review).toBe(1.5);
     expect(stats.review_timing.median_seconds).toBe(42);
+  });
+
+  it('fetchIssue parses stringified assignees/labels/triage/suggestions', async () => {
+    fetchMock.mockResolvedValue(
+      okJson({
+        issue: {
+          id: 5,
+          assignees: '["alice","bob"]',
+          labels: '["bug","p1"]',
+          latest_review: {
+            id: 9,
+            triage: '{"severity":"HIGH","category":"security"}',
+            suggestions: '["patch the thing"]'
+          }
+        },
+        reviews: [
+          {
+            id: 9,
+            triage: '{"severity":"LOW"}',
+            suggestions: '[]'
+          }
+        ]
+      })
+    );
+    const detail = await fetchIssue(5);
+    expect(detail.issue.assignees).toEqual(['alice', 'bob']);
+    expect(detail.issue.labels).toEqual(['bug', 'p1']);
+    expect(detail.issue.latest_review!.triage).toEqual({ severity: 'HIGH', category: 'security' });
+    expect(detail.issue.latest_review!.suggestions).toEqual(['patch the thing']);
+    expect(detail.reviews[0].triage).toEqual({ severity: 'LOW' });
+    expect(detail.reviews[0].suggestions).toEqual([]);
   });
 });

--- a/web_ui/src/tests/filters.test.ts
+++ b/web_ui/src/tests/filters.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { filterIssues, filterPRs } from '../lib/filters.js';
+import type { Issue, PR } from '../lib/types.js';
+
+function mkPR(overrides: Partial<PR> = {}): PR {
+  return {
+    id: 1,
+    github_id: 1,
+    repo: 'o/r',
+    number: 1,
+    title: 't',
+    author: 'a',
+    url: 'u',
+    state: 'open',
+    updated_at: '2026-04-10T00:00:00Z',
+    fetched_at: '2026-04-10T00:00:00Z',
+    dismissed: false,
+    ...overrides
+  };
+}
+
+function mkIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 1,
+    github_id: 1,
+    repo: 'o/r',
+    number: 1,
+    title: 't',
+    body: '',
+    author: 'a',
+    assignees: [],
+    labels: [],
+    state: 'open',
+    created_at: '2026-04-10T00:00:00Z',
+    fetched_at: '2026-04-10T00:00:00Z',
+    dismissed: false,
+    ...overrides
+  };
+}
+
+describe('filterPRs', () => {
+  it('filters by repo when set, passes through when empty', () => {
+    const prs = [mkPR({ id: 1, repo: 'a/b' }), mkPR({ id: 2, repo: 'c/d' })];
+    expect(
+      filterPRs(prs, { repo: 'a/b', severity: 'any', state: 'open' }).map((p) => p.id)
+    ).toEqual([1]);
+    expect(filterPRs(prs, { repo: '', severity: 'any', state: 'open' }).map((p) => p.id)).toEqual([
+      1, 2
+    ]);
+  });
+
+  it('filters by state case-insensitively; "all" is passthrough', () => {
+    const prs = [mkPR({ id: 1, state: 'open' }), mkPR({ id: 2, state: 'CLOSED' })];
+    expect(filterPRs(prs, { repo: '', severity: 'any', state: 'open' }).map((p) => p.id)).toEqual([
+      1
+    ]);
+    expect(filterPRs(prs, { repo: '', severity: 'any', state: 'closed' }).map((p) => p.id)).toEqual(
+      [2]
+    );
+    expect(filterPRs(prs, { repo: '', severity: 'any', state: 'all' }).map((p) => p.id)).toEqual([
+      1, 2
+    ]);
+  });
+
+  it('filters by severity case-insensitively; "any" is passthrough', () => {
+    const prs = [
+      mkPR({ id: 1, latest_review: { severity: 'HIGH' } as PR['latest_review'] }),
+      mkPR({ id: 2, latest_review: { severity: 'low' } as PR['latest_review'] }),
+      mkPR({ id: 3 })
+    ];
+    expect(filterPRs(prs, { repo: '', severity: 'high', state: 'all' }).map((p) => p.id)).toEqual([
+      1
+    ]);
+    expect(filterPRs(prs, { repo: '', severity: 'any', state: 'all' }).map((p) => p.id)).toEqual([
+      1, 2, 3
+    ]);
+  });
+});
+
+describe('filterIssues', () => {
+  it('drops dismissed issues always', () => {
+    const issues = [mkIssue({ id: 1 }), mkIssue({ id: 2, dismissed: true })];
+    expect(
+      filterIssues(issues, { repo: '', severity: 'any', mode: 'all' }).map((i) => i.id)
+    ).toEqual([1]);
+  });
+
+  it('filters by mode via labels; "all" is passthrough', () => {
+    const issues = [
+      mkIssue({ id: 1, labels: ['auto_implement'] }),
+      mkIssue({ id: 2, labels: ['review_only'] }),
+      mkIssue({ id: 3, labels: ['feature'] })
+    ];
+    expect(
+      filterIssues(issues, { repo: '', severity: 'any', mode: 'auto_implement' }).map((i) => i.id)
+    ).toEqual([1]);
+    expect(
+      filterIssues(issues, { repo: '', severity: 'any', mode: 'all' }).map((i) => i.id)
+    ).toEqual([1, 2, 3]);
+  });
+
+  it('filters by severity from triage, case-insensitive', () => {
+    const issues = [
+      mkIssue({ id: 1, latest_review: { triage: { severity: 'HIGH' } } as Issue['latest_review'] }),
+      mkIssue({ id: 2, latest_review: { triage: { severity: 'low' } } as Issue['latest_review'] }),
+      mkIssue({ id: 3 })
+    ];
+    expect(
+      filterIssues(issues, { repo: '', severity: 'high', mode: 'all' }).map((i) => i.id)
+    ).toEqual([1]);
+  });
+});

--- a/web_ui/src/tests/persisted.test.ts
+++ b/web_ui/src/tests/persisted.test.ts
@@ -1,0 +1,58 @@
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { persistedBoolean, persistedString } from '../lib/persisted.js';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('persistedBoolean', () => {
+  it('uses default when key is absent', () => {
+    const s = persistedBoolean('key1', true);
+    expect(get(s)).toBe(true);
+  });
+
+  it('reads existing value from localStorage', () => {
+    localStorage.setItem('key2', 'false');
+    const s = persistedBoolean('key2', true);
+    expect(get(s)).toBe(false);
+  });
+
+  it('persists on write', () => {
+    const s = persistedBoolean('key3', true);
+    s.set(false);
+    expect(localStorage.getItem('key3')).toBe('false');
+  });
+
+  it('tolerates malformed stored value by falling back to default', () => {
+    localStorage.setItem('key4', 'not a bool');
+    const s = persistedBoolean('key4', true);
+    expect(get(s)).toBe(true);
+  });
+});
+
+describe('persistedString', () => {
+  it('uses default when key is absent', () => {
+    const s = persistedString('sk1', 'newest');
+    expect(get(s)).toBe('newest');
+  });
+
+  it('persists on write', () => {
+    const s = persistedString('sk2', 'newest');
+    s.set('priority');
+    expect(localStorage.getItem('sk2')).toBe('priority');
+  });
+});
+
+describe('subscribe behavior', () => {
+  it('does not re-write the initial value on cold start', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem');
+    persistedBoolean('coldStartKey', true);
+    expect(spy).not.toHaveBeenCalledWith('coldStartKey', 'true');
+    spy.mockRestore();
+  });
+});

--- a/web_ui/src/tests/severity.test.ts
+++ b/web_ui/src/tests/severity.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { severityClass, severityOrder } from '../lib/severity.js';
+
+describe('severityClass', () => {
+  it('returns red classes for critical', () => {
+    expect(severityClass('critical')).toBe('bg-red-100 text-red-700');
+  });
+  it('returns orange classes for high', () => {
+    expect(severityClass('high')).toBe('bg-orange-100 text-orange-700');
+  });
+  it('returns amber classes for medium', () => {
+    expect(severityClass('medium')).toBe('bg-amber-100 text-amber-700');
+  });
+  it('returns gray classes for low and for unknown', () => {
+    expect(severityClass('low')).toBe('bg-gray-100 text-gray-600');
+    expect(severityClass('whatever')).toBe('bg-gray-100 text-gray-600');
+    expect(severityClass('')).toBe('bg-gray-100 text-gray-600');
+  });
+  it('is case-insensitive', () => {
+    expect(severityClass('HIGH')).toBe('bg-orange-100 text-orange-700');
+    expect(severityClass('Critical')).toBe('bg-red-100 text-red-700');
+  });
+});
+
+describe('severityOrder', () => {
+  it('ranks critical highest, unknown lowest', () => {
+    const sorted = ['low', 'critical', 'medium', 'unknown', 'high'].sort(
+      (a, b) => severityOrder(b) - severityOrder(a)
+    );
+    expect(sorted).toEqual(['critical', 'high', 'medium', 'low', 'unknown']);
+  });
+});

--- a/web_ui/src/tests/sort.test.ts
+++ b/web_ui/src/tests/sort.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { byPriority, byUpdated, desc } from '../lib/sort.js';
+import type { PR } from '../lib/types.js';
+
+function mkPR(overrides: Partial<PR> = {}): PR {
+  return {
+    id: 1,
+    github_id: 100,
+    repo: 'o/r',
+    number: 1,
+    title: 't',
+    author: 'a',
+    url: 'https://github.com/o/r/pull/1',
+    state: 'open',
+    updated_at: '2026-04-10T00:00:00Z',
+    fetched_at: '2026-04-10T00:00:00Z',
+    dismissed: false,
+    ...overrides
+  };
+}
+
+describe('byUpdated', () => {
+  it('sorts newer first', () => {
+    const a = mkPR({ id: 1, updated_at: '2026-04-10T00:00:00Z' });
+    const b = mkPR({ id: 2, updated_at: '2026-04-15T00:00:00Z' });
+    expect([a, b].sort(byUpdated).map((p) => p.id)).toEqual([2, 1]);
+  });
+
+  it('treats missing/malformed dates as oldest', () => {
+    const a = mkPR({ id: 1, updated_at: '2026-04-10T00:00:00Z' });
+    const b = mkPR({ id: 2, updated_at: 'not-a-date' as string });
+    expect([a, b].sort(byUpdated).map((p) => p.id)).toEqual([1, 2]);
+  });
+
+  it('is stable for equal timestamps', () => {
+    const a = mkPR({ id: 1, updated_at: '2026-04-10T00:00:00Z' });
+    const b = mkPR({ id: 2, updated_at: '2026-04-10T00:00:00Z' });
+    const c = mkPR({ id: 3, updated_at: '2026-04-10T00:00:00Z' });
+    expect([a, b, c].sort(byUpdated).map((p) => p.id)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('byPriority', () => {
+  it('sorts critical highest, unknown lowest', () => {
+    const low = mkPR({ id: 1, latest_review: { severity: 'low' } as PR['latest_review'] });
+    const critical = mkPR({
+      id: 2,
+      latest_review: { severity: 'critical' } as PR['latest_review']
+    });
+    const medium = mkPR({ id: 3, latest_review: { severity: 'medium' } as PR['latest_review'] });
+    const none = mkPR({ id: 4 });
+    const high = mkPR({ id: 5, latest_review: { severity: 'high' } as PR['latest_review'] });
+    expect([low, critical, medium, none, high].sort(byPriority).map((p) => p.id)).toEqual([
+      2, 5, 3, 1, 4
+    ]);
+  });
+
+  it('tiebreaks equal severity by updated_at desc', () => {
+    const older = mkPR({
+      id: 1,
+      updated_at: '2026-04-01T00:00:00Z',
+      latest_review: { severity: 'high' } as PR['latest_review']
+    });
+    const newer = mkPR({
+      id: 2,
+      updated_at: '2026-04-10T00:00:00Z',
+      latest_review: { severity: 'high' } as PR['latest_review']
+    });
+    expect([older, newer].sort(byPriority).map((p) => p.id)).toEqual([2, 1]);
+  });
+});
+
+describe('desc(field)', () => {
+  it('creates a descending comparator for a date-typed field', () => {
+    const cmp = desc<{ fetched_at: string }>('fetched_at');
+    const a = { fetched_at: '2026-04-01T00:00:00Z' };
+    const b = { fetched_at: '2026-04-10T00:00:00Z' };
+    expect([a, b].sort(cmp)).toEqual([b, a]);
+  });
+});

--- a/web_ui/src/tests/sse.test.ts
+++ b/web_ui/src/tests/sse.test.ts
@@ -1,0 +1,99 @@
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { connectEvents } from '../lib/sse.js';
+
+type Listener = (e: MessageEvent) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  url: string;
+  readyState = MockEventSource.CONNECTING;
+  onopen: ((e: Event) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  closed = false;
+  listeners: Record<string, Listener[]> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: Listener): void {
+    (this.listeners[type] ||= []).push(cb);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = MockEventSource.CLOSED;
+  }
+
+  // test helpers
+  emit(type: string, data: string): void {
+    const ev = new MessageEvent(type, { data });
+    this.listeners[type]?.forEach((cb) => cb(ev));
+  }
+  fireOpen(): void {
+    this.readyState = MockEventSource.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+  fireError(): void {
+    this.onerror?.(new Event('error'));
+  }
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  vi.stubGlobal('EventSource', MockEventSource);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('connectEvents', () => {
+  it('opens EventSource at /events', () => {
+    connectEvents();
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe('/events');
+  });
+
+  it('pushes typed events into the events store', () => {
+    const handle = connectEvents();
+    const es = MockEventSource.instances[0];
+    const received: unknown[] = [];
+    const unsub = handle.events.subscribe((e) => {
+      if (e) received.push(e);
+    });
+    es.emit('pr_detected', JSON.stringify({ id: 1 }));
+    es.emit('review_completed', '{"pr_id":1}');
+    unsub();
+    expect(received).toEqual([
+      { type: 'pr_detected', data: { id: 1 } },
+      { type: 'review_completed', data: { pr_id: 1 } }
+    ]);
+  });
+
+  it('connected store reflects open/error transitions', () => {
+    const handle = connectEvents();
+    const es = MockEventSource.instances[0];
+    expect(get(handle.connected)).toBe(false);
+    es.fireOpen();
+    expect(get(handle.connected)).toBe(true);
+    es.fireError();
+    expect(get(handle.connected)).toBe(false);
+  });
+
+  it('close() calls EventSource.close() and sets connected to false', () => {
+    const handle = connectEvents();
+    const es = MockEventSource.instances[0];
+    es.fireOpen();
+    expect(get(handle.connected)).toBe(true);
+    handle.close();
+    expect(es.closed).toBe(true);
+    expect(get(handle.connected)).toBe(false);
+  });
+});

--- a/web_ui/src/tests/sse.test.ts
+++ b/web_ui/src/tests/sse.test.ts
@@ -96,4 +96,20 @@ describe('connectEvents', () => {
     expect(es.closed).toBe(true);
     expect(get(handle.connected)).toBe(false);
   });
+
+  it('retries opening a new EventSource after a CLOSED error', () => {
+    vi.useFakeTimers();
+    try {
+      const handle = connectEvents();
+      const es = MockEventSource.instances[0];
+      es.readyState = MockEventSource.CLOSED;
+      es.fireError();
+      // initial retry scheduled at 2s
+      vi.advanceTimersByTime(2_000);
+      expect(MockEventSource.instances).toHaveLength(2);
+      handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/web_ui/src/tests/stores.test.ts
+++ b/web_ui/src/tests/stores.test.ts
@@ -1,0 +1,139 @@
+import { get, writable } from 'svelte/store';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { issueListRefresh, prListRefresh, reviewingIssues, reviewingPRs } from '../lib/stores.js';
+import { initSseBridge, watchReconnectAndSweep } from '../lib/sseBridge.js';
+import type { SseEvent } from '../lib/types.js';
+
+function makeEvents() {
+  return writable<SseEvent | null>(null);
+}
+
+beforeEach(() => {
+  prListRefresh.set(0);
+  issueListRefresh.set(0);
+  reviewingPRs.set(new Set());
+  reviewingIssues.set(new Set());
+});
+
+describe('initSseBridge', () => {
+  it('increments prListRefresh on pr_detected', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set({ type: 'pr_detected', data: {} });
+    expect(get(prListRefresh)).toBe(1);
+  });
+
+  it('adds pr_id to reviewingPRs on review_started', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set({ type: 'review_started', data: { pr_id: 42 } });
+    expect(get(reviewingPRs).has(42)).toBe(true);
+  });
+
+  it('removes pr_id and bumps prListRefresh on review_completed', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set({ type: 'review_started', data: { pr_id: 42 } });
+    events.set({ type: 'review_completed', data: { pr_id: 42 } });
+    expect(get(reviewingPRs).has(42)).toBe(false);
+    expect(get(prListRefresh)).toBe(1);
+  });
+
+  it('removes pr_id without bumping on review_error', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set({ type: 'review_started', data: { pr_id: 42 } });
+    events.set({ type: 'review_error', data: { pr_id: 42 } });
+    expect(get(reviewingPRs).has(42)).toBe(false);
+    expect(get(prListRefresh)).toBe(0);
+  });
+
+  it('handles all four issue review events symmetrically', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set({ type: 'issue_detected', data: {} });
+    expect(get(issueListRefresh)).toBe(1);
+
+    events.set({ type: 'issue_review_started', data: { issue_id: 7 } });
+    expect(get(reviewingIssues).has(7)).toBe(true);
+
+    events.set({ type: 'issue_review_completed', data: { issue_id: 7 } });
+    expect(get(reviewingIssues).has(7)).toBe(false);
+    expect(get(issueListRefresh)).toBe(2);
+
+    events.set({ type: 'issue_review_started', data: { issue_id: 8 } });
+    events.set({ type: 'issue_review_error', data: { issue_id: 8 } });
+    expect(get(reviewingIssues).has(8)).toBe(false);
+  });
+
+  it('bumps both refresh counters and clears reviewingIssues on issue_implemented', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+
+    // Simulate the auto_implement sequence: started → implemented (no
+    // review_completed in between — that's the daemon's actual behavior).
+    events.set({ type: 'issue_review_started', data: { issue_id: 7 } });
+    expect(get(reviewingIssues).has(7)).toBe(true);
+
+    events.set({
+      type: 'issue_implemented',
+      data: { issue_id: 7, number: 42, repo: 'o/r', pr_created: 99, branch: 'auto/fix-42' }
+    });
+    expect(get(reviewingIssues).has(7)).toBe(false);
+    expect(get(issueListRefresh)).toBe(1);
+    expect(get(prListRefresh)).toBe(1);
+  });
+
+  it('ignores a null event (no crash, no state change)', () => {
+    const events = makeEvents();
+    initSseBridge({ subscribe: events.subscribe });
+    events.set(null);
+    expect(get(prListRefresh)).toBe(0);
+    expect(get(issueListRefresh)).toBe(0);
+  });
+});
+
+describe('watchReconnectAndSweep', () => {
+  it('clears reviewingPRs and reviewingIssues on false→true transition', () => {
+    const connected = writable(false);
+    watchReconnectAndSweep({ subscribe: connected.subscribe });
+
+    // Prime both sets.
+    reviewingPRs.set(new Set([1, 2]));
+    reviewingIssues.set(new Set([3]));
+
+    // No transition yet — sets should be untouched.
+    expect(get(reviewingPRs).size).toBe(2);
+    expect(get(reviewingIssues).size).toBe(1);
+
+    // Still disconnected — no sweep.
+    connected.set(false);
+    expect(get(reviewingPRs).size).toBe(2);
+
+    // First connect — counts as reconnect (false → true).
+    connected.set(true);
+    expect(get(reviewingPRs).size).toBe(0);
+    expect(get(reviewingIssues).size).toBe(0);
+  });
+
+  it('does not sweep on the very first emission if it is true', () => {
+    const connected = writable(true);
+    reviewingPRs.set(new Set([99]));
+    watchReconnectAndSweep({ subscribe: connected.subscribe });
+    expect(get(reviewingPRs).size).toBe(1);
+  });
+
+  it('sweeps on every subsequent false→true transition', () => {
+    const connected = writable(false);
+    watchReconnectAndSweep({ subscribe: connected.subscribe });
+
+    reviewingPRs.set(new Set([1]));
+    connected.set(true);
+    expect(get(reviewingPRs).size).toBe(0);
+
+    reviewingPRs.set(new Set([2]));
+    connected.set(false);
+    connected.set(true);
+    expect(get(reviewingPRs).size).toBe(0);
+  });
+});

--- a/web_ui/src/tests/token.test.ts
+++ b/web_ui/src/tests/token.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readFileMock = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: unknown[]) => readFileMock(...args)
+}));
+
+const originalEnv = { ...process.env };
+
+beforeEach(async () => {
+  vi.resetModules();
+  readFileMock.mockReset();
+  process.env = { ...originalEnv };
+  delete process.env.HEIMDALLM_API_TOKEN;
+  delete process.env.HEIMDALLM_API_TOKEN_FILE;
+});
+
+describe('loadToken', () => {
+  it('returns env var when set and non-empty', async () => {
+    process.env.HEIMDALLM_API_TOKEN = 'env-token';
+    readFileMock.mockResolvedValue('file-token\n');
+    const { loadToken } = await import('../lib/server/token.js');
+    expect(await loadToken()).toBe('env-token');
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to file when env var missing, trimming trailing newline', async () => {
+    readFileMock.mockResolvedValue('file-token\n');
+    const { loadToken } = await import('../lib/server/token.js');
+    expect(await loadToken()).toBe('file-token');
+    expect(readFileMock).toHaveBeenCalledWith('/data/api_token', 'utf-8');
+  });
+
+  it('caches the resolved token across calls', async () => {
+    readFileMock.mockResolvedValue('file-token\n');
+    const { loadToken } = await import('../lib/server/token.js');
+    expect(await loadToken()).toBe('file-token');
+    expect(await loadToken()).toBe('file-token');
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when neither env nor file yields a token', async () => {
+    readFileMock.mockRejectedValue(new Error('ENOENT'));
+    const { loadToken } = await import('../lib/server/token.js');
+    expect(await loadToken()).toBeNull();
+  });
+
+  it('uses HEIMDALLM_API_TOKEN_FILE override when set', async () => {
+    process.env.HEIMDALLM_API_TOKEN_FILE = '/run/secrets/token';
+    readFileMock.mockResolvedValue('secret\n');
+    const { loadToken } = await import('../lib/server/token.js');
+    expect(await loadToken()).toBe('secret');
+    expect(readFileMock).toHaveBeenCalledWith('/run/secrets/token', 'utf-8');
+  });
+});

--- a/web_ui/svelte.config.js
+++ b/web_ui/svelte.config.js
@@ -1,0 +1,12 @@
+import adapter from '@sveltejs/adapter-node';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter()
+  }
+};
+
+export default config;

--- a/web_ui/tsconfig.json
+++ b/web_ui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler",
+    "types": ["vitest/globals", "node"]
+  }
+}

--- a/web_ui/vite.config.ts
+++ b/web_ui/vite.config.ts
@@ -1,0 +1,12 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tailwindcss(), sveltekit()],
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'jsdom',
+    globals: true
+  }
+});


### PR DESCRIPTION
Closes #30.

Implements the Fase-3 foundational scaffold per [design spec](docs/superpowers/specs/2026-04-17-web-ui-scaffold-design.md) and [implementation plan](docs/superpowers/plans/2026-04-17-web-ui-scaffold.md). Everything lives under `web_ui/`; nothing outside is touched functionally.

## Summary

- **SvelteKit 2 + Svelte 5 (runes) + TypeScript + Vite 6 + TailwindCSS 4 + `adapter-node`.** Production dep tree resolves cleanly; Node 22 LTS pinned via `engines` and `.npmrc`.
- **Server-side proxy.** Browser only talks to same-origin SvelteKit endpoints — `/api/[...path]` catch-all + `/events` SSE passthrough — which inject `X-Heimdallm-Token` when forwarding to the daemon at `$HEIMDALLM_API_URL`. **Token never ships to the browser.** No CORS, no polyfills; native `EventSource` handles SSE.
- **Typed HTTP client** (`src/lib/api.ts`) mirroring `api_client.dart`, including Fase-2 issue methods. `parseReview`/`parsePR` transparently unwrap the daemon's JSON-string `issues`/`suggestions` fields into typed arrays (same as Dart's `_parseReviewMap`).
- **SSE wrapper** (`src/lib/sse.ts`) exposing `events` and `connected` Svelte stores. Single connection per tab via layout context.
- **Auth-aware layout shell** with nav, `$auth` store, and error banner on daemon unreachable.
- **Landing page** at `/` with connection indicator and four stats cards sourced from `fetchStats()` — acts as an end-to-end smoke test of the wiring.
- **Dockerfile** multi-stage, 164 MB image, runs as `node` user on port 3000. docker-compose integration ships in #33.
- **Unit tests** (vitest): 15 tests across `token.ts` (5, env/file precedence), `api.ts` (6, incl. stringified-review parsing), and `sse.ts` (4, mock `EventSource`).

## Architecture

```
Browser ── /api/* ──▶ SvelteKit server ──▶ daemon :7842
        └─ /events ─▶ (X-Heimdallm-Token injected server-side)
```

Token resolution (in `src/lib/server/token.ts`):
1. `HEIMDALLM_API_TOKEN` env var, or
2. `HEIMDALLM_API_TOKEN_FILE` (default `/data/api_token`).

Cached after first successful read.

## Test plan

- [x] `cd web_ui && npm run check` — 0 errors / 0 warnings
- [x] `cd web_ui && npm test` — 15/15 passing (token.ts × 5, api.ts × 6, sse.ts × 4)
- [x] `cd web_ui && npm run lint` — prettier + eslint clean
- [x] `cd web_ui && npm run build` — adapter-node output in `build/`
- [x] `cd web_ui && docker build -t heimdallm-web:dev .` — 164 MB image, `curl /` returns shell
- [x] End-to-end trace (mock daemon): `fetchPRs`, `/api/me`, `/events` event-stream all verified
- [ ] Manual: `/api/me` returns real login with daemon running
- [ ] Manual: `/events` streams real SSE events

## Issue #30 acceptance criteria

| AC | Evidence |
|---|---|
| `npm run build` sin errores | `web_ui/build/handler.js` present; Dockerfile build stage exercises it |
| `npm run dev` levanta el servidor | Vite dev server smoke test passes on port 5173 |
| `api.ts` tipado + conecta al daemon | `web_ui/src/lib/api.ts` + `web_ui/src/tests/api.test.ts`; end-to-end verified |
| SSE recibe y parsea eventos | `web_ui/src/lib/sse.ts` + `web_ui/src/tests/sse.test.ts`; end-to-end verified |
| Token leído automáticamente | `web_ui/src/lib/server/token.ts` + 5 tests (env/file/cache/override) |

## Follow-ups (explicitly out of scope)

- **Routes #31/#32** — Dashboard, PRs, Issues, Agents, Config, Logs pages. Nav links 404 until then.
- **docker-compose integration + `make setup`** — issue #33.
- **Fase-2 type parity with now-shipped daemon.** Fase 2 landed on `main` while this branch was in review; the TS `Issue`, `IssueReview`, and `SseEventType` union were written against the design spec's speculative shapes. They need tightening (e.g. `assignees`/`labels` are JSON strings on the wire, not arrays; `issue_detected`/`issue_review_*` events exist). `#31` will be the natural place to address — no runtime bug in this scaffold since no code consumes Issue data yet.
- **CI workflow for `web_ui/`** — not included; can follow in its own PR.
- **Dark mode / theming** — defaults only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)