### PR TITLE
fix: re-reviews no longer repeat false positives — structured review cycle context

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -121,6 +121,15 @@ func main() {
 	}
 
 	p := pipeline.New(s, ghClient, exec, &notifyWithSSE{notifier: notifier})
+
+	// Resolve bot login for re-review context filtering.
+	if login, err := ghClient.AuthenticatedUser(); err == nil {
+		p.SetBotLogin(login)
+		slog.Info("bot login resolved", "login", login)
+	} else {
+		slog.Warn("could not resolve bot login for re-review context", "err", err)
+	}
+
 	// GitExec drives the auto_implement flow (#27): branch, commit, push, PR.
 	// Wired unconditionally — the pipeline guards against running git ops on
 	// an issue that is classified as review_only, so this dep is harmless

--- a/daemon/internal/executor/prompt.go
+++ b/daemon/internal/executor/prompt.go
@@ -9,13 +9,14 @@ const maxDiffBytes = 32 * 1024 // 32KB ~ 8k tokens
 
 // PRContext holds all substitutable data for a prompt template.
 type PRContext struct {
-	Title    string
-	Number   int
-	Repo     string
-	Author   string
-	Link     string
-	Diff     string
-	Comments string // pre-formatted discussion section; empty string if no comments
+	Title         string
+	Number        int
+	Repo          string
+	Author        string
+	Link          string
+	Diff          string
+	Comments      string // pre-formatted discussion section; empty string if no comments
+	ReviewContext string // structured re-review context; empty on first review
 }
 
 // defaultTemplate is used when no custom agent template is configured.
@@ -39,6 +40,7 @@ Diff:
 {diff}
 </user_content>
 
+{review_context}
 {comments}
 
 Review the above diff and respond with ONLY valid JSON in this exact format (no markdown, no explanation):
@@ -75,6 +77,7 @@ Diff:
 {diff}
 </user_content>
 
+{review_context}
 {comments}
 
 Review the diff according to the focus above and respond with ONLY valid JSON (no markdown, no explanation):
@@ -101,7 +104,7 @@ func BuildPrompt(title, author, diff string) string {
 }
 
 // BuildPromptFromTemplate substitutes placeholders in a template.
-// Supported placeholders: {title} {number} {repo} {author} {link} {diff} {comments}
+// Supported placeholders: {title} {number} {repo} {author} {link} {diff} {comments} {review_context}
 //
 // Behavior for {comments}:
 //
@@ -114,6 +117,7 @@ func BuildPromptFromTemplate(tmpl string, ctx PRContext) string {
 	}
 
 	hasPlaceholder := strings.Contains(tmpl, "{comments}")
