### PR TITLE
feat(make): add `make up-build` for local-source rebuild-and-start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 .PHONY: build-daemon build-app test test-docker dev dev-daemon dev-stop \
         release-local package-macos install-service verify-linux run-linux \
-        setup up up-daemon down logs logs-daemon ps restart clean \
+        setup up up-build up-daemon down logs logs-daemon ps restart clean \
         _check-docker _check-env
 
 # ── Build ─────────────────────────────────────────────────────────────────────
@@ -300,6 +300,13 @@ _check-env: _check-docker
 
 up: _check-env
 	docker compose -f $(COMPOSE_FILE) up -d
+
+# up-build is the same as `up` but forces a fresh image build from the local
+# source tree. Use after `git pull` on main: the published `:latest` on GHCR
+# only refreshes when release-please cuts a tag, so `make up` alone would
+# silently serve the last cached image.
+up-build: _check-env
+	docker compose -f $(COMPOSE_FILE) up -d --build
 
 up-daemon: _check-env
 	docker compose -f $(COMPOSE_FILE) up -d heimdallm

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ endif
 
 .PHONY: build-daemon build-app test test-docker dev dev-daemon dev-stop \
         release-local package-macos install-service verify-linux run-linux \
-        setup up up-build up-daemon down logs logs-daemon ps restart clean \
-        _check-docker _check-env
+        setup up up-build up-daemon up-build-daemon down logs logs-daemon \
+        ps restart clean _check-docker _check-env
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 
@@ -301,15 +301,16 @@ _check-env: _check-docker
 up: _check-env
 	docker compose -f $(COMPOSE_FILE) up -d
 
-# up-build is the same as `up` but forces a fresh image build from the local
-# source tree. Use after `git pull` on main: the published `:latest` on GHCR
-# only refreshes when release-please cuts a tag, so `make up` alone would
-# silently serve the last cached image.
+# Like `up` but rebuilds images from local source (use after `git pull` on main).
 up-build: _check-env
-	docker compose -f $(COMPOSE_FILE) up -d --build
+	docker compose -f $(COMPOSE_FILE) up -d --build --pull always
 
 up-daemon: _check-env
 	docker compose -f $(COMPOSE_FILE) up -d heimdallm
+
+# Like `up-daemon` but rebuilds the daemon image from local source.
+up-build-daemon: _check-env
+	docker compose -f $(COMPOSE_FILE) up -d --build --pull always heimdallm
 
 down: _check-docker
 	docker compose -f $(COMPOSE_FILE) down

--- a/README.md
+++ b/README.md
@@ -122,11 +122,12 @@ See [`docker/.env.example`](docker/.env.example) for every supported variable in
 #### 3. Start the stack
 
 ```bash
-make up            # daemon + web UI (recommended)
+make up                # daemon + web UI (recommended)
 # or:
-make up-daemon     # daemon only, no web UI
+make up-daemon         # daemon only, no web UI
 # after `git pull` on main:
-make up-build      # same as `make up` but rebuilds from local source
+make up-build          # same as `make up` but rebuilds from local source
+make up-build-daemon   # same as `make up-daemon` but rebuilds from local source
 ```
 
 `make up` refuses to start if `docker/.env` is missing and prints the exact copy-from-template command. The web container waits for the daemon's healthcheck before accepting traffic, so the first UI request never races a half-initialised daemon.
@@ -308,9 +309,10 @@ make test          # Run Go + Flutter test suites on the host
 make test-docker   # Run Go tests inside a pinned Docker image (EDR-safe)
 make dev-daemon    # Run daemon only (debug API at localhost:7842)
 make dev-stop      # Stop the running daemon
-make up            # Docker: bring up daemon + web UI
-make up-build      # Docker: same as `up`, rebuild from local source (use on main)
-make up-daemon     # Docker: daemon only
+make up                # Docker: bring up daemon + web UI
+make up-build          # Docker: same as `up`, rebuild from local source (use on main)
+make up-daemon         # Docker: daemon only
+make up-build-daemon   # Docker: same as `up-daemon`, rebuild from local source
 make down          # Docker: stop and remove containers
 make logs          # Docker: follow all services
 make restart       # Docker: bounce both containers

--- a/README.md
+++ b/README.md
@@ -125,9 +125,13 @@ See [`docker/.env.example`](docker/.env.example) for every supported variable in
 make up            # daemon + web UI (recommended)
 # or:
 make up-daemon     # daemon only, no web UI
+# after `git pull` on main:
+make up-build      # same as `make up` but rebuilds from local source
 ```
 
 `make up` refuses to start if `docker/.env` is missing and prints the exact copy-from-template command. The web container waits for the daemon's healthcheck before accepting traffic, so the first UI request never races a half-initialised daemon.
+
+> **Tracking `main`?** `make up` reuses the last cached image. The published `:latest` on GHCR only refreshes when release-please cuts a tag, so between a PR merge and the next release you'll still be running the old binary. Use `make up-build` to rebuild from your checkout.
 
 > **Port already in use?** If `make up` fails with `bind: address already in use` for port `3000` (common collision: a local Next.js / Vite / Grafana dev server) or `7842`, override the host-side port in `docker/.env` and re-run:
 > ```bash
@@ -305,6 +309,7 @@ make test-docker   # Run Go tests inside a pinned Docker image (EDR-safe)
 make dev-daemon    # Run daemon only (debug API at localhost:7842)
 make dev-stop      # Stop the running daemon
 make up            # Docker: bring up daemon + web UI
+make up-build      # Docker: same as `up`, rebuild from local source (use on main)
 make up-daemon     # Docker: daemon only
 make down          # Docker: stop and remove containers
 make logs          # Docker: follow all services


### PR DESCRIPTION
## Summary

After `git pull` on main, `make down && make up` silently kept running the cached image because Compose doesn't rebuild unless asked. GHCR `:latest` only refreshes on release-please tag cuts, so there was a real "merged but not running" gap with no obvious fix in the Makefile.

- New `up-build` target: same `_check-env` preflight as `up`, invokes `docker compose up -d --build`.
- Added to `.PHONY`.
- Documented in the Docker install section and the Development targets list, with a callout explaining the cached-image gotcha for anyone tracking main.

## Test plan

- [x] `make -n up-build` expands to the expected `docker compose -f docker/docker-compose.yml up -d --build` with both preflight checks (docker available + `docker/.env` present).
- [ ] Reviewer smoke: `make down && make up-build` on main after a change to a string in `daemon/`, confirm the new string appears in `make logs-daemon`.

## Out of scope

- Changing the default of `make up` (`--build` is opt-in; users happy with cached images keep current behaviour).
- `--no-cache` variant (rare, operators can invoke Compose directly).

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)