### PR TITLE
fix(daemon): make /logs stream work under Docker

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -55,7 +55,12 @@ func main() {
 	// /logs stream reads that file; writing only to stderr (as we used
 	// to) left the stream empty under Docker — see #75.
 	logDir := dataDir()
-	setupLogging(logDir)
+	logFile := setupLogging(logDir)
+	if logFile != nil {
+		// Flush buffered writes on shutdown so the last lines reach
+		// disk even when the daemon is killed mid-log.
+		defer logFile.Close()
+	}
 
 	cfgPath := configPath()
 	var cfg *config.Config
@@ -663,41 +668,41 @@ func main() {
 	broker.Stop()
 }
 
-// DaemonLogFileName is the name of the on-disk log file the daemon writes
-// alongside stderr. Lives next to heimdallm.db inside the resolved data
-// directory so the web UI's /logs endpoint can tail it from the same
-// volume it already mounts (see #75).
-const DaemonLogFileName = "heimdallm.log"
-
-func setupLogging(dataDir string) {
+// setupLogging configures slog to write to stderr and, when possible, also
+// to <dataDir>/heimdallm.log — the file the web UI's /logs endpoint tails
+// (see #75). Returns the opened file handle so the caller can Close it on
+// shutdown; returns nil when we're running stderr-only (either dataDir is
+// empty or the file open failed). Either way the daemon never refuses to
+// start because logging to disk failed; `docker logs` / the host terminal
+// continue to work.
+func setupLogging(dataDir string) *os.File {
 	handlerOpts := &slog.HandlerOptions{Level: slog.LevelInfo}
 
-	// Default: stderr-only. If the file open fails we keep going — the
-	// daemon must not refuse to start just because logs cannot be
-	// persisted. `docker logs` / the host terminal still work.
-	var out io.Writer = os.Stderr
-
-	if dataDir != "" {
-		// O_APPEND so restarts extend the log rather than truncating it;
-		// 0640 so the web container (different UID, same data volume)
-		// could read via group membership, and the host user keeps full
-		// write access. The web container today reads this over HTTP via
-		// the daemon, not directly, but keeping the mode narrow is still
-		// the right posture.
-		logPath := filepath.Join(dataDir, DaemonLogFileName)
-		f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
-		if err == nil {
-			out = io.MultiWriter(os.Stderr, f)
-		} else {
-			// Emit the warning via a temporary logger so it is visible on
-			// stderr even before SetDefault runs below.
-			tmp := slog.New(slog.NewTextHandler(os.Stderr, handlerOpts))
-			tmp.Warn("logging: could not open daemon log file, stderr only",
-				"path", logPath, "err", err)
-		}
+	if dataDir == "" {
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, handlerOpts)))
+		return nil
 	}
 
-	slog.SetDefault(slog.New(slog.NewTextHandler(out, handlerOpts)))
+	// O_APPEND so restarts extend the log rather than truncating it;
+	// 0640 so the web container (different UID, same data volume) could
+	// read via group membership, and the host user keeps full write
+	// access. The web container today reads this over HTTP via the
+	// daemon, not directly, but keeping the mode narrow is still the
+	// right posture.
+	logPath := filepath.Join(dataDir, server.DaemonLogFileName)
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	if err != nil {
+		// Warn via a temporary logger that is visible on stderr even
+		// before SetDefault runs below.
+		tmp := slog.New(slog.NewTextHandler(os.Stderr, handlerOpts))
+		tmp.Warn("logging: could not open daemon log file, stderr only",
+			"path", logPath, "err", err)
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, handlerOpts)))
+		return nil
+	}
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.MultiWriter(os.Stderr, f), handlerOpts)))
+	return f
 }
 
 // dataDir resolves the data directory.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -49,7 +50,12 @@ func main() {
 		}
 	}
 
