### PR TITLE
chore(make): Docker compose wrappers + README setup guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ endif
 
 .PHONY: build-daemon build-app test test-docker dev dev-daemon dev-stop \
         release-local package-macos install-service verify-linux run-linux \
-        setup clean
+        setup up up-daemon down logs logs-daemon ps restart clean \
+        _check-docker _check-env
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 
@@ -241,8 +242,7 @@ install-service: build-daemon
 # value without digging into the volume.
 #
 # Usage:
-#   docker compose -f docker/docker-compose.yml up -d heimdallm
-#   make setup
+#   make up-daemon && make setup
 #
 # Replaces any existing HEIMDALLM_API_TOKEN line rather than appending, so
 # rerunning the target after a daemon reset does not leave stale duplicates.
@@ -259,7 +259,7 @@ setup:
 	@test -f $(DOCKER_ENV) || { echo "❌  $(DOCKER_ENV) missing — copy docker/.env.example first."; exit 1; }
 	@docker compose -f $(COMPOSE_FILE) ps --status running --services 2>/dev/null | grep -q '^heimdallm$$' \
 	  || { echo "❌  heimdallm container is not running. Start it with:"; \
-	       echo "     docker compose -f $(COMPOSE_FILE) up -d heimdallm"; exit 1; }
+	       echo "     make up-daemon"; exit 1; }
 	@TOKEN=$$(docker compose -f $(COMPOSE_FILE) exec -T heimdallm cat /data/api_token 2>/dev/null | tr -d '\r\n'); \
 	 if [ -z "$$TOKEN" ]; then \
 	   echo "❌  /data/api_token is empty — wait for the daemon's first full startup and retry."; \
@@ -273,6 +273,51 @@ setup:
 	 mv "$$TMP" $(DOCKER_ENV); \
 	 trap - EXIT; \
 	 echo "✓  HEIMDALLM_API_TOKEN written to $(DOCKER_ENV)"
+
+# ── Docker compose wrappers ───────────────────────────────────────────────────
+#
+# Thin shortcuts around `docker compose -f $(COMPOSE_FILE)`. They exist so the
+# README can point newcomers at `make up` / `make logs` / `make down` instead
+# of the longer compose invocation — and so the invocation stays in one place
+# if the compose path changes.
+#
+# `up` brings both services (daemon + web) online. `up-daemon` is the escape
+# hatch for operators who do not want the web UI.
+#
+# `make up` also validates `docker/.env` exists — the most common first-run
+# mistake is forgetting to copy `.env.example`.
+
+_check-docker:
+	@command -v docker >/dev/null || { echo "❌  Docker is required. Install from https://docs.docker.com/get-docker/"; exit 1; }
+
+_check-env: _check-docker
+	@test -f $(DOCKER_ENV) || { \
+	  echo "❌  $(DOCKER_ENV) missing."; \
+	  echo "    Copy the template and fill in GITHUB_TOKEN + your AI API key:"; \
+	  echo "    cp docker/.env.example $(DOCKER_ENV)"; \
+	  exit 1; \
+	}
+
+up: _check-env
+	docker compose -f $(COMPOSE_FILE) up -d
+
+up-daemon: _check-env
+	docker compose -f $(COMPOSE_FILE) up -d heimdallm
+
+down: _check-docker
+	docker compose -f $(COMPOSE_FILE) down
+
+logs: _check-docker
+	docker compose -f $(COMPOSE_FILE) logs -f
+
+logs-daemon: _check-docker
+	docker compose -f $(COMPOSE_FILE) logs -f heimdallm
+
+ps: _check-docker
+	docker compose -f $(COMPOSE_FILE) ps
+
+restart: _check-docker
+	docker compose -f $(COMPOSE_FILE) restart
 
 # ── CI packaging (used by GitHub Actions) ─────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,11 @@ make logs          # tail logs from daemon + web
 make logs-daemon   # daemon only
 make restart       # restart both containers
 make down          # stop and remove containers (data volume persists)
