### PR TITLE
fix(daemon): persist PUT /config — store > env > TOML precedence

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -90,6 +90,18 @@ func main() {
 	}
 	defer s.Close()
 
+	// Merge PUT /config values on top of TOML+env. This is the third and
+	// highest-precedence layer: UI saves win over env vars, env vars win
+	// over TOML. See daemon/internal/config/store.go for the key mapping.
+	if rows, lcErr := s.ListConfigs(); lcErr != nil {
+		slog.Warn("config: list store rows failed, continuing with TOML+env", "err", lcErr)
+	} else if asErr := cfg.ApplyStore(rows); asErr != nil {
+		slog.Warn("config: apply store failed, continuing with TOML+env", "err", asErr)
+	} else if vErr := cfg.Validate(); vErr != nil {
+		slog.Error("config invalid after applying store, refusing to start", "err", vErr)
+		os.Exit(1)
+	}
+
 	if err := s.PurgeOldReviews(cfg.Retention.MaxDays); err != nil {
 		slog.Warn("retention purge failed", "err", err)
 	}
@@ -430,6 +442,7 @@ func main() {
 			"ai_fallback":    c.AI.Fallback,
 			"review_mode":    c.AI.ReviewMode,
 			"retention_days": c.Retention.MaxDays,
+			"issue_tracking": c.GitHub.IssueTracking,
 			"repo_overrides": repoOverrides,
 			"agent_configs":  agentConfigs,
 		}