-	setupLogging()
+	// Resolve the data directory first so setupLogging can mirror the
+	// daemon's slog output into <dataDir>/heimdallm.log. The web UI's
+	// /logs stream reads that file; writing only to stderr (as we used
+	// to) left the stream empty under Docker — see #75.
+	logDir := dataDir()
+	setupLogging(logDir)
 
 	cfgPath := configPath()
 	var cfg *config.Config
@@ -657,10 +663,41 @@ func main() {
 	broker.Stop()
 }
 
-func setupLogging() {
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	})))
+// DaemonLogFileName is the name of the on-disk log file the daemon writes
+// alongside stderr. Lives next to heimdallm.db inside the resolved data
+// directory so the web UI's /logs endpoint can tail it from the same
+// volume it already mounts (see #75).
+const DaemonLogFileName = "heimdallm.log"
+
+func setupLogging(dataDir string) {
+	handlerOpts := &slog.HandlerOptions{Level: slog.LevelInfo}
+
+	// Default: stderr-only. If the file open fails we keep going — the
+	// daemon must not refuse to start just because logs cannot be
+	// persisted. `docker logs` / the host terminal still work.
+	var out io.Writer = os.Stderr
+
+	if dataDir != "" {
+		// O_APPEND so restarts extend the log rather than truncating it;
+		// 0640 so the web container (different UID, same data volume)
+		// could read via group membership, and the host user keeps full
+		// write access. The web container today reads this over HTTP via
+		// the daemon, not directly, but keeping the mode narrow is still
+		// the right posture.
+		logPath := filepath.Join(dataDir, DaemonLogFileName)
+		f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+		if err == nil {
+			out = io.MultiWriter(os.Stderr, f)
+		} else {
+			// Emit the warning via a temporary logger so it is visible on
+			// stderr even before SetDefault runs below.
+			tmp := slog.New(slog.NewTextHandler(os.Stderr, handlerOpts))
+			tmp.Warn("logging: could not open daemon log file, stderr only",
+				"path", logPath, "err", err)
+		}
+	}
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(out, handlerOpts)))
 }
 
 // dataDir resolves the data directory.

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -683,6 +683,12 @@ func (srv *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, stats)
 }
 
+// DaemonLogFileName is the name of the on-disk log file the daemon writes
+// alongside heimdallm.db inside the resolved data directory. Shared between
+// the writer (cmd/heimdallm setupLogging) and the reader (daemonLogPath
+// below) so the two sides cannot drift.
+const DaemonLogFileName = "heimdallm.log"
+
 // daemonLogPath returns the path to the daemon log file the /logs stream
 // tails. Priority (matches cmd/heimdallm/main.go's dataDir() ordering, which
 // is the directory setupLogging writes to):
@@ -701,10 +707,10 @@ func (srv *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 // `docker logs`, never to a file.
 func daemonLogPath() string {
 	if v := os.Getenv("HEIMDALLM_DATA_DIR"); v != "" {
-		return filepath.Join(v, "heimdallm.log")
+		return filepath.Join(v, DaemonLogFileName)
 	}
 	if info, err := os.Stat("/data"); err == nil && info.IsDir() {
-		return "/data/heimdallm.log"
+		return filepath.Join("/data", DaemonLogFileName)
 	}
 	home, _ := os.UserHomeDir()
 	switch runtime.GOOS {
@@ -712,9 +718,9 @@ func daemonLogPath() string {
 		return filepath.Join(home, "Library", "Logs", "heimdallm", "heimdallm-daemon-error.log")
 	default:
 		if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
-			return filepath.Join(xdg, "heimdallm", "heimdallm.log")
+			return filepath.Join(xdg, "heimdallm", DaemonLogFileName)
 		}
-		return filepath.Join(home, ".local", "share", "heimdallm", "heimdallm.log")
+		return filepath.Join(home, ".local", "share", "heimdallm", DaemonLogFileName)
 	}
 }
 

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -683,10 +683,29 @@ func (srv *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, stats)
 }
 