+	hasReviewCtx := strings.Contains(tmpl, "{review_context}")
 
 	r := strings.NewReplacer(
 		"{title}", ctx.Title,
@@ -123,6 +127,7 @@ func BuildPromptFromTemplate(tmpl string, ctx PRContext) string {
 		"{link}", ctx.Link,
 		"{diff}", ctx.Diff,
 		"{comments}", ctx.Comments,
+		"{review_context}", ctx.ReviewContext,
 	)
 	result := r.Replace(tmpl)
 
@@ -134,6 +139,11 @@ func BuildPromptFromTemplate(tmpl string, ctx PRContext) string {
 	// B: append comments if the template had no {comments} placeholder
 	if !hasPlaceholder && ctx.Comments != "" {
 		result += "\n\n" + ctx.Comments
+	}
+
+	// Prepend review context if template had no {review_context} placeholder
+	if !hasReviewCtx && ctx.ReviewContext != "" {
+		result = ctx.ReviewContext + "\n" + result
 	}
 
 	return result

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -50,6 +50,7 @@ type Pipeline struct {
 	}
 	executor CLIExecutor
 	notify   Notifier
+	botLogin string
 }
 
 // New creates a new Pipeline with the provided dependencies.
@@ -60,6 +61,10 @@ func New(s *store.Store, gh interface {
 }, exec CLIExecutor, n Notifier) *Pipeline {
 	return &Pipeline{store: s, gh: gh, executor: exec, notify: n}
 }
+
+// SetBotLogin sets the GitHub login of the bot account. Used to filter
+// the bot's own comments from re-review discussion context.
+func (p *Pipeline) SetBotLogin(login string) { p.botLogin = login }
 
 // applyPrompt resolves a prompt with priority: repoPromptID > agentPromptID > global default.
 func (p *Pipeline) applyPrompt(repoPromptID, agentPromptID string, tmpl *string, flags *string) {
@@ -159,19 +164,32 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	}
 	commentsSection := formatComments(prComments, pr.User.Login)
 
+	// 2c. Build re-review context if a previous review exists for this PR.
+	var reviewCtx string
+	if prevReview, err := p.store.LatestReviewForPR(prID); err == nil && prevReview != nil {
+		reviewCtx = buildReviewContext(
+			prevReview.Issues,
+			prevReview.Severity,
+			prevReview.CreatedAt,
+			prComments,
+			p.botLogin,
+		)
+	}
+
 	// 3. Build prompt:
 	//    Priority: repo override > agent-level prompt > globally active default > built-in default
 	promptTemplate := executor.DefaultTemplate()
 	var cliFlags string
 	p.applyPrompt(promptOverride, opts.AgentPromptID, &promptTemplate, &cliFlags)
 	prompt := executor.BuildPromptFromTemplate(promptTemplate, executor.PRContext{
-		Title:    pr.Title,
-		Number:   pr.Number,
-		Repo:     pr.Repo,
-		Author:   pr.User.Login,
-		Link:     pr.HTMLURL,
-		Diff:     diff,
-		Comments: commentsSection,
+		Title:         pr.Title,
+		Number:        pr.Number,
+		Repo:          pr.Repo,
+		Author:        pr.User.Login,
+		Link:          pr.HTMLURL,
+		Diff:          diff,
+		Comments:      commentsSection,
+		ReviewContext: reviewCtx,
 	})
 
 	// 4. Select CLI (profile can override the global primary/fallback)

--- a/daemon/internal/pipeline/review_context.go
+++ b/daemon/internal/pipeline/review_context.go
@@ -1,6 +1,9 @@
 package pipeline
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/heimdallm/daemon/internal/github"
@@ -16,4 +19,65 @@ func partitionComments(comments []github.Comment, cutoff time.Time) (before, aft
 		}
 	}
 	return