@@ -463,6 +476,13 @@ func main() {
 		newCfg, err := config.Load(cfgPath)
 		if err != nil {
 			return fmt.Errorf("reload: %w", err)
+		}
+		if rows, lcErr := s.ListConfigs(); lcErr != nil {
+			slog.Warn("config: list store rows on reload failed", "err", lcErr)
+		} else if asErr := newCfg.ApplyStore(rows); asErr != nil {
+			return fmt.Errorf("reload: apply store: %w", asErr)
+		} else if vErr := newCfg.Validate(); vErr != nil {
+			return fmt.Errorf("reload: validate after store: %w", vErr)
 		}
 
 		cfgMu.Lock()

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -101,36 +101,36 @@ const (
 // highest-precedence match. This is a fail-safe ordering: when in doubt,
 // review before developing, and skip before either.
 type IssueTrackingConfig struct {
-	Enabled bool `toml:"enabled"`
+	Enabled bool `toml:"enabled" json:"enabled"`
 
 	// FilterMode decides how the org / assignee / label dimensions are
 	// combined ("exclusive" = AND, "inclusive" = OR). Applied by the
 	// pipeline; not consulted by Classify itself.
-	FilterMode FilterMode `toml:"filter_mode"`
+	FilterMode FilterMode `toml:"filter_mode" json:"filter_mode"`
 
 	// Organizations limits processing to issues belonging to these orgs.
 	// Empty = no org filter.
-	Organizations []string `toml:"organizations"`
+	Organizations []string `toml:"organizations" json:"organizations"`
 
 	// Assignees limits processing to issues assigned to these GitHub users.
 	// Empty = no assignee filter.
-	Assignees []string `toml:"assignees"`
+	Assignees []string `toml:"assignees" json:"assignees"`
 
 	// DevelopLabels are labels that mark an issue as "please implement".
-	DevelopLabels []string `toml:"develop_labels"`
+	DevelopLabels []string `toml:"develop_labels" json:"develop_labels"`
 
 	// ReviewOnlyLabels are labels that mark an issue as "please analyse and
 	// comment only". Takes precedence over DevelopLabels when both are
 	// present on the same issue — fail-safe default.
-	ReviewOnlyLabels []string `toml:"review_only_labels"`
+	ReviewOnlyLabels []string `toml:"review_only_labels" json:"review_only_labels"`
 
 	// SkipLabels are labels that opt an issue out of processing entirely.
 	// Highest precedence.
-	SkipLabels []string `toml:"skip_labels"`
+	SkipLabels []string `toml:"skip_labels" json:"skip_labels"`
 
 	// DefaultAction is applied when an issue carries no label from any of
 	// the three lists above. Must be "ignore" or "review_only".
-	DefaultAction string `toml:"default_action"`
+	DefaultAction string `toml:"default_action" json:"default_action"`
 }
 
 // Classify returns the processing mode for an issue given its labels.
@@ -447,6 +447,16 @@ func (c *Config) Validate() error {
 		return err
 	}
 	return nil
+}
+
+// ValidateIssueTracking is the package-exported form of validateIssueTracking.
+// Used by the PUT /config handler to pre-check a standalone IssueTrackingConfig
+// without having to assemble a full Config (which would trip over other
+// required fields like ai.primary).
+func ValidateIssueTracking(it IssueTrackingConfig) error {
+	c := &Config{}
+	c.GitHub.IssueTracking = it
+	return c.validateIssueTracking()
 }
 
 // validateIssueTracking enforces the small set of invariants the pipeline

--- a/daemon/internal/config/store.go
+++ b/daemon/internal/config/store.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+)
+
+// ApplyStore merges runtime-overridable config values written by the
+// PUT /config handler on top of whatever is already in the Config (TOML +
+// env vars). Precedence is TOML < env < store, so this step runs last.
+//
+// The handler stores string values bare and everything else as JSON, so the
+// decoding here is symmetric to handlers.go:handlePutConfig.
+//
+// Unknown keys are logged and skipped rather than rejected so a newer writer
+// can't brick an older reader during a staggered deploy.
+func (c *Config) ApplyStore(rows map[string]string) error {
+	for key, raw := range rows {
+		switch key {
+		case "poll_interval":
+			c.GitHub.PollInterval = raw
+		case "ai_primary":
+			c.AI.Primary = raw
+		case "ai_fallback":
+			c.AI.Fallback = raw
+		case "review_mode":
+			c.AI.ReviewMode = raw
+		case "repositories":
+			var repos []string
+			if err := json.Unmarshal([]byte(raw), &repos); err != nil {
+				return fmt.Errorf("config: apply store key %q: %w", key, err)
+			}
+			c.GitHub.Repositories = repos
+		case "retention_days":
+			var days int
+			if err := json.Unmarshal([]byte(raw), &days); err != nil {
+				return fmt.Errorf("config: apply store key %q: %w", key, err)
+			}
+			c.Retention.MaxDays = days
+		case "server_port":
+			var port int
+			if err := json.Unmarshal([]byte(raw), &port); err != nil {
+				return fmt.Errorf("config: apply store key %q: %w", key, err)
+			}
+			c.Server.Port = port
+		case "issue_tracking":
+			var it IssueTrackingConfig
+			if err := json.Unmarshal([]byte(raw), &it); err != nil {
+				return fmt.Errorf("config: apply store key %q: %w", key, err)
+			}
+			c.GitHub.IssueTracking = it
+		default:
+			slog.Warn("config: unknown store key, skipping", "key", key)
+		}
+	}
+	return nil
+}

