### PR TITLE
feat(web_ui): dark mode with system / light / dark toggle

### DIFF
--- a/web_ui/src/app.css
+++ b/web_ui/src/app.css
@@ -1,7 +1,15 @@
 @import 'tailwindcss';
 
+/* Opt into class-based dark mode so a manual toggle in the header can
+   override `prefers-color-scheme`. With v4 the variant is user-defined. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
+}
+
+:root.dark {
+  color-scheme: dark;
 }
 
 html,

--- a/web_ui/src/app.html
+++ b/web_ui/src/app.html
@@ -4,9 +4,28 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Heimdallm</title>
+    <script>
+      // Resolve the theme before the first paint to avoid a light→dark flash
+      // when the user prefers dark. Mirrors src/lib/theme.ts — keep in sync.
+      (function () {
+        try {
+          var choice = localStorage.getItem('heimdallm-theme') || 'system';
+          var isDark =
+            choice === 'dark' ||
+            (choice === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (isDark) document.documentElement.classList.add('dark');
+        } catch (_) {
+          // localStorage unavailable (private mode, SSR hydration, etc.) —
+          // fall through and let the client-side helper handle it.
+        }
+      })();
+    </script>
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data="hover" class="min-h-screen bg-white text-gray-900 antialiased">
+  <body
+    data-sveltekit-preload-data="hover"
+    class="min-h-screen bg-white text-gray-900 antialiased dark:bg-gray-950 dark:text-gray-100"
+  >
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/web_ui/src/lib/components/CollapseHeader.svelte
+++ b/web_ui/src/lib/components/CollapseHeader.svelte
@@ -12,11 +12,13 @@
 <button
   type="button"
   onclick={onToggle}
-  class="flex w-full items-center gap-2 border-b border-gray-200 bg-gray-50 px-4 py-2 text-left hover:bg-gray-100"
+  class="flex w-full items-center gap-2 border-b border-gray-200 bg-gray-50 px-4 py-2 text-left hover:bg-gray-100 dark:border-gray-800 dark:bg-gray-900 dark:hover:bg-gray-800"
   aria-expanded={expanded}
 >
   <svg
-    class="h-4 w-4 shrink-0 text-gray-500 transition-transform {expanded ? 'rotate-90' : ''}"
+    class="h-4 w-4 shrink-0 text-gray-500 transition-transform dark:text-gray-400 {expanded
+      ? 'rotate-90'
+      : ''}"
     viewBox="0 0 20 20"
     fill="currentColor"
     aria-hidden="true"
@@ -27,6 +29,9 @@
       clip-rule="evenodd"
     />
   </svg>
-  <span class="text-sm font-semibold text-gray-700">{title}</span>
-  <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-600">{count}</span>
+  <span class="text-sm font-semibold text-gray-700 dark:text-gray-200">{title}</span>
+  <span
+    class="rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+    >{count}</span
+  >
 </button>

--- a/web_ui/src/lib/components/ConnectionPill.svelte
+++ b/web_ui/src/lib/components/ConnectionPill.svelte
@@ -4,7 +4,11 @@
 
   const connected = getContext<Readable<boolean>>('sse-connected');
 
-  const cls = $derived($connected ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700');
+  const cls = $derived(
+    $connected
+      ? 'bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300'
+      : 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300'
+  );
   const label = $derived($connected ? 'connected' : 'disconnected');
 </script>
 

--- a/web_ui/src/lib/components/IssueFilterBar.svelte
+++ b/web_ui/src/lib/components/IssueFilterBar.svelte
@@ -22,12 +22,12 @@
 </script>
 
 <div
-  class="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-gray-200 bg-gray-50 p-3"
+  class="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-800 dark:bg-gray-900"
 >
-  <label class="flex items-center gap-1 text-xs text-gray-600">
+  <label class="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-300">
     <span>Repo:</span>
     <select
-      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
       value={filters.repo}
       onchange={(e) => update('repo', (e.currentTarget as HTMLSelectElement).value)}
     >
@@ -38,10 +38,10 @@
     </select>
   </label>
 
-  <label class="flex items-center gap-1 text-xs text-gray-600">
+  <label class="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-300">
     <span>Severity:</span>
     <select
-      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
       value={filters.severity || 'any'}
       onchange={(e) => update('severity', (e.currentTarget as HTMLSelectElement).value)}
     >
@@ -51,10 +51,10 @@
     </select>
   </label>
 
-  <label class="flex items-center gap-1 text-xs text-gray-600">
+  <label class="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-300">
     <span>Mode:</span>
     <select
-      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
       value={filters.mode ?? 'all'}
       onchange={(e) => update('mode', (e.currentTarget as HTMLSelectElement).value)}
     >

--- a/web_ui/src/lib/components/IssueReviewCard.svelte
+++ b/web_ui/src/lib/components/IssueReviewCard.svelte
@@ -7,24 +7,28 @@
   const triage = $derived(review.triage);
 </script>
 
-<article class="mb-3 rounded-md border border-gray-200 bg-white p-4">
+<article
+  class="mb-3 rounded-md border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900"
+>
   <header class="mb-2 flex items-center justify-between gap-2">
     <div class="flex items-center gap-2">
       {#if triage.severity}
         <SeverityBadge severity={triage.severity} />
       {/if}
-      <span class="text-xs text-gray-500">{review.cli_used}</span>
+      <span class="text-xs text-gray-500 dark:text-gray-400">{review.cli_used}</span>
     </div>
-    <time class="text-xs text-gray-400" datetime={review.created_at}>
+    <time class="text-xs text-gray-400 dark:text-gray-500" datetime={review.created_at}>
       {new Date(review.created_at).toLocaleString()}
     </time>
   </header>
 
   {#if review.summary}
-    <p class="text-sm text-gray-800">{review.summary}</p>
+    <p class="text-sm text-gray-800 dark:text-gray-200">{review.summary}</p>
   {/if}
 
-  <section class="mt-3 rounded bg-gray-50 p-2 text-xs text-gray-700">
+  <section
+    class="mt-3 rounded bg-gray-50 p-2 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+  >
     {#if triage.severity}<div><strong>Severity:</strong> {triage.severity}</div>{/if}
     {#if triage.category}<div><strong>Category:</strong> {triage.category}</div>{/if}
     {#if typeof triage.suggested_assignee === 'string' && triage.suggested_assignee}
@@ -34,8 +38,10 @@
 
   {#if review.suggestions.length > 0}
     <section class="mt-3">
-      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Suggestions</h4>
-      <ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-gray-800">
+      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        Suggestions
+      </h4>
+      <ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-gray-800 dark:text-gray-200">
         {#each review.suggestions as s, i (i)}
           <li>{typeof s === 'string' ? s : JSON.stringify(s)}</li>
         {/each}
@@ -45,7 +51,10 @@
 
   {#if review.action_taken === 'auto_implement' && review.pr_created > 0}
     <p class="mt-3 text-xs">
-      <a href="/prs/{review.pr_created}" class="text-indigo-600 hover:underline">
+      <a
+        href="/prs/{review.pr_created}"
+        class="text-indigo-600 hover:underline dark:text-indigo-400"
+      >
         View created PR →
       </a>
     </p>

--- a/web_ui/src/lib/components/IssueTile.svelte
+++ b/web_ui/src/lib/components/IssueTile.svelte
@@ -17,11 +17,14 @@
   });
 </script>
 
-<a href="/issues/{issue.id}" class="block border-b border-gray-100 px-4 py-3 hover:bg-gray-50">
+<a
+  href="/issues/{issue.id}"
+  class="block border-b border-gray-100 px-4 py-3 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-900"
+>
   <div class="flex items-start gap-3">
     <div class="min-w-0 flex-1">
-      <p class="truncate text-sm font-medium text-gray-900">{issue.title}</p>
-      <p class="mt-0.5 truncate text-xs text-gray-500">
+      <p class="truncate text-sm font-medium text-gray-900 dark:text-gray-100">{issue.title}</p>
+      <p class="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-400">
         <span class="font-mono">{issue.repo}</span>
         · #{issue.number}
         · {issue.author}
@@ -30,8 +33,8 @@
         <span
           class="mt-1 inline-flex rounded px-1.5 py-0.5 text-[10px] font-medium
           {mode === 'auto_implement'
-            ? 'bg-indigo-100 text-indigo-700'
-            : 'bg-blue-100 text-blue-700'}"
+            ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300'
+            : 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300'}"
         >
           {mode}
         </span>
@@ -39,12 +42,14 @@
     </div>
     <div class="flex shrink-0 items-center gap-2">
       {#if isReviewing}
-        <span class="text-xs text-indigo-600">reviewing…</span>
+        <span class="text-xs text-indigo-600 dark:text-indigo-400">reviewing…</span>
       {/if}
       {#if severity}
         <SeverityBadge {severity} />
       {:else}
-        <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+        <span
+          class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+        >
           PENDING
         </span>
       {/if}

--- a/web_ui/src/lib/components/PRFilterBar.svelte
+++ b/web_ui/src/lib/components/PRFilterBar.svelte
@@ -22,12 +22,12 @@
 </script>
 
 <div
-  class="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-gray-200 bg-gray-50 p-3"
+  class="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-800 dark:bg-gray-900"
 >
-  <label class="flex items-center gap-1 text-xs text-gray-600">
+  <label class="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-300">
     <span>Repo:</span>
     <select
-      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
       value={filters.repo}
       onchange={(e) => update('repo', (e.currentTarget as HTMLSelectElement).value)}
     >
@@ -38,10 +38,10 @@
     </select>
   </label>
 
-  <label class="flex items-center gap-1 text-xs text-gray-600">
+  <label class="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-300">
     <span>Severity:</span>
     <select
-      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
       value={filters.severity || 'any'}
       onchange={(e) => update('severity', (e.currentTarget as HTMLSelectElement).value)}
     >
@@ -51,10 +51,10 @@
     </select>
   </label>
 
-  <label class="flex items-center gap-1 text-xs text-gray-600">
+  <label class="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-300">
     <span>State:</span>
     <select
-      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs"
+      class="rounded border border-gray-300 bg-white px-2 py-1 text-xs dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
       value={filters.state ?? 'open'}
       onchange={(e) => update('state', (e.currentTarget as HTMLSelectElement).value)}
     >

--- a/web_ui/src/lib/components/PRReviewCard.svelte
+++ b/web_ui/src/lib/components/PRReviewCard.svelte
@@ -5,32 +5,35 @@
   let { review }: { review: Review } = $props();
 </script>
 
-<article class="mb-3 rounded-md border border-gray-200 bg-white p-4">
+<article
+  class="mb-3 rounded-md border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900"
+>
   <header class="mb-2 flex items-center justify-between gap-2">
     <div class="flex items-center gap-2">
       <SeverityBadge severity={review.severity} />
-      <span class="text-xs text-gray-500">{review.cli_used}</span>
+      <span class="text-xs text-gray-500 dark:text-gray-400">{review.cli_used}</span>
     </div>
-    <time class="text-xs text-gray-400" datetime={review.created_at}>
+    <time class="text-xs text-gray-400 dark:text-gray-500" datetime={review.created_at}>
       {new Date(review.created_at).toLocaleString()}
     </time>
   </header>
 
   {#if review.summary}
-    <p class="text-sm text-gray-800">{review.summary}</p>
+    <p class="text-sm text-gray-800 dark:text-gray-200">{review.summary}</p>
   {/if}
 
   {#if review.issues.length > 0}
     <section class="mt-3">
-      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">
+      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
         Findings ({review.issues.length})
       </h4>
       <ul class="mt-1 space-y-1 text-sm">
         {#each review.issues as f (f.file + f.line + f.description)}
           <li class="flex items-start gap-2">
             <SeverityBadge severity={f.severity} />
-            <span class="font-mono text-xs text-gray-500">{f.file}:{f.line}</span>
-            <span class="text-gray-800">{f.description}</span>
+            <span class="font-mono text-xs text-gray-500 dark:text-gray-400">{f.file}:{f.line}</span
+            >
+            <span class="text-gray-800 dark:text-gray-200">{f.description}</span>
           </li>
         {/each}
       </ul>
@@ -39,8 +42,10 @@
 
   {#if review.suggestions.length > 0}
     <section class="mt-3">
-      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Suggestions</h4>
-      <ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-gray-800">
+      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        Suggestions
+      </h4>
+      <ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-gray-800 dark:text-gray-200">
         {#each review.suggestions as s, i (i)}
           <li>{typeof s === 'string' ? s : JSON.stringify(s)}</li>
         {/each}

--- a/web_ui/src/lib/components/PRTile.svelte
+++ b/web_ui/src/lib/components/PRTile.svelte
@@ -9,11 +9,14 @@
   const severity = $derived(pr.latest_review?.severity ?? null);
 </script>
 
-<a href="/prs/{pr.id}" class="block border-b border-gray-100 px-4 py-3 hover:bg-gray-50">
+<a
+  href="/prs/{pr.id}"
+  class="block border-b border-gray-100 px-4 py-3 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-900"
+>
   <div class="flex items-start gap-3">
     <div class="min-w-0 flex-1">
-      <p class="truncate text-sm font-medium text-gray-900">{pr.title}</p>
-      <p class="mt-0.5 truncate text-xs text-gray-500">
+      <p class="truncate text-sm font-medium text-gray-900 dark:text-gray-100">{pr.title}</p>
+      <p class="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-400">
         <span class="font-mono">{pr.repo}</span>
         · #{pr.number}
         · {pr.author}
@@ -21,7 +24,9 @@
     </div>
     <div class="flex shrink-0 items-center gap-2">
       {#if isReviewing}
-        <span class="text-xs text-indigo-600" data-testid="reviewing-spinner">reviewing…</span>
+        <span class="text-xs text-indigo-600 dark:text-indigo-400" data-testid="reviewing-spinner"
+          >reviewing…</span
+        >
       {/if}
       <SeverityBadge {severity} />
     </div>

--- a/web_ui/src/lib/components/SeverityBadge.svelte
+++ b/web_ui/src/lib/components/SeverityBadge.svelte
@@ -4,7 +4,11 @@
   let { severity }: { severity: string | null | undefined } = $props();
 
   const label = $derived((severity ?? 'none').toUpperCase());
-  const cls = $derived(severity ? severityClass(severity) : 'bg-gray-100 text-gray-500');
+  const cls = $derived(
+    severity
+      ? severityClass(severity)
+      : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'
+  );
 </script>
 
 <span class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {cls}">

--- a/web_ui/src/lib/components/StatsCards.svelte
+++ b/web_ui/src/lib/components/StatsCards.svelte
@@ -13,9 +13,15 @@
 
 <section class="grid grid-cols-2 gap-4 md:grid-cols-4">
   {#each cells as cell (cell.label)}
-    <div class="rounded-lg border border-gray-200 bg-white p-4">
-      <dt class="text-xs uppercase tracking-wide text-gray-500">{cell.label}</dt>
-      <dd class="mt-1 text-2xl font-semibold">{cell.value ?? '—'}</dd>
+    <div
+      class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900"
+    >
+      <dt class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {cell.label}
+      </dt>
+      <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">
+        {cell.value ?? '—'}
+      </dd>
     </div>
   {/each}
 </section>

--- a/web_ui/src/lib/severity.ts
+++ b/web_ui/src/lib/severity.ts
@@ -1,8 +1,13 @@
+// Default (and `low`) palette — also returned for unknown severities so
+// they blend into the neutral UI chrome. Extracted as a constant so the
+// two consumers below can't drift apart.
+const NEUTRAL_BADGE = 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400';
+
 const CLASSES: Record<string, string> = {
   critical: 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300',
   high: 'bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-300',
   medium: 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300',
-  low: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+  low: NEUTRAL_BADGE
 };
 
 const ORDER: Record<string, number> = {
@@ -13,9 +18,7 @@ const ORDER: Record<string, number> = {
 };
 
 export function severityClass(sev: string): string {
-  return (
-    CLASSES[sev.toLowerCase()] ?? 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-  );
+  return CLASSES[sev.toLowerCase()] ?? NEUTRAL_BADGE;
 }
 
 export function severityOrder(sev: string): number {

--- a/web_ui/src/lib/severity.ts
+++ b/web_ui/src/lib/severity.ts
@@ -1,8 +1,8 @@
 const CLASSES: Record<string, string> = {
-  critical: 'bg-red-100 text-red-700',
-  high: 'bg-orange-100 text-orange-700',
-  medium: 'bg-amber-100 text-amber-700',
-  low: 'bg-gray-100 text-gray-600'
+  critical: 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300',
+  high: 'bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-300',
+  medium: 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300',
+  low: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
 };
 
 const ORDER: Record<string, number> = {
@@ -13,7 +13,9 @@ const ORDER: Record<string, number> = {
 };
 
 export function severityClass(sev: string): string {
-  return CLASSES[sev.toLowerCase()] ?? 'bg-gray-100 text-gray-600';
+  return (
+    CLASSES[sev.toLowerCase()] ?? 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+  );
 }
 
 export function severityOrder(sev: string): number {

--- a/web_ui/src/lib/theme.ts
+++ b/web_ui/src/lib/theme.ts
@@ -1,6 +1,10 @@
 export type ThemeChoice = 'system' | 'light' | 'dark';
 
-const STORAGE_KEY = 'heimdallm-theme';
+// Must stay in lockstep with the pre-paint script in src/app.html (the key
+// there is a hardcoded string literal because app.html can't import TS).
+// The theme.test.ts `STORAGE_KEY stays in sync with app.html` case guards
+// against silent drift between the two.
+export const STORAGE_KEY = 'heimdallm-theme';
 const VALID_CHOICES: readonly ThemeChoice[] = ['system', 'light', 'dark'] as const;
 
 function isBrowser(): boolean {
@@ -29,9 +33,21 @@ function saveThemeChoice(choice: ThemeChoice): void {
   }
 }
 
+// Cached MediaQueryList — subscribe/unsubscribe used to call matchMedia()
+// independently, which worked but obscured the fact that both paths must
+// share the same object so removeEventListener matches.
+let darkMediaQuery: MediaQueryList | null = null;
+
+function darkMedia(): MediaQueryList | null {
+  if (!isBrowser() || typeof window.matchMedia !== 'function') return null;
+  if (!darkMediaQuery) {
+    darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  }
+  return darkMediaQuery;
+}
+
 function systemPrefersDark(): boolean {
-  if (!isBrowser()) return false;
-  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return darkMedia()?.matches ?? false;
 }
 
 function resolveDark(choice: ThemeChoice): boolean {
@@ -47,17 +63,23 @@ function applyDarkClass(isDark: boolean): void {
 
 // Track the single active media listener so setThemeChoice('system') after
 // setThemeChoice('light') re-subscribes without leaking the previous one.
+//
+// This is module-level mutable state, which is safe here because every
+// caller is browser-only (initTheme short-circuits during SSR via
+// isBrowser()). If this helper ever gains a server-side path, the state
+// must move into a per-request scope.
 let mediaListener: ((event: MediaQueryListEvent) => void) | null = null;
 
 function unsubscribeSystem(): void {
-  if (!isBrowser() || !mediaListener) return;
-  window.matchMedia('(prefers-color-scheme: dark)').removeEventListener('change', mediaListener);
+  const mq = darkMedia();
+  if (!mq || !mediaListener) return;
+  mq.removeEventListener('change', mediaListener);
   mediaListener = null;
 }
 
 function subscribeSystem(): void {
-  if (!isBrowser() || mediaListener) return;
-  const mq = window.matchMedia('(prefers-color-scheme: dark)');
+  const mq = darkMedia();
+  if (!mq || mediaListener) return;
   mediaListener = (event: MediaQueryListEvent) => {
     applyDarkClass(event.matches);
   };
@@ -91,7 +113,9 @@ export function initTheme(): ThemeChoice {
   return choice;
 }
 
-// Test hook: clears the media listener so tests can observe clean state.
+// Test hook: clears the media listener and the cached MediaQueryList so
+// tests that install a fresh fake matchMedia observe clean state.
 export function __resetThemeForTests(): void {
   unsubscribeSystem();
+  darkMediaQuery = null;
 }

--- a/web_ui/src/lib/theme.ts
+++ b/web_ui/src/lib/theme.ts
@@ -1,0 +1,97 @@
+export type ThemeChoice = 'system' | 'light' | 'dark';
+
+const STORAGE_KEY = 'heimdallm-theme';
+const VALID_CHOICES: readonly ThemeChoice[] = ['system', 'light', 'dark'] as const;
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+export function loadThemeChoice(): ThemeChoice {
+  if (!isBrowser()) return 'system';
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw && (VALID_CHOICES as readonly string[]).includes(raw)) {
+      return raw as ThemeChoice;
+    }
+  } catch {
+    // localStorage blocked (Safari private mode, tightened site settings).
+  }
+  return 'system';
+}
+
+function saveThemeChoice(choice: ThemeChoice): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, choice);
+  } catch {
+    // Best-effort — the in-memory choice still drives the UI this session.
+  }
+}
+
+function systemPrefersDark(): boolean {
+  if (!isBrowser()) return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+function resolveDark(choice: ThemeChoice): boolean {
+  if (choice === 'dark') return true;
+  if (choice === 'light') return false;
+  return systemPrefersDark();
+}
+
+function applyDarkClass(isDark: boolean): void {
+  if (!isBrowser()) return;
+  document.documentElement.classList.toggle('dark', isDark);
+}
+
+// Track the single active media listener so setThemeChoice('system') after
+// setThemeChoice('light') re-subscribes without leaking the previous one.
+let mediaListener: ((event: MediaQueryListEvent) => void) | null = null;
+
+function unsubscribeSystem(): void {
+  if (!isBrowser() || !mediaListener) return;
+  window.matchMedia('(prefers-color-scheme: dark)').removeEventListener('change', mediaListener);
+  mediaListener = null;
+}
+
+function subscribeSystem(): void {
+  if (!isBrowser() || mediaListener) return;
+  const mq = window.matchMedia('(prefers-color-scheme: dark)');
+  mediaListener = (event: MediaQueryListEvent) => {
+    applyDarkClass(event.matches);
+  };
+  mq.addEventListener('change', mediaListener);
+}
+
+/**
+ * Apply the given theme choice: toggle the `dark` class on <html>, persist
+ * the choice, and (for 'system') keep the UI in sync with OS changes.
+ *
+ * Idempotent and safe to call on every page load.
+ */
+export function setThemeChoice(choice: ThemeChoice): void {
+  saveThemeChoice(choice);
+  applyDarkClass(resolveDark(choice));
+  if (choice === 'system') {
+    subscribeSystem();
+  } else {
+    unsubscribeSystem();
+  }
+}
+
+/**
+ * Initialise the theme system on client mount. Re-reads the stored choice
+ * and re-applies it — the inline script in app.html already set the class
+ * pre-paint, so this is mainly about wiring up the system media listener.
+ */
+export function initTheme(): ThemeChoice {
+  const choice = loadThemeChoice();
+  setThemeChoice(choice);
+  return choice;
+}
+
+// Test hook: clears the media listener so tests can observe clean state.
+export function __resetThemeForTests(): void {
+  unsubscribeSystem();
+}

