### PR TITLE
feat: multi-tier polling pipeline (#107)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -180,7 +180,8 @@ func main() {
 	srv := server.New(s, broker, p, apiToken)
 
 	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.
-	var cfgMu sync.Mutex
+	var cfgMu   sync.Mutex
+	var reloadMu sync.Mutex // serialises config reloads to prevent duplicate pipelines
 
 	// discoverySvc holds the discovered repo cache.
 	discoverySvc := discovery.NewService(ghClient)
@@ -415,6 +416,13 @@ func main() {
 	// startup so the two paths cannot drift on which loader they pick — both
 	// see the same HEIMDALLM_DATA_DIR snapshot.
 	srv.SetReloadFn(func() error {
+		// Serialise reloads: without this, two concurrent /reload calls
+		// could each read the same oldPipe, both stop it, both build a
+		// new pipeline, and leave two pipelines running against the same
+		// GitHub API budget.
+		reloadMu.Lock()
+		defer reloadMu.Unlock()
+
 		newCfg, err := loadConfig(cfgPath)
 		if err != nil {
 			return fmt.Errorf("reload: %w", err)
@@ -736,9 +744,14 @@ func parseDiscoveryInterval(s string) time.Duration {
 }
 
 func parseWatchInterval(s string) time.Duration {
+	const minWatch = 10 * time.Second
 	d, err := time.ParseDuration(s)
 	if err != nil || d <= 0 {
 		return 1 * time.Minute
+	}
+	if d < minWatch {
+		slog.Warn("watch_interval too small, clamping to minimum", "configured", d, "minimum", minWatch)
+		return minWatch
 	}
 	return d
 }
@@ -977,7 +990,15 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 		}
 		a.runReview(ghPR, aiCfg)
 	}
-	// For issues, Tier 2 will pick up the change on its next cycle.
+	// For issues we cannot trigger an immediate re-triage from Tier 3,
+	// but returning nil signals the caller (RunTier3) to call
+	// queue.ResetBackoff — which resets the item's backoff to 1m so it
+	// gets re-checked quickly rather than waiting at a potentially 15m
+	// backoff for Tier 2's next full cycle.
+	if item.Type == "issue" {
+		slog.Info("tier3: issue change detected, backoff will reset",
+			"repo", item.Repo, "number", item.Number)
+	}
 	return nil
 }
 

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -325,7 +325,16 @@ func main() {
 
 	pipe := buildPipeline(cfg)
 	pipe.Start(context.Background())
-	defer pipe.Stop()
+	// Use a closure so the defer reads the current pipe variable at shutdown
+	// time, not the initial pointer captured at defer-statement time. After a
+	// reload, pipe points to a new pipeline — the bare defer would stop the
+	// already-halted original pipeline and leak the post-reload one.
+	defer func() {
+		cfgMu.Lock()
+		p := pipe
+		cfgMu.Unlock()
+		p.Stop()
+	}()
 
 	// Expose live config for GET /config
 	srv.SetRepoMetaFns(ghClient.FetchLabels, ghClient.FetchCollaborators)
@@ -418,17 +427,26 @@ func main() {
 			return fmt.Errorf("reload: %w", err)
 		}
 
-		// Stop the old pipeline before starting a new one. The Search API
-		// rate limit (30 req/min) is tight enough that running two loops in
-		// parallel — even briefly during reload — risks throttling.
-		pipe.Stop()
-
+		// Read the current pipe under cfgMu, then stop it OUTSIDE the lock.
+		// Holding cfgMu across Stop() risks deadlock: if Stop() blocks
+		// waiting for in-flight goroutines that also acquire cfgMu (e.g.
+		// tier2Adapter callbacks), both sides block forever.
 		cfgMu.Lock()
-		cfg = newCfg
+		oldPipe := pipe
 		cfgMu.Unlock()
 
-		pipe = buildPipeline(newCfg)
-		pipe.Start(context.Background())
+		oldPipe.Stop()
+
+		newPipe := buildPipeline(newCfg)
+
+		// Swap cfg + pipe atomically under the lock so readers never see
+		// a half-updated state.
+		cfgMu.Lock()
+		cfg = newCfg
+		pipe = newPipe
+		cfgMu.Unlock()
+
+		newPipe.Start(context.Background())
 		return nil
 	})
 
@@ -738,8 +756,6 @@ type tier2Adapter struct {
 	cfg       **config.Config
 	loginMu   *sync.Mutex
 	login     *string
-	reviewMu  *sync.Mutex
-	inFlight  map[int64]bool
 	runReview func(pr *gh.PullRequest, aiCfg config.RepoAI)
 }
 
@@ -760,6 +776,10 @@ func (a *tier2Adapter) FetchPRsToReview() ([]scheduler.Tier2PR, error) {
 			ID:        pr.ID,
 			Number:    pr.Number,
 			Repo:      pr.Repo,
+			Title:     pr.Title,
+			HTMLURL:   pr.HTMLURL,
+			Author:    pr.User.Login,
+			State:     pr.State,
 			UpdatedAt: pr.UpdatedAt,
 		})
 	}
@@ -773,13 +793,14 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 	aiCfg := c.AIForRepo(pr.Repo)
 	a.cfgMu.Unlock()
 
-	// Reconstruct the full gh.PullRequest from the minimal Tier2PR.
-	// FetchPRsToReview already resolved the repo and set UpdatedAt; we
-	// need at minimum ID, Number, Repo, UpdatedAt for the pipeline.
 	ghPR := &gh.PullRequest{
 		ID:        pr.ID,
 		Number:    pr.Number,
 		Repo:      pr.Repo,
+		Title:     pr.Title,
+		HTMLURL:   pr.HTMLURL,
+		User:      gh.User{Login: pr.Author},
+		State:     pr.State,
 		UpdatedAt: pr.UpdatedAt,
 	}
 	a.runReview(ghPR, aiCfg)
@@ -882,7 +903,11 @@ func (a *tier2Adapter) PromoteReady(ctx context.Context, repos []string) (int, e
 	globalIT := c.GitHub.IssueTracking
 	a.cfgMu.Unlock()
 
-	if !globalIT.Enabled || len(globalIT.BlockedLabels) == 0 {
+	// Promotion only makes sense when blocked labels are configured.
+	// Intentionally NOT gated on globalIT.Enabled — per-repo IT configs
+	// can enable issue tracking independently while global is disabled.
+	// Gating on Enabled here would silently regress promotion for those users.
+	if len(globalIT.BlockedLabels) == 0 {
 		return 0, nil
 	}
 	return issuepipeline.PromoteReady(ctx, a.ghClient, globalIT, repos, a.broker)
@@ -921,15 +946,34 @@ func (a *tier2Adapter) CheckItem(ctx context.Context, item *scheduler.WatchItem)
 // HandleChange implements scheduler.Tier3ItemChecker.
 func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchItem) error {
 	if item.Type == "pr" {
+		// Apply the same dedup gate as Tier 2: skip dismissed PRs and
+		// recently-reviewed PRs. Note: there is a small TOCTOU window
+		// between this check and the actual runReview call — the worst
+		// case is an occasional harmless duplicate review.
+		if a.PRAlreadyReviewed(item.GithubID, item.LastSeen) {
+			slog.Debug("tier3: PR already reviewed, skipping", "pr", item.Number, "repo", item.Repo)
+			return nil
+		}
+
 		a.cfgMu.Lock()
 		c := *a.cfg
 		aiCfg := c.AIForRepo(item.Repo)
 		a.cfgMu.Unlock()
 
+		// Fetch the full PR from the store so runReview receives all
+		// fields (Title, Author, URL, etc.) instead of a sparse struct.
+		stored, _ := a.store.GetPRByGithubID(item.GithubID)
 		ghPR := &gh.PullRequest{
 			ID:     item.GithubID,
 			Number: item.Number,
 			Repo:   item.Repo,
+		}
+		if stored != nil {
+			ghPR.Title = stored.Title
+			ghPR.HTMLURL = stored.URL
+			ghPR.User = gh.User{Login: stored.Author}
+			ghPR.State = stored.State
+			ghPR.UpdatedAt = stored.UpdatedAt
 		}
 		a.runReview(ghPR, aiCfg)
 	}

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -179,15 +179,11 @@ func main() {
 	issueFetcher := issuepipeline.NewFetcher(ghClient, s, issuePipe)
 	srv := server.New(s, broker, p, apiToken)
 
-	// cfgMu protects cfg, sched and the discovery loop so reload is safe from any goroutine.
+	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
-	var sched *scheduler.Scheduler
 
-	// discoverySvc holds the discovered repo cache; it is nil when topic-based
-	// discovery is disabled. discoveryCancel stops the background loop so reload
-	// can restart it with fresh config.
+	// discoverySvc holds the discovered repo cache.
 	discoverySvc := discovery.NewService(ghClient)
-	var discoveryCancel context.CancelFunc
 
 	// loginMu guards cachedLogin against concurrent reads/writes from the
 	// poll cycle and HTTP goroutines.
@@ -274,215 +270,62 @@ func main() {
 		})})
 	}
 
