### PR TITLE
fix(docker): forward HEIMDALLM_ISSUE_* + HEIMDALLM_DISCOVERY_* env vars

### DIFF
--- a/daemon/internal/config/store.go
+++ b/daemon/internal/config/store.go
@@ -84,11 +84,16 @@ func (c *Config) ApplyStore(rows map[string]string) error {
 			}
 			shadow.Retention.MaxDays = days
 		case "issue_tracking":
-			var it IssueTrackingConfig
-			if err := json.Unmarshal([]byte(raw), &it); err != nil {
+			// Unmarshal INTO the existing struct (not a fresh zero value).
+			// Go's encoding/json only overwrites fields the JSON mentions,
+			// so fields absent from the stored payload keep whatever the
+			// TOML+env layers already put there. Without this, a row
+			// written by an older build that predates a field (e.g. pre-#93
+			// save lacks blocked_labels) would silently zero-out the
+			// env-supplied value on every reload.
+			if err := json.Unmarshal([]byte(raw), &shadow.GitHub.IssueTracking); err != nil {
 				return fmt.Errorf("config: apply store key %q: %w", key, err)
 			}
-			shadow.GitHub.IssueTracking = it
 		case "server_port":
 			// Explicitly unsupported (not unknown): mutating the listening
 			// port at runtime would invalidate every in-flight connection

--- a/daemon/internal/config/store_test.go
+++ b/daemon/internal/config/store_test.go
@@ -223,6 +223,71 @@ func TestApplyStore_ServerPort_IsIgnored(t *testing.T) {
 	}
 }
 
