### PR TITLE
feat(flutter): Activity log tab with timeline, filters, and date picker

### DIFF
--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart' as http;
+import '../models/activity.dart';
 import '../models/pr.dart';
 import '../models/review.dart';
 import '../models/tracked_issue.dart';
@@ -76,6 +77,21 @@ class ApiClient {
         .map((r) => _parseReview(r as Map<String, dynamic>))
         .toList();
     return {'pr': pr, 'reviews': reviews};
+  }
+
+  Future<ActivityPage> fetchActivity(ActivityQuery q) async {
+    final headers = await _authHeaders();
+    final uri = Uri.parse('http://127.0.0.1:$port/activity')
+        .replace(queryParameters: q.toQueryParameters());
+    final resp = await _client.get(uri, headers: headers);
+    if (resp.statusCode == 503) {
+      throw ActivityDisabledException();
+    }
+    if (resp.statusCode != 200) {
+      throw ApiException('GET /activity failed: ${resp.statusCode}');
+    }
+    final body = jsonDecode(resp.body) as Map<String, dynamic>;
+    return ActivityPage.fromJson(body);
   }
 
   Future<void> triggerReview(int prId) async {

--- a/flutter_app/lib/core/models/activity.dart
+++ b/flutter_app/lib/core/models/activity.dart
@@ -68,7 +68,10 @@ class ActivityQuery {
     this.repos = const {},
     this.actions = const {},
     this.limit = 500,
-  });
+  }) : assert(
+          (from == null) == (to == null),
+          'from and to must both be set or both null',
+        );
 
   /// Returns a copy with the given fields overridden. `date`, `from`, `to`
   /// use a sentinel to distinguish "not passed" (keep current) from

--- a/flutter_app/lib/core/models/activity.dart
+++ b/flutter_app/lib/core/models/activity.dart
@@ -2,22 +2,10 @@
 /// safety fallback so the UI never crashes on a forward-compat value.
 enum ActivityAction { review, triage, implement, promote, error, unknown }
 
-ActivityAction _parseAction(String s) {
-  switch (s) {
-    case 'review':
-      return ActivityAction.review;
-    case 'triage':
-      return ActivityAction.triage;
-    case 'implement':
-      return ActivityAction.implement;
-    case 'promote':
-      return ActivityAction.promote;
-    case 'error':
-      return ActivityAction.error;
-    default:
-      return ActivityAction.unknown;
-  }
-}
+final Map<String, ActivityAction> _actionByName = ActivityAction.values.asNameMap();
+
+ActivityAction _parseAction(String s) =>
+    _actionByName[s] ?? ActivityAction.unknown;
 
 class ActivityEntry {
   final int id;
@@ -60,6 +48,8 @@ class ActivityEntry {
   }
 }
 
+const Object _unset = Object();
+
 /// Query used by the providers and API layer. All fields optional.
 class ActivityQuery {
   final DateTime? date;
@@ -79,6 +69,29 @@ class ActivityQuery {
     this.actions = const {},
     this.limit = 500,
   });