--- a/web_ui/src/routes/+layout.svelte
+++ b/web_ui/src/routes/+layout.svelte
@@ -53,10 +53,10 @@
     { href: '/logs', label: 'Logs' }
   ];
 
-  const themeOptions: { value: ThemeChoice; label: string; title: string }[] = [
-    { value: 'light', label: '☀', title: 'Light' },
-    { value: 'system', label: '🖥', title: 'System' },
-    { value: 'dark', label: '🌙', title: 'Dark' }
+  const themeOptions: { value: ThemeChoice; title: string }[] = [
+    { value: 'light', title: 'Light' },
+    { value: 'system', title: 'System' },
+    { value: 'dark', title: 'Dark' }
   ];
 </script>
 
@@ -94,11 +94,51 @@
             aria-checked={themeChoice === opt.value}
             title={opt.title}
             onclick={() => chooseTheme(opt.value)}
-            class="px-2 py-1 {themeChoice === opt.value
+            class="flex items-center justify-center px-2 py-1.5 {themeChoice === opt.value
               ? 'bg-indigo-600 text-white dark:bg-indigo-500'
               : 'bg-white text-gray-600 hover:bg-gray-50 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800'}"
           >
-            <span aria-hidden="true">{opt.label}</span>
+            {#if opt.value === 'light'}
+              <svg
+                class="h-4 w-4"
+                viewBox="0 0 20 20"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                aria-hidden="true"
+              >
+                <circle cx="10" cy="10" r="3.2" />
+                <path d="M10 2.5v1.8M10 15.7v1.8M3.5 10H1.7M18.3 10h-1.8" />
+                <path d="M5.2 5.2l1.3 1.3M13.5 13.5l1.3 1.3M5.2 14.8l1.3-1.3M13.5 6.5l1.3-1.3" />
+              </svg>
+            {:else if opt.value === 'system'}
+              <svg
+                class="h-4 w-4"
+                viewBox="0 0 20 20"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="2.5" y="3.5" width="15" height="10" rx="1.5" />
+                <path d="M7 17h6M10 13.5V17" stroke-linecap="round" />
+              </svg>
+            {:else}
+              <svg
+                class="h-4 w-4"
+                viewBox="0 0 20 20"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M16.5 12.3A7 7 0 1 1 7.7 3.5a5.6 5.6 0 0 0 8.8 8.8z" />
+              </svg>
+            {/if}
             <span class="sr-only">{opt.title}</span>
           </button>
         {/each}

--- a/web_ui/src/routes/+layout.svelte
+++ b/web_ui/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
   import { connectEvents, type EventsHandle } from '$lib/sse.js';
   import { initSseBridge, watchReconnectAndSweep } from '$lib/sseBridge.js';
   import { auth } from '$lib/stores.js';
+  import { initTheme, setThemeChoice, type ThemeChoice } from '$lib/theme.js';
   import { onDestroy, onMount, setContext } from 'svelte';
   import { writable, type Readable } from 'svelte/store';
 
@@ -20,8 +21,11 @@
   let bridgeUnsub: (() => void) | undefined;
   let reconnectUnsub: (() => void) | undefined;
 
+  let themeChoice = $state<ThemeChoice>('system');
+
   onMount(() => {
     if (!browser) return;
+    themeChoice = initTheme();
     sse = connectEvents();
     connUnsub = sse.connected.subscribe((v) => connected.set(v));
     bridgeUnsub = initSseBridge(sse.events);
@@ -35,6 +39,11 @@
     sse?.close();
   });
 
+  function chooseTheme(choice: ThemeChoice) {
+    themeChoice = choice;
+    setThemeChoice(choice);
+  }
+
   const navItems = [
     { href: '/', label: 'Dashboard' },
     { href: '/prs', label: 'PRs' },
@@ -43,34 +52,68 @@
     { href: '/config', label: 'Config' },
     { href: '/logs', label: 'Logs' }
   ];
+
+  const themeOptions: { value: ThemeChoice; label: string; title: string }[] = [
+    { value: 'light', label: '☀', title: 'Light' },
+    { value: 'system', label: '🖥', title: 'System' },
+    { value: 'dark', label: '🌙', title: 'Dark' }
+  ];
 </script>
 
-<header class="border-b border-gray-200 bg-white">
+<header class="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
   <nav class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-3">
-    <a href="/" class="text-lg font-semibold tracking-tight">Heimdallm</a>
+    <a href="/" class="text-lg font-semibold tracking-tight text-gray-900 dark:text-gray-100"
+      >Heimdallm</a
+    >
     <ul class="flex items-center gap-4 text-sm">
       {#each navItems as item (item.href)}
         <li>
           <a
             href={item.href}
             aria-current={$page.url.pathname === item.href ? 'page' : undefined}
-            class="hover:text-indigo-600 {$page.url.pathname === item.href
-              ? 'text-indigo-600 font-medium'
-              : 'text-gray-600'}"
+            class="hover:text-indigo-600 dark:hover:text-indigo-400 {$page.url.pathname ===
+            item.href
+              ? 'font-medium text-indigo-600 dark:text-indigo-400'
+              : 'text-gray-600 dark:text-gray-400'}"
           >
             {item.label}
           </a>
         </li>
       {/each}
     </ul>
