### PR TITLE
fix: config save + reload resilience (three linked bugs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,4 @@ daemon/bin/
 
 # Local Docker runtime state
 # - docker/.env holds GITHUB_TOKEN + provider credentials; never commit.
-# - docker/config/ is the mounted config volume (config.toml auto-written
-#   by the daemon on first run).
 docker/.env
-docker/config/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,9 @@ daemon/bin/
 
 # Local Docker runtime state
 # - docker/.env holds GITHUB_TOKEN + provider credentials; never commit.
+# - docker/config/ is a legacy directory from the pre-named-volume setup.
+#   The mount switched to a named volume; the directory is no longer created
+#   on fresh installs, but old checkouts may still have one sitting around
+#   — keeping the ignore entry prevents accidental commits.
 docker/.env
+docker/config/

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -495,8 +495,22 @@ func main() {
 	// Wire the reload callback: re-read config from disk, restart scheduler
 	// and the discovery loop so changes to discovery_topic / orgs / interval
 	// take effect without a daemon restart.
+	//
+	// Mirrors the startup load logic (line 66 above): in Docker deployments
+	// HEIMDALLM_DATA_DIR is set and we use LoadOrCreate so a missing TOML
+	// is not fatal — the daemon rebuilds from env vars and persists a
+	// fresh config.toml. Without this, `POST /reload` after a deployment
+	// that lost its config volume (or on fresh docker-compose startups
+	// where writeConfigTOML warned but didn't error) returned 500 even
+	// though startup itself had succeeded on the same env vars.
 	srv.SetReloadFn(func() error {
-		newCfg, err := config.Load(cfgPath)
+		var newCfg *config.Config
+		var err error
+		if os.Getenv("HEIMDALLM_DATA_DIR") != "" {
+			newCfg, err = config.LoadOrCreate(cfgPath)
+		} else {
+			newCfg, err = config.Load(cfgPath)
+		}
 		if err != nil {
 			return fmt.Errorf("reload: %w", err)
 		}

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -64,13 +64,20 @@ func main() {
 	}
 
 	cfgPath := configPath()
-	var cfg *config.Config
-	var err error
+
+	// loadConfig is captured once at startup so the reload path further
+	// down cannot drift: both read the same env-var and select the same
+	// loader. Docker deployments (HEIMDALLM_DATA_DIR set) use LoadOrCreate
+	// so a missing config.toml is not fatal — the daemon rebuilds from env
+	// vars. Desktop deployments use Load; the Flutter app is expected to
+	// have written the TOML before the daemon starts, so ENOENT is a real
+	// error there.
+	loadConfig := config.Load
 	if os.Getenv("HEIMDALLM_DATA_DIR") != "" {
-		cfg, err = config.LoadOrCreate(cfgPath)
-	} else {
-		cfg, err = config.Load(cfgPath)
+		loadConfig = config.LoadOrCreate
 	}
+
+	cfg, err := loadConfig(cfgPath)
 	if err != nil {
 		slog.Error("config load failed", "path", cfgPath, "err", err)
 		os.Exit(1)
@@ -494,23 +501,11 @@ func main() {
 
 	// Wire the reload callback: re-read config from disk, restart scheduler
 	// and the discovery loop so changes to discovery_topic / orgs / interval
-	// take effect without a daemon restart.
-	//
-	// Mirrors the startup load logic (line 66 above): in Docker deployments
-	// HEIMDALLM_DATA_DIR is set and we use LoadOrCreate so a missing TOML
-	// is not fatal — the daemon rebuilds from env vars and persists a
-	// fresh config.toml. Without this, `POST /reload` after a deployment
-	// that lost its config volume (or on fresh docker-compose startups
-	// where writeConfigTOML warned but didn't error) returned 500 even
-	// though startup itself had succeeded on the same env vars.
+	// take effect without a daemon restart. Reuses the `loadConfig` closure
+	// captured at startup so the two paths cannot drift on which loader
+	// they pick — both see the same HEIMDALLM_DATA_DIR snapshot.
 	srv.SetReloadFn(func() error {
-		var newCfg *config.Config
-		var err error
-		if os.Getenv("HEIMDALLM_DATA_DIR") != "" {
-			newCfg, err = config.LoadOrCreate(cfgPath)
-		} else {
-			newCfg, err = config.Load(cfgPath)
-		}
+		newCfg, err := loadConfig(cfgPath)
 		if err != nil {
 			return fmt.Errorf("reload: %w", err)
 		}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -68,6 +68,20 @@ services:
       # POST /reload return 500 whenever config.toml was missing. The
       # image already declares VOLUME ["/config"] and chowns the path to
       # heimdallm:heimdallm during build.
+      #
+      # Migration (pre-v0.1.8 -> this): if you had a customised
+      # docker/config/config.toml under the old bind mount, copy it into
+      # the new named volume BEFORE your first `docker compose up` with
+      # this version, otherwise the daemon will regenerate from env vars
+      # and your manual edits are lost silently:
+      #
+      #   docker compose up --no-start heimdallm     # create container
+      #   docker cp docker/config/config.toml heimdallm:/config/config.toml
+      #   docker compose up -d                        # start with the file in place
+      #
+      # Env-driven setups (HEIMDALLM_* in docker/.env) and saves you made
+      # via the web UI Configuration screen are unaffected; both flow
+      # through the store layer and survive the volume swap.
       - heimdallm-config:/config
       #
       # Gemini OAuth tokens from host (if using browser-based auth):

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,8 +60,15 @@ services:
     volumes:
       # Persistent data (SQLite DB + API token)
       - heimdallm-data:/data
-      # Configuration (optional — env vars work without this)
-      - ./config:/config
+      # Configuration. Named volume (not a bind mount) so the daemon user
+      # inside the container owns the directory and can persist the
+      # generated config.toml on first boot. A `./config:/config` bind
+      # mount inherits the host directory's ownership (root, since Docker
+      # creates it on demand), which blocked writeConfigTOML and made
+      # POST /reload return 500 whenever config.toml was missing. The
+      # image already declares VOLUME ["/config"] and chowns the path to
+      # heimdallm:heimdallm during build.
+      - heimdallm-config:/config
       #
       # Gemini OAuth tokens from host (if using browser-based auth):
       # - ~/.gemini:/home/heimdallm/.gemini:ro
@@ -130,4 +137,6 @@ services:
 
 volumes:
   heimdallm-data:
+    driver: local
+  heimdallm-config:
     driver: local

--- a/web_ui/src/routes/config/+page.svelte
+++ b/web_ui/src/routes/config/+page.svelte
@@ -105,24 +105,29 @@
     err = null;
     savedFlash = null;
     try {
-      // Compose payload: raw keeps unknown fields, we override what we own.
-      const payload: Config = { ...raw };
-      payload.poll_interval = pollInterval;
-      payload.ai_primary = aiPrimary;
-      payload.ai_fallback = aiFallback || undefined;
-      payload.review_mode = reviewMode;
-      payload.retention_days = retentionDays;
-      payload.repositories = parseLines(repositoriesText);
-      payload.issue_tracking = {
-        ...((raw.issue_tracking as Record<string, unknown> | undefined) ?? {}),
-        enabled: Boolean(it.enabled),
-        filter_mode: it.filter_mode || 'exclusive',
-        default_action: it.default_action || 'ignore',
-        organizations: it.organizations ?? [],
-        assignees: it.assignees ?? [],
-        develop_labels: it.develop_labels ?? [],
-        review_only_labels: it.review_only_labels ?? [],
-        skip_labels: it.skip_labels ?? []
+      // Compose payload with ONLY the keys the daemon's PUT /config accepts.
+      // `{ ...raw }` would round-trip server-returned read-only fields
+      // (repo_overrides, agent_configs, server_port, non_monitored) which
+      // the daemon rejects with 400 unless explicitly allowlisted — see
+      // daemon/internal/server/handlers.go validConfigKeys.
+      const payload: Config = {
+        poll_interval: pollInterval,
+        ai_primary: aiPrimary,
+        ai_fallback: aiFallback || undefined,
+        review_mode: reviewMode,
+        retention_days: retentionDays,
+        repositories: parseLines(repositoriesText),
+        issue_tracking: {
+          ...((raw.issue_tracking as Record<string, unknown> | undefined) ?? {}),
+          enabled: Boolean(it.enabled),
+          filter_mode: it.filter_mode || 'exclusive',
+          default_action: it.default_action || 'ignore',
+          organizations: it.organizations ?? [],
+          assignees: it.assignees ?? [],
+          develop_labels: it.develop_labels ?? [],
+          review_only_labels: it.review_only_labels ?? [],
+          skip_labels: it.skip_labels ?? []
+        }
       };
 
       await updateConfig(payload);

--- a/web_ui/src/routes/config/+page.svelte
+++ b/web_ui/src/routes/config/+page.svelte
@@ -3,10 +3,11 @@
   import { fetchConfig, reloadConfig, updateConfig } from '$lib/api.js';
   import type { Config } from '$lib/types.js';
 
-  // Known primitive fields + the nested issue_tracking block. The daemon's
-  // Config is free-form (Record<string, unknown>), so we load the raw
-  // payload, only edit the fields we know about, and write the whole
-  // object back on save — unknown fields round-trip unchanged.
+  // Known primitive fields + the nested issue_tracking block. GET /config
+  // returns a larger payload (including server-returned read-only fields
+  // like repo_overrides and agent_configs), but we deliberately extract
+  // only the fields this screen edits — the save payload is enumerated
+  // explicitly below so nothing unknown round-trips back to the daemon.
   type IssueTracking = {
     enabled?: boolean;
     filter_mode?: string;
@@ -18,7 +19,6 @@
     skip_labels?: string[];
   };
 
-  let raw: Config = $state({});
   let pollInterval = $state('5m');
   let aiPrimary = $state('');
   let aiFallback = $state('');
@@ -68,7 +68,6 @@
     err = null;
     fetchConfig()
       .then((c) => {
-        raw = c;
         pollInterval = asString(c.poll_interval, '5m');
         aiPrimary = asString(c.ai_primary);
         aiFallback = asString(c.ai_fallback);
@@ -106,19 +105,32 @@
     savedFlash = null;
     try {
       // Compose payload with ONLY the keys the daemon's PUT /config accepts.
-      // `{ ...raw }` would round-trip server-returned read-only fields
-      // (repo_overrides, agent_configs, server_port, non_monitored) which
-      // the daemon rejects with 400 unless explicitly allowlisted — see
-      // daemon/internal/server/handlers.go validConfigKeys.
+      // Contract mirrors `validConfigKeys` in
+      // daemon/internal/server/handlers.go — when that allowlist gains or
+      // loses a field, this object must be updated in lockstep or the save
+      // will silently drop writes / hit an "unknown config key" 400. The
+      // earlier `{ ...raw }` spread made us tolerant to server-returned
+      // read-only fields (repo_overrides, agent_configs, server_port,
+      // non_monitored) but also hid that lockstep requirement, so dropping
+      // the spread is intentional.
+      //
+      // issue_tracking is enumerated explicitly too — no `...raw.issue_tracking`
+      // — so an unknown sub-key a newer daemon starts returning doesn't
+      // flow through as a sub-field the daemon then rejects.
       const payload: Config = {
         poll_interval: pollInterval,
         ai_primary: aiPrimary,
-        ai_fallback: aiFallback || undefined,
+        // `!== ''` rather than `|| undefined`: the user has explicitly
+        // picked "— (none)" in the dropdown when the value is the empty
+        // string, and we want to transmit "no fallback". Any other falsy
+        // string (e.g. a hypothetical "0") would previously have been
+        // silently dropped — not a concrete bug today but defensible to
+        // fix now alongside the other payload tightening.
+        ai_fallback: aiFallback !== '' ? aiFallback : undefined,
         review_mode: reviewMode,
         retention_days: retentionDays,
         repositories: parseLines(repositoriesText),
         issue_tracking: {
-          ...((raw.issue_tracking as Record<string, unknown> | undefined) ?? {}),
           enabled: Boolean(it.enabled),
           filter_mode: it.filter_mode || 'exclusive',
           default_action: it.default_action || 'ignore',


### PR DESCRIPTION
Three independent fixes for the config-save + reload flow that the web UI exercises. Each commit stands alone; together they close the chain of errors surfaced while trying to save the Configuration screen in a dockerised deployment.

## The chain

1. Web UI saves config → PUT sends `{ ...raw, ...edits }`.
2. Daemon rejects an unknown key → web UI shows "unknown config key: ..." and never gets to the reload step.
3. Once the PUT is accepted, web UI fires POST /reload.
4. Daemon reload hard-calls `config.Load(/config/config.toml)` → ENOENT because the bind-mounted `/config` dir was created as root and the daemon user could never write the auto-generated TOML → 500.

Each commit fixes one link, but none is load-bearing on the others — #87 already added a server-side accept-and-drop for the read-only keys, so Fix 1 below is defence-in-depth, not a blocker.

## Commits

### `3e8854e` — `fix(web_ui): send only writable keys in config PUT payload`

The save flow used `{ ...raw, ...edits }` to forward-compat unknown fields. But the daemon's PUT /config has a strict allowlist; `server_port`, `non_monitored`, `repo_overrides` and `agent_configs` round-trip back from GET but are rejected on write (currently tolerated via `readOnlyConfigKeys`, but that contract is daemon-side and can drift if a new read-only key is added to GET).

Build the payload explicitly from the known-writable keys only.

**Files:** `web_ui/src/routes/config/+page.svelte` (+23 / -18)

### `36bc9d7` — `fix(docker): use a named volume for /config so the daemon user can write`

`./config:/config` was a bind mount; Docker creates the host directory as root when the mount first fires, so the `heimdallm` user (uid 100 inside the image) could read `/config` but not write `config.toml` on first boot. `writeConfigTOML` silently failed, no TOML was ever created, and reload blew up downstream.

Switch to a named `heimdallm-config` volume. Docker initialises named volumes with the ownership the image already `chown`'d in — `heimdallm:heimdallm` — so the auto-generated `config.toml` persists as intended.

**Migration note:** operators with hand-edited `docker/config/config.toml` lose those edits on the first `docker compose up` after this merges. Replicate them via `docker/.env` env vars or the web UI's Configuration screen (both persist to the store layer, which survives the volume swap).

**Files:** `docker/docker-compose.yml`, `.gitignore` (+11 / -5)

### `eef3d88` — `fix(daemon): tolerate missing config.toml on reload, mirroring startup`

Cold-start uses `LoadOrCreate` when `HEIMDALLM_DATA_DIR` is set (Docker), rebuilding from env vars if no TOML exists. Reload hard-called `config.Load`, so POST /reload returned 500 the moment `config.toml` was absent — even though the daemon was happily serving traffic on the same env + store state.

Mirror the startup branch in `SetReloadFn`. In Docker we use `LoadOrCreate`; everywhere else we keep `Load` so the desktop flow doesn't auto-create a config at an unexpected path.

**Files:** `daemon/cmd/heimdallm/main.go` (+15 / -1)

## Tests

- [x] `make test-docker` — all packages pass (server, config, pipeline, issues, store, …). No regressions.
- [x] `cd web_ui && npm run check && npm test && npm run lint && npm run build` — 81/81 tests green, 0 type errors, lint clean, build succeeds.
- [x] `LoadOrCreate` already covered by `TestLoadOrCreate_Creates`, `TestLoadOrCreate_LoadsExisting`, `TestLoadOrCreate_FailsWithoutPrimary` in `daemon/internal/config/config_test.go`. No new unit test needed for the reload wrapper's env-check branch — it's two lines choosing between those two functions.

## Manual verification plan (for the reviewer)

After checkout:

```bash
# 1. Force a full rebuild — Docker's layer cache is the common reason
# these fixes "don't apply" on a laptop that's been running for a while.
docker compose -f docker/docker-compose.yml down --volumes
docker compose -f docker/docker-compose.yml build --no-cache
docker compose -f docker/docker-compose.yml up -d

# 2. Verify no "could not persist generated config" warning in daemon logs
docker logs heimdallm 2>&1 | grep -i "could not persist" || echo OK

# 3. Save config through the web UI, then hit reload
#    → should return HTTP 200, not 500
TOKEN=\$(docker exec heimdallm cat /data/api_token)
curl -sS -X POST http://127.0.0.1:7842/reload \\
  -H "X-Heimdallm-Token: \$TOKEN" -w "\\nHTTP %{http_code}\\n"
```

Expected: `HTTP 200 {"status":"reloaded"}`.

## Scope

Does **not** touch:
- PR list UI (the approved/changes-requested badge is a separate follow-up — different feature, different shape).
- Flutter app.
- Daemon handlers beyond the reload wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)