-	makePollFn := func(c *config.Config) func() {
-		return func() {
-			cfgMu.Lock()
-			static := c.GitHub.Repositories
-			cfgMu.Unlock()
-			// Merge static list with repos discovered via topic tag (empty when disabled).
-			repos := discovery.MergeRepos(static, discoverySvc.Discovered(), c.GitHub.NonMonitored)
+	// ── Multi-tier Pipeline ──────────────────────────────────────────────
+	// tier2Adapter bridges main.go's concrete types to the Pipeline's
+	// Tier 2 / Tier 3 interfaces.
+	adapter := &tier2Adapter{
+		ghClient:  ghClient,
+		pipeline:  p,
+		issuePipe: issuePipe,
+		fetcher:   issueFetcher,
+		store:     s,
+		broker:    broker,
+		cfgMu:     &cfgMu,
+		cfg:       &cfg,
+		loginMu:   &loginMu,
+		login:     &cachedLogin,
+		runReview: runReview,
+	}
 
-			// Fetch all review-requested PRs without a repo filter — adding many
-			// repo: terms to the Search API query can exceed its length limit and
-			// silently return zero results. We filter to monitored repos below.
-			prs, err := ghClient.FetchPRsToReview()
-			if err != nil {
-				slog.Error("poll: fetch PRs to review", "err", err)
-				return
-			}
-			// Build a quick lookup set for monitored repos.
-			monitoredSet := make(map[string]struct{}, len(repos))
-			for _, r := range repos {
-				monitoredSet[r] = struct{}{}
-			}
-			for _, pr := range prs {
-				pr.ResolveRepo()
-				if pr.Repo == "" {
-					slog.Warn("poll: skipping PR with empty repo", "pr_number", pr.Number)
-					continue
-				}
-				// Only auto-review PRs from repos the user has opted in to monitor.
-				if _, monitored := monitoredSet[pr.Repo]; !monitored {
-					continue
-				}
+	buildPipeline := func(c *config.Config) *scheduler.Pipeline {
+		return scheduler.NewPipeline(scheduler.PipelineConfig{
+			DiscoveryInterval: parseDiscoveryInterval(c.GitHub.DiscoveryInterval),
+			PollInterval:      parsePollInterval(c.GitHub.PollInterval),
+			WatchInterval:     parseWatchInterval(c.GitHub.WatchInterval),
+			RateLimitPerHour:  4500,
+		}, scheduler.PipelineDeps{
+			Discovery: discoverySvc,
+			Tier1ConfigFn: func() scheduler.Tier1Config {
 				cfgMu.Lock()
-				aiCfg := c.AIForRepo(pr.Repo)
-				cfgMu.Unlock()
-				existing, _ := s.GetPRByGithubID(pr.ID)
-				if existing != nil {
-					// Skip PRs the user has dismissed
-					if existing.Dismissed {
-						continue
-					}
-					if rev, err := s.LatestReviewForPR(existing.ID); err == nil && rev != nil {
-						// Skip if PR hasn't been meaningfully updated since our last review.
-						// Add a 30-second grace period: GitHub bumps updated_at by ~2s when
-						// a review is submitted, which would otherwise trigger an immediate re-review.
-						if !pr.UpdatedAt.After(rev.CreatedAt.Add(30 * time.Second)) {
-							continue
-						}
-					}
+				defer cfgMu.Unlock()
+				orgs := append([]string(nil), cfg.GitHub.DiscoveryOrgs...)
+				if len(orgs) == 0 {
+					orgs = discovery.InferOrgs(cfg.GitHub.Repositories)
 				}
-				prCopy := *pr // copy to avoid loop variable capture
-				// Run each review in its own goroutine so the poll loop is not
-				// blocked by a long-running AI review (especially when local_dir
-				// is set and the CLI analyses the full repo).  The inFlight guard
-				// inside runReview prevents concurrent reviews of the same PR.
-				go runReview(&prCopy, aiCfg)
-			}
-			// Retry reviews stored locally but not yet published to GitHub
-			p.PublishPending()
-
-			// ── Issue tracking cycle ─────────────────────────────────────
-			// Check if ANY repo has issue tracking enabled (global or per-repo).
-			cfgMu.Lock()
-			globalIT := c.GitHub.IssueTracking
-			anyITEnabled := globalIT.Enabled
-			if !anyITEnabled {
-				for _, r := range c.AI.Repos {
-					if r.IssueTracking != nil && r.IssueTracking.Enabled {
-						anyITEnabled = true
-						break
-					}
+				return scheduler.Tier1Config{
+					StaticRepos:    cfg.GitHub.Repositories,
+					NonMonitored:   cfg.GitHub.NonMonitored,
+					DiscoveryTopic: cfg.GitHub.DiscoveryTopic,
+					DiscoveryOrgs:  orgs,
 				}
-			}
-			cfgMu.Unlock()
-			if anyITEnabled {
-				loginMu.Lock()
-				authUser := cachedLogin
-				loginMu.Unlock()
-				if authUser == "" {
-					if u, err := ghClient.AuthenticatedUser(); err == nil {
-						authUser = u
-						loginMu.Lock()
-						cachedLogin = u
-						loginMu.Unlock()
-					}
-				}
-
-				optsFor := func(issue *gh.Issue) issuepipeline.RunOptions {
-					cfgMu.Lock()
-					aiCfg := c.AIForRepo(issue.Repo)
-					if aiCfg.Primary == "" {
-						aiCfg.Primary = c.AI.Primary
-					}
-					agentCfg := c.AgentConfigFor(aiCfg.Primary)
-					cfgMu.Unlock()
-
-					extraFlags := agentCfg.ExtraFlags
-					if extraFlags != "" {
-						if err := executor.ValidateExtraFlags(extraFlags); err != nil {
-							slog.Warn("issue poll: extra_flags rejected", "err", err)
-							extraFlags = ""
-						}
-					}
-
-					issuePrompt, issueInstructions := resolveIssuePrompt(s, aiCfg.IssuePrompt, agentCfg.PromptID)
-					implPrompt, implInstructions := resolveImplementPrompt(s, aiCfg.ImplementPrompt, agentCfg.PromptID)
-
-					return issuepipeline.RunOptions{
-						Primary:  aiCfg.Primary,
-						Fallback: aiCfg.Fallback,
-						ExecOpts: executor.ExecOptions{
-							Model:                agentCfg.Model,
-							MaxTurns:             agentCfg.MaxTurns,
-							ApprovalMode:         agentCfg.ApprovalMode,
-							ExtraFlags:           extraFlags,
-							WorkDir:              aiCfg.LocalDir,
-							Effort:               agentCfg.Effort,
-							PermissionMode:       agentCfg.PermissionMode,
-							Bare:                 agentCfg.Bare,
-							DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
-							NoSessionPersistence: agentCfg.NoSessionPersistence,
-						},
-						IssuePromptOverride:     issuePrompt,
-						IssueInstructions:       issueInstructions,
-						ImplementPromptOverride: implPrompt,
-						ImplementInstructions:   implInstructions,
-						PRReviewers: aiCfg.PRReviewers,
-						PRAssignee:  aiCfg.PRAssignee,
-						PRLabels:    aiCfg.PRLabels,
-						PRDraft:     aiCfg.PRDraft,
-					}
-				}
-
-				// Dependency promotion pass: flip issues carrying a
-				// blocked label to the promote-to label once all their
-				// declared `## Depends on` targets have closed. Runs BEFORE
-				// the fetch so a freshly-promoted issue is picked up in the
-				// same poll cycle rather than waiting for the next one.
-				// No-op when BlockedLabels is unset, so default installs
-				// don't pay for the extra calls.
-				if len(globalIT.BlockedLabels) > 0 {
-					if n, err := issuepipeline.PromoteReady(context.Background(), ghClient, globalIT, repos, broker); err != nil {
-						slog.Error("poll: issue promotion failed", "err", err)
-					} else if n > 0 {
-						slog.Info("poll: promoted issues", "count", n)
-					}
-				}
-
-				for _, repo := range repos {
-					cfgMu.Lock()
-					repoIT := c.IssueTrackingForRepo(repo)
-					cfgMu.Unlock()
-					if !repoIT.Enabled {
-						continue
-					}
-					n, err := issueFetcher.ProcessRepo(context.Background(), repo, repoIT, authUser, optsFor)
-					if err != nil {
-						slog.Error("poll: issue fetch failed", "repo", repo, "err", err)
-						continue
-					}
-					if n > 0 {
-						slog.Info("poll: processed issues", "repo", repo, "count", n)
-					}
-				}
-			}
-		}
+			},
+			PRFetcher:      adapter,
+			PRProcessor:    adapter,
+			IssueProcessor: adapter,
+			Promoter:       adapter,
+			Store:          adapter,
+			Tier2ConfigFn: func() []string {
+				cfgMu.Lock()
+				defer cfgMu.Unlock()
+				return discovery.MergeRepos(cfg.GitHub.Repositories, discoverySvc.Discovered(), cfg.GitHub.NonMonitored)
+			},
+			ItemChecker: adapter,
+		})
 	}
 
-	startScheduler := func(c *config.Config) *scheduler.Scheduler {
-		sc := scheduler.New(parsePollInterval(c.GitHub.PollInterval), makePollFn(c))
-		sc.Start()
-		return sc
-	}
-
-	// startDiscovery spawns the discovery loop when discovery_topic is configured.
-	// It returns a cancel func for the running loop, or nil when discovery is off.
-	// Must be called with cfgMu held so the caller can swap cancel funcs atomically.
-	startDiscovery := func(c *config.Config) context.CancelFunc {
-		if c.GitHub.DiscoveryTopic == "" {
-			return nil
-		}
-		interval := parseDiscoveryInterval(c.GitHub.DiscoveryInterval)
-		ctx, cancel := context.WithCancel(context.Background())
-		topic := c.GitHub.DiscoveryTopic
-		orgs := append([]string(nil), c.GitHub.DiscoveryOrgs...)
-		if len(orgs) == 0 {
-			orgs = discovery.InferOrgs(c.GitHub.Repositories)
-		}
-		go discoverySvc.Run(ctx, interval, topic, orgs)
-		slog.Info("discovery: loop started", "topic", topic, "orgs", orgs, "interval", interval)
-		return cancel
-	}
-
-	cfgMu.Lock()
-	sched = startScheduler(cfg)
-	discoveryCancel = startDiscovery(cfg)
-	cfgMu.Unlock()
-
-	// Capture the scheduler pointer under mutex so the deferred Stop is safe
-	// even if a concurrent reload replaces sched before this goroutine exits.
-	defer func() {
-		cfgMu.Lock()
-		sc := sched
-		dc := discoveryCancel
-		cfgMu.Unlock()
-		sc.Stop()
-		if dc != nil {
-			dc()
-		}
-	}()
+	pipe := buildPipeline(cfg)
+	pipe.Start(context.Background())
+	defer pipe.Stop()
 
 	// Expose live config for GET /config
 	srv.SetRepoMetaFns(ghClient.FetchLabels, ghClient.FetchCollaborators)
@@ -557,11 +400,11 @@ func main() {
 		return login, err
 	})
 
-	// Wire the reload callback: re-read config from disk, restart scheduler
-	// and the discovery loop so changes to discovery_topic / orgs / interval
-	// take effect without a daemon restart. Reuses the `loadConfig` closure
-	// captured at startup so the two paths cannot drift on which loader
-	// they pick — both see the same HEIMDALLM_DATA_DIR snapshot.
+	// Wire the reload callback: re-read config from disk, restart the
+	// pipeline so changes to discovery_topic / orgs / intervals take effect
+	// without a daemon restart. Reuses the `loadConfig` closure captured at
+	// startup so the two paths cannot drift on which loader they pick — both
+	// see the same HEIMDALLM_DATA_DIR snapshot.
 	srv.SetReloadFn(func() error {
 		newCfg, err := loadConfig(cfgPath)
 		if err != nil {
@@ -575,31 +418,17 @@ func main() {
 			return fmt.Errorf("reload: %w", err)
 		}
 
-		cfgMu.Lock()
-		oldSched := sched
-		oldDiscoveryCancel := discoveryCancel
-		cfgMu.Unlock()
-
-		// Stop the old discovery loop BEFORE starting the new one. The Search
-		// API rate limit (30 req/min) is tight enough that running two loops
-		// in parallel — even briefly during reload — risks throttling the
-		// daemon.
-		if oldDiscoveryCancel != nil {
-			oldDiscoveryCancel()
-		}
+		// Stop the old pipeline before starting a new one. The Search API
+		// rate limit (30 req/min) is tight enough that running two loops in
+		// parallel — even briefly during reload — risks throttling.
+		pipe.Stop()
 
 		cfgMu.Lock()
 		cfg = newCfg
-		sched = startScheduler(newCfg)
-		discoveryCancel = startDiscovery(newCfg)
 		cfgMu.Unlock()
 
-		// Scheduler overlap is pre-existing behaviour and tolerated; Stop is
-		// idempotent and safe to call outside the lock.
-		oldSched.Stop()
-
-		// Run first poll immediately with new config
-		go makePollFn(newCfg)()
+		pipe = buildPipeline(newCfg)
+		pipe.Start(context.Background())
 		return nil
 	})
 
@@ -759,9 +588,6 @@ func main() {
 		return nil
 	})
 
-	// Initial poll
-	go makePollFn(cfg)()
-
 	go func() {
 		slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
 		if err := srv.Start(cfg.Server.Port, cfg.Server.BindAddr); err != nil {
@@ -889,6 +715,226 @@ func parseDiscoveryInterval(s string) time.Duration {
 		return 15 * time.Minute
 	}
 	return d
+}
+
+func parseWatchInterval(s string) time.Duration {
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 1 * time.Minute
+	}
+	return d
+}
+
+// ── tier2Adapter bridges main.go's concrete types to Pipeline interfaces ──
+
+type tier2Adapter struct {
+	ghClient  *gh.Client
+	pipeline  *pipeline.Pipeline
+	issuePipe *issuepipeline.Pipeline
+	fetcher   *issuepipeline.Fetcher
+	store     *store.Store
+	broker    *sse.Broker
+	cfgMu     *sync.Mutex
+	cfg       **config.Config
+	loginMu   *sync.Mutex
+	login     *string
+	reviewMu  *sync.Mutex
+	inFlight  map[int64]bool
+	runReview func(pr *gh.PullRequest, aiCfg config.RepoAI)
+}
+
+// FetchPRsToReview implements scheduler.Tier2PRFetcher.
+func (a *tier2Adapter) FetchPRsToReview() ([]scheduler.Tier2PR, error) {
+	prs, err := a.ghClient.FetchPRsToReview()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]scheduler.Tier2PR, 0, len(prs))
+	for _, pr := range prs {
+		pr.ResolveRepo()
+		if pr.Repo == "" {
+			slog.Warn("adapter: skipping PR with empty repo", "pr_number", pr.Number)
+			continue
+		}
+		out = append(out, scheduler.Tier2PR{
+			ID:        pr.ID,
+			Number:    pr.Number,
+			Repo:      pr.Repo,
+			UpdatedAt: pr.UpdatedAt,
+		})
+	}
+	return out, nil
+}
+
+// ProcessPR implements scheduler.Tier2PRProcessor.
+func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) error {
+	a.cfgMu.Lock()
+	c := *a.cfg
+	aiCfg := c.AIForRepo(pr.Repo)
+	a.cfgMu.Unlock()
+
+	// Reconstruct the full gh.PullRequest from the minimal Tier2PR.
+	// FetchPRsToReview already resolved the repo and set UpdatedAt; we
+	// need at minimum ID, Number, Repo, UpdatedAt for the pipeline.
+	ghPR := &gh.PullRequest{
+		ID:        pr.ID,
+		Number:    pr.Number,
+		Repo:      pr.Repo,
+		UpdatedAt: pr.UpdatedAt,
+	}
+	a.runReview(ghPR, aiCfg)
+	return nil
+}
+
+// PublishPending implements scheduler.Tier2PRProcessor.
+func (a *tier2Adapter) PublishPending() {
+	a.pipeline.PublishPending()
+}
+
+// ProcessRepo implements scheduler.Tier2IssueProcessor.
+func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error) {
+	a.cfgMu.Lock()
+	c := *a.cfg
+	repoIT := c.IssueTrackingForRepo(repo)
+	globalIT := c.GitHub.IssueTracking
+	anyITEnabled := globalIT.Enabled
+	if !anyITEnabled {
+		for _, r := range c.AI.Repos {
+			if r.IssueTracking != nil && r.IssueTracking.Enabled {
+				anyITEnabled = true
+				break
+			}
+		}
+	}
+	a.cfgMu.Unlock()
+
+	if !anyITEnabled || !repoIT.Enabled {
+		return 0, nil
+	}
+
+	// Resolve authenticated user
+	a.loginMu.Lock()
+	authUser := *a.login
+	a.loginMu.Unlock()
+	if authUser == "" {
+		if u, err := a.ghClient.AuthenticatedUser(); err == nil {
+			authUser = u
+			a.loginMu.Lock()
+			*a.login = u
+			a.loginMu.Unlock()
+		}
+	}
+
+	optsFor := func(issue *gh.Issue) issuepipeline.RunOptions {
+		a.cfgMu.Lock()
+		c := *a.cfg
+		aiCfg := c.AIForRepo(issue.Repo)
+		if aiCfg.Primary == "" {
+			aiCfg.Primary = c.AI.Primary
+		}
+		agentCfg := c.AgentConfigFor(aiCfg.Primary)
+		a.cfgMu.Unlock()
+
+		extraFlags := agentCfg.ExtraFlags
+		if extraFlags != "" {
+			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+				slog.Warn("issue poll: extra_flags rejected", "err", err)
+				extraFlags = ""
+			}
+		}
+
+		issuePrompt, issueInstructions := resolveIssuePrompt(a.store, aiCfg.IssuePrompt, agentCfg.PromptID)
+		implPrompt, implInstructions := resolveImplementPrompt(a.store, aiCfg.ImplementPrompt, agentCfg.PromptID)
+
+		return issuepipeline.RunOptions{
+			Primary:  aiCfg.Primary,
+			Fallback: aiCfg.Fallback,
+			ExecOpts: executor.ExecOptions{
+				Model:                agentCfg.Model,
+				MaxTurns:             agentCfg.MaxTurns,
+				ApprovalMode:         agentCfg.ApprovalMode,
+				ExtraFlags:           extraFlags,
+				WorkDir:              aiCfg.LocalDir,
+				Effort:               agentCfg.Effort,
+				PermissionMode:       agentCfg.PermissionMode,
+				Bare:                 agentCfg.Bare,
+				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
+				NoSessionPersistence: agentCfg.NoSessionPersistence,
+			},
+			IssuePromptOverride:     issuePrompt,
+			IssueInstructions:       issueInstructions,
+			ImplementPromptOverride: implPrompt,
+			ImplementInstructions:   implInstructions,
+			PRReviewers:             aiCfg.PRReviewers,
+			PRAssignee:              aiCfg.PRAssignee,
+			PRLabels:                aiCfg.PRLabels,
+			PRDraft:                 aiCfg.PRDraft,
+		}
+	}
+
+	return a.fetcher.ProcessRepo(ctx, repo, repoIT, authUser, optsFor)
+}
+
+// PromoteReady implements scheduler.Tier2Promoter.
+func (a *tier2Adapter) PromoteReady(ctx context.Context, repos []string) (int, error) {
+	a.cfgMu.Lock()
+	c := *a.cfg
+	globalIT := c.GitHub.IssueTracking
+	a.cfgMu.Unlock()
+
+	if !globalIT.Enabled || len(globalIT.BlockedLabels) == 0 {
+		return 0, nil
+	}
+	return issuepipeline.PromoteReady(ctx, a.ghClient, globalIT, repos, a.broker)
+}
+
+// PRAlreadyReviewed implements scheduler.Tier2Store.
+func (a *tier2Adapter) PRAlreadyReviewed(githubID int64, updatedAt time.Time) bool {
+	existing, _ := a.store.GetPRByGithubID(githubID)
+	if existing == nil {
+		return false
+	}
+	// Skip PRs the user has dismissed
+	if existing.Dismissed {
+		return true
+	}
+	rev, err := a.store.LatestReviewForPR(existing.ID)
+	if err != nil || rev == nil {
+		return false
+	}
+	// Add a 30-second grace period: GitHub bumps updated_at by ~2s when
+	// a review is submitted, which would otherwise trigger an immediate re-review.
+	return !updatedAt.After(rev.CreatedAt.Add(30 * time.Second))
+}
+
+// CheckItem implements scheduler.Tier3ItemChecker.
+func (a *tier2Adapter) CheckItem(ctx context.Context, item *scheduler.WatchItem) (bool, error) {
+	// Use the GitHub Issues API — works for both issues and PRs.
+	issue, err := a.ghClient.GetIssue(item.Repo, item.Number)
+	if err != nil {
+		return false, err
+	}
+	changed := issue.UpdatedAt.After(item.LastSeen)
+	return changed, nil
+}
+
+// HandleChange implements scheduler.Tier3ItemChecker.
+func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchItem) error {
+	if item.Type == "pr" {
+		a.cfgMu.Lock()
+		c := *a.cfg
+		aiCfg := c.AIForRepo(item.Repo)
+		a.cfgMu.Unlock()
+
+		ghPR := &gh.PullRequest{
+			ID:     item.GithubID,
+			Number: item.Number,
+			Repo:   item.Repo,
+		}
+		a.runReview(ghPR, aiCfg)
+	}
+	// For issues, Tier 2 will pick up the change on its next cycle.
+	return nil
 }
 
 type notifyWithSSE struct {

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -64,6 +64,11 @@ type GitHubConfig struct {
 	// is enabled. Accepts any Go time.ParseDuration value.
 	DiscoveryInterval string `toml:"discovery_interval"`
 
+	// WatchInterval controls Tier 3 per-item polling — how often active
+	// items (PRs/issues with recent activity) are re-checked for state
+	// changes (label updates, new comments, merge/close). Defaults to "1m".
+	WatchInterval string `toml:"watch_interval"`
+
 	// IssueTracking turns the issue-tracking pipeline (fase-2) on and off and
 	// governs how issues are filtered and classified. The pipeline itself
 	// lives in downstream issues (#25 onward); this struct is the
@@ -462,6 +467,9 @@ func (c *Config) applyEnvOverrides() {
 	}
 	if v := os.Getenv("HEIMDALLM_DISCOVERY_INTERVAL"); v != "" {
 		c.GitHub.DiscoveryInterval = v
+	}
+	if v := os.Getenv("HEIMDALLM_WATCH_INTERVAL"); v != "" {
+		c.GitHub.WatchInterval = v
 	}
 	c.applyIssueTrackingEnv()
 	c.applyPRMetadataEnv()

--- a/daemon/internal/scheduler/pipeline.go
+++ b/daemon/internal/scheduler/pipeline.go
@@ -41,8 +41,9 @@ type Pipeline struct {
 	limiter *RateLimiter
 	queue   *WatchQueue
 
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	stopOnce sync.Once
 }
 
 // NewPipeline creates a new pipeline. Call Start to begin processing.
@@ -143,12 +144,17 @@ func (p *Pipeline) Start(parentCtx context.Context) {
 }
 
 // Stop cancels all goroutines and waits for them to finish.
+// It is idempotent — calling Stop multiple times is safe (e.g. the reload
+// path stops the old pipeline, and the deferred shutdown may also call Stop
+// if it reads a stale pointer).
 func (p *Pipeline) Stop() {
-	if p.cancel != nil {
-		p.cancel()
-	}
-	p.wg.Wait()
-	slog.Info("pipeline: stopped")
+	p.stopOnce.Do(func() {
+		if p.cancel != nil {
+			p.cancel()
+		}
+		p.wg.Wait()
+		slog.Info("pipeline: stopped")
+	})
 }
 
 // Queue returns the watch queue for external inspection/testing.

--- a/daemon/internal/scheduler/pipeline.go
+++ b/daemon/internal/scheduler/pipeline.go
@@ -1,0 +1,157 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// PipelineConfig holds the interval configuration for each tier.
+type PipelineConfig struct {
+	DiscoveryInterval time.Duration // Tier 1 (default 15m)
+	PollInterval      time.Duration // Tier 2 (default 5m)
+	WatchInterval     time.Duration // Tier 3 base (default 1m)
+	RateLimitPerHour  int           // total API budget (default 4500)
+}
+
+// PipelineDeps bundles all external dependencies the pipeline needs.
+type PipelineDeps struct {
+	// Tier 1
+	Discovery     Tier1Discovery
+	Tier1ConfigFn func() Tier1Config
+
+	// Tier 2
+	PRFetcher      Tier2PRFetcher
+	PRProcessor    Tier2PRProcessor
+	IssueProcessor Tier2IssueProcessor
+	Promoter       Tier2Promoter
+	Store          Tier2Store
+	Tier2ConfigFn  func() []string // monitored repos
+
+	// Tier 3
+	ItemChecker Tier3ItemChecker
+}
+
+// Pipeline orchestrates the 3-tier polling architecture.
+type Pipeline struct {
+	cfg  PipelineConfig
+	deps PipelineDeps
+
+	limiter *RateLimiter
+	queue   *WatchQueue
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewPipeline creates a new pipeline. Call Start to begin processing.
+func NewPipeline(cfg PipelineConfig, deps PipelineDeps) *Pipeline {
+	if cfg.RateLimitPerHour <= 0 {
+		cfg.RateLimitPerHour = 4500
+	}
+	if cfg.DiscoveryInterval <= 0 {
+		cfg.DiscoveryInterval = 15 * time.Minute
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 5 * time.Minute
+	}
+	if cfg.WatchInterval <= 0 {
+		cfg.WatchInterval = 1 * time.Minute
+	}
+	return &Pipeline{
+		cfg:     cfg,
+		deps:    deps,
+		limiter: NewRateLimiter(cfg.RateLimitPerHour),
+		queue:   NewWatchQueue(),
+	}
+}
+
+// Start launches all 3 tiers and the rate limiter refill goroutine.
+func (p *Pipeline) Start(parentCtx context.Context) {
+	ctx, cancel := context.WithCancel(parentCtx)
+	p.cancel = cancel
+
+	reposChan := make(chan []string, 1)
+
+	// Rate limiter hourly refill
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.limiter.Refill()
+				slog.Info("pipeline: rate limiter refilled")
+			}
+		}
+	}()
+
+	// Tier 1: Discovery
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		RunTier1(ctx, Tier1Deps{
+			Discovery: p.deps.Discovery,
+			Limiter:   p.limiter,
+			ReposChan: reposChan,
+			ConfigFn:  p.deps.Tier1ConfigFn,
+			Interval:  p.cfg.DiscoveryInterval,
+		})
+	}()
+
+	// Tier 2: Per-repo
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		RunTier2(ctx, Tier2Deps{
+			Limiter:        p.limiter,
+			WatchQueue:     p.queue,
+			PRFetcher:      p.deps.PRFetcher,
+			PRProcessor:    p.deps.PRProcessor,
+			IssueProcessor: p.deps.IssueProcessor,
+			Promoter:       p.deps.Promoter,
+			Store:          p.deps.Store,
+			ConfigFn:       p.deps.Tier2ConfigFn,
+			Interval:       p.cfg.PollInterval,
+		}, reposChan)
+	}()
+
+	// Tier 3: Per-item watch
+	if p.deps.ItemChecker != nil {
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			RunTier3(ctx, Tier3Deps{
+				Limiter:  p.limiter,
+				Queue:    p.queue,
+				Checker:  p.deps.ItemChecker,
+				Interval: p.cfg.WatchInterval,
+			})
+		}()
+	}
+
+	slog.Info("pipeline: started",
+		"discovery", p.cfg.DiscoveryInterval,
+		"poll", p.cfg.PollInterval,
+		"watch", p.cfg.WatchInterval,
+		"rate_limit", p.cfg.RateLimitPerHour)
+}
+
+// Stop cancels all goroutines and waits for them to finish.
+func (p *Pipeline) Stop() {
+	if p.cancel != nil {
+		p.cancel()
+	}
+	p.wg.Wait()
+	slog.Info("pipeline: stopped")
+}
+
+// Queue returns the watch queue for external inspection/testing.
+func (p *Pipeline) Queue() *WatchQueue {
+	return p.queue
+}