-    <span class="text-sm text-gray-500" data-testid="login">
-      {$auth.login ?? '—'}
-    </span>
+    <div class="flex items-center gap-3">
+      <div
+        role="radiogroup"
+        aria-label="Theme"
+        class="inline-flex overflow-hidden rounded-md border border-gray-200 text-xs dark:border-gray-700"
+      >
+        {#each themeOptions as opt (opt.value)}
+          <button
+            type="button"
+            role="radio"
+            aria-checked={themeChoice === opt.value}
+            title={opt.title}
+            onclick={() => chooseTheme(opt.value)}
+            class="px-2 py-1 {themeChoice === opt.value
+              ? 'bg-indigo-600 text-white dark:bg-indigo-500'
+              : 'bg-white text-gray-600 hover:bg-gray-50 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800'}"
+          >
+            <span aria-hidden="true">{opt.label}</span>
+            <span class="sr-only">{opt.title}</span>
+          </button>
+        {/each}
+      </div>
+      <span class="text-sm text-gray-500 dark:text-gray-400" data-testid="login">
+        {$auth.login ?? '—'}
+      </span>
+    </div>
   </nav>
 </header>
 
 {#if $auth.authError}
-  <div class="border-b border-red-200 bg-red-50 px-6 py-2 text-sm text-red-700">
+  <div
+    class="border-b border-red-200 bg-red-50 px-6 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300"
+  >
     Daemon unreachable — check <code>HEIMDALLM_API_URL</code>. ({$auth.authError})
   </div>
 {/if}

--- a/web_ui/src/routes/+layout.svelte
+++ b/web_ui/src/routes/+layout.svelte
@@ -83,18 +83,24 @@
     </ul>
     <div class="flex items-center gap-3">
       <div
-        role="radiogroup"
         aria-label="Theme"
         class="inline-flex overflow-hidden rounded-md border border-gray-200 text-xs dark:border-gray-700"
       >
+        <!--
+          Not using role="radiogroup" / role="radio": the WAI-ARIA radio
+          pattern requires arrow-key navigation between options, which adds
+          complexity this simple 3-choice toggle does not need. Plain
+          buttons with aria-pressed convey the same state to AT and keep
+          Tab-navigation behaviour unchanged.
+        -->
         {#each themeOptions as opt (opt.value)}
           <button
             type="button"
-            role="radio"
-            aria-checked={themeChoice === opt.value}
+            aria-pressed={themeChoice === opt.value}
             title={opt.title}
             onclick={() => chooseTheme(opt.value)}
-            class="flex items-center justify-center px-2 py-1.5 {themeChoice === opt.value
+            class="flex items-center justify-center px-2 py-1.5 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset {themeChoice ===
+            opt.value
               ? 'bg-indigo-600 text-white dark:bg-indigo-500'
               : 'bg-white text-gray-600 hover:bg-gray-50 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800'}"
           >

--- a/web_ui/src/routes/+page.svelte
+++ b/web_ui/src/routes/+page.svelte
@@ -73,20 +73,20 @@
 </script>
 
 <section class="mb-6 flex items-center gap-3">
-  <h1 class="text-3xl font-bold">Dashboard</h1>
+  <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Dashboard</h1>
   <ConnectionPill />
 </section>
 
 <StatsCards {stats} />
 
 <section class="mt-6 mb-3 flex items-center gap-2">
-  <span class="text-xs text-gray-500">Sort:</span>
+  <span class="text-xs text-gray-500 dark:text-gray-400">Sort:</span>
   <button
     type="button"
     aria-pressed={$sort === 'priority'}
     class="rounded px-2 py-1 text-xs font-medium {$sort === 'priority'
-      ? 'bg-indigo-100 text-indigo-700'
-      : 'text-gray-600 hover:bg-gray-100'}"
+      ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300'
+      : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'}"
     onclick={() => sort.set('priority')}
   >
     Priority