+
+  /// Returns a copy with the given fields overridden. `date`, `from`, `to`
+  /// use a sentinel to distinguish "not passed" (keep current) from
+  /// "explicit null" (clear).
+  ActivityQuery copyWith({
+    Object? date = _unset,
+    Object? from = _unset,
+    Object? to = _unset,
+    Set<String>? orgs,
+    Set<String>? repos,
+    Set<ActivityAction>? actions,
+    int? limit,
+  }) {
+    return ActivityQuery(
+      date:    identical(date, _unset) ? this.date : date as DateTime?,
+      from:    identical(from, _unset) ? this.from : from as DateTime?,
+      to:      identical(to,   _unset) ? this.to   : to   as DateTime?,
+      orgs:    orgs    ?? this.orgs,
+      repos:   repos   ?? this.repos,
+      actions: actions ?? this.actions,
+      limit:   limit   ?? this.limit,
+    );
+  }
 
   Map<String, List<String>> toQueryParameters() {
     String ymd(DateTime d) =>

--- a/flutter_app/lib/core/models/activity.dart
+++ b/flutter_app/lib/core/models/activity.dart
@@ -1,0 +1,130 @@
+/// Known activity actions from the daemon's activity_log. `unknown` is a
+/// safety fallback so the UI never crashes on a forward-compat value.
+enum ActivityAction { review, triage, implement, promote, error, unknown }
+
+ActivityAction _parseAction(String s) {
+  switch (s) {
+    case 'review':
+      return ActivityAction.review;
+    case 'triage':
+      return ActivityAction.triage;
+    case 'implement':
+      return ActivityAction.implement;
+    case 'promote':
+      return ActivityAction.promote;
+    case 'error':
+      return ActivityAction.error;
+    default:
+      return ActivityAction.unknown;
+  }
+}
+
+class ActivityEntry {
+  final int id;
+  final DateTime timestamp;
+  final String org;
+  final String repo;
+  final String itemType; // 'pr' | 'issue'
+  final int itemNumber;
+  final String itemTitle;
+  final ActivityAction action;
+  final String outcome;
+  final Map<String, dynamic> details;
+
+  const ActivityEntry({
+    required this.id,
+    required this.timestamp,
+    required this.org,
+    required this.repo,
+    required this.itemType,
+    required this.itemNumber,
+    required this.itemTitle,
+    required this.action,
+    required this.outcome,
+    required this.details,
+  });
+
+  factory ActivityEntry.fromJson(Map<String, dynamic> json) {
+    return ActivityEntry(
+      id: json['id'] as int,
+      timestamp: DateTime.parse(json['ts'] as String).toLocal(),
+      org: json['org'] as String,
+      repo: json['repo'] as String,
+      itemType: json['item_type'] as String,
+      itemNumber: json['item_number'] as int,
+      itemTitle: json['item_title'] as String,
+      action: _parseAction(json['action'] as String),
+      outcome: (json['outcome'] as String?) ?? '',
+      details: (json['details'] as Map?)?.cast<String, dynamic>() ?? {},
+    );
+  }
+}
+
+/// Query used by the providers and API layer. All fields optional.
+class ActivityQuery {
+  final DateTime? date;
+  final DateTime? from;
+  final DateTime? to;
+  final Set<String> orgs;
+  final Set<String> repos;
+  final Set<ActivityAction> actions;
+  final int limit;
+
+  const ActivityQuery({
+    this.date,
+    this.from,
+    this.to,
+    this.orgs = const {},
+    this.repos = const {},
+    this.actions = const {},
+    this.limit = 500,
+  });
+
+  Map<String, List<String>> toQueryParameters() {
+    String ymd(DateTime d) =>
+        '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+    final params = <String, List<String>>{};
+    if (date != null) {
+      params['date'] = [ymd(date!)];
+    } else if (from != null && to != null) {
+      params['from'] = [ymd(from!)];
+      params['to'] = [ymd(to!)];
+    }
+    if (orgs.isNotEmpty) params['org'] = orgs.toList();
+    if (repos.isNotEmpty) params['repo'] = repos.toList();
+    if (actions.isNotEmpty) {
+      params['action'] = actions.map((a) => a.name).toList();
+    }
+    params['limit'] = [limit.toString()];
+    return params;
+  }
+}
+
+class ActivityPage {
+  final List<ActivityEntry> entries;
+  final bool truncated;
+  final int count;
+
+  const ActivityPage({
+    required this.entries,
+    required this.truncated,
+    required this.count,
+  });
+
+  factory ActivityPage.fromJson(Map<String, dynamic> json) {
+    final list = (json['entries'] as List? ?? [])
+        .map((e) => ActivityEntry.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return ActivityPage(
+      entries: list,
+      truncated: json['truncated'] as bool? ?? false,
+      count: json['count'] as int? ?? list.length,
+    );
+  }
+}
+
+/// Thrown by the API client when the daemon returns 503 for /activity.
+class ActivityDisabledException implements Exception {
+  @override
+  String toString() => 'Activity log is disabled in daemon config';
+}

--- a/flutter_app/lib/features/activity/activity_providers.dart
+++ b/flutter_app/lib/features/activity/activity_providers.dart
@@ -22,11 +22,10 @@ class ActivityQueryNotifier extends StateNotifier<ActivityQuery> {
   }
 
   void setRange(DateTime from, DateTime to) {
-    state = state.copyWith(
-      date: null,
-      from: DateTime(from.year, from.month, from.day),
-      to:   DateTime(to.year,   to.month,   to.day),
-    );
+    final start = DateTime(from.year, from.month, from.day);
+    final end   = DateTime(to.year,   to.month,   to.day);
+    final (a, b) = start.isAfter(end) ? (end, start) : (start, end);
+    state = state.copyWith(date: null, from: a, to: b);
   }
 
   void toggleOrg(String org) =>
@@ -67,13 +66,17 @@ final activityEntriesProvider = FutureProvider<ActivityPage>((ref) async {
 /// window as the main query but drops org/repo/action filters — so the
 /// option lists show the full universe for the window instead of shrinking
 /// to the already-filtered slice.
+/// Oversized so the distinct org/repo lists reflect the full window even when
+/// the main entries view is truncated. A dedicated facets endpoint would be
+/// the proper long-term fix.
+const int _activityOptionsLimit = 10000;
+
 final activityOptionsProvider = FutureProvider<ActivityPage>((ref) async {
-  final date  = ref.watch(activityQueryProvider.select((q) => q.date));
-  final from  = ref.watch(activityQueryProvider.select((q) => q.from));
-  final to    = ref.watch(activityQueryProvider.select((q) => q.to));
-  final limit = ref.watch(activityQueryProvider.select((q) => q.limit));
+  final date = ref.watch(activityQueryProvider.select((q) => q.date));
+  final from = ref.watch(activityQueryProvider.select((q) => q.from));
+  final to   = ref.watch(activityQueryProvider.select((q) => q.to));
   final api = ref.watch(apiClientProvider);
   return api.fetchActivity(
-    ActivityQuery(date: date, from: from, to: to, limit: limit),
+    ActivityQuery(date: date, from: from, to: to, limit: _activityOptionsLimit),
   );
 });

--- a/flutter_app/lib/features/activity/activity_providers.dart
+++ b/flutter_app/lib/features/activity/activity_providers.dart
@@ -14,49 +14,33 @@ class ActivityQueryNotifier extends StateNotifier<ActivityQuery> {
   }
 
   void setDate(DateTime day) {
-    state = ActivityQuery(
+    state = state.copyWith(
       date: DateTime(day.year, day.month, day.day),
-      orgs: state.orgs,
-      repos: state.repos,
-      actions: state.actions,
-      limit: state.limit,
+      from: null,
+      to: null,
     );
   }
 
   void setRange(DateTime from, DateTime to) {
-    state = ActivityQuery(
+    state = state.copyWith(
+      date: null,
       from: DateTime(from.year, from.month, from.day),
-      to:   DateTime(to.year, to.month, to.day),
-      orgs: state.orgs,
-      repos: state.repos,
-      actions: state.actions,
-      limit: state.limit,
+      to:   DateTime(to.year,   to.month,   to.day),
     );
   }
 
-  void toggleOrg(String org)    => _replace(orgs:    _toggled(state.orgs,    org));
-  void toggleRepo(String repo)  => _replace(repos:   _toggled(state.repos,   repo));
+  void toggleOrg(String org) =>
+      state = state.copyWith(orgs: _toggled(state.orgs, org));
+  void toggleRepo(String repo) =>
+      state = state.copyWith(repos: _toggled(state.repos, repo));
   void toggleAction(ActivityAction a) =>
-      _replace(actions: _toggled(state.actions, a));
+      state = state.copyWith(actions: _toggled(state.actions, a));
 
-  void clearFilters() =>
-      _replace(orgs: const {}, repos: const {}, actions: const {});
-
-  void _replace({
-    Set<String>? orgs,
-    Set<String>? repos,
-    Set<ActivityAction>? actions,
-  }) {
-    state = ActivityQuery(
-      date:    state.date,
-      from:    state.from,
-      to:      state.to,
-      orgs:    orgs    ?? state.orgs,
-      repos:   repos   ?? state.repos,
-      actions: actions ?? state.actions,
-      limit:   state.limit,
-    );
-  }
+  void clearFilters() => state = state.copyWith(
+        orgs: const {},
+        repos: const {},
+        actions: const {},
+      );
 
   static Set<T> _toggled<T>(Set<T> set, T v) {
     final next = Set<T>.from(set);
@@ -77,4 +61,19 @@ final activityEntriesProvider = FutureProvider<ActivityPage>((ref) async {
   final q = ref.watch(activityQueryProvider);
   final api = ref.watch(apiClientProvider);
   return api.fetchActivity(q);
+});
+
+/// Source for filter chip option lists (orgs/repos). Uses the same date
+/// window as the main query but drops org/repo/action filters — so the
+/// option lists show the full universe for the window instead of shrinking
+/// to the already-filtered slice.
+final activityOptionsProvider = FutureProvider<ActivityPage>((ref) async {
+  final date  = ref.watch(activityQueryProvider.select((q) => q.date));
+  final from  = ref.watch(activityQueryProvider.select((q) => q.from));
+  final to    = ref.watch(activityQueryProvider.select((q) => q.to));
+  final limit = ref.watch(activityQueryProvider.select((q) => q.limit));
+  final api = ref.watch(apiClientProvider);
+  return api.fetchActivity(
+    ActivityQuery(date: date, from: from, to: to, limit: limit),
+  );
 });

--- a/flutter_app/lib/features/activity/activity_providers.dart
+++ b/flutter_app/lib/features/activity/activity_providers.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/activity.dart';
+import '../dashboard/dashboard_providers.dart' show apiClientProvider;
+
+/// Notifier managing the current query (date, range, filter sets).
+/// Widgets read & mutate this; the entries provider watches it.
+class ActivityQueryNotifier extends StateNotifier<ActivityQuery> {
+  ActivityQueryNotifier() : super(_today());
+
+  static ActivityQuery _today() {
+    final now = DateTime.now();
+    return ActivityQuery(date: DateTime(now.year, now.month, now.day));
+  }
+
+  void setDate(DateTime day) {
+    state = ActivityQuery(
+      date: DateTime(day.year, day.month, day.day),
+      orgs: state.orgs,
+      repos: state.repos,
+      actions: state.actions,
+      limit: state.limit,
+    );
+  }
+
+  void setRange(DateTime from, DateTime to) {
+    state = ActivityQuery(
+      from: DateTime(from.year, from.month, from.day),
+      to:   DateTime(to.year, to.month, to.day),
+      orgs: state.orgs,
+      repos: state.repos,
+      actions: state.actions,
+      limit: state.limit,
+    );
+  }
+
+  void toggleOrg(String org)    => _replace(orgs:    _toggled(state.orgs,    org));
+  void toggleRepo(String repo)  => _replace(repos:   _toggled(state.repos,   repo));
+  void toggleAction(ActivityAction a) =>
+      _replace(actions: _toggled(state.actions, a));
+
+  void clearFilters() =>
+      _replace(orgs: const {}, repos: const {}, actions: const {});
+
+  void _replace({
+    Set<String>? orgs,
+    Set<String>? repos,
+    Set<ActivityAction>? actions,
+  }) {
+    state = ActivityQuery(
+      date:    state.date,
+      from:    state.from,
+      to:      state.to,
+      orgs:    orgs    ?? state.orgs,
+      repos:   repos   ?? state.repos,
+      actions: actions ?? state.actions,
+      limit:   state.limit,
+    );
+  }
+
+  static Set<T> _toggled<T>(Set<T> set, T v) {
+    final next = Set<T>.from(set);
+    if (!next.add(v)) next.remove(v);
+    return next;
+  }
+}
+
+/// Current query state.
+final activityQueryProvider =
+    StateNotifierProvider<ActivityQueryNotifier, ActivityQuery>(
+  (ref) => ActivityQueryNotifier(),
+);
+
+/// Entries for the current query. Watches the query so filter changes
+/// trigger a refetch automatically.
+final activityEntriesProvider = FutureProvider<ActivityPage>((ref) async {
+  final q = ref.watch(activityQueryProvider);
+  final api = ref.watch(apiClientProvider);
+  return api.fetchActivity(q);
+});

--- a/flutter_app/lib/features/activity/activity_screen.dart
+++ b/flutter_app/lib/features/activity/activity_screen.dart
@@ -42,15 +42,47 @@ class ActivityScreen extends ConsumerWidget {
           child: async.when(
             data: (page) => _Timeline(page: page),
             loading: () => const Center(child: CircularProgressIndicator()),
-            error: (err, _) => Center(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Text('Error: $err'),
-              ),
-            ),
+            error: (err, _) => _ErrorView(error: err),
           ),
         ),
       ],
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  final Object error;
+  const _ErrorView({required this.error});
+
+  @override
+  Widget build(BuildContext context) {
+    if (error is ActivityDisabledException) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.toggle_off_outlined, size: 48, color: Colors.grey),
+              SizedBox(height: 12),
+              Text('Activity log is disabled',
+                  style: TextStyle(fontWeight: FontWeight.w600)),
+              SizedBox(height: 4),
+              Text(
+                'Enable activity_log in the daemon config to start recording activity.',
+                style: TextStyle(color: Colors.grey),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text('Could not load activity: $error'),
+      ),
     );
   }
 }
@@ -106,6 +138,9 @@ class _DatePickerBar extends ConsumerWidget {
               context: context,
               firstDate: today.subtract(const Duration(days: 365)),
               lastDate: today,
+              initialDateRange: (query.from != null && query.to != null)
+                  ? DateTimeRange(start: query.from!, end: query.to!)
+                  : null,
             );
             if (picked != null) notifier.setRange(picked.start, picked.end);
           },
@@ -115,9 +150,63 @@ class _DatePickerBar extends ConsumerWidget {
   }
 }
 