--- a/daemon/internal/scheduler/queue.go
+++ b/daemon/internal/scheduler/queue.go
@@ -1,0 +1,164 @@
+package scheduler
+
+import (
+	"container/heap"
+	"sync"
+	"time"
+)
+
+const (
+	initialBackoff = 1 * time.Minute
+	maxBackoff     = 15 * time.Minute
+	evictAfter     = 1 * time.Hour
+)
+
+// WatchItem represents a PR or issue being actively watched for changes.
+type WatchItem struct {
+	Type      string        // "pr" | "issue"
+	Repo      string
+	Number    int
+	GithubID  int64
+	NextCheck time.Time
+	Backoff   time.Duration
+	LastSeen  time.Time // last detected activity
+
+	index int // heap internal
+}
+
+// WatchQueue is a thread-safe priority queue ordered by NextCheck.
+type WatchQueue struct {
+	mu    sync.Mutex
+	items watchHeap
+	seen  map[int64]bool // dedup by GithubID
+}
+
+func NewWatchQueue() *WatchQueue {
+	q := &WatchQueue{seen: make(map[int64]bool)}
+	heap.Init(&q.items)
+	return q
+}
+
+// Push adds an item to the queue. If the item (by GithubID) is already
+// queued, it is silently ignored (dedup).
+func (q *WatchQueue) Push(item *WatchItem) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.seen[item.GithubID] {
+		return
+	}
+	if item.Backoff == 0 {
+		item.Backoff = initialBackoff
+	}
+	if item.NextCheck.IsZero() {
+		item.NextCheck = time.Now().Add(item.Backoff)
+	}
+	if item.LastSeen.IsZero() {
+		item.LastSeen = time.Now()
+	}
+	q.seen[item.GithubID] = true
+	heap.Push(&q.items, item)
+}
+
+// PopReady returns all items whose NextCheck is at or before now.
+func (q *WatchQueue) PopReady() []*WatchItem {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	now := time.Now()
+	var ready []*WatchItem
+	for q.items.Len() > 0 {
+		peek := q.items[0]
+		if peek.NextCheck.After(now) {
+			break
+		}
+		item := heap.Pop(&q.items).(*WatchItem)
+		delete(q.seen, item.GithubID)
+		ready = append(ready, item)
+	}
+	return ready
+}
+
+// ReEnqueue puts an item back with doubled backoff (capped at maxBackoff).
+func (q *WatchQueue) ReEnqueue(item *WatchItem) {
+	item.Backoff *= 2
+	if item.Backoff > maxBackoff {
+		item.Backoff = maxBackoff
+	}
+	item.NextCheck = time.Now().Add(item.Backoff)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.seen[item.GithubID] {
+		return
+	}
+	q.seen[item.GithubID] = true
+	heap.Push(&q.items, item)
+}
+
+// ResetBackoff resets an item's backoff to initial and re-enqueues it.
+// Called when activity is detected on the item.
+func (q *WatchQueue) ResetBackoff(item *WatchItem) {
+	item.Backoff = initialBackoff
+	item.LastSeen = time.Now()
+	item.NextCheck = time.Now().Add(initialBackoff)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.seen[item.GithubID] {
+		return
+	}
+	q.seen[item.GithubID] = true
+	heap.Push(&q.items, item)
+}
+
+// Evict removes items that haven't had activity in over evictAfter.
+func (q *WatchQueue) Evict() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	cutoff := time.Now().Add(-evictAfter)
+	evicted := 0
+	var keep watchHeap
+	for _, item := range q.items {
+		if item.LastSeen.Before(cutoff) {
+			delete(q.seen, item.GithubID)
+			evicted++
+		} else {
+			keep = append(keep, item)
+		}
+	}
+	if evicted > 0 {
+		q.items = keep
+		heap.Init(&q.items)
+	}
+	return evicted
+}
+
+// Len returns the number of items in the queue.
+func (q *WatchQueue) Len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.items.Len()
+}
+
+// ── heap implementation ─────────────────────────────────────────────────
+
+type watchHeap []*WatchItem
+
+func (h watchHeap) Len() int           { return len(h) }
+func (h watchHeap) Less(i, j int) bool { return h[i].NextCheck.Before(h[j].NextCheck) }
+func (h watchHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+func (h *watchHeap) Push(x any) {
+	item := x.(*WatchItem)
+	item.index = len(*h)
+	*h = append(*h, item)
+}
+func (h *watchHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*h = old[:n-1]
+	return item
+}

--- a/daemon/internal/scheduler/queue.go
+++ b/daemon/internal/scheduler/queue.go
@@ -78,32 +78,38 @@ func (q *WatchQueue) PopReady() []*WatchItem {
 }
 
 // ReEnqueue puts an item back with doubled backoff (capped at maxBackoff).
+//
+// Concurrency contract: the caller must own the item exclusively between
+// PopReady and ReEnqueue. The queue lock protects the heap and seen map;
+// item field mutations happen inside the lock to avoid races with concurrent
+// readers (e.g. Tier 3 logging a recently popped item's fields).
 func (q *WatchQueue) ReEnqueue(item *WatchItem) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.seen[item.GithubID] {
+		return
+	}
 	item.Backoff *= 2
 	if item.Backoff > maxBackoff {
 		item.Backoff = maxBackoff
 	}
 	item.NextCheck = time.Now().Add(item.Backoff)
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if q.seen[item.GithubID] {
-		return
-	}
 	q.seen[item.GithubID] = true
 	heap.Push(&q.items, item)
 }
 
 // ResetBackoff resets an item's backoff to initial and re-enqueues it.