--- a/daemon/internal/config/store_test.go
+++ b/daemon/internal/config/store_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"testing"
+)
+
+// ApplyStore is the third layer of config precedence: TOML < env < store.
+// It receives the `configs` table rows (key → raw value string) that the
+// PUT /config handler writes, and merges them onto an already-loaded cfg.
+//
+// Values stored as bare strings (e.g. "5m" for poll_interval) are assigned
+// as-is; everything else was json.Marshal'd by the handler, so we unmarshal
+// here symmetrically.
+
+func TestApplyStore_MergesRepositoriesAndIssueTracking(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.GitHub.Repositories = []string{"toml/one"}
+
+	rows := map[string]string{
+		"repositories":   `["store/a","store/b"]`,
+		"issue_tracking": `{"enabled":true,"filter_mode":"inclusive","develop_labels":["feature","bug"],"default_action":"review_only"}`,
+	}
+
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+
+	got := cfg.GitHub.Repositories
+	if len(got) != 2 || got[0] != "store/a" || got[1] != "store/b" {
+		t.Errorf("Repositories = %v, want [store/a store/b]", got)
+	}
+	it := cfg.GitHub.IssueTracking
+	if !it.Enabled {
+		t.Errorf("IssueTracking.Enabled = false, want true")
+	}
+	if it.FilterMode != FilterModeInclusive {
+		t.Errorf("FilterMode = %q, want inclusive", it.FilterMode)
+	}
+	if len(it.DevelopLabels) != 2 || it.DevelopLabels[0] != "feature" || it.DevelopLabels[1] != "bug" {
+		t.Errorf("DevelopLabels = %v, want [feature bug]", it.DevelopLabels)
+	}
+	if it.DefaultAction != "review_only" {
+		t.Errorf("DefaultAction = %q, want review_only", it.DefaultAction)
+	}
+}
+
+func TestApplyStore_WinsOverEnvOverrides(t *testing.T) {
+	t.Setenv("HEIMDALLM_POLL_INTERVAL", "1m")
+	t.Setenv("HEIMDALLM_AI_PRIMARY", "gemini")
+
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.applyEnvOverrides()
+
+	if cfg.GitHub.PollInterval != "1m" {
+		t.Fatalf("setup: env should have set poll_interval=1m, got %q", cfg.GitHub.PollInterval)
+	}
+	if cfg.AI.Primary != "gemini" {
+		t.Fatalf("setup: env should have set ai_primary=gemini, got %q", cfg.AI.Primary)
+	}
+
+	rows := map[string]string{
+		"poll_interval": "30m",
+		"ai_primary":    "claude",
+	}
+
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+
+	if cfg.GitHub.PollInterval != "30m" {
+		t.Errorf("PollInterval = %q, want 30m (store wins over env)", cfg.GitHub.PollInterval)
+	}
+	if cfg.AI.Primary != "claude" {
+		t.Errorf("AI.Primary = %q, want claude (store wins over env)", cfg.AI.Primary)
+	}
+}
+
+func TestApplyStore_InvalidJSON_ReturnsError(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+
+	rows := map[string]string{
+		"repositories": "this is not json",
+	}
+
+	if err := cfg.ApplyStore(rows); err == nil {
+		t.Fatal("ApplyStore with malformed JSON: expected error, got nil")
+	}
+}
+
+func TestApplyStore_UnknownKey_IsIgnored(t *testing.T) {
+	// Forward-compat: if an older daemon sees a key written by a newer
+	// handler, we skip it rather than fail the whole reload.
+	cfg := &Config{}
+	cfg.applyDefaults()
+
+	rows := map[string]string{
+		"future_key":    "some-value",
+		"poll_interval": "30m", // known key alongside unknown one
+	}
+
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Errorf("ApplyStore with unknown key: expected nil error, got %v", err)
+	}
+	if cfg.GitHub.PollInterval != "30m" {
+		t.Errorf("PollInterval = %q, want 30m (known key should still apply)", cfg.GitHub.PollInterval)
+	}
+}

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/heimdallm/daemon/internal/config"
 	"github.com/heimdallm/daemon/internal/executor"
 	"github.com/heimdallm/daemon/internal/pipeline"
 	"github.com/heimdallm/daemon/internal/sse"
@@ -310,6 +311,7 @@ var validConfigKeys = map[string]struct{}{
 	"ai_fallback":    {},
 	"review_mode":    {},
 	"retention_days": {},
+	"issue_tracking": {},
 }
 
 // validPollIntervals is the allowlist of permitted poll_interval values.
