### PR TITLE
feat(daemon): size-based rotation for heimdallm.log

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -55,11 +56,11 @@ func main() {
 	// /logs stream reads that file; writing only to stderr (as we used
 	// to) left the stream empty under Docker — see #75.
 	logDir := dataDir()
-	logFile := setupLogging(logDir)
-	if logFile != nil {
+	logCloser := setupLogging(logDir)
+	if logCloser != nil {
 		// Flush buffered writes on shutdown so the last lines reach
 		// disk even when the daemon is killed mid-log.
-		defer logFile.Close()
+		defer logCloser.Close()
 	}
 
 	cfgPath := configPath()
@@ -668,14 +669,39 @@ func main() {
 	broker.Stop()
 }
 
+// logRotationConfig reads HEIMDALLM_LOG_MAX_MB and HEIMDALLM_LOG_KEEP from
+// the environment, falling back to the package defaults. Invalid values
+// fall back silently rather than refusing to start — logging is
+// non-critical enough that a typo in an env var shouldn't take the daemon
+// down.
+func logRotationConfig() (maxBytes int64, keep int) {
+	maxBytes = server.DefaultLogMaxBytes
+	keep = server.DefaultLogKeep
+	if v := os.Getenv("HEIMDALLM_LOG_MAX_MB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			maxBytes = int64(n) * 1024 * 1024
+		}
+	}
+	if v := os.Getenv("HEIMDALLM_LOG_KEEP"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			keep = n
+		}
+	}
+	return
+}
+
 // setupLogging configures slog to write to stderr and, when possible, also
 // to <dataDir>/heimdallm.log — the file the web UI's /logs endpoint tails
-// (see #75). Returns the opened file handle so the caller can Close it on
-// shutdown; returns nil when we're running stderr-only (either dataDir is
-// empty or the file open failed). Either way the daemon never refuses to
-// start because logging to disk failed; `docker logs` / the host terminal
-// continue to work.
-func setupLogging(dataDir string) *os.File {
+// (see #75). Returns an io.Closer so the caller can flush on shutdown;
+// returns nil when we're running stderr-only (either dataDir is empty or
+// the file open failed). The daemon never refuses to start because
+// logging to disk failed; `docker logs` / the host terminal continue to
+// work.
+//
+// The log file is wrapped in a size-based rotator (see #77). MaxBytes
+// and Keep come from HEIMDALLM_LOG_MAX_MB / HEIMDALLM_LOG_KEEP with the
+// server package defaults.
+func setupLogging(dataDir string) io.Closer {
 	handlerOpts := &slog.HandlerOptions{Level: slog.LevelInfo}
 
 	if dataDir == "" {
@@ -683,14 +709,9 @@ func setupLogging(dataDir string) *os.File {
 		return nil
 	}
 
-	// O_APPEND so restarts extend the log rather than truncating it;
-	// 0640 so the web container (different UID, same data volume) could
-	// read via group membership, and the host user keeps full write
-	// access. The web container today reads this over HTTP via the
-	// daemon, not directly, but keeping the mode narrow is still the
-	// right posture.
 	logPath := filepath.Join(dataDir, server.DaemonLogFileName)
-	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	maxBytes, keep := logRotationConfig()
+	w, err := server.NewRotatingWriter(logPath, maxBytes, keep)
 	if err != nil {
 		// Warn via a temporary logger that is visible on stderr even
 		// before SetDefault runs below.
@@ -701,8 +722,8 @@ func setupLogging(dataDir string) *os.File {
 		return nil
 	}
 
-	slog.SetDefault(slog.New(slog.NewTextHandler(io.MultiWriter(os.Stderr, f), handlerOpts)))
-	return f
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.MultiWriter(os.Stderr, w), handlerOpts)))
+	return w
 }
 
 // dataDir resolves the data directory.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -671,20 +671,27 @@ func main() {
 
 // logRotationConfig reads HEIMDALLM_LOG_MAX_MB and HEIMDALLM_LOG_KEEP from
 // the environment, falling back to the package defaults. Invalid values