-make setup         # (optional) copy the daemon API token into docker/.env
-                   #  for scripts / CI / local curl from the host
+make setup         # (optional) copy the daemon API token into docker/.env.
+                   #  Only needed if you want to call the daemon's HTTP API
+                   #  from outside Docker (scripts, CI, `curl` from the host).
+                   #  The web UI does NOT need this — it reads the token from
+                   #  the shared volume automatically.
 ```
 
 The Docker image is published to `ghcr.io/theburrowhub/heimdallm:latest` on every release — `make up` pulls it automatically when the `build:` contexts haven't changed locally.

--- a/README.md
+++ b/README.md
@@ -50,48 +50,69 @@ Installs to `/opt/heimdallm/` with a desktop entry and `/usr/bin/heimdallm` syml
 
 ### Docker
 
-For headless/server deployment, Heimdallm runs as a Docker container with all four AI CLIs bundled.
+For headless/server deployment, Heimdallm runs as a Docker container with all four AI CLIs bundled. The repository ships Make wrappers around `docker compose` so you don't have to remember the compose path.
+
+#### 1. Prerequisites
+
+- **Docker Desktop** (or Docker Engine + compose plugin) running.
+- A **GitHub personal access token** with `repo` scope (or `public_repo` for public-only). Create one at https://github.com/settings/tokens.
+- An **API key for your chosen AI provider** — at least one of:
+  - Claude: https://console.anthropic.com/settings/keys (or `CLAUDE_CODE_OAUTH_TOKEN` via `claude setup-token`)
+  - Gemini: https://aistudio.google.com/apikey
+  - OpenAI / Codex: https://platform.openai.com/api-keys
+  - OpenRouter (for OpenCode): https://openrouter.ai/keys
+
+#### 2. Configure
 
 ```bash
-# 1. Set up configuration
-cd docker
-cp .env.example .env
-# Edit .env — set GITHUB_TOKEN, HEIMDALLM_REPOSITORIES, and AI API key(s)
-
-# 2. Start the service
-docker compose up -d
-
-# 3. Verify
-curl http://localhost:7842/health
-# {"status":"ok"}
+cp docker/.env.example docker/.env
+# Edit docker/.env — at minimum fill in:
+#   GITHUB_TOKEN
+#   HEIMDALLM_AI_PRIMARY      (claude | gemini | codex | opencode)
+#   <provider>_API_KEY        (matching your primary)
+#   HEIMDALLM_REPOSITORIES    (owner/repo1,owner/repo2 — or leave empty if
+#                              using HEIMDALLM_DISCOVERY_TOPIC)
 ```
 
-The Docker image is published to `ghcr.io/theburrowhub/heimdallm:latest` on every release. See [`docker/.env.example`](docker/.env.example) for all configuration options.
+See [`docker/.env.example`](docker/.env.example) for every supported variable including issue-tracking, topic-based discovery, and web UI settings.
 
-#### Web UI alongside the daemon (optional)
-
-The compose file ships a second service, `web`, that serves the SvelteKit
-admin UI on port `3000`. It starts alongside the daemon by default; to keep
-the previous daemon-only behaviour, name the service explicitly
-(`docker compose up -d heimdallm`).
+#### 3. Start the stack
 
 ```bash