-// Called when activity is detected on the item.
+// Called when activity is detected on the item. Same concurrency contract
+// as ReEnqueue — caller must own the item exclusively.
 func (q *WatchQueue) ResetBackoff(item *WatchItem) {
-	item.Backoff = initialBackoff
-	item.LastSeen = time.Now()
-	item.NextCheck = time.Now().Add(initialBackoff)
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if q.seen[item.GithubID] {
 		return
 	}
+	item.Backoff = initialBackoff
+	item.LastSeen = time.Now()
+	item.NextCheck = time.Now().Add(initialBackoff)
 	q.seen[item.GithubID] = true
 	heap.Push(&q.items, item)
 }

--- a/daemon/internal/scheduler/queue_test.go
+++ b/daemon/internal/scheduler/queue_test.go
@@ -1,0 +1,108 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWatchQueue_PushAndPop(t *testing.T) {
+	q := NewWatchQueue()
+	q.Push(&WatchItem{Type: "pr", Repo: "org/a", Number: 1, GithubID: 100,
+		NextCheck: time.Now().Add(-1 * time.Second)})
+	q.Push(&WatchItem{Type: "issue", Repo: "org/a", Number: 2, GithubID: 200,
+		NextCheck: time.Now().Add(-1 * time.Second)})
+	ready := q.PopReady()
+	if len(ready) != 2 {
+		t.Fatalf("expected 2 ready, got %d", len(ready))
+	}
+	if q.Len() != 0 {
+		t.Errorf("queue should be empty after pop, got %d", q.Len())
+	}
+}
+
+func TestWatchQueue_NotYetReady(t *testing.T) {
+	q := NewWatchQueue()
+	q.Push(&WatchItem{Type: "pr", Repo: "org/a", Number: 1, GithubID: 100,
+		NextCheck: time.Now().Add(1 * time.Hour)})
+	ready := q.PopReady()
+	if len(ready) != 0 {
+		t.Errorf("expected 0 ready (future NextCheck), got %d", len(ready))
+	}
+	if q.Len() != 1 {
+		t.Errorf("item should still be in queue")
+	}
+}
+
+func TestWatchQueue_Dedup(t *testing.T) {
+	q := NewWatchQueue()
+	q.Push(&WatchItem{Type: "pr", GithubID: 100, NextCheck: time.Now()})
+	q.Push(&WatchItem{Type: "pr", GithubID: 100, NextCheck: time.Now()})
+	if q.Len() != 1 {
+		t.Errorf("dedup failed, got %d items", q.Len())
+	}
+}
+
+func TestWatchQueue_BackoffDoubles(t *testing.T) {
+	q := NewWatchQueue()
+	item := &WatchItem{Type: "pr", GithubID: 100, Backoff: 1 * time.Minute}
+	q.ReEnqueue(item)
+	if item.Backoff != 2*time.Minute {
+		t.Errorf("backoff = %v, want 2m", item.Backoff)
+	}
+	q.PopReady() // drain
+	q.ReEnqueue(item)
+	if item.Backoff != 4*time.Minute {
+		t.Errorf("backoff = %v, want 4m", item.Backoff)
+	}
+}
+
+func TestWatchQueue_BackoffCapped(t *testing.T) {
+	q := NewWatchQueue()
+	item := &WatchItem{Type: "pr", GithubID: 100, Backoff: 10 * time.Minute}
+	q.ReEnqueue(item)
+	if item.Backoff != maxBackoff {
+		t.Errorf("backoff = %v, want %v (cap)", item.Backoff, maxBackoff)
+	}
+}
+
+func TestWatchQueue_ResetBackoff(t *testing.T) {
+	q := NewWatchQueue()
+	item := &WatchItem{Type: "pr", GithubID: 100, Backoff: 8 * time.Minute}
+	q.ResetBackoff(item)
+	if item.Backoff != initialBackoff {
+		t.Errorf("backoff = %v, want %v", item.Backoff, initialBackoff)
+	}
+}
+
+func TestWatchQueue_Evict(t *testing.T) {
+	q := NewWatchQueue()
+	q.Push(&WatchItem{Type: "pr", GithubID: 100,
+		NextCheck: time.Now().Add(1 * time.Hour),
+		LastSeen:  time.Now().Add(-2 * time.Hour)}) // stale
+	q.Push(&WatchItem{Type: "pr", GithubID: 200,
+		NextCheck: time.Now().Add(1 * time.Hour),
+		LastSeen:  time.Now()}) // fresh
+	evicted := q.Evict()
+	if evicted != 1 {
+		t.Errorf("evicted = %d, want 1", evicted)
+	}
+	if q.Len() != 1 {
+		t.Errorf("queue len = %d, want 1", q.Len())
+	}
+}
+
+func TestWatchQueue_PopOrderedByNextCheck(t *testing.T) {
+	q := NewWatchQueue()
+	now := time.Now()
+	q.Push(&WatchItem{Type: "pr", GithubID: 100, NextCheck: now.Add(-2 * time.Second)})
+	q.Push(&WatchItem{Type: "pr", GithubID: 200, NextCheck: now.Add(-5 * time.Second)})
+	q.Push(&WatchItem{Type: "pr", GithubID: 300, NextCheck: now.Add(-1 * time.Second)})
+	ready := q.PopReady()
+	if len(ready) != 3 {
+		t.Fatalf("expected 3 ready, got %d", len(ready))
+	}
+	// Should be ordered: 200 (earliest), 100, 300
+	if ready[0].GithubID != 200 {
+		t.Errorf("first = %d, want 200 (earliest NextCheck)", ready[0].GithubID)
+	}
+}

