### PR TITLE
feat(flutter): unified Activity view with advanced filters (#109)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -910,10 +910,12 @@ func (a *tier2Adapter) CheckItem(ctx context.Context, item *scheduler.WatchItem)
 // HandleChange implements scheduler.Tier3ItemChecker.
 func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchItem) error {
 	if item.Type == "pr" {
-		// Apply the same dedup gate as Tier 2: skip dismissed PRs and
-		// recently-reviewed PRs. Note: there is a small TOCTOU window
-		// between this check and the actual runReview call — the worst
-		// case is an occasional harmless duplicate review.
+		// Dedup: skip if the PR was already reviewed at or after the last
+		// detected change — mirrors the same check Tier 2 performs.
+		// NOTE (TOCTOU): between this check and the runReview call below, another
+		// goroutine could complete the same review. The impact is a rare harmless
+		// duplicate review; the in-flight guard in runReview prevents concurrent
+		// reviews of the same PR.
 		if a.PRAlreadyReviewed(item.GithubID, item.LastSeen) {
 			slog.Debug("tier3: PR already reviewed, skipping", "pr", item.Number, "repo", item.Repo)
 			return nil

--- a/daemon/internal/scheduler/queue.go
+++ b/daemon/internal/scheduler/queue.go
@@ -26,6 +26,11 @@ type WatchItem struct {
 }
 
 // WatchQueue is a thread-safe priority queue ordered by NextCheck.
+// The mutex protects the heap and seen map. Item field mutations (Backoff,
+// NextCheck, LastSeen) happen outside the lock in ReEnqueue/ResetBackoff —
+// this is safe because Tier 3 processes items sequentially (single writer).
+// If concurrent callers ever mutate the same item, the fields should be
+// moved inside the lock.
 type WatchQueue struct {
 	mu    sync.Mutex
 	items watchHeap

--- a/docs/superpowers/specs/2026-04-21-flutter-web-replaces-svelte-design.md
+++ b/docs/superpowers/specs/2026-04-21-flutter-web-replaces-svelte-design.md
@@ -1,0 +1,307 @@
+# Flutter Web replaces SvelteKit web_ui
+
+**Date:** 2026-04-21
+**Status:** Draft
+**Scope:** Replace the SvelteKit `web_ui/` with a Flutter Web build of `flutter_app/`, served by Nginx behind a token-injecting reverse proxy.
+
+---
+
+## Motivation
+
+Heimdallm ships two independent UI codebases:
+
+| UI | Tech | Purpose |
+|---|---|---|
+| `flutter_app/` | Flutter (macOS/Linux) | Desktop app |
+| `web_ui/` | SvelteKit + Node.js | Web dashboard for Docker deployments |
+
+Both implement the same screens (dashboard, PR detail, issues, config, logs, agents) against the same daemon REST + SSE API. Every new feature must be built twice.
+
+**Goal:** eliminate `web_ui/` by compiling `flutter_app/` for the web platform, unifying both UIs into one Dart codebase. The web target is internal-only (accessed when the daemon runs in Docker), so CanvasKit bundle size and SEO are non-concerns.
+
+---
+
+## Architecture
+
+### Before
+
+```
+browser :3000 ──► SvelteKit (Node.js) ──proxy──► daemon :7842
+                  reads /data/api_token
+                  injects X-Heimdallm-Token
+```
+
+### After
+
+```
+browser :3000 ──► Nginx
+                  ├─ /           → Flutter Web static assets (build/web/)
+                  ├─ /api/*      → proxy_pass daemon :7842, injects token
+                  └─ /events     → proxy_pass daemon :7842/events, injects token
+```
+
+- **Nginx** replaces both the SvelteKit server and the Node.js runtime.
+- **Token injection** stays server-side: Nginx reads the token from env var (or file) and sets the `X-Heimdallm-Token` header on every proxied request. The browser never sees the token.
+- **The daemon is unchanged** — no CORS, no new auth endpoints.
+
+---
+
+## Tasks
+
+### Phase 1: Platform abstraction layer
+
+Create a thin abstraction that isolates desktop-only code from the shared codebase.
+
+#### 1.1 Create `lib/core/platform/` service layer
+
+```
+lib/core/platform/
+  platform_services.dart          # abstract interface + conditional export
+  platform_services_desktop.dart  # real: tray, window, notifier, PID, signals
+  platform_services_web.dart      # no-op stubs
+```
+
+**Interface (abstract class `PlatformServices`):**
+- `Future<void> initWindow()`
+- `Future<void> initTray(ApiClient api)`
+- `Future<void> initNotifications()`
+- `Future<bool> ensureSingleInstance()`
+- `void listenForActivationSignal()`
+- `void sendNotification({String title, String body, int? prId})`
+- `void onWindowClose()` / `void setPreventClose(bool)`
+- `bool get isDesktop`
+
+**Desktop implementation:** moves existing code from `main.dart` lines 20-156 and `core/tray/tray_menu.dart` into the desktop implementation.
+
+**Web implementation:** all methods are no-ops or return immediately. `isDesktop` returns `false`.
+
+**Conditional export** in `platform_services.dart`:
+```dart
+export 'platform_services_web.dart'
+    if (dart.library.io) 'platform_services_desktop.dart';
+```
+
+#### 1.2 Adapt `ApiClient` for web
+
+Currently `ApiClient` (`lib/core/api/api_client.dart`) reads the token from `~/.local/share/heimdallm/api_token` using `dart:io`. On web:
+
+- **No token needed** — Nginx injects it server-side.
+- **Base URL is relative** — `/api/` instead of `http://127.0.0.1:7842/`.
+
+Changes:
+- Extract token-loading and URI building into overridable methods or use conditional import.
+- On web: `_uri(path)` returns `Uri.parse('/api$path')`, `_apiToken()` returns `null`.
+- On desktop: unchanged (reads token from file, uses `localhost:7842`).
+
+#### 1.3 Adapt `SseClient` for web
+
+Same pattern as ApiClient:
+- On web: connect to `/events` (relative), no token header.
+- On desktop: unchanged (`http://127.0.0.1:7842/events` with file-based token).
+
+#### 1.4 Adapt `main.dart` bootstrap
+
+Current boot sequence (desktop):
+1. `_ensureSingleInstance()` — PID file, SIGUSR1
+2. `_listenForActivationSignal()` — process signals
+3. `_setupWindow()` — window_manager
+4. `_setupTray()` — tray_manager
+5. `localNotifier.setup()` — native notifications
+6. `_BootstrapApp._boot()` — detect token → write config → find daemon binary → spawn daemon → health check
+
+**Web boot sequence:**
+1. Health check (`GET /api/health` via Nginx) → success → go to `/`.
+2. If unhealthy → show error screen ("daemon not reachable").
+
+Steps 1-5 and daemon spawn are skipped entirely. The `_BootstrapApp` widget uses `PlatformServices.isDesktop` to choose the desktop vs web boot path.
+
+#### 1.5 Remove `dart:io` from shared code
+
+12 files import `dart:io`. After the platform layer:
+- `main.dart` — uses PlatformServices, no direct `dart:io`.
+- `api_client.dart` — conditional import for token/URI.
+- `sse_client.dart` — conditional import for token/URI.
+- `daemon_lifecycle.dart` — only imported on desktop (behind conditional).
+- `first_run_setup.dart` — only imported on desktop (behind conditional).
+- `gh_cli.dart` — only imported on desktop (behind conditional).
+- `core/tray/tray_menu.dart` — moved into `platform_services_desktop.dart`.
+- `config_providers.dart` — guard daemon-spawn code with `PlatformServices.isDesktop`.
+- `config_screen.dart` — verify; may only need Platform for display logic.
+
+### Phase 2: Enable Flutter Web platform
+
+#### 2.1 Add web platform support
+
+```bash
+cd flutter_app && flutter create --platforms web .
+```
+
+This generates `web/index.html`, `web/manifest.json`, `web/favicon.png`.
+
+#### 2.2 Customize `web/index.html`
+
+- Set title to "Heimdallm".
+- Set favicon/icons to Heimdallm branding (reuse `assets/icon.png`).
+- Use CanvasKit renderer (default) — internal tool, no bundle-size concern.
+
+#### 2.3 Verify `flutter build web --release` compiles
+
+Gate: zero compilation errors. Run and verify the app loads in a browser against a local daemon.
+
+### Phase 3: Nginx + Docker
+
+#### 3.1 Create `flutter_app/nginx.conf.template`
+
+```nginx
+server {
+    listen 3000;
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://heimdallm:${HEIMDALLM_PORT}/;
+        proxy_set_header X-Heimdallm-Token "${HEIMDALLM_API_TOKEN}";
+        proxy_set_header Host $host;
+    }
+
+    location /events {
+        proxy_pass http://heimdallm:${HEIMDALLM_PORT}/events;
+        proxy_set_header X-Heimdallm-Token "${HEIMDALLM_API_TOKEN}";
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+    }
+}
+```
+
+Token is injected via `envsubst` at container start.
+
+#### 3.2 Create `flutter_app/Dockerfile.web`
+
+```dockerfile
+# ── Build stage ──────────────────────────────────────────────────────
+FROM ghcr.io/cirruslabs/flutter:stable AS build
+WORKDIR /app
+COPY . .
+RUN flutter build web --release
+
+# ── Runtime stage ────────────────────────────────────────────────────
+FROM nginx:alpine AS runtime
+COPY --from=build /app/build/web /usr/share/nginx/html
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+
+# envsubst in the official nginx:alpine image reads *.template from
+# /etc/nginx/templates/ and writes the resolved output to
+# /etc/nginx/conf.d/ at container start — no custom entrypoint needed.
+
+ENV HEIMDALLM_API_TOKEN=""
+ENV HEIMDALLM_PORT="7842"
+
+EXPOSE 3000
+```
+
+Entrypoint reads `/data/api_token` as fallback if `HEIMDALLM_API_TOKEN` is empty. Add a small `docker-entrypoint.d/` script:
+
+```sh
+#!/bin/sh
+# 10-load-token.sh — read token from shared volume if not set via env
+if [ -z "$HEIMDALLM_API_TOKEN" ] && [ -f /data/api_token ]; then
+  export HEIMDALLM_API_TOKEN=$(cat /data/api_token)
+fi
+```
+
+Result: image ~30 MB (vs ~180 MB for the Node.js image).
+
+#### 3.3 Update `docker/docker-compose.yml`
+
+Replace the `web` service:
+
+```yaml
+web:
+  build:
+    context: ../flutter_app
+    dockerfile: Dockerfile.web
+  container_name: heimdallm-web
+  restart: unless-stopped
+  ports:
+    - "${HEIMDALLM_WEB_PORT:-3000}:3000"
+  environment:
+    - HEIMDALLM_API_TOKEN=${HEIMDALLM_API_TOKEN:-}
+    - HEIMDALLM_PORT=${HEIMDALLM_PORT:-7842}
+  volumes:
+    - heimdallm-data:/data:ro
+  depends_on:
+    heimdallm:
+      condition: service_healthy
+  healthcheck:
+    test: ["CMD", "wget", "-qO-", "http://localhost:3000/"]
+    interval: 30s
+    timeout: 5s
+    start_period: 10s
+    retries: 3
+```
+
+Healthcheck switches from Node.js script to `wget` (available in nginx:alpine).
+
+### Phase 4: Cleanup
+
+#### 4.1 Delete `web_ui/` directory
+
+Remove entirely: `web_ui/`, including its `Dockerfile`, `package.json`, `src/`, `svelte.config.js`, etc.
+
+#### 4.2 Update CI workflows
+
+- If any workflow references `web_ui/`, update or remove those steps.
+- Add `flutter build web` validation to PR checks (optional, can be a follow-up).
+
+#### 4.3 Update `docs/index.html` (landing page)
+
+No change — the static landing page in `docs/` is independent of the web dashboard.
+
+---
+
+## Files created
+
+| File | Purpose |
+|---|---|
+| `lib/core/platform/platform_services.dart` | Abstract interface + conditional export |
+| `lib/core/platform/platform_services_desktop.dart` | Desktop implementation (tray, window, notifier, PID) |
+| `lib/core/platform/platform_services_web.dart` | Web no-op stubs |
+| `flutter_app/web/` (directory) | Flutter web platform (generated by `flutter create`) |
+| `flutter_app/nginx.conf.template` | Nginx config with token injection |
+| `flutter_app/Dockerfile.web` | Multi-stage: Flutter build + nginx:alpine |
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `lib/main.dart` | Use PlatformServices; split desktop/web boot path |
+| `lib/core/api/api_client.dart` | Conditional import for token/URI (web: relative, no token) |
+| `lib/core/api/sse_client.dart` | Conditional import for token/URI (web: relative, no token) |
+| `lib/core/daemon/daemon_lifecycle.dart` | Only imported on desktop |
+| `lib/core/setup/first_run_setup.dart` | Only imported on desktop |
+| `lib/core/setup/gh_cli.dart` | Only imported on desktop |
+| `lib/features/config/config_providers.dart` | Guard daemon-spawn with isDesktop |
+| `lib/features/config/config_screen.dart` | Guard any Platform checks |
+| `docker/docker-compose.yml` | Replace web service (SvelteKit → Nginx + Flutter) |
+| `pubspec.yaml` | No dep changes needed (desktop deps are platform-filtered by Flutter) |
+
+## Files deleted
+
+| File/Directory | Reason |
+|---|---|
+| `web_ui/` (entire directory) | Replaced by Flutter Web |
+
+---
+
+## Out of scope
+
+- Modifying the daemon (Go) — no CORS, no auth changes.
+- The static landing page (`docs/index.html`) — unrelated.
+- Adding CI for Flutter Web builds — can be a follow-up issue.
+- Theme/dark-mode parity with SvelteKit — Flutter app already has dark theme support.

--- a/flutter_app/lib/features/dashboard/activity_filter_bar.dart
+++ b/flutter_app/lib/features/dashboard/activity_filter_bar.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'activity_filters.dart';
+
+/// Compact filter bar for the unified Activity view.
+class ActivityFilterBar extends ConsumerStatefulWidget {
+  /// All known repo full-names (e.g. "org/repo") from combined PR+Issue data.
+  final Set<String> allRepos;
+
+  const ActivityFilterBar({super.key, required this.allRepos});
+
+  @override
+  ConsumerState<ActivityFilterBar> createState() => _ActivityFilterBarState();
+}
+
+class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
+  final _searchController = TextEditingController();
+  final _searchFocus = FocusNode();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _searchFocus.dispose();
+    super.dispose();
+  }
+
+  Set<String> get _allOrgs => widget.allRepos
+      .map((r) => r.contains('/') ? r.split('/').first : r)
+      .toSet();
+
+  /// Repos filtered by currently selected orgs (or all repos if no org filter).
+  Set<String> get _filteredRepos {
+    final filters = ref.read(activityFiltersProvider);
+    if (filters.orgs.isEmpty) return widget.allRepos;
+    return widget.allRepos.where((r) {
+      final org = r.contains('/') ? r.split('/').first : r;
+      return filters.orgs.contains(org);
+    }).toSet();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final filters = ref.watch(activityFiltersProvider);
+
+    // Keep search controller in sync when filters are reset externally.
+    if (filters.search != _searchController.text) {
+      _searchController.text = filters.search;
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 6,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          // ── Type chips ───────────────────────────────────────────────
+          _typeChip('pr', 'PR', Colors.blue, filters),
+          _typeChip('it', 'IT', Colors.orange, filters),
+          _typeChip('dev', 'DEV', Colors.green, filters),
+
+          // ── Org multi-select ─────────────────────────────────────────
+          if (_allOrgs.isNotEmpty)
+            _multiSelectPopup(
+              label: 'Org',
+              icon: Icons.business,
+              allValues: _allOrgs.toList()..sort(),
+              selected: filters.orgs,
+              onChanged: (orgs) {
+                final notifier = ref.read(activityFiltersProvider.notifier);
+                // When orgs change, remove any repo selections that no longer
+                // belong to the selected orgs.
+                var repos = filters.repos;
+                if (orgs.isNotEmpty) {
+                  repos = repos.where((r) {
+                    final org = r.contains('/') ? r.split('/').first : r;
+                    return orgs.contains(org);
+                  }).toSet();
+                }
+                notifier.state = filters.copyWith(orgs: orgs, repos: repos);
+              },
+            ),
+
+          // ── Repo multi-select ────────────────────────────────────────
+          if (widget.allRepos.isNotEmpty)
+            _multiSelectPopup(
+              label: 'Repo',
+              icon: Icons.folder_outlined,
+              allValues: _filteredRepos.toList()..sort(),
+              selected: filters.repos,
+              onChanged: (repos) => ref
+                  .read(activityFiltersProvider.notifier)
+                  .state = filters.copyWith(repos: repos),
+            ),
+
+          // ── Search field ─────────────────────────────────────────────
+          SizedBox(
+            width: 180,
+            height: 32,
+            child: TextField(
+              controller: _searchController,
+              focusNode: _searchFocus,
+              style: const TextStyle(fontSize: 12),
+              decoration: InputDecoration(
+                hintText: 'Search...',
+                hintStyle: const TextStyle(fontSize: 12),
+                prefixIcon: const Icon(Icons.search, size: 16),
+                prefixIconConstraints:
+                    const BoxConstraints(minWidth: 32, minHeight: 0),
+                isDense: true,
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                ),
+              ),
+              onChanged: (v) => ref
+                  .read(activityFiltersProvider.notifier)
+                  .state = filters.copyWith(search: v),
+            ),
+          ),
+
+          // ── Reset button ─────────────────────────────────────────────
+          if (filters.hasFilters)
+            IconButton(
+              icon: const Icon(Icons.clear_all, size: 18),
+              tooltip: 'Reset filters',
+              visualDensity: VisualDensity.compact,
+              onPressed: () {
+                ref.read(activityFiltersProvider.notifier).state =
+                    const ActivityFilters();
+                _searchController.clear();
+              },
+            ),
+        ],
+      ),
+    );
+  }
+
+  // ── Type chip ──────────────────────────────────────────────────────────────
+
+  Widget _typeChip(
+      String type, String label, Color color, ActivityFilters filters) {
+    final selected = filters.types.contains(type);
+    return FilterChip(
+      label: Text(label,
+          style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: selected ? Colors.white : color)),
+      selected: selected,
+      selectedColor: color,
+      backgroundColor: color.withValues(alpha: 0.1),
+      side: BorderSide(color: color.withValues(alpha: 0.4)),
+      checkmarkColor: Colors.white,
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      onSelected: (_) {
+        final types = Set<String>.from(filters.types);
+        selected ? types.remove(type) : types.add(type);
+        ref.read(activityFiltersProvider.notifier).state =
+            filters.copyWith(types: types);
+      },
+    );
+  }
+
+  // ── Multi-select popup ─────────────────────────────────────────────────────
+
+  Widget _multiSelectPopup({
+    required String label,
+    required IconData icon,
+    required List<String> allValues,
+    required Set<String> selected,
+    required ValueChanged<Set<String>> onChanged,
+  }) {
+    final hasSelection = selected.isNotEmpty;
+    return PopupMenuButton<String>(
+      tooltip: '$label filter',
+      offset: const Offset(0, 36),
+      constraints: const BoxConstraints(maxHeight: 320, maxWidth: 260),
+      itemBuilder: (_) => allValues.map((v) {
+        final checked = selected.contains(v);
+        return PopupMenuItem<String>(
+          value: v,
+          padding: EdgeInsets.zero,
+          child: StatefulBuilder(
+            builder: (ctx, setMenuState) => CheckboxListTile(
+              dense: true,
+              title: Text(v, style: const TextStyle(fontSize: 12)),
+              value: checked,
+              onChanged: (val) {
+                final next = Set<String>.from(selected);
+                val == true ? next.add(v) : next.remove(v);
+                onChanged(next);
+                // Close after toggling so the filter applies immediately.
+                Navigator.of(ctx).pop();
+              },
+            ),
+          ),
+        );
+      }).toList(),
+      child: Chip(
+        avatar: Icon(icon, size: 14,
+            color: hasSelection
+                ? Theme.of(context).colorScheme.primary
+                : Colors.grey.shade600),
+        label: Text(
+          hasSelection ? '$label (${selected.length})' : label,
+          style: TextStyle(
+            fontSize: 11,
+            color: hasSelection
+                ? Theme.of(context).colorScheme.primary
+                : Colors.grey.shade600,
+          ),
+        ),
+        visualDensity: VisualDensity.compact,
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        side: BorderSide(
+          color: hasSelection
+              ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.5)
+              : Colors.grey.shade400,
+        ),
+        backgroundColor: hasSelection
+            ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
+            : null,
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/features/dashboard/activity_filter_bar.dart
+++ b/flutter_app/lib/features/dashboard/activity_filter_bar.dart
@@ -233,30 +233,14 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
     required ValueChanged<Set<String>> onChanged,
   }) {
     final hasSelection = selected.isNotEmpty;
-    return PopupMenuButton<String>(
-      tooltip: '$label filter',
-      offset: const Offset(0, 36),
-      constraints: const BoxConstraints(maxHeight: 400, maxWidth: 360),
-      itemBuilder: (_) => allValues.map((v) {
-        final checked = selected.contains(v);
-        return PopupMenuItem<String>(
-          value: v,
-          padding: EdgeInsets.zero,
-          child: StatefulBuilder(
-            builder: (ctx, setMenuState) => CheckboxListTile(
-              dense: true,
-              title: Text(displayFn(v), style: const TextStyle(fontSize: 12)),
-              value: checked,
-              onChanged: (val) {
-                final next = Set<String>.from(selected);
-                val == true ? next.add(v) : next.remove(v);
-                onChanged(next);
-                Navigator.of(ctx).pop();
-              },
-            ),
-          ),
-        );
-      }).toList(),
+    return GestureDetector(
+      onTap: () => _showMultiSelectDialog(
+        label: label,
+        allValues: allValues,
+        selected: selected,
+        displayFn: displayFn,
+        onChanged: onChanged,
+      ),
       child: Chip(
         avatar: Icon(icon, size: 14,
             color: hasSelection
@@ -281,6 +265,111 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
         backgroundColor: hasSelection
             ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
             : null,
+      ),
+    );
+  }
+
+  void _showMultiSelectDialog({
+    required String label,
+    required List<String> allValues,
+    required Set<String> selected,
+    required String Function(String) displayFn,
+    required ValueChanged<Set<String>> onChanged,
+  }) {
+    var current = Set<String>.from(selected);
+    showDialog(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => Dialog(
+          backgroundColor: Theme.of(context).colorScheme.surface,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(color: Colors.grey.shade700),
+          ),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 340, maxHeight: 420),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // Header
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 16, 12, 8),
+                  child: Row(
+                    children: [
+                      Text('Filter by $label',
+                          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+                      const Spacer(),
+                      if (current.isNotEmpty)
+                        TextButton(
+                          onPressed: () {
+                            setDialogState(() => current = {});
+                          },
+                          child: const Text('Clear', style: TextStyle(fontSize: 12)),
+                        ),
+                    ],
+                  ),
+                ),
+                const Divider(height: 1),
+                // List
+                Flexible(
+                  child: ListView.builder(
+                    shrinkWrap: true,
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    itemCount: allValues.length,
+                    itemBuilder: (_, i) {
+                      final v = allValues[i];
+                      final checked = current.contains(v);
+                      return InkWell(
+                        onTap: () {
+                          setDialogState(() {
+                            checked ? current.remove(v) : current.add(v);
+                          });
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: Text(displayFn(v),
+                                    style: TextStyle(
+                                      fontSize: 13,
+                                      color: checked ? Theme.of(context).colorScheme.primary : null,
+                                      fontWeight: checked ? FontWeight.w600 : FontWeight.normal,
+                                    )),
+                              ),
+                              Icon(
+                                checked ? Icons.check_box : Icons.check_box_outline_blank,
+                                size: 20,
+                                color: checked
+                                    ? Theme.of(context).colorScheme.primary
+                                    : Colors.grey.shade600,
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+                const Divider(height: 1),
+                // Apply button
+                Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: () {
+                        onChanged(current);
+                        Navigator.of(ctx).pop();
+                      },
+                      child: Text('Apply${current.isNotEmpty ? ' (${current.length})' : ''}'),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/flutter_app/lib/features/dashboard/activity_filter_bar.dart
+++ b/flutter_app/lib/features/dashboard/activity_filter_bar.dart
@@ -40,8 +40,7 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
       .map((r) => r.contains('/') ? r.split('/').first : r)
       .toSet();
 
-  Set<String> get _filteredRepos {
-    final filters = ref.read(activityFiltersProvider);
+  Set<String> _filteredRepos(ActivityFilters filters) {
     if (filters.orgs.isEmpty) return widget.allRepos;
     return widget.allRepos.where((r) {
       final org = r.contains('/') ? r.split('/').first : r;
@@ -53,7 +52,9 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
   Widget build(BuildContext context) {
     final filters = ref.watch(activityFiltersProvider);
 
-    if (filters.search != _searchController.text) {
+    // Sync controller on external reset (e.g. Reset button) without
+    // clobbering cursor position during normal typing.
+    if (filters.search != _searchController.text && !_searchFocus.hasFocus) {
       _searchController.text = filters.search;
     }
 
@@ -105,7 +106,7 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
             _multiSelectPopup(
               label: 'Repo',
               icon: Icons.folder_outlined,
-              allValues: _filteredRepos.toList()..sort(),
+              allValues: _filteredRepos(filters).toList()..sort(),
               selected: filters.repos,
               displayFn: (v) => v.contains('/') ? v.split('/').last : v,
               onChanged: (repos) => ref

--- a/flutter_app/lib/features/dashboard/activity_filter_bar.dart
+++ b/flutter_app/lib/features/dashboard/activity_filter_bar.dart
@@ -2,11 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'activity_filters.dart';
 
-/// Sort mode — must match dashboard_screen.dart's _SortMode.
-/// Duplicated here to avoid exposing private enum; the dashboard passes
-/// the current value and a callback.
-enum SortMode { priority, newest }
-
 /// Compact filter bar for the unified Activity view.
 /// Includes sort buttons, type chips, org/repo popups, search, and reset.
 class ActivityFilterBar extends ConsumerStatefulWidget {

--- a/flutter_app/lib/features/dashboard/activity_filter_bar.dart
+++ b/flutter_app/lib/features/dashboard/activity_filter_bar.dart
@@ -2,12 +2,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'activity_filters.dart';
 
-/// Compact filter bar for the unified Activity view.
-class ActivityFilterBar extends ConsumerStatefulWidget {
-  /// All known repo full-names (e.g. "org/repo") from combined PR+Issue data.
-  final Set<String> allRepos;
+/// Sort mode — must match dashboard_screen.dart's _SortMode.
+/// Duplicated here to avoid exposing private enum; the dashboard passes
+/// the current value and a callback.
+enum SortMode { priority, newest }
 
-  const ActivityFilterBar({super.key, required this.allRepos});
+/// Compact filter bar for the unified Activity view.
+/// Includes sort buttons, type chips, org/repo popups, search, and reset.
+class ActivityFilterBar extends ConsumerStatefulWidget {
+  final Set<String> allRepos;
+  final SortMode sort;
+  final ValueChanged<SortMode> onSortChanged;
+
+  const ActivityFilterBar({
+    super.key,
+    required this.allRepos,
+    required this.sort,
+    required this.onSortChanged,
+  });
 
   @override
   ConsumerState<ActivityFilterBar> createState() => _ActivityFilterBarState();
@@ -28,7 +40,6 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
       .map((r) => r.contains('/') ? r.split('/').first : r)
       .toSet();
 
-  /// Repos filtered by currently selected orgs (or all repos if no org filter).
   Set<String> get _filteredRepos {
     final filters = ref.read(activityFiltersProvider);
     if (filters.orgs.isEmpty) return widget.allRepos;
@@ -42,34 +53,42 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
   Widget build(BuildContext context) {
     final filters = ref.watch(activityFiltersProvider);
 
-    // Keep search controller in sync when filters are reset externally.
     if (filters.search != _searchController.text) {
       _searchController.text = filters.search;
     }
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       child: Wrap(
-        spacing: 8,
+        spacing: 6,
         runSpacing: 6,
         crossAxisAlignment: WrapCrossAlignment.center,
         children: [
-          // ── Type chips ───────────────────────────────────────────────
+          // ── Sort buttons ────────────────────────────────────────────
+          _sortChip('Priority', Icons.sort, SortMode.priority),
+          _sortChip('Newest', Icons.schedule, SortMode.newest),
+
+          // Separator
+          SizedBox(
+            height: 20,
+            child: VerticalDivider(width: 16, thickness: 1, color: Colors.grey.shade700),
+          ),
+
+          // ── Type chips ──────────────────────────────────────────────
           _typeChip('pr', 'PR', Colors.blue, filters),
           _typeChip('it', 'IT', Colors.orange, filters),
           _typeChip('dev', 'DEV', Colors.green, filters),
 
-          // ── Org multi-select ─────────────────────────────────────────
+          // ── Org multi-select ────────────────────────────────────────
           if (_allOrgs.isNotEmpty)
             _multiSelectPopup(
               label: 'Org',
               icon: Icons.business,
               allValues: _allOrgs.toList()..sort(),
               selected: filters.orgs,
+              displayFn: (v) => v,
               onChanged: (orgs) {
                 final notifier = ref.read(activityFiltersProvider.notifier);
-                // When orgs change, remove any repo selections that no longer
-                // belong to the selected orgs.
                 var repos = filters.repos;
                 if (orgs.isNotEmpty) {
                   repos = repos.where((r) {
@@ -81,37 +100,42 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
               },
             ),
 
-          // ── Repo multi-select ────────────────────────────────────────
+          // ── Repo multi-select ───────────────────────────────────────
           if (widget.allRepos.isNotEmpty)
             _multiSelectPopup(
               label: 'Repo',
               icon: Icons.folder_outlined,
               allValues: _filteredRepos.toList()..sort(),
               selected: filters.repos,
+              displayFn: (v) => v.contains('/') ? v.split('/').last : v,
               onChanged: (repos) => ref
                   .read(activityFiltersProvider.notifier)
                   .state = filters.copyWith(repos: repos),
             ),
 
-          // ── Search field ─────────────────────────────────────────────
+          // ── Search field ────────────────────────────────────────────
           SizedBox(
-            width: 180,
-            height: 32,
+            width: 160,
             child: TextField(
               controller: _searchController,
               focusNode: _searchFocus,
-              style: const TextStyle(fontSize: 12),
+              style: const TextStyle(fontSize: 11),
               decoration: InputDecoration(
                 hintText: 'Search...',
-                hintStyle: const TextStyle(fontSize: 12),
-                prefixIcon: const Icon(Icons.search, size: 16),
+                hintStyle: const TextStyle(fontSize: 11),
+                prefixIcon: const Icon(Icons.search, size: 14),
                 prefixIconConstraints:
-                    const BoxConstraints(minWidth: 32, minHeight: 0),
+                    const BoxConstraints(minWidth: 28, minHeight: 0),
                 isDense: true,
                 contentPadding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
                 border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(6),
+                  borderRadius: BorderRadius.circular(20),
+                  borderSide: BorderSide(color: Colors.grey.shade600),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(20),
+                  borderSide: BorderSide(color: Colors.grey.shade700),
                 ),
               ),
               onChanged: (v) => ref
@@ -120,24 +144,56 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
             ),
           ),
 
-          // ── Reset button ─────────────────────────────────────────────
+          // ── Reset button ────────────────────────────────────────────
           if (filters.hasFilters)
-            IconButton(
-              icon: const Icon(Icons.clear_all, size: 18),
-              tooltip: 'Reset filters',
-              visualDensity: VisualDensity.compact,
-              onPressed: () {
+            GestureDetector(
+              onTap: () {
                 ref.read(activityFiltersProvider.notifier).state =
                     const ActivityFilters();
                 _searchController.clear();
               },
+              child: Chip(
+                avatar: Icon(Icons.clear_all, size: 14, color: Colors.red.shade400),
+                label: Text('Reset', style: TextStyle(fontSize: 11, color: Colors.red.shade400)),
+                visualDensity: VisualDensity.compact,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                side: BorderSide(color: Colors.red.shade400.withValues(alpha: 0.4)),
+              ),
             ),
         ],
       ),
     );
   }
 
-  // ── Type chip ──────────────────────────────────────────────────────────────
+  // ── Sort chip ───────────────────────────────────────────────────────────────
+
+  Widget _sortChip(String label, IconData icon, SortMode mode) {
+    final selected = widget.sort == mode;
+    final color = selected
+        ? Theme.of(context).colorScheme.primary
+        : Colors.grey.shade600;
+    return GestureDetector(
+      onTap: () => widget.onSortChanged(mode),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: selected
+              ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.15)
+              : Colors.transparent,
+          border: Border.all(color: color.withValues(alpha: 0.5)),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(mainAxisSize: MainAxisSize.min, children: [
+          Icon(icon, size: 13, color: color),
+          const SizedBox(width: 4),
+          Text(label, style: TextStyle(fontSize: 11, color: color,
+              fontWeight: selected ? FontWeight.w600 : FontWeight.normal)),
+        ]),
+      ),
+    );
+  }
+
+  // ── Type chip ───────────────────────────────────────────────────────────────
 
   Widget _typeChip(
       String type, String label, Color color, ActivityFilters filters) {
@@ -153,8 +209,10 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
       backgroundColor: color.withValues(alpha: 0.1),
       side: BorderSide(color: color.withValues(alpha: 0.4)),
       checkmarkColor: Colors.white,
+      showCheckmark: false,
       visualDensity: VisualDensity.compact,
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      padding: const EdgeInsets.symmetric(horizontal: 4),
       onSelected: (_) {
         final types = Set<String>.from(filters.types);
         selected ? types.remove(type) : types.add(type);
@@ -164,20 +222,21 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
     );
   }
 
-  // ── Multi-select popup ─────────────────────────────────────────────────────
+  // ── Multi-select popup ──────────────────────────────────────────────────────
 
   Widget _multiSelectPopup({
     required String label,
     required IconData icon,
     required List<String> allValues,
     required Set<String> selected,
+    required String Function(String) displayFn,
     required ValueChanged<Set<String>> onChanged,
   }) {
     final hasSelection = selected.isNotEmpty;
     return PopupMenuButton<String>(
       tooltip: '$label filter',
       offset: const Offset(0, 36),
-      constraints: const BoxConstraints(maxHeight: 320, maxWidth: 260),
+      constraints: const BoxConstraints(maxHeight: 400, maxWidth: 360),
       itemBuilder: (_) => allValues.map((v) {
         final checked = selected.contains(v);
         return PopupMenuItem<String>(
@@ -186,13 +245,12 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
           child: StatefulBuilder(
             builder: (ctx, setMenuState) => CheckboxListTile(
               dense: true,
-              title: Text(v, style: const TextStyle(fontSize: 12)),
+              title: Text(displayFn(v), style: const TextStyle(fontSize: 12)),
               value: checked,
               onChanged: (val) {
                 final next = Set<String>.from(selected);
                 val == true ? next.add(v) : next.remove(v);
                 onChanged(next);
-                // Close after toggling so the filter applies immediately.
                 Navigator.of(ctx).pop();
               },
             ),
@@ -218,7 +276,7 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
         side: BorderSide(
           color: hasSelection
               ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.5)
-              : Colors.grey.shade400,
+              : Colors.grey.shade600,
         ),
         backgroundColor: hasSelection
             ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)

--- a/flutter_app/lib/features/dashboard/activity_filters.dart
+++ b/flutter_app/lib/features/dashboard/activity_filters.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Filter state for the unified Activity view.
+class ActivityFilters {
+  final Set<String> types; // 'pr', 'it', 'dev' -- empty = show all
+  final Set<String> orgs; // empty = all orgs
+  final Set<String> repos; // empty = all repos
+  final String search; // free text search
+
+  const ActivityFilters({
+    this.types = const {},
+    this.orgs = const {},
+    this.repos = const {},
+    this.search = '',
+  });
+
+  ActivityFilters copyWith({
+    Set<String>? types,
+    Set<String>? orgs,
+    Set<String>? repos,
+    String? search,
+  }) =>
+      ActivityFilters(
+        types: types ?? this.types,
+        orgs: orgs ?? this.orgs,
+        repos: repos ?? this.repos,
+        search: search ?? this.search,
+      );
+
+  bool get hasFilters =>
+      types.isNotEmpty ||
+      orgs.isNotEmpty ||
+      repos.isNotEmpty ||
+      search.isNotEmpty;
+
+  ActivityFilters reset() => const ActivityFilters();
+}
+
+final activityFiltersProvider =
+    StateProvider<ActivityFilters>((ref) => const ActivityFilters());

--- a/flutter_app/lib/features/dashboard/activity_filters.dart
+++ b/flutter_app/lib/features/dashboard/activity_filters.dart
@@ -36,3 +36,7 @@ class ActivityFilters {
 
 final activityFiltersProvider =
     StateProvider<ActivityFilters>((ref) => const ActivityFilters());
+
+/// Sort mode for the Activity view — shared between dashboard_screen
+/// and activity_filter_bar to avoid duplication.
+enum SortMode { priority, newest }

--- a/flutter_app/lib/features/dashboard/activity_filters.dart
+++ b/flutter_app/lib/features/dashboard/activity_filters.dart
@@ -32,8 +32,6 @@ class ActivityFilters {
       orgs.isNotEmpty ||
       repos.isNotEmpty ||
       search.isNotEmpty;
-
-  ActivityFilters reset() => const ActivityFilters();
 }
 
 final activityFiltersProvider =

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -178,7 +178,7 @@ int _itemPriorityKey(_ActivityItem item) => switch (item) {
         },
 };
 
-bool _matchesFilters(_ActivityItem item, ActivityFilters filters, String me) {
+bool _matchesFilters(_ActivityItem item, ActivityFilters filters) {
   // Type filter
   if (filters.types.isNotEmpty) {
     final type = _itemType(item);
@@ -232,7 +232,6 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
   Widget build(BuildContext context) {
     final prsAsync    = ref.watch(prsProvider);
     final issuesAsync = ref.watch(issuesProvider);
-    final meAsync     = ref.watch(meProvider);
     final sort        = ref.watch(_reviewsSortProvider);
     final filters     = ref.watch(activityFiltersProvider);
 
@@ -246,8 +245,6 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
 
     final prs    = prsAsync.valueOrNull ?? [];
     final issues = issuesAsync.valueOrNull ?? [];
-    final me     = meAsync.valueOrNull ?? '';
-
     // Collect all known repos for the filter bar.
     final allRepos = <String>{
       ...prs.map((p) => p.repo),
@@ -261,7 +258,7 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
     ];
 
     // Apply filters.
-    final filtered = items.where((item) => _matchesFilters(item, filters, me)).toList();
+    final filtered = items.where((item) => _matchesFilters(item, filters)).toList();
 
     // Sort.
     _sortItems(filtered, sort);
@@ -273,32 +270,15 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 8),
       children: [
-        // Sort selector
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-          child: Row(
-            children: [
-              Text('Sort:',
-                  style: TextStyle(fontSize: 12, color: Colors.grey.shade500)),
-              const SizedBox(width: 8),
-              _SortButton(
-                label: 'Priority',
-                icon: Icons.sort,
-                selected: sort == _SortMode.priority,
-                onTap: () => ref.read(_reviewsSortProvider.notifier).set(_SortMode.priority),
-              ),
-              const SizedBox(width: 6),
-              _SortButton(
-                label: 'Newest',
-                icon: Icons.schedule,
-                selected: sort == _SortMode.newest,
-                onTap: () => ref.read(_reviewsSortProvider.notifier).set(_SortMode.newest),
-              ),
-            ],
-          ),
+        // Sort + Filter bar — single unified row
+        ActivityFilterBar(
+          allRepos: allRepos,
+          sort: sort == _SortMode.priority ? SortMode.priority : SortMode.newest,
+          onSortChanged: (mode) {
+            final internal = mode == SortMode.priority ? _SortMode.priority : _SortMode.newest;
+            ref.read(_reviewsSortProvider.notifier).set(internal);
+          },
         ),
-        // Filter bar
-        ActivityFilterBar(allRepos: allRepos),
         // Filtered count when filters are active
         if (filters.hasFilters)
           Padding(
@@ -353,43 +333,6 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
             ],
           ),
         ],
-      ),
-    );
-  }
-}
-
-// ── Sort button ───────────────────────────────────────────────────────────────
-
-class _SortButton extends StatelessWidget {
-  final String label;
-  final IconData icon;
-  final bool selected;
-  final VoidCallback onTap;
-  const _SortButton({required this.label, required this.icon,
-      required this.selected, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    final color = selected
-        ? Theme.of(context).colorScheme.primary
-        : Colors.grey.shade600;
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-        decoration: BoxDecoration(
-          color: selected
-              ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.15)
-              : Colors.transparent,
-          border: Border.all(color: color.withValues(alpha: 0.5)),
-          borderRadius: BorderRadius.circular(6),
-        ),
-        child: Row(mainAxisSize: MainAxisSize.min, children: [
-          Icon(icon, size: 13, color: color),
-          const SizedBox(width: 4),
-          Text(label, style: TextStyle(fontSize: 12, color: color,
-              fontWeight: selected ? FontWeight.w600 : FontWeight.normal)),
-        ]),
       ),
     );
   }

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -76,7 +76,6 @@ enum _SortMode { priority, newest }
 const _sortPrefKey = 'activity_sort_mode';
 
 /// Notifier that owns both the sort state and its SharedPreferences persistence.
-/// Replaces the previous StateProvider + async .then() anti-pattern.
 class _SortNotifier extends Notifier<_SortMode> {
   @override
   _SortMode build() {

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -245,6 +245,7 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
 
     final prs    = prsAsync.valueOrNull ?? [];
     final issues = issuesAsync.valueOrNull ?? [];
+
     // Collect all known repos for the filter bar.
     final allRepos = <String>{
       ...prs.map((p) => p.repo),
@@ -503,10 +504,7 @@ class _IssueActivityTile extends StatelessWidget {
   final TrackedIssue issue;
   const _IssueActivityTile({required this.issue});
 
-  String get _type =>
-      (issue.latestReview != null && issue.latestReview!.actionTaken == 'develop')
-          ? 'dev'
-          : 'it';
+  String get _type => _itemType(_IssueItem(issue));
 
   @override
   Widget build(BuildContext context) {

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -6,12 +6,14 @@ import '../../core/models/pr.dart';
 import '../../core/models/tracked_issue.dart';
 import '../../shared/widgets/severity_badge.dart';
 import '../../shared/widgets/toast.dart';
+import '../../shared/widgets/type_badge.dart';
 import '../agents/agents_screen.dart';
 import '../cli_agents/cli_agents_screen.dart';
-import '../issues/issues_screen.dart';
 import '../issues/issues_providers.dart';
 import '../repositories/repos_screen.dart';
 import '../stats/stats_screen.dart';
+import 'activity_filter_bar.dart';
+import 'activity_filters.dart';
 import 'dashboard_providers.dart';
 
 class DashboardScreen extends ConsumerWidget {
@@ -20,7 +22,7 @@ class DashboardScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return DefaultTabController(
-      length: 6,
+      length: 5,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Heimdallm'),
@@ -46,7 +48,6 @@ class DashboardScreen extends ConsumerWidget {
           bottom: const TabBar(
             tabs: [
               Tab(icon: Icon(Icons.dashboard),       text: 'Activity'),
-              Tab(icon: Icon(Icons.bug_report),      text: 'Issues'),
               Tab(icon: Icon(Icons.folder_outlined), text: 'Repositories'),
               Tab(icon: Icon(Icons.auto_awesome),    text: 'Prompts'),
               Tab(icon: Icon(Icons.smart_toy),       text: 'Agents'),
@@ -57,7 +58,6 @@ class DashboardScreen extends ConsumerWidget {
         body: const TabBarView(
           children: [
             _ActivityTab(),
-            IssuesScreen(),
             ReposScreen(),
             AgentsScreen(),
             CLIAgentsScreen(),
@@ -109,29 +109,116 @@ class _SortNotifier extends Notifier<_SortMode> {
 final _reviewsSortProvider =
     NotifierProvider<_SortNotifier, _SortMode>(_SortNotifier.new);
 
-/// Sort by priority: pending → high → medium → low, then most recent first within group.
-int _prSortKey(PR p) {
-  if (p.latestReview == null) return 0;
-  switch (p.latestReview!.severity.toLowerCase()) {
-    case 'high':   return 1;
-    case 'medium': return 2;
-    default:       return 3;
-  }
+// ── Unified activity item ────────────────────────────────────────────────────
+
+sealed class _ActivityItem {
+  const _ActivityItem();
+  factory _ActivityItem.pr(PR pr) = _PRItem;
+  factory _ActivityItem.issue(TrackedIssue issue) = _IssueItem;
 }
 
-List<PR> _sortedPRs(List<PR> prs, _SortMode mode) {
-  final list = [...prs];
+class _PRItem extends _ActivityItem {
+  final PR pr;
+  const _PRItem(this.pr);
+}
+
+class _IssueItem extends _ActivityItem {
+  final TrackedIssue issue;
+  const _IssueItem(this.issue);
+}
+
+String _itemType(_ActivityItem item) => switch (item) {
+  _PRItem() => 'pr',
+  _IssueItem(:final issue) =>
+      (issue.latestReview != null && issue.latestReview!.actionTaken == 'develop')
+          ? 'dev'
+          : 'it',
+};
+
+String _itemRepo(_ActivityItem item) => switch (item) {
+  _PRItem(:final pr)       => pr.repo,
+  _IssueItem(:final issue) => issue.repo,
+};
+
+String _itemTitle(_ActivityItem item) => switch (item) {
+  _PRItem(:final pr)       => pr.title,
+  _IssueItem(:final issue) => issue.title,
+};
+
+int _itemNumber(_ActivityItem item) => switch (item) {
+  _PRItem(:final pr)       => pr.number,
+  _IssueItem(:final issue) => issue.number,
+};
+
+String _itemAuthor(_ActivityItem item) => switch (item) {
+  _PRItem(:final pr)       => pr.author,
+  _IssueItem(:final issue) => issue.author,
+};
+
+DateTime _itemDate(_ActivityItem item) => switch (item) {
+  _PRItem(:final pr)       => pr.updatedAt,
+  _IssueItem(:final issue) => issue.latestReview?.createdAt ?? issue.fetchedAt,
+};
+
+int _itemPriorityKey(_ActivityItem item) => switch (item) {
+  _PRItem(:final pr) => pr.latestReview == null
+      ? 0
+      : switch (pr.latestReview!.severity.toLowerCase()) {
+          'high'   => 1,
+          'medium' => 2,
+          _        => 3,
+        },
+  _IssueItem(:final issue) => issue.latestReview == null
+      ? 0
+      : switch (issue.latestReview!.severity.toLowerCase()) {
+          'critical' => 0,
+          'high'     => 1,
+          'medium'   => 2,
+          _          => 3,
+        },
+};
+
+bool _matchesFilters(_ActivityItem item, ActivityFilters filters, String me) {
+  // Type filter
+  if (filters.types.isNotEmpty) {
+    final type = _itemType(item);
+    if (!filters.types.contains(type)) return false;
+  }
+  // Org filter
+  if (filters.orgs.isNotEmpty) {
+    final repo = _itemRepo(item);
+    final org = repo.contains('/') ? repo.split('/').first : repo;
+    if (!filters.orgs.contains(org)) return false;
+  }
+  // Repo filter
+  if (filters.repos.isNotEmpty) {
+    if (!filters.repos.contains(_itemRepo(item))) return false;
+  }
+  // Search
+  if (filters.search.isNotEmpty) {
+    final q = filters.search.toLowerCase();
+    final title  = _itemTitle(item).toLowerCase();
+    final repo   = _itemRepo(item).toLowerCase();
+    final number = _itemNumber(item).toString();
+    final author = _itemAuthor(item).toLowerCase();
+    if (!title.contains(q) && !repo.contains(q) && !number.contains(q) && !author.contains(q)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void _sortItems(List<_ActivityItem> items, _SortMode mode) {
   switch (mode) {
     case _SortMode.priority:
-      list.sort((a, b) {
-        final sev = _prSortKey(a).compareTo(_prSortKey(b));
+      items.sort((a, b) {
+        final sev = _itemPriorityKey(a).compareTo(_itemPriorityKey(b));
         if (sev != 0) return sev;
-        return b.updatedAt.compareTo(a.updatedAt);
+        return _itemDate(b).compareTo(_itemDate(a));
       });
     case _SortMode.newest:
-      list.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+      items.sort((a, b) => _itemDate(b).compareTo(_itemDate(a)));
   }
-  return list;
 }
 
 class _ActivityTab extends ConsumerStatefulWidget {
@@ -141,16 +228,13 @@ class _ActivityTab extends ConsumerStatefulWidget {
 }
 
 class _ActivityTabState extends ConsumerState<_ActivityTab> {
-  bool _reviewsExpanded = true;
-  bool _prsExpanded     = true;
-  bool _issuesExpanded  = true;
-
   @override
   Widget build(BuildContext context) {
     final prsAsync    = ref.watch(prsProvider);
     final issuesAsync = ref.watch(issuesProvider);
     final meAsync     = ref.watch(meProvider);
     final sort        = ref.watch(_reviewsSortProvider);
+    final filters     = ref.watch(activityFiltersProvider);
 
     // Combine loading states
     if (prsAsync.isLoading && issuesAsync.isLoading) {
@@ -164,10 +248,23 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
     final issues = issuesAsync.valueOrNull ?? [];
     final me     = meAsync.valueOrNull ?? '';
 
-    final myReviews = _sortedPRs(prs.where((p) =>
-        p.repo.isNotEmpty && p.author.toLowerCase() != me.toLowerCase()).toList(), sort);
-    final myPRs = _sortedPRs(prs.where((p) =>
-        p.repo.isNotEmpty && p.author.toLowerCase() == me.toLowerCase()).toList(), sort);
+    // Collect all known repos for the filter bar.
+    final allRepos = <String>{
+      ...prs.map((p) => p.repo),
+      ...issues.map((i) => i.repo),
+    }..remove('');
+
+    // Build unified list of items.
+    final List<_ActivityItem> items = [
+      ...prs.where((p) => p.repo.isNotEmpty).map((p) => _ActivityItem.pr(p)),
+      ...issues.map((i) => _ActivityItem.issue(i)),
+    ];
+
+    // Apply filters.
+    final filtered = items.where((item) => _matchesFilters(item, filters, me)).toList();
+
+    // Sort.
+    _sortItems(filtered, sort);
 
     if (prs.isEmpty && issues.isEmpty) {
       return const Center(child: Text('No activity yet'));
@@ -200,36 +297,27 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
             ],
           ),
         ),
-        if (myReviews.isNotEmpty) ...[
-          _CollapseHeader(
-            title: 'My Reviews',
-            count: myReviews.length,
-            expanded: _reviewsExpanded,
-            onToggle: () => setState(() => _reviewsExpanded = !_reviewsExpanded),
+        // Filter bar
+        ActivityFilterBar(allRepos: allRepos),
+        // Filtered count when filters are active
+        if (filters.hasFilters)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+            child: Text(
+              '${filtered.length} item${filtered.length == 1 ? '' : 's'}',
+              style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+            ),
           ),
-          if (_reviewsExpanded)
-            ...myReviews.map((pr) => _PRTile(pr: pr)),
-        ],
-        if (myPRs.isNotEmpty) ...[
-          _CollapseHeader(
-            title: 'My PRs',
-            count: myPRs.length,
-            expanded: _prsExpanded,
-            onToggle: () => setState(() => _prsExpanded = !_prsExpanded),
-          ),
-          if (_prsExpanded)
-            ...myPRs.map((pr) => _PRTile(pr: pr)),
-        ],
-        if (issues.isNotEmpty) ...[
-          _CollapseHeader(
-            title: 'Tracked Issues',
-            count: issues.length,
-            expanded: _issuesExpanded,
-            onToggle: () => setState(() => _issuesExpanded = !_issuesExpanded),
-          ),
-          if (_issuesExpanded)
-            ...issues.map((issue) => _IssueActivityTile(issue: issue)),
-        ],
+        if (filtered.isEmpty && filters.hasFilters)
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 32),
+            child: Center(child: Text('No items match the current filters.')),
+          )
+        else
+          ...filtered.map((item) => switch (item) {
+            _PRItem(:final pr) => _PRTile(pr: pr),
+            _IssueItem(:final issue) => _IssueActivityTile(issue: issue),
+          }),
       ],
     );
   }
@@ -270,8 +358,6 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
   }
 }
 
-// ── Collapsible section header ────────────────────────────────────────────────
-
 // ── Sort button ───────────────────────────────────────────────────────────────
 
 class _SortButton extends StatelessWidget {
@@ -303,47 +389,6 @@ class _SortButton extends StatelessWidget {
           const SizedBox(width: 4),
           Text(label, style: TextStyle(fontSize: 12, color: color,
               fontWeight: selected ? FontWeight.w600 : FontWeight.normal)),
-        ]),
-      ),
-    );
-  }
-}
-
-class _CollapseHeader extends StatelessWidget {
-  final String title;
-  final int count;
-  final bool expanded;
-  final VoidCallback onToggle;
-
-  const _CollapseHeader({
-    required this.title, required this.count,
-    required this.expanded, required this.onToggle,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onToggle,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-        child: Row(children: [
-          Text(title,
-              style: Theme.of(context).textTheme.titleSmall
-                  ?.copyWith(fontWeight: FontWeight.bold)),
-          const SizedBox(width: 8),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.primaryContainer,
-              borderRadius: BorderRadius.circular(10),
-            ),
-            child: Text('$count',
-                style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600,
-                    color: Theme.of(context).colorScheme.onPrimaryContainer)),
-          ),
-          const Spacer(),
-          Icon(expanded ? Icons.expand_less : Icons.expand_more,
-              size: 18, color: Colors.grey),
         ]),
       ),
     );
@@ -425,6 +470,11 @@ class _PRTileState extends ConsumerState<_PRTile> {
                           : Colors.grey.shade600,
                   borderRadius: BorderRadius.circular(2),
                 ),
+              ),
+              // Type badge
+              const Padding(
+                padding: EdgeInsets.only(right: 10),
+                child: TypeBadge(type: 'pr'),
               ),
               // Title + subtitle
               Expanded(
@@ -510,6 +560,11 @@ class _IssueActivityTile extends StatelessWidget {
   final TrackedIssue issue;
   const _IssueActivityTile({required this.issue});
 
+  String get _type =>
+      (issue.latestReview != null && issue.latestReview!.actionTaken == 'develop')
+          ? 'dev'
+          : 'it';
+
   @override
   Widget build(BuildContext context) {
     final reviewed = issue.latestReview != null;
@@ -532,8 +587,11 @@ class _IssueActivityTile extends StatelessWidget {
                   borderRadius: BorderRadius.circular(2),
                 ),
               ),
-              Icon(Icons.bug_report, size: 16, color: Colors.grey.shade500),
-              const SizedBox(width: 8),
+              // Type badge
+              Padding(
+                padding: const EdgeInsets.only(right: 10),
+                child: TypeBadge(type: _type),
+              ),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -71,16 +71,18 @@ class DashboardScreen extends ConsumerWidget {
 
 // ── Reviews tab ──────────────────────────────────────────────────────────────
 
-enum _SortMode { priority, newest }
+// SortMode is defined in activity_filters.dart (shared with activity_filter_bar)
 
 const _sortPrefKey = 'activity_sort_mode';
 
-/// Notifier that owns both the sort state and its SharedPreferences persistence.
-class _SortNotifier extends Notifier<_SortMode> {
+final reviewsSortProvider =
+    NotifierProvider<SortNotifier, SortMode>(SortNotifier.new);
+
+class SortNotifier extends Notifier<SortMode> {
   @override
-  _SortMode build() {
+  SortMode build() {
     _loadAsync();
-    return _SortMode.priority;
+    return SortMode.priority;
   }
 
   void _loadAsync() async {
@@ -88,14 +90,14 @@ class _SortNotifier extends Notifier<_SortMode> {
       final prefs = await SharedPreferences.getInstance();
       final value = prefs.getString(_sortPrefKey);
       if (value == 'newest') {
-        state = _SortMode.newest;
+        state = SortMode.newest;
       }
     } catch (e) {
       debugPrint('SortNotifier: failed to load preference: $e');
     }
   }
 
-  void set(_SortMode mode) {
+  void set(SortMode mode) {
     state = mode;
     SharedPreferences.getInstance().then((prefs) {
       prefs.setString(_sortPrefKey, mode.name);
@@ -104,9 +106,6 @@ class _SortNotifier extends Notifier<_SortMode> {
     });
   }
 }
-
-final _reviewsSortProvider =
-    NotifierProvider<_SortNotifier, _SortMode>(_SortNotifier.new);
 
 // ── Unified activity item ────────────────────────────────────────────────────
 
@@ -207,15 +206,15 @@ bool _matchesFilters(_ActivityItem item, ActivityFilters filters) {
   return true;
 }
 
-void _sortItems(List<_ActivityItem> items, _SortMode mode) {
+void _sortItems(List<_ActivityItem> items, SortMode mode) {
   switch (mode) {
-    case _SortMode.priority:
+    case SortMode.priority:
       items.sort((a, b) {
         final sev = _itemPriorityKey(a).compareTo(_itemPriorityKey(b));
         if (sev != 0) return sev;
         return _itemDate(b).compareTo(_itemDate(a));
       });
-    case _SortMode.newest:
+    case SortMode.newest:
       items.sort((a, b) => _itemDate(b).compareTo(_itemDate(a)));
   }
 }
@@ -231,7 +230,7 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
   Widget build(BuildContext context) {
     final prsAsync    = ref.watch(prsProvider);
     final issuesAsync = ref.watch(issuesProvider);
-    final sort        = ref.watch(_reviewsSortProvider);
+    final sort        = ref.watch(reviewsSortProvider);
     final filters     = ref.watch(activityFiltersProvider);
 
     // Combine loading states
@@ -273,11 +272,8 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
         // Sort + Filter bar — single unified row
         ActivityFilterBar(
           allRepos: allRepos,
-          sort: sort == _SortMode.priority ? SortMode.priority : SortMode.newest,
-          onSortChanged: (mode) {
-            final internal = mode == SortMode.priority ? _SortMode.priority : _SortMode.newest;
-            ref.read(_reviewsSortProvider.notifier).set(internal);
-          },
+          sort: sort,
+          onSortChanged: (mode) => ref.read(reviewsSortProvider.notifier).set(mode),
         ),
         // Filtered count when filters are active
         if (filters.hasFilters)

--- a/flutter_app/lib/shared/widgets/type_badge.dart
+++ b/flutter_app/lib/shared/widgets/type_badge.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class TypeBadge extends StatelessWidget {
+  final String type; // 'pr', 'it', 'dev'
+  const TypeBadge({super.key, required this.type});
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color) = switch (type) {
+      'pr' => ('PR', Colors.blue),
+      'it' => ('IT', Colors.orange),
+      'dev' => ('DEV', Colors.green),
+      _ => ('?', Colors.grey),
+    };
+    return Container(
+      width: 32,
+      height: 32,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(label,
+          style: TextStyle(
+              fontSize: 10, fontWeight: FontWeight.w700, color: color)),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Merged Activity and Issues tabs into a single unified Activity view with:

- **Type filter**: PR (blue), IT (orange), DEV (green) as toggleable FilterChips
- **Organization multi-select**: popup derived from known repos
- **Repository multi-select**: popup filtered by selected orgs
- **Free text search**: matches title, repo, number, author
- **Reset button**: clears all filters (keeps sort)
- **Type badge**: 32x32 colored square (PR/IT/DEV) on each item between severity bar and text

Dashboard now has 5 tabs (Activity, Repositories, Prompts, Agents, Stats). Issues tab removed — all items shown in Activity with type filtering.

### New files
- `activity_filters.dart` — `ActivityFilters` model + `activityFiltersProvider`
- `activity_filter_bar.dart` — compact filter bar widget
- `type_badge.dart` — PR/IT/DEV colored badge

### Modified
- `dashboard_screen.dart` — unified `_ActivityItem` sealed class, filter/sort logic, removed Issues tab

## Test Plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 15/15 pass
- [ ] Manual: filter by type, org, repo, search — verify results
- [ ] Manual: reset clears filters but keeps sort

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)