+/// An item in the timeline: either a date/hour header or an entry tile.
+/// Pre-flattening the sequence lets us render with ListView.builder so tiles
+/// are built lazily and rebuilds don't allocate the full widget tree.
+sealed class _TimelineItem {
+  const _TimelineItem();
+}
+
+class _TruncationBanner extends _TimelineItem {
+  final int shown;
+  const _TruncationBanner(this.shown);
+}
+
+class _DateHeader extends _TimelineItem {
+  final DateTime day;
+  const _DateHeader(this.day);
+}
+
+class _HourHeader extends _TimelineItem {
+  final int hour;
+  const _HourHeader(this.hour);
+}
+
+class _EntryItem extends _TimelineItem {
+  final ActivityEntry entry;
+  const _EntryItem(this.entry);
+}
+
 class _Timeline extends StatelessWidget {
   final ActivityPage page;
   const _Timeline({required this.page});
+
+  static bool _sameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  List<_TimelineItem> _buildItems() {
+    final items = <_TimelineItem>[];
+    if (page.truncated) {
+      items.add(_TruncationBanner(page.entries.length));
+    }
+
+    DateTime? currentDay;
+    int? currentHour;
+    for (final e in page.entries) {
+      final ts = e.timestamp;
+      if (currentDay == null || !_sameDay(currentDay, ts)) {
+        items.add(_DateHeader(DateTime(ts.year, ts.month, ts.day)));
+        currentDay = ts;
+        currentHour = null;
+      }
+      if (ts.hour != currentHour) {
+        items.add(_HourHeader(ts.hour));
+        currentHour = ts.hour;
+      }
+      items.add(_EntryItem(e));
+    }
+    return items;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -125,47 +214,68 @@ class _Timeline extends StatelessWidget {
       return const Center(child: Text('No activity for this period.'));
     }
 
-    final items = <Widget>[];
-    if (page.truncated) {
-      items.add(Container(
-        width: double.infinity,
-        padding: const EdgeInsets.all(12),
-        color: Theme.of(context).colorScheme.surfaceContainerHighest,
-        child: Text(
-          'Showing ${page.entries.length} most recent entries. Narrow filters to see more.',
-        ),
-      ));
-    }
+    final items = _buildItems();
+    return ListView.builder(
+      itemCount: items.length,
+      itemBuilder: (context, i) => _renderItem(context, items[i]),
+    );
+  }
 
-    int? currentHour;
-    for (final e in page.entries) {
-      if (e.timestamp.hour != currentHour) {
-        currentHour = e.timestamp.hour;
-        items.add(Padding(
-          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+  Widget _renderItem(BuildContext context, _TimelineItem item) {
+    switch (item) {
+      case _TruncationBanner(:final shown):
+        return Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
           child: Text(
-            '${currentHour.toString().padLeft(2, '0')}:00',
+            'Showing $shown most recent entries. Narrow filters to see more.',
+          ),
+        );
+      case _DateHeader(:final day):
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+          child: Text(
+            _formatDay(day),
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+        );
+      case _HourHeader(:final hour):
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+          child: Text(
+            '${hour.toString().padLeft(2, '0')}:00',
             style: Theme.of(context).textTheme.titleSmall,
           ),
-        ));
-      }
-      items.add(ActivityEntryTile(
-        entry: e,
-        onTap: () {
-          // Tap → detail navigation is deferred: the activity_log row knows
-          // repo + number but not the PR/issue store ID the /prs/:id and
-          // /issues/:id routes expect. Follow-up spec (AI report generation)
-          // will add a by-number lookup endpoint.
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('${e.repo} #${e.itemNumber}'),
-              duration: const Duration(seconds: 2),
-            ),
-          );
-        },
-      ));
+        );
+      case _EntryItem(:final entry):
+        return ActivityEntryTile(
+          entry: entry,
+          onTap: () {
+            // Tap → detail navigation is deferred: the activity_log row knows
+            // repo + number but not the PR/issue store ID the /prs/:id and
+            // /issues/:id routes expect. Follow-up spec (AI report generation)
+            // will add a by-number lookup endpoint.
+            final messenger = ScaffoldMessenger.of(context);
+            messenger.hideCurrentSnackBar();
+            messenger.showSnackBar(
+              SnackBar(
+                content: Text('${entry.repo} #${entry.itemNumber}'),
+                duration: const Duration(seconds: 2),
+              ),
+            );
+          },
+        );
     }
+  }
 
-    return ListView(children: items);
+  static String _formatDay(DateTime d) {
+    const months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    return '${months[d.month - 1]} ${d.day}, ${d.year}';
   }
 }

--- a/flutter_app/lib/features/activity/activity_screen.dart
+++ b/flutter_app/lib/features/activity/activity_screen.dart
@@ -18,10 +18,13 @@ class ActivityScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final q = ref.watch(activityQueryProvider);
     final async = ref.watch(activityEntriesProvider);
+    final optionsAsync = ref.watch(activityOptionsProvider);
 
-    final orgs = async.valueOrNull?.entries.map((e) => e.org).toSet().toList()
+    final orgs = optionsAsync.valueOrNull?.entries
+            .map((e) => e.org).toSet().toList()
         ?? const <String>[];