--- a/daemon/internal/scheduler/queue_test.go
+++ b/daemon/internal/scheduler/queue_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"container/heap"
 	"testing"
 	"time"
 )
@@ -44,15 +45,44 @@ func TestWatchQueue_Dedup(t *testing.T) {
 
 func TestWatchQueue_BackoffDoubles(t *testing.T) {
 	q := NewWatchQueue()
-	item := &WatchItem{Type: "pr", GithubID: 100, Backoff: 1 * time.Minute}
+	// Use a past NextCheck so PopReady actually drains the item, clearing
+	// the seen map entry and allowing the subsequent ReEnqueue to succeed.
+	item := &WatchItem{
+		Type:      "pr",
+		GithubID:  100,
+		Backoff:   1 * time.Minute,
+		NextCheck: time.Now().Add(-1 * time.Second),
+	}
+	q.Push(item)
+
+	// Pop the item — removes it from seen map
+	ready := q.PopReady()
+	if len(ready) != 1 {
+		t.Fatalf("expected 1 ready item, got %d", len(ready))
+	}
+
+	// Re-enqueue: backoff doubles from 1m → 2m
 	q.ReEnqueue(item)
 	if item.Backoff != 2*time.Minute {
-		t.Errorf("backoff = %v, want 2m", item.Backoff)
+		t.Errorf("after first ReEnqueue: backoff = %v, want 2m", item.Backoff)
 	}
-	q.PopReady() // drain
+	if q.Len() != 1 {
+		t.Errorf("item should be back in queue, got len %d", q.Len())
+	}
+
+	// Pop again and re-enqueue: backoff doubles from 2m → 4m
+	// Item's NextCheck is in the future (now+2m), so set it to the past.
+	item.NextCheck = time.Now().Add(-1 * time.Second)
+	q.mu.Lock()
+	heap.Fix(&q.items, item.index)
+	q.mu.Unlock()
+	ready = q.PopReady()
+	if len(ready) != 1 {
+		t.Fatalf("expected 1 ready item on second pop, got %d", len(ready))
+	}
 	q.ReEnqueue(item)
 	if item.Backoff != 4*time.Minute {
-		t.Errorf("backoff = %v, want 4m", item.Backoff)
+		t.Errorf("after second ReEnqueue: backoff = %v, want 4m", item.Backoff)
 	}
 }
 

--- a/daemon/internal/scheduler/ratelimit.go
+++ b/daemon/internal/scheduler/ratelimit.go
@@ -1,0 +1,76 @@
+package scheduler
+
+import (
+	"context"
+	"time"
+)
+
+// Tier identifies which polling tier is requesting API access.
+type Tier int
+
+const (
+	TierDiscovery Tier = iota // Tier 1: slow, lowest priority
+	TierRepo                  // Tier 2: medium
+	TierWatch                 // Tier 3: fast, highest priority
+)
+
+// tierWait is how long each tier will wait for a token before giving up.
+var tierWait = map[Tier]time.Duration{
+	TierDiscovery: 500 * time.Millisecond,
+	TierRepo:      200 * time.Millisecond,
+	TierWatch:     50 * time.Millisecond,
+}
+
+// RateLimiter is a shared token pool that governs GitHub API usage across
+// all polling tiers. Higher-priority tiers (Watch) get shorter initial wait
+// times, meaning they acquire tokens faster when the pool is under pressure.
+type RateLimiter struct {
+	pool chan struct{}
+	size int
+}
+
+// NewRateLimiter creates a rate limiter with the given number of tokens.
+func NewRateLimiter(tokens int) *RateLimiter {
+	pool := make(chan struct{}, tokens)
+	for i := 0; i < tokens; i++ {
+		pool <- struct{}{}
+	}
+	return &RateLimiter{pool: pool, size: tokens}
+}
+
+// Acquire blocks until a token is available or the context is done.
+func (r *RateLimiter) Acquire(ctx context.Context, tier Tier) error {
+	wait := tierWait[tier]
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-r.pool:
+		return nil
+	case <-timer.C:
+		select {
+		case <-r.pool:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Refill restores the token pool to its original capacity.
+func (r *RateLimiter) Refill() {
+	for {
+		select {
+		case r.pool <- struct{}{}:
+		default:
+			return
+		}
+	}
+}
+
+// Available returns the number of tokens currently in the pool.
+func (r *RateLimiter) Available() int {
+	return len(r.pool)
+}

--- a/daemon/internal/scheduler/ratelimit_test.go
+++ b/daemon/internal/scheduler/ratelimit_test.go
@@ -1,0 +1,59 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_AcquireWithinBudget(t *testing.T) {
+	rl := NewRateLimiter(100)
+	ctx := context.Background()
+	for i := 0; i < 50; i++ {
+		if err := rl.Acquire(ctx, TierRepo); err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+	}
+	if rl.Available() != 50 {
+		t.Errorf("available = %d, want 50", rl.Available())
+	}
+}
+
+func TestRateLimiter_PriorityOrdering(t *testing.T) {
+	rl := NewRateLimiter(1)
+	ctx := context.Background()
+	// Drain the single token
+	if err := rl.Acquire(ctx, TierWatch); err != nil {
+		t.Fatal(err)
+	}
+	// T1 (low priority) should timeout
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel2()
+	if err := rl.Acquire(ctx2, TierDiscovery); err == nil {
+		t.Error("expected timeout for low-priority tier with empty pool")
+	}
+}
+
+func TestRateLimiter_ContextCancellation(t *testing.T) {
+	rl := NewRateLimiter(0)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := rl.Acquire(ctx, TierWatch); err == nil {
+		t.Error("expected error on cancelled context")
+	}
+}
+
+func TestRateLimiter_Refill(t *testing.T) {
+	rl := NewRateLimiter(10)
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		rl.Acquire(ctx, TierRepo)
+	}
+	if rl.Available() != 0 {
+		t.Errorf("should be empty, got %d", rl.Available())
+	}
+	rl.Refill()
+	if rl.Available() != 10 {
+		t.Errorf("after refill = %d, want 10", rl.Available())
+	}
+}

--- a/daemon/internal/scheduler/tier1.go
+++ b/daemon/internal/scheduler/tier1.go
@@ -1,0 +1,90 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// Tier1Discovery is the interface the discovery tier needs.
+type Tier1Discovery interface {
+	Discovered() []string
+}
+
+// Tier1Config provides the repo lists for merging.
+type Tier1Config struct {
+	StaticRepos    []string
+	NonMonitored   []string
+	DiscoveryTopic string
+	DiscoveryOrgs  []string
+}
+
+// Tier1Deps holds all dependencies for the discovery tier.
+type Tier1Deps struct {
+	Discovery Tier1Discovery
+	Limiter   *RateLimiter
+	ReposChan chan<- []string
+	ConfigFn  func() Tier1Config
+	Interval  time.Duration
+}
+
+// RunTier1 runs the discovery tier. It periodically merges static repos
+// with discovered repos and sends the full list to reposChan.
+func RunTier1(ctx context.Context, deps Tier1Deps) {
+	// Send initial repos immediately
+	sendRepos(ctx, deps)
+
+	ticker := time.NewTicker(deps.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := deps.Limiter.Acquire(ctx, TierDiscovery); err != nil {
+				return
+			}
+			sendRepos(ctx, deps)
+		}
+	}
+}
+
+func sendRepos(ctx context.Context, deps Tier1Deps) {
+	cfg := deps.ConfigFn()
+	discovered := deps.Discovery.Discovered()
+
+	// Merge static + discovered, exclude non-monitored
+	nonMon := make(map[string]struct{}, len(cfg.NonMonitored))
+	for _, r := range cfg.NonMonitored {
+		nonMon[r] = struct{}{}
+	}
+	seen := make(map[string]struct{})
+	var repos []string
+	for _, r := range cfg.StaticRepos {
+		if _, skip := nonMon[r]; skip {
+			continue
+		}
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		seen[r] = struct{}{}
+		repos = append(repos, r)
+	}
+	for _, r := range discovered {
+		if _, skip := nonMon[r]; skip {
+			continue
+		}
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		seen[r] = struct{}{}
+		repos = append(repos, r)
+	}
+
+	slog.Info("tier1: discovery complete", "repos", len(repos))
+	select {
+	case deps.ReposChan <- repos:
+	case <-ctx.Done():
+	}
+}

--- a/daemon/internal/scheduler/tier2.go
+++ b/daemon/internal/scheduler/tier2.go
@@ -12,11 +12,18 @@ type Tier2PRFetcher interface {
 	FetchPRsToReview() ([]Tier2PR, error)
 }
 
-// Tier2PR is a minimal PR representation for Tier 2.
+// Tier2PR carries the PR fields that the review pipeline needs.
+// FetchPRsToReview already fetches these from the GitHub Search API;
+// passing them through avoids a per-PR re-fetch and prevents silent
+// zero-value bugs in the pipeline's UpsertPR call.
 type Tier2PR struct {
 	ID        int64
 	Number    int
 	Repo      string
+	Title     string
+	HTMLURL   string
+	Author    string
+	State     string
 	UpdatedAt time.Time
 }
 

--- a/daemon/internal/scheduler/tier2.go
+++ b/daemon/internal/scheduler/tier2.go
@@ -1,0 +1,172 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Tier2PRFetcher fetches PRs for review.
+type Tier2PRFetcher interface {
+	FetchPRsToReview() ([]Tier2PR, error)
+}
+
+// Tier2PR is a minimal PR representation for Tier 2.
+type Tier2PR struct {
+	ID        int64
+	Number    int
+	Repo      string
+	UpdatedAt time.Time
+}
+
+// Tier2PRProcessor runs the PR review pipeline on a single PR.
+type Tier2PRProcessor interface {
+	ProcessPR(ctx context.Context, pr Tier2PR) error
+	PublishPending()
+}
+
+// Tier2IssueProcessor processes issues for a single repo.
+type Tier2IssueProcessor interface {
+	ProcessRepo(ctx context.Context, repo string) (int, error)
+}
+
+// Tier2Promoter runs the issue promotion pass.
+type Tier2Promoter interface {
+	PromoteReady(ctx context.Context, repos []string) (int, error)
+}
+
+// Tier2Store checks if a PR has already been reviewed recently.
+type Tier2Store interface {
+	PRAlreadyReviewed(githubID int64, updatedAt time.Time) bool
+}
+
+// Tier2Deps holds all dependencies for the per-repo tier.
+type Tier2Deps struct {
+	Limiter        *RateLimiter
+	WatchQueue     *WatchQueue
+	PRFetcher      Tier2PRFetcher
+	PRProcessor    Tier2PRProcessor
+	IssueProcessor Tier2IssueProcessor
+	Promoter       Tier2Promoter
+	Store          Tier2Store
+	ConfigFn       func() []string // returns monitored repos for PR filtering
+	Interval       time.Duration
+}
+
+// RunTier2 runs the per-repo processing tier. It consumes repos from
+// reposChan and runs PR + issue processing on each repo per tick.
+func RunTier2(ctx context.Context, deps Tier2Deps, reposChan <-chan []string) {
+	var (
+		mu    sync.Mutex
+		repos []string
+	)
+
+	// Goroutine to receive repo updates from Tier 1
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case r := <-reposChan:
+				mu.Lock()
+				repos = r
+				mu.Unlock()
+				slog.Info("tier2: received repo list", "count", len(r))
+			}
+		}
+	}()
+
+	// Brief delay for Tier 1 to send first batch
+	select {
+	case <-time.After(2 * time.Second):
+	case <-ctx.Done():
+		return
+	}
+
+	ticker := time.NewTicker(deps.Interval)
+	defer ticker.Stop()
+
+	processTick := func() {
+		mu.Lock()
+		currentRepos := append([]string(nil), repos...)
+		mu.Unlock()
+
+		if len(currentRepos) == 0 {
+			return
+		}
+
+		// PR processing
+		if err := deps.Limiter.Acquire(ctx, TierRepo); err != nil {
+			return
+		}
+		prs, err := deps.PRFetcher.FetchPRsToReview()
+		if err != nil {
+			slog.Error("tier2: fetch PRs", "err", err)
+		} else {
+			monitoredSet := make(map[string]struct{}, len(currentRepos))
+			for _, r := range currentRepos {
+				monitoredSet[r] = struct{}{}
+			}
+			for _, pr := range prs {
+				if _, ok := monitoredSet[pr.Repo]; !ok {
+					continue
+				}
+				if deps.Store.PRAlreadyReviewed(pr.ID, pr.UpdatedAt) {
+					continue
+				}
+				go func(p Tier2PR) {
+					if err := deps.PRProcessor.ProcessPR(ctx, p); err != nil {
+						slog.Error("tier2: PR pipeline", "repo", p.Repo, "pr", p.Number, "err", err)
+					}
+					// Enqueue to Tier 3 watch
+					deps.WatchQueue.Push(&WatchItem{
+						Type: "pr", Repo: p.Repo, Number: p.Number, GithubID: p.ID,
+					})
+				}(pr)
+			}
+		}
+
+		// Issue promotion
+		if deps.Promoter != nil {
+			if err := deps.Limiter.Acquire(ctx, TierRepo); err != nil {
+				return
+			}
+			if n, err := deps.Promoter.PromoteReady(ctx, currentRepos); err != nil {
+				slog.Error("tier2: promotion", "err", err)
+			} else if n > 0 {
+				slog.Info("tier2: promoted issues", "count", n)
+			}
+		}
+
+		// Issue processing per repo
+		for _, repo := range currentRepos {
+			if err := deps.Limiter.Acquire(ctx, TierRepo); err != nil {
+				return
+			}
+			n, err := deps.IssueProcessor.ProcessRepo(ctx, repo)
+			if err != nil {
+				slog.Error("tier2: issue processing", "repo", repo, "err", err)
+				continue
+			}
+			if n > 0 {
+				slog.Info("tier2: processed issues", "repo", repo, "count", n)
+			}
+		}
+
+		// Retry pending publishes
+		deps.PRProcessor.PublishPending()
+	}
+
+	// Run immediately
+	processTick()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			processTick()
+		}
+	}
+}

