### PR TITLE
feat: RepoDetailScreen + per-repo issue tracking config

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -300,10 +300,20 @@ func main() {
 			p.PublishPending()
 
 			// ── Issue tracking cycle ─────────────────────────────────────
+			// Check if ANY repo has issue tracking enabled (global or per-repo).
 			cfgMu.Lock()
 			globalIT := c.GitHub.IssueTracking
+			anyITEnabled := globalIT.Enabled
+			if !anyITEnabled {
+				for _, r := range c.AI.Repos {
+					if r.IssueTracking != nil && r.IssueTracking.Enabled {
+						anyITEnabled = true
+						break
+					}
+				}
+			}
 			cfgMu.Unlock()
-			if globalIT.Enabled {
+			if anyITEnabled {
 				loginMu.Lock()
 				authUser := cachedLogin
 				loginMu.Unlock()
@@ -381,6 +391,9 @@ func main() {
 					cfgMu.Lock()
 					repoIT := c.IssueTrackingForRepo(repo)
 					cfgMu.Unlock()
+					if !repoIT.Enabled {
+						continue
+					}
 					n, err := issueFetcher.ProcessRepo(context.Background(), repo, repoIT, authUser, optsFor)
 					if err != nil {
 						slog.Error("poll: issue fetch failed", "repo", repo, "err", err)

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -301,9 +301,9 @@ func main() {
 
 			// ── Issue tracking cycle ─────────────────────────────────────
 			cfgMu.Lock()
-			itCfg := c.GitHub.IssueTracking
+			globalIT := c.GitHub.IssueTracking
 			cfgMu.Unlock()
-			if itCfg.Enabled {
+			if globalIT.Enabled {
 				loginMu.Lock()
 				authUser := cachedLogin
 				loginMu.Unlock()
@@ -378,7 +378,10 @@ func main() {
 				}
 
 				for _, repo := range repos {
-					n, err := issueFetcher.ProcessRepo(context.Background(), repo, itCfg, authUser, optsFor)
+					cfgMu.Lock()
+					repoIT := c.IssueTrackingForRepo(repo)
+					cfgMu.Unlock()
+					n, err := issueFetcher.ProcessRepo(context.Background(), repo, repoIT, authUser, optsFor)
 					if err != nil {
 						slog.Error("poll: issue fetch failed", "repo", repo, "err", err)
 						continue
@@ -439,14 +442,18 @@ func main() {
 		cfgMu.Lock()
 		c := cfg
 		cfgMu.Unlock()
-		repoOverrides := make(map[string]map[string]string)
+		repoOverrides := make(map[string]map[string]any)
 		for repo, ai := range c.AI.Repos {
-			repoOverrides[repo] = map[string]string{
+			ro := map[string]any{
 				"primary":     ai.Primary,
 				"fallback":    ai.Fallback,
 				"review_mode": ai.ReviewMode,
 				"local_dir":   ai.LocalDir,
 			}
+			if ai.IssueTracking != nil {
+				ro["issue_tracking"] = ai.IssueTracking
+			}
+			repoOverrides[repo] = ro
 		}
 		agentConfigs := make(map[string]map[string]any)
 		for name, ac := range c.AI.Agents {

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -438,6 +438,8 @@ func main() {
 	}()
 
 	// Expose live config for GET /config
+	srv.SetRepoMetaFns(ghClient.FetchLabels, ghClient.FetchCollaborators)
+
 	srv.SetConfigFn(func() map[string]any {
 		cfgMu.Lock()
 		c := cfg

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -369,8 +369,8 @@ func main() {
 				// same poll cycle rather than waiting for the next one.
 				// No-op when BlockedLabels is unset, so default installs
 				// don't pay for the extra calls.
-				if len(itCfg.BlockedLabels) > 0 {
-					if n, err := issuepipeline.PromoteReady(context.Background(), ghClient, itCfg, repos); err != nil {
+				if len(globalIT.BlockedLabels) > 0 {
+					if n, err := issuepipeline.PromoteReady(context.Background(), ghClient, globalIT, repos); err != nil {
 						slog.Error("poll: issue promotion failed", "err", err)
 					} else if n > 0 {
 						slog.Info("poll: promoted issues", "count", n)

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -312,6 +312,11 @@ func (c *Config) IssueTrackingForRepo(repo string) IssueTrackingConfig {
 	}
 	ov := r.IssueTracking
 	merged := global
+	// Enabled is a bool — zero value (false) is meaningful when the per-repo
+	// override exists. If the per-repo section is present, its Enabled field
+	// wins unconditionally, allowing repos to enable issue tracking even when
+	// the global is off (or disable it when global is on).
+	merged.Enabled = ov.Enabled
 	if len(ov.DevelopLabels) > 0 {
 		merged.DevelopLabels = ov.DevelopLabels
 	}

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -249,6 +249,10 @@ type RepoAI struct {
 	PRAssignee  string   `toml:"pr_assignee"`  // GitHub login to assign the PR to
 	PRLabels    []string `toml:"pr_labels"`    // labels to add to the PR
 	PRDraft     bool     `toml:"pr_draft"`     // create as draft PR
+
+	// Per-repo issue tracking override. When set, non-zero fields replace
+	// the global [github.issue_tracking] values for this repo only.
+	IssueTracking *IssueTrackingConfig `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
 }
 
 // PRMetadataConfig holds global defaults for PR creation metadata,
@@ -292,6 +296,44 @@ func (c *Config) AIForRepo(repo string) RepoAI {
 		Primary: c.AI.Primary, Fallback: c.AI.Fallback, ReviewMode: c.AI.ReviewMode,
 		PRReviewers: c.AI.PRMetadata.Reviewers, PRLabels: c.AI.PRMetadata.Labels,
 	}
+}
+
+// IssueTrackingForRepo returns the issue tracking config for a specific repo,
+// merging per-repo overrides (field-level) with the global config.
+// Non-zero per-repo fields win; zero/nil fields inherit from global.
+func (c *Config) IssueTrackingForRepo(repo string) IssueTrackingConfig {
+	global := c.GitHub.IssueTracking
+	if c.AI.Repos == nil {
+		return global
+	}
+	r, ok := c.AI.Repos[repo]
+	if !ok || r.IssueTracking == nil {
+		return global
+	}
+	ov := r.IssueTracking
+	merged := global
+	if len(ov.DevelopLabels) > 0 {
+		merged.DevelopLabels = ov.DevelopLabels
+	}
+	if len(ov.ReviewOnlyLabels) > 0 {
+		merged.ReviewOnlyLabels = ov.ReviewOnlyLabels
+	}
+	if len(ov.SkipLabels) > 0 {
+		merged.SkipLabels = ov.SkipLabels
+	}
+	if ov.FilterMode != "" {
+		merged.FilterMode = ov.FilterMode
+	}
+	if ov.DefaultAction != "" {
+		merged.DefaultAction = ov.DefaultAction
+	}
+	if len(ov.Organizations) > 0 {
+		merged.Organizations = ov.Organizations
+	}
+	if len(ov.Assignees) > 0 {
+		merged.Assignees = ov.Assignees
+	}
+	return merged
 }
 
 // AgentConfigFor returns the CLIAgentConfig for a given CLI name, or an empty struct.

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -775,6 +775,74 @@ func TestAIForRepo_PerRepoInheritsGlobal(t *testing.T) {
 	}
 }
 
+// ── IssueTrackingForRepo ─────────────────────────────────────────────────────
+
+func TestIssueTrackingForRepo_GlobalOnly(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{
+		Enabled:       true,
+		FilterMode:    FilterModeExclusive,
+		DevelopLabels: []string{"bug", "feature"},
+		SkipLabels:    []string{"wontfix"},
+		DefaultAction: "ignore",
+	}
+	got := c.IssueTrackingForRepo("org/repo")
+	if !got.Enabled || got.FilterMode != FilterModeExclusive {
+		t.Errorf("expected global values, got %+v", got)
+	}
+	if len(got.DevelopLabels) != 2 || got.DevelopLabels[0] != "bug" {
+		t.Errorf("develop_labels = %v, want [bug feature]", got.DevelopLabels)
+	}
+}
+
+func TestIssueTrackingForRepo_PerRepoOverride(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{
+		Enabled:       true,
+		FilterMode:    FilterModeExclusive,
+		DevelopLabels: []string{"bug", "feature"},
+		SkipLabels:    []string{"wontfix"},
+		DefaultAction: "ignore",
+	}
+	c.AI.Primary = "claude"
+	c.AI.Repos = map[string]RepoAI{
+		"org/secure-repo": {
+			IssueTracking: &IssueTrackingConfig{
+				DevelopLabels: []string{"security-fix"},
+				SkipLabels:    []string{"wontfix", "stale"},
+			},
+		},
+	}
+	got := c.IssueTrackingForRepo("org/secure-repo")
+	if len(got.DevelopLabels) != 1 || got.DevelopLabels[0] != "security-fix" {
+		t.Errorf("develop_labels = %v, want [security-fix]", got.DevelopLabels)
+	}
+	if len(got.SkipLabels) != 2 {
+		t.Errorf("skip_labels = %v, want [wontfix stale]", got.SkipLabels)
+	}
+	if got.FilterMode != FilterModeExclusive {
+		t.Errorf("filter_mode = %v, want exclusive (inherited)", got.FilterMode)
+	}
+	if got.DefaultAction != "ignore" {
+		t.Errorf("default_action = %v, want ignore (inherited)", got.DefaultAction)
+	}
+	if !got.Enabled {
+		t.Error("enabled should be inherited as true")
+	}
+}
+
+func TestIssueTrackingForRepo_UnknownRepo(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{
+		Enabled:    true,
+		SkipLabels: []string{"wontfix"},
+	}
+	got := c.IssueTrackingForRepo("org/unknown")
+	if !got.Enabled || len(got.SkipLabels) != 1 {
+		t.Errorf("unknown repo should return global, got %+v", got)
+	}
+}
+
 // ── AgentConfigFor ───────────────────────────────────────────────────────────
 
 func TestAgentConfigFor_Found(t *testing.T) {

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -808,6 +808,7 @@ func TestIssueTrackingForRepo_PerRepoOverride(t *testing.T) {
 	c.AI.Repos = map[string]RepoAI{
 		"org/secure-repo": {
 			IssueTracking: &IssueTrackingConfig{
+				Enabled:       true, // per-repo Enabled overrides global unconditionally
 				DevelopLabels: []string{"security-fix"},
 				SkipLabels:    []string{"wontfix", "stale"},
 			},
@@ -827,7 +828,7 @@ func TestIssueTrackingForRepo_PerRepoOverride(t *testing.T) {
 		t.Errorf("default_action = %v, want ignore (inherited)", got.DefaultAction)
 	}
 	if !got.Enabled {
-		t.Error("enabled should be inherited as true")
+		t.Error("enabled should be true (per-repo override)")
 	}
 }
 
@@ -840,6 +841,35 @@ func TestIssueTrackingForRepo_UnknownRepo(t *testing.T) {
 	got := c.IssueTrackingForRepo("org/unknown")
 	if !got.Enabled || len(got.SkipLabels) != 1 {
 		t.Errorf("unknown repo should return global, got %+v", got)
+	}
+}
+
+func TestIssueTrackingForRepo_PerRepoEnablesWhenGlobalOff(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{
+		Enabled:       false,
+		DevelopLabels: []string{"bug"},
+	}
+	c.AI.Repos = map[string]RepoAI{
+		"org/active-repo": {
+			IssueTracking: &IssueTrackingConfig{
+				Enabled:       true,
+				DevelopLabels: []string{"feature"},
+			},
+		},
+	}
+	got := c.IssueTrackingForRepo("org/active-repo")
+	if !got.Enabled {
+		t.Error("per-repo should enable issue tracking even when global is off")
+	}
+	if len(got.DevelopLabels) != 1 || got.DevelopLabels[0] != "feature" {
+		t.Errorf("develop_labels = %v, want [feature]", got.DevelopLabels)
+	}
+
+	// Repo without override inherits global (disabled)
+	got2 := c.IssueTrackingForRepo("org/other-repo")
+	if got2.Enabled {
+		t.Error("repo without override should inherit global disabled")
 	}
 }
 

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -500,3 +500,57 @@ func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) 
 	}
 	return comments, nil
 }
+
+// FetchLabels returns the label names for a repository.
+func (c *Client) FetchLabels(repo string) ([]string, error) {
+	if repo == "" {
+		return nil, nil
+	}
+	resp, err := c.do("GET", fmt.Sprintf("/repos/%s/labels?per_page=100", repo), "application/vnd.github+json")
+	if err != nil {
+		return nil, fmt.Errorf("github: fetch labels: %w", err)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github: fetch labels %s: status %d", repo, resp.StatusCode)
+	}
+	var raw []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("github: decode labels: %w", err)
+	}
+	names := make([]string, len(raw))
+	for i, l := range raw {
+		names[i] = l.Name
+	}
+	return names, nil
+}
+
+// FetchCollaborators returns the login names of repository collaborators.
+func (c *Client) FetchCollaborators(repo string) ([]string, error) {
+	if repo == "" {
+		return nil, nil
+	}
+	resp, err := c.do("GET", fmt.Sprintf("/repos/%s/collaborators?per_page=100", repo), "application/vnd.github+json")
+	if err != nil {
+		return nil, fmt.Errorf("github: fetch collaborators: %w", err)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github: fetch collaborators %s: status %d", repo, resp.StatusCode)
+	}
+	var raw []struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("github: decode collaborators: %w", err)
+	}
+	logins := make([]string, len(raw))
+	for i, u := range raw {
+		logins[i] = u.Login
+	}
+	return logins, nil
+}

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -37,6 +37,9 @@ type Server struct {
 	meFn                 func() (string, error)
 	// configFn returns the current running config as a JSON-serializable map.
 	configFn func() map[string]any
+	// repoMetaFns fetch repo metadata from GitHub for autocomplete.
+	fetchLabelsFn        func(repo string) ([]string, error)
+	fetchCollaboratorsFn func(repo string) ([]string, error)
 	// apiToken is required on all state-mutating requests (POST/PUT/DELETE).
 	// Empty string disables authentication (should not happen in production).
 	apiToken  string
@@ -89,6 +92,7 @@ var sensitiveGETPaths = []string{
 	"/prs",    // exposes PR titles, repos, authors
 	"/stats",  // exposes review activity metadata
 	"/issues", // covers /issues and /issues/{id}
+	"/repos",  // covers /repos/{name}/labels and /repos/{name}/collaborators
 }
 
 // authMiddleware rejects:
@@ -141,6 +145,12 @@ func (srv *Server) SetMeFn(fn func() (string, error)) { srv.meFn = fn }
 // SetConfigFn wires the callback that returns the live config for GET /config.
 func (srv *Server) SetConfigFn(fn func() map[string]any) { srv.configFn = fn }
 
+// SetRepoMetaFns wires GitHub metadata fetchers for autocomplete endpoints.
+func (srv *Server) SetRepoMetaFns(labels func(string) ([]string, error), collabs func(string) ([]string, error)) {
+	srv.fetchLabelsFn = labels
+	srv.fetchCollaboratorsFn = collabs
+}
+
 // Router returns the underlying http.Handler for use in tests or embedding.
 func (srv *Server) Router() http.Handler {
 	return srv.router
@@ -182,6 +192,8 @@ func (srv *Server) buildRouter() chi.Router {
 	r.Post("/issues/{id}/review", srv.handleTriggerIssueReview)
 	r.Post("/issues/{id}/dismiss", srv.handleDismissIssue)
 	r.Post("/issues/{id}/undismiss", srv.handleUndismissIssue)
+	r.Get("/repos/{name}/labels", srv.handleRepoLabels)
+	r.Get("/repos/{name}/collaborators", srv.handleRepoCollaborators)
 	r.Get("/stats", srv.handleStats)
 	r.Get("/agents", srv.handleListAgents)
 	r.Post("/agents", srv.handleUpsertAgent)
@@ -724,6 +736,42 @@ func (srv *Server) handleTriggerIssueReview(w http.ResponseWriter, r *http.Reque
 		}
 	}()
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "review queued"})
+}
+
+func (srv *Server) handleRepoLabels(w http.ResponseWriter, r *http.Request) {
+	repo := chi.URLParam(r, "name")
+	if srv.fetchLabelsFn == nil {
+		http.Error(w, "not configured", http.StatusServiceUnavailable)
+		return
+	}
+	labels, err := srv.fetchLabelsFn(repo)
+	if err != nil {
+		slog.Error("handleRepoLabels: fetch error", "repo", repo, "err", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	if labels == nil {
+		labels = []string{}
+	}
+	writeJSON(w, http.StatusOK, labels)
+}
+
+func (srv *Server) handleRepoCollaborators(w http.ResponseWriter, r *http.Request) {
+	repo := chi.URLParam(r, "name")
+	if srv.fetchCollaboratorsFn == nil {
+		http.Error(w, "not configured", http.StatusServiceUnavailable)
+		return
+	}
+	collabs, err := srv.fetchCollaboratorsFn(repo)
+	if err != nil {
+		slog.Error("handleRepoCollaborators: fetch error", "repo", repo, "err", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	if collabs == nil {
+		collabs = []string{}
+	}
+	writeJSON(w, http.StatusOK, collabs)
 }
 
 func (srv *Server) handleStats(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -739,7 +740,7 @@ func (srv *Server) handleTriggerIssueReview(w http.ResponseWriter, r *http.Reque
 }
 
 func (srv *Server) handleRepoLabels(w http.ResponseWriter, r *http.Request) {
-	repo := chi.URLParam(r, "name")
+	repo, _ := url.PathUnescape(chi.URLParam(r, "name"))
 	if srv.fetchLabelsFn == nil {
 		http.Error(w, "not configured", http.StatusServiceUnavailable)
 		return
@@ -757,7 +758,7 @@ func (srv *Server) handleRepoLabels(w http.ResponseWriter, r *http.Request) {
 }
 
 func (srv *Server) handleRepoCollaborators(w http.ResponseWriter, r *http.Request) {
-	repo := chi.URLParam(r, "name")
+	repo, _ := url.PathUnescape(chi.URLParam(r, "name"))
 	if srv.fetchCollaboratorsFn == nil {
 		http.Error(w, "not configured", http.StatusServiceUnavailable)
 		return

--- a/docs/superpowers/plans/2026-04-20-repo-detail-screen.md
+++ b/docs/superpowers/plans/2026-04-20-repo-detail-screen.md
@@ -1,0 +1,872 @@
+# Repo Detail Screen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace inline repo config with a dedicated RepoDetailScreen and add per-repo issue tracking with field-level override/merge.
+
+**Architecture:** Daemon gets `RepoAI.IssueTracking *IssueTrackingConfig` with a `IssueTrackingForRepo(repo)` merge helper; poll cycle uses per-repo config. Flutter gets a new `RepoDetailScreen` navigated from the simplified repo list, with a reusable `OverrideField` widget for the per-field inherit/override pattern. `GET /config` response expands `repo_overrides` to include issue tracking sub-objects.
+
+**Tech Stack:** Go 1.21 (config, chi router), Flutter 3.8+ (Riverpod, GoRouter)
+
+---
+
+## File Structure
+
+### Daemon (Go) — files to modify
+
+| File | Responsibility |
+|------|---------------|
+| `daemon/internal/config/config.go` | Add `RepoAI.IssueTracking`, `IssueTrackingForRepo()` |
+| `daemon/internal/config/config_test.go` | Tests for field-level merge |
+| `daemon/cmd/heimdallm/main.go` | Poll cycle uses per-repo config, `GET /config` includes per-repo IT |
+
+### Flutter (Dart) — files to create/modify
+
+| File | Responsibility |
+|------|---------------|
+| `lib/core/models/config_model.dart` | Extend `RepoConfig` with IT + PR metadata fields, parse/serialize |
+| `lib/shared/widgets/override_field.dart` | **Create** — reusable per-field override widget |
+| `lib/features/repositories/repo_detail_screen.dart` | **Create** — full settings page for one repo |
+| `lib/features/repositories/repos_screen.dart` | Simplify: remove ExpansionTile, add tap-to-navigate |
+| `lib/shared/router.dart` | Add `/repos/:name` route |
+| `lib/core/setup/first_run_setup.dart` | TOML writer: per-repo `[ai.repos."org/repo".issue_tracking]` |
+
+---
+
+### Task 1: Daemon — per-repo issue tracking config + merge
+
+**Files:**
+- Modify: `daemon/internal/config/config.go`
+- Modify: `daemon/internal/config/config_test.go`
+
+- [ ] **Step 1: Write failing test for IssueTrackingForRepo**
+
+Add to `daemon/internal/config/config_test.go`:
+
+```go
+func TestIssueTrackingForRepo_GlobalOnly(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{
+		Enabled:       true,
+		FilterMode:    FilterModeExclusive,
+		DevelopLabels: []string{"bug", "feature"},
+		SkipLabels:    []string{"wontfix"},
+		DefaultAction: "ignore",
+	}
+	got := c.IssueTrackingForRepo("org/repo")
+	if !got.Enabled || got.FilterMode != FilterModeExclusive {
+		t.Errorf("expected global values, got %+v", got)
+	}
+	if len(got.DevelopLabels) != 2 || got.DevelopLabels[0] != "bug" {
+		t.Errorf("develop_labels = %v, want [bug feature]", got.DevelopLabels)
+	}
+}
+
+func TestIssueTrackingForRepo_PerRepoOverride(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{
+		Enabled:       true,
+		FilterMode:    FilterModeExclusive,
+		DevelopLabels: []string{"bug", "feature"},
+		SkipLabels:    []string{"wontfix"},
+		DefaultAction: "ignore",
+	}
+	c.AI.Primary = "claude"
+	c.AI.Repos = map[string]RepoAI{
+		"org/secure-repo": {
+			IssueTracking: &IssueTrackingConfig{
+				DevelopLabels: []string{"security-fix"},
+				SkipLabels:    []string{"wontfix", "stale"},
+			},
+		},
+	}
+	got := c.IssueTrackingForRepo("org/secure-repo")
+	// Overridden fields
+	if len(got.DevelopLabels) != 1 || got.DevelopLabels[0] != "security-fix" {
+		t.Errorf("develop_labels = %v, want [security-fix]", got.DevelopLabels)
+	}
+	if len(got.SkipLabels) != 2 {
+		t.Errorf("skip_labels = %v, want [wontfix stale]", got.SkipLabels)
+	}
+	// Inherited fields
+	if got.FilterMode != FilterModeExclusive {
+		t.Errorf("filter_mode = %v, want exclusive (inherited)", got.FilterMode)
+	}
+	if got.DefaultAction != "ignore" {
+		t.Errorf("default_action = %v, want ignore (inherited)", got.DefaultAction)
+	}
+	if !got.Enabled {
+		t.Error("enabled should be inherited as true")
+	}
+}
+
+func TestIssueTrackingForRepo_UnknownRepo(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{
+		Enabled:    true,
+		SkipLabels: []string{"wontfix"},
+	}
+	got := c.IssueTrackingForRepo("org/unknown")
+	if !got.Enabled || len(got.SkipLabels) != 1 {
+		t.Errorf("unknown repo should return global, got %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd daemon && go test ./internal/config/ -run "TestIssueTrackingForRepo" -v -timeout 30s`
+Expected: FAIL — `IssueTrackingForRepo` not defined.
+
+- [ ] **Step 3: Add IssueTracking field to RepoAI and implement IssueTrackingForRepo**
+
+In `daemon/internal/config/config.go`:
+
+1. Add field to `RepoAI` (after `PRDraft`):
+```go
+	// Per-repo issue tracking override. When set, non-zero fields replace
+	// the global [github.issue_tracking] values for this repo only.
+	IssueTracking *IssueTrackingConfig `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
+```
+
+2. Add method after `AgentConfigFor`:
+```go
+// IssueTrackingForRepo returns the issue tracking config for a specific repo,
+// merging per-repo overrides (field-level) with the global config.
+// Non-zero per-repo fields win; zero/nil fields inherit from global.
+func (c *Config) IssueTrackingForRepo(repo string) IssueTrackingConfig {
+	global := c.GitHub.IssueTracking
+	if c.AI.Repos == nil {
+		return global
+	}
+	r, ok := c.AI.Repos[repo]
+	if !ok || r.IssueTracking == nil {
+		return global
+	}
+	ov := r.IssueTracking
+	merged := global
+	if len(ov.DevelopLabels) > 0 {
+		merged.DevelopLabels = ov.DevelopLabels
+	}
+	if len(ov.ReviewOnlyLabels) > 0 {
+		merged.ReviewOnlyLabels = ov.ReviewOnlyLabels
+	}
+	if len(ov.SkipLabels) > 0 {
+		merged.SkipLabels = ov.SkipLabels
+	}
+	if ov.FilterMode != "" {
+		merged.FilterMode = ov.FilterMode
+	}
+	if ov.DefaultAction != "" {
+		merged.DefaultAction = ov.DefaultAction
+	}
+	if len(ov.Organizations) > 0 {
+		merged.Organizations = ov.Organizations
+	}
+	if len(ov.Assignees) > 0 {
+		merged.Assignees = ov.Assignees
+	}
+	return merged
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd daemon && go test ./internal/config/ -run "TestIssueTrackingForRepo" -v -timeout 30s`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add daemon/internal/config/config.go daemon/internal/config/config_test.go
+git commit -m "feat(config): add per-repo issue tracking with field-level merge
+
+RepoAI gains IssueTracking *IssueTrackingConfig for per-repo overrides.
+IssueTrackingForRepo(repo) merges per-repo non-zero fields over global."
+```
+
+---
+
+### Task 2: Daemon — poll cycle uses per-repo config + GET /config includes IT overrides
+
+**Files:**
+- Modify: `daemon/cmd/heimdallm/main.go`
+
+- [ ] **Step 1: Update poll cycle to use IssueTrackingForRepo**
+
+In `daemon/cmd/heimdallm/main.go`, replace in the issue tracking cycle section (around line 287-350):
+
+Change:
+```go
+cfgMu.Lock()
+itCfg := c.GitHub.IssueTracking
+cfgMu.Unlock()
+if itCfg.Enabled {
+    // ...
+    for _, repo := range repos {
+        n, err := issueFetcher.ProcessRepo(context.Background(), repo, itCfg, authUser, optsFor)
+```
+
+To:
+```go
+cfgMu.Lock()
+globalIT := c.GitHub.IssueTracking
+cfgMu.Unlock()
+if globalIT.Enabled {
+    // ...
+    for _, repo := range repos {
+        cfgMu.Lock()
+        repoIT := c.IssueTrackingForRepo(repo)
+        cfgMu.Unlock()
+        n, err := issueFetcher.ProcessRepo(context.Background(), repo, repoIT, authUser, optsFor)
+```
+
+- [ ] **Step 2: Update GET /config to include per-repo issue tracking**
+
+In `srv.SetConfigFn(...)` (around line 411-418), change the `repoOverrides` builder from `map[string]map[string]string` to `map[string]map[string]any`:
+
+```go
+repoOverrides := make(map[string]map[string]any)
+for repo, ai := range c.AI.Repos {
+    ro := map[string]any{
+        "primary":     ai.Primary,
+        "fallback":    ai.Fallback,
+        "review_mode": ai.ReviewMode,
+        "local_dir":   ai.LocalDir,
+    }
+    if ai.IssueTracking != nil {
+        ro["issue_tracking"] = ai.IssueTracking
+    }
+    repoOverrides[repo] = ro
+}
+```
+
+- [ ] **Step 3: Verify daemon builds**
+
+Run: `cd daemon && go build -o bin/heimdallm ./cmd/heimdallm`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Run full daemon tests**
+
+Run: `cd /path/to/project && make test-docker`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add daemon/cmd/heimdallm/main.go
+git commit -m "feat(issues): poll cycle uses per-repo issue tracking config
+
+Each repo now gets its own merged IssueTrackingConfig in the poll cycle.
+GET /config includes per-repo issue_tracking overrides in repo_overrides."
+```
+
+---
+
+### Task 3: Flutter — extend RepoConfig model with IT + PR metadata fields
+
+**Files:**
+- Modify: `flutter_app/lib/core/models/config_model.dart`
+
+- [ ] **Step 1: Add fields to RepoConfig**
+
+Add after `localDir`:
+
+```dart
+  // Issue tracking overrides (null = inherit global)
+  final List<String>? developLabels;
+  final List<String>? reviewOnlyLabels;
+  final List<String>? skipLabels;
+  final String? issueFilterMode;
+  final String? issueDefaultAction;
+  final List<String>? issueOrganizations;
+  final List<String>? issueAssignees;
+
+  // PR metadata (null = inherit global)
+  final List<String>? prReviewers;
+  final String? prAssignee;
+  final List<String>? prLabels;
+  final bool? prDraft;
+```
+
+Update constructor with all new fields (defaults all null). Update `hasAiOverride` getter to include the new fields. Update `copyWith` with all new fields using the `_sentinel` pattern.
+
+- [ ] **Step 2: Update AppConfig.fromJson to parse per-repo IT overrides**
+
+In the `repo_overrides` parsing section, after parsing `local_dir`, add:
+
+```dart
+final itRaw = ov['issue_tracking'] as Map<String, dynamic>?;
+List<String>? _nullableList(dynamic v) =>
+    (v as List<dynamic>?)?.cast<String>().where((s) => s.isNotEmpty).toList();
+
+configs[entry.key] = RepoConfig(
+  monitored:          existing?.monitored ?? configs.containsKey(entry.key),
+  aiPrimary:          _nonEmpty(ov['primary']),
+  aiFallback:         _nonEmpty(ov['fallback']),
+  reviewMode:         _nonEmpty(ov['review_mode']),
+  localDir:           _nonEmpty(ov['local_dir']),
+  developLabels:      itRaw != null ? _nullableList(itRaw['develop_labels']) : null,
+  reviewOnlyLabels:   itRaw != null ? _nullableList(itRaw['review_only_labels']) : null,
+  skipLabels:         itRaw != null ? _nullableList(itRaw['skip_labels']) : null,
+  issueFilterMode:    itRaw != null ? _nonEmpty(itRaw['filter_mode']) : null,
+  issueDefaultAction: itRaw != null ? _nonEmpty(itRaw['default_action']) : null,
+  issueOrganizations: itRaw != null ? _nullableList(itRaw['organizations']) : null,
+  issueAssignees:     itRaw != null ? _nullableList(itRaw['assignees']) : null,
+  prReviewers:        _nullableList(ov['pr_reviewers']),
+  prAssignee:         _nonEmpty(ov['pr_assignee']),
+  prLabels:           _nullableList(ov['pr_labels']),
+  prDraft:            ov['pr_draft'] as bool?,
+);
+```
+
+- [ ] **Step 3: Verify no analysis errors**
+
+Run: `cd flutter_app && flutter analyze`
+Expected: No issues found.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add flutter_app/lib/core/models/config_model.dart
+git commit -m "feat(flutter): extend RepoConfig with IT + PR metadata fields
+
+Per-repo issue tracking and PR metadata fields (all nullable = inherit
+global). fromJson parses issue_tracking sub-object from repo_overrides."
+```
+
+---
+
+### Task 4: Flutter — OverrideField reusable widget
+
+**Files:**
+- Create: `flutter_app/lib/shared/widgets/override_field.dart`
+
+- [ ] **Step 1: Create the widget**
+
+```dart
+import 'package:flutter/material.dart';
+
+/// A field that shows the effective value (global or overridden) with
+/// visual indicators and a reset-to-global control.
+///
+/// When [overrideValue] is null, the field shows [globalValue] in muted
+/// style with a "global" badge. When non-null, it shows the override
+/// with a green left border, "overridden" badge, and reset button.
+class OverrideTextField extends StatefulWidget {
+  final String label;
+  final String? helper;
+  final String globalValue;
+  final String? overrideValue;
+  final ValueChanged<String?> onChanged;
+
+  const OverrideTextField({
+    super.key,
+    required this.label,
+    this.helper,
+    required this.globalValue,
+    required this.overrideValue,
+    required this.onChanged,
+  });
+
+  @override
+  State<OverrideTextField> createState() => _OverrideTextFieldState();
+}
+
+class _OverrideTextFieldState extends State<OverrideTextField> {
+  late TextEditingController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = TextEditingController(text: widget.overrideValue ?? widget.globalValue);
+  }
+
+  @override
+  void didUpdateWidget(OverrideTextField old) {
+    super.didUpdateWidget(old);
+    if (widget.overrideValue != old.overrideValue ||
+        widget.globalValue != old.globalValue) {
+      _ctrl.text = widget.overrideValue ?? widget.globalValue;
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  bool get _isOverridden => widget.overrideValue != null;
+
+  void _reset() {
+    _ctrl.text = widget.globalValue;
+    widget.onChanged(null);
+  }
+
+  void _handleChange(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty || trimmed == widget.globalValue) {
+      widget.onChanged(null);
+    } else {
+      widget.onChanged(trimmed);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(6),
+        border: Border(
+          left: BorderSide(
+            width: 3,
+            color: _isOverridden ? Colors.green.shade600 : Colors.transparent,
+          ),
+        ),
+      ),
+      padding: const EdgeInsets.all(10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(widget.label,
+                  style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
+              const Spacer(),
+              if (_isOverridden) ...[
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                  decoration: BoxDecoration(
+                    color: Colors.green.shade900.withValues(alpha: 0.4),
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                  child: Text('overridden',
+                      style: TextStyle(fontSize: 10, color: Colors.green.shade400)),
+                ),
+                const SizedBox(width: 6),
+                GestureDetector(
+                  onTap: _reset,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.grey.shade700),
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                    child: Text('\u00d7 reset',
+                        style: TextStyle(fontSize: 10, color: Colors.grey.shade500)),
+                  ),
+                ),
+              ] else
+                Text('global',
+                    style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+            ],
+          ),
+          const SizedBox(height: 6),
+          TextFormField(
+            controller: _ctrl,
+            style: TextStyle(
+              fontSize: 12,
+              color: _isOverridden ? null : Colors.grey.shade600,
+            ),
+            decoration: InputDecoration(
+              isDense: true,
+              border: const OutlineInputBorder(),
+              helperText: widget.helper,
+              helperMaxLines: 2,
+              contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+            ),
+            onChanged: _handleChange,
+          ),
+          if (_isOverridden)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text('Global: ${widget.globalValue}',
+                  style: TextStyle(fontSize: 10, color: Colors.grey.shade700)),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Dropdown variant of the override field.
+class OverrideDropdown extends StatelessWidget {
+  final String label;
+  final String globalValue;
+  final String? overrideValue;
+  final List<String> options;
+  final ValueChanged<String?> onChanged;
+
+  const OverrideDropdown({
+    super.key,
+    required this.label,
+    required this.globalValue,
+    required this.overrideValue,
+    required this.options,
+    required this.onChanged,
+  });
+
+  bool get _isOverridden => overrideValue != null;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(6),
+        border: Border(
+          left: BorderSide(
+            width: 3,
+            color: _isOverridden ? Colors.green.shade600 : Colors.transparent,
+          ),
+        ),
+      ),
+      padding: const EdgeInsets.all(10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(label,
+                  style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
+              const Spacer(),
+              if (_isOverridden) ...[
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                  decoration: BoxDecoration(
+                    color: Colors.green.shade900.withValues(alpha: 0.4),
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                  child: Text('overridden',
+                      style: TextStyle(fontSize: 10, color: Colors.green.shade400)),
+                ),
+                const SizedBox(width: 6),
+                GestureDetector(
+                  onTap: () => onChanged(null),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.grey.shade700),
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                    child: Text('\u00d7 reset',
+                        style: TextStyle(fontSize: 10, color: Colors.grey.shade500)),
+                  ),
+                ),
+              ] else
+                Text('global',
+                    style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+            ],
+          ),
+          const SizedBox(height: 6),
+          DropdownButtonFormField<String?>(
+            value: overrideValue,
+            decoration: InputDecoration(
+              isDense: true,
+              border: const OutlineInputBorder(),
+              contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+            ),
+            items: [
+              DropdownMenuItem<String?>(
+                value: null,
+                child: Text('Global ($globalValue)',
+                    style: TextStyle(color: Colors.grey.shade600, fontSize: 12)),
+              ),
+              ...options.map((v) => DropdownMenuItem<String?>(
+                    value: v,
+                    child: Text(v, style: const TextStyle(fontSize: 12)),
+                  )),
+            ],
+            onChanged: onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Verify no analysis errors**
+
+Run: `cd flutter_app && flutter analyze`
+Expected: No issues found.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add flutter_app/lib/shared/widgets/override_field.dart
+git commit -m "feat(flutter): add OverrideTextField and OverrideDropdown widgets
+
+Reusable per-field override pattern: shows inherited global value in
+muted style or overridden value with green border + reset button."
+```
+
+---
+
+### Task 5: Flutter — RepoDetailScreen
+
+**Files:**
+- Create: `flutter_app/lib/features/repositories/repo_detail_screen.dart`
+
+- [ ] **Step 1: Create RepoDetailScreen**
+
+This file is large — it contains 4 section cards (General, AI Agent, Issue Tracking, PR Metadata), each using the `OverrideField` widgets. Auto-save with 800ms debounce.
+
+The screen receives the repo name as a path parameter, looks up its `RepoConfig` from `configNotifierProvider`, and renders all fields.
+
+Key structure:
+```dart
+class RepoDetailScreen extends ConsumerStatefulWidget {
+  final String repoName;
+  const RepoDetailScreen({super.key, required this.repoName});
+  // ...
+}
+
+class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
+  RepoConfig _config = const RepoConfig();
+  bool _initialized = false;
+  Timer? _debounce;
+  // ...
+
+  void _update(RepoConfig updated) {
+    setState(() => _config = updated);
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 800), _autoSave);
+  }
+
+  Widget build(BuildContext context) {
+    // 4 section cards: _generalSection, _aiSection, _issueTrackingSection, _prMetadataSection
+  }
+}
+```
+
+Each section uses `OverrideTextField` / `OverrideDropdown` with `globalValue` from `AppConfig` and `overrideValue` from `RepoConfig`. The `onChanged` calls `_update(config.copyWith(...))`.
+
+The implementation should follow the mockup layout from the spec: section cards with the per-field override pattern for every configurable field.
+
+- [ ] **Step 2: Verify no analysis errors**
+
+Run: `cd flutter_app && flutter analyze`
+Expected: No issues found.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add flutter_app/lib/features/repositories/repo_detail_screen.dart
+git commit -m "feat(flutter): add RepoDetailScreen with all config sections
+
+Full-page repo settings: General (local dir, review mode), AI Agent
+(primary, fallback, prompt), Issue Tracking (labels, filter mode),
+PR Metadata (reviewers, assignee, labels, draft). Per-field override
+pattern with auto-save."
+```
+
+---
+
+### Task 6: Flutter — simplify repos_screen + add route
+
+**Files:**
+- Modify: `flutter_app/lib/features/repositories/repos_screen.dart`
+- Modify: `flutter_app/lib/shared/router.dart`
+
+- [ ] **Step 1: Add route to router.dart**
+
+Add import:
+```dart
+import '../features/repositories/repo_detail_screen.dart';
+```
+
+Add route after `/issues/:id`:
+```dart
+GoRoute(
+  path: '/repos/:name',
+  builder: (context, state) {
+    final name = Uri.decodeComponent(state.pathParameters['name']!);
+    return RepoDetailScreen(repoName: name);
+  },
+),
+```
+
+- [ ] **Step 2: Simplify _RepoTile in repos_screen.dart**
+
+Replace the `ExpansionTile` in `_RepoTile.build` with a simple `Card` + `InkWell` that navigates to `/repos/:name`:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final hasDirMapping = config.localDir != null && config.localDir!.isNotEmpty;
+  final hasOverrides = config.hasAiOverride;
+
+  return Card(
+    margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
+    child: InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: () => context.push('/repos/${Uri.encodeComponent(repo)}'),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        child: Row(
+          children: [
+            Switch(
+              value: config.monitored,
+              onChanged: (v) => onChanged(config.copyWith(monitored: v)),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(repo,
+                      style: TextStyle(
+                        fontWeight: config.monitored ? FontWeight.w600 : FontWeight.normal,
+                        color: config.monitored ? null : Colors.grey,
+                      )),
+                  const SizedBox(height: 2),
+                  Row(children: [
+                    Icon(
+                      hasDirMapping ? Icons.folder : Icons.folder_off_outlined,
+                      size: 13,
+                      color: hasDirMapping ? Colors.green.shade500 : Colors.grey.shade600,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      hasDirMapping
+                          ? config.localDir!.split('/').last
+                          : 'No local dir',
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: hasDirMapping ? Colors.green.shade500 : Colors.grey.shade600,
+                      ),
+                    ),
+                    if (hasOverrides) ...[
+                      const SizedBox(width: 8),
+                      Icon(Icons.tune, size: 12, color: Colors.blue.shade400),
+                      const SizedBox(width: 2),
+                      Text('overrides',
+                          style: TextStyle(fontSize: 10, color: Colors.blue.shade400)),
+                    ],
+                  ]),
+                ],
+              ),
+            ),
+            Icon(Icons.chevron_right, size: 18, color: Colors.grey.shade600),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+```
+
+Remove the old `_aiDropdown`, `_promptDropdown`, `_overrideDropdown`, and `_LocalDirField` from `_RepoTile` — they move to `RepoDetailScreen`. Keep `_LocalDirField` as a standalone class at the bottom since `RepoDetailScreen` will import it, OR move it to a shared location. Simplest: keep `_LocalDirField` in `repos_screen.dart` and also copy it into `repo_detail_screen.dart` as a private widget.
+
+- [ ] **Step 3: Verify no analysis errors**
+
+Run: `cd flutter_app && flutter analyze`
+Expected: No issues found.
+
+- [ ] **Step 4: Run flutter tests**
+
+Run: `cd flutter_app && flutter test`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flutter_app/lib/shared/router.dart flutter_app/lib/features/repositories/repos_screen.dart
+git commit -m "feat(flutter): simplify repo list + navigate to RepoDetailScreen
+
+Repos tab now shows simple cards with toggle + tap-to-navigate.
+ExpansionTile removed — all config lives in /repos/:name."
+```
+
+---
+
+### Task 7: Flutter — TOML writer for per-repo issue tracking
+
+**Files:**
+- Modify: `flutter_app/lib/core/setup/first_run_setup.dart`
+
+- [ ] **Step 1: Update _buildToml per-repo section**
+
+In the per-repo overrides loop, after writing `local_dir`, add issue tracking sub-table:
+
+```dart
+// Issue tracking overrides
+final hasIT = rc.developLabels != null || rc.reviewOnlyLabels != null ||
+    rc.skipLabels != null || rc.issueFilterMode != null ||
+    rc.issueDefaultAction != null || rc.issueOrganizations != null ||
+    rc.issueAssignees != null;
+if (hasIT) {
+  buf.writeln('[ai.repos."${_tomlEscapeString(repo)}".issue_tracking]');
+  if (rc.developLabels != null && rc.developLabels!.isNotEmpty) {
+    buf.writeln('develop_labels = [${rc.developLabels!.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+  }
+  if (rc.reviewOnlyLabels != null && rc.reviewOnlyLabels!.isNotEmpty) {
+    buf.writeln('review_only_labels = [${rc.reviewOnlyLabels!.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+  }
+  if (rc.skipLabels != null && rc.skipLabels!.isNotEmpty) {
+    buf.writeln('skip_labels = [${rc.skipLabels!.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+  }
+  if (rc.issueFilterMode != null) {
+    buf.writeln('filter_mode = "${_tomlEscapeString(rc.issueFilterMode!)}"');
+  }
+  if (rc.issueDefaultAction != null) {
+    buf.writeln('default_action = "${_tomlEscapeString(rc.issueDefaultAction!)}"');
+  }
+  if (rc.issueOrganizations != null && rc.issueOrganizations!.isNotEmpty) {
+    buf.writeln('organizations = [${rc.issueOrganizations!.map((o) => '"${_tomlEscapeString(o)}"').join(', ')}]');
+  }
+  if (rc.issueAssignees != null && rc.issueAssignees!.isNotEmpty) {
+    buf.writeln('assignees = [${rc.issueAssignees!.map((a) => '"${_tomlEscapeString(a)}"').join(', ')}]');
+  }
+  buf.writeln();
+}
+```
+
+- [ ] **Step 2: Verify no analysis errors**
+
+Run: `cd flutter_app && flutter analyze`
+Expected: No issues found.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add flutter_app/lib/core/setup/first_run_setup.dart
+git commit -m "feat(flutter): TOML writer generates per-repo issue tracking
+
+Writes [ai.repos.\"org/repo\".issue_tracking] section with only
+non-null override fields."
+```
+
+---
+
+### Task 8: Full verification
+
+**Files:** None — verification only.
+
+- [ ] **Step 1: Run daemon tests**
+
+Run: `cd /path/to/project && make test-docker`
+Expected: All tests pass.
+
+- [ ] **Step 2: Build daemon binary**
+
+Run: `cd daemon && go build -o bin/heimdallm ./cmd/heimdallm`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run flutter analyze**
+
+Run: `cd flutter_app && flutter analyze`
+Expected: No new issues.
+
+- [ ] **Step 4: Run flutter tests**
+
+Run: `cd flutter_app && flutter test`
+Expected: All tests pass.
+
+- [ ] **Step 5: Build flutter app**
+
+Run: `cd flutter_app && flutter build macos --release`
+Expected: Build succeeds.

--- a/docs/superpowers/specs/2026-04-20-repo-detail-screen-design.md
+++ b/docs/superpowers/specs/2026-04-20-repo-detail-screen-design.md
@@ -1,0 +1,214 @@
+# Repo Detail Screen + Per-Repo Issue Tracking — Design Spec
+
+**Date**: 2026-04-20
+**Scope**: Dedicated repo settings page, per-field override pattern, daemon per-repo issue tracking
+
+---
+
+## Overview
+
+Replace the inline `ExpansionTile` in the Repositories tab with a dedicated `RepoDetailScreen` — a full-page settings view for a single repo. Every configurable option lives on this page, with a per-field override pattern: each field shows the effective value (global or overridden), and an override indicator + reset button appears when the value differs from global.
+
+The daemon gains per-repo issue tracking config with field-level merging.
+
+---
+
+## 1. Navigation
+
+The repo list (`repos_screen.dart`) becomes a simple list of cards:
+- **Toggle switch** stays inline for quick enable/disable without navigating
+- **Tap anywhere else on the card** navigates to `/repos/:name` (URL-encoded `org/repo`)
+- The `ExpansionTile` with AI dropdowns is removed — all config moves to the detail page
+
+New route: `GoRoute(path: '/repos/:name', builder: ...)` in `router.dart`.
+
+---
+
+## 2. RepoDetailScreen — Layout
+
+Single scrollable page with 4 section cards, top to bottom:
+
+### 2.1 General
+- Local directory (text field + file picker, same `_LocalDirField` widget)
+- Review mode (dropdown: Global / single / multi)
+
+### 2.2 AI Agent
+- Primary (dropdown: Global / claude / gemini / codex)
+- Fallback (dropdown: Global / claude / gemini / codex)
+- Prompt (dropdown: Global active / list of agent profiles)
+
+### 2.3 Issue Tracking
+- Develop labels (comma-separated text)
+- Review-only labels (comma-separated text)
+- Skip labels (comma-separated text)
+- Filter mode (dropdown: Global / exclusive / inclusive)
+- Default action (dropdown: Global / ignore / review_only)
+- Organizations (comma-separated text)
+- Assignees (comma-separated text)
+
+### 2.4 PR Metadata (auto_implement)
+- Reviewers (comma-separated text)
+- Assignee (text)
+- Labels (comma-separated text)
+- Draft (checkbox / Global)
+
+AppBar: back button + repo full name. Auto-save with 800ms debounce (same pattern as current `repos_screen.dart`).
+
+---
+
+## 3. Per-Field Override Pattern
+
+Every field in the detail screen follows this pattern:
+
+### Inherited (no override)
+- Value shown in muted text (grey)
+- Badge: "global" in grey
+- Input placeholder or disabled appearance showing global value
+- Typing a value creates an override
+
+### Overridden
+- Green left border on the field container
+- Badge: "overridden" in green
+- `x reset` button that clears the override (one click)
+- Below the input: "Global: ..." hint text showing what the global value is
+- The input shows the repo-specific value in normal (non-muted) text
+
+### Reset behavior
+- Clicking reset clears the repo-level value, field reverts to inherited
+- Emptying a field manually = same as reset (no "override with empty string")
+
+### Reusable widget
+`OverrideField` — a generic widget parameterized by:
+- `globalValue` (String or List<String>)
+- `overrideValue` (nullable — null means inherited)
+- `onChanged(value?)` — null = reset to global
+- `label`, `helper` text
+- Widget type (text field, dropdown, checkbox)
+
+---
+
+## 4. Model Changes — Flutter
+
+### RepoConfig
+```dart
+class RepoConfig {
+  // Existing
+  final bool monitored;
+  final String? aiPrimary;
+  final String? aiFallback;
+  final String? promptId;
+  final String? reviewMode;
+  final String? localDir;
+
+  // Issue tracking overrides (null = inherit global)
+  final List<String>? developLabels;
+  final List<String>? reviewOnlyLabels;
+  final List<String>? skipLabels;
+  final String? issueFilterMode;
+  final String? issueDefaultAction;
+  final List<String>? issueOrganizations;
+  final List<String>? issueAssignees;
+
+  // PR metadata (null = inherit global)
+  final List<String>? prReviewers;
+  final String? prAssignee;
+  final List<String>? prLabels;
+  final bool? prDraft;
+}
+```
+
+### AppConfig.fromJson
+`repo_overrides` from the daemon already carries per-repo fields. Extend parsing to read issue tracking and PR metadata sub-objects when present.
+
+### AppConfig.toJson
+Serialize per-repo issue tracking overrides as `issue_tracking` sub-object within each repo override. Only include non-null fields.
+
+---
+
+## 5. Daemon — Per-Repo Issue Tracking
+
+### Config
+`RepoAI` gains:
+```go
+IssueTracking *IssueTrackingConfig `toml:"issue_tracking,omitempty"`
+```
+
+New helper:
+```go
+func (c *Config) IssueTrackingForRepo(repo string) IssueTrackingConfig {
+    global := c.GitHub.IssueTracking
+    if c.AI.Repos == nil {
+        return global
+    }
+    r, ok := c.AI.Repos[repo]
+    if !ok || r.IssueTracking == nil {
+        return global
+    }
+    // Field-level merge: per-repo wins when non-zero
+    merged := global
+    override := r.IssueTracking
+    if len(override.DevelopLabels) > 0 { merged.DevelopLabels = override.DevelopLabels }
+    if len(override.ReviewOnlyLabels) > 0 { merged.ReviewOnlyLabels = override.ReviewOnlyLabels }
+    if len(override.SkipLabels) > 0 { merged.SkipLabels = override.SkipLabels }
+    if override.FilterMode != "" { merged.FilterMode = override.FilterMode }
+    if override.DefaultAction != "" { merged.DefaultAction = override.DefaultAction }
+    if len(override.Organizations) > 0 { merged.Organizations = override.Organizations }
+    if len(override.Assignees) > 0 { merged.Assignees = override.Assignees }
+    return merged
+}
+```
+
+### Poll cycle (main.go)
+Replace:
+```go
+itCfg := c.GitHub.IssueTracking
+// ... same for all repos
+```
+With:
+```go
+for _, repo := range repos {
+    repoIT := c.IssueTrackingForRepo(repo)
+    issueFetcher.ProcessRepo(ctx, repo, repoIT, authUser, optsFor)
+}
+```
+
+### GET /config response
+`repo_overrides` gains `issue_tracking` sub-object per repo (only when override exists).
+
+---
+
+## 6. TOML Serialization
+
+Per-repo issue tracking writes as nested TOML table:
+```toml
+[ai.repos."org/repo"]
+primary = "claude"
+local_dir = "/path/to/repo"
+
+[ai.repos."org/repo".issue_tracking]
+develop_labels = ["security-fix", "critical-bug"]
+skip_labels = ["wontfix", "stale"]
+```
+
+Only non-null/non-empty override fields are written. The Flutter TOML writer handles this in `_buildToml`.
+
+---
+
+## 7. Files Changed
+
+### Daemon (Go)
+| File | Change |
+|------|--------|
+| `daemon/internal/config/config.go` | `RepoAI.IssueTracking`, `IssueTrackingForRepo()` |
+| `daemon/cmd/heimdallm/main.go` | Poll cycle uses per-repo issue tracking |
+| `daemon/internal/config/config_test.go` | Tests for `IssueTrackingForRepo` merging |
+
+### Flutter (Dart)
+| File | Change |
+|------|--------|
+| `lib/core/models/config_model.dart` | `RepoConfig` + issue tracking + PR metadata fields |
+| `lib/features/repositories/repos_screen.dart` | Simplify to list + navigate (remove ExpansionTile) |
+| `lib/features/repositories/repo_detail_screen.dart` | **New** — full settings page |
+| `lib/shared/widgets/override_field.dart` | **New** — reusable per-field override widget |
+| `lib/shared/router.dart` | Add `/repos/:name` route |
+| `lib/core/setup/first_run_setup.dart` | TOML writer for per-repo issue tracking |

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -167,6 +167,24 @@ class ApiClient {
     }
   }
 
+  // ── Repo metadata (autocomplete) ─────────────────────────────────────
+
+  Future<List<String>> fetchRepoLabels(String repo) async {
+    final resp = await _client.get(
+        _uri('/repos/${Uri.encodeComponent(repo)}/labels'),
+        headers: await _authHeaders());
+    if (resp.statusCode != 200) return [];
+    return (jsonDecode(resp.body) as List<dynamic>).cast<String>();
+  }
+
+  Future<List<String>> fetchRepoCollaborators(String repo) async {
+    final resp = await _client.get(
+        _uri('/repos/${Uri.encodeComponent(repo)}/collaborators'),
+        headers: await _authHeaders());
+    if (resp.statusCode != 200) return [];
+    return (jsonDecode(resp.body) as List<dynamic>).cast<String>();
+  }
+
   // ── Issues ────────────────────────────────────────────────────────────
 
   Future<List<TrackedIssue>> fetchIssues() async {

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -92,6 +92,21 @@ class RepoConfig {
   final String? reviewMode;  // null = use global ("single" | "multi")
   final String? localDir;    // local repo directory for full-repo analysis
 
+  // Issue tracking overrides (null = inherit global)
+  final List<String>? developLabels;
+  final List<String>? reviewOnlyLabels;
+  final List<String>? skipLabels;
+  final String? issueFilterMode;
+  final String? issueDefaultAction;
+  final List<String>? issueOrganizations;
+  final List<String>? issueAssignees;
+
+  // PR metadata (null = inherit global)
+  final List<String>? prReviewers;
+  final String? prAssignee;
+  final List<String>? prLabels;
+  final bool? prDraft;
+
   const RepoConfig({
     this.monitored = true,
     this.aiPrimary,
@@ -99,27 +114,63 @@ class RepoConfig {
     this.promptId,
     this.reviewMode,
     this.localDir,
+    this.developLabels,
+    this.reviewOnlyLabels,
+    this.skipLabels,
+    this.issueFilterMode,
+    this.issueDefaultAction,
+    this.issueOrganizations,
+    this.issueAssignees,
+    this.prReviewers,
+    this.prAssignee,
+    this.prLabels,
+    this.prDraft,
   });
 
   bool get hasAiOverride =>
       aiPrimary != null || aiFallback != null || promptId != null ||
-      reviewMode != null || (localDir != null && localDir!.isNotEmpty);
+      reviewMode != null || (localDir != null && localDir!.isNotEmpty) ||
+      developLabels != null || reviewOnlyLabels != null || skipLabels != null ||
+      issueFilterMode != null || issueDefaultAction != null ||
+      prReviewers != null || prAssignee != null || prLabels != null;
 
   RepoConfig copyWith({
     bool? monitored,
-    Object? aiPrimary  = _sentinel,
-    Object? aiFallback = _sentinel,
-    Object? promptId   = _sentinel,
-    Object? reviewMode = _sentinel,
-    Object? localDir   = _sentinel,
+    Object? aiPrimary         = _sentinel,
+    Object? aiFallback        = _sentinel,
+    Object? promptId          = _sentinel,
+    Object? reviewMode        = _sentinel,
+    Object? localDir          = _sentinel,
+    Object? developLabels     = _sentinel,
+    Object? reviewOnlyLabels  = _sentinel,
+    Object? skipLabels        = _sentinel,
+    Object? issueFilterMode   = _sentinel,
+    Object? issueDefaultAction = _sentinel,
+    Object? issueOrganizations = _sentinel,
+    Object? issueAssignees    = _sentinel,
+    Object? prReviewers       = _sentinel,
+    Object? prAssignee        = _sentinel,
+    Object? prLabels          = _sentinel,
+    Object? prDraft           = _sentinel,
   }) {
     return RepoConfig(
-      monitored:  monitored  ?? this.monitored,
-      aiPrimary:  aiPrimary  == _sentinel ? this.aiPrimary  : aiPrimary  as String?,
-      aiFallback: aiFallback == _sentinel ? this.aiFallback : aiFallback as String?,
-      promptId:   promptId   == _sentinel ? this.promptId   : promptId   as String?,
-      reviewMode: reviewMode == _sentinel ? this.reviewMode : reviewMode as String?,
-      localDir:   localDir   == _sentinel ? this.localDir   : localDir   as String?,
+      monitored:          monitored          ?? this.monitored,
+      aiPrimary:          aiPrimary          == _sentinel ? this.aiPrimary          : aiPrimary          as String?,
+      aiFallback:         aiFallback         == _sentinel ? this.aiFallback         : aiFallback         as String?,
+      promptId:           promptId           == _sentinel ? this.promptId           : promptId           as String?,
+      reviewMode:         reviewMode         == _sentinel ? this.reviewMode         : reviewMode         as String?,
+      localDir:           localDir           == _sentinel ? this.localDir           : localDir           as String?,
+      developLabels:      developLabels      == _sentinel ? this.developLabels      : developLabels      as List<String>?,
+      reviewOnlyLabels:   reviewOnlyLabels   == _sentinel ? this.reviewOnlyLabels   : reviewOnlyLabels   as List<String>?,
+      skipLabels:         skipLabels         == _sentinel ? this.skipLabels         : skipLabels         as List<String>?,
+      issueFilterMode:    issueFilterMode    == _sentinel ? this.issueFilterMode    : issueFilterMode    as String?,
+      issueDefaultAction: issueDefaultAction == _sentinel ? this.issueDefaultAction : issueDefaultAction as String?,
+      issueOrganizations: issueOrganizations == _sentinel ? this.issueOrganizations : issueOrganizations as List<String>?,
+      issueAssignees:     issueAssignees     == _sentinel ? this.issueAssignees     : issueAssignees     as List<String>?,
+      prReviewers:        prReviewers        == _sentinel ? this.prReviewers        : prReviewers        as List<String>?,
+      prAssignee:         prAssignee         == _sentinel ? this.prAssignee         : prAssignee         as String?,
+      prLabels:           prLabels           == _sentinel ? this.prLabels           : prLabels           as List<String>?,
+      prDraft:            prDraft            == _sentinel ? this.prDraft            : prDraft            as bool?,
     );
   }
 }
@@ -131,6 +182,12 @@ const _sentinel = Object();
 String? _nonEmpty(dynamic v) {
   final s = v as String?;
   return (s == null || s.isEmpty) ? null : s;
+}
+
+/// Returns null when the list is absent or empty, otherwise a non-empty String list.
+List<String>? _nullableStringList(dynamic v) {
+  final list = (v as List<dynamic>?)?.cast<String>().where((s) => s.isNotEmpty).toList();
+  return (list != null && list.isNotEmpty) ? list : null;
 }
 
 /// Issue tracking pipeline configuration.
@@ -283,12 +340,24 @@ class AppConfig {
       for (final entry in overrides.entries) {
         final ov = entry.value as Map<String, dynamic>;
         final existing = configs[entry.key];
+        final itRaw = ov['issue_tracking'] as Map<String, dynamic>?;
         configs[entry.key] = RepoConfig(
-          monitored:  existing?.monitored ?? configs.containsKey(entry.key),
-          aiPrimary:  _nonEmpty(ov['primary']),
-          aiFallback: _nonEmpty(ov['fallback']),
-          reviewMode: _nonEmpty(ov['review_mode']),
-          localDir:   _nonEmpty(ov['local_dir']),
+          monitored:          existing?.monitored ?? configs.containsKey(entry.key),
+          aiPrimary:          _nonEmpty(ov['primary']),
+          aiFallback:         _nonEmpty(ov['fallback']),
+          reviewMode:         _nonEmpty(ov['review_mode']),
+          localDir:           _nonEmpty(ov['local_dir']),
+          developLabels:      itRaw != null ? _nullableStringList(itRaw['develop_labels']) : null,
+          reviewOnlyLabels:   itRaw != null ? _nullableStringList(itRaw['review_only_labels']) : null,
+          skipLabels:         itRaw != null ? _nullableStringList(itRaw['skip_labels']) : null,
+          issueFilterMode:    itRaw != null ? _nonEmpty(itRaw['filter_mode']) : null,
+          issueDefaultAction: itRaw != null ? _nonEmpty(itRaw['default_action']) : null,
+          issueOrganizations: itRaw != null ? _nullableStringList(itRaw['organizations']) : null,
+          issueAssignees:     itRaw != null ? _nullableStringList(itRaw['assignees']) : null,
+          prReviewers:        _nullableStringList(ov['pr_reviewers']),
+          prAssignee:         _nonEmpty(ov['pr_assignee']),
+          prLabels:           _nullableStringList(ov['pr_labels']),
+          prDraft:            ov['pr_draft'] as bool?,
         );
       }
     }

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -243,17 +243,23 @@ class IssueTrackingConfig {
     'assignees':          assignees,
   };
 
-  factory IssueTrackingConfig.fromJson(Map<String, dynamic> json) =>
-      IssueTrackingConfig(
+  static const validFilterModes = ['exclusive', 'inclusive'];
+  static const validDefaultActions = ['ignore', 'review_only'];
+
+  factory IssueTrackingConfig.fromJson(Map<String, dynamic> json) {
+    final rawFilterMode = (json['filter_mode'] as String?) ?? 'exclusive';
+    final rawDefaultAction = (json['default_action'] as String?) ?? 'ignore';
+    return IssueTrackingConfig(
         enabled:          (json['enabled']       as bool?)   ?? false,
-        filterMode:       (json['filter_mode']   as String?) ?? 'exclusive',
-        defaultAction:    (json['default_action'] as String?) ?? 'ignore',
+        filterMode:       validFilterModes.contains(rawFilterMode) ? rawFilterMode : 'exclusive',
+        defaultAction:    validDefaultActions.contains(rawDefaultAction) ? rawDefaultAction : 'ignore',
         developLabels:    _stringList(json['develop_labels']),
         reviewOnlyLabels: _stringList(json['review_only_labels']),
         skipLabels:       _stringList(json['skip_labels']),
         organizations:    _stringList(json['organizations']),
         assignees:        _stringList(json['assignees']),
       );
+  }
 
   static List<String> _stringList(dynamic v) =>
       (v as List<dynamic>?)?.cast<String>() ?? [];

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -133,6 +133,75 @@ String? _nonEmpty(dynamic v) {
   return (s == null || s.isEmpty) ? null : s;
 }
 
+/// Issue tracking pipeline configuration.
+class IssueTrackingConfig {
+  final bool enabled;
+  final String filterMode;      // "exclusive" | "inclusive"
+  final String defaultAction;   // "ignore" | "review_only"
+  final List<String> developLabels;
+  final List<String> reviewOnlyLabels;
+  final List<String> skipLabels;
+  final List<String> organizations;
+  final List<String> assignees;
+
+  const IssueTrackingConfig({
+    this.enabled = false,
+    this.filterMode = 'exclusive',
+    this.defaultAction = 'ignore',
+    this.developLabels = const [],
+    this.reviewOnlyLabels = const [],
+    this.skipLabels = const [],
+    this.organizations = const [],
+    this.assignees = const [],
+  });
+
+  IssueTrackingConfig copyWith({
+    bool? enabled,
+    String? filterMode,
+    String? defaultAction,
+    List<String>? developLabels,
+    List<String>? reviewOnlyLabels,
+    List<String>? skipLabels,
+    List<String>? organizations,
+    List<String>? assignees,
+  }) => IssueTrackingConfig(
+    enabled:          enabled          ?? this.enabled,
+    filterMode:       filterMode       ?? this.filterMode,
+    defaultAction:    defaultAction    ?? this.defaultAction,
+    developLabels:    developLabels    ?? this.developLabels,
+    reviewOnlyLabels: reviewOnlyLabels ?? this.reviewOnlyLabels,
+    skipLabels:       skipLabels       ?? this.skipLabels,
+    organizations:    organizations    ?? this.organizations,
+    assignees:        assignees        ?? this.assignees,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'enabled':            enabled,
+    'filter_mode':        filterMode,
+    'default_action':     defaultAction,
+    'develop_labels':     developLabels,
+    'review_only_labels': reviewOnlyLabels,
+    'skip_labels':        skipLabels,
+    'organizations':      organizations,
+    'assignees':          assignees,
+  };
+
+  factory IssueTrackingConfig.fromJson(Map<String, dynamic> json) =>
+      IssueTrackingConfig(
+        enabled:          (json['enabled']       as bool?)   ?? false,
+        filterMode:       (json['filter_mode']   as String?) ?? 'exclusive',
+        defaultAction:    (json['default_action'] as String?) ?? 'ignore',
+        developLabels:    _stringList(json['develop_labels']),
+        reviewOnlyLabels: _stringList(json['review_only_labels']),
+        skipLabels:       _stringList(json['skip_labels']),
+        organizations:    _stringList(json['organizations']),
+        assignees:        _stringList(json['assignees']),
+      );
+
+  static List<String> _stringList(dynamic v) =>
+      (v as List<dynamic>?)?.cast<String>() ?? [];
+}
+
 class AppConfig {
   final int serverPort;
   final String pollInterval;
@@ -142,6 +211,7 @@ class AppConfig {
   final int retentionDays;
   final Map<String, CLIAgentConfig> agentConfigs; // keyed by CLI name
   final Map<String, RepoConfig> repoConfigs;      // keyed by "org/repo"
+  final IssueTrackingConfig issueTracking;
 
   const AppConfig({
     this.serverPort = 7842,
@@ -152,6 +222,7 @@ class AppConfig {
     this.retentionDays = 90,
     this.agentConfigs = const {},
     this.repoConfigs = const {},
+    this.issueTracking = const IssueTrackingConfig(),
   });
 
   /// Computed list of monitored repos — this is what the daemon uses.
@@ -170,27 +241,30 @@ class AppConfig {
     int? retentionDays,
     Map<String, CLIAgentConfig>? agentConfigs,
     Map<String, RepoConfig>? repoConfigs,
+    IssueTrackingConfig? issueTracking,
   }) {
     return AppConfig(
-      serverPort:   serverPort   ?? this.serverPort,
-      pollInterval: pollInterval ?? this.pollInterval,
-      aiPrimary:    aiPrimary    ?? this.aiPrimary,
-      aiFallback:   aiFallback   ?? this.aiFallback,
-      reviewMode:   reviewMode   ?? this.reviewMode,
+      serverPort:    serverPort    ?? this.serverPort,
+      pollInterval:  pollInterval  ?? this.pollInterval,
+      aiPrimary:     aiPrimary     ?? this.aiPrimary,
+      aiFallback:    aiFallback    ?? this.aiFallback,
+      reviewMode:    reviewMode    ?? this.reviewMode,
       retentionDays: retentionDays ?? this.retentionDays,
-      agentConfigs: agentConfigs ?? this.agentConfigs,
-      repoConfigs:  repoConfigs  ?? this.repoConfigs,
+      agentConfigs:  agentConfigs  ?? this.agentConfigs,
+      repoConfigs:   repoConfigs   ?? this.repoConfigs,
+      issueTracking: issueTracking ?? this.issueTracking,
     );
   }
 
   Map<String, dynamic> toJson() => {
-    'server_port':   serverPort,
-    'poll_interval': pollInterval,
-    'repositories':  repositories,
-    'ai_primary':    aiPrimary,
-    'ai_fallback':   aiFallback,
-    'review_mode':   reviewMode,
+    'server_port':    serverPort,
+    'poll_interval':  pollInterval,
+    'repositories':   repositories,
+    'ai_primary':     aiPrimary,
+    'ai_fallback':    aiFallback,
+    'review_mode':    reviewMode,
     'retention_days': retentionDays,
+    'issue_tracking': issueTracking.toJson(),
   };
 
   factory AppConfig.fromJson(Map<String, dynamic> json) {
@@ -227,15 +301,21 @@ class AppConfig {
             CLIAgentConfig.fromJson(entry.value as Map<String, dynamic>);
       }
     }
+    final itRaw = json['issue_tracking'] as Map<String, dynamic>?;
+    final issueTracking = itRaw != null
+        ? IssueTrackingConfig.fromJson(itRaw)
+        : const IssueTrackingConfig();
+
     return AppConfig(
-      serverPort:   (json['server_port']   as int?)    ?? 7842,
-      pollInterval: (json['poll_interval'] as String?) ?? '5m',
-      aiPrimary:    (json['ai_primary']    as String?) ?? 'claude',
-      aiFallback:   (json['ai_fallback']   as String?) ?? '',
-      reviewMode:   (json['review_mode']   as String?) ?? 'single',
-      retentionDays: (json['retention_days'] as int?)  ?? 90,
-      agentConfigs: agentConfigs,
-      repoConfigs:  configs,
+      serverPort:    (json['server_port']   as int?)    ?? 7842,
+      pollInterval:  (json['poll_interval'] as String?) ?? '5m',
+      aiPrimary:     (json['ai_primary']    as String?) ?? 'claude',
+      aiFallback:    (json['ai_fallback']   as String?) ?? '',
+      reviewMode:    (json['review_mode']   as String?) ?? 'single',
+      retentionDays: (json['retention_days'] as int?)   ?? 90,
+      agentConfigs:  agentConfigs,
+      repoConfigs:   configs,
+      issueTracking: issueTracking,
     );
   }
 }

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -85,88 +85,135 @@ class CLIAgentConfig {
 
 /// Per-repo AI override. null fields mean "use global default".
 class RepoConfig {
-  final bool monitored;
-  final String? aiPrimary;   // null = use global
-  final String? aiFallback;  // null = use global
-  final String? promptId;    // null = use globally active prompt
-  final String? reviewMode;  // null = use global ("single" | "multi")
-  final String? localDir;    // local repo directory for full-repo analysis
+  // Per-feature activation (null = inherit global behavior)
+  final bool? prEnabled;      // PR auto-review
+  final bool? itEnabled;      // Issue tracking (triage)
+  final bool? devEnabled;     // Develop (auto-implement)
+
+  // General
+  final String? localDir;     // local repo directory for full-repo analysis
+
+  // PR Review config
+  final String? aiPrimary;    // null = use global
+  final String? aiFallback;   // null = use global
+  final String? promptId;     // null = use globally active prompt
+  final String? reviewMode;   // null = use global ("single" | "multi")
 
   // Issue tracking overrides (null = inherit global)
-  final List<String>? developLabels;
   final List<String>? reviewOnlyLabels;
   final List<String>? skipLabels;
   final String? issueFilterMode;
   final String? issueDefaultAction;
   final List<String>? issueOrganizations;
   final List<String>? issueAssignees;
+  final String? issuePromptId;
 
-  // PR metadata (null = inherit global)
+  // Develop overrides (null = inherit global)
+  final List<String>? developLabels;
+  final String? developPromptId;
+
+  // PR metadata applied after auto_implement creates a PR
   final List<String>? prReviewers;
   final String? prAssignee;
   final List<String>? prLabels;
   final bool? prDraft;
 
   const RepoConfig({
-    this.monitored = true,
+    this.prEnabled,
+    this.itEnabled,
+    this.devEnabled,
+    this.localDir,
     this.aiPrimary,
     this.aiFallback,
     this.promptId,
     this.reviewMode,
-    this.localDir,
-    this.developLabels,
     this.reviewOnlyLabels,
     this.skipLabels,
     this.issueFilterMode,
     this.issueDefaultAction,
     this.issueOrganizations,
     this.issueAssignees,
+    this.issuePromptId,
+    this.developLabels,
+    this.developPromptId,
     this.prReviewers,
     this.prAssignee,
     this.prLabels,
     this.prDraft,
   });
 
+  /// True if any feature is actively enabled (per-repo or inherited).
+  /// Used by the repo list to classify monitored vs not-monitored.
+  bool get isMonitored => (prEnabled ?? false) || (itEnabled ?? false) || (devEnabled ?? false);
+
+  /// Legacy getter — repos with any override need to be written to TOML.
   bool get hasAiOverride =>
+      prEnabled != null || itEnabled != null || devEnabled != null ||
       aiPrimary != null || aiFallback != null || promptId != null ||
       reviewMode != null || (localDir != null && localDir!.isNotEmpty) ||
       developLabels != null || reviewOnlyLabels != null || skipLabels != null ||
       issueFilterMode != null || issueDefaultAction != null ||
+      issuePromptId != null || developPromptId != null ||
       prReviewers != null || prAssignee != null || prLabels != null;
 
+  /// LED status for each feature: 'off', 'global', 'repo'
+  String prLedStatus(bool globalMonitored) {
+    if (prEnabled == true) return 'repo';
+    if (prEnabled == false) return 'off';
+    return globalMonitored ? 'global' : 'off';
+  }
+  String itLedStatus(bool globalITEnabled) {
+    if (itEnabled == true) return 'repo';
+    if (itEnabled == false) return 'off';
+    return globalITEnabled ? 'global' : 'off';
+  }
+  String devLedStatus(bool globalITEnabled, bool hasLocalDir) {
+    if (devEnabled == true && hasLocalDir) return 'repo';
+    if (devEnabled == false) return 'off';
+    return (globalITEnabled && hasLocalDir) ? 'global' : 'off';
+  }
+
   RepoConfig copyWith({
-    bool? monitored,
-    Object? aiPrimary         = _sentinel,
-    Object? aiFallback        = _sentinel,
-    Object? promptId          = _sentinel,
-    Object? reviewMode        = _sentinel,
-    Object? localDir          = _sentinel,
-    Object? developLabels     = _sentinel,
-    Object? reviewOnlyLabels  = _sentinel,
-    Object? skipLabels        = _sentinel,
-    Object? issueFilterMode   = _sentinel,
+    Object? prEnabled          = _sentinel,
+    Object? itEnabled          = _sentinel,
+    Object? devEnabled         = _sentinel,
+    Object? localDir           = _sentinel,
+    Object? aiPrimary          = _sentinel,
+    Object? aiFallback         = _sentinel,
+    Object? promptId           = _sentinel,
+    Object? reviewMode         = _sentinel,
+    Object? reviewOnlyLabels   = _sentinel,
+    Object? skipLabels         = _sentinel,
+    Object? issueFilterMode    = _sentinel,
     Object? issueDefaultAction = _sentinel,
     Object? issueOrganizations = _sentinel,
-    Object? issueAssignees    = _sentinel,
-    Object? prReviewers       = _sentinel,
-    Object? prAssignee        = _sentinel,
-    Object? prLabels          = _sentinel,
-    Object? prDraft           = _sentinel,
+    Object? issueAssignees     = _sentinel,
+    Object? issuePromptId      = _sentinel,
+    Object? developLabels      = _sentinel,
+    Object? developPromptId    = _sentinel,
+    Object? prReviewers        = _sentinel,
+    Object? prAssignee         = _sentinel,
+    Object? prLabels           = _sentinel,
+    Object? prDraft            = _sentinel,
   }) {
     return RepoConfig(
-      monitored:          monitored          ?? this.monitored,
+      prEnabled:          prEnabled          == _sentinel ? this.prEnabled          : prEnabled          as bool?,
+      itEnabled:          itEnabled          == _sentinel ? this.itEnabled          : itEnabled          as bool?,
+      devEnabled:         devEnabled         == _sentinel ? this.devEnabled         : devEnabled         as bool?,
+      localDir:           localDir           == _sentinel ? this.localDir           : localDir           as String?,
       aiPrimary:          aiPrimary          == _sentinel ? this.aiPrimary          : aiPrimary          as String?,
       aiFallback:         aiFallback         == _sentinel ? this.aiFallback         : aiFallback         as String?,
       promptId:           promptId           == _sentinel ? this.promptId           : promptId           as String?,
       reviewMode:         reviewMode         == _sentinel ? this.reviewMode         : reviewMode         as String?,
-      localDir:           localDir           == _sentinel ? this.localDir           : localDir           as String?,
-      developLabels:      developLabels      == _sentinel ? this.developLabels      : developLabels      as List<String>?,
       reviewOnlyLabels:   reviewOnlyLabels   == _sentinel ? this.reviewOnlyLabels   : reviewOnlyLabels   as List<String>?,
       skipLabels:         skipLabels         == _sentinel ? this.skipLabels         : skipLabels         as List<String>?,
       issueFilterMode:    issueFilterMode    == _sentinel ? this.issueFilterMode    : issueFilterMode    as String?,
       issueDefaultAction: issueDefaultAction == _sentinel ? this.issueDefaultAction : issueDefaultAction as String?,
       issueOrganizations: issueOrganizations == _sentinel ? this.issueOrganizations : issueOrganizations as List<String>?,
       issueAssignees:     issueAssignees     == _sentinel ? this.issueAssignees     : issueAssignees     as List<String>?,
+      issuePromptId:      issuePromptId      == _sentinel ? this.issuePromptId      : issuePromptId      as String?,
+      developLabels:      developLabels      == _sentinel ? this.developLabels      : developLabels      as List<String>?,
+      developPromptId:    developPromptId    == _sentinel ? this.developPromptId    : developPromptId    as String?,
       prReviewers:        prReviewers        == _sentinel ? this.prReviewers        : prReviewers        as List<String>?,
       prAssignee:         prAssignee         == _sentinel ? this.prAssignee         : prAssignee         as String?,
       prLabels:           prLabels           == _sentinel ? this.prLabels           : prLabels           as List<String>?,
@@ -289,8 +336,9 @@ class AppConfig {
   });
 
   /// Computed list of monitored repos — this is what the daemon uses.
+  /// A repo is monitored if any of its 3 features (PR, IT, Dev) is active.
   List<String> get repositories => (repoConfigs.entries
-      .where((e) => e.value.monitored)
+      .where((e) => e.value.isMonitored)
       .map((e) => e.key)
       .toList()
     ..sort());
@@ -333,12 +381,13 @@ class AppConfig {
   factory AppConfig.fromJson(Map<String, dynamic> json) {
     final repos = (json['repositories'] as List<dynamic>?)?.cast<String>() ?? [];
     final configs = <String, RepoConfig>{
-      for (final r in repos) r: const RepoConfig(monitored: true),
+      // Repos in the monitored list have PR review enabled
+      for (final r in repos) r: const RepoConfig(prEnabled: true),
     };
     // Restore non-monitored repos
     final nonMonitored = (json['non_monitored'] as List<dynamic>?)?.cast<String>() ?? [];
     for (final r in nonMonitored) {
-      configs.putIfAbsent(r, () => const RepoConfig(monitored: false));
+      configs.putIfAbsent(r, () => const RepoConfig());
     }
     // Per-repo overrides (normalize empty strings to null)
     final overrides = json['repo_overrides'] as Map<String, dynamic>?;
@@ -347,19 +396,25 @@ class AppConfig {
         final ov = entry.value as Map<String, dynamic>;
         final existing = configs[entry.key];
         final itRaw = ov['issue_tracking'] as Map<String, dynamic>?;
+        final itEnabled = itRaw?['enabled'] as bool?;
         configs[entry.key] = RepoConfig(
-          monitored:          existing?.monitored ?? configs.containsKey(entry.key),
+          prEnabled:          existing?.prEnabled,
+          itEnabled:          itEnabled,
+          devEnabled:         itRaw?['develop_enabled'] as bool?,
+          localDir:           _nonEmpty(ov['local_dir']),
           aiPrimary:          _nonEmpty(ov['primary']),
           aiFallback:         _nonEmpty(ov['fallback']),
           reviewMode:         _nonEmpty(ov['review_mode']),
-          localDir:           _nonEmpty(ov['local_dir']),
-          developLabels:      itRaw != null ? _nullableStringList(itRaw['develop_labels']) : null,
+          promptId:           _nonEmpty(ov['prompt']),
           reviewOnlyLabels:   itRaw != null ? _nullableStringList(itRaw['review_only_labels']) : null,
           skipLabels:         itRaw != null ? _nullableStringList(itRaw['skip_labels']) : null,
           issueFilterMode:    itRaw != null ? _nonEmpty(itRaw['filter_mode']) : null,
           issueDefaultAction: itRaw != null ? _nonEmpty(itRaw['default_action']) : null,
           issueOrganizations: itRaw != null ? _nullableStringList(itRaw['organizations']) : null,
           issueAssignees:     itRaw != null ? _nullableStringList(itRaw['assignees']) : null,
+          issuePromptId:      itRaw != null ? _nonEmpty(itRaw['issue_prompt']) : null,
+          developLabels:      itRaw != null ? _nullableStringList(itRaw['develop_labels']) : null,
+          developPromptId:    itRaw != null ? _nonEmpty(itRaw['develop_prompt']) : null,
           prReviewers:        _nullableStringList(ov['pr_reviewers']),
           prAssignee:         _nonEmpty(ov['pr_assignee']),
           prLabels:           _nullableStringList(ov['pr_labels']),

--- a/flutter_app/lib/core/setup/first_run_setup.dart
+++ b/flutter_app/lib/core/setup/first_run_setup.dart
@@ -185,7 +185,7 @@ class FirstRunSetup {
     buf.writeln('repositories = [$repos]');
     // Persist non-monitored repos so the UI can display and re-enable them after restart.
     final nonMonitored = config.repoConfigs.entries
-        .where((e) => !e.value.monitored)
+        .where((e) => !e.value.isMonitored)
         .map((e) => e.key)
         .toList()..sort();
     if (nonMonitored.isNotEmpty) {

--- a/flutter_app/lib/core/setup/first_run_setup.dart
+++ b/flutter_app/lib/core/setup/first_run_setup.dart
@@ -258,6 +258,35 @@ class FirstRunSetup {
         if (rc.localDir != null && rc.localDir!.isNotEmpty) {
           buf.writeln('local_dir = "${_tomlEscapeString(rc.localDir!)}"');
         }
+        // Issue tracking overrides
+        final hasIT = rc.developLabels != null || rc.reviewOnlyLabels != null ||
+            rc.skipLabels != null || rc.issueFilterMode != null ||
+            rc.issueDefaultAction != null || rc.issueOrganizations != null ||
+            rc.issueAssignees != null;
+        if (hasIT) {
+          buf.writeln('[ai.repos."${_tomlEscapeString(repo)}".issue_tracking]');
+          if (rc.developLabels != null && rc.developLabels!.isNotEmpty) {
+            buf.writeln('develop_labels = [${rc.developLabels!.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+          }
+          if (rc.reviewOnlyLabels != null && rc.reviewOnlyLabels!.isNotEmpty) {
+            buf.writeln('review_only_labels = [${rc.reviewOnlyLabels!.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+          }
+          if (rc.skipLabels != null && rc.skipLabels!.isNotEmpty) {
+            buf.writeln('skip_labels = [${rc.skipLabels!.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+          }
+          if (rc.issueFilterMode != null) {
+            buf.writeln('filter_mode = "${_tomlEscapeString(rc.issueFilterMode!)}"');
+          }
+          if (rc.issueDefaultAction != null) {
+            buf.writeln('default_action = "${_tomlEscapeString(rc.issueDefaultAction!)}"');
+          }
+          if (rc.issueOrganizations != null && rc.issueOrganizations!.isNotEmpty) {
+            buf.writeln('organizations = [${rc.issueOrganizations!.map((o) => '"${_tomlEscapeString(o)}"').join(', ')}]');
+          }
+          if (rc.issueAssignees != null && rc.issueAssignees!.isNotEmpty) {
+            buf.writeln('assignees = [${rc.issueAssignees!.map((a) => '"${_tomlEscapeString(a)}"').join(', ')}]');
+          }
+        }
         buf.writeln();
       }
     }

--- a/flutter_app/lib/core/setup/first_run_setup.dart
+++ b/flutter_app/lib/core/setup/first_run_setup.dart
@@ -194,6 +194,29 @@ class FirstRunSetup {
     }
     buf.writeln();
 
+    // Issue tracking
+    final it = config.issueTracking;
+    buf.writeln('[github.issue_tracking]');
+    buf.writeln('enabled = ${it.enabled}');
+    buf.writeln('filter_mode = "${_tomlEscapeString(it.filterMode)}"');
+    buf.writeln('default_action = "${_tomlEscapeString(it.defaultAction)}"');
+    if (it.developLabels.isNotEmpty) {
+      buf.writeln('develop_labels = [${it.developLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+    }
+    if (it.reviewOnlyLabels.isNotEmpty) {
+      buf.writeln('review_only_labels = [${it.reviewOnlyLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+    }
+    if (it.skipLabels.isNotEmpty) {
+      buf.writeln('skip_labels = [${it.skipLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+    }
+    if (it.organizations.isNotEmpty) {
+      buf.writeln('organizations = [${it.organizations.map((o) => '"${_tomlEscapeString(o)}"').join(', ')}]');
+    }
+    if (it.assignees.isNotEmpty) {
+      buf.writeln('assignees = [${it.assignees.map((a) => '"${_tomlEscapeString(a)}"').join(', ')}]');
+    }
+    buf.writeln();
+
     buf.writeln('[ai]');
     buf.writeln('primary = "${_tomlEscapeString(config.aiPrimary)}"');
     if (config.aiFallback.isNotEmpty) {

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -379,7 +379,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             children: [
               Expanded(
                 child: DropdownButtonFormField<String>(
-                  value: _issueTracking.filterMode,
+                  initialValue: _issueTracking.filterMode,
                   decoration: const InputDecoration(
                     labelText: 'Filter mode',
                     helperText: 'exclusive = AND, inclusive = OR',
@@ -397,7 +397,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
               const SizedBox(width: 12),
               Expanded(
                 child: DropdownButtonFormField<String>(
-                  value: _issueTracking.defaultAction,
+                  initialValue: _issueTracking.defaultAction,
                   decoration: const InputDecoration(
                     labelText: 'Default action',
                     helperText: 'When no label matches',

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -471,6 +471,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     required ValueChanged<List<String>> onChanged,
   }) {
     return TextFormField(
+      key: ValueKey('$label:${values.join(',')}'),
       initialValue: values.join(', '),
       decoration: InputDecoration(
         labelText: label,

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -90,7 +90,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       setState(() {
         for (final repo in discovered) {
           // Keep existing toggle state; default new ones to monitored
-          _repoConfigs.putIfAbsent(repo, () => const RepoConfig(monitored: true));
+          _repoConfigs.putIfAbsent(repo, () => const RepoConfig(prEnabled: true));
         }
         _discovering = false;
       });
@@ -242,15 +242,15 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       margin: const EdgeInsets.only(bottom: 4),
       child: ExpansionTile(
         leading: Switch(
-          value: rc.monitored,
+          value: rc.isMonitored,
           onChanged: (v) => setState(() {
-            _repoConfigs[repo] = rc.copyWith(monitored: v);
+            _repoConfigs[repo] = rc.copyWith(prEnabled: v);
           }),
         ),
         title: Text(repo,
             style: TextStyle(
-              color: rc.monitored ? null : Colors.grey,
-              fontWeight: rc.monitored ? FontWeight.w600 : FontWeight.normal,
+              color: rc.isMonitored ? null : Colors.grey,
+              fontWeight: rc.isMonitored ? FontWeight.w600 : FontWeight.normal,
             )),
         subtitle: rc.hasAiOverride
             ? Text('AI: ${rc.aiPrimary ?? "global"}', style: const TextStyle(fontSize: 12))

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -27,6 +27,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
 
   String _pollInterval = '5m';
   int _retentionDays = 90;
+  IssueTrackingConfig _issueTracking = const IssueTrackingConfig();
 
   // All known repos. Key = "org/repo", Value = per-repo settings.
   Map<String, RepoConfig> _repoConfigs = {};
@@ -74,6 +75,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     _pollInterval = config.pollInterval;
     _retentionDays = config.retentionDays;
     _repoConfigs = Map.from(config.repoConfigs);
+    _issueTracking = config.issueTracking;
   }
 
   /// Auto-discovers repos from the user's PRs. Runs silently on init.
@@ -139,6 +141,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             _pollSection(),
             const SizedBox(height: 20),
             _retentionSection(),
+            const SizedBox(height: 20),
+            _issueTrackingSection(),
             const SizedBox(height: 28),
             _saveButton(context, config, daemonRunning),
           ],
@@ -351,6 +355,141 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     );
   }
 
+  // ── Issue tracking ──────────────────────────────────────────────────────
+
+  Widget _issueTrackingSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            _sectionHeaderInline('Issue Tracking'),
+            const Spacer(),
+            Switch(
+              value: _issueTracking.enabled,
+              onChanged: (v) => setState(() {
+                _issueTracking = _issueTracking.copyWith(enabled: v);
+              }),
+            ),
+          ],
+        ),
+        if (_issueTracking.enabled) ...[
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: DropdownButtonFormField<String>(
+                  value: _issueTracking.filterMode,
+                  decoration: const InputDecoration(
+                    labelText: 'Filter mode',
+                    helperText: 'exclusive = AND, inclusive = OR',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                  items: ['exclusive', 'inclusive']
+                      .map((v) => DropdownMenuItem(value: v, child: Text(v)))
+                      .toList(),
+                  onChanged: (v) => setState(() {
+                    _issueTracking = _issueTracking.copyWith(filterMode: v);
+                  }),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: DropdownButtonFormField<String>(
+                  value: _issueTracking.defaultAction,
+                  decoration: const InputDecoration(
+                    labelText: 'Default action',
+                    helperText: 'When no label matches',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                  items: ['ignore', 'review_only']
+                      .map((v) => DropdownMenuItem(value: v, child: Text(v)))
+                      .toList(),
+                  onChanged: (v) => setState(() {
+                    _issueTracking = _issueTracking.copyWith(defaultAction: v);
+                  }),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _labelListField(
+            label: 'Develop labels (auto_implement)',
+            helper: 'Issues with these labels get a branch + PR',
+            values: _issueTracking.developLabels,
+            onChanged: (v) => setState(() {
+              _issueTracking = _issueTracking.copyWith(developLabels: v);
+            }),
+          ),
+          const SizedBox(height: 12),
+          _labelListField(
+            label: 'Review-only labels',
+            helper: 'Issues with these labels get an AI triage comment',
+            values: _issueTracking.reviewOnlyLabels,
+            onChanged: (v) => setState(() {
+              _issueTracking = _issueTracking.copyWith(reviewOnlyLabels: v);
+            }),
+          ),
+          const SizedBox(height: 12),
+          _labelListField(
+            label: 'Skip labels',
+            helper: 'Issues with these labels are ignored (highest priority)',
+            values: _issueTracking.skipLabels,
+            onChanged: (v) => setState(() {
+              _issueTracking = _issueTracking.copyWith(skipLabels: v);
+            }),
+          ),
+          const SizedBox(height: 12),
+          _labelListField(
+            label: 'Organizations',
+            helper: 'Limit to issues from these orgs (empty = all monitored)',
+            values: _issueTracking.organizations,
+            onChanged: (v) => setState(() {
+              _issueTracking = _issueTracking.copyWith(organizations: v);
+            }),
+          ),
+          const SizedBox(height: 12),
+          _labelListField(
+            label: 'Assignees',
+            helper: 'Only process issues assigned to these users (empty = any)',
+            values: _issueTracking.assignees,
+            onChanged: (v) => setState(() {
+              _issueTracking = _issueTracking.copyWith(assignees: v);
+            }),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _labelListField({
+    required String label,
+    required String helper,
+    required List<String> values,
+    required ValueChanged<List<String>> onChanged,
+  }) {
+    return TextFormField(
+      initialValue: values.join(', '),
+      decoration: InputDecoration(
+        labelText: label,
+        helperText: helper,
+        helperMaxLines: 2,
+        border: const OutlineInputBorder(),
+        isDense: true,
+      ),
+      onChanged: (text) {
+        final parsed = text
+            .split(',')
+            .map((s) => s.trim())
+            .where((s) => s.isNotEmpty)
+            .toList();
+        onChanged(parsed);
+      },
+    );
+  }
+
   // ── Save button ──────────────────────────────────────────────────────────
 
   Widget _saveButton(BuildContext context, AppConfig base, bool daemonRunning) {
@@ -421,6 +560,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     pollInterval: _pollInterval,
     retentionDays: _retentionDays,
     repoConfigs: Map.from(_repoConfigs),
+    issueTracking: _issueTracking,
     // aiPrimary, aiFallback, reviewMode, agentConfigs managed in Agents tab
   );
 

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -141,7 +141,7 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
             padding: const EdgeInsets.all(16),
             child: Column(
               children: [
-                // ── General ──────────────────────────────────────────────
+                // ── Section 1: General ─────────────────────────────────
                 _sectionCard('General', [
                   const Text('Local directory',
                       style: TextStyle(fontSize: 12, color: Colors.grey)),
@@ -157,19 +157,20 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                     onChanged: (dir) => _update(_config.copyWith(
                         localDir: dir.isEmpty ? null : dir)),
                   ),
-                  const SizedBox(height: 12),
-                  OverrideDropdown(
-                    label: 'Review mode',
-                    globalValue: appConfig.reviewMode,
-                    overrideValue: _config.reviewMode,
-                    options: const ['single', 'multi'],
-                    onChanged: (v) =>
-                        _update(_config.copyWith(reviewMode: v)),
-                  ),
                 ]),
 
-                // ── AI Agent ─────────────────────────────────────────────
-                _sectionCard('AI Agent', [
+                // ── Section 2: PR Review ───────────────────────────────
+                _sectionCard('PR Review', [
+                  SwitchListTile(
+                    title: const Text('Auto-review PRs',
+                        style: TextStyle(fontSize: 13)),
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    value: _config.prEnabled ?? false,
+                    onChanged: (v) =>
+                        _update(_config.copyWith(prEnabled: v)),
+                  ),
+                  const SizedBox(height: 6),
                   OverrideDropdown(
                     label: 'Primary',
                     globalValue: appConfig.aiPrimary,
@@ -191,6 +192,15 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
+                    label: 'Review mode',
+                    globalValue: appConfig.reviewMode,
+                    overrideValue: _config.reviewMode,
+                    options: const ['single', 'multi'],
+                    onChanged: (v) =>
+                        _update(_config.copyWith(reviewMode: v)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
                     label: 'Prompt',
                     globalValue: 'default',
                     overrideValue: _config.promptId,
@@ -200,19 +210,18 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                   ),
                 ]),
 
-                // ── Issue Tracking ───────────────────────────────────────
+                // ── Section 3: Issue Tracking ──────────────────────────
                 _sectionCard('Issue Tracking', [
-                  AutocompleteChipField(
-                    label: 'Develop labels',
-                    helper: 'Issues with these labels get a branch + PR',
-                    selectedValues: _config.developLabels ?? appConfig.issueTracking.developLabels,
-                    availableOptions: _repoLabels,
-                    isOverridden: _config.developLabels != null,
-                    globalHint: _joinList(appConfig.issueTracking.developLabels),
-                    onChanged: (v) => _update(_config.copyWith(developLabels: v)),
-                    onReset: () => _update(_config.copyWith(developLabels: null)),
+                  SwitchListTile(
+                    title: const Text('Triage issues',
+                        style: TextStyle(fontSize: 13)),
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    value: _config.itEnabled ?? false,
+                    onChanged: (v) =>
+                        _update(_config.copyWith(itEnabled: v)),
                   ),
-                  const SizedBox(height: 10),
+                  const SizedBox(height: 6),
                   AutocompleteChipField(
                     label: 'Review-only labels',
                     helper: 'Issues with these labels get a review comment only',
@@ -274,12 +283,42 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                     onChanged: (v) => _update(_config.copyWith(issueAssignees: v)),
                     onReset: () => _update(_config.copyWith(issueAssignees: null)),
                   ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Prompt',
+                    globalValue: 'default',
+                    overrideValue: _config.issuePromptId,
+                    options: prompts.map((p) => p.id).toList(),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issuePromptId: v)),
+                  ),
                 ]),
 
-                // ── PR Metadata ──────────────────────────────────────────
-                _sectionCard('PR Metadata', [
+                // ── Section 4: Develop ─────────────────────────────────
+                _sectionCard('Develop', [
+                  SwitchListTile(
+                    title: const Text('Auto-implement issues',
+                        style: TextStyle(fontSize: 13)),
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    value: _config.devEnabled ?? false,
+                    onChanged: (v) =>
+                        _update(_config.copyWith(devEnabled: v)),
+                  ),
+                  const SizedBox(height: 6),
                   AutocompleteChipField(
-                    label: 'Reviewers',
+                    label: 'Develop labels',
+                    helper: 'Issues with these labels get a branch + PR',
+                    selectedValues: _config.developLabels ?? appConfig.issueTracking.developLabels,
+                    availableOptions: _repoLabels,
+                    isOverridden: _config.developLabels != null,
+                    globalHint: _joinList(appConfig.issueTracking.developLabels),
+                    onChanged: (v) => _update(_config.copyWith(developLabels: v)),
+                    onReset: () => _update(_config.copyWith(developLabels: null)),
+                  ),
+                  const SizedBox(height: 10),
+                  AutocompleteChipField(
+                    label: 'PR Reviewers',
                     helper: 'GitHub usernames to request review',
                     selectedValues: _config.prReviewers ?? [],
                     availableOptions: _repoCollaborators,
@@ -289,7 +328,7 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(
-                    label: 'Assignee',
+                    label: 'PR Assignee',
                     helper: 'GitHub username to assign to PRs',
                     selectedValues: _config.prAssignee != null ? [_config.prAssignee!] : [],
                     availableOptions: _repoCollaborators,
@@ -300,7 +339,7 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(
-                    label: 'Labels',
+                    label: 'PR Labels',
                     helper: 'Labels to add to PRs',
                     selectedValues: _config.prLabels ?? [],
                     availableOptions: _repoLabels,
@@ -316,6 +355,15 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                     options: const ['true', 'false'],
                     onChanged: (v) => _update(_config.copyWith(
                         prDraft: v != null ? v == 'true' : null)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Prompt',
+                    globalValue: 'default',
+                    overrideValue: _config.developPromptId,
+                    options: prompts.map((p) => p.id).toList(),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(developPromptId: v)),
                   ),
                 ]),
               ],

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -5,10 +5,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../core/models/config_model.dart';
 import '../../core/models/agent.dart';
+import '../../shared/widgets/autocomplete_chip_field.dart';
 import '../../shared/widgets/override_field.dart';
 import '../../shared/widgets/toast.dart';
 import '../agents/agents_screen.dart' show agentsProvider;
 import '../config/config_providers.dart';
+import '../dashboard/dashboard_providers.dart';
 
 class RepoDetailScreen extends ConsumerStatefulWidget {
   final String repoName;
@@ -22,6 +24,8 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
   RepoConfig _config = const RepoConfig();
   bool _initialized = false;
   Timer? _debounce;
+  List<String> _repoLabels = [];
+  List<String> _repoCollaborators = [];
 
   @override
   void dispose() {
@@ -33,6 +37,25 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
     if (_initialized) return;
     _initialized = true;
     _config = config.repoConfigs[widget.repoName] ?? const RepoConfig();
+    _loadRepoMeta();
+  }
+
+  Future<void> _loadRepoMeta() async {
+    final api = ref.read(apiClientProvider);
+    try {
+      final results = await Future.wait([
+        api.fetchRepoLabels(widget.repoName),
+        api.fetchRepoCollaborators(widget.repoName),
+      ]);
+      if (mounted) {
+        setState(() {
+          _repoLabels = results[0];
+          _repoCollaborators = results[1];
+        });
+      }
+    } catch (_) {
+      // Non-fatal — autocomplete just won't have suggestions
+    }
   }
 
   void _update(RepoConfig updated) {
@@ -179,39 +202,37 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
 
                 // ── Issue Tracking ───────────────────────────────────────
                 _sectionCard('Issue Tracking', [
-                  OverrideTextField(
+                  AutocompleteChipField(
                     label: 'Develop labels',
-                    helper:
-                        'Issues with these labels get a branch + PR',
-                    globalValue: _joinList(
-                        appConfig.issueTracking.developLabels),
-                    overrideValue: _config.developLabels?.join(', '),
-                    onChanged: (v) => _update(_config.copyWith(
-                        developLabels:
-                            v != null ? _parseList(v) : null)),
+                    helper: 'Issues with these labels get a branch + PR',
+                    selectedValues: _config.developLabels ?? appConfig.issueTracking.developLabels,
+                    availableOptions: _repoLabels,
+                    isOverridden: _config.developLabels != null,
+                    globalHint: _joinList(appConfig.issueTracking.developLabels),
+                    onChanged: (v) => _update(_config.copyWith(developLabels: v)),
+                    onReset: () => _update(_config.copyWith(developLabels: null)),
                   ),
                   const SizedBox(height: 10),
-                  OverrideTextField(
+                  AutocompleteChipField(
                     label: 'Review-only labels',
-                    helper:
-                        'Issues with these labels get a review comment only',
-                    globalValue: _joinList(
-                        appConfig.issueTracking.reviewOnlyLabels),
-                    overrideValue: _config.reviewOnlyLabels?.join(', '),
-                    onChanged: (v) => _update(_config.copyWith(
-                        reviewOnlyLabels:
-                            v != null ? _parseList(v) : null)),
+                    helper: 'Issues with these labels get a review comment only',
+                    selectedValues: _config.reviewOnlyLabels ?? appConfig.issueTracking.reviewOnlyLabels,
+                    availableOptions: _repoLabels,
+                    isOverridden: _config.reviewOnlyLabels != null,
+                    globalHint: _joinList(appConfig.issueTracking.reviewOnlyLabels),
+                    onChanged: (v) => _update(_config.copyWith(reviewOnlyLabels: v)),
+                    onReset: () => _update(_config.copyWith(reviewOnlyLabels: null)),
                   ),
                   const SizedBox(height: 10),
-                  OverrideTextField(
+                  AutocompleteChipField(
                     label: 'Skip labels',
                     helper: 'Issues with these labels are ignored',
-                    globalValue:
-                        _joinList(appConfig.issueTracking.skipLabels),
-                    overrideValue: _config.skipLabels?.join(', '),
-                    onChanged: (v) => _update(_config.copyWith(
-                        skipLabels:
-                            v != null ? _parseList(v) : null)),
+                    selectedValues: _config.skipLabels ?? appConfig.issueTracking.skipLabels,
+                    availableOptions: _repoLabels,
+                    isOverridden: _config.skipLabels != null,
+                    globalHint: _joinList(appConfig.issueTracking.skipLabels),
+                    onChanged: (v) => _update(_config.copyWith(skipLabels: v)),
+                    onReset: () => _update(_config.copyWith(skipLabels: null)),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
@@ -236,59 +257,56 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                   const SizedBox(height: 10),
                   OverrideTextField(
                     label: 'Organizations',
-                    helper:
-                        'Comma-separated GitHub org names to filter issues',
-                    globalValue: _joinList(
-                        appConfig.issueTracking.organizations),
+                    helper: 'GitHub org names to filter issues',
+                    globalValue: _joinList(appConfig.issueTracking.organizations),
                     overrideValue: _config.issueOrganizations?.join(', '),
                     onChanged: (v) => _update(_config.copyWith(
-                        issueOrganizations:
-                            v != null ? _parseList(v) : null)),
+                        issueOrganizations: v != null ? _parseList(v) : null)),
                   ),
                   const SizedBox(height: 10),
-                  OverrideTextField(
+                  AutocompleteChipField(
                     label: 'Assignees',
-                    helper:
-                        'Comma-separated GitHub usernames to filter issues',
-                    globalValue:
-                        _joinList(appConfig.issueTracking.assignees),
-                    overrideValue: _config.issueAssignees?.join(', '),
-                    onChanged: (v) => _update(_config.copyWith(
-                        issueAssignees:
-                            v != null ? _parseList(v) : null)),
+                    helper: 'Only process issues assigned to these users',
+                    selectedValues: _config.issueAssignees ?? appConfig.issueTracking.assignees,
+                    availableOptions: _repoCollaborators,
+                    isOverridden: _config.issueAssignees != null,
+                    globalHint: _joinList(appConfig.issueTracking.assignees),
+                    onChanged: (v) => _update(_config.copyWith(issueAssignees: v)),
+                    onReset: () => _update(_config.copyWith(issueAssignees: null)),
                   ),
                 ]),
 
                 // ── PR Metadata ──────────────────────────────────────────
                 _sectionCard('PR Metadata', [
-                  OverrideTextField(
+                  AutocompleteChipField(
                     label: 'Reviewers',
-                    helper:
-                        'Comma-separated GitHub usernames to request review',
-                    globalValue: '',
-                    overrideValue: _config.prReviewers?.join(', '),
-                    onChanged: (v) => _update(_config.copyWith(
-                        prReviewers:
-                            v != null ? _parseList(v) : null)),
+                    helper: 'GitHub usernames to request review',
+                    selectedValues: _config.prReviewers ?? [],
+                    availableOptions: _repoCollaborators,
+                    isOverridden: _config.prReviewers != null,
+                    onChanged: (v) => _update(_config.copyWith(prReviewers: v)),
+                    onReset: () => _update(_config.copyWith(prReviewers: null)),
                   ),
                   const SizedBox(height: 10),
-                  OverrideTextField(
+                  AutocompleteChipField(
                     label: 'Assignee',
                     helper: 'GitHub username to assign to PRs',
-                    globalValue: '',
-                    overrideValue: _config.prAssignee,
-                    onChanged: (v) =>
-                        _update(_config.copyWith(prAssignee: v)),
+                    selectedValues: _config.prAssignee != null ? [_config.prAssignee!] : [],
+                    availableOptions: _repoCollaborators,
+                    isOverridden: _config.prAssignee != null,
+                    onChanged: (v) => _update(_config.copyWith(
+                        prAssignee: v != null && v.isNotEmpty ? v.first : null)),
+                    onReset: () => _update(_config.copyWith(prAssignee: null)),
                   ),
                   const SizedBox(height: 10),
-                  OverrideTextField(
+                  AutocompleteChipField(
                     label: 'Labels',
-                    helper: 'Comma-separated labels to add to PRs',
-                    globalValue: '',
-                    overrideValue: _config.prLabels?.join(', '),
-                    onChanged: (v) => _update(_config.copyWith(
-                        prLabels:
-                            v != null ? _parseList(v) : null)),
+                    helper: 'Labels to add to PRs',
+                    selectedValues: _config.prLabels ?? [],
+                    availableOptions: _repoLabels,
+                    isOverridden: _config.prLabels != null,
+                    onChanged: (v) => _update(_config.copyWith(prLabels: v)),
+                    onReset: () => _update(_config.copyWith(prLabels: null)),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -1,0 +1,385 @@
+import 'dart:async';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../core/models/config_model.dart';
+import '../../core/models/agent.dart';
+import '../../shared/widgets/override_field.dart';
+import '../../shared/widgets/toast.dart';
+import '../agents/agents_screen.dart' show agentsProvider;
+import '../config/config_providers.dart';
+
+class RepoDetailScreen extends ConsumerStatefulWidget {
+  final String repoName;
+  const RepoDetailScreen({super.key, required this.repoName});
+
+  @override
+  ConsumerState<RepoDetailScreen> createState() => _RepoDetailScreenState();
+}
+
+class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
+  RepoConfig _config = const RepoConfig();
+  bool _initialized = false;
+  Timer? _debounce;
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  void _initFrom(AppConfig config) {
+    if (_initialized) return;
+    _initialized = true;
+    _config = config.repoConfigs[widget.repoName] ?? const RepoConfig();
+  }
+
+  void _update(RepoConfig updated) {
+    setState(() => _config = updated);
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 800), _autoSave);
+  }
+
+  Future<void> _autoSave() async {
+    final current = ref.read(configNotifierProvider).valueOrNull;
+    if (current == null) return;
+    final updatedRepos = Map<String, RepoConfig>.from(current.repoConfigs);
+    updatedRepos[widget.repoName] = _config;
+    final updated = current.copyWith(repoConfigs: updatedRepos);
+    try {
+      await ref.read(configNotifierProvider.notifier).save(updated);
+      if (mounted) showToast(context, 'Saved');
+    } catch (e) {
+      if (mounted) showToast(context, 'Error: $e', isError: true);
+    }
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  String _joinList(List<String>? list) => list?.join(', ') ?? '';
+
+  List<String>? _parseList(String? value) {
+    if (value == null) return null;
+    final parsed = value
+        .split(',')
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty)
+        .toList();
+    return parsed.isEmpty ? null : parsed;
+  }
+
+  // ── Section card ─────────────────────────────────────────────────────────────
+
+  Widget _sectionCard(String title, List<Widget> children) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title,
+                style: const TextStyle(
+                    fontWeight: FontWeight.w600, fontSize: 15)),
+            const SizedBox(height: 12),
+            ...children,
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ── Build ────────────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final configAsync = ref.watch(configNotifierProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.repoName),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () =>
+              context.canPop() ? context.pop() : context.go('/'),
+        ),
+      ),
+      body: configAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) =>
+            const Center(child: Text('Could not load config')),
+        data: (appConfig) {
+          _initFrom(appConfig);
+          final prompts =
+              ref.watch(agentsProvider).valueOrNull ?? <ReviewPrompt>[];
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                // ── General ──────────────────────────────────────────────
+                _sectionCard('General', [
+                  const Text('Local directory',
+                      style: TextStyle(fontSize: 12, color: Colors.grey)),
+                  const SizedBox(height: 4),
+                  Text(
+                    'When set, the AI agent runs inside this directory and can read all project files.',
+                    style: TextStyle(
+                        fontSize: 11, color: Colors.grey.shade600),
+                  ),
+                  const SizedBox(height: 8),
+                  _LocalDirField(
+                    value: _config.localDir ?? '',
+                    onChanged: (dir) => _update(_config.copyWith(
+                        localDir: dir.isEmpty ? null : dir)),
+                  ),
+                  const SizedBox(height: 12),
+                  OverrideDropdown(
+                    label: 'Review mode',
+                    globalValue: appConfig.reviewMode,
+                    overrideValue: _config.reviewMode,
+                    options: const ['single', 'multi'],
+                    onChanged: (v) =>
+                        _update(_config.copyWith(reviewMode: v)),
+                  ),
+                ]),
+
+                // ── AI Agent ─────────────────────────────────────────────
+                _sectionCard('AI Agent', [
+                  OverrideDropdown(
+                    label: 'Primary',
+                    globalValue: appConfig.aiPrimary,
+                    overrideValue: _config.aiPrimary,
+                    options: const ['claude', 'gemini', 'codex'],
+                    onChanged: (v) =>
+                        _update(_config.copyWith(aiPrimary: v)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Fallback',
+                    globalValue: appConfig.aiFallback.isEmpty
+                        ? 'none'
+                        : appConfig.aiFallback,
+                    overrideValue: _config.aiFallback,
+                    options: const ['claude', 'gemini', 'codex'],
+                    onChanged: (v) =>
+                        _update(_config.copyWith(aiFallback: v)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Prompt',
+                    globalValue: 'default',
+                    overrideValue: _config.promptId,
+                    options: prompts.map((p) => p.id).toList(),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(promptId: v)),
+                  ),
+                ]),
+
+                // ── Issue Tracking ───────────────────────────────────────
+                _sectionCard('Issue Tracking', [
+                  OverrideTextField(
+                    label: 'Develop labels',
+                    helper:
+                        'Issues with these labels get a branch + PR',
+                    globalValue: _joinList(
+                        appConfig.issueTracking.developLabels),
+                    overrideValue: _config.developLabels?.join(', '),
+                    onChanged: (v) => _update(_config.copyWith(
+                        developLabels:
+                            v != null ? _parseList(v) : null)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideTextField(
+                    label: 'Review-only labels',
+                    helper:
+                        'Issues with these labels get a review comment only',
+                    globalValue: _joinList(
+                        appConfig.issueTracking.reviewOnlyLabels),
+                    overrideValue: _config.reviewOnlyLabels?.join(', '),
+                    onChanged: (v) => _update(_config.copyWith(
+                        reviewOnlyLabels:
+                            v != null ? _parseList(v) : null)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideTextField(
+                    label: 'Skip labels',
+                    helper: 'Issues with these labels are ignored',
+                    globalValue:
+                        _joinList(appConfig.issueTracking.skipLabels),
+                    overrideValue: _config.skipLabels?.join(', '),
+                    onChanged: (v) => _update(_config.copyWith(
+                        skipLabels:
+                            v != null ? _parseList(v) : null)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Filter mode',
+                    globalValue:
+                        appConfig.issueTracking.filterMode,
+                    overrideValue: _config.issueFilterMode,
+                    options: const ['exclusive', 'inclusive'],
+                    onChanged: (v) => _update(
+                        _config.copyWith(issueFilterMode: v)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Default action',
+                    globalValue:
+                        appConfig.issueTracking.defaultAction,
+                    overrideValue: _config.issueDefaultAction,
+                    options: const ['ignore', 'review_only'],
+                    onChanged: (v) => _update(
+                        _config.copyWith(issueDefaultAction: v)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideTextField(
+                    label: 'Organizations',
+                    helper:
+                        'Comma-separated GitHub org names to filter issues',
+                    globalValue: _joinList(
+                        appConfig.issueTracking.organizations),
+                    overrideValue: _config.issueOrganizations?.join(', '),
+                    onChanged: (v) => _update(_config.copyWith(
+                        issueOrganizations:
+                            v != null ? _parseList(v) : null)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideTextField(
+                    label: 'Assignees',
+                    helper:
+                        'Comma-separated GitHub usernames to filter issues',
+                    globalValue:
+                        _joinList(appConfig.issueTracking.assignees),
+                    overrideValue: _config.issueAssignees?.join(', '),
+                    onChanged: (v) => _update(_config.copyWith(
+                        issueAssignees:
+                            v != null ? _parseList(v) : null)),
+                  ),
+                ]),
+
+                // ── PR Metadata ──────────────────────────────────────────
+                _sectionCard('PR Metadata', [
+                  OverrideTextField(
+                    label: 'Reviewers',
+                    helper:
+                        'Comma-separated GitHub usernames to request review',
+                    globalValue: '',
+                    overrideValue: _config.prReviewers?.join(', '),
+                    onChanged: (v) => _update(_config.copyWith(
+                        prReviewers:
+                            v != null ? _parseList(v) : null)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideTextField(
+                    label: 'Assignee',
+                    helper: 'GitHub username to assign to PRs',
+                    globalValue: '',
+                    overrideValue: _config.prAssignee,
+                    onChanged: (v) =>
+                        _update(_config.copyWith(prAssignee: v)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideTextField(
+                    label: 'Labels',
+                    helper: 'Comma-separated labels to add to PRs',
+                    globalValue: '',
+                    overrideValue: _config.prLabels?.join(', '),
+                    onChanged: (v) => _update(_config.copyWith(
+                        prLabels:
+                            v != null ? _parseList(v) : null)),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Draft',
+                    globalValue: 'false',
+                    overrideValue: _config.prDraft?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(_config.copyWith(
+                        prDraft: v != null ? v == 'true' : null)),
+                  ),
+                ]),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ── Local directory picker ─────────────────────────────────────────────────
+
+class _LocalDirField extends StatefulWidget {
+  final String value;
+  final ValueChanged<String> onChanged;
+  const _LocalDirField({required this.value, required this.onChanged});
+
+  @override
+  State<_LocalDirField> createState() => _LocalDirFieldState();
+}
+
+class _LocalDirFieldState extends State<_LocalDirField> {
+  late final TextEditingController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = TextEditingController(text: widget.value);
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pick() async {
+    final dir = await FilePicker.platform.getDirectoryPath(
+      dialogTitle: 'Select local repository directory',
+      lockParentWindow: true,
+    );
+    if (dir == null) return;
+    setState(() => _ctrl.text = dir);
+    widget.onChanged(dir);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(children: [
+      Expanded(
+        child: TextFormField(
+          controller: _ctrl,
+          decoration: const InputDecoration(
+            hintText: '/path/to/local/repo',
+            border: OutlineInputBorder(),
+            isDense: true,
+          ),
+          onChanged: widget.onChanged,
+        ),
+      ),
+      const SizedBox(width: 8),
+      OutlinedButton.icon(
+        icon: const Icon(Icons.folder_open, size: 16),
+        label: const Text('Browse'),
+        onPressed: _pick,
+        style: OutlinedButton.styleFrom(
+          padding:
+              const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+        ),
+      ),
+      if (_ctrl.text.isNotEmpty) ...[
+        const SizedBox(width: 4),
+        IconButton(
+          icon: const Icon(Icons.clear, size: 16),
+          tooltip: 'Clear',
+          onPressed: () {
+            setState(() => _ctrl.clear());
+            widget.onChanged('');
+          },
+        ),
+      ],
+    ]);
+  }
+}

--- a/flutter_app/lib/features/repositories/repos_screen.dart
+++ b/flutter_app/lib/features/repositories/repos_screen.dart
@@ -164,6 +164,7 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
                   : _RepoListWithSections(
                       repos: filtered,
                       configs: _repoConfigs,
+                      appConfig: config,
                       onChanged: _onChange,
                     ),
             ),
@@ -179,11 +180,13 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
 class _RepoListWithSections extends ConsumerStatefulWidget {
   final List<String> repos;
   final Map<String, RepoConfig> configs;
+  final AppConfig appConfig;
   final void Function(String repo, RepoConfig rc) onChanged;
 
   const _RepoListWithSections({
     required this.repos,
     required this.configs,
+    required this.appConfig,
     required this.onChanged,
   });
 
@@ -274,7 +277,7 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
           items.add(_RepoTile(
             repo: r,
             config: widget.configs[r]!,
-            onChanged: (rc) => widget.onChanged(r, rc),
+            appConfig: widget.appConfig,
           ));
         }
       }
@@ -331,23 +334,52 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
   }
 }
 
+// ── LED indicator ────────────────────────────────────────────────────────────
+
+class _Led extends StatelessWidget {
+  final String status; // 'off', 'global', 'repo'
+  final String tooltip;
+  const _Led({required this.status, required this.tooltip});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = switch (status) {
+      'repo'   => Colors.green.shade500,
+      'global' => Colors.blue.shade500,
+      _        => Colors.red.shade800,
+    };
+    return Tooltip(
+      message: '$tooltip: ${_label()}',
+      child: Container(
+        width: 8, height: 8,
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+      ),
+    );
+  }
+
+  String _label() => switch (status) {
+    'repo'   => 'active (repo)',
+    'global' => 'active (global)',
+    _        => 'inactive',
+  };
+}
+
 // ── Repo tile ─────────────────────────────────────────────────────────────
 
 class _RepoTile extends StatelessWidget {
   final String repo;
   final RepoConfig config;
-  final ValueChanged<RepoConfig> onChanged;
+  final AppConfig appConfig;
 
   const _RepoTile({
     required this.repo,
     required this.config,
-    required this.onChanged,
+    required this.appConfig,
   });
 
   @override
   Widget build(BuildContext context) {
     final hasDirMapping = config.localDir != null && config.localDir!.isNotEmpty;
-    final hasOverrides = config.hasAiOverride;
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
@@ -358,11 +390,22 @@ class _RepoTile extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
           child: Row(
             children: [
-              Switch(
-                value: config.isMonitored,
-                onChanged: (v) => onChanged(config.copyWith(prEnabled: v)),
+              _Led(
+                status: config.prLedStatus(appConfig.repositories.contains(repo)),
+                tooltip: 'PR Review',
               ),
-              const SizedBox(width: 8),
+              const SizedBox(width: 4),
+              _Led(
+                status: config.itLedStatus(appConfig.issueTracking.enabled),
+                tooltip: 'Issue Tracking',
+              ),
+              const SizedBox(width: 4),
+              _Led(
+                status: config.devLedStatus(
+                    appConfig.issueTracking.enabled, hasDirMapping),
+                tooltip: 'Develop',
+              ),
+              const SizedBox(width: 10),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -389,13 +432,6 @@ class _RepoTile extends StatelessWidget {
                           color: hasDirMapping ? Colors.green.shade500 : Colors.grey.shade600,
                         ),
                       ),
-                      if (hasOverrides) ...[
-                        const SizedBox(width: 8),
-                        Icon(Icons.tune, size: 12, color: Colors.blue.shade400),
-                        const SizedBox(width: 2),
-                        Text('overrides',
-                            style: TextStyle(fontSize: 10, color: Colors.blue.shade400)),
-                      ],
                     ]),
                   ],
                 ),
@@ -407,6 +443,4 @@ class _RepoTile extends StatelessWidget {
       ),
     );
   }
-
 }
-

--- a/flutter_app/lib/features/repositories/repos_screen.dart
+++ b/flutter_app/lib/features/repositories/repos_screen.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import '../../core/models/config_model.dart';
-import '../../core/models/agent.dart';
 import '../../core/setup/first_run_setup.dart';
 import '../../core/setup/repo_discovery.dart';
 import '../../shared/widgets/toast.dart';
-import '../agents/agents_screen.dart' show agentsProvider;
 import '../config/config_providers.dart';
 
 class ReposScreen extends ConsumerStatefulWidget {
@@ -221,7 +219,6 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
 
   @override
   Widget build(BuildContext context) {
-    final prompts = ref.watch(agentsProvider).valueOrNull ?? [];
     final monitored =
         widget.repos.where((r) => widget.configs[r]!.monitored).toList();
     final disabled =
@@ -237,7 +234,7 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
             monitored.length,
             Colors.green.shade700,
           ),
-          ..._buildOrgGroups('monitored', monitored, prompts),
+          ..._buildOrgGroups('monitored', monitored),
         ],
         _sectionHeader(
           context,
@@ -254,7 +251,7 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
             ),
           )
         else
-          ..._buildOrgGroups('disabled', disabled, prompts),
+          ..._buildOrgGroups('disabled', disabled),
       ],
     );
   }
@@ -262,7 +259,6 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
   List<Widget> _buildOrgGroups(
     String section,
     List<String> repos,
-    List<ReviewPrompt> prompts,
   ) {
     final groups = _groupByOrg(repos);
     final items = <Widget>[];
@@ -278,7 +274,6 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
           items.add(_RepoTile(
             repo: r,
             config: widget.configs[r]!,
-            prompts: prompts,
             onChanged: (rc) => widget.onChanged(r, rc),
           ));
         }
@@ -341,249 +336,77 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
 class _RepoTile extends StatelessWidget {
   final String repo;
   final RepoConfig config;
-  final List<ReviewPrompt> prompts;
   final ValueChanged<RepoConfig> onChanged;
 
   const _RepoTile({
     required this.repo,
     required this.config,
-    required this.prompts,
     required this.onChanged,
   });
 
   @override
   Widget build(BuildContext context) {
-    final overrides = _buildOverrides();
     final hasDirMapping = config.localDir != null && config.localDir!.isNotEmpty;
-    final dirLabel = hasDirMapping
-        ? config.localDir!.split('/').last
-        : null;
+    final hasOverrides = config.hasAiOverride;
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
-      child: ExpansionTile(
-        leading: Switch(
-          value: config.monitored,
-          onChanged: (v) => onChanged(config.copyWith(monitored: v)),
-        ),
-        title: Text(repo,
-            style: TextStyle(
-              fontWeight: config.monitored ? FontWeight.w600 : FontWeight.normal,
-              color: config.monitored ? null : Colors.grey,
-            )),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (overrides != null)
-              Text(overrides, style: const TextStyle(fontSize: 12)),
-            const SizedBox(height: 2),
-            // Directory mapping — always visible
-            Row(children: [
-              Icon(
-                hasDirMapping ? Icons.folder : Icons.folder_off_outlined,
-                size: 13,
-                color: hasDirMapping ? Colors.green.shade500 : Colors.grey.shade600,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => context.push('/repos/${Uri.encodeComponent(repo)}'),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          child: Row(
+            children: [
+              Switch(
+                value: config.monitored,
+                onChanged: (v) => onChanged(config.copyWith(monitored: v)),
               ),
-              const SizedBox(width: 4),
-              Text(
-                hasDirMapping ? dirLabel! : 'No local dir',
-                style: TextStyle(
-                  fontSize: 11,
-                  color: hasDirMapping ? Colors.green.shade500 : Colors.grey.shade600,
-                  fontStyle: hasDirMapping ? FontStyle.normal : FontStyle.italic,
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(repo,
+                        style: TextStyle(
+                          fontWeight: config.monitored ? FontWeight.w600 : FontWeight.normal,
+                          color: config.monitored ? null : Colors.grey,
+                        )),
+                    const SizedBox(height: 2),
+                    Row(children: [
+                      Icon(
+                        hasDirMapping ? Icons.folder : Icons.folder_off_outlined,
+                        size: 13,
+                        color: hasDirMapping ? Colors.green.shade500 : Colors.grey.shade600,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        hasDirMapping
+                            ? config.localDir!.split('/').last
+                            : 'No local dir',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: hasDirMapping ? Colors.green.shade500 : Colors.grey.shade600,
+                        ),
+                      ),
+                      if (hasOverrides) ...[
+                        const SizedBox(width: 8),
+                        Icon(Icons.tune, size: 12, color: Colors.blue.shade400),
+                        const SizedBox(width: 2),
+                        Text('overrides',
+                            style: TextStyle(fontSize: 10, color: Colors.blue.shade400)),
+                      ],
+                    ]),
+                  ],
                 ),
               ),
-            ]),
-          ],
-        ),
-        childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 14),
-        children: [
-          const Divider(height: 1),
-          const SizedBox(height: 10),
-          // AI overrides
-          const Text('AI agent override',
-              style: TextStyle(fontSize: 12, color: Colors.grey)),
-          const SizedBox(height: 8),
-          Row(children: [
-            Expanded(child: _aiDropdown('Primary', config.aiPrimary,
-                (v) => onChanged(config.copyWith(aiPrimary: v)))),
-            const SizedBox(width: 10),
-            Expanded(child: _aiDropdown('Fallback', config.aiFallback,
-                (v) => onChanged(config.copyWith(aiFallback: v)))),
-          ]),
-          const SizedBox(height: 12),
-          // Prompt override
-          const Text('Review prompt',
-              style: TextStyle(fontSize: 12, color: Colors.grey)),
-          const SizedBox(height: 8),
-          _promptDropdown(),
-          const SizedBox(height: 12),
-          // Review mode override
-          const Text('Feedback mode',
-              style: TextStyle(fontSize: 12, color: Colors.grey)),
-          const SizedBox(height: 8),
-          DropdownButtonFormField<String?>(
-            // ignore: deprecated_member_use
-            value: config.reviewMode,
-            decoration: const InputDecoration(
-                labelText: 'Override mode',
-                border: OutlineInputBorder(), isDense: true),
-            items: const [
-              DropdownMenuItem<String?>(value: null,     child: Text('Global')),
-              DropdownMenuItem<String?>(value: 'single', child: Text('Single (consolidated review)')),
-              DropdownMenuItem<String?>(value: 'multi',  child: Text('Multi (one comment per issue)')),
+              Icon(Icons.chevron_right, size: 18, color: Colors.grey.shade600),
             ],
-            onChanged: (v) => onChanged(config.copyWith(reviewMode: v)),
           ),
-          const SizedBox(height: 12),
-          // Local directory for full-repo analysis
-          const Text('Local directory',
-              style: TextStyle(fontSize: 12, color: Colors.grey)),
-          const SizedBox(height: 4),
-          Text(
-            'When set, the AI agent runs inside this directory and can read all project files.',
-            style: TextStyle(fontSize: 11, color: Colors.grey.shade600),
-          ),
-          const SizedBox(height: 8),
-          _LocalDirField(
-            value: config.localDir ?? '',
-            onChanged: (dir) => onChanged(config.copyWith(localDir: dir.isEmpty ? null : dir)),
-          ),
-        ],
-      ),
-    );
-  }
-
-  String? _buildOverrides() {
-    final parts = <String>[];
-    if (config.aiPrimary != null) parts.add('AI: ${config.aiPrimary}');
-    if (config.promptId != null) {
-      final p = prompts.where((p) => p.id == config.promptId).firstOrNull;
-      parts.add('Prompt: ${p?.name ?? config.promptId}');
-    }
-    if (config.reviewMode != null) parts.add('Mode: ${config.reviewMode}');
-    return parts.isEmpty ? null : parts.join(' · ');
-  }
-
-  Widget _aiDropdown(String label, String? value, ValueChanged<String?> onChanged) {
-    return DropdownButtonFormField<String?>(
-      // ignore: deprecated_member_use
-      value: value,
-      decoration: InputDecoration(labelText: label,
-          border: const OutlineInputBorder(), isDense: true),
-      items: const [
-        DropdownMenuItem<String?>(value: null, child: Text('Global')),
-        DropdownMenuItem<String?>(value: 'claude', child: Text('claude')),
-        DropdownMenuItem<String?>(value: 'gemini', child: Text('gemini')),
-        DropdownMenuItem<String?>(value: 'codex',  child: Text('codex')),
-      ],
-      onChanged: onChanged,
-    );
-  }
-
-  Widget _promptDropdown() {
-    return DropdownButtonFormField<String?>(
-      // ignore: deprecated_member_use
-      value: config.promptId,
-      decoration: const InputDecoration(
-          labelText: 'Override prompt',
-          border: OutlineInputBorder(), isDense: true),
-      items: [
-        const DropdownMenuItem<String?>(value: null,
-            child: Text('Global active prompt')),
-        ...prompts.map((p) => DropdownMenuItem<String?>(
-          value: p.id,
-          child: Text('${_focusEmoji(p.focus)} ${p.name}'),
-        )),
-      ],
-      onChanged: (v) => onChanged(config.copyWith(promptId: v)),
-    );
-  }
-
-}
-
-// ── Local directory picker ─────────────────────────────────────────────────
-
-class _LocalDirField extends StatefulWidget {
-  final String value;
-  final ValueChanged<String> onChanged;
-  const _LocalDirField({required this.value, required this.onChanged});
-
-  @override
-  State<_LocalDirField> createState() => _LocalDirFieldState();
-}
-
-class _LocalDirFieldState extends State<_LocalDirField> {
-  late final TextEditingController _ctrl;
-
-  @override
-  void initState() {
-    super.initState();
-    _ctrl = TextEditingController(text: widget.value);
-  }
-
-  @override
-  void dispose() {
-    _ctrl.dispose();
-    super.dispose();
-  }
-
-  Future<void> _pick() async {
-    final dir = await FilePicker.platform.getDirectoryPath(
-      dialogTitle: 'Select local repository directory',
-      lockParentWindow: true,
-    );
-    if (dir == null) return;
-    setState(() => _ctrl.text = dir);
-    widget.onChanged(dir);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(children: [
-      Expanded(
-        child: TextFormField(
-          controller: _ctrl,
-          decoration: const InputDecoration(
-            hintText: '/path/to/local/repo',
-            border: OutlineInputBorder(),
-            isDense: true,
-          ),
-          onChanged: widget.onChanged,
         ),
       ),
-      const SizedBox(width: 8),
-      OutlinedButton.icon(
-        icon: const Icon(Icons.folder_open, size: 16),
-        label: const Text('Browse'),
-        onPressed: _pick,
-        style: OutlinedButton.styleFrom(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-        ),
-      ),
-      if (_ctrl.text.isNotEmpty) ...[
-        const SizedBox(width: 4),
-        IconButton(
-          icon: const Icon(Icons.clear, size: 16),
-          tooltip: 'Clear',
-          onPressed: () {
-            setState(() => _ctrl.clear());
-            widget.onChanged('');
-          },
-        ),
-      ],
-    ]);
+    );
   }
+
 }
 
-// ── (end of _LocalDirField) ────────────────────────────────────────────────
-
-String _focusEmoji(String f) {
-  switch (f) {
-    case 'security':     return '🔒';
-    case 'performance':  return '⚡';
-    case 'architecture': return '🏛️';
-    case 'docs':         return '📝';
-    default:             return '🔍';
-  }
-}

--- a/flutter_app/lib/features/repositories/repos_screen.dart
+++ b/flutter_app/lib/features/repositories/repos_screen.dart
@@ -55,7 +55,7 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
       if (!mounted) return;
       setState(() {
         for (final repo in discovered) {
-          _repoConfigs.putIfAbsent(repo, () => const RepoConfig(monitored: true));
+          _repoConfigs.putIfAbsent(repo, () => const RepoConfig(prEnabled: true));
         }
         _discovering = false;
         if (discovered.isEmpty) _discoverError = 'No active PRs found.';
@@ -101,8 +101,8 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
         // Monitored first, disabled last; both groups sorted alphabetically
         final allRepos = _repoConfigs.keys.toList()
           ..sort((a, b) {
-            final ma = _repoConfigs[a]!.monitored ? 0 : 1;
-            final mb = _repoConfigs[b]!.monitored ? 0 : 1;
+            final ma = _repoConfigs[a]!.isMonitored ? 0 : 1;
+            final mb = _repoConfigs[b]!.isMonitored ? 0 : 1;
             if (ma != mb) return ma.compareTo(mb);
             return a.compareTo(b);
           });
@@ -220,9 +220,9 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
   @override
   Widget build(BuildContext context) {
     final monitored =
-        widget.repos.where((r) => widget.configs[r]!.monitored).toList();
+        widget.repos.where((r) => widget.configs[r]!.isMonitored).toList();
     final disabled =
-        widget.repos.where((r) => !widget.configs[r]!.monitored).toList();
+        widget.repos.where((r) => !widget.configs[r]!.isMonitored).toList();
 
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 4),
@@ -359,8 +359,8 @@ class _RepoTile extends StatelessWidget {
           child: Row(
             children: [
               Switch(
-                value: config.monitored,
-                onChanged: (v) => onChanged(config.copyWith(monitored: v)),
+                value: config.isMonitored,
+                onChanged: (v) => onChanged(config.copyWith(prEnabled: v)),
               ),
               const SizedBox(width: 8),
               Expanded(
@@ -369,8 +369,8 @@ class _RepoTile extends StatelessWidget {
                   children: [
                     Text(repo,
                         style: TextStyle(
-                          fontWeight: config.monitored ? FontWeight.w600 : FontWeight.normal,
-                          color: config.monitored ? null : Colors.grey,
+                          fontWeight: config.isMonitored ? FontWeight.w600 : FontWeight.normal,
+                          color: config.isMonitored ? null : Colors.grey,
                         )),
                     const SizedBox(height: 2),
                     Row(children: [

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -222,7 +222,7 @@ class _BootstrapAppState extends State<_BootstrapApp> with WindowListener {
       _setStatus('Setting up…');
       final config = AppConfig(
         repoConfigs: {
-          for (final r in repos) r: const RepoConfig(monitored: true),
+          for (final r in repos) r: const RepoConfig(prEnabled: true),
         },
       );
       await FirstRunSetup.storeToken(token);

--- a/flutter_app/lib/shared/router.dart
+++ b/flutter_app/lib/shared/router.dart
@@ -4,6 +4,7 @@ import '../features/issues/issue_detail_screen.dart';
 import '../features/pr_detail/pr_detail_screen.dart';
 import '../features/config/config_screen.dart';
 import '../features/logs/logs_screen.dart';
+import '../features/repositories/repo_detail_screen.dart';
 
 GoRouter createRouter({String initialLocation = '/'}) => GoRouter(
   initialLocation: initialLocation,
@@ -24,6 +25,13 @@ GoRouter createRouter({String initialLocation = '/'}) => GoRouter(
       builder: (context, state) {
         final id = int.parse(state.pathParameters['id']!);
         return IssueDetailScreen(issueId: id);
+      },
+    ),
+    GoRoute(
+      path: '/repos/:name',
+      builder: (context, state) {
+        final name = Uri.decodeComponent(state.pathParameters['name']!);
+        return RepoDetailScreen(repoName: name);
       },
     ),
     GoRoute(

--- a/flutter_app/lib/shared/widgets/autocomplete_chip_field.dart
+++ b/flutter_app/lib/shared/widgets/autocomplete_chip_field.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+
+/// A chip-based input field with autocomplete suggestions.
+/// Shows selected values as chips with remove buttons, and a text field
+/// that filters suggestions from [availableOptions] as the user types.
+class AutocompleteChipField extends StatefulWidget {
+  final String label;
+  final String? helper;
+  final List<String> selectedValues;
+  final List<String> availableOptions;
+  final String? globalHint;
+  final bool isOverridden;
+  final ValueChanged<List<String>?> onChanged;
+  final VoidCallback? onReset;
+
+  const AutocompleteChipField({
+    super.key,
+    required this.label,
+    this.helper,
+    required this.selectedValues,
+    required this.availableOptions,
+    this.globalHint,
+    this.isOverridden = false,
+    required this.onChanged,
+    this.onReset,
+  });
+
+  @override
+  State<AutocompleteChipField> createState() => _AutocompleteChipFieldState();
+}
+
+class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
+  final _ctrl = TextEditingController();
+  final _focusNode = FocusNode();
+  bool _showSuggestions = false;
+
+  List<String> get _filteredSuggestions {
+    final query = _ctrl.text.trim().toLowerCase();
+    final alreadySelected = widget.selectedValues.toSet();
+    return widget.availableOptions
+        .where((o) => !alreadySelected.contains(o))
+        .where((o) => query.isEmpty || o.toLowerCase().contains(query))
+        .take(8)
+        .toList();
+  }
+
+  void _addValue(String value) {
+    final updated = [...widget.selectedValues, value];
+    widget.onChanged(updated.isEmpty ? null : updated);
+    _ctrl.clear();
+    setState(() => _showSuggestions = false);
+    _focusNode.requestFocus();
+  }
+
+  void _removeValue(String value) {
+    final updated = widget.selectedValues.where((v) => v != value).toList();
+    widget.onChanged(updated.isEmpty ? null : updated);
+  }
+
+  void _handleSubmit(String text) {
+    final trimmed = text.trim();
+    if (trimmed.isNotEmpty && !widget.selectedValues.contains(trimmed)) {
+      _addValue(trimmed);
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(6),
+        border: Border(
+          left: BorderSide(
+            width: 3,
+            color: widget.isOverridden ? Colors.green.shade600 : Colors.transparent,
+          ),
+        ),
+      ),
+      padding: const EdgeInsets.all(10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header with label + override badge
+          Row(
+            children: [
+              Text(widget.label,
+                  style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
+              const Spacer(),
+              if (widget.isOverridden) ...[
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                  decoration: BoxDecoration(
+                    color: Colors.green.shade900.withValues(alpha: 0.4),
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                  child: Text('overridden',
+                      style: TextStyle(fontSize: 10, color: Colors.green.shade400)),
+                ),
+                if (widget.onReset != null) ...[
+                  const SizedBox(width: 6),
+                  GestureDetector(
+                    onTap: widget.onReset,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                      decoration: BoxDecoration(
+                        border: Border.all(color: Colors.grey.shade700),
+                        borderRadius: BorderRadius.circular(3),
+                      ),
+                      child: Text('\u00d7 reset',
+                          style: TextStyle(fontSize: 10, color: Colors.grey.shade500)),
+                    ),
+                  ),
+                ],
+              ] else
+                Text('global',
+                    style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+            ],
+          ),
+          const SizedBox(height: 6),
+          // Chips
+          if (widget.selectedValues.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Wrap(
+                spacing: 4,
+                runSpacing: 4,
+                children: widget.selectedValues.map((v) => Chip(
+                  label: Text(v, style: const TextStyle(fontSize: 11)),
+                  deleteIcon: const Icon(Icons.close, size: 14),
+                  onDeleted: () => _removeValue(v),
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  visualDensity: VisualDensity.compact,
+                )).toList(),
+              ),
+            ),
+          // Text input + suggestions
+          Focus(
+            onFocusChange: (focused) {
+              if (!focused) {
+                // Delay hiding so tap on suggestion registers first
+                Future.delayed(const Duration(milliseconds: 200), () {
+                  if (mounted) setState(() => _showSuggestions = false);
+                });
+              }
+            },
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextFormField(
+                  controller: _ctrl,
+                  focusNode: _focusNode,
+                  style: const TextStyle(fontSize: 12),
+                  decoration: InputDecoration(
+                    isDense: true,
+                    border: const OutlineInputBorder(),
+                    hintText: 'Type to add...',
+                    helperText: widget.helper,
+                    helperMaxLines: 2,
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                  ),
+                  onChanged: (_) => setState(() => _showSuggestions = true),
+                  onFieldSubmitted: _handleSubmit,
+                ),
+                if (_showSuggestions && _filteredSuggestions.isNotEmpty)
+                  Container(
+                    margin: const EdgeInsets.only(top: 2),
+                    constraints: const BoxConstraints(maxHeight: 160),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(4),
+                      border: Border.all(color: Colors.grey.shade700),
+                    ),
+                    child: ListView(
+                      shrinkWrap: true,
+                      padding: EdgeInsets.zero,
+                      children: _filteredSuggestions.map((s) => InkWell(
+                        onTap: () => _addValue(s),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                          child: Text(s, style: const TextStyle(fontSize: 12)),
+                        ),
+                      )).toList(),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (widget.isOverridden && widget.globalHint != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text('Global: ${widget.globalHint}',
+                  style: TextStyle(fontSize: 10, color: Colors.grey.shade700)),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/shared/widgets/override_field.dart
+++ b/flutter_app/lib/shared/widgets/override_field.dart
@@ -1,0 +1,241 @@
+import 'package:flutter/material.dart';
+
+/// A field that shows the effective value (global or overridden) with
+/// visual indicators and a reset-to-global control.
+///
+/// When [overrideValue] is null, the field shows [globalValue] in muted
+/// style with a "global" badge. When non-null, it shows the override
+/// with a green left border, "overridden" badge, and reset button.
+class OverrideTextField extends StatefulWidget {
+  final String label;
+  final String? helper;
+  final String globalValue;
+  final String? overrideValue;
+  final ValueChanged<String?> onChanged;
+
+  const OverrideTextField({
+    super.key,
+    required this.label,
+    this.helper,
+    required this.globalValue,
+    required this.overrideValue,
+    required this.onChanged,
+  });
+
+  @override
+  State<OverrideTextField> createState() => _OverrideTextFieldState();
+}
+
+class _OverrideTextFieldState extends State<OverrideTextField> {
+  late TextEditingController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = TextEditingController(text: widget.overrideValue ?? widget.globalValue);
+  }
+
+  @override
+  void didUpdateWidget(OverrideTextField old) {
+    super.didUpdateWidget(old);
+    if (widget.overrideValue != old.overrideValue ||
+        widget.globalValue != old.globalValue) {
+      _ctrl.text = widget.overrideValue ?? widget.globalValue;
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  bool get _isOverridden => widget.overrideValue != null;
+
+  void _reset() {
+    _ctrl.text = widget.globalValue;
+    widget.onChanged(null);
+  }
+
+  void _handleChange(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty || trimmed == widget.globalValue) {
+      widget.onChanged(null);
+    } else {
+      widget.onChanged(trimmed);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(6),
+        border: Border(
+          left: BorderSide(
+            width: 3,
+            color: _isOverridden ? Colors.green.shade600 : Colors.transparent,
+          ),
+        ),
+      ),
+      padding: const EdgeInsets.all(10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(widget.label,
+                  style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
+              const Spacer(),
+              if (_isOverridden) ...[
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                  decoration: BoxDecoration(
+                    color: Colors.green.shade900.withValues(alpha: 0.4),
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                  child: Text('overridden',
+                      style: TextStyle(fontSize: 10, color: Colors.green.shade400)),
+                ),
+                const SizedBox(width: 6),
+                GestureDetector(
+                  onTap: _reset,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.grey.shade700),
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                    child: Text('\u00d7 reset',
+                        style: TextStyle(fontSize: 10, color: Colors.grey.shade500)),
+                  ),
+                ),
+              ] else
+                Text('global',
+                    style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+            ],
+          ),
+          const SizedBox(height: 6),
+          TextFormField(
+            controller: _ctrl,
+            style: TextStyle(
+              fontSize: 12,
+              color: _isOverridden ? null : Colors.grey.shade600,
+            ),
+            decoration: InputDecoration(
+              isDense: true,
+              border: const OutlineInputBorder(),
+              helperText: widget.helper,
+              helperMaxLines: 2,
+              contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+            ),
+            onChanged: _handleChange,
+          ),
+          if (_isOverridden)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text('Global: ${widget.globalValue}',
+                  style: TextStyle(fontSize: 10, color: Colors.grey.shade700)),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Dropdown variant of the override field.
+class OverrideDropdown extends StatelessWidget {
+  final String label;
+  final String globalValue;
+  final String? overrideValue;
+  final List<String> options;
+  final ValueChanged<String?> onChanged;
+
+  const OverrideDropdown({
+    super.key,
+    required this.label,
+    required this.globalValue,
+    required this.overrideValue,
+    required this.options,
+    required this.onChanged,
+  });
+
+  bool get _isOverridden => overrideValue != null;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(6),
+        border: Border(
+          left: BorderSide(
+            width: 3,
+            color: _isOverridden ? Colors.green.shade600 : Colors.transparent,
+          ),
+        ),
+      ),
+      padding: const EdgeInsets.all(10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(label,
+                  style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
+              const Spacer(),
+              if (_isOverridden) ...[
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                  decoration: BoxDecoration(
+                    color: Colors.green.shade900.withValues(alpha: 0.4),
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                  child: Text('overridden',
+                      style: TextStyle(fontSize: 10, color: Colors.green.shade400)),
+                ),
+                const SizedBox(width: 6),
+                GestureDetector(
+                  onTap: () => onChanged(null),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.grey.shade700),
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                    child: Text('\u00d7 reset',
+                        style: TextStyle(fontSize: 10, color: Colors.grey.shade500)),
+                  ),
+                ),
+              ] else
+                Text('global',
+                    style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+            ],
+          ),
+          const SizedBox(height: 6),
+          DropdownButtonFormField<String?>(
+            initialValue: overrideValue,
+            decoration: const InputDecoration(
+              isDense: true,
+              border: OutlineInputBorder(),
+              contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+            ),
+            items: [
+              DropdownMenuItem<String?>(
+                value: null,
+                child: Text('Global ($globalValue)',
+                    style: TextStyle(color: Colors.grey.shade600, fontSize: 12)),
+              ),
+              ...options.map((v) => DropdownMenuItem<String?>(
+                    value: v,
+                    child: Text(v, style: const TextStyle(fontSize: 12)),
+                  )),
+            ],
+            onChanged: onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/shared/widgets/override_field.dart
+++ b/flutter_app/lib/shared/widgets/override_field.dart
@@ -28,6 +28,7 @@ class OverrideTextField extends StatefulWidget {
 
 class _OverrideTextFieldState extends State<OverrideTextField> {
   late TextEditingController _ctrl;
+  bool _selfEditing = false;
 
   @override
   void initState() {
@@ -38,6 +39,13 @@ class _OverrideTextFieldState extends State<OverrideTextField> {
   @override
   void didUpdateWidget(OverrideTextField old) {
     super.didUpdateWidget(old);
+    // Only update the controller from external changes (reset, config reload).
+    // Skip when the change originated from our own onChanged to avoid
+    // clobbering the user's in-progress typing.
+    if (_selfEditing) {
+      _selfEditing = false;
+      return;
+    }
     if (widget.overrideValue != old.overrideValue ||
         widget.globalValue != old.globalValue) {
       _ctrl.text = widget.overrideValue ?? widget.globalValue;
@@ -58,6 +66,7 @@ class _OverrideTextFieldState extends State<OverrideTextField> {
   }
 
   void _handleChange(String value) {
+    _selfEditing = true;
     final trimmed = value.trim();
     if (trimmed.isEmpty || trimmed == widget.globalValue) {
       widget.onChanged(null);

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -20,7 +20,7 @@ void main() {
     const config = AppConfig(
       pollInterval: '5m',
       aiPrimary: 'claude',
-      repoConfigs: {'org/repo': RepoConfig(monitored: true)},
+      repoConfigs: {'org/repo': RepoConfig(prEnabled: true)},
     );
 
     final mockApi = MockApiClient();


### PR DESCRIPTION
## Summary

Replaces the inline repo expansion tile with a dedicated full-page settings screen per repository, and adds per-repo issue tracking with field-level override/merge.

### Daemon (Go)
- `RepoAI` gains `IssueTracking *IssueTrackingConfig` for per-repo overrides
- `IssueTrackingForRepo(repo)` merges per-repo non-zero fields over global config (3 tests)
- Poll cycle uses per-repo config instead of global for each repo
- `GET /config` response includes per-repo `issue_tracking` in `repo_overrides`

### Flutter (Dart)
- **RepoDetailScreen** — full-page settings with 4 section cards: General, AI Agent, Issue Tracking, PR Metadata
- **OverrideTextField / OverrideDropdown** — reusable widgets for per-field override pattern (green border + "overridden" badge + reset button when overriding, muted "global" display when inheriting)
- **RepoConfig** extended with 11 nullable fields (IT + PR metadata)
- **repos_screen.dart** simplified: ExpansionTile removed, repos navigate to `/repos/:name`
- **TOML writer** generates `[ai.repos."org/repo".issue_tracking]` sections
- **Global issue tracking** configurable in Settings screen

## Test Plan

- [x] `make test-docker` — all daemon packages pass (incl. 3 new merge tests)
- [x] `flutter analyze` — 0 new issues
- [x] `flutter test` — 15/15 pass
- [x] `flutter build macos --release` — 48.9MB OK
- [ ] Manual: open repo detail, set develop_labels override, save — verify config.toml
- [ ] Manual: verify daemon uses per-repo labels (check triage classification)
- [ ] Manual: reset an override field — verify it reverts to global value

🤖 Generated with [Claude Code](https://claude.com/claude-code)