-    final repos = async.valueOrNull?.entries.map((e) => e.repo).toSet().toList()
+    final repos = optionsAsync.valueOrNull?.entries
+            .map((e) => e.repo).toSet().toList()
         ?? const <String>[];
 
     return Column(
@@ -127,7 +130,7 @@ class _Timeline extends StatelessWidget {
       items.add(Container(
         width: double.infinity,
         padding: const EdgeInsets.all(12),
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         child: Text(
           'Showing ${page.entries.length} most recent entries. Narrow filters to see more.',
         ),

--- a/flutter_app/lib/features/activity/activity_screen.dart
+++ b/flutter_app/lib/features/activity/activity_screen.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/activity.dart';
+import 'activity_providers.dart';
+import 'widgets/activity_entry_tile.dart';
+import 'widgets/activity_filter_chips.dart';
+
+/// The "Activity log" tab content. Shows a date picker bar, filter chips,
+/// and a timeline of activity entries grouped by hour.
+///
+/// No Scaffold/AppBar — this is rendered inside the dashboard's TabBarView,
+/// which supplies the shared AppBar.
+class ActivityScreen extends ConsumerWidget {
+  const ActivityScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final q = ref.watch(activityQueryProvider);
+    final async = ref.watch(activityEntriesProvider);
+
+    final orgs = async.valueOrNull?.entries.map((e) => e.org).toSet().toList()
+        ?? const <String>[];
+    final repos = async.valueOrNull?.entries.map((e) => e.repo).toSet().toList()
+        ?? const <String>[];
+
+    return Column(
+      children: [
+        _DatePickerBar(query: q),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: ActivityFilterChips(
+            availableOrgs: orgs,
+            availableRepos: repos,
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: async.when(
+            data: (page) => _Timeline(page: page),
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (err, _) => Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text('Error: $err'),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DatePickerBar extends ConsumerWidget {
+  final ActivityQuery query;
+  const _DatePickerBar({required this.query});
+
+  static bool _isSameDay(DateTime? a, DateTime b) =>
+      a != null && a.year == b.year && a.month == b.month && a.day == b.day;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notifier   = ref.read(activityQueryProvider.notifier);
+    final today      = DateTime.now();
+    final yesterday  = today.subtract(const Duration(days: 1));
+    final isToday    = _isSameDay(query.date, today);
+    final isYesterday = _isSameDay(query.date, yesterday);
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(children: [
+        ChoiceChip(
+          label: const Text('Today'),
+          selected: isToday,
+          onSelected: (_) => notifier.setDate(today),
+        ),
+        const SizedBox(width: 8),
+        ChoiceChip(
+          label: const Text('Yesterday'),
+          selected: isYesterday,
+          onSelected: (_) => notifier.setDate(yesterday),
+        ),
+        const SizedBox(width: 8),
+        ActionChip(
+          label: const Text('Pick day'),
+          onPressed: () async {
+            final picked = await showDatePicker(
+              context: context,
+              initialDate: query.date ?? today,
+              firstDate: today.subtract(const Duration(days: 365)),
+              lastDate: today,
+            );
+            if (picked != null) notifier.setDate(picked);
+          },
+        ),
+        const SizedBox(width: 8),
+        ActionChip(
+          label: const Text('Pick range'),
+          onPressed: () async {
+            final picked = await showDateRangePicker(
+              context: context,
+              firstDate: today.subtract(const Duration(days: 365)),
+              lastDate: today,
+            );
+            if (picked != null) notifier.setRange(picked.start, picked.end);
+          },
+        ),
+      ]),
+    );
+  }
+}
+
+class _Timeline extends StatelessWidget {
+  final ActivityPage page;
+  const _Timeline({required this.page});
+
+  @override
+  Widget build(BuildContext context) {
+    if (page.entries.isEmpty) {
+      return const Center(child: Text('No activity for this period.'));
+    }
+
+    final items = <Widget>[];
+    if (page.truncated) {
+      items.add(Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(12),
+        color: Theme.of(context).colorScheme.surfaceVariant,
+        child: Text(
+          'Showing ${page.entries.length} most recent entries. Narrow filters to see more.',
+        ),
+      ));
+    }
+
+    int? currentHour;
+    for (final e in page.entries) {
+      if (e.timestamp.hour != currentHour) {
+        currentHour = e.timestamp.hour;
+        items.add(Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          child: Text(
+            '${currentHour.toString().padLeft(2, '0')}:00',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+        ));
+      }
+      items.add(ActivityEntryTile(
+        entry: e,
+        onTap: () {
+          // Tap → detail navigation is deferred: the activity_log row knows
+          // repo + number but not the PR/issue store ID the /prs/:id and
+          // /issues/:id routes expect. Follow-up spec (AI report generation)
+          // will add a by-number lookup endpoint.
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('${e.repo} #${e.itemNumber}'),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+        },
+      ));
+    }
+
+    return ListView(children: items);
+  }
+}

--- a/flutter_app/lib/features/activity/widgets/activity_entry_tile.dart
+++ b/flutter_app/lib/features/activity/widgets/activity_entry_tile.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/models/activity.dart';
+
+/// One row in the activity timeline.
+class ActivityEntryTile extends StatelessWidget {
+  final ActivityEntry entry;
+  final VoidCallback? onTap;
+
+  const ActivityEntryTile({super.key, required this.entry, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final iconColor = entry.action == ActivityAction.error
+        ? scheme.error
+        : scheme.primary;
+
+    return ListTile(
+      leading: Icon(_iconFor(entry.action), color: iconColor),
+      title: Text(
+        '${entry.repo} · #${entry.itemNumber} · ${entry.itemTitle}',
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(_subtitle(entry)),
+      trailing: Text(
+        _hhmmss(entry.timestamp),
+        style: const TextStyle(fontFamily: 'monospace'),
+      ),
+      onTap: onTap,
+    );
+  }
+
+  static IconData _iconFor(ActivityAction a) {
+    switch (a) {
+      case ActivityAction.review:    return Icons.rate_review;
+      case ActivityAction.triage:    return Icons.label;
+      case ActivityAction.implement: return Icons.build;
+      case ActivityAction.promote:   return Icons.swap_horiz;
+      case ActivityAction.error:     return Icons.error_outline;
+      case ActivityAction.unknown:   return Icons.help_outline;
+    }
+  }
+
+  static String _subtitle(ActivityEntry e) {
+    switch (e.action) {
+      case ActivityAction.review:
+        final cli = e.details['cli_used'];
+        final suffix = (cli is String && cli.isNotEmpty) ? ' by $cli' : '';
+        return '${e.outcome} review$suffix';
+      case ActivityAction.triage:
+        final cat = e.details['category'];
+        final catStr = (cat is String && cat.isNotEmpty) ? ' ($cat)' : '';
+        return 'triaged${e.outcome.isEmpty ? '' : ': ${e.outcome}'}$catStr';
+      case ActivityAction.implement:
+        final n = e.details['pr_number'];
+        if (n is num && n > 0) return 'opened PR #${n.toInt()}';
+        return 'implement failed';
+      case ActivityAction.promote:
+        return 'promoted: ${e.outcome}';
+      case ActivityAction.error:
+        return e.outcome;
+      case ActivityAction.unknown:
+        return '';
+    }
+  }
+
+  static String _hhmmss(DateTime t) =>
+      '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}:${t.second.toString().padLeft(2, '0')}';
+}

--- a/flutter_app/lib/features/activity/widgets/activity_filter_chips.dart
+++ b/flutter_app/lib/features/activity/widgets/activity_filter_chips.dart
@@ -19,7 +19,6 @@ class ActivityFilterChips extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final q = ref.watch(activityQueryProvider);
-    final n = ref.read(activityQueryProvider.notifier);
     final anyActive = q.orgs.isNotEmpty || q.repos.isNotEmpty || q.actions.isNotEmpty;
 
     return Wrap(
@@ -30,25 +29,34 @@ class ActivityFilterChips extends ConsumerWidget {
         _chip(context,
             label: 'Organization',
             count: q.orgs.length,
-            onTap: () => _pickStrings(context,
-                options: availableOrgs,
-                selected: q.orgs,
-                toggle: n.toggleOrg)),
+            onTap: () => _pickStrings(
+                  context,
+                  options: availableOrgs,
+                  select: (q) => q.orgs,
+                  toggle: (v) =>
+                      ref.read(activityQueryProvider.notifier).toggleOrg(v),
+                )),
         _chip(context,
             label: 'Repository',
             count: q.repos.length,
-            onTap: () => _pickStrings(context,
-                options: availableRepos,
-                selected: q.repos,
-                toggle: n.toggleRepo)),
+            onTap: () => _pickStrings(
+                  context,
+                  options: availableRepos,
+                  select: (q) => q.repos,
+                  toggle: (v) =>
+                      ref.read(activityQueryProvider.notifier).toggleRepo(v),
+                )),
         _chip(context,
             label: 'Action',
             count: q.actions.length,
-            onTap: () => _pickActions(context,
-                selected: q.actions, toggle: n.toggleAction)),
+            onTap: () => _pickActions(
+                  context,
+                  toggle: (a) =>
+                      ref.read(activityQueryProvider.notifier).toggleAction(a),
+                )),
         if (anyActive)
           TextButton(
-            onPressed: n.clearFilters,
+            onPressed: ref.read(activityQueryProvider.notifier).clearFilters,
             child: const Text('Clear filters'),
           ),
       ],
@@ -63,32 +71,35 @@ class ActivityFilterChips extends ConsumerWidget {
     );
   }
 
-  Future<void> _pickStrings(BuildContext context,
-      {required List<String> options,
-      required Set<String> selected,
-      required void Function(String) toggle}) async {
+  Future<void> _pickStrings(
+    BuildContext context, {
+    required List<String> options,
+    required Set<String> Function(ActivityQuery q) select,
+    required void Function(String) toggle,
+  }) async {
     await showModalBottomSheet<void>(
       context: context,
-      builder: (_) => StatefulBuilder(
-        builder: (ctx, setState) => ListView(
-          children: options
-              .map((o) => CheckboxListTile(
-                    value: selected.contains(o),
-                    title: Text(o),
-                    onChanged: (_) {
-                      toggle(o);
-                      setState(() {});
-                    },
-                  ))
-              .toList(),
-        ),
+      builder: (_) => Consumer(
+        builder: (ctx, ref, _) {
+          final selected = select(ref.watch(activityQueryProvider));
+          return ListView(
+            children: options
+                .map((o) => CheckboxListTile(
+                      value: selected.contains(o),
+                      title: Text(o),
+                      onChanged: (_) => toggle(o),
+                    ))
+                .toList(),
+          );
+        },
       ),
     );
   }
 
-  Future<void> _pickActions(BuildContext context,
-      {required Set<ActivityAction> selected,
-      required void Function(ActivityAction) toggle}) async {
+  Future<void> _pickActions(
+    BuildContext context, {
+    required void Function(ActivityAction) toggle,
+  }) async {
     const options = [
       ActivityAction.review,
       ActivityAction.triage,
@@ -98,19 +109,19 @@ class ActivityFilterChips extends ConsumerWidget {
     ];
     await showModalBottomSheet<void>(
       context: context,
-      builder: (_) => StatefulBuilder(
-        builder: (ctx, setState) => ListView(
-          children: options
-              .map((a) => CheckboxListTile(
-                    value: selected.contains(a),
-                    title: Text(a.name),
-                    onChanged: (_) {
-                      toggle(a);
-                      setState(() {});
-                    },
-                  ))
-              .toList(),
-        ),
+      builder: (_) => Consumer(
+        builder: (ctx, ref, _) {
+          final selected = ref.watch(activityQueryProvider).actions;
+          return ListView(
+            children: options
+                .map((a) => CheckboxListTile(
+                      value: selected.contains(a),
+                      title: Text(a.name),
+                      onChanged: (_) => toggle(a),
+                    ))
+                .toList(),
+          );
+        },
       ),
     );
   }

--- a/flutter_app/lib/features/activity/widgets/activity_filter_chips.dart
+++ b/flutter_app/lib/features/activity/widgets/activity_filter_chips.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/activity.dart';
+import '../activity_providers.dart';
+
+/// Three chips (Organization / Repository / Action) with multi-select popups,
+/// plus a Clear-filters button when any filter is active.
+class ActivityFilterChips extends ConsumerWidget {
+  final List<String> availableOrgs;
+  final List<String> availableRepos;
+
+  const ActivityFilterChips({
+    super.key,
+    required this.availableOrgs,
+    required this.availableRepos,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final q = ref.watch(activityQueryProvider);
+    final n = ref.read(activityQueryProvider.notifier);
+    final anyActive = q.orgs.isNotEmpty || q.repos.isNotEmpty || q.actions.isNotEmpty;
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 4,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        _chip(context,
+            label: 'Organization',
+            count: q.orgs.length,
+            onTap: () => _pickStrings(context,
+                options: availableOrgs,
+                selected: q.orgs,
+                toggle: n.toggleOrg)),
+        _chip(context,
+            label: 'Repository',
+            count: q.repos.length,
+            onTap: () => _pickStrings(context,
+                options: availableRepos,
+                selected: q.repos,
+                toggle: n.toggleRepo)),
+        _chip(context,
+            label: 'Action',
+            count: q.actions.length,
+            onTap: () => _pickActions(context,
+                selected: q.actions, toggle: n.toggleAction)),
+        if (anyActive)
+          TextButton(
+            onPressed: n.clearFilters,
+            child: const Text('Clear filters'),
+          ),
+      ],
+    );
+  }
+
+  Widget _chip(BuildContext context,
+      {required String label, required int count, required VoidCallback onTap}) {
+    return ActionChip(
+      label: Text(count == 0 ? label : '$label · $count'),
+      onPressed: onTap,
+    );
+  }
+
+  Future<void> _pickStrings(BuildContext context,
+      {required List<String> options,
+      required Set<String> selected,
+      required void Function(String) toggle}) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (_) => StatefulBuilder(
+        builder: (ctx, setState) => ListView(
+          children: options
+              .map((o) => CheckboxListTile(
+                    value: selected.contains(o),
+                    title: Text(o),
+                    onChanged: (_) {
+                      toggle(o);
+                      setState(() {});
+                    },
+                  ))
+              .toList(),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickActions(BuildContext context,
+      {required Set<ActivityAction> selected,
+      required void Function(ActivityAction) toggle}) async {
+    const options = [
+      ActivityAction.review,
+      ActivityAction.triage,
+      ActivityAction.implement,
+      ActivityAction.promote,
+      ActivityAction.error,
+    ];
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (_) => StatefulBuilder(
+        builder: (ctx, setState) => ListView(
+          children: options
+              .map((a) => CheckboxListTile(
+                    value: selected.contains(a),
+                    title: Text(a.name),
+                    onChanged: (_) {
+                      toggle(a);
+                      setState(() {});
+                    },
+                  ))
+              .toList(),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -42,6 +42,7 @@ class DashboardScreen extends ConsumerWidget {
                 ref.invalidate(issuesProvider);
                 ref.invalidate(statsProvider);
                 ref.invalidate(activityEntriesProvider);
+                ref.invalidate(activityOptionsProvider);
               },
             ),
           ],

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -5,6 +5,8 @@ import '../../core/models/pr.dart';
 import '../../core/models/tracked_issue.dart';
 import '../../shared/widgets/severity_badge.dart';
 import '../../shared/widgets/toast.dart';
+import '../activity/activity_screen.dart';
+import '../activity/activity_providers.dart';
 import '../agents/agents_screen.dart';
 import '../cli_agents/cli_agents_screen.dart';
 import '../issues/issues_screen.dart';
@@ -19,7 +21,7 @@ class DashboardScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return DefaultTabController(
-      length: 6,
+      length: 7,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Heimdallm'),
@@ -39,6 +41,7 @@ class DashboardScreen extends ConsumerWidget {
                 ref.invalidate(prsProvider);
                 ref.invalidate(issuesProvider);
                 ref.invalidate(statsProvider);
+                ref.invalidate(activityEntriesProvider);
               },
             ),
           ],
@@ -46,6 +49,7 @@ class DashboardScreen extends ConsumerWidget {
             tabs: [
               Tab(icon: Icon(Icons.dashboard),       text: 'Activity'),
               Tab(icon: Icon(Icons.bug_report),      text: 'Issues'),
+              Tab(icon: Icon(Icons.timeline),        text: 'Activity log'),
               Tab(icon: Icon(Icons.folder_outlined), text: 'Repositories'),
               Tab(icon: Icon(Icons.auto_awesome),    text: 'Prompts'),
               Tab(icon: Icon(Icons.smart_toy),       text: 'Agents'),
@@ -57,6 +61,7 @@ class DashboardScreen extends ConsumerWidget {
           children: [
             _ActivityTab(),
             IssuesScreen(),
+            ActivityScreen(),
             ReposScreen(),
             AgentsScreen(),
             CLIAgentsScreen(),

--- a/flutter_app/test/features/activity/activity_entry_tile_test.dart
+++ b/flutter_app/test/features/activity/activity_entry_tile_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/models/activity.dart';
+import 'package:heimdallm/features/activity/widgets/activity_entry_tile.dart';
+
+ActivityEntry _mk({
+  required ActivityAction action,
+  String outcome = '',
+  Map<String, dynamic> details = const {},
+  DateTime? ts,
+}) =>
+    ActivityEntry(
+      id: 1,
+      timestamp: ts ?? DateTime(2026, 4, 20, 9, 34, 12),
+      org: 'acme',
+      repo: 'acme/api',
+      itemType: 'pr',
+      itemNumber: 42,
+      itemTitle: 'Fix rate limiter race',
+      action: action,
+      outcome: outcome,
+      details: details,
+    );
+
+void main() {
+  testWidgets('renders repo, number, title, time, outcome for review', (tester) async {
+    final entry = _mk(
+      action: ActivityAction.review,
+      outcome: 'major',
+      details: {'cli_used': 'claude'},
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: ActivityEntryTile(entry: entry, onTap: () {})),
+    ));
+
+    expect(find.textContaining('acme/api'),             findsOneWidget);
+    expect(find.textContaining('#42'),                   findsOneWidget);
+    expect(find.textContaining('Fix rate limiter race'), findsOneWidget);
+    expect(find.textContaining('09:34:12'),              findsOneWidget);
+    expect(find.textContaining('major review by claude'), findsOneWidget);
+    expect(find.byIcon(Icons.rate_review), findsOneWidget);
+  });
+
+  testWidgets('error action shows error icon and outcome text', (tester) async {
+    final entry = _mk(action: ActivityAction.error, outcome: 'cli_not_found');
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: ActivityEntryTile(entry: entry)),
+    ));
+    expect(find.byIcon(Icons.error_outline),     findsOneWidget);
+    expect(find.textContaining('cli_not_found'), findsOneWidget);
+  });
+
+  testWidgets('implement with pr_number > 0 shows opened PR text', (tester) async {
+    final entry = _mk(
+      action: ActivityAction.implement,
+      details: {'pr_number': 99},
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: ActivityEntryTile(entry: entry)),
+    ));
+    expect(find.byIcon(Icons.build),              findsOneWidget);
+    expect(find.textContaining('opened PR #99'),  findsOneWidget);
+  });
+
+  testWidgets('implement with pr_number 0 shows failed text', (tester) async {
+    final entry = _mk(
+      action: ActivityAction.implement,
+      details: {'pr_number': 0},
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: ActivityEntryTile(entry: entry)),
+    ));
+    expect(find.textContaining('implement failed'), findsOneWidget);
+  });
+
+  testWidgets('promote shows from → to outcome', (tester) async {
+    final entry = _mk(
+      action: ActivityAction.promote,
+      outcome: 'blocked → develop',
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: ActivityEntryTile(entry: entry)),
+    ));
+    expect(find.byIcon(Icons.swap_horiz),                      findsOneWidget);
+    expect(find.textContaining('promoted: blocked → develop'), findsOneWidget);
+  });
+
+  testWidgets('triage shows category', (tester) async {
+    final entry = _mk(
+      action: ActivityAction.triage,
+      outcome: 'major',
+      details: {'category': 'develop'},
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: ActivityEntryTile(entry: entry)),
+    ));
+    expect(find.byIcon(Icons.label),              findsOneWidget);
+    expect(find.textContaining('major'),          findsOneWidget);
+    expect(find.textContaining('(develop)'),      findsOneWidget);
+  });
+}

--- a/flutter_app/test/features/activity/activity_filter_chips_test.dart
+++ b/flutter_app/test/features/activity/activity_filter_chips_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/models/activity.dart';
+import 'package:heimdallm/features/activity/activity_providers.dart';
+import 'package:heimdallm/features/activity/widgets/activity_filter_chips.dart';
+
+Widget _host({List<String> orgs = const ['acme', 'initech']}) {
+  return ProviderScope(
+    child: MaterialApp(
+      home: Scaffold(
+        body: ActivityFilterChips(
+          availableOrgs: orgs,
+          availableRepos: const [],
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('org checkbox updates visually when tapped in bottom sheet',
+      (tester) async {
+    await tester.pumpWidget(_host());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Organization'));
+    await tester.pumpAndSettle();
+
+    final acmeTile = find.ancestor(
+      of: find.text('acme'),
+      matching: find.byType(CheckboxListTile),
+    );
+    expect(tester.widget<CheckboxListTile>(acmeTile).value, isFalse);
+
+    await tester.tap(acmeTile);
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<CheckboxListTile>(acmeTile).value, isTrue);
+
+    await tester.tap(acmeTile);
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<CheckboxListTile>(acmeTile).value, isFalse);
+  });
+
+  testWidgets('action checkbox updates visually when tapped in bottom sheet',
+      (tester) async {
+    await tester.pumpWidget(_host());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Action'));
+    await tester.pumpAndSettle();
+
+    final reviewTile = find.ancestor(
+      of: find.text('review'),
+      matching: find.byType(CheckboxListTile),
+    );
+    expect(tester.widget<CheckboxListTile>(reviewTile).value, isFalse);
+
+    await tester.tap(reviewTile);
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<CheckboxListTile>(reviewTile).value, isTrue);
+  });
+
+  testWidgets('chip label shows selection count', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(activityQueryProvider.notifier).toggleOrg('acme');
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: ActivityFilterChips(
+              availableOrgs: ['acme'],
+              availableRepos: [],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Organization · 1'), findsOneWidget);
+  });
+
+  testWidgets('Clear filters button appears when any filter is active and resets',
+      (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(activityQueryProvider.notifier).toggleOrg('acme');
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: ActivityFilterChips(
+              availableOrgs: ['acme'],
+              availableRepos: [],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Clear filters'), findsOneWidget);
+    await tester.tap(find.text('Clear filters'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Clear filters'), findsNothing);
+    expect(container.read(activityQueryProvider).orgs, isEmpty);
+  });
+}

--- a/flutter_app/test/features/activity/activity_filter_chips_test.dart
+++ b/flutter_app/test/features/activity/activity_filter_chips_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:heimdallm/core/models/activity.dart';
 import 'package:heimdallm/features/activity/activity_providers.dart';
 import 'package:heimdallm/features/activity/widgets/activity_filter_chips.dart';
 

--- a/flutter_app/test/features/activity/activity_models_test.dart
+++ b/flutter_app/test/features/activity/activity_models_test.dart
@@ -137,4 +137,49 @@ void main() {
       );
     });
   });
+
+  group('ActivityQuery constructor', () {
+    test('asserts on partial range (from only)', () {
+      expect(
+        () => ActivityQuery(from: DateTime(2026, 4, 18)),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('asserts on partial range (to only)', () {
+      expect(
+        () => ActivityQuery(to: DateTime(2026, 4, 18)),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('both null is fine', () {
+      expect(() => const ActivityQuery(), returnsNormally);
+    });
+  });
+
+  group('ActivityQuery.copyWith', () {
+    test('keeps unspecified date/from/to', () {
+      final q = ActivityQuery(date: DateTime(2026, 4, 20));
+      final c = q.copyWith(orgs: {'a'});
+      expect(c.date, DateTime(2026, 4, 20));
+      expect(c.orgs, {'a'});
+    });
+
+    test('explicit null clears date', () {
+      final q = ActivityQuery(date: DateTime(2026, 4, 20));
+      final c = q.copyWith(date: null);
+      expect(c.date, isNull);
+    });
+
+    test('explicit from/to both null clears range', () {
+      final q = ActivityQuery(
+        from: DateTime(2026, 4, 18),
+        to: DateTime(2026, 4, 20),
+      );
+      final c = q.copyWith(from: null, to: null);
+      expect(c.from, isNull);
+      expect(c.to, isNull);
+    });
+  });
 }

--- a/flutter_app/test/features/activity/activity_models_test.dart
+++ b/flutter_app/test/features/activity/activity_models_test.dart
@@ -115,7 +115,7 @@ void main() {
     });
 
     test('multi-value filters', () {
-      final q = ActivityQuery(
+      const q = ActivityQuery(
         orgs: {'a', 'b'},
         repos: {'a/x'},
         actions: {ActivityAction.review, ActivityAction.triage},

--- a/flutter_app/test/features/activity/activity_models_test.dart
+++ b/flutter_app/test/features/activity/activity_models_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/models/activity.dart';
+
+void main() {
+  group('ActivityEntry.fromJson', () {
+    test('parses a full entry', () {
+      final json = {
+        'id': 1,
+        'ts': '2026-04-20T09:34:12+02:00',
+        'org': 'acme',
+        'repo': 'acme/api',
+        'item_type': 'pr',
+        'item_number': 42,
+        'item_title': 'Fix bug',
+        'action': 'review',
+        'outcome': 'major',
+        'details': {'cli_used': 'claude'},
+      };
+      final e = ActivityEntry.fromJson(json);
+      expect(e.id, 1);
+      expect(e.repo, 'acme/api');
+      expect(e.itemNumber, 42);
+      expect(e.action, ActivityAction.review);
+      expect(e.outcome, 'major');
+      expect(e.details['cli_used'], 'claude');
+    });
+
+    test('unknown action falls back', () {
+      final e = ActivityEntry.fromJson({
+        'id': 1,
+        'ts': '2026-04-20T09:34:12+02:00',
+        'org': 'a',
+        'repo': 'a/b',
+        'item_type': 'pr',
+        'item_number': 1,
+        'item_title': 't',
+        'action': 'frobnicate',
+        'outcome': '',
+        'details': {},
+      });
+      expect(e.action, ActivityAction.unknown);
+    });
+
+    test('missing outcome defaults to empty string', () {
+      final e = ActivityEntry.fromJson({
+        'id': 1,
+        'ts': '2026-04-20T09:34:12+02:00',
+        'org': 'a',
+        'repo': 'a/b',
+        'item_type': 'pr',
+        'item_number': 1,
+        'item_title': 't',
+        'action': 'review',
+        'details': {},
+      });
+      expect(e.outcome, '');
+    });
+  });
+
+  group('ActivityPage.fromJson', () {
+    test('parses empty page', () {
+      final p = ActivityPage.fromJson({
+        'entries': [],
+        'count': 0,
+        'truncated': false,
+      });
+      expect(p.entries, isEmpty);
+      expect(p.count, 0);
+      expect(p.truncated, isFalse);
+    });
+
+    test('parses populated page with truncation', () {
+      final p = ActivityPage.fromJson({
+        'entries': [
+          {
+            'id': 1,
+            'ts': '2026-04-20T09:34:12+02:00',
+            'org': 'a',
+            'repo': 'a/b',
+            'item_type': 'pr',
+            'item_number': 1,
+            'item_title': 't',
+            'action': 'review',
+            'outcome': 'minor',
+            'details': {},
+          }
+        ],
+        'count': 500,
+        'truncated': true,
+      });
+      expect(p.entries.length, 1);
+      expect(p.truncated, isTrue);
+      expect(p.count, 500);
+    });
+  });
+
+  group('ActivityQuery.toQueryParameters', () {
+    test('emits date when set', () {
+      final q = ActivityQuery(date: DateTime(2026, 4, 20));
+      final p = q.toQueryParameters();
+      expect(p['date'], ['2026-04-20']);
+      expect(p.containsKey('from'), isFalse);
+      expect(p.containsKey('to'), isFalse);
+    });
+
+    test('emits from/to when range set', () {
+      final q = ActivityQuery(
+        from: DateTime(2026, 4, 18),
+        to: DateTime(2026, 4, 20),
+      );
+      final p = q.toQueryParameters();
+      expect(p['from'], ['2026-04-18']);
+      expect(p['to'], ['2026-04-20']);
+      expect(p.containsKey('date'), isFalse);
+    });
+
+    test('multi-value filters', () {
+      final q = ActivityQuery(
+        orgs: {'a', 'b'},
+        repos: {'a/x'},
+        actions: {ActivityAction.review, ActivityAction.triage},
+      );
+      final p = q.toQueryParameters();
+      expect(p['org']!.toSet(), {'a', 'b'});
+      expect(p['repo'], ['a/x']);
+      expect(p['action']!.toSet(), {'review', 'triage'});
+    });
+
+    test('always includes limit', () {
+      expect(
+        const ActivityQuery().toQueryParameters()['limit'],
+        ['500'],
+      );
+      expect(
+        const ActivityQuery(limit: 250).toQueryParameters()['limit'],
+        ['250'],
+      );
+    });
+  });
+}

--- a/flutter_app/test/features/activity/activity_providers_test.dart
+++ b/flutter_app/test/features/activity/activity_providers_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:heimdallm/core/models/activity.dart';
+import 'package:heimdallm/features/activity/activity_providers.dart';
+
+void main() {
+  group('ActivityQueryNotifier', () {
+    test('default query is today', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+
+      final q = c.read(activityQueryProvider);
+      final today = DateTime.now();
+      expect(q.date?.year,  today.year);
+      expect(q.date?.month, today.month);
+      expect(q.date?.day,   today.day);
+      expect(q.from, isNull);
+      expect(q.to,   isNull);
+    });
+
+    test('setDate clears range and keeps filters', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+
+      final n = c.read(activityQueryProvider.notifier);
+      n.toggleOrg('acme');
+      n.setDate(DateTime(2026, 4, 18));
+
+      final q = c.read(activityQueryProvider);
+      expect(q.date,  DateTime(2026, 4, 18));
+      expect(q.from,  isNull);
+      expect(q.to,    isNull);
+      expect(q.orgs,  {'acme'});
+    });
+
+    test('setRange clears date and keeps filters', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+
+      final n = c.read(activityQueryProvider.notifier);
+      n.toggleRepo('acme/api');
+      n.setRange(DateTime(2026, 4, 18), DateTime(2026, 4, 20));
+
+      final q = c.read(activityQueryProvider);
+      expect(q.date,  isNull);
+      expect(q.from,  DateTime(2026, 4, 18));
+      expect(q.to,    DateTime(2026, 4, 20));
+      expect(q.repos, {'acme/api'});
+    });
+
+    test('toggle functions add then remove', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final n = c.read(activityQueryProvider.notifier);
+
+      n.toggleOrg('a');
+      n.toggleOrg('b');
+      expect(c.read(activityQueryProvider).orgs, {'a', 'b'});
+
+      n.toggleOrg('a');
+      expect(c.read(activityQueryProvider).orgs, {'b'});
+
+      n.toggleAction(ActivityAction.review);
+      n.toggleAction(ActivityAction.triage);
+      expect(c.read(activityQueryProvider).actions,
+          {ActivityAction.review, ActivityAction.triage});
+
+      n.toggleAction(ActivityAction.review);
+      expect(c.read(activityQueryProvider).actions, {ActivityAction.triage});
+    });
+
+    test('clearFilters resets only filter sets', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final n = c.read(activityQueryProvider.notifier);
+
+      n.setDate(DateTime(2026, 4, 18));
+      n.toggleOrg('a');
+      n.toggleRepo('a/b');
+      n.toggleAction(ActivityAction.review);
+      n.clearFilters();
+
+      final q = c.read(activityQueryProvider);
+      expect(q.date,    DateTime(2026, 4, 18));   // date preserved
+      expect(q.orgs,    isEmpty);
+      expect(q.repos,   isEmpty);
+      expect(q.actions, isEmpty);
+    });
+  });
+}

--- a/flutter_app/test/features/activity/activity_providers_test.dart
+++ b/flutter_app/test/features/activity/activity_providers_test.dart
@@ -69,6 +69,18 @@ void main() {
       expect(c.read(activityQueryProvider).actions, {ActivityAction.triage});
     });
 
+    test('setRange swaps from/to when inverted', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final n = c.read(activityQueryProvider.notifier);
+
+      n.setRange(DateTime(2026, 4, 20), DateTime(2026, 4, 18));
+
+      final q = c.read(activityQueryProvider);
+      expect(q.from, DateTime(2026, 4, 18));
+      expect(q.to,   DateTime(2026, 4, 20));
+    });
+
     test('clearFilters resets only filter sets', () {
       final c = ProviderContainer();
       addTearDown(c.dispose);

--- a/flutter_app/test/features/activity/activity_screen_test.dart
+++ b/flutter_app/test/features/activity/activity_screen_test.dart
@@ -75,4 +75,43 @@ void main() {
     expect(find.textContaining('Showing'), findsOneWidget);
     expect(find.textContaining('Narrow filters'), findsOneWidget);
   });
+
+  testWidgets('emits a date header per day in multi-day ranges', (tester) async {
+    await tester.pumpWidget(_scope(
+      value: AsyncData(ActivityPage(
+        entries: [
+          _mk(1, DateTime(2026, 4, 18, 9, 5)),
+          _mk(2, DateTime(2026, 4, 19, 9, 30)),
+          _mk(3, DateTime(2026, 4, 19, 10, 0)),
+        ],
+        truncated: false,
+        count: 3,
+      )),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('Apr 18, 2026'), findsOneWidget);
+    expect(find.text('Apr 19, 2026'), findsOneWidget);
+    // '09:00' appears twice — once per day — which was the pre-fix bug
+    expect(find.text('09:00'), findsNWidgets(2));
+    expect(find.text('10:00'), findsOneWidget);
+  });
+
+  testWidgets('ActivityDisabledException renders friendly empty state',
+      (tester) async {
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        activityEntriesProvider.overrideWith(
+          (ref) => Future<ActivityPage>.error(ActivityDisabledException()),
+        ),
+        activityOptionsProvider.overrideWith(
+          (ref) => Future<ActivityPage>.error(ActivityDisabledException()),
+        ),
+      ],
+      child: const MaterialApp(home: Scaffold(body: ActivityScreen())),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('Activity log is disabled'), findsOneWidget);
+    expect(find.textContaining('Enable activity_log'), findsOneWidget);
+    expect(find.textContaining('Error:'), findsNothing);
+  });
 }

--- a/flutter_app/test/features/activity/activity_screen_test.dart
+++ b/flutter_app/test/features/activity/activity_screen_test.dart
@@ -20,14 +20,17 @@ ActivityEntry _mk(int n, DateTime ts, {ActivityAction a = ActivityAction.review}
     );
 
 ProviderScope _scope({required AsyncValue<ActivityPage> value}) {
+  Future<ActivityPage> resolve() async {
+    if (value is AsyncError) {
+      throw (value as AsyncError).error;
+    }
+    return (value.valueOrNull)!;
+  }
+
   return ProviderScope(
     overrides: [
-      activityEntriesProvider.overrideWith((ref) async {
-        if (value is AsyncError) {
-          throw (value as AsyncError).error;
-        }
-        return (value.valueOrNull)!;
-      }),
+      activityEntriesProvider.overrideWith((ref) => resolve()),
+      activityOptionsProvider.overrideWith((ref) => resolve()),
     ],
     child: const MaterialApp(home: Scaffold(body: ActivityScreen())),
   );

--- a/flutter_app/test/features/activity/activity_screen_test.dart
+++ b/flutter_app/test/features/activity/activity_screen_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/models/activity.dart';
+import 'package:heimdallm/features/activity/activity_providers.dart';
+import 'package:heimdallm/features/activity/activity_screen.dart';
+
+ActivityEntry _mk(int n, DateTime ts, {ActivityAction a = ActivityAction.review}) =>
+    ActivityEntry(
+      id: n,
+      timestamp: ts,
+      org: 'acme',
+      repo: 'acme/api',
+      itemType: 'pr',
+      itemNumber: n,
+      itemTitle: 'Title $n',
+      action: a,
+      outcome: 'minor',
+      details: const {},
+    );
+
+ProviderScope _scope({required AsyncValue<ActivityPage> value}) {
+  return ProviderScope(
+    overrides: [
+      activityEntriesProvider.overrideWith((ref) async {
+        if (value is AsyncError) {
+          throw (value as AsyncError).error;
+        }
+        return (value.valueOrNull)!;
+      }),
+    ],
+    child: const MaterialApp(home: Scaffold(body: ActivityScreen())),
+  );
+}
+
+void main() {
+  testWidgets('empty state when no entries', (tester) async {
+    await tester.pumpWidget(_scope(
+      value: const AsyncData(ActivityPage(entries: [], truncated: false, count: 0)),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('No activity'), findsOneWidget);
+  });
+
+  testWidgets('groups entries by hour', (tester) async {
+    final base = DateTime(2026, 4, 20, 9);
+    await tester.pumpWidget(_scope(
+      value: AsyncData(ActivityPage(
+        entries: [
+          _mk(1, base.add(const Duration(minutes: 5))),
+          _mk(2, base.add(const Duration(minutes: 30))),
+          _mk(3, base.add(const Duration(hours: 1, minutes: 10))),
+        ],
+        truncated: false,
+        count: 3,
+      )),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('09:00'), findsOneWidget);
+    expect(find.text('10:00'), findsOneWidget);
+  });
+
+  testWidgets('shows truncation banner when truncated', (tester) async {
+    await tester.pumpWidget(_scope(
+      value: AsyncData(ActivityPage(
+        entries: [_mk(1, DateTime.now())],
+        truncated: true,
+        count: 1,
+      )),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Showing'), findsOneWidget);
+    expect(find.textContaining('Narrow filters'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Phase E of the activity log feature (#113). Stacked on top of #123.

Adds a new "Activity log" tab to the dashboard showing a daily timeline of Heimdallm actions with date/range selection, multi-select filters (org, repo, action), and an auto-refresh on the dashboard's refresh button.

## Scope decision: tab name

There is already a tab called "Activity" in the dashboard (it shows PR reviews). To avoid confusion, the new tab is called **"Activity log"** with icon `Icons.timeline`. It is inserted between "Issues" and "Repositories" — resulting tab order: Activity, Issues, **Activity log**, Repositories, Prompts, Agents, Stats.

## Scope decision: tap-to-detail

Tapping a timeline entry currently shows a snackbar with `repo #number`. Navigating to the real PR / issue detail screen requires a by-number lookup (activity rows store the PR/issue *number* within a repo, but the existing `/prs/:id` and `/issues/:id` routes expect internal store IDs). Rather than add a new endpoint for this PR, the tap is stubbed out. The follow-up report-generation spec is a natural place to add a `/prs/by-number` helper — the snackbar will be replaced with navigation then.

## Changes

- `lib/core/models/activity.dart` — `ActivityEntry`, `ActivityAction` (with `unknown` forward-compat fallback), `ActivityQuery` with `toQueryParameters()` emitting `Map<String, List<String>>` for multi-value URL params, `ActivityPage`, `ActivityDisabledException`.
- `lib/core/api/api_client.dart` — new `fetchActivity(ActivityQuery)` method; throws `ActivityDisabledException` on 503.
- `lib/features/activity/activity_providers.dart` — `ActivityQueryNotifier` with toggle/set/clear methods; `activityEntriesProvider`.
- `lib/features/activity/widgets/activity_entry_tile.dart` — row renderer (icon by action, monospace time, action-specific subtitle).
- `lib/features/activity/widgets/activity_filter_chips.dart` — Organization / Repository / Action multi-select popups + Clear-filters button.
- `lib/features/activity/activity_screen.dart` — date picker bar + filter chips + hour-grouped timeline + empty state + truncation banner.
- `lib/features/dashboard/dashboard_screen.dart` — tab inserted at index 2; refresh button invalidates `activityEntriesProvider`.
- Widget tests under `test/features/activity/` (models, providers, entry tile, screen).

## Test plan

**Note:** Flutter is not installed on my dev host, so tests were not run locally. They will run in CI on push.

- [ ] CI: `flutter test` — all new widget / model / provider tests pass
- [ ] Smoke test on a running daemon + app:
  - [ ] New "Activity log" tab appears between Issues and Repositories
  - [ ] Opens on "Today" showing entries for today in daemon's local TZ
  - [ ] Entries grouped by `HH:00` hour header
  - [ ] Organization / Repository / Action filter chips work; counts update; "Clear filters" resets them
  - [ ] Pick day / Pick range date selectors send correct query params
  - [ ] Truncation banner appears when > 500 entries
  - [ ] Dashboard refresh button refetches activity
  - [ ] Tapping an entry shows snackbar with `repo #N`
  - [ ] When `activity_log.enabled = false` in config, the tab surfaces the error state (503 → `ActivityDisabledException`)

## Base

Stacked on #123 (`feat/activity-log-recorder`), which is stacked on #120 (`feat/activity-log`). GitHub will re-target to the next living ancestor as parents merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)