+}
+
+// reviewIssue is the minimal struct for deserializing previous review issues from JSON.
+type reviewIssue struct {
+	File        string `json:"file"`
+	Line        int    `json:"line"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+}
+
+// buildReviewContext creates a structured prompt section for re-reviews.
+// Returns empty string for first-time reviews (no previous review exists).
+func buildReviewContext(prevIssuesJSON, prevSeverity string, lastReviewAt time.Time, comments []github.Comment, botLogin string) string {
+	if prevIssuesJSON == "" && lastReviewAt.IsZero() {
+		return ""
+	}
+
+	var b strings.Builder
+
+	b.WriteString("IMPORTANT: This is a RE-REVIEW. You previously reviewed this PR.\n")
+	b.WriteString("Your previous findings and the discussion since then are shown below.\n")
+	b.WriteString("- Do NOT repeat findings that the author has addressed (check the diff for changes)\n")
+	b.WriteString("- Only re-flag a finding if the code is STILL unchanged despite the feedback\n")
+	b.WriteString("- Focus on NEW changes since the last review\n\n")
+
+	var issues []reviewIssue
+	if prevIssuesJSON != "" {
+		json.Unmarshal([]byte(prevIssuesJSON), &issues)
+	}
+
+	if len(issues) > 0 {
+		b.WriteString(fmt.Sprintf("## Your previous review (severity: %s)\n\n", prevSeverity))
+		b.WriteString("Previous findings:\n")
+		for _, iss := range issues {
+			b.WriteString(fmt.Sprintf("- [%s] %s:%d — %s\n", strings.ToUpper(iss.Severity), iss.File, iss.Line, iss.Description))
+		}
+		b.WriteString("\n")
+	}
+
+	_, afterComments := partitionComments(comments, lastReviewAt)
+
+	var newDiscussion []github.Comment
+	for _, c := range afterComments {
+		if !strings.EqualFold(c.Author, botLogin) {
+			newDiscussion = append(newDiscussion, c)
+		}
+	}
+
+	if len(newDiscussion) > 0 {
+		b.WriteString("## Discussion since last review\n\n")
+		for _, c := range newDiscussion {
+			if c.File != "" {
+				b.WriteString(fmt.Sprintf("@%s (%s:%d): %s\n", c.Author, c.File, c.Line, c.Body))
+			} else {
+				b.WriteString(fmt.Sprintf("@%s: %s\n", c.Author, c.Body))
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
 }

--- a/daemon/internal/pipeline/review_context.go
+++ b/daemon/internal/pipeline/review_context.go
@@ -1,0 +1,19 @@
+package pipeline
+
+import (
+	"time"
+
+	"github.com/heimdallm/daemon/internal/github"
+)
+
+// partitionComments splits comments into those created before and after the cutoff timestamp.
+func partitionComments(comments []github.Comment, cutoff time.Time) (before, after []github.Comment) {
+	for _, c := range comments {
+		if c.CreatedAt.After(cutoff) {
+			after = append(after, c)
+		} else {
+			before = append(before, c)
+		}
+	}
+	return
+}

--- a/daemon/internal/pipeline/review_context_test.go
+++ b/daemon/internal/pipeline/review_context_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -51,5 +52,59 @@ func TestPartitionComments_Empty(t *testing.T) {
 	before, after := partitionComments(nil, time.Now())
 	if len(before) != 0 || len(after) != 0 {
 		t.Error("expected empty slices for nil input")
+	}
+}
+
+func TestBuildReviewContext_WithPreviousReview(t *testing.T) {
+	prevIssues := `[{"file":"handler.go","line":42,"description":"Missing error handling","severity":"high"}]`
+	lastReviewAt := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+
+	comments := []github.Comment{
+		{Author: "heimdallm-bot", Body: "Review comment", CreatedAt: lastReviewAt.Add(-1 * time.Minute)},
+		{Author: "author", Body: "Fixed the error handling in latest commit", CreatedAt: lastReviewAt.Add(1 * time.Hour)},
+		{Author: "other-reviewer", Body: "Looks good now", CreatedAt: lastReviewAt.Add(2 * time.Hour)},
+	}
+
+	ctx := buildReviewContext(prevIssues, "high", lastReviewAt, comments, "heimdallm-bot")
+
+	if ctx == "" {
+		t.Fatal("expected non-empty review context")
+	}
+	if !strings.Contains(ctx, "RE-REVIEW") {
+		t.Error("missing RE-REVIEW instruction")
+	}
+	if !strings.Contains(ctx, "Missing error handling") {
+		t.Error("missing previous finding")
+	}
+	if !strings.Contains(ctx, "Fixed the error handling") {
+		t.Error("missing author response in discussion")
+	}
+	// Bot's own comment should NOT appear in "Discussion since last review"
+	if strings.Contains(ctx, "Review comment") {
+		t.Error("bot's own comment should be filtered from new discussion")
+	}
+}
+
+func TestBuildReviewContext_NoPreviousReview(t *testing.T) {
+	ctx := buildReviewContext("", "", time.Time{}, nil, "bot")
+	if ctx != "" {
+		t.Errorf("expected empty context for first review, got: %q", ctx)
+	}
+}
+
+func TestBuildReviewContext_PreviousReviewNoNewComments(t *testing.T) {
+	prevIssues := `[{"file":"main.go","line":10,"description":"Unused import","severity":"low"}]`
+	lastReviewAt := time.Now()
+
+	ctx := buildReviewContext(prevIssues, "low", lastReviewAt, nil, "bot")
+
+	if !strings.Contains(ctx, "RE-REVIEW") {
+		t.Error("missing RE-REVIEW instruction")
+	}
+	if !strings.Contains(ctx, "Unused import") {
+		t.Error("missing previous finding")
+	}
+	if strings.Contains(ctx, "Discussion since") {
+		t.Error("should not have discussion section with no new comments")
 	}
 }

--- a/daemon/internal/pipeline/review_context_test.go
+++ b/daemon/internal/pipeline/review_context_test.go
@@ -1,0 +1,55 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/github"
+)
+
+func TestPartitionComments_SplitsByTimestamp(t *testing.T) {
+	cutoff := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "old comment", CreatedAt: cutoff.Add(-1 * time.Hour)},
+		{Author: "author", Body: "old response", CreatedAt: cutoff.Add(-30 * time.Minute)},
+		{Author: "author", Body: "new push", CreatedAt: cutoff.Add(1 * time.Hour)},
+		{Author: "other", Body: "new feedback", CreatedAt: cutoff.Add(2 * time.Hour)},
+	}
+
+	before, after := partitionComments(comments, cutoff)
+	if len(before) != 2 {
+		t.Errorf("before = %d, want 2", len(before))
+	}
+	if len(after) != 2 {
+		t.Errorf("after = %d, want 2", len(after))
+	}
+}
+
+func TestPartitionComments_AllBefore(t *testing.T) {
+	cutoff := time.Now()
+	comments := []github.Comment{
+		{Author: "a", Body: "old", CreatedAt: cutoff.Add(-1 * time.Hour)},
+	}
+	before, after := partitionComments(comments, cutoff)
+	if len(before) != 1 || len(after) != 0 {
+		t.Errorf("before=%d after=%d, want 1/0", len(before), len(after))
+	}
+}
+
+func TestPartitionComments_AllAfter(t *testing.T) {
+	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	comments := []github.Comment{
+		{Author: "a", Body: "new", CreatedAt: time.Now()},
+	}
+	before, after := partitionComments(comments, cutoff)
+	if len(before) != 0 || len(after) != 1 {
+		t.Errorf("before=%d after=%d, want 0/1", len(before), len(after))
+	}
+}
+
+func TestPartitionComments_Empty(t *testing.T) {
+	before, after := partitionComments(nil, time.Now())
+	if len(before) != 0 || len(after) != 0 {
+		t.Error("expected empty slices for nil input")
+	}
+}


### PR DESCRIPTION
Closes #90

## Summary

When re-reviewing a PR, Heimdallm now provides the LLM with structured context about its previous review findings and the discussion that followed. This prevents the model from repeating findings that the author has already addressed.

## Problem

Previously, all PR comments were injected as a flat list without any context about review cycles. The model couldn't distinguish between:
- Its own previous findings
- Author responses addressing those findings
- New feedback from other reviewers

Result: false positives were repeated on every re-review.

## Solution

### Comment partitioning
Comments are split into "before last review" and "after last review" using the previous review's timestamp.

### Structured review context
When a previous review exists, the prompt now includes:

```
IMPORTANT: This is a RE-REVIEW. You previously reviewed this PR.
- Do NOT repeat findings that the author has addressed
- Only re-flag a finding if the code is STILL unchanged
- Focus on NEW changes since the last review

## Your previous review (severity: high)
Previous findings:
- [HIGH] handler.go:42 — Missing error handling

## Discussion since last review
@author: Fixed the error handling in latest commit
@other-reviewer: Looks good now
```

### Bot comment filtering
The bot's own comments are excluded from the "Discussion since last review" section (they're already represented in "Previous findings").

## Changes

1. **`review_context.go`** (new) — `partitionComments()` and `buildReviewContext()`
2. **`review_context_test.go`** (new) — 7 tests for partitioning and context building
3. **`prompt.go`** — `ReviewContext` field in `PRContext`, `{review_context}` placeholder
4. **`pipeline.go`** — Queries previous review, builds context, passes to prompt
5. **`main.go`** — Resolves bot login for comment filtering

## Test plan

- [ ] `go test ./internal/pipeline/ -v` — 7 new tests pass
- [ ] `go test ./... -timeout 60s` — no regressions
- [ ] First-time reviews: identical behavior (ReviewContext empty)
- [ ] Re-reviews: prompt includes previous findings + new discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)