@@ -374,6 +376,26 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		}
 		if _, valid := validReviewModes[s]; !valid {
 			http.Error(w, "review_mode must be one of: single, multi", http.StatusBadRequest)
+			return
+		}
+	}
+	if v, ok := body["issue_tracking"]; ok {
+		// Round-trip through JSON to decode into the typed struct. This
+		// rejects malformed payloads (e.g. the client sent a string or
+		// array by mistake) before we ever hit the store, so a single bad
+		// request cannot persist a value that breaks the next reload.
+		raw, err := json.Marshal(v)
+		if err != nil {
+			http.Error(w, "issue_tracking must be a JSON object", http.StatusBadRequest)
+			return
+		}
+		var it config.IssueTrackingConfig
+		if err := json.Unmarshal(raw, &it); err != nil {
+			http.Error(w, fmt.Sprintf("issue_tracking: %v", err), http.StatusBadRequest)
+			return
+		}
+		if err := config.ValidateIssueTracking(it); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/heimdallm/daemon/internal/config"
 	"github.com/heimdallm/daemon/internal/server"
 	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
@@ -479,6 +480,91 @@ func TestIssueEndpointsRequireAuthWhenTokenSet(t *testing.T) {
 			t.Errorf("POST %s with valid token: unexpected 401", path)
 		}
 	}
