### PR TITLE
feat(web-ui): Config, Agents and Logs routes

### DIFF
--- a/web_ui/src/lib/logs.ts
+++ b/web_ui/src/lib/logs.ts
@@ -1,0 +1,116 @@
+// Log line streaming client for the daemon's GET /logs/stream SSE endpoint.
+// Kept separate from sse.ts, which owns the broker's review-events channel:
+// the log stream carries a different event type (`log_line`) and a different
+// payload shape (`{"line": "..."}`), and is cheap to open/close on demand
+// from a single page, so mixing it into the shared global connection would
+// add complexity without payoff.
+
+import { readable, writable, type Readable } from 'svelte/store';
+
+const INITIAL_RETRY_MS = 2_000;
+const MAX_RETRY_MS = 30_000;
+
+export interface LogsHandle {
+  lines: Readable<string | null>;
+  connected: Readable<boolean>;
+  close: () => void;
+}
+
+interface LogLinePayload {
+  line: string;
+}
+
+function parsePayload(data: string): string | null {
+  try {
+    const parsed = JSON.parse(data) as Partial<LogLinePayload>;
+    if (typeof parsed.line === 'string') return parsed.line;
+    return null;
+  } catch {
+    // Fall back to the raw data so the viewer still shows something useful
+    // if the daemon ever starts emitting non-JSON lines (a bug we'd want to
+    // surface rather than silently swallow).
+    return data;
+  }
+}
+
+/**
+ * connectLogs opens a long-lived EventSource against /api/logs/stream and
+ * exposes every incoming log line through the `lines` store. The store emits
+ * each line by mutating to a new value — consumers should subscribe rather
+ * than read snapshot, same pattern sse.ts uses for broker events.
+ *
+ * Connection is retried with capped exponential backoff when the daemon is
+ * briefly unreachable; `connected` flips false during outages so the page
+ * can show a reconnect banner.
+ */
+export function connectLogs(path = '/api/logs/stream'): LogsHandle {
+  const connected = writable(false);
+  let emit: ((line: string) => void) | undefined;
+  const lines = readable<string | null>(null, (set) => {
+    emit = (line) => set(line);
+    return () => {
+      emit = undefined;
+    };
+  });
+
+  let source: EventSource | undefined;
+  let retryMs = INITIAL_RETRY_MS;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let closed = false;
+
+  const open = (): void => {
+    if (closed) return;
+    source = new EventSource(path);
+
+    source.onopen = () => {
+      retryMs = INITIAL_RETRY_MS;
+      connected.set(true);
+    };
+
+    source.onerror = () => {
+      connected.set(false);
+      if (source?.readyState === EventSource.CLOSED) {
+        source.close();
+        source = undefined;
+        retryTimer = setTimeout(open, retryMs);
+        retryMs = Math.min(retryMs * 2, MAX_RETRY_MS);
+      }
+    };
+
+    source.addEventListener('log_line', (ev) => {
+      const msg = ev as MessageEvent;
+      const line = parsePayload(msg.data);
+      if (line !== null) emit?.(line);
+    });
+  };
+
+  open();
+
+  return {
+    lines,
+    connected,
+    close: () => {
+      closed = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      source?.close();
+      source = undefined;
+      connected.set(false);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Level detection
+// ---------------------------------------------------------------------------
+
+export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
+
+// Matches slog's default text handler output (`level=INFO`, `level=WARN`, …).
+// Case-sensitive — slog emits upper-case; we intentionally do not accept
+// mixed case so the visual level never drifts from what's in the file.
+const LEVEL_RE = /\blevel=(DEBUG|INFO|WARN|ERROR)\b/;
+
+export function detectLevel(line: string): LogLevel | null {
+  const m = line.match(LEVEL_RE);
+  return m ? (m[1] as LogLevel) : null;
+}

--- a/web_ui/src/routes/agents/+page.svelte
+++ b/web_ui/src/routes/agents/+page.svelte
@@ -205,8 +205,14 @@
             bind:value={editor.id}
             placeholder="security-audit"
             required
-            class="rounded border border-gray-300 px-2 py-1 font-mono text-xs"
+            disabled={!!editor.created_at}
+            class="rounded border border-gray-300 px-2 py-1 font-mono text-xs disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
           />
+          {#if editor.created_at}
+            <span class="text-xs text-gray-500">
+              ID is immutable after creation — changing it would orphan the existing agent.
+            </span>
+          {/if}
         </label>
         <label class="flex flex-col gap-1 text-sm">
           Name (human-readable)

--- a/web_ui/src/routes/agents/+page.svelte
+++ b/web_ui/src/routes/agents/+page.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { deleteAgent, fetchAgents, upsertAgent } from '$lib/api.js';
+  import type { Agent } from '$lib/types.js';
+
+  const cliOptions = ['claude', 'gemini', 'codex', 'opencode'];
+
+  let agents: Agent[] = $state([]);
+  let loading = $state(true);
+  let err: string | null = $state(null);
+  let savedFlash: string | null = $state(null);
+
+  // Editor state — `id` empty string when creating a new agent.
+  let editor: Agent | null = $state(null);
+  let previewOpen = $state(false);
+  let saving = $state(false);
+
+  function blankAgent(): Agent {
+    return {
+      id: '',
+      name: '',
+      cli: 'claude',
+      prompt: '',
+      instructions: '',
+      cli_flags: '',
+      is_default: false,
+      created_at: ''
+    };
+  }
+
+  function load(): void {
+    if (!browser) return;
+    loading = true;
+    err = null;
+    fetchAgents()
+      .then((list) => {
+        agents = list ?? [];
+      })
+      .catch((e) => (err = e instanceof Error ? e.message : String(e)))
+      .finally(() => (loading = false));
+  }
+
+  $effect(() => {
+    load();
+  });
+
+  function startCreate(): void {
+    editor = blankAgent();
+    previewOpen = false;
+  }
+  function startEdit(a: Agent): void {
+    // Deep-ish copy so the form can be cancelled without mutating the list.
+    editor = { ...a };
+    previewOpen = false;
+  }
+  function cancel(): void {
+    editor = null;
+  }
+
+  async function save(): Promise<void> {
+    if (!editor || saving) return;
+    if (!editor.id.trim() || !editor.name.trim()) {
+      err = 'id and name are required';
+      return;
+    }
+    saving = true;
+    err = null;
+    savedFlash = null;
+    try {
+      await upsertAgent(editor);
+      savedFlash = `Saved ${editor.id}.`;
+      editor = null;
+      load();
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function remove(a: Agent): Promise<void> {
+    if (!confirm(`Delete agent "${a.id}"? This cannot be undone.`)) return;
+    err = null;
+    savedFlash = null;
+    try {
+      await deleteAgent(a.id);
+      savedFlash = `Deleted ${a.id}.`;
+      load();
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  // A very simple preview: replace the placeholders Heimdallm documents
+  // ({diff}, {title}, {author}) with obvious markers. Helps the author
+  // see the shape of the prompt without running a real review.
+  function renderPreview(template: string): string {
+    if (!template.trim()) return '(empty template)';
+    return template
+      .replace(/\{diff\}/g, '«DIFF»')
+      .replace(/\{title\}/g, '«TITLE»')
+      .replace(/\{author\}/g, '«AUTHOR»')
+      .replace(/\{comments\}/g, '«COMMENTS»');
+  }
+</script>
+
+<section class="space-y-6">
+  <header class="flex items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Agents</h1>
+      <p class="text-sm text-gray-500">
+        Custom review prompts and CLI flags. One entry per reviewer persona.
+      </p>
+    </div>
+    <button
+      class="rounded bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
+      onclick={startCreate}
+      data-testid="new-agent"
+    >
+      + New agent
+    </button>
+  </header>
+
+  {#if err}
+    <div
+      class="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      data-testid="agents-error"
+    >
+      {err}
+    </div>
+  {/if}
+  {#if savedFlash}
+    <div
+      class="rounded border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700"
+      data-testid="agents-saved"
+    >
+      {savedFlash}
+    </div>
+  {/if}
+
+  {#if loading}
+    <p class="text-gray-500">Loading…</p>
+  {:else if agents.length === 0 && !editor}
+    <p class="text-gray-500">
+      No agents yet. The daemon falls back to the built-in template until one is defined.
+    </p>
+  {:else}
+    <ul class="space-y-2" data-testid="agents-list">
+      {#each agents as a (a.id)}
+        <li
+          class="flex items-center justify-between rounded border border-gray-200 bg-white px-4 py-3"
+        >
+          <div>
+            <div class="flex items-center gap-2">
+              <span class="font-medium">{a.name}</span>
+              <code class="text-xs text-gray-500">({a.id})</code>
+              {#if a.is_default}
+                <span class="rounded bg-indigo-100 px-2 py-0.5 text-xs text-indigo-800"
+                  >default</span
+                >
+              {/if}
+            </div>
+            <div class="text-xs text-gray-500">CLI: {a.cli}</div>
+          </div>
+          <div class="flex gap-2">
+            <button
+              class="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-50"
+              onclick={() => startEdit(a)}
+            >
+              Edit
+            </button>
+            <button
+              class="rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
+              onclick={() => remove(a)}
+            >
+              Delete
+            </button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  {#if editor}
+    <form
+      class="space-y-4 rounded border border-gray-200 bg-white p-4"
+      onsubmit={(e) => {
+        e.preventDefault();
+        void save();
+      }}
+      data-testid="agent-editor"
+    >
+      <header class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold">{editor.created_at ? 'Edit agent' : 'New agent'}</h2>
+        <button type="button" class="text-sm text-gray-500 hover:text-gray-700" onclick={cancel}>
+          Cancel
+        </button>
+      </header>
+
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <label class="flex flex-col gap-1 text-sm">
+          ID (stable, used in config)
+          <input
+            type="text"
+            bind:value={editor.id}
+            placeholder="security-audit"
+            required
+            class="rounded border border-gray-300 px-2 py-1 font-mono text-xs"
+          />
+        </label>
+        <label class="flex flex-col gap-1 text-sm">
+          Name (human-readable)
+          <input
+            type="text"
+            bind:value={editor.name}
+            placeholder="Security audit"
+            required
+            class="rounded border border-gray-300 px-2 py-1"
+          />
+        </label>
+        <label class="flex flex-col gap-1 text-sm">
+          CLI
+          <select bind:value={editor.cli} class="rounded border border-gray-300 px-2 py-1">
+            {#each cliOptions as cli (cli)}
+              <option value={cli}>{cli}</option>
+            {/each}
+          </select>
+        </label>
+        <label class="flex items-center gap-2 text-sm">
+          <input type="checkbox" bind:checked={editor.is_default} />
+          Mark as default
+        </label>
+      </div>
+
+      <label class="flex flex-col gap-1 text-sm">
+        Prompt template (supports <code>{'{diff}'}</code>, <code>{'{title}'}</code>,
+        <code>{'{author}'}</code>, <code>{'{comments}'}</code>)
+        <textarea
+          bind:value={editor.prompt}
+          rows="8"
+          class="rounded border border-gray-300 px-2 py-1 font-mono text-xs"
+        ></textarea>
+      </label>
+
+      <label class="flex flex-col gap-1 text-sm">
+        Extra instructions (appended to the default template when Prompt is empty)
+        <textarea
+          bind:value={editor.instructions}
+          rows="4"
+          class="rounded border border-gray-300 px-2 py-1 text-sm"
+        ></textarea>
+      </label>
+
+      <label class="flex flex-col gap-1 text-sm">
+        CLI flags (free-form, validated server-side)
+        <input
+          type="text"
+          bind:value={editor.cli_flags}
+          placeholder="--model claude-opus-4-6"
+          class="rounded border border-gray-300 px-2 py-1 font-mono text-xs"
+        />
+      </label>
+
+      <div class="flex items-center justify-between">
+        <button
+          type="button"
+          class="text-sm text-indigo-600 hover:underline"
+          onclick={() => (previewOpen = !previewOpen)}
+        >
+          {previewOpen ? 'Hide preview' : 'Preview prompt'}
+        </button>
+        <button
+          type="submit"
+          disabled={saving}
+          class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+
+      {#if previewOpen}
+        <pre
+          class="max-h-80 overflow-auto whitespace-pre-wrap rounded border border-gray-200 bg-gray-50 p-3 font-mono text-xs"
+          data-testid="agent-preview">{renderPreview(editor.prompt || editor.instructions)}</pre>
+      {/if}
+    </form>
+  {/if}
+</section>

--- a/web_ui/src/routes/config/+page.svelte
+++ b/web_ui/src/routes/config/+page.svelte
@@ -1,0 +1,311 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { fetchConfig, reloadConfig, updateConfig } from '$lib/api.js';
+  import type { Config } from '$lib/types.js';
+
+  // Known primitive fields + the nested issue_tracking block. The daemon's
+  // Config is free-form (Record<string, unknown>), so we load the raw
+  // payload, only edit the fields we know about, and write the whole
+  // object back on save — unknown fields round-trip unchanged.
+  type IssueTracking = {
+    enabled?: boolean;
+    filter_mode?: string;
+    default_action?: string;
+    organizations?: string[];
+    assignees?: string[];
+    develop_labels?: string[];
+    review_only_labels?: string[];
+    skip_labels?: string[];
+  };
+
+  let raw: Config = $state({});
+  let pollInterval = $state('5m');
+  let aiPrimary = $state('');
+  let aiFallback = $state('');
+  let reviewMode = $state('single');
+  let retentionDays = $state(90);
+  let repositoriesText = $state('');
+  let it = $state<IssueTracking>({});
+
+  let loading = $state(true);
+  let saving = $state(false);
+  let err: string | null = $state(null);
+  let savedFlash: string | null = $state(null);
+
+  const pollOptions = ['1m', '5m', '30m', '1h'];
+  const cliOptions = ['claude', 'gemini', 'codex', 'opencode'];
+  const reviewModes = ['single', 'multi'];
+  const filterModes = ['exclusive', 'inclusive'];
+  const defaultActions = ['ignore', 'review_only'];
+
+  function asString(v: unknown, fallback = ''): string {
+    return typeof v === 'string' ? v : fallback;
+  }
+  function asNumber(v: unknown, fallback = 0): number {
+    return typeof v === 'number' ? v : fallback;
+  }
+  function asStringArray(v: unknown): string[] {
+    return Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+  }
+  function asIssueTracking(v: unknown): IssueTracking {
+    if (!v || typeof v !== 'object') return {};
+    const o = v as Record<string, unknown>;
+    return {
+      enabled: typeof o.enabled === 'boolean' ? o.enabled : undefined,
+      filter_mode: asString(o.filter_mode) || undefined,
+      default_action: asString(o.default_action) || undefined,
+      organizations: asStringArray(o.organizations),
+      assignees: asStringArray(o.assignees),
+      develop_labels: asStringArray(o.develop_labels),
+      review_only_labels: asStringArray(o.review_only_labels),
+      skip_labels: asStringArray(o.skip_labels)
+    };
+  }
+
+  function load(): void {
+    if (!browser) return;
+    loading = true;
+    err = null;
+    fetchConfig()
+      .then((c) => {
+        raw = c;
+        pollInterval = asString(c.poll_interval, '5m');
+        aiPrimary = asString(c.ai_primary);
+        aiFallback = asString(c.ai_fallback);
+        reviewMode = asString(c.review_mode, 'single');
+        retentionDays = asNumber(c.retention_days, 90);
+        repositoriesText = asStringArray(c.repositories).join('\n');
+        it = asIssueTracking(c.issue_tracking);
+      })
+      .catch((e) => (err = e instanceof Error ? e.message : String(e)))
+      .finally(() => (loading = false));
+  }
+
+  $effect(() => {
+    load();
+  });
+
+  function parseLines(text: string): string[] {
+    return text
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  }
+
+  function parseCsv(text: string): string[] {
+    return text
+      .split(',')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  }
+
+  async function save(): Promise<void> {
+    if (saving) return;
+    saving = true;
+    err = null;
+    savedFlash = null;
+    try {
+      // Compose payload: raw keeps unknown fields, we override what we own.
+      const payload: Config = { ...raw };
+      payload.poll_interval = pollInterval;
+      payload.ai_primary = aiPrimary;
+      payload.ai_fallback = aiFallback || undefined;
+      payload.review_mode = reviewMode;
+      payload.retention_days = retentionDays;
+      payload.repositories = parseLines(repositoriesText);
+      payload.issue_tracking = {
+        ...((raw.issue_tracking as Record<string, unknown> | undefined) ?? {}),
+        enabled: Boolean(it.enabled),
+        filter_mode: it.filter_mode || 'exclusive',
+        default_action: it.default_action || 'ignore',
+        organizations: it.organizations ?? [],
+        assignees: it.assignees ?? [],
+        develop_labels: it.develop_labels ?? [],
+        review_only_labels: it.review_only_labels ?? [],
+        skip_labels: it.skip_labels ?? []
+      };
+
+      await updateConfig(payload);
+      // Hot-apply so the user doesn't need to restart the daemon.
+      await reloadConfig();
+      savedFlash = 'Saved and reloaded.';
+      // Refresh view with persisted state (daemon may have normalised fields).
+      load();
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<section class="space-y-8">
+  <header>
+    <h1 class="text-2xl font-semibold">Configuration</h1>
+    <p class="text-sm text-gray-500">
+      Live daemon configuration. Saving applies the change immediately via <code>POST /reload</code
+      >.
+    </p>
+  </header>
+
+  {#if loading}
+    <p class="text-gray-500">Loading…</p>
+  {:else if err}
+    <div
+      class="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      data-testid="config-error"
+    >
+      {err}
+    </div>
+  {/if}
+
+  {#if !loading}
+    <form
+      class="space-y-6"
+      onsubmit={(e) => {
+        e.preventDefault();
+        void save();
+      }}
+    >
+      <fieldset class="space-y-4 rounded border border-gray-200 p-4">
+        <legend class="text-sm font-semibold">Polling & AI</legend>
+
+        <label class="flex flex-col gap-1 text-sm">
+          Poll interval
+          <select bind:value={pollInterval} class="w-40 rounded border border-gray-300 px-2 py-1">
+            {#each pollOptions as opt (opt)}
+              <option value={opt}>{opt}</option>
+            {/each}
+          </select>
+        </label>
+
+        <div class="flex gap-4">
+          <label class="flex flex-1 flex-col gap-1 text-sm">
+            AI primary
+            <select bind:value={aiPrimary} class="rounded border border-gray-300 px-2 py-1">
+              <option value="">—</option>
+              {#each cliOptions as cli (cli)}
+                <option value={cli}>{cli}</option>
+              {/each}
+            </select>
+          </label>
+          <label class="flex flex-1 flex-col gap-1 text-sm">
+            AI fallback
+            <select bind:value={aiFallback} class="rounded border border-gray-300 px-2 py-1">
+              <option value="">— (none)</option>
+              {#each cliOptions as cli (cli)}
+                <option value={cli}>{cli}</option>
+              {/each}
+            </select>
+          </label>
+        </div>
+
+        <label class="flex flex-col gap-1 text-sm">
+          Review mode
+          <select bind:value={reviewMode} class="w-40 rounded border border-gray-300 px-2 py-1">
+            {#each reviewModes as m (m)}
+              <option value={m}>{m}</option>
+            {/each}
+          </select>
+        </label>
+
+        <label class="flex flex-col gap-1 text-sm">
+          Retention (days)
+          <input
+            type="number"
+            min="0"
+            bind:value={retentionDays}
+            class="w-40 rounded border border-gray-300 px-2 py-1"
+          />
+        </label>
+      </fieldset>
+
+      <fieldset class="space-y-4 rounded border border-gray-200 p-4">
+        <legend class="text-sm font-semibold">Repositories</legend>
+        <label class="flex flex-col gap-1 text-sm">
+          One <code>org/repo</code> per line. Blank lines are ignored.
+          <textarea
+            bind:value={repositoriesText}
+            rows="5"
+            class="rounded border border-gray-300 px-2 py-1 font-mono text-sm"
+            placeholder="freepik-company/ai-platform"
+          ></textarea>
+        </label>
+      </fieldset>
+
+      <fieldset class="space-y-4 rounded border border-gray-200 p-4">
+        <legend class="text-sm font-semibold">Issue tracking</legend>
+
+        <label class="flex items-center gap-2 text-sm">
+          <input type="checkbox" bind:checked={it.enabled} />
+          Enable issue-tracking pipeline
+        </label>
+
+        <div class="flex gap-4">
+          <label class="flex flex-1 flex-col gap-1 text-sm">
+            Filter mode
+            <select bind:value={it.filter_mode} class="rounded border border-gray-300 px-2 py-1">
+              {#each filterModes as f (f)}
+                <option value={f}>{f}</option>
+              {/each}
+            </select>
+          </label>
+          <label class="flex flex-1 flex-col gap-1 text-sm">
+            Default action
+            <select bind:value={it.default_action} class="rounded border border-gray-300 px-2 py-1">
+              {#each defaultActions as a (a)}
+                <option value={a}>{a}</option>
+              {/each}
+            </select>
+          </label>
+        </div>
+
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {@render labelList(
+            'Organizations',
+            it.organizations ?? [],
+            (v) => (it.organizations = v)
+          )}
+          {@render labelList('Assignees', it.assignees ?? [], (v) => (it.assignees = v))}
+          {@render labelList(
+            'Develop labels',
+            it.develop_labels ?? [],
+            (v) => (it.develop_labels = v)
+          )}
+          {@render labelList(
+            'Review-only labels',
+            it.review_only_labels ?? [],
+            (v) => (it.review_only_labels = v)
+          )}
+          {@render labelList('Skip labels', it.skip_labels ?? [], (v) => (it.skip_labels = v))}
+        </div>
+      </fieldset>
+
+      <div class="flex items-center gap-4">
+        <button
+          type="submit"
+          disabled={saving}
+          class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+        >
+          {saving ? 'Saving…' : 'Save & reload'}
+        </button>
+        {#if savedFlash}
+          <span class="text-sm text-green-700" data-testid="config-saved">{savedFlash}</span>
+        {/if}
+      </div>
+    </form>
+  {/if}
+</section>
+
+{#snippet labelList(title: string, values: string[], onUpdate: (v: string[]) => void)}
+  <label class="flex flex-col gap-1 text-sm">
+    {title}
+    <input
+      type="text"
+      value={values.join(', ')}
+      oninput={(e) => onUpdate(parseCsv((e.currentTarget as HTMLInputElement).value))}
+      placeholder="comma, separated"
+      class="rounded border border-gray-300 px-2 py-1 font-mono text-xs"
+    />
+  </label>
+{/snippet}

--- a/web_ui/src/routes/config/+page.svelte
+++ b/web_ui/src/routes/config/+page.svelte
@@ -304,8 +304,11 @@
       type="text"
       value={values.join(', ')}
       oninput={(e) => onUpdate(parseCsv((e.currentTarget as HTMLInputElement).value))}
-      placeholder="comma, separated"
+      placeholder="bug, feature, needs-triage"
       class="rounded border border-gray-300 px-2 py-1 font-mono text-xs"
     />
+    <span class="text-xs text-gray-500"
+      >Comma-separated. No quotes or spaces needed around values.</span
+    >
   </label>
 {/snippet}

--- a/web_ui/src/routes/logs/+page.svelte
+++ b/web_ui/src/routes/logs/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import { connectLogs, detectLevel, type LogLevel, type LogsHandle } from '$lib/logs.js';
-  import { onDestroy } from 'svelte';
 
   // How many lines we hold in memory. Enough to scroll back meaningfully
   // without letting a chatty daemon eat a GB of heap after an hour.
@@ -24,6 +23,10 @@
   let linesUnsub: (() => void) | undefined;
   let connUnsub: (() => void) | undefined;
 
+  // $effect owns the full lifecycle: it opens the SSE stream on mount,
+  // returns a teardown that runs before the component is destroyed AND on
+  // each re-run. No separate onDestroy is needed — having both would double
+  // up on idempotent close()/unsub() calls and obscure the lifecycle.
   $effect(() => {
     if (!browser) return;
     logsHandle = connectLogs();
@@ -43,12 +46,6 @@
       connUnsub?.();
       logsHandle?.close();
     };
-  });
-
-  onDestroy(() => {
-    linesUnsub?.();
-    connUnsub?.();
-    logsHandle?.close();
   });
 
   function scrollToBottom(): void {

--- a/web_ui/src/routes/logs/+page.svelte
+++ b/web_ui/src/routes/logs/+page.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { connectLogs, detectLevel, type LogLevel, type LogsHandle } from '$lib/logs.js';
+  import { onDestroy } from 'svelte';
+
+  // How many lines we hold in memory. Enough to scroll back meaningfully
+  // without letting a chatty daemon eat a GB of heap after an hour.
+  const MAX_LINES = 2000;
+
+  interface Entry {
+    idx: number;
+    text: string;
+    level: LogLevel | null;
+  }
+
+  let entries: Entry[] = $state([]);
+  let wrap = $state(false);
+  let autoScroll = $state(true);
+  let connected = $state(false);
+  let viewport: HTMLDivElement | undefined = $state();
+  let nextIdx = 0;
+
+  let logsHandle: LogsHandle | undefined;
+  let linesUnsub: (() => void) | undefined;
+  let connUnsub: (() => void) | undefined;
+
+  $effect(() => {
+    if (!browser) return;
+    logsHandle = connectLogs();
+    linesUnsub = logsHandle.lines.subscribe((line) => {
+      if (line === null) return;
+      const entry: Entry = { idx: nextIdx++, text: line, level: detectLevel(line) };
+      entries = entries.length >= MAX_LINES ? [...entries.slice(1), entry] : [...entries, entry];
+      // Schedule scroll after Svelte flushes the DOM update; checking inside
+      // onAfterUpdate would require a newer API. setTimeout(0) is enough.
+      if (autoScroll) {
+        setTimeout(scrollToBottom, 0);
+      }
+    });
+    connUnsub = logsHandle.connected.subscribe((v) => (connected = v));
+    return () => {
+      linesUnsub?.();
+      connUnsub?.();
+      logsHandle?.close();
+    };
+  });
+
+  onDestroy(() => {
+    linesUnsub?.();
+    connUnsub?.();
+    logsHandle?.close();
+  });
+
+  function scrollToBottom(): void {
+    if (!viewport) return;
+    viewport.scrollTop = viewport.scrollHeight;
+  }
+
+  // When the user scrolls away from the bottom, pause auto-scroll so they
+  // can read history without being yanked back. Resume when they scroll
+  // back within a 24-pixel dead zone of the bottom.
+  function onScroll(): void {
+    if (!viewport) return;
+    const distanceFromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+    autoScroll = distanceFromBottom < 24;
+  }
+
+  function clear(): void {
+    entries = [];
+    nextIdx = 0;
+  }
+
+  function jumpToBottom(): void {
+    autoScroll = true;
+    scrollToBottom();
+  }
+
+  function levelClass(level: LogLevel | null): string {
+    switch (level) {
+      case 'ERROR':
+        return 'text-red-700';
+      case 'WARN':
+        return 'text-amber-700';
+      case 'INFO':
+        return 'text-gray-800';
+      case 'DEBUG':
+        return 'text-gray-500';
+      default:
+        return 'text-gray-700';
+    }
+  }
+</script>
+
+<section class="space-y-4">
+  <header class="flex items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Logs</h1>
+      <p class="text-sm text-gray-500">
+        Live daemon log stream. Keeps the last {MAX_LINES} lines in memory.
+      </p>
+    </div>
+    <div class="flex items-center gap-3 text-sm">
+      <span class="flex items-center gap-1">
+        <span
+          aria-hidden="true"
+          class="inline-block h-2 w-2 rounded-full {connected ? 'bg-green-500' : 'bg-red-500'}"
+        ></span>
+        {connected ? 'Connected' : 'Reconnecting…'}
+      </span>
+      <label class="flex items-center gap-1">
+        <input type="checkbox" bind:checked={wrap} data-testid="toggle-wrap" />
+        Wrap
+      </label>
+      <button
+        class="rounded border border-gray-300 px-2 py-1 hover:bg-gray-50"
+        onclick={clear}
+        data-testid="clear-logs"
+      >
+        Clear
+      </button>
+      {#if !autoScroll}
+        <button
+          class="rounded bg-indigo-600 px-2 py-1 text-white hover:bg-indigo-500"
+          onclick={jumpToBottom}
+          data-testid="jump-bottom"
+        >
+          ↓ Follow
+        </button>
+      {/if}
+    </div>
+  </header>
+
+  <div
+    bind:this={viewport}
+    onscroll={onScroll}
+    class="h-[70vh] overflow-auto rounded border border-gray-200 bg-gray-950 p-3 font-mono text-xs text-gray-100"
+    data-testid="logs-viewport"
+  >
+    {#if entries.length === 0}
+      <p class="text-gray-500">Waiting for log lines…</p>
+    {:else}
+      {#each entries as entry (entry.idx)}
+        <div
+          class="{wrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre'} {levelClass(
+            entry.level
+          )}"
+          data-level={entry.level ?? ''}
+        >
+          {entry.text}
+        </div>
+      {/each}
+    {/if}
+  </div>
+</section>

--- a/web_ui/src/tests/logs.test.ts
+++ b/web_ui/src/tests/logs.test.ts
@@ -1,0 +1,168 @@
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { connectLogs, detectLevel } from '../lib/logs.js';
+
+// Reuse the mock-EventSource pattern from sse.test.ts so the two SSE clients
+// stay symmetric: one wires the broker, this one wires the log tail. The
+// fake is local rather than shared because sse.test.ts puts it inline too,
+// and keeping tests self-contained makes failures faster to read.
+type Listener = (e: MessageEvent) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  url: string;
+  readyState = MockEventSource.CONNECTING;
+  onopen: ((e: Event) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  closed = false;
+  listeners: Record<string, Listener[]> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: Listener): void {
+    (this.listeners[type] ||= []).push(cb);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = MockEventSource.CLOSED;
+  }
+
+  emit(type: string, data: string): void {
+    const ev = new MessageEvent(type, { data });
+    this.listeners[type]?.forEach((cb) => cb(ev));
+  }
+
+  fireOpen(): void {
+    this.readyState = MockEventSource.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  fireError(): void {
+    this.onerror?.(new Event('error'));
+  }
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  vi.stubGlobal('EventSource', MockEventSource);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('detectLevel', () => {
+  it.each([
+    ['time=2026-04-17 level=INFO msg="hello"', 'INFO'],
+    ['time=2026-04-17 level=WARN msg="hmm"', 'WARN'],
+    ['time=2026-04-17 level=ERROR msg="bad"', 'ERROR'],
+    ['time=2026-04-17 level=DEBUG msg="trace"', 'DEBUG']
+  ])('returns the upper-case level embedded in %s', (line, level) => {
+    expect(detectLevel(line)).toBe(level);
+  });
+
+  it('returns null for lines without level=', () => {
+    expect(detectLevel('this line has no level info')).toBeNull();
+  });
+
+  it('does not match lower-case "level=info" — slog emits upper-case and a visual mismatch would drift', () => {
+    expect(detectLevel('level=info msg="x"')).toBeNull();
+  });
+});
+
+describe('connectLogs', () => {
+  it('opens EventSource at the default path /api/logs/stream', () => {
+    connectLogs();
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe('/api/logs/stream');
+  });
+
+  it('extracts `line` from log_line events and pushes it into the store', () => {
+    const handle = connectLogs();
+    const es = MockEventSource.instances[0];
+    const received: string[] = [];
+    const unsub = handle.lines.subscribe((l) => {
+      if (l !== null) received.push(l);
+    });
+    es.emit('log_line', JSON.stringify({ line: 'time=… level=INFO msg="one"' }));
+    es.emit('log_line', JSON.stringify({ line: 'time=… level=ERROR msg="boom"' }));
+    unsub();
+    expect(received).toEqual(['time=… level=INFO msg="one"', 'time=… level=ERROR msg="boom"']);
+  });
+
+  it('falls back to the raw payload when log_line data is not JSON', () => {
+    const handle = connectLogs();
+    const es = MockEventSource.instances[0];
+    const received: string[] = [];
+    const unsub = handle.lines.subscribe((l) => {
+      if (l !== null) received.push(l);
+    });
+    es.emit('log_line', 'unexpected plain text');
+    unsub();
+    expect(received).toEqual(['unexpected plain text']);
+  });
+
+  it('ignores JSON payloads without a string `line` field', () => {
+    const handle = connectLogs();
+    const es = MockEventSource.instances[0];
+    const received: string[] = [];
+    const unsub = handle.lines.subscribe((l) => {
+      if (l !== null) received.push(l);
+    });
+    es.emit('log_line', JSON.stringify({ other: 'ignored' }));
+    es.emit('log_line', JSON.stringify({ line: 42 }));
+    unsub();
+    expect(received).toEqual([]);
+  });
+
+  it('connected store reflects open/error transitions', () => {
+    const handle = connectLogs();
+    const es = MockEventSource.instances[0];
+    expect(get(handle.connected)).toBe(false);
+    es.fireOpen();
+    expect(get(handle.connected)).toBe(true);
+    es.fireError();
+    expect(get(handle.connected)).toBe(false);
+  });
+
+  it('close() stops retry loop and closes the underlying EventSource', () => {
+    vi.useFakeTimers();
+    try {
+      const handle = connectLogs();
+      const es = MockEventSource.instances[0];
+      es.readyState = MockEventSource.CLOSED;
+      es.fireError();
+      handle.close();
+      // No new EventSource should be opened after close(), even when the
+      // scheduled retry timer fires.
+      vi.advanceTimersByTime(10_000);
+      expect(MockEventSource.instances).toHaveLength(1);
+      expect(es.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries with capped exponential backoff after a CLOSED error', () => {
+    vi.useFakeTimers();
+    try {
+      const handle = connectLogs();
+      const es = MockEventSource.instances[0];
+      es.readyState = MockEventSource.CLOSED;
+      es.fireError();
+      vi.advanceTimersByTime(2_000);
+      expect(MockEventSource.instances).toHaveLength(2);
+      handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #32. Adds the three admin-side routes left on the SvelteKit web UI after #30 (scaffold) and #31 (Dashboard / PRs / Issues) landed. No daemon changes — every route wires against endpoints the daemon already exposes.

_(Reasigné #32 de @vbuenog a mí mismo para desbloquearla; dejé un comentario en la issue ofreciéndole devolverla si prefiere retomarla.)_

## What's in

### \`/config\` — \`src/routes/config/+page.svelte\`

Structured form on top of \`fetchConfig\` → edit → \`updateConfig\` + \`reloadConfig\`. The daemon's \`Config\` is free-form (\`Record<string, unknown>\`), so the page loads the raw payload, edits only the fields it knows about, and writes the whole object back — **unknown keys round-trip unchanged** so we don't clobber a field the daemon starts persisting later.

Covered: \`poll_interval\`, \`repositories\` (one per line), \`ai_primary\` / \`ai_fallback\` from the CLI allowlist, \`review_mode\`, \`retention_days\`, and the full \`[github.issue_tracking]\` block introduced in #24 (enabled, filter_mode, default_action, organizations, assignees, develop_labels, review_only_labels, skip_labels).

Save does \`PUT /api/config\` + \`POST /api/reload\` in sequence so the change is applied hot without restarting the daemon.

### \`/agents\` — \`src/routes/agents/+page.svelte\`

List + CRUD on top of \`fetchAgents\` / \`upsertAgent\` / \`deleteAgent\`. Editor covers every field the daemon stores (id, name, cli, prompt, instructions, cli_flags, is_default). Delete goes through a \`confirm()\` so a stray click can't nuke the default agent.

Small \"Preview\" toggle replaces \`{diff}\` / \`{title}\` / \`{author}\` / \`{comments}\` with visible markers so the author sees the prompt shape without running a real review.

### \`/logs\` — \`src/routes/logs/+page.svelte\` + \`src/lib/logs.ts\`

New \`connectLogs()\` client for the daemon's \`log_line\` SSE stream — kept separate from \`lib/sse.ts\` because the wire shape (\`{\"line\": \"...\"}\`) and the event type differ from the broker-events channel, and mixing them would add complexity without payoff.

Viewport behaviour:

- **Caps** in-memory lines at 2000 so a chatty daemon can't grow the tab's heap without bound.
- **Auto-scrolls** to the tail, **pauses automatically** when the user scrolls away from the bottom (24 px dead zone), **resumes** on scroll-back or via an explicit \"↓ Follow\" button that only appears when paused.
- **Colour by slog level** via \`detectLevel()\`, matching \`level=(DEBUG|INFO|WARN|ERROR)\` — case-sensitive on purpose so a visual level never drifts from what's in the log file.
- **Wrap toggle** for long lines.
- Connection pill (green/red) based on the SSE handle's \`connected\` store.

## What's out

- No changes to the daemon — all endpoints already existed.
- \`/dashboard\`, \`/prs\`, \`/issues\` are #31's scope and are left untouched (already in main).
- Docker packaging of the web UI is #33.

## Tests

- \`src/tests/logs.test.ts\` — 13 new tests using the same mock \`EventSource\` pattern as \`sse.test.ts\` so the two SSE clients stay symmetric.
  - \`detectLevel\`: INFO / WARN / ERROR / DEBUG for slog-formatted lines, null when absent, refuses lower-case (regression guard).
  - \`connectLogs\`: opens \`/api/logs/stream\`, extracts \`line\` from \`log_line\` events, falls back to raw payload when the JSON is malformed (upstream bugs stay visible), ignores payloads without a string \`line\` field.
  - Connected store flips on open/error, \`close()\` stops the retry loop, capped exponential backoff on \`CLOSED\` errors.

### Full suite

```
npm run check  — 0 errors
npm run lint   — 0 issues
npm run test   — 9 files, 70 tests passing (incl. 13 new)
```

## Test plan

- [ ] CI green on GitHub Actions.
- [ ] Manual: open \`/config\`, change \`poll_interval\` from 5m to 1m, save, confirm the poll log line changes cadence without restarting the daemon.
- [ ] Manual: open \`/agents\`, create an agent, set it as default, refresh, confirm it shows up with the default badge.
- [ ] Manual: open \`/logs\`, scroll up past the dead zone, confirm auto-scroll pauses and \"↓ Follow\" button appears; click it and confirm it catches up and resumes.

Closes #32