-// fall back silently rather than refusing to start — logging is
-// non-critical enough that a typo in an env var shouldn't take the daemon
-// down.
+// fall back to the default *and* warn to stderr so operators notice typos
+// instead of silently losing the override they thought they had set.
+// Logging is non-critical enough that a bad env var should never take the
+// daemon down.
 func logRotationConfig() (maxBytes int64, keep int) {
 	maxBytes = server.DefaultLogMaxBytes
 	keep = server.DefaultLogKeep
 	if v := os.Getenv("HEIMDALLM_LOG_MAX_MB"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			maxBytes = int64(n) * 1024 * 1024
+		} else {
+			fmt.Fprintf(os.Stderr, "heimdallm: ignoring invalid HEIMDALLM_LOG_MAX_MB=%q (want positive integer, using default %d MiB)\n",
+				v, server.DefaultLogMaxBytes/(1024*1024))
 		}
 	}
 	if v := os.Getenv("HEIMDALLM_LOG_KEEP"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			keep = n
+		} else {
+			fmt.Fprintf(os.Stderr, "heimdallm: ignoring invalid HEIMDALLM_LOG_KEEP=%q (want positive integer, using default %d)\n",
+				v, server.DefaultLogKeep)
 		}
 	}
 	return

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -770,6 +770,14 @@ func (srv *Server) handleLogsStream(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				continue
 			}
+			// Detect rotation: if the on-disk file is now smaller than
+			// our saved offset, the rotator renamed the old file and
+			// re-created a fresh one. Reset to 0 so we stream the new
+			// content from the beginning rather than stalling at an
+			// offset that points past EOF. See #77.
+			if stat, err := f2.Stat(); err == nil && stat.Size() < offset {
+				offset = 0
+			}
 			f2.Seek(offset, io.SeekStart) //nolint:errcheck
 			scanner := bufio.NewScanner(f2)
 			for scanner.Scan() {

--- a/daemon/internal/server/rotating_writer.go
+++ b/daemon/internal/server/rotating_writer.go
@@ -88,6 +88,14 @@ func (w *RotatingWriter) Write(p []byte) (int, error) {
 			fmt.Fprintf(os.Stderr, "heimdallm: log rotation failed: %v\n", err)
 		}
 	}
+	// Defensive guard: rotation's recovery path aims to always leave
+	// w.f non-nil, but if every fallback also failed (e.g. the data
+	// directory became read-only) the handle can still be nil. Surface
+	// os.ErrClosed instead of panicking so the caller — typically slog
+	// — can degrade instead of crashing the daemon.
+	if w.f == nil {
+		return 0, os.ErrClosed
+	}
 	n, err := w.f.Write(p)
 	w.written += int64(n)
 	return n, err
