### PR TITLE
feat(issues): sub-issues support + promotion robustness (closes #94, #97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A SvelteKit web dashboard (`:3000`) with Dashboard, PR list, Issue list, prompt/
 
 - **Automatic reviews** — polls `review-requested:@me` on GitHub and submits reviews as your account
 - **Issue pipeline** — label-driven triage + optional auto-implement with branch/commit/PR cycle
-- **Issue dependencies** — mark downstream work with a `blocked` label and a `## Depends on` body section; Heimdallm auto-promotes when blockers close
+- **Issue dependencies** — mark downstream work with a `blocked` label; declare deps via a `## Depends on` body section *or* GitHub's native sub-issues; Heimdallm auto-promotes when all blockers close
 - **Configurable prompts** — general review, security audit, performance, architecture, or your own with `{diff}` `{title}` `{author}` `{comments}` placeholders, managed from the web UI at `/agents`
 - **Two feedback modes** — *single* (one consolidated review) or *multi* (one GitHub comment per issue + summary), globally and per repo
 - **Per-repo overrides** — different AI agent, prompt, and feedback mode per repository
@@ -250,34 +250,52 @@ HEIMDALLM_ISSUE_BLOCKED_LABELS=blocked
 HEIMDALLM_ISSUE_PROMOTE_TO_LABEL=ready
 ```
 
-**Declare dependencies** in the issue body under a `## Depends on` heading:
+**Declare dependencies** in either (or both) of two ways — Heimdallm
+reads both on every poll and unions the results:
 
-```markdown
-## Depends on
-- #42
-- other-org/shared#57
-```
+1. **Markdown `## Depends on` section** in the issue body:
 
-- Same-repo refs use `#N`. Cross-repo refs use `owner/repo#N` — works with
-  any repo your `GITHUB_TOKEN` can read, whether or not it's in your
-  monitored list.
-- The heading is case-insensitive and accepts an optional trailing colon
-  (`## Depends On:`). Multiple refs per bullet are fine.
+    ```markdown
+    ## Depends on
+    - #42
+    - other-org/shared#57
+    ```
+
+    Same-repo refs use `#N`. Cross-repo refs use `owner/repo#N` — works
+    with any repo your `GITHUB_TOKEN` can read (cross-org included). The
+    heading is case-insensitive and accepts an optional trailing colon.
+    Multiple refs per bullet are fine.
+
+2. **GitHub native sub-issues** attached to the parent via the issue UI
+   or REST API. Available since the sub-issues GA; fully same-owner,
+   cross-repo supported (`org/repo-a#1` can have `org/repo-b#2` as a
+   sub-issue — but **not** `other-org/repo#3`, GitHub refuses that).
+   No extra declaration in the body needed.
+
+Either source alone is enough to mark an issue as having dependencies.
+Refs that appear in both are deduped, and the sub-issue's state
+pre-populates the dep cache so Heimdallm spends one fewer GitHub API
+call on shared refs.
 
 **How it runs.** Every poll cycle, for each issue carrying a blocked
 label:
 
-1. Parse the `## Depends on` bullets.
-2. Ask GitHub for each referenced issue/PR state.
-3. If all are `closed` (merged PRs count as closed), remove the blocked
+1. Parse the `## Depends on` bullets from the body.
+2. Call GitHub's sub-issues REST endpoint for the same issue.
+3. Union the refs from both sources; dedup.
+4. For each unique ref, fetch state via the GitHub API (cached within
+   the cycle).
+5. If all are `closed` (merged PRs count as closed), remove the blocked
    label(s), add `HEIMDALLM_ISSUE_PROMOTE_TO_LABEL`, and leave an audit
-   comment.
-4. The same poll cycle's fetch pass then classifies the promoted issue
+   comment listing each dep and its state at check time.
+6. The same poll cycle's fetch pass then classifies the promoted issue
    normally and dispatches it to triage or auto-implement.
 
-Issues with a blocked label but **no `## Depends on` section** stay
-blocked — the daemon won't guess when to unblock them. Remove the label
-manually to opt out.
+Issues with a blocked label but **no declared deps in either source**
+stay blocked — the daemon won't guess when to unblock them. Remove the
+label manually to opt out. If the sub-issues API errors transiently on
+a given issue, Heimdallm skips that issue for the current cycle rather
+than risk promoting on incomplete information.
 
 Classification precedence is
 `skip > blocked > review_only > develop > default_action`, so an issue

--- a/daemon/internal/github/models.go
+++ b/daemon/internal/github/models.go
@@ -39,8 +39,16 @@ type Issue struct {
 	CreatedAt   time.Time        `json:"created_at"`
 	UpdatedAt   time.Time        `json:"updated_at"`
 	PullRequest *struct{}        `json:"pull_request,omitempty"`
-	Repo        string           `json:"-"`
-	Mode        config.IssueMode `json:"-"`
+	// Repository is populated by GitHub on endpoints that can return issues
+	// from more than one repo in a single response (e.g. the sub-issues
+	// endpoint — same-owner, possibly cross-repo children). Kept as a
+	// pointer so the extra field is zero-cost when the endpoint doesn't
+	// include it. Consumers normally read Repo (below) — that's set by
+	// the client from this field when present, else from the parent
+	// context.
+	Repository *Repo            `json:"repository,omitempty"`
+	Repo       string           `json:"-"`
+	Mode       config.IssueMode `json:"-"`
 }
 
 // IsPullRequest reports whether the record returned by the issues endpoint is

--- a/daemon/internal/github/repos.go
+++ b/daemon/internal/github/repos.go
@@ -192,6 +192,44 @@ func (c *Client) GetIssue(repo string, number int) (*Issue, error) {
 	return &issue, nil
 }
 
+// ListSubIssues returns the native GitHub sub-issues declared under a
+// parent issue. GitHub's sub-issues are same-owner only (the REST endpoint
+// refuses cross-owner children) but can span repos inside that owner, so
+// each returned *Issue has its Repo resolved from the embedded repository
+// object when present, falling back to the parent repo.
+//
+// Used by the dependency promotion pass to pick up deps declared via the
+// native UI/API instead of (or alongside) a `## Depends on` Markdown
+// section in the parent body. A 200 with an empty array is returned as a
+// nil slice and nil error — GitHub's semantics for "no sub-issues".
+func (c *Client) ListSubIssues(repo string, number int) ([]*Issue, error) {
+	if repo == "" {
+		return nil, fmt.Errorf("github: ListSubIssues: empty repo")
+	}
+	path := fmt.Sprintf("/repos/%s/issues/%d/sub_issues", repo, number)
+	resp, err := c.do("GET", path, "application/vnd.github+json")
+	if err != nil {
+		return nil, fmt.Errorf("github: list sub-issues %s#%d: %w", repo, number, err)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github: list sub-issues %s#%d: status %d: %s", repo, number, resp.StatusCode, safeTruncate(string(body), maxErrBodyLen))
+	}
+	var out []*Issue
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("github: decode sub-issues %s#%d: %w", repo, number, err)
+	}
+	for _, issue := range out {
+		if issue.Repository != nil && issue.Repository.FullName != "" {
+			issue.Repo = issue.Repository.FullName
+		} else {
+			issue.Repo = repo
+		}
+	}
+	return out, nil
+}
+
 // SetAssignees sets assignees on an issue or pull request.
 func (c *Client) SetAssignees(repo string, number int, assignees []string) error {
 	if repo == "" || number == 0 || len(assignees) == 0 {

--- a/daemon/internal/github/repos_test.go
+++ b/daemon/internal/github/repos_test.go
@@ -372,6 +372,99 @@ func TestGetIssue_NotFound(t *testing.T) {
 	}
 }
 
+// ── ListSubIssues ─────────────────────────────────────────────────────────────
+
+func TestListSubIssues(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/repos/org/repo/issues/10/sub_issues" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[
+			{"number": 1, "state": "closed", "title": "first child"},
+			{"number": 2, "state": "open",   "title": "second child"}
+		]`))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := c.ListSubIssues("org/repo", 10)
+	if err != nil {
+		t.Fatalf("ListSubIssues: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Number != 1 || got[0].State != "closed" {
+		t.Errorf("child[0] = %+v, want number=1 state=closed", got[0])
+	}
+	if got[1].Number != 2 || got[1].State != "open" {
+		t.Errorf("child[1] = %+v, want number=2 state=open", got[1])
+	}
+	// Repo must be resolved so downstream consumers can use IssueRef keys.
+	if got[0].Repo != "org/repo" {
+		t.Errorf("Repo = %q, want org/repo", got[0].Repo)
+	}
+}
+
+func TestListSubIssues_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := c.ListSubIssues("org/repo", 10)
+	if err != nil {
+		t.Fatalf("ListSubIssues: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d, want 0", len(got))
+	}
+}
+
+func TestListSubIssues_NotFound(t *testing.T) {
+	// If the parent issue doesn't exist, the endpoint 404s. That's a real
+	// error, not an empty list — surface it so the caller logs and the
+	// next cycle retries.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	if _, err := c.ListSubIssues("org/repo", 10); err == nil {
+		t.Fatal("expected error on 404, got nil")
+	}
+}
+
+func TestListSubIssues_CrossRepoSameOwner(t *testing.T) {
+	// GitHub's sub-issues endpoint returns the child issue with a
+	// `repository.full_name` that may differ from the parent's repo (same
+	// owner, different repo). The client must resolve Repo to the actual
+	// child repo, not the parent's, so the promoter keys refs correctly.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[
+			{"number": 5, "state": "closed", "repository": {"full_name": "org/other-repo"}}
+		]`))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := c.ListSubIssues("org/parent-repo", 10)
+	if err != nil {
+		t.Fatalf("ListSubIssues: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Repo != "org/other-repo" {
+		t.Errorf("Repo = %q, want org/other-repo (cross-repo same-owner sub-issue)", got[0].Repo)
+	}
+}
+
 // ── SetAssignees ──────────────────────────────────────────────────────────────
 
 func TestSetAssignees(t *testing.T) {

--- a/daemon/internal/issues/promoter.go
+++ b/daemon/internal/issues/promoter.go
@@ -111,7 +111,7 @@ func PromoteReady(ctx context.Context, c PromoteIssueClient, cfg config.IssueTra
 				// manually.
 				continue
 			}
-			states, err := checkDeps(c, deps, issueCache)
+			states, err := checkDeps(ctx, c, deps, issueCache)
 			if err != nil {
 				slog.Warn("issues promote: dep check failed",
 					"repo", repo, "issue", issue.Number, "err", err)
@@ -150,11 +150,18 @@ type depState struct {
 // too (merged is a sub-state we don't need to inspect — "closed" covers
 // "this work has landed one way or another").
 //
+// `ctx` is consulted before every GetIssue fetch so a daemon shutdown
+// partway through a long dep chain exits promptly instead of blocking
+// on up to N × HTTP timeouts.
+//
 // On any GitHub call failure the function returns (nil, err) — the
 // caller logs and skips this issue, the next cycle retries.
-func checkDeps(c PromoteIssueClient, deps []IssueRef, cache map[string]*github.Issue) ([]depState, error) {
+func checkDeps(ctx context.Context, c PromoteIssueClient, deps []IssueRef, cache map[string]*github.Issue) ([]depState, error) {
 	out := make([]depState, 0, len(deps))
 	for _, d := range deps {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		key := fmt.Sprintf("%s#%d", d.Repo, d.Number)
 		got, ok := cache[key]
 		if !ok {
@@ -192,6 +199,18 @@ func applyPromotion(c PromoteIssueClient, issue *github.Issue, blockedLabels []s
 		return fmt.Errorf("remove blocked: %w", err)
 	}
 	if err := c.AddLabels(issue.Repo, issue.Number, []string{promoteTo}); err != nil {
+		// Compensating action: the blocked label is already removed, so
+		// if we return now the issue is orphaned — invisible to the
+		// promotion pass (no blocked label) AND to the normal pipeline
+		// (no promote-to label). Best-effort re-apply of the blocked
+		// label(s) keeps the issue in the queue so the next cycle
+		// retries. If that ALSO fails, we can only log loudly; the
+		// operator gets a paper trail in the logs.
+		if reErr := c.AddLabels(issue.Repo, issue.Number, blockedLabels); reErr != nil {
+			slog.Error("issues promote: could not restore blocked label after AddLabels failure; issue may be orphaned",
+				"repo", issue.Repo, "issue", issue.Number,
+				"original_err", err, "restore_err", reErr)
+		}
 		return fmt.Errorf("add promote-to: %w", err)
 	}
 	if err := c.PostComment(issue.Repo, issue.Number, auditCommentBody(promoteTo, states)); err != nil {

--- a/daemon/internal/issues/promoter.go
+++ b/daemon/internal/issues/promoter.go
@@ -14,6 +14,7 @@ import (
 // uses. Scoped to the minimum so tests can inject an in-memory fake.
 type PromoteIssueClient interface {
 	ListOpenIssues(repo string) ([]*github.Issue, error)
+	ListSubIssues(repo string, number int) ([]*github.Issue, error)
 	GetIssue(repo string, number int) (*github.Issue, error)
 	AddLabels(repo string, number int, labels []string) error
 	RemoveLabels(repo string, number int, labels []string) error
@@ -76,11 +77,38 @@ func PromoteReady(ctx context.Context, c PromoteIssueClient, cfg config.IssueTra
 			if len(blockedOnIssue) == 0 {
 				continue
 			}
+			// Collect deps from BOTH sources: the `## Depends on` body
+			// parser (cross-org-capable) AND GitHub's native sub-issues
+			// REST (same-owner-only). Unioned and deduped so operators
+			// can use either or both without double-counting.
 			deps := ParseDependencies(issue.Body, repo)
+			subIssues, err := c.ListSubIssues(repo, issue.Number)
+			if err != nil {
+				// Can't see native sub-issues this cycle: skip the whole
+				// issue rather than promote on incomplete information.
+				// Body-alone might say "ready" while a native sub-issue
+				// we can't read is still open — worst-case scenario.
+				slog.Warn("issues promote: sub-issues lookup failed, skipping issue this cycle",
+					"repo", repo, "issue", issue.Number, "err", err)
+				continue
+			}
+			for _, si := range subIssues {
+				ref := IssueRef{Repo: si.Repo, Number: si.Number}
+				if !containsRef(deps, ref) {
+					deps = append(deps, ref)
+				}
+				// Pre-populate the cache with the sub-issue's state —
+				// the sub_issues endpoint returns full issue objects,
+				// saving a GetIssue round-trip during checkDeps.
+				cacheKey := fmt.Sprintf("%s#%d", ref.Repo, ref.Number)
+				if _, cached := issueCache[cacheKey]; !cached {
+					issueCache[cacheKey] = si
+				}
+			}
 			if len(deps) == 0 {
-				// Carries a blocked label but no structured deps declared.
-				// We can't know what "ready" means here, so stay out — the
-				// operator likely wants to unblock manually.
+				// Carries a blocked label but no deps declared in either
+				// source. Stay out — operator likely wants to unblock
+				// manually.
 				continue
 			}
 			states, err := checkDeps(c, deps, issueCache)
@@ -188,6 +216,18 @@ func auditCommentBody(promoteTo string, states []depState) string {
 	}
 	sb.WriteString("\n---\n*Promoted by Heimdallm*")
 	return sb.String()
+}
+
+// containsRef reports whether refs already includes target. Cheap linear
+// scan — dep lists are small (single digits in practice), so the map
+// allocation overhead of a set wouldn't pay off.
+func containsRef(refs []IssueRef, target IssueRef) bool {
+	for _, r := range refs {
+		if r.Repo == target.Repo && r.Number == target.Number {
+			return true
+		}
+	}
+	return false
 }
 
 func lowerSet(xs []string) map[string]struct{} {

--- a/daemon/internal/issues/promoter_test.go
+++ b/daemon/internal/issues/promoter_test.go
@@ -16,16 +16,18 @@ import (
 // every mutating call so tests can assert the exact side effects without
 // an HTTP server standing in.
 type fakePromoteClient struct {
-	open          map[string][]*github.Issue              // repo → open issues (listed)
-	byRef         map[string]*github.Issue                // "repo#N" → issue (for GetIssue)
-	added         []struct{ Repo string; N int; Labels []string }
-	removed       []struct{ Repo string; N int; Labels []string }
-	comments      []struct{ Repo string; N int; Body string }
-	listErr       error
-	getErr        error
-	addErr        error
-	removeErr     error
-	commentErr    error
+	open       map[string][]*github.Issue              // repo → open issues (listed)
+	byRef      map[string]*github.Issue                // "repo#N" → issue (for GetIssue)
+	subIssues  map[string][]*github.Issue              // "repo#N" → children (for ListSubIssues)
+	added      []struct{ Repo string; N int; Labels []string }
+	removed    []struct{ Repo string; N int; Labels []string }
+	comments   []struct{ Repo string; N int; Body string }
+	listErr    error
+	getErr     error
+	subErr     error
+	addErr     error
+	removeErr  error
+	commentErr error
 }
 
 func (f *fakePromoteClient) ListOpenIssues(repo string) ([]*github.Issue, error) {
@@ -43,6 +45,13 @@ func (f *fakePromoteClient) GetIssue(repo string, number int) (*github.Issue, er
 		return got, nil
 	}
 	return nil, fmt.Errorf("fake: no issue for %s", key)
+}
+func (f *fakePromoteClient) ListSubIssues(repo string, number int) ([]*github.Issue, error) {
+	if f.subErr != nil {
+		return nil, f.subErr
+	}
+	key := fmt.Sprintf("%s#%d", repo, number)
+	return f.subIssues[key], nil
 }
 func (f *fakePromoteClient) AddLabels(repo string, n int, labels []string) error {
 	if f.addErr != nil {
@@ -260,6 +269,9 @@ func (f *failingPromoteClient) ListOpenIssues(repo string) ([]*github.Issue, err
 	}
 	return f.inner.ListOpenIssues(repo)
 }
+func (f *failingPromoteClient) ListSubIssues(repo string, n int) ([]*github.Issue, error) {
+	return f.inner.ListSubIssues(repo, n)
+}
 func (f *failingPromoteClient) GetIssue(repo string, n int) (*github.Issue, error) {
 	return f.inner.GetIssue(repo, n)
 }
@@ -271,6 +283,124 @@ func (f *failingPromoteClient) RemoveLabels(repo string, n int, ls []string) err
 }
 func (f *failingPromoteClient) PostComment(repo string, n int, body string) error {
 	return f.inner.PostComment(repo, n, body)
+}
+
+// ── native sub-issues support ────────────────────────────────────────────
+
+func TestPromoteReady_MergesSubIssuesWithBodyParser(t *testing.T) {
+	// Body declares one dep, sub-issues endpoint returns a different one.
+	// Both closed → promote. Assert both sources were consulted.
+	blocked := mkIssue("org/r", 10, "open", "## Depends on\n- #5\n", "blocked")
+	fake := &fakePromoteClient{
+		open:  map[string][]*github.Issue{"org/r": {blocked}},
+		byRef: map[string]*github.Issue{"org/r#5": mkIssue("org/r", 5, "closed", "")},
+		subIssues: map[string][]*github.Issue{
+			"org/r#10": {mkIssue("org/r", 7, "closed", "")},
+		},
+	}
+	n, err := PromoteReady(context.Background(), fake, baseCfg(), []string{"org/r"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("n = %d, want 1", n)
+	}
+	if len(fake.removed) != 1 {
+		t.Errorf("expected one label-remove call, got %d", len(fake.removed))
+	}
+}
+
+func TestPromoteReady_SubIssueStillOpen_NotPromoted(t *testing.T) {
+	// Body says "ready"; a native sub-issue is still open → must NOT promote.
+	// This is the safety case for "fall back to body would be unsafe" — the
+	// invariant we protect against sub-issues-API-failure.
+	blocked := mkIssue("org/r", 10, "open", "## Depends on\n- #5\n", "blocked")
+	fake := &fakePromoteClient{
+		open:  map[string][]*github.Issue{"org/r": {blocked}},
+		byRef: map[string]*github.Issue{"org/r#5": mkIssue("org/r", 5, "closed", "")},
+		subIssues: map[string][]*github.Issue{
+			"org/r#10": {mkIssue("org/r", 7, "open", "")},
+		},
+	}
+	n, err := PromoteReady(context.Background(), fake, baseCfg(), []string{"org/r"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("n = %d, want 0 (open sub-issue blocks promotion)", n)
+	}
+}
+
+func TestPromoteReady_SubIssuesOnly_NoBodySection(t *testing.T) {
+	// Issue uses native sub-issues exclusively (no `## Depends on` section).
+	// Previously this would be skipped as "no deps declared". With native
+	// support, sub-issues themselves ARE declared deps.
+	blocked := mkIssue("org/r", 10, "open", "body with no deps section", "blocked")
+	fake := &fakePromoteClient{
+		open: map[string][]*github.Issue{"org/r": {blocked}},
+		subIssues: map[string][]*github.Issue{
+			"org/r#10": {mkIssue("org/r", 7, "closed", "")},
+		},
+	}
+	n, err := PromoteReady(context.Background(), fake, baseCfg(), []string{"org/r"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("n = %d, want 1 (native sub-issue drives promotion)", n)
+	}
+}
+
+func TestPromoteReady_SubIssuesAPIFailure_SkipsIssue(t *testing.T) {
+	// Transient sub-issues API outage → skip this issue, don't fall back
+	// to body-only. Body could say "ready" while a native sub-issue we
+	// can't see is open, which would promote prematurely.
+	blocked := mkIssue("org/r", 10, "open", "## Depends on\n- #5\n", "blocked")
+	fake := &fakePromoteClient{
+		open:   map[string][]*github.Issue{"org/r": {blocked}},
+		byRef:  map[string]*github.Issue{"org/r#5": mkIssue("org/r", 5, "closed", "")},
+		subErr: errors.New("simulated 5xx"),
+	}
+	n, err := PromoteReady(context.Background(), fake, baseCfg(), []string{"org/r"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("n = %d, want 0 (sub-issues API error must skip, not fall back)", n)
+	}
+	if len(fake.removed) != 0 {
+		t.Errorf("expected no label mutations on sub-issues failure, got %v", fake.removed)
+	}
+}
+
+func TestPromoteReady_SubIssuesDedupWithBodyRefs(t *testing.T) {
+	// Same dep listed in both the body section and as a native sub-issue.
+	// Must be deduped — we don't want to GetIssue the same ref twice or
+	// double-list it in the audit comment.
+	blocked := mkIssue("org/r", 10, "open", "## Depends on\n- #5\n", "blocked")
+	counting := &countingPromoteClient{
+		inner: &fakePromoteClient{
+			open: map[string][]*github.Issue{"org/r": {blocked}},
+			byRef: map[string]*github.Issue{
+				"org/r#5": mkIssue("org/r", 5, "closed", ""),
+			},
+			subIssues: map[string][]*github.Issue{
+				"org/r#10": {mkIssue("org/r", 5, "closed", "")}, // same #5 via native
+			},
+		},
+	}
+	n, err := PromoteReady(context.Background(), counting, baseCfg(), []string{"org/r"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("n = %d, want 1", n)
+	}
+	// checkDeps consults the cache first; the sub-issue's state pre-populated
+	// it. So GetIssue for #5 should NOT be hit at all in this test.
+	if counting.getIssueCalls != 0 {
+		t.Errorf("GetIssue calls = %d, want 0 (sub-issue state should prime the cache and satisfy the body ref)", counting.getIssueCalls)
+	}
 }
 
 func TestPromoteReady_CachesGetIssueAcrossBlockedIssues(t *testing.T) {
@@ -335,6 +465,9 @@ type countingPromoteClient struct {
 
 func (c *countingPromoteClient) ListOpenIssues(repo string) ([]*github.Issue, error) {
 	return c.inner.ListOpenIssues(repo)
+}
+func (c *countingPromoteClient) ListSubIssues(repo string, n int) ([]*github.Issue, error) {
+	return c.inner.ListSubIssues(repo, n)
 }
 func (c *countingPromoteClient) GetIssue(repo string, n int) (*github.Issue, error) {
 	c.getIssueCalls++

--- a/daemon/internal/issues/promoter_test.go
+++ b/daemon/internal/issues/promoter_test.go
@@ -26,8 +26,13 @@ type fakePromoteClient struct {
 	getErr     error
 	subErr     error
 	addErr     error
-	removeErr  error
-	commentErr error
+	// addLabelsFn lets a test inject custom per-call behaviour (e.g.
+	// "fail the first call, succeed the second"). When set, addErr is
+	// ignored. A nil return falls through to the normal "record call"
+	// path so successful calls still show up in `added`.
+	addLabelsFn func(repo string, n int, labels []string) error
+	removeErr   error
+	commentErr  error
 }
 
 func (f *fakePromoteClient) ListOpenIssues(repo string) ([]*github.Issue, error) {
@@ -54,7 +59,11 @@ func (f *fakePromoteClient) ListSubIssues(repo string, number int) ([]*github.Is
 	return f.subIssues[key], nil
 }
 func (f *fakePromoteClient) AddLabels(repo string, n int, labels []string) error {
-	if f.addErr != nil {
+	if f.addLabelsFn != nil {
+		if err := f.addLabelsFn(repo, n, labels); err != nil {
+			return err
+		}
+	} else if f.addErr != nil {
 		return f.addErr
 	}
 	f.added = append(f.added, struct{ Repo string; N int; Labels []string }{repo, n, labels})
@@ -481,6 +490,88 @@ func (c *countingPromoteClient) RemoveLabels(repo string, n int, ls []string) er
 }
 func (c *countingPromoteClient) PostComment(repo string, n int, body string) error {
 	return c.inner.PostComment(repo, n, body)
+}
+
+// ── robustness (#94) ─────────────────────────────────────────────────────
+
+func TestPromoteReady_AddLabelsFailure_RestoresBlockedLabel(t *testing.T) {
+	// Scenario: RemoveLabels(blocked) succeeds, AddLabels(promoteTo)
+	// fails mid-flight (e.g. promote-to label missing in repo, transient
+	// 5xx). Without a compensating action the issue is orphaned: no
+	// blocked label (promotion pass skips it) AND no promote-to label
+	// (classification falls through to default_action=ignore).
+	//
+	// Contract: on AddLabels failure, applyPromotion must attempt to
+	// re-apply the blocked label(s) so the next cycle retries cleanly.
+	blocked := mkIssue("org/r", 10, "open", "## Depends on\n- #5\n", "blocked")
+	addCall := 0
+	fake := &fakePromoteClient{
+		open:  map[string][]*github.Issue{"org/r": {blocked}},
+		byRef: map[string]*github.Issue{"org/r#5": mkIssue("org/r", 5, "closed", "")},
+		addLabelsFn: func(repo string, n int, labels []string) error {
+			addCall++
+			if addCall == 1 {
+				// First call: the promote-to AddLabels. Fail it.
+				return errors.New("simulated AddLabels 5xx")
+			}
+			// Subsequent calls (the compensating one) succeed.
+			return nil
+		},
+	}
+
+	n, err := PromoteReady(context.Background(), fake, baseCfg(), []string{"org/r"})
+	if err != nil {
+		t.Fatalf("PromoteReady: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("n = %d, want 0 (AddLabels failure must abort the promotion)", n)
+	}
+	if addCall != 2 {
+		t.Errorf("AddLabels calls = %d, want 2 (one promote-to attempt + one compensating restore)", addCall)
+	}
+	// The successful call (the compensating one) must re-apply the
+	// blocked labels, not the promote-to.
+	if len(fake.added) != 1 {
+		t.Fatalf("expected 1 recorded successful AddLabels (the compensating one), got %d: %+v", len(fake.added), fake.added)
+	}
+	got := fake.added[0].Labels
+	if len(got) != 1 || got[0] != "blocked" {
+		t.Errorf("compensating AddLabels labels = %v, want [blocked] (blocked label restored)", got)
+	}
+}
+
+func TestCheckDeps_ContextCancellation_StopsLoop(t *testing.T) {
+	// Per-dep ctx check: with a cancelled context, checkDeps must exit
+	// before issuing any GetIssue HTTP call. Protects daemon shutdowns
+	// from 10-minute waits on issues with many deps + unresponsive
+	// GitHub.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled
+
+	client := &fakePromoteClient{
+		byRef: map[string]*github.Issue{
+			"org/r#1": mkIssue("org/r", 1, "closed", ""),
+			"org/r#2": mkIssue("org/r", 2, "closed", ""),
+		},
+	}
+	counting := &countingPromoteClient{inner: client}
+
+	deps := []IssueRef{
+		{Repo: "org/r", Number: 1},
+		{Repo: "org/r", Number: 2},
+	}
+	cache := make(map[string]*github.Issue)
+
+	_, err := checkDeps(ctx, counting, deps, cache)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if counting.getIssueCalls > 0 {
+		t.Errorf("GetIssue called %d times, want 0 (ctx cancelled before any fetch)", counting.getIssueCalls)
+	}
 }
 
 func TestPromoteReady_MissingPromoteTarget_ReturnsError(t *testing.T) {


### PR DESCRIPTION
## Summary

Two concerns bundled because they share `promoter.go` and would otherwise conflict on the `checkDeps` signature:

### 1. Native sub-issues as a second dep source (#97)

Complements #93's `## Depends on` Markdown parser with GitHub's native sub-issues REST endpoint. Both sources are read on every poll, refs unioned and deduped, sub-issue state pre-primes the dep cache.

- **Cross-org**: sub-issues is same-owner-only (GitHub refuses cross-owner children at the API). The Markdown parser stays for any repo the token can read.
- **Wire-format stability**: the bot (and anyone else writing issue bodies by hand) already emits `## Depends on`. No push to migrate consumers onto POST-based sub-issue creation.
- **Zero regression**: operators who don't use sub-issues see no new behaviour. The new code path only activates when `ListSubIssues` returns entries.

#### Policy matrix

| Body `## Depends on` | Native sub-issues | Behaviour |
|---|---|---|
| Has deps | Has deps | Refs unioned + deduped |
| Has deps | Empty | As today |
| Empty | Has deps | Promotion driven by native (new) |
| Empty | Empty | Skip, operator unblocks manually |
| Has deps | API error | Skip issue this cycle (don't promote on partial info) |

### 2. Promotion robustness (#94)

Two MEDIUM-severity concerns raised by `Muriano` after #93's approval:

- **Orphan guard on partial failure** — if `RemoveLabels(blocked)` succeeds but `AddLabels(promoteTo)` fails, the issue previously became invisible to both pipelines. Fix: compensating best-effort re-apply of the blocked label(s); if THAT fails too, escalate to `slog.Error` with both error details.
- **Per-dep ctx check** — `checkDeps` now accepts `ctx` and calls `ctx.Err()` before each `GetIssue` so a daemon shutdown mid-dep-chain exits promptly instead of blocking up to N × HTTP timeouts. Interface-level ctx threading through `PromoteIssueClient` remains as a broader follow-up.

## API additions

- `*github.Client.ListSubIssues(repo, number) ([]*Issue, error)` — REST `GET /repos/{owner}/{repo}/issues/{N}/sub_issues`. Returns full issue objects; `Repo` is resolved from the embedded `repository.full_name` so cross-repo same-owner children key correctly in the cache.
- `PromoteIssueClient` interface grows `ListSubIssues`.
- `checkDeps` now takes `ctx context.Context` as first parameter.

## Test plan

- [x] `make test-docker` — full suite green.
- [x] Sub-issues tests (new):
  - `TestListSubIssues` — happy, empty, 404, cross-repo same-owner
  - `TestPromoteReady_MergesSubIssuesWithBodyParser`
  - `TestPromoteReady_SubIssueStillOpen_NotPromoted`
  - `TestPromoteReady_SubIssuesOnly_NoBodySection`
  - `TestPromoteReady_SubIssuesAPIFailure_SkipsIssue`
  - `TestPromoteReady_SubIssuesDedupWithBodyRefs`
- [x] Robustness tests (new):
  - `TestPromoteReady_AddLabelsFailure_RestoresBlockedLabel`
  - `TestCheckDeps_ContextCancellation_StopsLoop`

## Docs

README "Dependency-based issue promotion" section rewritten to show both dep sources, note the same-owner limit of sub-issues vs. cross-org Markdown, and document the "skip on transient sub-issues API failure" safety behaviour. Headline bullet updated.

Closes #97
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)