+}
+
+func TestHandlerPutConfig_IssueTracking_Accepted(t *testing.T) {
+	srv, _ := setupServer(t)
+	body := `{"issue_tracking":{"enabled":true,"filter_mode":"exclusive","default_action":"ignore","develop_labels":["feature","bug"],"review_only_labels":["question"],"skip_labels":["wontfix"],"organizations":[],"assignees":[]}}`
+	req := httptest.NewRequest("PUT", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerPutConfig_IssueTracking_InvalidFilterMode(t *testing.T) {
+	srv, _ := setupServer(t)
+	// filter_mode "weird" with enabled=true should trip validateIssueTracking.
+	body := `{"issue_tracking":{"enabled":true,"filter_mode":"weird","default_action":"ignore"}}`
+	req := httptest.NewRequest("PUT", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerPutConfig_IssueTracking_InvalidDefaultAction(t *testing.T) {
+	srv, _ := setupServer(t)
+	body := `{"issue_tracking":{"enabled":true,"filter_mode":"exclusive","default_action":"delete_the_repo"}}`
+	req := httptest.NewRequest("PUT", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerPutConfig_IssueTracking_PersistsAndIsReadable(t *testing.T) {
+	// End-to-end: PUT → ListConfigs → ApplyStore → cfg reflects the change.
+	// This is the scenario that is broken on main today and the reason the
+	// web UI's "Save & reload" silently loses values on refresh.
+	srv, s := setupServer(t)
+	body := `{"issue_tracking":{"enabled":true,"filter_mode":"inclusive","default_action":"review_only","develop_labels":["feature"]}}`
+	req := httptest.NewRequest("PUT", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT: expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	rows, err := s.ListConfigs()
+	if err != nil {
+		t.Fatalf("ListConfigs: %v", err)
+	}
+	raw, ok := rows["issue_tracking"]
+	if !ok {
+		t.Fatalf("store: expected issue_tracking row, got keys %v", rows)
+	}
+
+	cfg := newCfgWithPrimary()
+	cfg.GitHub.PollInterval = "5m"
+	if err := cfg.ApplyStore(map[string]string{"issue_tracking": raw}); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate after ApplyStore: %v", err)
+	}
+	it := cfg.GitHub.IssueTracking
+	if !it.Enabled || it.FilterMode != config.FilterModeInclusive || it.DefaultAction != "review_only" {
+		t.Errorf("round-trip: got %+v", it)
+	}
+	if len(it.DevelopLabels) != 1 || it.DevelopLabels[0] != "feature" {
+		t.Errorf("DevelopLabels = %v, want [feature]", it.DevelopLabels)
+	}
+}
+
+// newCfgWithPrimary builds a minimal valid Config for tests that want to run
+// cfg.Validate() after ApplyStore (Validate requires ai.primary).
+func newCfgWithPrimary() *config.Config {
+	c := &config.Config{}
+	c.AI.Primary = "claude"
+	return c
 }
 
 func TestHandlerPutConfigValueValidation(t *testing.T) {

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -147,6 +147,30 @@ func (s *Store) GetConfig(key string) (string, error) {
 	return value, err
 }
 
+// ListConfigs returns every row in the configs table as a key→value map.
+// Consumed by config.ApplyStore during reload so user edits made via
+// PUT /config actually reach the running Config struct.
+func (s *Store) ListConfigs() (map[string]string, error) {
+	rows, err := s.db.Query("SELECT key, value FROM configs")
+	if err != nil {
+		return nil, fmt.Errorf("store: list configs: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]string)
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return nil, fmt.Errorf("store: scan config row: %w", err)
+		}
+		out[k] = v
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: iterate configs: %w", err)
+	}
+	return out, nil
+}
+
 // ReviewTimingStats contains metrics about how long reviews take.
 // Duration is measured from prs.fetched_at (pipeline start) to reviews.created_at (AI done).
 type ReviewTimingStats struct {

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -112,6 +112,43 @@ func TestRetentionPurge(t *testing.T) {
 	}
 }
 
+func TestConfigs_ListReturnsAllRows(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, err := s.SetConfig("poll_interval", "30m"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if _, err := s.SetConfig("repositories", `["org/a","org/b"]`); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	got, err := s.ListConfigs()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows, got %d: %v", len(got), got)
+	}
+	if got["poll_interval"] != "30m" {
+		t.Errorf("poll_interval = %q, want 30m", got["poll_interval"])
+	}
+	if got["repositories"] != `["org/a","org/b"]` {
+		t.Errorf("repositories = %q", got["repositories"])
+	}
+}
+
+func TestConfigs_ListOnEmptyTableReturnsEmptyMap(t *testing.T) {
+	s := newTestStore(t)
+
+	got, err := s.ListConfigs()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map, got %v", got)
+	}
+}
+
 func TestStore_AgentImplementFieldsRoundTrip(t *testing.T) {
 	s := newTestStore(t)
 


### PR DESCRIPTION
## Summary

- `PUT /config` now actually persists. `ApplyStore` merges the SQLite `configs` table on top of TOML + env vars at both bootstrap and `POST /reload`, so web-UI saves survive refresh and daemon restart.
- `issue_tracking` added to the PUT allowlist with typed validation (rejects bad `filter_mode` / `default_action` before they reach the store).
- `IssueTrackingConfig` dual-tagged with `json:"..."` so the snake_case keys the web UI sends round-trip cleanly.
- `GET /config` now returns `issue_tracking`, so the form prefills with whatever was last saved.

## Why

Before this change, `PUT /config` wrote to `configs` but nothing read those rows — the reload path only re-read TOML + env. Saves returned 200 but silently vanished on refresh. The `issue_tracking` allowlist gap compounded the problem: the body was rejected with HTTP 400 shown at the top of the form, where operators editing labels at the bottom never saw it.

Precedence is now **TOML < env < store**. The UI is the primary surface for operator edits, so it wins; env vars remain the bootstrap default. If someone wants an env var to re-take control, delete the matching row from `configs` (a small follow-up can add a reset endpoint — intentionally out of scope here).

## Test plan

- [x] `make test-docker` — all packages green (vet + tests).
- [x] New tests:
  - `config.TestApplyStore_*` (4 cases: merge, store-wins-over-env, bad JSON, unknown key)
  - `store.TestConfigs_ListReturnsAllRows` + empty-table case
  - `server.TestHandlerPutConfig_IssueTracking_*` (4 cases: accepted, invalid filter_mode, invalid default_action, end-to-end round-trip)
- [ ] Manual smoke in Docker: `make up` → open `/config` → edit `issue_tracking` labels → Save & reload → refresh page → values persist. (Recommended reviewer check.)

## Out of scope

- Preserving TOML comments/formatting on rewrite (we never rewrite TOML after bootstrap).
- Endpoint to reset a key back to env/TOML (manual DELETE from `configs` works for now).
- Migration of existing `configs` rows (none expected in live deployments — the endpoint was dead-write until this PR).

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)