-// daemonLogPath returns the platform-specific path to the daemon stderr log.
-// macOS: ~/Library/Logs/heimdallm/heimdallm-daemon-error.log (LaunchAgent convention)
-// Linux/other: $XDG_STATE_HOME/heimdallm/heimdallm.log (fallback ~/.local/share/heimdallm/heimdallm.log)
+// daemonLogPath returns the path to the daemon log file the /logs stream
+// tails. Priority (matches cmd/heimdallm/main.go's dataDir() ordering, which
+// is the directory setupLogging writes to):
+//
+//  1. $HEIMDALLM_DATA_DIR/heimdallm.log — explicit override (native or Docker).
+//  2. /data/heimdallm.log — Docker convention, used when /data exists as a
+//     directory (the compose file mounts the heimdallm-data volume there).
+//  3. macOS: ~/Library/Logs/heimdallm/heimdallm-daemon-error.log — LaunchAgent
+//     convention; the plist redirects stderr there so the file pre-exists
+//     without setupLogging having to write it.
+//  4. Linux/other: $XDG_STATE_HOME/heimdallm/heimdallm.log, fallback
+//     ~/.local/share/heimdallm/heimdallm.log.
+//
+// See #75 — previously (1) and (2) did not exist and the endpoint always
+// returned "file not found" under Docker because stderr was redirected to
+// `docker logs`, never to a file.
 func daemonLogPath() string {
+	if v := os.Getenv("HEIMDALLM_DATA_DIR"); v != "" {
+		return filepath.Join(v, "heimdallm.log")
+	}
+	if info, err := os.Stat("/data"); err == nil && info.IsDir() {
+		return "/data/heimdallm.log"
+	}
 	home, _ := os.UserHomeDir()
 	switch runtime.GOOS {
 	case "darwin":

--- a/daemon/internal/server/handlers_internal_test.go
+++ b/daemon/internal/server/handlers_internal_test.go
@@ -39,7 +39,7 @@ func TestDaemonLogPath_HeimdallmDataDirWins(t *testing.T) {
 	withEnv(t, "XDG_STATE_HOME", "") // ensure we are not falling through to it
 
 	got := daemonLogPath()
-	want := filepath.Join(dir, "heimdallm.log")
+	want := filepath.Join(dir, DaemonLogFileName)
 	if got != want {
 		t.Fatalf("daemonLogPath() = %q, want %q", got, want)
 	}
@@ -58,9 +58,10 @@ func TestDaemonLogPath_FallsBackToNativeWhenDataDirUnset(t *testing.T) {
 		// macOS: ~/Library/Logs/heimdallm/heimdallm-daemon-error.log,
 		// unless /data happens to exist on the host (unusual on macOS
 		// dev machines but possible if something else mounted it).
+		dockerPath := filepath.Join("/data", DaemonLogFileName)
 		if _, err := os.Stat("/data"); err == nil {
-			if got != "/data/heimdallm.log" {
-				t.Fatalf("with /data present, daemonLogPath() = %q, want /data/heimdallm.log", got)
+			if got != dockerPath {
+				t.Fatalf("with /data present, daemonLogPath() = %q, want %q", got, dockerPath)
 			}
 			return
 		}
@@ -72,14 +73,15 @@ func TestDaemonLogPath_FallsBackToNativeWhenDataDirUnset(t *testing.T) {
 
 	// Linux: inside the test-docker sandbox there is no /data mount,
 	// and HOME points at /tmp/home. Assert we got the XDG/HOME path.
+	dockerPath := filepath.Join("/data", DaemonLogFileName)
 	if _, err := os.Stat("/data"); err == nil {
-		if got != "/data/heimdallm.log" {
-			t.Fatalf("with /data present, daemonLogPath() = %q, want /data/heimdallm.log", got)
+		if got != dockerPath {
+			t.Fatalf("with /data present, daemonLogPath() = %q, want %q", got, dockerPath)
 		}
 		return
 	}
-	if !strings.HasSuffix(got, filepath.Join("heimdallm", "heimdallm.log")) {
-		t.Fatalf("daemonLogPath() = %q, want to end in heimdallm/heimdallm.log", got)
+	if !strings.HasSuffix(got, filepath.Join("heimdallm", DaemonLogFileName)) {
+		t.Fatalf("daemonLogPath() = %q, want to end in heimdallm/%s", got, DaemonLogFileName)
 	}
 }
 
@@ -99,7 +101,7 @@ func TestDaemonLogPath_XDGStateHomeUsedWhenSet(t *testing.T) {
 	}
 
 	got := daemonLogPath()
-	want := filepath.Join(xdg, "heimdallm", "heimdallm.log")
+	want := filepath.Join(xdg, "heimdallm", DaemonLogFileName)
 	if got != want {
 		t.Fatalf("daemonLogPath() = %q, want %q", got, want)
 	}

--- a/daemon/internal/server/handlers_internal_test.go
+++ b/daemon/internal/server/handlers_internal_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Regression coverage for #75: the /logs SSE stream reads from
+// daemonLogPath(), which must resolve to wherever setupLogging() in
+// cmd/heimdallm actually wrote the file. Priorities:
+//
+//  1. $HEIMDALLM_DATA_DIR/heimdallm.log
+//  2. /data/heimdallm.log (Docker convention)
+//  3. Native fallback (macOS LaunchAgent path or XDG)
+
+func withEnv(t *testing.T, key, value string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	if value == "" {
+		_ = os.Unsetenv(key)
+	} else {
+		_ = os.Setenv(key, value)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+func TestDaemonLogPath_HeimdallmDataDirWins(t *testing.T) {
+	dir := t.TempDir()
+	withEnv(t, "HEIMDALLM_DATA_DIR", dir)
+	withEnv(t, "XDG_STATE_HOME", "") // ensure we are not falling through to it
+
+	got := daemonLogPath()
+	want := filepath.Join(dir, "heimdallm.log")
+	if got != want {
+		t.Fatalf("daemonLogPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDaemonLogPath_FallsBackToNativeWhenDataDirUnset(t *testing.T) {
+	withEnv(t, "HEIMDALLM_DATA_DIR", "")
+	withEnv(t, "XDG_STATE_HOME", "")
+
+	got := daemonLogPath()
+
+	// The native fallback depends on GOOS. We assert on the *shape* of
+	// the path rather than a hard-coded string so the test stays
+	// portable when run on both macOS and Linux CI.
+	if runtime.GOOS == "darwin" {
+		// macOS: ~/Library/Logs/heimdallm/heimdallm-daemon-error.log,
+		// unless /data happens to exist on the host (unusual on macOS
+		// dev machines but possible if something else mounted it).
+		if _, err := os.Stat("/data"); err == nil {
+			if got != "/data/heimdallm.log" {
+				t.Fatalf("with /data present, daemonLogPath() = %q, want /data/heimdallm.log", got)
+			}
+			return
+		}
+		if !strings.Contains(got, filepath.Join("Library", "Logs", "heimdallm")) {
+			t.Fatalf("daemonLogPath() = %q, want macOS LaunchAgent path", got)
+		}
+		return
+	}
+
+	// Linux: inside the test-docker sandbox there is no /data mount,
+	// and HOME points at /tmp/home. Assert we got the XDG/HOME path.
+	if _, err := os.Stat("/data"); err == nil {
+		if got != "/data/heimdallm.log" {
+			t.Fatalf("with /data present, daemonLogPath() = %q, want /data/heimdallm.log", got)
+		}
+		return
+	}
+	if !strings.HasSuffix(got, filepath.Join("heimdallm", "heimdallm.log")) {
+		t.Fatalf("daemonLogPath() = %q, want to end in heimdallm/heimdallm.log", got)
+	}
+}
+
+func TestDaemonLogPath_XDGStateHomeUsedWhenSet(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("XDG path only used on non-darwin when HEIMDALLM_DATA_DIR is unset")
+	}
+	withEnv(t, "HEIMDALLM_DATA_DIR", "")
+	xdg := t.TempDir()
+	withEnv(t, "XDG_STATE_HOME", xdg)
+
+	// When /data exists (Docker mode), it takes precedence over XDG —
+	// matches the real setupLogging behaviour because dataDir() returns
+	// "/data" in that situation. Skip the strict assertion in that case.
+	if _, err := os.Stat("/data"); err == nil {
+		t.Skip("/data exists on this host — Docker path wins over XDG, which is correct")
+	}
+
+	got := daemonLogPath()
+	want := filepath.Join(xdg, "heimdallm", "heimdallm.log")
+	if got != want {
+		t.Fatalf("daemonLogPath() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #75.

## Summary

The web UI's \`/logs\` view kept showing *\"log file not found at …heimdallm.log — daemon may be running in dev mode or log path differs\"* and reconnecting in a loop. Root cause: \`setupLogging()\` wired slog to \`os.Stderr\` only, but Docker redirects stderr to \`docker logs\`, never to a file — while \`handleLogsStream\` tails a file path. The two ends disagreed about where \"logs\" live.

Fix: have \`setupLogging()\` mirror slog output to \`<dataDir>/heimdallm.log\` via \`io.MultiWriter(os.Stderr, file)\`, and teach \`daemonLogPath()\` to prefer that same location. \`docker logs heimdallm\` keeps working — nothing is lost.

## What changed

- \`daemon/cmd/heimdallm/main.go\`
  - \`setupLogging\` now takes a \`dataDir\` and opens \`<dataDir>/heimdallm.log\` in append mode (0640) alongside stderr. I/O failures degrade to stderr-only with a \`slog.Warn\` — the daemon never refuses to start because of disk logging.
  - Exported \`DaemonLogFileName\` so the writer and the HTTP handler agree on the name.
  - Call site reordered: resolve \`dataDir()\` **before** \`setupLogging\` so the log file lands in the same volume as \`heimdallm.db\`.

- \`daemon/internal/server/handlers.go\`
  - \`daemonLogPath()\` priority now matches \`dataDir()\` exactly:
    1. \`\$HEIMDALLM_DATA_DIR/heimdallm.log\`
    2. \`/data/heimdallm.log\` (when \`/data\` exists as a directory — Docker convention)
    3. macOS LaunchAgent path
    4. \`\$XDG_STATE_HOME/heimdallm/heimdallm.log\`, with \`~/.local/share/heimdallm/heimdallm.log\` as final fallback.

- \`daemon/internal/server/handlers_internal_test.go\` (new)
  - Three regression tests for \`daemonLogPath()\` in the internal package so the unexported helper stays covered without widening its visibility.
  - Env vars saved/restored via a \`withEnv\` helper to keep the suite hermetic under parallel runs.

## Why not rotate?

Deliberately out of scope. The log file will grow indefinitely under long-lived Docker deployments. A follow-up issue can add either a built-in rotator or a documented \`logrotate\` config — whichever the team prefers — but fixing visibility is the blocker today.

## Out of scope

- \`docker-compose.yml\` — untouched. The existing \`heimdallm-data:/data\` mount already persists the log across restarts.
- \`docker/Dockerfile\` — untouched. \`/data\` is already \`chown heimdallm:heimdallm\` so the new \`O_CREATE\` succeeds as the runtime user.
- Flutter / macOS LaunchAgent path — same path as before, just now reached via a clearer precedence chain.

## Test plan

- [x] \`make test-docker\` — all packages green, including the three new tests.
- [x] \`docker compose up -d --build heimdallm\` on a fresh volume: \`/data/heimdallm.log\` is created with mode \`0640\`, owner \`heimdallm\`, contains the \`"daemon started"\` line.
- [x] \`docker compose logs heimdallm\` shows the same lines — no regression for \`docker logs\` users.
- [ ] Reviewer: hit \`/logs\` on \`http://localhost:3000\` after rebuild — lines stream live, connection pill stays green.