--- a/daemon/internal/scheduler/tier3.go
+++ b/daemon/internal/scheduler/tier3.go
@@ -1,0 +1,76 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// Tier3ItemChecker checks a single item for state changes.
+type Tier3ItemChecker interface {
+	// CheckItem returns true if the item has changed since LastSeen.
+	CheckItem(ctx context.Context, item *WatchItem) (changed bool, err error)
+	// HandleChange processes a detected change (re-review, re-triage, etc).
+	HandleChange(ctx context.Context, item *WatchItem) error
+}
+
+// Tier3Deps holds all dependencies for the per-item watch tier.
+type Tier3Deps struct {
+	Limiter  *RateLimiter
+	Queue    *WatchQueue
+	Checker  Tier3ItemChecker
+	Interval time.Duration
+}
+
+// RunTier3 runs the per-item watch tier. It pops ready items from the
+// queue, checks them for changes, and re-enqueues with backoff.
+func RunTier3(ctx context.Context, deps Tier3Deps) {
+	ticker := time.NewTicker(deps.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Evict stale items first
+			if evicted := deps.Queue.Evict(); evicted > 0 {
+				slog.Debug("tier3: evicted stale items", "count", evicted)
+			}
+
+			// Pop all ready items
+			ready := deps.Queue.PopReady()
+			if len(ready) == 0 {
+				continue
+			}
+
+			slog.Debug("tier3: checking items", "count", len(ready))
+			for _, item := range ready {
+				if err := deps.Limiter.Acquire(ctx, TierWatch); err != nil {
+					// Context cancelled — re-enqueue and exit
+					deps.Queue.ReEnqueue(item)
+					return
+				}
+
+				changed, err := deps.Checker.CheckItem(ctx, item)
+				if err != nil {
+					slog.Warn("tier3: check failed", "type", item.Type,
+						"repo", item.Repo, "number", item.Number, "err", err)
+					deps.Queue.ReEnqueue(item)
+					continue
+				}
+
+				if changed {
+					slog.Info("tier3: change detected",
+						"type", item.Type, "repo", item.Repo, "number", item.Number)
+					if err := deps.Checker.HandleChange(ctx, item); err != nil {
+						slog.Error("tier3: handle change", "err", err)
+					}
+					deps.Queue.ResetBackoff(item)
+				} else {
+					deps.Queue.ReEnqueue(item)
+				}
+			}
+		}
+	}
+}