-# Start both services (web waits for the daemon's healthcheck)
-docker compose -f docker/docker-compose.yml up -d
-
-# Then open the UI in your browser of choice:
-#   macOS:   open http://localhost:3000
-#   Linux:   xdg-open http://localhost:3000
-#   Or just browse to http://localhost:3000 manually.
+make up            # daemon + web UI (recommended)
+# or:
+make up-daemon     # daemon only, no web UI
 ```
 
-The `web` container reads the daemon's API token from the shared
-`heimdallm-data` volume automatically — no manual copy needed. If you prefer
-to pin it explicitly (for scripting, CI, or running `curl` against the daemon
-from your host), run `make setup` once the daemon is up and it will extract
-the token into `docker/.env` as `HEIMDALLM_API_TOKEN`. Rerunning the target
-replaces the line instead of appending, so it's safe to call again after a
-daemon reset.
+`make up` refuses to start if `docker/.env` is missing and prints the exact copy-from-template command. The web container waits for the daemon's healthcheck before accepting traffic, so the first UI request never races a half-initialised daemon.
+
+#### 4. Verify
+
+```bash
+make ps                          # show container status
+curl http://localhost:7842/health  # -> {"status":"ok"}
+```
+
+Then open the web UI:
+
+- macOS: `open http://localhost:3000`
+- Linux: `xdg-open http://localhost:3000`
+- Or browse to `http://localhost:3000` manually.
+
+The `web` container reads the daemon's API token from the shared `heimdallm-data` volume automatically — no manual copy needed.
+
+#### 5. Day-to-day commands
+
+```bash
+make logs          # tail logs from daemon + web
+make logs-daemon   # daemon only
+make restart       # restart both containers
+make down          # stop and remove containers (data volume persists)
+make setup         # (optional) copy the daemon API token into docker/.env
+                   #  for scripts / CI / local curl from the host
+```
+
+The Docker image is published to `ghcr.io/theburrowhub/heimdallm:latest` on every release — `make up` pulls it automatically when the `build:` contexts haven't changed locally.
 
 #### Auto-discover repositories by topic
 


### PR DESCRIPTION
Closes #69.

## Summary

- Adds Make wrappers around the Docker compose flow so newcomers can get the stack up with `make up` instead of `docker compose -f docker/docker-compose.yml up -d`.
- Rewrites the README **Docker** section as a linear end-to-end setup guide (prerequisites → configure → start → verify → day-to-day) built on those targets.
- Updates the existing `setup` hint text to suggest `make up-daemon` over the raw compose invocation.

## New Make targets

| Target | What it does |
|--------|--------------|
| `make up` | `docker compose up -d` (daemon + web) |
| `make up-daemon` | `docker compose up -d heimdallm` (daemon only) |
| `make down` | `docker compose down` |
| `make logs` | `docker compose logs -f` (whole stack) |
| `make logs-daemon` | `docker compose logs -f heimdallm` |
| `make ps` | `docker compose ps` |
| `make restart` | `docker compose restart` |

All targets share `_check-docker` (Docker available) and, for `up`/`up-daemon`, `_check-env` (docker/.env present, otherwise print the exact copy-from-template command). `COMPOSE_FILE` is reused from the existing `setup` target so the compose path lives in one place.

## README

The Docker section is now a single flow:

1. Prerequisites — Docker, GitHub token, provider API key (with links to each provider's key page).
2. Configure — `cp docker/.env.example docker/.env` with a checklist of minimum variables.
3. Start — `make up` (or `make up-daemon`).
4. Verify — `make ps`, `curl :7842/health`, browse to `:3000`.
5. Day-to-day — `make logs` / `make restart` / `make down` / `make setup`.

Keeps the cross-platform notes (macOS `open`, Linux `xdg-open`, manual browse) that #68 added — I didn't want to regress that.

## Out of scope

- `docker/docker-compose.yml`, Dockerfiles, and `make setup` logic are untouched.
- `AGENTS.md` untouched — its scope is tests, not compose orchestration.
- No daemon / web_ui / Flutter changes.

## Test plan

- [x] `make -n up` with missing `docker/.env` exits with actionable error
- [x] `make -n up` with `docker/.env` present prints the expected `docker compose up -d`
- [x] All other dry-runs match the expected compose invocation
- [ ] Reviewer: run `make up` on a fresh checkout, confirm web UI reaches `:3000`
- [ ] Reviewer: run `make down` and confirm containers stopped