@@ -95,8 +95,8 @@
     type="button"
     aria-pressed={$sort === 'newest'}
     class="rounded px-2 py-1 text-xs font-medium {$sort === 'newest'
-      ? 'bg-indigo-100 text-indigo-700'
-      : 'text-gray-600 hover:bg-gray-100'}"
+      ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300'
+      : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'}"
     onclick={() => sort.set('newest')}
   >
     Newest
@@ -104,13 +104,15 @@
 </section>
 
 {#if err}
-  <p class="text-sm text-red-600">Could not load PRs: {err}</p>
+  <p class="text-sm text-red-600 dark:text-red-400">Could not load PRs: {err}</p>
 {:else if loading && prs.length === 0 && issues.length === 0}
-  <p class="mt-6 text-center text-sm text-gray-500">Loading…</p>
+  <p class="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">Loading…</p>
 {:else if empty}
-  <p class="mt-6 text-center text-sm text-gray-500">No activity yet.</p>
+  <p class="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
 {:else}
-  <div class="overflow-hidden rounded-md border border-gray-200 bg-white">
+  <div
+    class="overflow-hidden rounded-md border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"
+  >
     {#if myReviews.length > 0}
       <CollapseHeader
         title={hasLogin ? 'My Reviews' : 'Pull Requests'}

--- a/web_ui/src/routes/agents/+page.svelte
+++ b/web_ui/src/routes/agents/+page.svelte
@@ -104,16 +104,16 @@
   }
 </script>
 
-<section class="space-y-6">
+<section class="space-y-6 text-gray-900 dark:text-gray-100">
   <header class="flex items-center justify-between gap-4">
     <div>
       <h1 class="text-2xl font-semibold">Agents</h1>
-      <p class="text-sm text-gray-500">
+      <p class="text-sm text-gray-500 dark:text-gray-400">
         Custom review prompts and CLI flags. One entry per reviewer persona.
       </p>
     </div>
     <button
-      class="rounded bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
+      class="rounded bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400"
       onclick={startCreate}
       data-testid="new-agent"
     >
@@ -123,7 +123,7 @@
 
   {#if err}
     <div
-      class="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      class="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300"
       data-testid="agents-error"
     >
       {err}
@@ -131,7 +131,7 @@
   {/if}
   {#if savedFlash}
     <div
-      class="rounded border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700"
+      class="rounded border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-300"
       data-testid="agents-saved"
     >
       {savedFlash}
@@ -139,38 +139,39 @@
   {/if}
 
   {#if loading}
-    <p class="text-gray-500">Loading…</p>
+    <p class="text-gray-500 dark:text-gray-400">Loading…</p>
   {:else if agents.length === 0 && !editor}
-    <p class="text-gray-500">
+    <p class="text-gray-500 dark:text-gray-400">
       No agents yet. The daemon falls back to the built-in template until one is defined.
     </p>
   {:else}
     <ul class="space-y-2" data-testid="agents-list">
       {#each agents as a (a.id)}
         <li
-          class="flex items-center justify-between rounded border border-gray-200 bg-white px-4 py-3"
+          class="flex items-center justify-between rounded border border-gray-200 bg-white px-4 py-3 dark:border-gray-800 dark:bg-gray-900"
         >
           <div>
             <div class="flex items-center gap-2">
               <span class="font-medium">{a.name}</span>
-              <code class="text-xs text-gray-500">({a.id})</code>
+              <code class="text-xs text-gray-500 dark:text-gray-400">({a.id})</code>
               {#if a.is_default}
-                <span class="rounded bg-indigo-100 px-2 py-0.5 text-xs text-indigo-800"
+                <span
+                  class="rounded bg-indigo-100 px-2 py-0.5 text-xs text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300"
                   >default</span
                 >
               {/if}
             </div>
-            <div class="text-xs text-gray-500">CLI: {a.cli}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">CLI: {a.cli}</div>
           </div>
           <div class="flex gap-2">
             <button
-              class="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-50"
+              class="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
               onclick={() => startEdit(a)}
             >
               Edit
             </button>
             <button
-              class="rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
+              class="rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
               onclick={() => remove(a)}
             >
               Delete
@@ -183,7 +184,7 @@
 
   {#if editor}
     <form
-      class="space-y-4 rounded border border-gray-200 bg-white p-4"
+      class="space-y-4 rounded border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900"
       onsubmit={(e) => {
         e.preventDefault();
         void save();
@@ -192,7 +193,11 @@
     >
       <header class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">{editor.created_at ? 'Edit agent' : 'New agent'}</h2>
-        <button type="button" class="text-sm text-gray-500 hover:text-gray-700" onclick={cancel}>
+        <button
+          type="button"
+          class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          onclick={cancel}
+        >
           Cancel
         </button>
       </header>
@@ -206,10 +211,10 @@
             placeholder="security-audit"
             required
             disabled={!!editor.created_at}
-            class="rounded border border-gray-300 px-2 py-1 font-mono text-xs disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
+            class="rounded border border-gray-300 px-2 py-1 font-mono text-xs disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:disabled:bg-gray-900 dark:disabled:text-gray-500"
           />
           {#if editor.created_at}
-            <span class="text-xs text-gray-500">
+            <span class="text-xs text-gray-500 dark:text-gray-400">
               ID is immutable after creation — changing it would orphan the existing agent.
             </span>
           {/if}
@@ -221,12 +226,15 @@
             bind:value={editor.name}
             placeholder="Security audit"
             required
-            class="rounded border border-gray-300 px-2 py-1"
+            class="rounded border border-gray-300 px-2 py-1 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
           />
         </label>
         <label class="flex flex-col gap-1 text-sm">
           CLI
-          <select bind:value={editor.cli} class="rounded border border-gray-300 px-2 py-1">
+          <select
+            bind:value={editor.cli}
+            class="rounded border border-gray-300 px-2 py-1 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+          >
             {#each cliOptions as cli (cli)}
               <option value={cli}>{cli}</option>
             {/each}
@@ -244,7 +252,7 @@
         <textarea
           bind:value={editor.prompt}
           rows="8"
-          class="rounded border border-gray-300 px-2 py-1 font-mono text-xs"
+          class="rounded border border-gray-300 px-2 py-1 font-mono text-xs dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
         ></textarea>
       </label>
 
@@ -253,7 +261,7 @@
         <textarea
           bind:value={editor.instructions}
           rows="4"
-          class="rounded border border-gray-300 px-2 py-1 text-sm"
+          class="rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
         ></textarea>
       </label>
 
@@ -263,14 +271,14 @@
           type="text"
           bind:value={editor.cli_flags}
           placeholder="--model claude-opus-4-6"
-          class="rounded border border-gray-300 px-2 py-1 font-mono text-xs"
+          class="rounded border border-gray-300 px-2 py-1 font-mono text-xs dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
         />
       </label>
 
       <div class="flex items-center justify-between">
         <button
           type="button"
-          class="text-sm text-indigo-600 hover:underline"
+          class="text-sm text-indigo-600 hover:underline dark:text-indigo-400"
           onclick={() => (previewOpen = !previewOpen)}
         >
           {previewOpen ? 'Hide preview' : 'Preview prompt'}
@@ -278,7 +286,7 @@
         <button
           type="submit"
           disabled={saving}
-          class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+          class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
         >
           {saving ? 'Saving…' : 'Save'}
         </button>
@@ -286,7 +294,7 @@
 
       {#if previewOpen}
         <pre
-          class="max-h-80 overflow-auto whitespace-pre-wrap rounded border border-gray-200 bg-gray-50 p-3 font-mono text-xs"
+          class="max-h-80 overflow-auto whitespace-pre-wrap rounded border border-gray-200 bg-gray-50 p-3 font-mono text-xs dark:border-gray-800 dark:bg-gray-800 dark:text-gray-100"
           data-testid="agent-preview">{renderPreview(editor.prompt || editor.instructions)}</pre>
       {/if}
     </form>

--- a/web_ui/src/routes/config/+page.svelte
+++ b/web_ui/src/routes/config/+page.svelte
@@ -141,18 +141,18 @@
 
 <section class="space-y-8">
   <header>
-    <h1 class="text-2xl font-semibold">Configuration</h1>
-    <p class="text-sm text-gray-500">
+    <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">Configuration</h1>
+    <p class="text-sm text-gray-500 dark:text-gray-400">
       Live daemon configuration. Saving applies the change immediately via <code>POST /reload</code
       >.
     </p>
   </header>
 
   {#if loading}
-    <p class="text-gray-500">Loading…</p>
+    <p class="text-gray-500 dark:text-gray-400">Loading…</p>
   {:else if err}
     <div
-      class="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      class="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300"
       data-testid="config-error"
     >
       {err}
@@ -167,12 +167,17 @@
         void save();
       }}
     >
-      <fieldset class="space-y-4 rounded border border-gray-200 p-4">
-        <legend class="text-sm font-semibold">Polling & AI</legend>
+      <fieldset
+        class="space-y-4 rounded border border-gray-200 p-4 dark:border-gray-800 dark:text-gray-200"
+      >
+        <legend class="text-sm font-semibold text-gray-900 dark:text-gray-100">Polling & AI</legend>
 
         <label class="flex flex-col gap-1 text-sm">
           Poll interval
-          <select bind:value={pollInterval} class="w-40 rounded border border-gray-300 px-2 py-1">
+          <select
+            bind:value={pollInterval}
+            class="w-40 rounded border border-gray-300 px-2 py-1 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+          >
             {#each pollOptions as opt (opt)}
               <option value={opt}>{opt}</option>
             {/each}
@@ -182,7 +187,10 @@
         <div class="flex gap-4">
           <label class="flex flex-1 flex-col gap-1 text-sm">
             AI primary
-            <select bind:value={aiPrimary} class="rounded border border-gray-300 px-2 py-1">
+            <select
+              bind:value={aiPrimary}
+              class="rounded border border-gray-300 px-2 py-1 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            >
               <option value="">—</option>
               {#each cliOptions as cli (cli)}
                 <option value={cli}>{cli}</option>
@@ -191,7 +199,10 @@
           </label>
           <label class="flex flex-1 flex-col gap-1 text-sm">
             AI fallback
-            <select bind:value={aiFallback} class="rounded border border-gray-300 px-2 py-1">
+            <select
+              bind:value={aiFallback}
+              class="rounded border border-gray-300 px-2 py-1 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            >
               <option value="">— (none)</option>
               {#each cliOptions as cli (cli)}
                 <option value={cli}>{cli}</option>
@@ -202,7 +213,10 @@
 
         <label class="flex flex-col gap-1 text-sm">
           Review mode
-          <select bind:value={reviewMode} class="w-40 rounded border border-gray-300 px-2 py-1">
+          <select
+            bind:value={reviewMode}
+            class="w-40 rounded border border-gray-300 px-2 py-1 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+          >
             {#each reviewModes as m (m)}
               <option value={m}>{m}</option>
             {/each}
@@ -215,26 +229,32 @@
             type="number"
             min="0"
             bind:value={retentionDays}
-            class="w-40 rounded border border-gray-300 px-2 py-1"
+            class="w-40 rounded border border-gray-300 px-2 py-1 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
           />
         </label>
       </fieldset>
 
-      <fieldset class="space-y-4 rounded border border-gray-200 p-4">
-        <legend class="text-sm font-semibold">Repositories</legend>
+      <fieldset
+        class="space-y-4 rounded border border-gray-200 p-4 dark:border-gray-800 dark:text-gray-200"
+      >
+        <legend class="text-sm font-semibold text-gray-900 dark:text-gray-100">Repositories</legend>
         <label class="flex flex-col gap-1 text-sm">
           One <code>org/repo</code> per line. Blank lines are ignored.
           <textarea
             bind:value={repositoriesText}
             rows="5"
-            class="rounded border border-gray-300 px-2 py-1 font-mono text-sm"
+            class="rounded border border-gray-300 px-2 py-1 font-mono text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             placeholder="freepik-company/ai-platform"
           ></textarea>
         </label>
       </fieldset>
 
-      <fieldset class="space-y-4 rounded border border-gray-200 p-4">
-        <legend class="text-sm font-semibold">Issue tracking</legend>
+      <fieldset
+        class="space-y-4 rounded border border-gray-200 p-4 dark:border-gray-800 dark:text-gray-200"
+      >
+        <legend class="text-sm font-semibold text-gray-900 dark:text-gray-100"
+          >Issue tracking</legend
+        >
 
         <label class="flex items-center gap-2 text-sm">
           <input type="checkbox" bind:checked={it.enabled} />
@@ -244,7 +264,10 @@
         <div class="flex gap-4">
           <label class="flex flex-1 flex-col gap-1 text-sm">
             Filter mode
-            <select bind:value={it.filter_mode} class="rounded border border-gray-300 px-2 py-1">
+            <select
+              bind:value={it.filter_mode}
+              class="rounded border border-gray-300 px-2 py-1 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            >
               {#each filterModes as f (f)}
                 <option value={f}>{f}</option>
               {/each}
@@ -252,7 +275,10 @@
           </label>
           <label class="flex flex-1 flex-col gap-1 text-sm">
             Default action
-            <select bind:value={it.default_action} class="rounded border border-gray-300 px-2 py-1">
+            <select
+              bind:value={it.default_action}
+              class="rounded border border-gray-300 px-2 py-1 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            >
               {#each defaultActions as a (a)}
                 <option value={a}>{a}</option>
               {/each}
@@ -285,12 +311,14 @@
         <button
           type="submit"
           disabled={saving}
-          class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+          class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
         >
           {saving ? 'Saving…' : 'Save & reload'}
         </button>
         {#if savedFlash}
-          <span class="text-sm text-green-700" data-testid="config-saved">{savedFlash}</span>
+          <span class="text-sm text-green-700 dark:text-green-400" data-testid="config-saved"
+            >{savedFlash}</span
+          >
         {/if}
       </div>
     </form>
@@ -305,9 +333,9 @@
       value={values.join(', ')}
       oninput={(e) => onUpdate(parseCsv((e.currentTarget as HTMLInputElement).value))}
       placeholder="bug, feature, needs-triage"
-      class="rounded border border-gray-300 px-2 py-1 font-mono text-xs"
+      class="rounded border border-gray-300 px-2 py-1 font-mono text-xs dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
     />
-    <span class="text-xs text-gray-500"
+    <span class="text-xs text-gray-500 dark:text-gray-400"
       >Comma-separated. No quotes or spaces needed around values.</span
     >
   </label>

--- a/web_ui/src/routes/issues/+page.svelte
+++ b/web_ui/src/routes/issues/+page.svelte
@@ -48,22 +48,26 @@
 </script>
 
 <section class="flex items-center gap-3">
-  <h1 class="text-2xl font-bold">Issues</h1>
+  <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Issues</h1>
   {#if $reviewingIssues.size > 0}
-    <span class="text-xs text-indigo-600">{$reviewingIssues.size} reviewing…</span>
+    <span class="text-xs text-indigo-600 dark:text-indigo-400"
+      >{$reviewingIssues.size} reviewing…</span
+    >
   {/if}
 </section>
 
 <IssueFilterBar filters={{ repo, severity, mode }} {repos} onChange={applyFilters} />
 
 {#if err}
-  <p class="text-sm text-red-600">Could not load issues: {err}</p>
+  <p class="text-sm text-red-600 dark:text-red-400">Could not load issues: {err}</p>
 {:else if loading && issues.length === 0}
-  <p class="text-sm text-gray-500">Loading…</p>
+  <p class="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
 {:else if filtered.length === 0}
-  <p class="text-sm text-gray-500">No issues match the current filters.</p>
+  <p class="text-sm text-gray-500 dark:text-gray-400">No issues match the current filters.</p>
 {:else}
-  <div class="overflow-hidden rounded-md border border-gray-200 bg-white">
+  <div
+    class="overflow-hidden rounded-md border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"
+  >
     {#each filtered as issue (issue.id)}
       <IssueTile {issue} />
     {/each}

--- a/web_ui/src/routes/issues/[id]/+page.svelte
+++ b/web_ui/src/routes/issues/[id]/+page.svelte
@@ -80,14 +80,16 @@
 </script>
 
 {#if err && !issue}
-  <p class="text-sm text-red-600">Could not load issue: {err}</p>
+  <p class="text-sm text-red-600 dark:text-red-400">Could not load issue: {err}</p>
 {:else if !issue}
-  <p class="text-sm text-gray-500">Loading…</p>
+  <p class="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
 {:else}
   <article>
-    <header class="mb-4 rounded-md border border-gray-200 bg-white p-4">
-      <h1 class="text-xl font-bold">{issue.title}</h1>
-      <p class="mt-1 text-sm text-gray-500">
+    <header
+      class="mb-4 rounded-md border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900"
+    >
+      <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">{issue.title}</h1>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
         <span class="font-mono">{issue.repo}</span>
         · #{issue.number}
         · {issue.author}
@@ -96,21 +98,23 @@
       {#if issue.labels.length > 0}
         <ul class="mt-2 flex flex-wrap gap-1">
           {#each issue.labels as l (l)}
-            <li class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-700">
+            <li
+              class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+            >
               {l}
             </li>
           {/each}
         </ul>
       {/if}
       {#if issue.assignees.length > 0}
-        <p class="mt-2 text-xs text-gray-500">
+        <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
           Assignees: {issue.assignees.join(', ')}
         </p>
       {/if}
       <p class="mt-2 text-xs">
         <a
           href="https://github.com/{issue.repo}/issues/{issue.number}"
-          class="text-indigo-600 hover:underline"
+          class="text-indigo-600 hover:underline dark:text-indigo-400"
           target="_blank"
           rel="noreferrer"
         >
@@ -119,7 +123,10 @@
       </p>
       {#if autoImplementPR}
         <p class="mt-2 text-xs">
-          <a href="/prs/{autoImplementPR}" class="text-indigo-600 hover:underline">
+          <a
+            href="/prs/{autoImplementPR}"
+            class="text-indigo-600 hover:underline dark:text-indigo-400"
+          >
             View created PR →
           </a>
         </p>
@@ -129,7 +136,7 @@
     <div class="mb-4 flex items-center gap-2">
       <button
         type="button"
-        class="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        class="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
         onclick={onReview}
         disabled={busy || reviewing}
       >
@@ -137,23 +144,25 @@
       </button>
       <button
         type="button"
-        class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800"
         onclick={onDismissToggle}
         disabled={busy}
       >
         {issue.dismissed ? 'Undismiss' : 'Dismiss'}
       </button>
       {#if err}
-        <span class="text-xs text-red-600">{err}</span>
+        <span class="text-xs text-red-600 dark:text-red-400">{err}</span>
       {/if}
     </div>
 
     <section>
-      <h2 class="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
+      <h2
+        class="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+      >
         Review history ({reviews.length})
       </h2>
       {#if reviews.length === 0}
-        <p class="text-sm text-gray-500">No reviews yet.</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">No reviews yet.</p>
       {:else}
         {#each reviews as r (r.id)}
           <IssueReviewCard review={r} />

--- a/web_ui/src/routes/logs/+page.svelte
+++ b/web_ui/src/routes/logs/+page.svelte
@@ -72,27 +72,29 @@
     scrollToBottom();
   }
 
+  // The viewport is always dark (see comment in the template), so these
+  // colours target a dark background in both light and dark modes.
   function levelClass(level: LogLevel | null): string {
     switch (level) {
       case 'ERROR':
-        return 'text-red-700';
+        return 'text-red-400';
       case 'WARN':
-        return 'text-amber-700';
+        return 'text-amber-400';
       case 'INFO':
-        return 'text-gray-800';
+        return 'text-gray-100';
       case 'DEBUG':
         return 'text-gray-500';
       default:
-        return 'text-gray-700';
+        return 'text-gray-300';
     }
   }
 </script>
 
-<section class="space-y-4">
+<section class="space-y-4 text-gray-900 dark:text-gray-100">
   <header class="flex items-center justify-between gap-4">
     <div>
       <h1 class="text-2xl font-semibold">Logs</h1>
-      <p class="text-sm text-gray-500">
+      <p class="text-sm text-gray-500 dark:text-gray-400">
         Live daemon log stream. Keeps the last {MAX_LINES} lines in memory.
       </p>
     </div>
@@ -109,7 +111,7 @@
         Wrap
       </label>
       <button
-        class="rounded border border-gray-300 px-2 py-1 hover:bg-gray-50"
+        class="rounded border border-gray-300 px-2 py-1 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
         onclick={clear}
         data-testid="clear-logs"
       >
@@ -117,7 +119,7 @@
       </button>
       {#if !autoScroll}
         <button
-          class="rounded bg-indigo-600 px-2 py-1 text-white hover:bg-indigo-500"
+          class="rounded bg-indigo-600 px-2 py-1 text-white hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400"
           onclick={jumpToBottom}
           data-testid="jump-bottom"
         >
@@ -127,10 +129,15 @@
     </div>
   </header>
 
+  <!--
+    The viewport is intentionally pinned to a dark terminal palette in both
+    themes — log streams are easier to skim in white-on-dark, and the level
+    colours are already tuned against that background.
+  -->
   <div
     bind:this={viewport}
     onscroll={onScroll}
-    class="h-[70vh] overflow-auto rounded border border-gray-200 bg-gray-950 p-3 font-mono text-xs text-gray-100"
+    class="h-[70vh] overflow-auto rounded border border-gray-200 bg-gray-950 p-3 font-mono text-xs text-gray-100 dark:border-gray-800"
     data-testid="logs-viewport"
   >
     {#if entries.length === 0}

--- a/web_ui/src/routes/prs/+page.svelte
+++ b/web_ui/src/routes/prs/+page.svelte
@@ -50,22 +50,25 @@
 </script>
 
 <section class="flex items-center gap-3">
-  <h1 class="text-2xl font-bold">PR Reviews</h1>
+  <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">PR Reviews</h1>
   {#if $reviewingPRs.size > 0}
-    <span class="text-xs text-indigo-600">{$reviewingPRs.size} reviewing…</span>
+    <span class="text-xs text-indigo-600 dark:text-indigo-400">{$reviewingPRs.size} reviewing…</span
+    >
   {/if}
 </section>
 
 <PRFilterBar filters={{ repo, severity, state: prState }} {repos} onChange={applyFilters} />
 
 {#if err}
-  <p class="text-sm text-red-600">Could not load PRs: {err}</p>
+  <p class="text-sm text-red-600 dark:text-red-400">Could not load PRs: {err}</p>
 {:else if loading && prs.length === 0}
-  <p class="text-sm text-gray-500">Loading…</p>
+  <p class="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
 {:else if filtered.length === 0}
-  <p class="text-sm text-gray-500">No PRs match the current filters.</p>
+  <p class="text-sm text-gray-500 dark:text-gray-400">No PRs match the current filters.</p>
 {:else}
-  <div class="overflow-hidden rounded-md border border-gray-200 bg-white">
+  <div
+    class="overflow-hidden rounded-md border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"
+  >
     {#each filtered as pr (pr.id)}
       <PRTile {pr} />
     {/each}

--- a/web_ui/src/routes/prs/[id]/+page.svelte
+++ b/web_ui/src/routes/prs/[id]/+page.svelte
@@ -74,21 +74,28 @@
 </script>
 
 {#if err && !pr}
-  <p class="text-sm text-red-600">Could not load PR: {err}</p>
+  <p class="text-sm text-red-600 dark:text-red-400">Could not load PR: {err}</p>
 {:else if !pr}
-  <p class="text-sm text-gray-500">Loading…</p>
+  <p class="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
 {:else}
   <article>
-    <header class="mb-4 rounded-md border border-gray-200 bg-white p-4">
-      <h1 class="text-xl font-bold">{pr.title}</h1>
-      <p class="mt-1 text-sm text-gray-500">
+    <header
+      class="mb-4 rounded-md border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900"
+    >
+      <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">{pr.title}</h1>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
         <span class="font-mono">{pr.repo}</span>
         · #{pr.number}
         · {pr.author}
         · <span class="capitalize">{pr.state}</span>
       </p>
       <p class="mt-2 text-xs">
-        <a href={pr.url} class="text-indigo-600 hover:underline" target="_blank" rel="noreferrer">
+        <a
+          href={pr.url}
+          class="text-indigo-600 hover:underline dark:text-indigo-400"
+          target="_blank"
+          rel="noreferrer"
+        >
           View on GitHub →
         </a>
       </p>
@@ -97,7 +104,7 @@
     <div class="mb-4 flex items-center gap-2">
       <button
         type="button"
-        class="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        class="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
         onclick={onReview}
         disabled={busy || reviewing}
       >
@@ -105,23 +112,25 @@
       </button>
       <button
         type="button"
-        class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800"
         onclick={onDismissToggle}
         disabled={busy}
       >
         {pr.dismissed ? 'Undismiss' : 'Dismiss'}
       </button>
       {#if err}
-        <span class="text-xs text-red-600">{err}</span>
+        <span class="text-xs text-red-600 dark:text-red-400">{err}</span>
       {/if}
     </div>
 
     <section>
-      <h2 class="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
+      <h2
+        class="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+      >
         Review history ({reviews.length})
       </h2>
       {#if reviews.length === 0}
-        <p class="text-sm text-gray-500">No reviews yet.</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">No reviews yet.</p>
       {:else}
         {#each reviews as r (r.id)}
           <PRReviewCard review={r} />

--- a/web_ui/src/tests/severity.test.ts
+++ b/web_ui/src/tests/severity.test.ts
@@ -3,22 +3,36 @@ import { severityClass, severityOrder } from '../lib/severity.js';
 
 describe('severityClass', () => {
   it('returns red classes for critical', () => {
-    expect(severityClass('critical')).toBe('bg-red-100 text-red-700');
+    expect(severityClass('critical')).toContain('bg-red-100');
+    expect(severityClass('critical')).toContain('text-red-700');
   });
   it('returns orange classes for high', () => {
-    expect(severityClass('high')).toBe('bg-orange-100 text-orange-700');
+    expect(severityClass('high')).toContain('bg-orange-100');
+    expect(severityClass('high')).toContain('text-orange-700');
   });
   it('returns amber classes for medium', () => {
-    expect(severityClass('medium')).toBe('bg-amber-100 text-amber-700');
+    expect(severityClass('medium')).toContain('bg-amber-100');
+    expect(severityClass('medium')).toContain('text-amber-700');
   });
   it('returns gray classes for low and for unknown', () => {
-    expect(severityClass('low')).toBe('bg-gray-100 text-gray-600');
-    expect(severityClass('whatever')).toBe('bg-gray-100 text-gray-600');
-    expect(severityClass('')).toBe('bg-gray-100 text-gray-600');
+    for (const input of ['low', 'whatever', '']) {
+      expect(severityClass(input)).toContain('bg-gray-100');
+      expect(severityClass(input)).toContain('text-gray-600');
+    }
+  });
+  it('includes dark-mode variants for every bucket', () => {
+    // Regression guard for #73: any future palette change must keep both
+    // the light and dark variants side-by-side so the badges stay legible
+    // under `.dark` on <html>.
+    for (const sev of ['critical', 'high', 'medium', 'low', 'unknown']) {
+      const cls = severityClass(sev);
+      expect(cls).toMatch(/dark:bg-/);
+      expect(cls).toMatch(/dark:text-/);
+    }
   });
   it('is case-insensitive', () => {
-    expect(severityClass('HIGH')).toBe('bg-orange-100 text-orange-700');
-    expect(severityClass('Critical')).toBe('bg-red-100 text-red-700');
+    expect(severityClass('HIGH')).toContain('bg-orange-100');
+    expect(severityClass('Critical')).toContain('bg-red-100');
   });
 });
 

--- a/web_ui/src/tests/theme.test.ts
+++ b/web_ui/src/tests/theme.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetThemeForTests, initTheme, loadThemeChoice, setThemeChoice } from '../lib/theme.js';
+
+type MqListener = (event: MediaQueryListEvent) => void;
+
+interface FakeMq {
+  matches: boolean;
+  listeners: Set<MqListener>;
+  addEventListener: (type: 'change', cb: MqListener) => void;
+  removeEventListener: (type: 'change', cb: MqListener) => void;
+  dispatchEvent: (matches: boolean) => void;
+}
+
+function installFakeMatchMedia(defaultMatches: boolean): FakeMq {
+  const mq: FakeMq = {
+    matches: defaultMatches,
+    listeners: new Set(),
+    addEventListener: (type, cb) => {
+      if (type === 'change') mq.listeners.add(cb);
+    },
+    removeEventListener: (type, cb) => {
+      if (type === 'change') mq.listeners.delete(cb);
+    },
+    dispatchEvent: (matches) => {
+      mq.matches = matches;
+      for (const cb of mq.listeners) cb({ matches } as MediaQueryListEvent);
+    }
+  };
+  vi.stubGlobal(
+    'matchMedia',
+    // jsdom's Window.matchMedia isn't present — return our fake regardless of query.
+    vi.fn(() => mq as unknown as MediaQueryList)
+  );
+  return mq;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.classList.remove('dark');
+  __resetThemeForTests();
+});
+
+afterEach(() => {
+  __resetThemeForTests();
+  vi.unstubAllGlobals();
+});
+
+describe('loadThemeChoice', () => {
+  it('returns system when nothing is stored', () => {
+    expect(loadThemeChoice()).toBe('system');
+  });
+
+  it('returns stored value when valid', () => {
+    localStorage.setItem('heimdallm-theme', 'dark');
+    expect(loadThemeChoice()).toBe('dark');
+  });
+
+  it('falls back to system for unknown values', () => {
+    localStorage.setItem('heimdallm-theme', 'sparkly');
+    expect(loadThemeChoice()).toBe('system');
+  });
+});
+
+describe('setThemeChoice', () => {
+  it('adds the dark class when choice is dark', () => {
+    installFakeMatchMedia(false);
+    setThemeChoice('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('removes the dark class when choice is light, even if system is dark', () => {
+    installFakeMatchMedia(true);
+    document.documentElement.classList.add('dark');
+    setThemeChoice('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('follows the system preference when choice is system', () => {
+    const mq = installFakeMatchMedia(true);
+    setThemeChoice('system');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    mq.dispatchEvent(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('persists the choice in localStorage', () => {
+    installFakeMatchMedia(false);
+    setThemeChoice('dark');
+    expect(localStorage.getItem('heimdallm-theme')).toBe('dark');
+  });
+
+  it('unsubscribes from system changes when switching away from system', () => {
+    const mq = installFakeMatchMedia(false);
+    setThemeChoice('system');
+    expect(mq.listeners.size).toBe(1);
+
+    setThemeChoice('light');
+    expect(mq.listeners.size).toBe(0);
+
+    // System flipping to dark must no longer drag the UI along.
+    mq.dispatchEvent(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});
+
+describe('initTheme', () => {
+  it('applies and returns the stored choice', () => {
+    installFakeMatchMedia(false);
+    localStorage.setItem('heimdallm-theme', 'dark');
+    const choice = initTheme();
+    expect(choice).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/web_ui/src/tests/theme.test.ts
+++ b/web_ui/src/tests/theme.test.ts
@@ -1,5 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { __resetThemeForTests, initTheme, loadThemeChoice, setThemeChoice } from '../lib/theme.js';
+import {
+  STORAGE_KEY,
+  __resetThemeForTests,
+  initTheme,
+  loadThemeChoice,
+  setThemeChoice
+} from '../lib/theme.js';
 
 type MqListener = (event: MediaQueryListEvent) => void;
 
@@ -111,5 +119,16 @@ describe('initTheme', () => {
     const choice = initTheme();
     expect(choice).toBe('dark');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});
+
+describe('STORAGE_KEY', () => {
+  it('stays in sync with the inline pre-paint script in app.html', () => {
+    // src/app.html can't import TypeScript, so its inline script hardcodes
+    // the storage key. If the module constant changes and the HTML isn't
+    // updated, the pre-paint script and the runtime helper disagree and
+    // users see a flash of the wrong theme on first load.
+    const appHtml = readFileSync(resolve(__dirname, '..', 'app.html'), 'utf8');
+    expect(appHtml).toContain(`'${STORAGE_KEY}'`);
   });
 });


### PR DESCRIPTION
Closes #73.

## Summary

The web UI only declared \`color-scheme: light dark\` at the root, so components were effectively hardcoded to light. Users with a dark OS preference saw blinding-white panels. This PR adds a real dark mode backed by Tailwind v4 class-based variants and a three-state toggle in the header.

## What the user sees

- **Toggle** in the top-right of every page: ☀ / 🖥 / 🌙 (Light / System / Dark). Persists via \`localStorage['heimdallm-theme']\`.
- **System** tracks \`prefers-color-scheme\` live — flip your OS toggle and the UI follows.
- **No FOUC** — an inline script in \`app.html\` resolves the stored choice before the first paint, so the page opens in the right mode instead of flashing light→dark.

## What changed

### Infrastructure
- \`src/app.css\` — opts into Tailwind v4 class-based dark with \`@custom-variant dark (&:where(.dark, .dark *))\`, and sets \`color-scheme\` conditionally on \`:root.dark\` so native form controls and scrollbars also match the theme.
- \`src/app.html\` — pre-paint IIFE + dark body classes.
- \`src/lib/theme.ts\` — new helper. Pure functions (\`loadThemeChoice\`, \`setThemeChoice\`, \`initTheme\`) plus a \`__resetThemeForTests\` hook. The \`system\` branch subscribes to \`matchMedia\` and the subscription is torn down when switching to light/dark to avoid listener leaks.

### UI
- \`src/routes/+layout.svelte\` — toggle in the header, \`initTheme()\` on mount, \`chooseTheme()\` wires clicks to the helper.
- Every route got \`dark:\` variants for bg/text/border/hover: \`/\`, \`/prs\`, \`/prs/[id]\`, \`/issues\`, \`/issues/[id]\`, \`/config\`, \`/agents\`, \`/logs\`.
- All shared components likewise: \`PRTile\`, \`IssueTile\`, \`SeverityBadge\`, \`ConnectionPill\`, \`StatsCards\`, \`CollapseHeader\`, \`PRFilterBar\`, \`IssueFilterBar\`, \`PRReviewCard\`, \`IssueReviewCard\`.
- \`lib/severity.ts\` — four severity buckets gained \`dark:bg-*-950 dark:text-*-300\` variants to maintain AA contrast on dark backgrounds.
- \`/logs\` viewport stays pinned to a dark terminal palette in both themes (log streams are easier to skim white-on-dark), but \`levelClass\` rebalanced so INFO isn't near-black on the dark background.

## Testing

- \`tests/theme.test.ts\` (9 cases): missing / valid / invalid stored choice; apply dark / light / system; system media listener sync; unsubscribe when leaving system; \`initTheme\` round-trip.
- \`tests/severity.test.ts\`: existing equality checks loosened to \`.toContain\` + a new regression case that every severity bucket exposes a \`dark:\` variant, so a future palette edit that forgets the dark side fails CI.

All 80 unit tests pass. \`svelte-check\`, \`prettier --check\`, and \`eslint\` all clean.

## Out of scope

- Flutter app (ships its own themeing).
- Per-component custom palettes — this lays the foundation; future tweaks can riff on it.
- A \"high-contrast\" third theme — if needed later, the helper already has room (just extend \`ThemeChoice\`).

## Test plan

- [x] \`npm run check && npm test && npm run lint\` clean
- [x] Verified locally with \`make up --build web\`: toggle works, persists across reloads, system branch follows OS toggle
- [ ] Reviewer: confirm no flash-of-wrong-theme on first load in dark mode
- [ ] Reviewer: spot-check contrast on \`/logs\`, \`/config\` (fieldsets), and severity badges