### PR TITLE
feat: show GitHub review decision badge on PR list + detail

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -194,8 +194,12 @@ func (c *Client) fetchByQualifier(username, qualifier string, repos []string) ([
 
 // SubmitReview posts an AI-generated review to GitHub as a PR review.
 // event should be "REQUEST_CHANGES", "COMMENT", or "APPROVE".
-// Returns the GitHub review ID.
-func (c *Client) SubmitReview(repo string, number int, body, event string) (int64, error) {
+// Returns the GitHub review ID and the review state reported by the API —
+// typically "APPROVED", "CHANGES_REQUESTED", or "COMMENTED" depending on the
+// event and on GitHub's server-side rules. We pass the state through to the
+// store so the web UI can show a review-decision badge sourced from GitHub
+// rather than derived locally from severity.
+func (c *Client) SubmitReview(repo string, number int, body, event string) (int64, string, error) {
 	path := fmt.Sprintf("/repos/%s/pulls/%d/reviews", repo, number)
 
 	payload := map[string]any{
@@ -206,7 +210,7 @@ func (c *Client) SubmitReview(repo string, number int, body, event string) (int6
 	data, _ := json.Marshal(payload)
 	req, err := http.NewRequest("POST", c.baseURL+path, strings.NewReader(string(data)))
 	if err != nil {
-		return 0, fmt.Errorf("github: submit review: %w", err)
+		return 0, "", fmt.Errorf("github: submit review: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Accept", "application/vnd.github+json")
@@ -215,22 +219,23 @@ func (c *Client) SubmitReview(repo string, number int, body, event string) (int6
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return 0, fmt.Errorf("github: submit review: %w", err)
+		return 0, "", fmt.Errorf("github: submit review: %w", err)
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != 200 {
 		errBody := safeTruncate(string(respBody), maxErrBodyLen)
-		return 0, fmt.Errorf("github: submit review: status %d: %s", resp.StatusCode, errBody)
+		return 0, "", fmt.Errorf("github: submit review: status %d: %s", resp.StatusCode, errBody)
 	}
 
 	var result struct {
-		ID int64 `json:"id"`
+		ID    int64  `json:"id"`
+		State string `json:"state"`
 	}
 	if err := json.Unmarshal(respBody, &result); err != nil {
-		return 0, fmt.Errorf("github: submit review: decode: %w", err)
+		return 0, "", fmt.Errorf("github: submit review: decode: %w", err)
 	}
-	return result.ID, nil
+	return result.ID, result.State, nil
 }
 
 // PostComment posts a general comment on a PR (issue comment).

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -30,7 +30,7 @@ type Notifier interface {
 
 // GitHubReviewer can submit a review and post issue comments to GitHub.
 type GitHubReviewer interface {
-	SubmitReview(repo string, number int, body, event string) (int64, error)
+	SubmitReview(repo string, number int, body, event string) (int64, string, error)
 	// PostComment posts a general PR comment (used in multi-feedback mode).
 	PostComment(repo string, number int, body string) error
 }
@@ -259,7 +259,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		reviewBody = buildGitHubBody(result)
 	}
 
-	ghReviewID, publishErr := p.gh.SubmitReview(
+	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
 		pr.Repo, pr.Number,
 		reviewBody,
 		severityToEvent(result.Severity, len(result.Issues)),
@@ -269,10 +269,13 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		slog.Warn("pipeline: failed to publish to GitHub, will retry",
 			"pr", pr.Number, "err", publishErr)
 	} else {
-		_ = p.store.UpdateGitHubReviewID(rev.ID, ghReviewID)
+		_ = p.store.MarkReviewPublished(rev.ID, ghReviewID, ghReviewState)
 		rev.GitHubReviewID = ghReviewID
+		rev.GitHubReviewState = ghReviewState
 		slog.Info("pipeline: review published to GitHub",
-			"pr", pr.Number, "github_review_id", ghReviewID)
+			"pr", pr.Number,
+			"github_review_id", ghReviewID,
+			"github_review_state", ghReviewState)
 	}
 
 	p.notify.Notify("PR Review Complete",
@@ -295,9 +298,9 @@ func (p *Pipeline) PublishPending() {
 			continue
 		}
 		// Skip reviews for PRs with no repo — orphaned records that will never publish.
-		// Mark them as permanently published (fake ID -1) to stop retry noise.
+		// Mark them as permanently published (fake ID -1, empty state) to stop retry noise.
 		if pr.Repo == "" {
-			_ = p.store.UpdateGitHubReviewID(rev.ID, -1)
+			_ = p.store.MarkReviewPublished(rev.ID, -1, "")
 			slog.Info("pipeline: skipping pending review for PR with no repo", "review_id", rev.ID)
 			continue
 		}
@@ -311,7 +314,7 @@ func (p *Pipeline) PublishPending() {
 		}
 		// PublishPending always uses single-mode body (individual comments were
 		// already posted when the review first ran; we only retry the formal review).
-		ghID, err := p.gh.SubmitReview(
+		ghID, ghState, err := p.gh.SubmitReview(
 			pr.Repo, pr.Number,
 			buildGitHubBody(result),
 			severityToEvent(rev.Severity, len(issues)),
@@ -320,8 +323,11 @@ func (p *Pipeline) PublishPending() {
 			slog.Warn("pipeline: retry publish failed", "review_id", rev.ID, "err", err)
 			continue
 		}
-		_ = p.store.UpdateGitHubReviewID(rev.ID, ghID)
-		slog.Info("pipeline: pending review published", "review_id", rev.ID, "github_review_id", ghID)
+		_ = p.store.MarkReviewPublished(rev.ID, ghID, ghState)
+		slog.Info("pipeline: pending review published",
+			"review_id", rev.ID,
+			"github_review_id", ghID,
+			"github_review_state", ghState)
 	}
 }
 

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -22,8 +22,18 @@ func (f *fakeGH) FetchDiff(repo string, number int) (string, error) {
 	return f.diff, nil
 }
 
-func (f *fakeGH) SubmitReview(repo string, number int, body, event string) (int64, error) {
-	return 12345, nil // fake GitHub review ID
+func (f *fakeGH) SubmitReview(repo string, number int, body, event string) (int64, string, error) {
+	// Mirror GitHub's actual mapping from the submitted event to the
+	// returned state so pipeline tests that inspect GitHubReviewState see
+	// something realistic rather than a hardcoded constant.
+	state := "COMMENTED"
+	switch event {
+	case "APPROVE":
+		state = "APPROVED"
+	case "REQUEST_CHANGES":
+		state = "CHANGES_REQUESTED"
+	}
+	return 12345, state, nil
 }
 
 func (f *fakeGH) PostComment(repo string, number int, body string) error {
@@ -120,8 +130,8 @@ func (f *fakeGHCommentsError) FetchDiff(repo string, number int) (string, error)
 	return f.diff, nil
 }
 
-func (f *fakeGHCommentsError) SubmitReview(repo string, number int, body, event string) (int64, error) {
-	return 1, nil
+func (f *fakeGHCommentsError) SubmitReview(repo string, number int, body, event string) (int64, string, error) {
+	return 1, "COMMENTED", nil
 }
 
 func (f *fakeGHCommentsError) PostComment(repo string, number int, body string) error {

--- a/daemon/internal/store/reviews.go
+++ b/daemon/internal/store/reviews.go
@@ -6,25 +6,33 @@ import (
 )
 
 // Review represents a code review result stored locally and (when published) on GitHub.
+//
+// GitHubReviewID and GitHubReviewState are populated together after a successful
+// SubmitReview call. GitHubReviewState is one of the GitHub pull-request review
+// states (APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED, PENDING) — empty
+// string on legacy rows and before publish. The web UI renders a
+// review-decision badge from this field rather than deriving it from severity,
+// so the displayed state reflects exactly what the daemon told GitHub.
 type Review struct {
-	ID             int64     `json:"id"`
-	PRID           int64     `json:"pr_id"`
-	CLIUsed        string    `json:"cli_used"`
-	Summary        string    `json:"summary"`
-	Issues         string    `json:"issues"`      // JSON array
-	Suggestions    string    `json:"suggestions"` // JSON array
-	Severity       string    `json:"severity"`
-	CreatedAt      time.Time `json:"created_at"`
-	GitHubReviewID int64     `json:"github_review_id"` // 0 = not yet published
+	ID                int64     `json:"id"`
+	PRID              int64     `json:"pr_id"`
+	CLIUsed           string    `json:"cli_used"`
+	Summary           string    `json:"summary"`
+	Issues            string    `json:"issues"`      // JSON array
+	Suggestions       string    `json:"suggestions"` // JSON array
+	Severity          string    `json:"severity"`
+	CreatedAt         time.Time `json:"created_at"`
+	GitHubReviewID    int64     `json:"github_review_id"`    // 0 = not yet published
+	GitHubReviewState string    `json:"github_review_state"` // '' until published
 }
 
 // InsertReview inserts a new review record and returns its row ID.
 func (s *Store) InsertReview(r *Review) (int64, error) {
 	res, err := s.db.Exec(`
-		INSERT INTO reviews (pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO reviews (pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, r.PRID, r.CLIUsed, r.Summary, r.Issues, r.Suggestions, r.Severity,
-		r.CreatedAt.UTC().Format(sqliteTimeFormat), r.GitHubReviewID,
+		r.CreatedAt.UTC().Format(sqliteTimeFormat), r.GitHubReviewID, r.GitHubReviewState,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("store: insert review: %w", err)
@@ -35,7 +43,7 @@ func (s *Store) InsertReview(r *Review) (int64, error) {
 // ListUnpublishedReviews returns reviews not yet submitted to GitHub (github_review_id == 0).
 func (s *Store) ListUnpublishedReviews() ([]*Review, error) {
 	rows, err := s.db.Query(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id FROM reviews WHERE github_review_id=0 ORDER BY created_at ASC",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state FROM reviews WHERE github_review_id=0 ORDER BY created_at ASC",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("store: list unpublished: %w", err)
@@ -52,16 +60,22 @@ func (s *Store) ListUnpublishedReviews() ([]*Review, error) {
 	return reviews, rows.Err()
 }
 
-// UpdateGitHubReviewID stores the GitHub review ID after successful submission.
-func (s *Store) UpdateGitHubReviewID(reviewID, ghReviewID int64) error {
-	_, err := s.db.Exec("UPDATE reviews SET github_review_id=? WHERE id=?", ghReviewID, reviewID)
+// MarkReviewPublished records the GitHub review ID and state after a successful
+// SubmitReview call. The state is one of GitHub's review states; see Review for
+// the full set. Pass the sentinel pair (-1, "") to mark an orphan review that
+// can never publish (e.g. the source PR's repo was unset).
+func (s *Store) MarkReviewPublished(reviewID, ghReviewID int64, ghReviewState string) error {
+	_, err := s.db.Exec(
+		"UPDATE reviews SET github_review_id=?, github_review_state=? WHERE id=?",
+		ghReviewID, ghReviewState, reviewID,
+	)
 	return err
 }
 
 // ListReviewsForPR returns all reviews for a given PR, ordered by created_at descending.
 func (s *Store) ListReviewsForPR(prID int64) ([]*Review, error) {
 	rows, err := s.db.Query(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id FROM reviews WHERE pr_id = ? ORDER BY created_at DESC",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state FROM reviews WHERE pr_id = ? ORDER BY created_at DESC",
 		prID,
 	)
 	if err != nil {
@@ -82,7 +96,7 @@ func (s *Store) ListReviewsForPR(prID int64) ([]*Review, error) {
 // LatestReviewForPR returns the most recent review for a PR. Returns sql.ErrNoRows if none.
 func (s *Store) LatestReviewForPR(prID int64) (*Review, error) {
 	row := s.db.QueryRow(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id FROM reviews WHERE pr_id = ? ORDER BY created_at DESC LIMIT 1",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state FROM reviews WHERE pr_id = ? ORDER BY created_at DESC LIMIT 1",
 		prID,
 	)
 	return scanReview(row)
@@ -108,7 +122,7 @@ func scanReview(s scanner) (*Review, error) {
 	var createdAt string
 	var err error
 	if err = s.Scan(&rev.ID, &rev.PRID, &rev.CLIUsed, &rev.Summary,
-		&rev.Issues, &rev.Suggestions, &rev.Severity, &createdAt, &rev.GitHubReviewID); err != nil {
+		&rev.Issues, &rev.Suggestions, &rev.Severity, &createdAt, &rev.GitHubReviewID, &rev.GitHubReviewState); err != nil {
 		return nil, fmt.Errorf("store: scan review: %w", err)
 	}
 	if rev.CreatedAt, err = time.Parse(sqliteTimeFormat, createdAt); err != nil {

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -36,15 +36,16 @@ CREATE TABLE IF NOT EXISTS prs (
 );
 
 CREATE TABLE IF NOT EXISTS reviews (
-  id               INTEGER PRIMARY KEY AUTOINCREMENT,
-  pr_id            INTEGER NOT NULL REFERENCES prs(id),
-  cli_used         TEXT NOT NULL,
-  summary          TEXT NOT NULL,
-  issues           TEXT NOT NULL,
-  suggestions      TEXT NOT NULL,
-  severity         TEXT NOT NULL,
-  created_at       DATETIME NOT NULL,
-  github_review_id INTEGER NOT NULL DEFAULT 0
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  pr_id               INTEGER NOT NULL REFERENCES prs(id),
+  cli_used            TEXT NOT NULL,
+  summary             TEXT NOT NULL,
+  issues              TEXT NOT NULL,
+  suggestions         TEXT NOT NULL,
+  severity            TEXT NOT NULL,
+  created_at          DATETIME NOT NULL,
+  github_review_id    INTEGER NOT NULL DEFAULT 0,
+  github_review_state TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS configs (
@@ -112,6 +113,7 @@ func Open(dsn string) (*Store, error) {
 	}
 	// Migrate existing DBs (ALTER TABLE ignores "duplicate column" errors silently)
 	db.Exec("ALTER TABLE reviews ADD COLUMN github_review_id INTEGER NOT NULL DEFAULT 0")
+	db.Exec("ALTER TABLE reviews ADD COLUMN github_review_state TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents ADD COLUMN instructions TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents ADD COLUMN cli_flags TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents RENAME COLUMN prompt TO prompt") // no-op, ensures column exists

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -80,6 +80,57 @@ func TestReview_InsertAndList(t *testing.T) {
 	}
 }
 
+func TestMarkReviewPublished_RoundTripsStateAndID(t *testing.T) {
+	// Locks in the behaviour the web UI relies on for the review-decision
+	// badge: after SubmitReview succeeds, the GitHub-returned state must
+	// survive a store round-trip so PRTile can render "Approved" vs
+	// "Changes requested" without re-deriving from severity.
+	s := newTestStore(t)
+	prID, _ := s.UpsertPR(&store.PR{
+		GithubID: 1, Repo: "org/r", Number: 1, Title: "t", Author: "a",
+		URL: "u", State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now(),
+	})
+
+	rev := &store.Review{
+		PRID:      prID,
+		CLIUsed:   "claude",
+		Summary:   "ok",
+		Issues:    "[]",
+		Suggestions: "[]",
+		Severity:  "low",
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	revID, err := s.InsertReview(rev)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Freshly inserted rows have no published state.
+	latest, err := s.LatestReviewForPR(prID)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	if latest.GitHubReviewID != 0 || latest.GitHubReviewState != "" {
+		t.Fatalf("pre-publish got (id=%d, state=%q), want (0, \"\")",
+			latest.GitHubReviewID, latest.GitHubReviewState)
+	}
+
+	if err := s.MarkReviewPublished(revID, 98765, "APPROVED"); err != nil {
+		t.Fatalf("mark published: %v", err)
+	}
+
+	got, err := s.LatestReviewForPR(prID)
+	if err != nil {
+		t.Fatalf("latest after publish: %v", err)
+	}
+	if got.GitHubReviewID != 98765 {
+		t.Errorf("GitHubReviewID = %d, want 98765", got.GitHubReviewID)
+	}
+	if got.GitHubReviewState != "APPROVED" {
+		t.Errorf("GitHubReviewState = %q, want %q", got.GitHubReviewState, "APPROVED")
+	}
+}
+
 func TestPR_ListAll(t *testing.T) {
 	s := newTestStore(t)
 	for i := 0; i < 3; i++ {

--- a/web_ui/src/lib/components/PRReviewCard.svelte
+++ b/web_ui/src/lib/components/PRReviewCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Review } from '$lib/types.js';
+  import ReviewDecisionBadge from './ReviewDecisionBadge.svelte';
   import SeverityBadge from './SeverityBadge.svelte';
 
   let { review }: { review: Review } = $props();
@@ -11,6 +12,7 @@
   <header class="mb-2 flex items-center justify-between gap-2">
     <div class="flex items-center gap-2">
       <SeverityBadge severity={review.severity} />
+      <ReviewDecisionBadge state={review.github_review_state} />
       <span class="text-xs text-gray-500 dark:text-gray-400">{review.cli_used}</span>
     </div>
     <time class="text-xs text-gray-400 dark:text-gray-500" datetime={review.created_at}>

--- a/web_ui/src/lib/components/PRTile.svelte
+++ b/web_ui/src/lib/components/PRTile.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { reviewingPRs } from '$lib/stores.js';
   import type { PR } from '$lib/types.js';
+  import ReviewDecisionBadge from './ReviewDecisionBadge.svelte';
   import SeverityBadge from './SeverityBadge.svelte';
 
   let { pr }: { pr: PR } = $props();
 
   const isReviewing = $derived($reviewingPRs.has(pr.id));
   const severity = $derived(pr.latest_review?.severity ?? null);
+  const decisionState = $derived(pr.latest_review?.github_review_state ?? null);
 </script>
 
 <a
@@ -28,6 +30,7 @@
           >reviewing…</span
         >
       {/if}
+      <ReviewDecisionBadge state={decisionState} />
       <SeverityBadge {severity} />
     </div>
   </div>

--- a/web_ui/src/lib/components/ReviewDecisionBadge.svelte
+++ b/web_ui/src/lib/components/ReviewDecisionBadge.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { decisionLabel } from '$lib/review.js';
+
+  let { state }: { state: string | null | undefined } = $props();
+
+  const decision = $derived(decisionLabel(state));
+</script>
+
+{#if decision}
+  <span
+    class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium {decision.class}"
+    data-testid="review-decision"
+    data-state={state}
+  >
+    {decision.label}
+  </span>
+{/if}

--- a/web_ui/src/lib/review.ts
+++ b/web_ui/src/lib/review.ts
@@ -1,0 +1,43 @@
+// Review-decision presentation helpers.
+//
+// The daemon stores the GitHub review state verbatim (APPROVED,
+// CHANGES_REQUESTED, COMMENTED, DISMISSED, PENDING — see
+// daemon/internal/store/reviews.go). We deliberately do NOT derive the
+// badge from severity here; the web UI renders exactly what GitHub reports.
+
+export interface ReviewDecision {
+  label: string;
+  class: string;
+}
+
+const DECISIONS: Record<string, ReviewDecision> = {
+  APPROVED: {
+    label: 'Approved',
+    class: 'bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300'
+  },
+  CHANGES_REQUESTED: {
+    label: 'Changes requested',
+    class: 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300'
+  },
+  COMMENTED: {
+    label: 'Commented',
+    class: 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
+  },
+  DISMISSED: {
+    label: 'Dismissed',
+    class: 'bg-gray-100 text-gray-500 line-through dark:bg-gray-800 dark:text-gray-400'
+  },
+  PENDING: {
+    label: 'Pending',
+    class: 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300'
+  }
+};
+
+// decisionLabel returns the pill styling for a GitHub review state.
+// Returns null for empty / unknown values so callers can simply not
+// render the badge — e.g. reviews that never published (legacy rows or
+// the -1 sentinel the pipeline writes for orphaned PRs).
+export function decisionLabel(state: string | null | undefined): ReviewDecision | null {
+  if (!state) return null;
+  return DECISIONS[state] ?? null;
+}

--- a/web_ui/src/lib/types.ts
+++ b/web_ui/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface Review {
   severity: string;
   created_at: string;
   github_review_id: number; // 0 = not yet published to GitHub
+  github_review_state: string; // GitHub review state: APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED, PENDING, or '' if not yet published
 }
 
 export interface PR {

--- a/web_ui/src/tests/review.test.ts
+++ b/web_ui/src/tests/review.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { decisionLabel } from '../lib/review.js';
+
+describe('decisionLabel', () => {
+  it('returns null for empty/null/undefined so the badge renders nothing', () => {
+    for (const input of ['', null, undefined]) {
+      expect(decisionLabel(input)).toBeNull();
+    }
+  });
+
+  it('returns null for unknown states rather than a mystery pill', () => {
+    // Guards against rendering whatever GitHub might add in the future
+    // (e.g. a new state constant) without explicit opt-in.
+    expect(decisionLabel('UNKNOWN_STATE')).toBeNull();
+  });
+
+  it('maps APPROVED to the green "Approved" pill', () => {
+    const d = decisionLabel('APPROVED');
+    expect(d?.label).toBe('Approved');
+    expect(d?.class).toContain('bg-green-100');
+    expect(d?.class).toContain('text-green-700');
+  });
+
+  it('maps CHANGES_REQUESTED to the red "Changes requested" pill', () => {
+    const d = decisionLabel('CHANGES_REQUESTED');
+    expect(d?.label).toBe('Changes requested');
+    expect(d?.class).toContain('bg-red-100');
+    expect(d?.class).toContain('text-red-700');
+  });
+
+  it('maps COMMENTED to the blue "Commented" pill', () => {
+    const d = decisionLabel('COMMENTED');
+    expect(d?.label).toBe('Commented');
+    expect(d?.class).toContain('bg-blue-100');
+  });
+
+  it('maps DISMISSED to a muted, strikethrough pill', () => {
+    const d = decisionLabel('DISMISSED');
+    expect(d?.label).toBe('Dismissed');
+    expect(d?.class).toContain('line-through');
+  });
+
+  it('maps PENDING to an amber pill', () => {
+    const d = decisionLabel('PENDING');
+    expect(d?.label).toBe('Pending');
+    expect(d?.class).toContain('bg-amber-100');
+  });
+
+  it('is case-sensitive — states arrive uppercase from GitHub', () => {
+    // GitHub emits uppercase constants (APPROVED, CHANGES_REQUESTED, …).
+    // Lowercasing them would mean we lost fidelity upstream — surface as
+    // null so the drift is visible instead of silently matching.
+    expect(decisionLabel('approved')).toBeNull();
+  });
+
+  it('includes dark-mode variants for every mapped state', () => {
+    for (const state of ['APPROVED', 'CHANGES_REQUESTED', 'COMMENTED', 'DISMISSED', 'PENDING']) {
+      const d = decisionLabel(state);
+      expect(d, `no decision for ${state}`).not.toBeNull();
+      expect(d!.class).toMatch(/dark:bg-/);
+      expect(d!.class).toMatch(/dark:text-/);
+    }
+  });
+});


### PR DESCRIPTION
Adds a second pill next to the existing severity badge showing the GitHub review decision the daemon recorded — sourced from GitHub itself, not derived locally from severity. The two answer different questions:

- **Severity** (existing): how bad is what the AI found?
- **Decision** (new): what did the daemon actually tell GitHub? (APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED, PENDING)

Keeping both preserves the at-a-glance severity sort while surfacing the published outcome alongside it.

## Why not derive from severity

The daemon's `severityToEvent` maps severity to the submit event (`high` → REQUEST_CHANGES, else APPROVE), so deriving would look equivalent today. But:

- GitHub's response is authoritative for what was recorded. If the mapping ever changes — or if dismissals get tracked here later — the UI reflects that automatically rather than drifting.
- The response body always includes `state`; we were throwing it away. Capturing it is free at the wire level.

## Commits

### `b37d962` — `feat(daemon): capture GitHub review state alongside review ID`

- `github.SubmitReview(...)` signature: `(int64, error)` → `(int64, string, error)`. Parses `state` from the response body alongside `id`.
- `store.Review.GitHubReviewState` added; schema column + ALTER migration (empty string default for legacy rows, so old reviews just don't render a badge).
- `store.UpdateGitHubReviewID` replaced with `MarkReviewPublished(reviewID, ghReviewID, ghReviewState)` — one call, two fields, same transaction. All three pipeline call-sites updated; the orphan-PR sentinel path passes `("", -1)` to silence retry noise without polluting the state.
- Pipeline fake `fakeGH.SubmitReview` now mirrors GitHub's event → state mapping so existing pipeline tests see realistic values.
- New `TestMarkReviewPublished_RoundTripsStateAndID` locks in the field's round-trip through the store.

### `75b2540` — `feat(web_ui): render review-decision badge sourced from GitHub`

- `types.ts` Review gains `github_review_state: string`.
- New `$lib/review.ts#decisionLabel(state)` — centralised state → pill mapping. Returns `null` for empty/unknown values so the badge simply doesn't render (legacy rows + orphan sentinel stay clean).
- New `ReviewDecisionBadge.svelte` — thin rendering wrapper. Exposes `data-state` for future E2E selectors.
- Wired into `PRTile.svelte` (dashboard tiles) and `PRReviewCard.svelte` (PR detail history).
- 9 new unit tests in `review.test.ts` — each mapped state, fallback cases, dark-mode variants, deliberate case-sensitivity (GitHub emits uppercase; lowercasing would mask upstream drift).

## Migration story

No backfill. Reviews that landed before this merge keep `github_review_state = ''` and show no decision badge. The next time the daemon reviews them (manual trigger or next poll cycle) the state will populate. Keeps us honest: the badge means "GitHub said this" — if it's blank, we don't know.

## Tests

- [x] `make test-docker` — all daemon packages pass, including the new store round-trip test.
- [x] `cd web_ui && npm run check` — 0 type errors.
- [x] `cd web_ui && npm test` — 90/90 (81 pre-existing + 9 new).
- [x] `cd web_ui && npm run lint` — prettier + eslint clean.
- [x] `cd web_ui && npm run build` — adapter-node bundle OK.

## Manual verification

After merge + rebuild:

```bash
# Trigger a fresh review so github_review_state populates.
curl -sS -X POST http://127.0.0.1:7842/prs/<id>/review \\
  -H "X-Heimdallm-Token: \$TOKEN"

# Wait a few seconds, then inspect the stored state:
curl -sS http://127.0.0.1:7842/prs/<id> -H "X-Heimdallm-Token: \$TOKEN" \\
  | jq '.reviews[0].github_review_state'
# Expected: "APPROVED" or "CHANGES_REQUESTED" (depending on severity).

# Open the PR list at http://localhost:3000/prs — decision pill
# should appear next to the severity pill on the reviewed PR.
```

## Stays out of scope

- PR B (config payload / named volume / reload tolerance) landed separately.
- No Flutter-side equivalent yet; the Dart `Review` model can add the same field when someone needs it there.
- No backfill of historical reviews — intentional, per above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)