--- a/docs/superpowers/plans/2026-04-20-multi-tier-polling.md
+++ b/docs/superpowers/plans/2026-04-20-multi-tier-polling.md
@@ -1,0 +1,480 @@
+# Multi-Tier Polling Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the monolithic poll cycle with a 3-tier pipeline: discovery → per-repo → per-item watch, with priority queue and shared rate limiter.
+
+**Architecture:** Three goroutines connected via channels. Tier 1 discovers repos. Tier 2 processes repos (PRs + issues). Tier 3 watches active items with exponential backoff. A shared rate limiter with priority (T3>T2>T1) governs API usage. All in `daemon/internal/scheduler/`.
+
+**Tech Stack:** Go 1.21, channels, sync/atomic, container/heap
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `daemon/internal/scheduler/ratelimit.go` | **Create** — Shared token bucket with tier priorities |
+| `daemon/internal/scheduler/ratelimit_test.go` | **Create** — Tests |
+| `daemon/internal/scheduler/queue.go` | **Create** — Priority queue with exponential backoff |
+| `daemon/internal/scheduler/queue_test.go` | **Create** — Tests |
+| `daemon/internal/scheduler/pipeline.go` | **Create** — Orchestrator, wires tiers |
+| `daemon/internal/scheduler/tier1.go` | **Create** — Discovery tier |
+| `daemon/internal/scheduler/tier2.go` | **Create** — Per-repo processing tier |
+| `daemon/internal/scheduler/tier3.go` | **Create** — Per-item watch tier |
+| `daemon/internal/scheduler/pipeline_test.go` | **Create** — Integration test |
+| `daemon/internal/config/config.go` | **Modify** — Add WatchInterval |
+| `daemon/cmd/heimdallm/main.go` | **Modify** — Replace makePollFn with Pipeline |
+
+---
+
+### Task 1: Rate Limiter
+
+**Files:**
+- Create: `daemon/internal/scheduler/ratelimit.go`
+- Create: `daemon/internal/scheduler/ratelimit_test.go`
+
+- [ ] **Step 1: Write tests**
+
+```go
+package scheduler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_AcquireWithinBudget(t *testing.T) {
+	rl := NewRateLimiter(100) // 100 tokens
+	ctx := context.Background()
+	for i := 0; i < 50; i++ {
+		if err := rl.Acquire(ctx, TierRepo); err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+	}
+}
+
+func TestRateLimiter_PriorityOrdering(t *testing.T) {
+	// Pool of 1 token — T3 should get it before T1
+	rl := NewRateLimiter(1)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Drain the single token
+	rl.Acquire(ctx, TierWatch)
+
+	// Now T1 should fail (no tokens, low priority)
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel2()
+	if err := rl.Acquire(ctx2, TierDiscovery); err == nil {
+		t.Error("expected timeout for low-priority tier with empty pool")
+	}
+}
+
+func TestRateLimiter_ContextCancellation(t *testing.T) {
+	rl := NewRateLimiter(0) // no tokens
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := rl.Acquire(ctx, TierWatch); err == nil {
+		t.Error("expected error on cancelled context")
+	}
+}
+
+func TestRateLimiter_Refill(t *testing.T) {
+	rl := NewRateLimiter(10)
+	ctx := context.Background()
+	// Drain all
+	for i := 0; i < 10; i++ {
+		rl.Acquire(ctx, TierRepo)
+	}
+	// Refill
+	rl.Refill()
+	// Should work again
+	if err := rl.Acquire(ctx, TierRepo); err != nil {
+		t.Fatalf("acquire after refill: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Implement rate limiter**
+
+```go
+package scheduler
+
+import (
+	"context"
+	"time"
+)
+
+// Tier identifies which polling tier is requesting API access.
+type Tier int
+
+const (
+	TierDiscovery Tier = iota // Tier 1: slow, lowest priority
+	TierRepo                  // Tier 2: medium
+	TierWatch                 // Tier 3: fast, highest priority
+)
+
+// tierWait is how long each tier will wait for a token before giving up.
+var tierWait = map[Tier]time.Duration{
+	TierDiscovery: 500 * time.Millisecond,
+	TierRepo:      200 * time.Millisecond,
+	TierWatch:     50 * time.Millisecond,
+}
+
+// RateLimiter is a shared token pool that governs GitHub API usage across
+// all polling tiers. Higher-priority tiers (Watch) get shorter wait times,
+// meaning they acquire tokens faster when the pool is under pressure.
+type RateLimiter struct {
+	pool chan struct{}
+	size int
+}
+
+// NewRateLimiter creates a rate limiter with the given number of tokens.
+// Tokens represent API calls available in the current refill window.
+func NewRateLimiter(tokens int) *RateLimiter {
+	pool := make(chan struct{}, tokens)
+	for i := 0; i < tokens; i++ {
+		pool <- struct{}{}
+	}
+	return &RateLimiter{pool: pool, size: tokens}
+}
+
+// Acquire blocks until a token is available or the context is done.
+// Lower-priority tiers have longer wait timeouts before they give up,
+// effectively yielding to higher-priority tiers under pressure.
+func (r *RateLimiter) Acquire(ctx context.Context, tier Tier) error {
+	wait := tierWait[tier]
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-r.pool:
+		return nil
+	case <-timer.C:
+		// Tier-specific timeout — try once more with context deadline
+		select {
+		case <-r.pool:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Refill restores the token pool to its original capacity.
+// Called periodically (e.g. every hour) by the pipeline.
+func (r *RateLimiter) Refill() {
+	for {
+		select {
+		case r.pool <- struct{}{}:
+		default:
+			return // pool full
+		}
+	}
+}
+
+// Available returns the number of tokens currently in the pool.
+func (r *RateLimiter) Available() int {
+	return len(r.pool)
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd daemon && go test ./internal/scheduler/ -run "TestRateLimiter" -v -timeout 30s`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add daemon/internal/scheduler/ratelimit.go daemon/internal/scheduler/ratelimit_test.go
+git commit -m "feat(scheduler): add shared rate limiter with tier priorities"
+```
+
+---
+
+### Task 2: Priority Queue
+
+**Files:**
+- Create: `daemon/internal/scheduler/queue.go`
+- Create: `daemon/internal/scheduler/queue_test.go`
+
+- [ ] **Step 1: Write tests**
+
+Tests for: enqueue, dequeue by priority + NextCheck, backoff doubling, cap at 15m, eviction after 1h inactivity, reset backoff on activity.
+
+- [ ] **Step 2: Implement priority queue**
+
+Uses `container/heap`. `WatchItem` struct with Type, Repo, Number, GithubID, Priority, NextCheck, Backoff, LastSeen. Methods: `Push(item)`, `Pop() *WatchItem` (returns item with earliest NextCheck that's past due), `ReEnqueue(item)` (doubles backoff, updates NextCheck), `ResetBackoff(item)`, `Evict()` (removes items inactive >1h), `Len()`.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd daemon && go test ./internal/scheduler/ -run "TestQueue" -v -timeout 30s`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add daemon/internal/scheduler/queue.go daemon/internal/scheduler/queue_test.go
+git commit -m "feat(scheduler): add priority queue with exponential backoff"
+```
+
+---
+
+### Task 3: Tier 1 — Discovery
+
+**Files:**
+- Create: `daemon/internal/scheduler/tier1.go`
+
+- [ ] **Step 1: Implement Tier 1**
+
+Tier 1 runs on a ticker (discovery_interval). Each tick:
+1. Acquires rate limit token (TierDiscovery)
+2. Runs topic-based discovery (existing discoverySvc logic)
+3. Sends discovered repos list to `reposChan`
+
+Interface-driven: takes `DiscoveryService` interface + `RateLimiter` + `reposChan chan<- []string`. Runs in a goroutine, stops on context cancellation.
+
+```go
+type DiscoveryDeps struct {
+    Discovery interface {
+        Discovered() []string
+    }
+    Limiter   *RateLimiter
+    ReposChan chan<- []string
+    ConfigFn  func() (repos []string, nonMonitored []string, topic string, orgs []string)
+    Interval  time.Duration
+}
+
+func RunTier1(ctx context.Context, deps DiscoveryDeps)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add daemon/internal/scheduler/tier1.go
+git commit -m "feat(scheduler): add Tier 1 discovery goroutine"
+```
+
+---
+
+### Task 4: Tier 2 — Per-Repo Processing
+
+**Files:**
+- Create: `daemon/internal/scheduler/tier2.go`
+
+- [ ] **Step 1: Implement Tier 2**
+
+Tier 2 runs on a ticker (poll_interval). Each tick:
+1. Merges repos from Tier 1 channel + static config
+2. For each repo (rate limited, TierRepo):
+   a. Fetch PRs to review → run PR pipeline → enqueue active PRs to Tier 3
+   b. Issue promotion pass
+   c. Fetch issues → classify → run pipeline → enqueue active issues to Tier 3
+3. Retry pending publishes
+
+Takes interfaces for all dependencies. The core logic is extracted from the current `makePollFn` in main.go — same dedup, same grace window, same in-flight guard.
+
+```go
+type Tier2Deps struct {
+    Limiter       *RateLimiter
+    WatchQueue    *WatchQueue
+    GHClient      interface{ ... }  // FetchPRsToReview, FetchIssues, etc.
+    PRPipeline    interface{ Run(...); PublishPending() }
+    IssueFetcher  interface{ ProcessRepo(...) }
+    Store         interface{ ... }
+    Broker        interface{ Publish(sse.Event) }
+    ConfigFn      func() *config.Config
+    Interval      time.Duration
+}
+
+func RunTier2(ctx context.Context, deps Tier2Deps, reposChan <-chan []string)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add daemon/internal/scheduler/tier2.go
+git commit -m "feat(scheduler): add Tier 2 per-repo processing goroutine"
+```
+
+---
+
+### Task 5: Tier 3 — Per-Item Watch
+
+**Files:**
+- Create: `daemon/internal/scheduler/tier3.go`
+
+- [ ] **Step 1: Implement Tier 3**
+
+Tier 3 runs on a tight ticker (watch_interval, default 1m). Each tick:
+1. Evict stale items from queue (>1h inactive)
+2. Pop all items whose NextCheck is past due
+3. For each item (rate limited, TierWatch):
+   a. Fetch current state from GitHub (single API call per item)
+   b. Compare with stored state (updated_at, labels, state, comment count)
+   c. If changed: reset backoff, trigger appropriate action (re-review, re-triage, re-classify)
+   d. If unchanged: re-enqueue with doubled backoff
+4. Publish SSE events for state changes
+
+```go
+type Tier3Deps struct {
+    Limiter    *RateLimiter
+    Queue      *WatchQueue
+    GHClient   interface{ ... }
+    Store      interface{ ... }
+    Broker     interface{ Publish(sse.Event) }
+    ConfigFn   func() *config.Config
+    Interval   time.Duration
+}
+
+func RunTier3(ctx context.Context, deps Tier3Deps)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add daemon/internal/scheduler/tier3.go
+git commit -m "feat(scheduler): add Tier 3 per-item watch with backoff"
+```
+
+---
+
+### Task 6: Pipeline Orchestrator
+
+**Files:**
+- Create: `daemon/internal/scheduler/pipeline.go`
+- Create: `daemon/internal/scheduler/pipeline_test.go`
+
+- [ ] **Step 1: Implement Pipeline**
+
+```go
+type PipelineConfig struct {
+    DiscoveryInterval time.Duration
+    PollInterval      time.Duration
+    WatchInterval     time.Duration
+    RateLimitPerHour  int // default 4500
+}
+
+type PipelineDeps struct {
+    GHClient      ...
+    Store         ...
+    PRPipeline    ...
+    IssuePipeline ...
+    IssueFetcher  ...
+    Discovery     ...
+    Broker        ...
+    ConfigFn      func() *config.Config
+}
+
+type Pipeline struct { ... }
+
+func NewPipeline(cfg PipelineConfig, deps PipelineDeps) *Pipeline
+func (p *Pipeline) Start(ctx context.Context)
+func (p *Pipeline) Stop()
+```
+
+Start spawns: Tier 1 goroutine, Tier 2 goroutine, Tier 3 goroutine, rate limiter refill ticker (hourly). Stop cancels the context and waits for all goroutines to finish.
+
+- [ ] **Step 2: Write integration test with fakes**
+
+Test: start pipeline with fake deps, verify Tier 1 sends repos, Tier 2 processes them, items appear in Tier 3 queue.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add daemon/internal/scheduler/pipeline.go daemon/internal/scheduler/pipeline_test.go
+git commit -m "feat(scheduler): add Pipeline orchestrator wiring 3 tiers"
+```
+
+---
+
+### Task 7: Config — add WatchInterval
+
+**Files:**
+- Modify: `daemon/internal/config/config.go`
+
+- [ ] **Step 1: Add WatchInterval field**
+
+Add to `GitHubConfig`:
+```go
+WatchInterval string `toml:"watch_interval"`
+```
+
+Add env var in `applyEnvOverrides`:
+```go
+if v := os.Getenv("HEIMDALLM_WATCH_INTERVAL"); v != "" {
+    c.GitHub.WatchInterval = v
+}
+```
+
+Add `parseWatchInterval` helper (default 1m).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add daemon/internal/config/config.go
+git commit -m "feat(config): add watch_interval for Tier 3 polling"
+```
+
+---
+
+### Task 8: main.go — Replace makePollFn with Pipeline
+
+**Files:**
+- Modify: `daemon/cmd/heimdallm/main.go`
+
+- [ ] **Step 1: Replace the monolithic poll cycle**
+
+Remove `makePollFn`, `startScheduler`, the manual discovery loop management. Replace with:
+
+```go
+pipe := scheduler.NewPipeline(scheduler.PipelineConfig{
+    DiscoveryInterval: parseDiscoveryInterval(cfg.GitHub.DiscoveryInterval),
+    PollInterval:      parsePollInterval(cfg.GitHub.PollInterval),
+    WatchInterval:     parseWatchInterval(cfg.GitHub.WatchInterval),
+    RateLimitPerHour:  4500,
+}, scheduler.PipelineDeps{
+    GHClient:      ghClient,
+    Store:         s,
+    PRPipeline:    p,
+    IssuePipeline: issuePipe,
+    IssueFetcher:  issueFetcher,
+    Discovery:     discoverySvc,
+    Broker:        broker,
+    ConfigFn:      func() *config.Config { cfgMu.Lock(); defer cfgMu.Unlock(); return cfg },
+})
+
+ctx, cancel := context.WithCancel(context.Background())
+pipe.Start(ctx)
+defer func() { cancel(); pipe.Stop() }()
+```
+
+Update reload callback to stop + restart the pipeline with new config.
+
+- [ ] **Step 2: Verify daemon builds**
+
+Run: `cd daemon && go build -o bin/heimdallm ./cmd/heimdallm`
+
+- [ ] **Step 3: Run full tests**
+
+Run: `cd /path/to/project && make test-docker`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add daemon/cmd/heimdallm/main.go
+git commit -m "feat: replace monolithic poll cycle with multi-tier pipeline (#107)"
+```
+
+---
+
+### Task 9: Full Verification
+
+- [ ] **Step 1: `make test-docker`** — all packages pass
+- [ ] **Step 2: `go build`** — binary builds
+- [ ] **Step 3: `flutter analyze`** — no issues (no Flutter changes, but verify)
+- [ ] **Step 4: Manual test** — start daemon, verify logs show 3 tiers running

--- a/docs/superpowers/specs/2026-04-20-multi-tier-polling-design.md
+++ b/docs/superpowers/specs/2026-04-20-multi-tier-polling-design.md
@@ -1,0 +1,128 @@
+# Multi-Tier Polling Pipeline — Design Spec
+
+**Date**: 2026-04-20
+**Issue**: [#107](https://github.com/theburrowhub/heimdallm/issues/107)
+
+---
+
+## Overview
+
+Replace the monolithic poll cycle with a 3-tier pipeline architecture. Tier 1 discovers repos, Tier 2 processes per-repo (PRs + issues), Tier 3 watches individual items for changes with exponential backoff. Connected via channels, governed by a shared rate limiter with priority.
+
+## Architecture
+
+```
+Tier 1 (discovery_interval, 15m) → repos channel →
+Tier 2 (poll_interval, 5m) → items queue →
+Tier 3 (priority queue, 1m base with backoff)
+```
+
+All tiers run as independent goroutines. Rate limiter: shared token pool (4500 req/h), priority T3 > T2 > T1, min guaranteed per tier.
+
+## Components
+
+All in `daemon/internal/scheduler/`:
+
+| File | Responsibility |
+|------|---------------|
+| `scheduler.go` | Existing timer — kept for backwards compat |
+| `pipeline.go` | Orchestrator: creates tiers, wires channels, manages shutdown |
+| `queue.go` | Priority queue with exponential backoff for Tier 3 |
+| `ratelimit.go` | Shared token bucket with tier priorities |
+| `tier1.go` | Discovery: repos by topic + new repos from PR activity |
+| `tier2.go` | Per-repo: fetch PRs, fetch/classify issues, pipeline dispatch, promotion |
+| `tier3.go` | Per-item: watch state changes, comments, label changes |
+
+## Tier 1: Global Discovery (slow)
+
+Interval: `discovery_interval` (default 15m). Responsibilities:
+- Topic-based repo discovery (existing `discoverySvc.Run` logic, moved here)
+- New repo detection from PR activity (repos seen in `review-requested:@me` that aren't in the monitored list)
+- Repos pushed to `reposChan chan []string`
+
+## Tier 2: Per-Repo Processing (medium)
+
+Interval: `poll_interval` (default 5m). Consumes repos from Tier 1 channel + its own timer. Per repo:
+- Fetch PRs to review → run PR pipeline → push active PRs to Tier 3 queue
+- Issue promotion (dependency check)
+- Fetch issues → classify → run triage/implement pipeline → push active issues to Tier 3 queue
+- Retry pending publishes (`p.PublishPending()`)
+
+## Tier 3: Per-Item Watch (fast, backoff)
+
+Priority queue, base interval 1m. Consumes items from Tier 2. Each item:
+
+```go
+type WatchItem struct {
+    Type      string        // "pr" | "issue"
+    Repo      string
+    Number    int
+    GithubID  int64
+    Priority  int           // 0 = highest
+    NextCheck time.Time
+    Backoff   time.Duration // 1m → 2m → 4m → 8m → 15m cap
+    LastSeen  time.Time
+}
+```
+
+Watches for:
+- Label changes → re-classify, re-run pipeline if mode changed
+- New comments / change requests → re-review/re-triage
+- State changes (merge/close) → update store, trigger dependency promotion
+- Backoff doubles after each check without changes; resets to 1m on activity
+- Items without activity for 1h are evicted
+
+## Rate Limiter
+
+```go
+type Tier int
+const (TierDiscovery Tier = iota; TierRepo; TierWatch)
+
+type RateLimiter struct {
+    pool      chan struct{}    // 4500 tokens, refilled hourly
+    minBudget map[Tier]int    // T1=200, T2=1500, T3=1000
+    spent     map[Tier]*atomic.Int64
+}
+
+func (r *RateLimiter) Acquire(ctx context.Context, tier Tier) error
+```
+
+Priority: T3 acquires immediately if tokens available. T2 waits up to 100ms. T1 waits up to 500ms. If pool exhausted, lower-priority tiers pause until next refill. Min budget ensures no tier starves completely.
+
+## Configuration
+
+```toml
+[github]
+discovery_interval = "15m"   # Tier 1
+poll_interval = "5m"          # Tier 2
+watch_interval = "1m"         # Tier 3 base
+```
+
+New: `watch_interval`. Default 1m. Parsed by `parseWatchInterval` in main.go.
+
+## main.go Integration
+
+Replace `makePollFn` + manual scheduler/discovery setup with:
+
+```go
+pipe := scheduler.NewPipeline(scheduler.PipelineConfig{...}, scheduler.PipelineDeps{...})
+pipe.Start(ctx)
+defer pipe.Stop()
+```
+
+The `PipelineDeps` struct carries all dependencies (ghClient, store, pipelines, broker, configFn). The pipeline owns the 3 tier goroutines and the rate limiter.
+
+## Testing
+
+- `queue_test.go`: enqueue, dequeue by priority, backoff doubling, eviction after 1h
+- `ratelimit_test.go`: token acquisition, priority ordering, min budget enforcement
+- `pipeline_test.go`: integration — fake deps, verify tier flow
+- `tier2_test.go`: per-repo processing with fake GitHub client
+- `tier3_test.go`: watch item state change detection
+
+## Backwards Compatibility
+
+- `poll_interval` and `discovery_interval` keep their meaning
+- `watch_interval` is new, defaults to 1m if absent
+- Old `scheduler.New()` still works for non-pipeline uses
+- Config validation accepts the new field without requiring it


### PR DESCRIPTION
## Summary

Replaces the monolithic poll cycle with a 3-tier pipeline architecture:

- **Tier 1 (Discovery, 15m)**: discovers repos via topic + PR activity, sends to Tier 2 via channel
- **Tier 2 (Per-repo, 5m)**: fetches PRs, processes issues, runs promotion, enqueues active items to Tier 3
- **Tier 3 (Per-item watch, 1m base + backoff)**: watches active items for state changes (label changes, new comments, merge/close) with exponential backoff (1m → 2m → 4m → 8m → 15m cap, evict after 1h inactivity)

### Architecture
```
Tier 1 → repos channel → Tier 2 → WatchQueue → Tier 3 (backoff)
```

Shared rate limiter (4500 req/h) with priority: T3 > T2 > T1.

### New files in `daemon/internal/scheduler/`
- `ratelimit.go` — token bucket with tier-based priority wait times
- `queue.go` — priority queue (container/heap) with exponential backoff
- `tier1.go` — discovery goroutine
- `tier2.go` — per-repo processing goroutine
- `tier3.go` — per-item watch goroutine
- `pipeline.go` — orchestrator, wires channels, manages shutdown

### main.go changes
- Removed `makePollFn`, `startScheduler`, `startDiscovery` (~238 lines)
- Added `tier2Adapter` bridging concrete types to scheduler interfaces (~286 lines)
- Simplified reload: stop pipeline → update config → start new pipeline

### Config
- New: `watch_interval` (default "1m") + `HEIMDALLM_WATCH_INTERVAL` env var

## Test Plan
- [x] `make test-docker` — all 14 packages pass
- [x] `go build` — compiles cleanly
- [x] Rate limiter: 4 tests (budget, priority, cancellation, refill)
- [x] Queue: 8 tests (push/pop, dedup, backoff, cap, reset, evict, ordering)
- [ ] Manual: start daemon, verify logs show "pipeline: started" with 3 tier intervals
- [ ] Manual: verify Tier 3 watches active items and detects changes

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)