+func TestApplyStore_IssueTracking_PreservesFieldsAbsentFromStoredJSON(t *testing.T) {
+	// Real-world scenario: a user saved issue_tracking via the UI with an
+	// older build that didn't know about BlockedLabels/PromoteToLabel. The
+	// row in `configs` only carries the eight fields the old build knew
+	// about. After upgrading the daemon, HEIMDALLM_ISSUE_BLOCKED_LABELS
+	// env var fills those new fields in applyEnvOverrides — and then
+	// ApplyStore must NOT clobber them back to zero just because the
+	// stored JSON doesn't mention them.
+	//
+	// Implementation contract: json.Unmarshal into the existing struct
+	// (not into a fresh zero value) so absent keys preserve the incoming
+	// value.
+	cfg := &Config{}
+	cfg.applyDefaults()
+	// Simulate applyEnvOverrides having populated the "new" fields.
+	cfg.GitHub.IssueTracking.BlockedLabels = []string{"heimdallm-queued"}
+	cfg.GitHub.IssueTracking.PromoteToLabel = "develop"
+	cfg.GitHub.IssueTracking.Enabled = true
+
+	// Stored JSON from an older UI save — no blocked_labels / promote_to_label.
+	rows := map[string]string{
+		"issue_tracking": `{"enabled":true,"filter_mode":"exclusive","default_action":"ignore","develop_labels":["develop"],"skip_labels":["wontfix"],"organizations":[],"assignees":[],"review_only_labels":[]}`,
+	}
+
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+
+	it := cfg.GitHub.IssueTracking
+	// Fields the stored JSON DID set must have landed:
+	if len(it.DevelopLabels) != 1 || it.DevelopLabels[0] != "develop" {
+		t.Errorf("DevelopLabels = %v, want [develop]", it.DevelopLabels)
+	}
+	if len(it.SkipLabels) != 1 || it.SkipLabels[0] != "wontfix" {
+		t.Errorf("SkipLabels = %v, want [wontfix]", it.SkipLabels)
+	}
+	// Fields the stored JSON did NOT set must survive from the env layer:
+	if len(it.BlockedLabels) != 1 || it.BlockedLabels[0] != "heimdallm-queued" {
+		t.Errorf("BlockedLabels = %v, want [heimdallm-queued] — stored JSON had no blocked_labels key, env value should survive", it.BlockedLabels)
+	}
+	if it.PromoteToLabel != "develop" {
+		t.Errorf("PromoteToLabel = %q, want develop — stored JSON had no promote_to_label key, env value should survive", it.PromoteToLabel)
+	}
+}
+
+func TestApplyStore_IssueTracking_ExplicitEmptyListStillClears(t *testing.T) {
+	// Symmetric contract: when the stored JSON DOES include a field and
+	// its value is an empty list, that IS a meaningful signal ("operator
+	// cleared this via UI") and must overwrite env. The fix for stale-
+	// JSON preservation cannot silently turn explicit `[]` into "no-op".
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.GitHub.IssueTracking.DevelopLabels = []string{"from-env"}
+
+	rows := map[string]string{
+		"issue_tracking": `{"enabled":false,"filter_mode":"exclusive","default_action":"ignore","develop_labels":[]}`,
+	}
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+	if len(cfg.GitHub.IssueTracking.DevelopLabels) != 0 {
+		t.Errorf("DevelopLabels = %v, want empty — explicit [] in stored JSON must override env", cfg.GitHub.IssueTracking.DevelopLabels)
+	}
+}
+
 func TestApplyStore_UnknownKey_IsIgnored(t *testing.T) {
 	// Forward-compat: if an older daemon sees a key written by a newer
 	// handler, we skip it rather than fail the whole reload.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,26 @@ services:
       - HEIMDALLM_PORT=${HEIMDALLM_PORT:-7842}
       - HEIMDALLM_BIND_ADDR=0.0.0.0
 
+      # ── Issue tracking pipeline ────────────────────────────────────────
+      # All optional. The daemon's applyIssueTrackingEnv reads these at
+      # startup; without forwarding them here the operator's docker/.env
+      # values stay outside the container and silently get defaults.
+      - HEIMDALLM_ISSUE_TRACKING_ENABLED=${HEIMDALLM_ISSUE_TRACKING_ENABLED:-}
+      - HEIMDALLM_ISSUE_FILTER_MODE=${HEIMDALLM_ISSUE_FILTER_MODE:-}
+      - HEIMDALLM_ISSUE_DEFAULT_ACTION=${HEIMDALLM_ISSUE_DEFAULT_ACTION:-}
+      - HEIMDALLM_ISSUE_ORGANIZATIONS=${HEIMDALLM_ISSUE_ORGANIZATIONS:-}
+      - HEIMDALLM_ISSUE_ASSIGNEES=${HEIMDALLM_ISSUE_ASSIGNEES:-}
+      - HEIMDALLM_ISSUE_DEVELOP_LABELS=${HEIMDALLM_ISSUE_DEVELOP_LABELS:-}
+      - HEIMDALLM_ISSUE_REVIEW_ONLY_LABELS=${HEIMDALLM_ISSUE_REVIEW_ONLY_LABELS:-}
+      - HEIMDALLM_ISSUE_SKIP_LABELS=${HEIMDALLM_ISSUE_SKIP_LABELS:-}
+      - HEIMDALLM_ISSUE_BLOCKED_LABELS=${HEIMDALLM_ISSUE_BLOCKED_LABELS:-}
+      - HEIMDALLM_ISSUE_PROMOTE_TO_LABEL=${HEIMDALLM_ISSUE_PROMOTE_TO_LABEL:-}
+
+      # ── Topic-based repository discovery ───────────────────────────────
+      - HEIMDALLM_DISCOVERY_TOPIC=${HEIMDALLM_DISCOVERY_TOPIC:-}
+      - HEIMDALLM_DISCOVERY_ORGS=${HEIMDALLM_DISCOVERY_ORGS:-}
+      - HEIMDALLM_DISCOVERY_INTERVAL=${HEIMDALLM_DISCOVERY_INTERVAL:-}
+
       # ── AI CLI authentication ──────────────────────────────────────────
       # Claude Code CLI (Anthropic)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}


### PR DESCRIPTION
## Summary

Two fixes paired because they're the same symptom: an operator edits `docker/.env` with `HEIMDALLM_ISSUE_*` values, runs `make up-build`, and the `/config` UI stubbornly reports them as unset. Running either fix alone leaves the bug partially reproducible.

### Fix 1 — compose env forwarding (`docker/docker-compose.yml`)

The service's `environment:` block was explicit, one `- VAR=${VAR:-}` line per forwarded value. Anything not in the block stayed in `docker/.env` but never reached the container. The ten `HEIMDALLM_ISSUE_*` vars and the three `HEIMDALLM_DISCOVERY_*` vars were missing, so values set in `.env` were silently dropped at the compose boundary.

Added explicit entries for all thirteen missing vars using the same `${VAR:-}` pattern as the existing optional keys.

### Fix 2 — partial merge in `ApplyStore` (`daemon/internal/config/store.go`)

Even with the env vars reaching the container, operators who had *ever* saved config via the web UI on an older build found the same result: the stored `configs.issue_tracking` row (written by a pre-#93 daemon that didn't know about `BlockedLabels` / `PromoteToLabel`) replaced the whole struct on every reload, zeroing out the env-supplied values for any field the old JSON didn't carry.

Root cause: `ApplyStore` was unmarshaling into a fresh `IssueTrackingConfig{}` and wholesale-assigning it back. Fix: unmarshal into the *existing* struct. Go's `encoding/json` only writes fields the JSON actually mentions, so absent keys retain their env layer. Explicit empty values (`"develop_labels": []` from a UI save that cleared the list) still clear as before — `TestApplyStore_IssueTracking_ExplicitEmptyListStillClears` pins that semantic down.

## Verification

After `make down && make up-build`:

```bash
# 1. Env vars reach the container (fix 1):
docker compose -f docker/docker-compose.yml exec heimdallm env | grep HEIMDALLM_ISSUE

# 2. Effective config picks them up even with a stale store row (fix 2):
TOKEN=$(docker compose exec -T heimdallm cat /data/api_token | tr -d '\r\n')
curl -s -H "X-Heimdallm-Token: $TOKEN" http://localhost:7842/config | jq .issue_tracking
```

Both must match the operator's `docker/.env` intent.

## Test plan

- [x] `make test-docker` — all packages green.
- [x] New tests:
  - `TestApplyStore_IssueTracking_PreservesFieldsAbsentFromStoredJSON` — fields absent from stored JSON survive from env layer.
  - `TestApplyStore_IssueTracking_ExplicitEmptyListStillClears` — explicit `[]` in stored JSON still overrides env, so UI-cleared lists aren't quietly re-populated.

## Why forwarding uses an allowlist

Compose supports `env_file: .env` which would blanket-forward everything. The allowlist pattern is more explicit but means every new knob requires a compose change — that's how this class of bug is born. A future follow-up could switch to `env_file:` to remove the gap for good, but that's a wider behavioural change and out of scope here.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)