@@ -114,8 +122,19 @@ func (w *RotatingWriter) backupPath(n int) string {
 
 // rotateLocked performs the rename shuffle and opens a fresh active file.
 // Must be called with w.mu held.
+//
+// Invariant: on every return path — success or error — w.f is either a
+// valid, writable file handle or (as a last resort, if even the recovery
+// open failed) nil. The Write path treats nil as os.ErrClosed rather
+// than panicking, but we try hard to never leave it nil: any failure
+// in the remove/shift/rename steps triggers recoverActive(), which
+// re-opens w.path so subsequent writes keep succeeding even though the
+// rotation itself gave up.
 func (w *RotatingWriter) rotateLocked() error {
 	if err := w.f.Close(); err != nil {
+		// We closed the file; we still want to try to recover a handle.
+		w.f = nil
+		w.recoverActive()
 		return fmt.Errorf("close active: %w", err)
 	}
 	w.f = nil
@@ -125,6 +144,7 @@ func (w *RotatingWriter) rotateLocked() error {
 	oldest := w.backupPath(w.keep)
 	if _, err := os.Stat(oldest); err == nil {
 		if err := os.Remove(oldest); err != nil {
+			w.recoverActive()
 			return fmt.Errorf("remove %s: %w", filepath.Base(oldest), err)
 		}
 	}
@@ -136,6 +156,7 @@ func (w *RotatingWriter) rotateLocked() error {
 		to := w.backupPath(n + 1)
 		if _, err := os.Stat(from); err == nil {
 			if err := os.Rename(from, to); err != nil {
+				w.recoverActive()
 				return fmt.Errorf("rename %s → %s: %w",
 					filepath.Base(from), filepath.Base(to), err)
 			}
@@ -144,11 +165,14 @@ func (w *RotatingWriter) rotateLocked() error {
 
 	// Promote the active file to .1.
 	if err := os.Rename(w.path, w.backupPath(1)); err != nil {
-		// Rename failed — truncate the active file as a fallback so the
-		// daemon can keep logging. History is lost but we stay healthy.
+		// Rename failed — truncate-then-reopen the active file as a
+		// fallback so the daemon can keep logging. History is lost but
+		// we stay healthy.
 		fallback, ferr := os.OpenFile(w.path,
 			os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0640)
 		if ferr != nil {
+			// Even truncate failed — leave w.f nil so Write returns
+			// os.ErrClosed instead of panicking.
 			return fmt.Errorf("rename failed (%v) and truncate fallback failed: %w", err, ferr)
 		}
 		w.f = fallback
@@ -160,9 +184,37 @@ func (w *RotatingWriter) rotateLocked() error {
 	fresh, err := os.OpenFile(w.path,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
 	if err != nil {
+		// The old active is already renamed to .1 — recoverActive will
+		// create a new empty file at w.path if it can.
+		w.recoverActive()
 		return fmt.Errorf("open fresh %s: %w", filepath.Base(w.path), err)
 	}
 	w.f = fresh
 	w.written = 0
 	return nil
+}
+
+// recoverActive is a best-effort attempt to leave w with a writable file
+// handle after a rotation step fails. It tries O_APPEND first (so we
+// keep any content that is still at w.path — e.g. the shift-backup path
+// never moved the active file) and falls back to O_TRUNC|O_CREATE if
+// that fails. If even that fails w.f stays nil and the next Write
+// returns os.ErrClosed — preferable to a panic. Must be called with
+// w.mu held and only when w.f is nil.
+func (w *RotatingWriter) recoverActive() {
+	f, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	if err == nil {
+		if info, statErr := f.Stat(); statErr == nil {
+			w.written = info.Size()
+		}
+		w.f = f
+		return
+	}
+	f, err = os.OpenFile(w.path, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0640)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "heimdallm: log rotation recovery failed: %v\n", err)
+		return
+	}
+	w.f = f
+	w.written = 0
 }

--- a/daemon/internal/server/rotating_writer.go
+++ b/daemon/internal/server/rotating_writer.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// DefaultLogMaxBytes is the default size cap for heimdallm.log before a
+// rotation fires. 50 MiB comfortably holds a few days of INFO-level output
+// from a chatty poll loop without feeling cramped on a Docker volume.
+const DefaultLogMaxBytes = int64(50 * 1024 * 1024)
+
+// DefaultLogKeep is how many rotated backups are retained alongside the
+// active file. 3 is a sweet spot: enough to diagnose a recent incident
+// after a restart, few enough that the volume never grows past
+// (Keep+1) * MaxBytes worst-case.
+const DefaultLogKeep = 3
+
+// RotatingWriter is a size-based file rotator used by setupLogging to wrap
+// heimdallm.log. It implements io.Writer and is safe for concurrent use —
+// the only writer in practice is slog's background emission, but callers
+// that pass the handle elsewhere (e.g. MultiWriter) don't need to know.
+//
+// Rotation scheme (simple, good enough for a single-process log):
+//   - heimdallm.log      ← active file
+//   - heimdallm.log.1    ← most recently rotated
+//   - heimdallm.log.2    ← one rotation older
+//   - …
+//   - heimdallm.log.<Keep>
+//
+// When rotation fires:
+//  1. Close the active file.
+//  2. Delete heimdallm.log.<Keep> (if it exists).
+//  3. Rename heimdallm.log.<Keep-1> → .<Keep>, .<Keep-2> → .<Keep-1>, …,
+//     heimdallm.log → heimdallm.log.1.
+//  4. Open a fresh heimdallm.log.
+//
+// On rename/open failures the rotator falls back to truncating the active
+// file so logging keeps working even if the underlying filesystem denies
+// the rename — losing history is preferable to blocking the daemon.
+type RotatingWriter struct {
+	mu       sync.Mutex
+	path     string
+	f        *os.File
+	maxBytes int64
+	keep     int
+	written  int64
+}
+
+// NewRotatingWriter opens (or creates) path in append mode and returns a
+// writer that rotates once writes push the file past maxBytes. maxBytes
+// <= 0 disables rotation entirely (plain append). keep <= 0 defaults to 1
+// backup, since fewer than that defeats the purpose.
+func NewRotatingWriter(path string, maxBytes int64, keep int) (*RotatingWriter, error) {
+	if keep < 1 {
+		keep = 1
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return &RotatingWriter{
+		path:     path,
+		f:        f,
+		maxBytes: maxBytes,
+		keep:     keep,
+		written:  info.Size(),
+	}, nil
+}
+
+// Write appends p to the active file, rotating first if the write would
+// push the file past maxBytes. Errors from rotation are logged to stderr
+// but do not prevent the write — we always return the result of the final
+// underlying Write so callers (slog) do not stall on a rotation hiccup.
+func (w *RotatingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.maxBytes > 0 && w.written+int64(len(p)) > w.maxBytes {
+		if err := w.rotateLocked(); err != nil {
+			fmt.Fprintf(os.Stderr, "heimdallm: log rotation failed: %v\n", err)
+		}
+	}
+	n, err := w.f.Write(p)
+	w.written += int64(n)
+	return n, err
+}
+
+// Close flushes and closes the active file. Subsequent writes fail until a
+// new writer is created — intended for shutdown only.
+func (w *RotatingWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return nil
+	}
+	err := w.f.Close()
+	w.f = nil
+	return err
+}
+
+// backupPath returns the rotated filename for index n (1-based):
+// "<path>.1", "<path>.2", …
+func (w *RotatingWriter) backupPath(n int) string {
+	return fmt.Sprintf("%s.%d", w.path, n)
+}
+
+// rotateLocked performs the rename shuffle and opens a fresh active file.
+// Must be called with w.mu held.
+func (w *RotatingWriter) rotateLocked() error {
+	if err := w.f.Close(); err != nil {
+		return fmt.Errorf("close active: %w", err)
+	}
+	w.f = nil
+
+	// Drop the oldest backup if it exists; os.Remove is a no-op when the
+	// file is absent, but we explicitly check to avoid masking real errors.
+	oldest := w.backupPath(w.keep)
+	if _, err := os.Stat(oldest); err == nil {
+		if err := os.Remove(oldest); err != nil {
+			return fmt.Errorf("remove %s: %w", filepath.Base(oldest), err)
+		}
+	}
+
+	// Shift .N-1 → .N, .N-2 → .N-1, …, .1 → .2 (reverse order so we
+	// never overwrite a backup we still need).
+	for n := w.keep - 1; n >= 1; n-- {
+		from := w.backupPath(n)
+		to := w.backupPath(n + 1)
+		if _, err := os.Stat(from); err == nil {
+			if err := os.Rename(from, to); err != nil {
+				return fmt.Errorf("rename %s → %s: %w",
+					filepath.Base(from), filepath.Base(to), err)
+			}
+		}
+	}
+
+	// Promote the active file to .1.
+	if err := os.Rename(w.path, w.backupPath(1)); err != nil {
+		// Rename failed — truncate the active file as a fallback so the
+		// daemon can keep logging. History is lost but we stay healthy.
+		fallback, ferr := os.OpenFile(w.path,
+			os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0640)
+		if ferr != nil {
+			return fmt.Errorf("rename failed (%v) and truncate fallback failed: %w", err, ferr)
+		}
+		w.f = fallback
+		w.written = 0
+		return fmt.Errorf("rename active: %w", err)
+	}
+
+	// Open a fresh active file.
+	fresh, err := os.OpenFile(w.path,
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	if err != nil {
+		return fmt.Errorf("open fresh %s: %w", filepath.Base(w.path), err)
+	}
+	w.f = fresh
+	w.written = 0
+	return nil
+}

--- a/daemon/internal/server/rotating_writer_test.go
+++ b/daemon/internal/server/rotating_writer_test.go
@@ -1,0 +1,165 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Scope: size-based rotation boundary behaviour introduced in #77.
+// The writer lives in the server package so these tests stay internal.
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func writeLine(t *testing.T, w *RotatingWriter, line string) {
+	t.Helper()
+	if _, err := w.Write([]byte(line)); err != nil {
+		t.Fatalf("write %q: %v", line, err)
+	}
+}
+
+func TestRotatingWriter_BelowCapDoesNotRotate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := NewRotatingWriter(path, 1024, 3)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	writeLine(t, w, "line1\n")
+	writeLine(t, w, "line2\n")
+
+	if _, err := os.Stat(path + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("expected no backup, but %s exists (err=%v)", path+".1", err)
+	}
+	if got := readFile(t, path); !strings.Contains(got, "line1") || !strings.Contains(got, "line2") {
+		t.Fatalf("active file = %q, want both lines", got)
+	}
+}
+
+func TestRotatingWriter_CrossingCapRotatesOnce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	// Cap at 10 bytes so a 6-byte write followed by a 6-byte write
+	// triggers rotation. keep=3.
+	w, err := NewRotatingWriter(path, 10, 3)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	writeLine(t, w, "first\n") // 6 bytes — fits under cap
+	writeLine(t, w, "second\n") // would exceed cap → rotates first
+
+	// .1 should now hold the first line, active file the second.
+	if got := readFile(t, path+".1"); !strings.Contains(got, "first") {
+		t.Fatalf(".1 = %q, want to contain first", got)
+	}
+	if got := readFile(t, path); !strings.Contains(got, "second") {
+		t.Fatalf("active = %q, want to contain second", got)
+	}
+
+	// .2 should not yet exist.
+	if _, err := os.Stat(path + ".2"); !os.IsNotExist(err) {
+		t.Fatalf("expected no .2 backup, got err=%v", err)
+	}
+}
+
+func TestRotatingWriter_EvictsOldestBeyondKeep(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	// keep=2, cap=6. Each write is exactly 6 bytes so every *next*
+	// write rotates.
+	w, err := NewRotatingWriter(path, 6, 2)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	// After 4 writes the sequence is:
+	//   write 1 → active: w1
+	//   write 2 → rotate (w1 → .1), active: w2
+	//   write 3 → rotate (.1 → .2, w2 → .1), active: w3
+	//   write 4 → rotate (.2 evicted, .1 → .2, w3 → .1), active: w4
+	for i := 1; i <= 4; i++ {
+		writeLine(t, w, fmt.Sprintf("w%d-xx", i)) // exactly 6 bytes
+	}
+
+	if got := readFile(t, path); !strings.Contains(got, "w4") {
+		t.Fatalf("active = %q, want w4", got)
+	}
+	if got := readFile(t, path+".1"); !strings.Contains(got, "w3") {
+		t.Fatalf(".1 = %q, want w3", got)
+	}
+	if got := readFile(t, path+".2"); !strings.Contains(got, "w2") {
+		t.Fatalf(".2 = %q, want w2", got)
+	}
+
+	// .3 must never exist — keep=2.
+	if _, err := os.Stat(path + ".3"); !os.IsNotExist(err) {
+		t.Fatalf("expected no .3 backup (keep=2), got err=%v", err)
+	}
+	// And w1 must have been evicted (no backup contains it).
+	for _, p := range []string{path, path + ".1", path + ".2"} {
+		if strings.Contains(readFile(t, p), "w1") {
+			t.Fatalf("w1 survived in %s — should have been evicted", p)
+		}
+	}
+}
+
+func TestRotatingWriter_MaxBytesZeroDisablesRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := NewRotatingWriter(path, 0, 3)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	// Write well past what a 50 MiB default would allow — rotation
+	// must stay off.
+	big := strings.Repeat("x", 10_000)
+	writeLine(t, w, big)
+	writeLine(t, w, big)
+
+	if _, err := os.Stat(path + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("expected no rotation with maxBytes=0, but %s exists (err=%v)", path+".1", err)
+	}
+}
+
+func TestRotatingWriter_ReopenPicksUpExistingSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	// Pre-populate the file with 5 bytes, then open the writer with
+	// cap=6. The very next write should push past the cap and rotate.
+	if err := os.WriteFile(path, []byte("older"), 0640); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	w, err := NewRotatingWriter(path, 6, 3)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	writeLine(t, w, "xx") // 5+2 > 6 → rotates
+
+	if got := readFile(t, path+".1"); !strings.Contains(got, "older") {
+		t.Fatalf(".1 = %q, want pre-existing content", got)
+	}
+}

--- a/daemon/internal/server/rotating_writer_test.go
+++ b/daemon/internal/server/rotating_writer_test.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -162,4 +165,103 @@ func TestRotatingWriter_ReopenPicksUpExistingSize(t *testing.T) {
 	if got := readFile(t, path+".1"); !strings.Contains(got, "older") {
 		t.Fatalf(".1 = %q, want pre-existing content", got)
 	}
+}
+
+func TestRotatingWriter_ClosedWriterReturnsErrNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := NewRotatingWriter(path, 1024, 3)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// After Close, w.f is nil. A write from a late slog.Info must
+	// surface os.ErrClosed instead of panicking on w.f.Write(p).
+	_, err = w.Write([]byte("after-close\n"))
+	if !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("Write after Close returned %v, want os.ErrClosed", err)
+	}
+}
+
+func TestRotatingWriter_RotationRecoversFromRenameFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics required")
+	}
+	if os.Geteuid() == 0 {
+		// Running as root bypasses file-mode permissions, so the
+		// recovery path is not exercised.
+		t.Skip("rotation recovery requires a non-root user")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := NewRotatingWriter(path, 6, 3)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	// Write under the cap so the file exists, then make the directory
+	// read-only: subsequent rename attempts will fail with EACCES and
+	// exercise the recoverActive fallback.
+	writeLine(t, w, "first\n")
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatalf("chmod %s 0500: %v", dir, err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	// This write crosses the cap and triggers a rotation that cannot
+	// complete (no rename allowed). The writer must leave a valid file
+	// handle behind and not panic.
+	if _, err := w.Write([]byte("second\n")); err != nil && !errors.Is(err, os.ErrClosed) {
+		// Write may succeed (recovered handle) or degrade to
+		// os.ErrClosed if the fallback open also failed. Any other
+		// error (or a panic) is a regression.
+		t.Fatalf("Write after failed rotation: unexpected err %v", err)
+	}
+	// Critically: a follow-up write must not panic. That's the #78
+	// regression this test guards against.
+	_, _ = w.Write([]byte("third\n"))
+}
+
+func TestRotatingWriter_ConcurrentWritesStaySafe(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	// Small cap forces many rotations during the run so the mutex is
+	// exercised across rotation boundaries.
+	w, err := NewRotatingWriter(path, 256, 5)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	const (
+		goroutines = 20
+		perWorker  = 50
+	)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			line := []byte(fmt.Sprintf("worker-%02d-xxxxxxxxxxxxxxxx\n", id))
+			for j := 0; j < perWorker; j++ {
+				if _, err := w.Write(line); err != nil {
+					// os.ErrClosed is acceptable if recovery ever
+					// fails, but a panic would abort the test.
+					if !errors.Is(err, os.ErrClosed) {
+						t.Errorf("concurrent write: %v", err)
+						return
+					}
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
 }

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -102,6 +102,20 @@ HEIMDALLM_RETENTION_DAYS=90
 # Server port (change if 7842 conflicts)
 HEIMDALLM_PORT=7842
 
+# ── Log rotation (optional — defaults are sensible) ────────────────────────
+#
+# The daemon mirrors its slog output into $HEIMDALLM_DATA_DIR/heimdallm.log
+# (or /data/heimdallm.log in Docker) so the web UI's /logs view can tail it.
+# That file is size-rotated to stop a chatty poll loop from filling the
+# volume. Worst-case disk use: (HEIMDALLM_LOG_KEEP + 1) * HEIMDALLM_LOG_MAX_MB.
+#
+# Max size of the active log file in MiB before rotation (default 50).
+# HEIMDALLM_LOG_MAX_MB=50
+#
+# How many rotated backups to retain alongside the active file (default 3).
+# Files are named heimdallm.log.1 (most recent) through heimdallm.log.<KEEP>.
+# HEIMDALLM_LOG_KEEP=3
+
 # ── Web UI (optional — only used if you bring up the `web` service) ────────
 
 # Host port to expose the SvelteKit UI on. Defaults to 3000.


### PR DESCRIPTION
Closes #77.

## Summary

#76 wired the daemon's slog output into \`<dataDir>/heimdallm.log\` so the web UI's \`/logs\` view could see it under Docker. But the file was opened \`O_APPEND|O_CREATE\` and never rotated — a chatty INFO-per-poll daemon would eventually fill the data volume on any long-lived deployment.

This PR adds a lightweight in-process rotator. No new dependency (single-process log, a \`sync.Mutex\` is all we need), ~170 lines of code covered by 5 unit tests.

## How it works

\`\`\`
heimdallm.log       ← active, capped at HEIMDALLM_LOG_MAX_MB (50 MiB)
heimdallm.log.1     ← most recently rotated
heimdallm.log.2
…
heimdallm.log.<KEEP>
\`\`\`

When a write would push the active file past the cap:
1. Close active.
2. Delete \`heimdallm.log.<KEEP>\` if present.
3. Rename \`.<KEEP-1>\` → \`.<KEEP>\`, …, active → \`.1\` in reverse order so we never clobber a backup we still need.
4. Open a fresh active file.

Rename failures fall back to truncating the active file — losing history is preferable to blocking the daemon, and the event is logged to stderr.

## Config

Two new env vars (both optional, documented in \`docker/.env.example\`):

| Var | Default | Meaning |
|-----|---------|---------|
| \`HEIMDALLM_LOG_MAX_MB\` | \`50\` | Active-file cap in MiB before rotation fires. \`0\` disables rotation. |
| \`HEIMDALLM_LOG_KEEP\` | \`3\` | Rotated backups to retain. Worst-case disk use = \`(KEEP+1) × MAX_MB\`. |

## /logs tail loop

The SSE handler in \`handleLogsStream\` saves an offset between polls. After rotation the old active file is renamed and a fresh one replaces it at byte 0 — leaving the saved offset pointing past EOF. The fix: on every poll, if \`stat.Size() < savedOffset\`, reset offset to 0 so we stream the new content from the start instead of stalling.

## What changed

- \`daemon/internal/server/rotating_writer.go\` (new) — \`RotatingWriter\`, thread-safe \`io.Writer\` + \`io.Closer\`, with \`DefaultLogMaxBytes\` / \`DefaultLogKeep\` constants.
- \`daemon/cmd/heimdallm/main.go\` — \`setupLogging\` wraps the file in \`RotatingWriter\` and returns \`io.Closer\`. New \`logRotationConfig()\` reads the env vars with safe fallbacks on parse errors.
- \`daemon/internal/server/handlers.go\` — \`handleLogsStream\` rotation detection.
- \`daemon/internal/server/rotating_writer_test.go\` (new) — 5 cases covering the boundary transitions.
- \`docker/.env.example\` — documents the new env vars.

## Out of scope

- **Time-based rotation** (\`MaxAge\`). Can be a follow-up if operators need it. Size-based is sufficient for the stated goal of not filling disk.
- **Compression of backups**. Nice-to-have; skipped to keep scope tight.
- **\`os.Stat(\"/data\")\` Docker heuristic refactor** — still pending per Muriano's comment on #76. Independent of rotation.

## Test plan

- [x] \`make test-docker\` — all packages green, 5 new tests pass.
- [x] \`docker compose up -d --build heimdallm\`: \`/data/heimdallm.log\` is created with mode 0640, content mirrors \`docker logs heimdallm\`.
- [ ] Reviewer: set \`HEIMDALLM_LOG_MAX_MB=1\`, \`HEIMDALLM_LOG_KEEP=2\`, run \`make restart\`, wait for a couple of polls, confirm \`heimdallm.log.1\` and \`.2\` appear on disk and \`/logs\` keeps streaming across the rotation boundary.