### PR TITLE
feat: Stats filters — org and repo multi-select (#110)

### DIFF
--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -778,7 +778,15 @@ func (srv *Server) handleRepoCollaborators(w http.ResponseWriter, r *http.Reques
 }
 
 func (srv *Server) handleStats(w http.ResponseWriter, r *http.Request) {
-	stats, err := srv.store.ComputeStats()
+	var repos []string
+	if raw := r.URL.Query().Get("repos"); raw != "" {
+		for _, s := range strings.Split(raw, ",") {
+			if s = strings.TrimSpace(s); s != "" {
+				repos = append(repos, s)
+			}
+		}
+	}
+	stats, err := srv.store.ComputeStats(repos)
 	if err != nil {
 		slog.Error("handleStats: store error", "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -226,17 +227,32 @@ type DayCount struct {
 }
 
 // ComputeStats aggregates statistics from the reviews and prs tables.
-func (s *Store) ComputeStats() (*Stats, error) {
+// When repos is non-empty, results are scoped to reviews of PRs in those repos.
+func (s *Store) ComputeStats(repos []string) (*Stats, error) {
 	stats := &Stats{
 		BySeverity: make(map[string]int),
 		ByCLI:      make(map[string]int),
 	}
 
+	// Build a reusable subquery that restricts review IDs to the given repos.
+	// When repos is empty, the subquery is omitted (global stats).
+	var repoFilter string
+	var repoArgs []any
+	if len(repos) > 0 {
+		placeholders := make([]string, len(repos))
+		for i, r := range repos {
+			placeholders[i] = "?"
+			repoArgs = append(repoArgs, r)
+		}
+		inClause := strings.Join(placeholders, ",")
+		repoFilter = " AND r.pr_id IN (SELECT id FROM prs WHERE repo IN (" + inClause + "))"
+	}
+
 	// Total reviews
-	s.db.QueryRow("SELECT COUNT(*) FROM reviews").Scan(&stats.TotalReviews)
+	s.db.QueryRow("SELECT COUNT(*) FROM reviews r WHERE 1=1"+repoFilter, repoArgs...).Scan(&stats.TotalReviews)
 
 	// By severity
-	rows, _ := s.db.Query("SELECT severity, COUNT(*) FROM reviews GROUP BY severity")
+	rows, _ := s.db.Query("SELECT severity, COUNT(*) FROM reviews r WHERE 1=1"+repoFilter+" GROUP BY severity", repoArgs...)
 	if rows != nil {
 		defer rows.Close()
 		for rows.Next() {
@@ -248,7 +264,7 @@ func (s *Store) ComputeStats() (*Stats, error) {
 	}
 
 	// By CLI
-	rows2, _ := s.db.Query("SELECT cli_used, COUNT(*) FROM reviews GROUP BY cli_used")
+	rows2, _ := s.db.Query("SELECT cli_used, COUNT(*) FROM reviews r WHERE 1=1"+repoFilter+" GROUP BY cli_used", repoArgs...)
 	if rows2 != nil {
 		defer rows2.Close()
 		for rows2.Next() {
@@ -260,12 +276,12 @@ func (s *Store) ComputeStats() (*Stats, error) {
 	}
 
 	// Top repos by review count
-	rows3, _ := s.db.Query(`
+	topRepoQuery := `
 		SELECT p.repo, COUNT(r.id) as cnt
 		FROM reviews r JOIN prs p ON p.id = r.pr_id
-		WHERE p.repo != ''
-		GROUP BY p.repo ORDER BY cnt DESC LIMIT 8
-	`)
+		WHERE p.repo != ''` + repoFilter + `
+		GROUP BY p.repo ORDER BY cnt DESC LIMIT 8`
+	rows3, _ := s.db.Query(topRepoQuery, repoArgs...)
 	if rows3 != nil {
 		defer rows3.Close()
 		for rows3.Next() {
@@ -276,12 +292,12 @@ func (s *Store) ComputeStats() (*Stats, error) {
 	}
 
 	// Reviews per day last 7 days
-	rows4, _ := s.db.Query(`
-		SELECT DATE(created_at) as day, COUNT(*) as cnt
-		FROM reviews
-		WHERE created_at >= datetime('now', '-7 days')
-		GROUP BY day ORDER BY day ASC
-	`)
+	last7Query := `
+		SELECT DATE(r.created_at) as day, COUNT(*) as cnt
+		FROM reviews r
+		WHERE r.created_at >= datetime('now', '-7 days')` + repoFilter + `
+		GROUP BY day ORDER BY day ASC`
+	rows4, _ := s.db.Query(last7Query, repoArgs...)
 	if rows4 != nil {
 		defer rows4.Close()
 		for rows4.Next() {
@@ -293,27 +309,25 @@ func (s *Store) ComputeStats() (*Stats, error) {
 
 	// Avg issues per review (issues is a JSON array stored as text)
 	var totalIssues, reviewsWithIssues int
-	s.db.QueryRow(`SELECT COUNT(*) FROM reviews WHERE issues != '[]' AND issues != 'null'`).Scan(&reviewsWithIssues)
+	s.db.QueryRow("SELECT COUNT(*) FROM reviews r WHERE issues != '[]' AND issues != 'null'"+repoFilter, repoArgs...).Scan(&reviewsWithIssues)
 	if reviewsWithIssues > 0 {
-		// Approximate: count total issue objects via json_array_length
-		s.db.QueryRow(`SELECT COALESCE(SUM(json_array_length(issues)),0) FROM reviews WHERE issues IS NOT NULL`).Scan(&totalIssues)
+		s.db.QueryRow("SELECT COALESCE(SUM(json_array_length(issues)),0) FROM reviews r WHERE issues IS NOT NULL"+repoFilter, repoArgs...).Scan(&totalIssues)
 		if stats.TotalReviews > 0 {
 			stats.AvgIssuesPerReview = float64(totalIssues) / float64(stats.TotalReviews)
 		}
 	}
 
 	// Review timing: duration from pipeline start (prs.fetched_at) to AI done (reviews.created_at).
-	// Fetch last 200 published reviews and compute stats in Go for accuracy.
-	timingRows, _ := s.db.Query(`
+	timingQuery := `
 		SELECT (julianday(r.created_at) - julianday(p.fetched_at)) * 86400.0
 		FROM reviews r
 		JOIN prs p ON p.id = r.pr_id
 		WHERE r.github_review_id > 0
 		  AND p.fetched_at IS NOT NULL
-		  AND p.fetched_at != ''
+		  AND p.fetched_at != ''` + repoFilter + `
 		ORDER BY r.created_at DESC
-		LIMIT 200
-	`)
+		LIMIT 200`
+	timingRows, _ := s.db.Query(timingQuery, repoArgs...)
 	if timingRows != nil {
 		var durations []float64
 		for timingRows.Next() {

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -234,9 +234,10 @@ func (s *Store) ComputeStats(repos []string) (*Stats, error) {
 		ByCLI:      make(map[string]int),
 	}
 
-	// Build a reusable subquery that restricts review IDs to the given repos.
-	// When repos is empty, the subquery is omitted (global stats).
-	var repoFilter string
+	// Build reusable filter clauses for the given repos.
+	// repoFilter: for queries on reviews only (uses subquery on prs table).
+	// repoFilterJoined: for queries that already JOIN prs p (direct p.repo IN).
+	var repoFilter, repoFilterJoined string
 	var repoArgs []any
 	if len(repos) > 0 {
 		placeholders := make([]string, len(repos))
@@ -246,6 +247,7 @@ func (s *Store) ComputeStats(repos []string) (*Stats, error) {
 		}
 		inClause := strings.Join(placeholders, ",")
 		repoFilter = " AND r.pr_id IN (SELECT id FROM prs WHERE repo IN (" + inClause + "))"
+		repoFilterJoined = " AND p.repo IN (" + inClause + ")"
 	}
 
 	// Total reviews
@@ -279,7 +281,7 @@ func (s *Store) ComputeStats(repos []string) (*Stats, error) {
 	topRepoQuery := `
 		SELECT p.repo, COUNT(r.id) as cnt
 		FROM reviews r JOIN prs p ON p.id = r.pr_id
-		WHERE p.repo != ''` + repoFilter + `
+		WHERE p.repo != ''` + repoFilterJoined + `
 		GROUP BY p.repo ORDER BY cnt DESC LIMIT 8`
 	rows3, _ := s.db.Query(topRepoQuery, repoArgs...)
 	if rows3 != nil {
@@ -324,7 +326,7 @@ func (s *Store) ComputeStats(repos []string) (*Stats, error) {
 		JOIN prs p ON p.id = r.pr_id
 		WHERE r.github_review_id > 0
 		  AND p.fetched_at IS NOT NULL
-		  AND p.fetched_at != ''` + repoFilter + `
+		  AND p.fetched_at != ''` + repoFilterJoined + `
 		ORDER BY r.created_at DESC
 		LIMIT 200`
 	timingRows, _ := s.db.Query(timingQuery, repoArgs...)

--- a/docs/superpowers/specs/2026-04-21-stats-filters-design.md
+++ b/docs/superpowers/specs/2026-04-21-stats-filters-design.md
@@ -1,0 +1,67 @@
+# Stats filters — organization and repository multi-select
+
+**Date:** 2026-04-21
+**Issue:** #110
+
+## Approach
+
+Server-side filtering via `GET /stats?repos=org/repo1,org/repo2`. The stats are computed with SQL (timing percentiles, 7-day bucketing, GROUP BY severity/cli). Reimplementing those aggregations client-side would be fragile and duplicative. Adding a `WHERE repo IN (?)` clause to the existing queries is minimal and precise.
+
+Empty `repos` param = global stats (current behavior, fully backwards compatible).
+
+## Daemon changes
+
+### `GET /stats` endpoint
+
+Add optional query param `repos` (comma-separated). Pass to `ComputeStats`.
+
+### `store.ComputeStats(repos []string)`
+
+Change signature from `ComputeStats()` to `ComputeStats(repos []string)`. When `repos` is non-empty, add `WHERE p.repo IN (?)` (or equivalent) to every query that joins `prs`. Queries that don't join `prs` (by_severity, by_cli) use a subquery: `WHERE r.pr_id IN (SELECT id FROM prs WHERE repo IN (?))`.
+
+## Flutter changes
+
+### `StatsFilters` model + provider
+
+Minimal filter state — only orgs and repos (no types, no search):
+
+```dart
+class StatsFilters {
+  final Set<String> orgs;
+  final Set<String> repos;
+  // copyWith, hasFilters, reset
+}
+
+final statsFiltersProvider = StateProvider<StatsFilters>(...);
+```
+
+### `StatsFilterBar` widget
+
+Org and repo multi-select popups. Same UX pattern as `ActivityFilterBar` (popup with checkboxes). No sort, no type chips, no search — just the two dropdowns and a reset button.
+
+Repo list derived from `prsProvider` + `issuesProvider` (same as Activity tab).
+
+### `statsProvider` update
+
+Currently a simple `FutureProvider` hitting `GET /stats`. Change to read `statsFiltersProvider` and append `?repos=` when filters are active.
+
+### `StatsScreen` update
+
+Add `StatsFilterBar` at the top of the scroll view, above the summary cards. The screen becomes `ConsumerWidget` → `ConsumerStatefulWidget` if needed for the filter bar state.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `daemon/internal/store/store.go` | `ComputeStats(repos []string)`, add WHERE clauses |
+| `daemon/internal/server/handlers.go` | Parse `?repos=` in `handleStats` |
+| `flutter_app/lib/features/stats/stats_screen.dart` | Add filter bar, wire to provider |
+| `flutter_app/lib/features/stats/stats_filters.dart` | New: StatsFilters model + provider |
+| `flutter_app/lib/features/stats/stats_filter_bar.dart` | New: filter bar widget |
+| `flutter_app/lib/features/dashboard/dashboard_providers.dart` | Update statsProvider to accept repos param |
+
+## Out of scope
+
+- Chart/graph enhancements
+- Date range filtering for stats
+- Issue-tracking stats (only PR reviews today)

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -155,8 +155,12 @@ class ApiClient {
     return body['login'] as String? ?? '';
   }
 
-  Future<Map<String, dynamic>> fetchStats() async {
-    final resp = await _client.get(_uri('/stats'), headers: await _authHeaders());
+  Future<Map<String, dynamic>> fetchStats({List<String> repos = const []}) async {
+    var path = '/stats';
+    if (repos.isNotEmpty) {
+      path += '?repos=${Uri.encodeQueryComponent(repos.join(','))}';
+    }
+    final resp = await _client.get(_uri(path), headers: await _authHeaders());
     if (resp.statusCode != 200) throw ApiException('GET /stats failed: ${resp.statusCode}');
     return jsonDecode(resp.body) as Map<String, dynamic>;
   }

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -144,9 +144,27 @@ final statsProvider = FutureProvider<Map<String, dynamic>>((ref) async {
   ref.watch(prListRefreshProvider); // refresh stats when reviews complete
   final filters = ref.watch(statsFiltersProvider);
   final api = ref.watch(apiClientProvider);
-  final repos = filters.repos.isNotEmpty
-      ? filters.repos.toList()
-      : <String>[];
+
+  // Effective repos: explicit repo selection takes priority. If only orgs
+  // are selected, derive the repo list from known PRs + issues so the
+  // org filter actually scopes the stats.
+  List<String> repos;
+  if (filters.repos.isNotEmpty) {
+    repos = filters.repos.toList();
+  } else if (filters.orgs.isNotEmpty) {
+    final prs = ref.read(prsProvider).valueOrNull ?? [];
+    final issues = ref.read(issuesProvider).valueOrNull ?? [];
+    final allRepos = <String>{
+      ...prs.map((p) => p.repo),
+      ...issues.map((i) => i.repo),
+    }..remove('');
+    repos = allRepos.where((r) {
+      final org = r.contains('/') ? r.split('/').first : r;
+      return filters.orgs.contains(org);
+    }).toList();
+  } else {
+    repos = [];
+  }
   return api.fetchStats(repos: repos);
 });
 

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -152,8 +152,8 @@ final statsProvider = FutureProvider<Map<String, dynamic>>((ref) async {
   if (filters.repos.isNotEmpty) {
     repos = filters.repos.toList();
   } else if (filters.orgs.isNotEmpty) {
-    final prs = ref.read(prsProvider).valueOrNull ?? [];
-    final issues = ref.read(issuesProvider).valueOrNull ?? [];
+    final prs = ref.watch(prsProvider).valueOrNull ?? [];
+    final issues = ref.watch(issuesProvider).valueOrNull ?? [];
     final allRepos = <String>{
       ...prs.map((p) => p.repo),
       ...issues.map((i) => i.repo),

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -6,6 +6,7 @@ import '../../core/models/pr.dart';
 import '../../core/platform/platform_services_provider.dart';
 import '../../main.dart' show sendPRNotification;
 import '../issues/issues_providers.dart';
+import '../stats/stats_filters.dart';
 
 final apiClientProvider = Provider<ApiClient>((ref) {
   return ApiClient(platform: ref.watch(platformServicesProvider));
@@ -141,8 +142,12 @@ final prsProvider = FutureProvider<List<PR>>((ref) async {
 
 final statsProvider = FutureProvider<Map<String, dynamic>>((ref) async {
   ref.watch(prListRefreshProvider); // refresh stats when reviews complete
+  final filters = ref.watch(statsFiltersProvider);
   final api = ref.watch(apiClientProvider);
-  return api.fetchStats();
+  final repos = filters.repos.isNotEmpty
+      ? filters.repos.toList()
+      : <String>[];
+  return api.fetchStats(repos: repos);
 });
 
 void _rebuildTray(Ref ref, List<PR> prs) {

--- a/flutter_app/lib/features/stats/stats_filter_bar.dart
+++ b/flutter_app/lib/features/stats/stats_filter_bar.dart
@@ -22,6 +22,8 @@ class StatsFilterBar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final filters = ref.watch(statsFiltersProvider);
+    final orgs = _allOrgs;
+    final visibleRepos = _filteredRepos(filters);
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
@@ -33,30 +35,30 @@ class StatsFilterBar extends ConsumerWidget {
           Text('Filter:', style: TextStyle(fontSize: 12, color: Colors.grey.shade500)),
 
           // Org multi-select
-          if (_allOrgs.isNotEmpty)
+          if (orgs.isNotEmpty)
             _filterChip(
               context: context,
               label: 'Org',
               icon: Icons.business,
-              allItems: _allOrgs.toList()..sort(),
+              allItems: orgs.toList()..sort(),
               selected: filters.orgs,
-              onChanged: (orgs) {
+              onChanged: (selectedOrgs) {
                 final validRepos = filters.repos.where((r) {
                   final org = r.contains('/') ? r.split('/').first : r;
-                  return orgs.isEmpty || orgs.contains(org);
+                  return selectedOrgs.isEmpty || selectedOrgs.contains(org);
                 }).toSet();
                 ref.read(statsFiltersProvider.notifier).state =
-                    filters.copyWith(orgs: orgs, repos: validRepos);
+                    filters.copyWith(orgs: selectedOrgs, repos: validRepos);
               },
             ),
 
           // Repo multi-select
-          if (_filteredRepos(filters).isNotEmpty)
+          if (visibleRepos.isNotEmpty)
             _filterChip(
               context: context,
               label: 'Repo',
               icon: Icons.folder_outlined,
-              allItems: _filteredRepos(filters).toList()..sort(),
+              allItems: visibleRepos.toList()..sort(),
               selected: filters.repos,
               onChanged: (repos) {
                 ref.read(statsFiltersProvider.notifier).state =

--- a/flutter_app/lib/features/stats/stats_filter_bar.dart
+++ b/flutter_app/lib/features/stats/stats_filter_bar.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'stats_filters.dart';
+
+/// Compact filter bar for Stats: org and repo multi-select + reset.
+class StatsFilterBar extends ConsumerWidget {
+  final Set<String> allRepos;
+
+  const StatsFilterBar({super.key, required this.allRepos});
+
+  Set<String> get _allOrgs =>
+      allRepos.map((r) => r.contains('/') ? r.split('/').first : r).toSet();
+
+  Set<String> _filteredRepos(StatsFilters filters) {
+    if (filters.orgs.isEmpty) return allRepos;
+    return allRepos.where((r) {
+      final org = r.contains('/') ? r.split('/').first : r;
+      return filters.orgs.contains(org);
+    }).toSet();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filters = ref.watch(statsFiltersProvider);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Wrap(
+        spacing: 6,
+        runSpacing: 6,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          Text('Filter:', style: TextStyle(fontSize: 12, color: Colors.grey.shade500)),
+
+          // Org multi-select
+          if (_allOrgs.isNotEmpty)
+            _multiSelectPopup(
+              context: context,
+              label: 'Org',
+              icon: Icons.business,
+              allItems: _allOrgs.toList()..sort(),
+              selected: filters.orgs,
+              onChanged: (orgs) {
+                // Clear repos that no longer match the selected orgs
+                final validRepos = filters.repos.where((r) {
+                  final org = r.contains('/') ? r.split('/').first : r;
+                  return orgs.isEmpty || orgs.contains(org);
+                }).toSet();
+                ref.read(statsFiltersProvider.notifier).state =
+                    filters.copyWith(orgs: orgs, repos: validRepos);
+              },
+            ),
+
+          // Repo multi-select
+          if (_filteredRepos(filters).isNotEmpty)
+            _multiSelectPopup(
+              context: context,
+              label: 'Repo',
+              icon: Icons.folder_outlined,
+              allItems: _filteredRepos(filters).toList()..sort(),
+              selected: filters.repos,
+              onChanged: (repos) {
+                ref.read(statsFiltersProvider.notifier).state =
+                    filters.copyWith(repos: repos);
+              },
+            ),
+
+          // Reset
+          if (filters.hasFilters)
+            ActionChip(
+              avatar: const Icon(Icons.clear, size: 14),
+              label: const Text('Reset', style: TextStyle(fontSize: 12)),
+              visualDensity: VisualDensity.compact,
+              onPressed: () {
+                ref.read(statsFiltersProvider.notifier).state =
+                    const StatsFilters();
+              },
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _multiSelectPopup({
+    required BuildContext context,
+    required String label,
+    required IconData icon,
+    required List<String> allItems,
+    required Set<String> selected,
+    required ValueChanged<Set<String>> onChanged,
+  }) {
+    final isActive = selected.isNotEmpty;
+    return PopupMenuButton<String>(
+      tooltip: label,
+      offset: const Offset(0, 36),
+      constraints: const BoxConstraints(minWidth: 220, maxWidth: 320),
+      itemBuilder: (_) => allItems.map((item) {
+        final checked = selected.contains(item);
+        return PopupMenuItem<String>(
+          value: item,
+          padding: EdgeInsets.zero,
+          child: StatefulBuilder(
+            builder: (ctx, setMenuState) => CheckboxListTile(
+              dense: true,
+              title: Text(item, style: const TextStyle(fontSize: 13)),
+              value: checked,
+              onChanged: (val) {
+                final updated = Set<String>.from(selected);
+                if (val == true) {
+                  updated.add(item);
+                } else {
+                  updated.remove(item);
+                }
+                onChanged(updated);
+                setMenuState(() {});
+              },
+            ),
+          ),
+        );
+      }).toList(),
+      child: Chip(
+        avatar: Icon(icon, size: 14,
+            color: isActive ? Theme.of(context).colorScheme.primary : Colors.grey),
+        label: Text(
+          isActive ? '$label (${selected.length})' : label,
+          style: TextStyle(
+            fontSize: 12,
+            color: isActive ? Theme.of(context).colorScheme.primary : null,
+          ),
+        ),
+        visualDensity: VisualDensity.compact,
+        side: isActive
+            ? BorderSide(color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5))
+            : const BorderSide(color: Colors.transparent),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/features/stats/stats_filter_bar.dart
+++ b/flutter_app/lib/features/stats/stats_filter_bar.dart
@@ -34,14 +34,13 @@ class StatsFilterBar extends ConsumerWidget {
 
           // Org multi-select
           if (_allOrgs.isNotEmpty)
-            _multiSelectPopup(
+            _filterChip(
               context: context,
               label: 'Org',
               icon: Icons.business,
               allItems: _allOrgs.toList()..sort(),
               selected: filters.orgs,
               onChanged: (orgs) {
-                // Clear repos that no longer match the selected orgs
                 final validRepos = filters.repos.where((r) {
                   final org = r.contains('/') ? r.split('/').first : r;
                   return orgs.isEmpty || orgs.contains(org);
@@ -53,7 +52,7 @@ class StatsFilterBar extends ConsumerWidget {
 
           // Repo multi-select
           if (_filteredRepos(filters).isNotEmpty)
-            _multiSelectPopup(
+            _filterChip(
               context: context,
               label: 'Repo',
               icon: Icons.folder_outlined,
@@ -81,7 +80,7 @@ class StatsFilterBar extends ConsumerWidget {
     );
   }
 
-  Widget _multiSelectPopup({
+  Widget _filterChip({
     required BuildContext context,
     required String label,
     required IconData icon,
@@ -90,34 +89,18 @@ class StatsFilterBar extends ConsumerWidget {
     required ValueChanged<Set<String>> onChanged,
   }) {
     final isActive = selected.isNotEmpty;
-    return PopupMenuButton<String>(
-      tooltip: label,
-      offset: const Offset(0, 36),
-      constraints: const BoxConstraints(minWidth: 220, maxWidth: 320),
-      itemBuilder: (_) => allItems.map((item) {
-        final checked = selected.contains(item);
-        return PopupMenuItem<String>(
-          value: item,
-          padding: EdgeInsets.zero,
-          child: StatefulBuilder(
-            builder: (ctx, setMenuState) => CheckboxListTile(
-              dense: true,
-              title: Text(item, style: const TextStyle(fontSize: 13)),
-              value: checked,
-              onChanged: (val) {
-                final updated = Set<String>.from(selected);
-                if (val == true) {
-                  updated.add(item);
-                } else {
-                  updated.remove(item);
-                }
-                onChanged(updated);
-                setMenuState(() {});
-              },
-            ),
+    return GestureDetector(
+      onTap: () async {
+        final result = await showDialog<Set<String>>(
+          context: context,
+          builder: (_) => _MultiSelectDialog(
+            title: label,
+            items: allItems,
+            selected: selected,
           ),
         );
-      }).toList(),
+        if (result != null) onChanged(result);
+      },
       child: Chip(
         avatar: Icon(icon, size: 14,
             color: isActive ? Theme.of(context).colorScheme.primary : Colors.grey),
@@ -133,6 +116,73 @@ class StatsFilterBar extends ConsumerWidget {
             ? BorderSide(color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5))
             : const BorderSide(color: Colors.transparent),
       ),
+    );
+  }
+}
+
+class _MultiSelectDialog extends StatefulWidget {
+  final String title;
+  final List<String> items;
+  final Set<String> selected;
+
+  const _MultiSelectDialog({
+    required this.title,
+    required this.items,
+    required this.selected,
+  });
+
+  @override
+  State<_MultiSelectDialog> createState() => _MultiSelectDialogState();
+}
+
+class _MultiSelectDialogState extends State<_MultiSelectDialog> {
+  late Set<String> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = Set<String>.from(widget.selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.title, style: const TextStyle(fontSize: 16)),
+      contentPadding: const EdgeInsets.only(top: 12),
+      content: SizedBox(
+        width: 300,
+        child: ListView.builder(
+          shrinkWrap: true,
+          itemCount: widget.items.length,
+          itemBuilder: (_, i) {
+            final item = widget.items[i];
+            return CheckboxListTile(
+              dense: true,
+              title: Text(item, style: const TextStyle(fontSize: 13)),
+              value: _selected.contains(item),
+              onChanged: (val) {
+                setState(() {
+                  if (val == true) {
+                    _selected.add(item);
+                  } else {
+                    _selected.remove(item);
+                  }
+                });
+              },
+            );
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, null),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, _selected),
+          child: const Text('Apply'),
+        ),
+      ],
     );
   }
 }

--- a/flutter_app/lib/features/stats/stats_filters.dart
+++ b/flutter_app/lib/features/stats/stats_filters.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Filter state for the Stats view — org and repo multi-select.
+class StatsFilters {
+  final Set<String> orgs;
+  final Set<String> repos;
+
+  const StatsFilters({this.orgs = const {}, this.repos = const {}});
+
+  StatsFilters copyWith({Set<String>? orgs, Set<String>? repos}) =>
+      StatsFilters(
+        orgs: orgs ?? this.orgs,
+        repos: repos ?? this.repos,
+      );
+
+  bool get hasFilters => orgs.isNotEmpty || repos.isNotEmpty;
+}
+
+final statsFiltersProvider =
+    StateProvider<StatsFilters>((ref) => const StatsFilters());

--- a/flutter_app/lib/features/stats/stats_screen.dart
+++ b/flutter_app/lib/features/stats/stats_screen.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/models/pr.dart';
+import '../../core/models/tracked_issue.dart';
 import '../dashboard/dashboard_providers.dart';
+import '../issues/issues_providers.dart';
+import 'stats_filter_bar.dart';
 
 class StatsScreen extends ConsumerWidget {
   const StatsScreen({super.key});
@@ -8,11 +12,25 @@ class StatsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final statsAsync = ref.watch(statsProvider);
+    final prs = ref.watch(prsProvider).valueOrNull ?? <PR>[];
+    final issues = ref.watch(issuesProvider).valueOrNull ?? <TrackedIssue>[];
 
-    return statsAsync.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(child: Text('Error loading stats: $e')),
-      data: (stats) => _StatsBody(stats: stats),
+    final allRepos = <String>{
+      ...prs.map((p) => p.repo),
+      ...issues.map((i) => i.repo),
+    }..remove('');
+
+    return Column(
+      children: [
+        StatsFilterBar(allRepos: allRepos),
+        Expanded(
+          child: statsAsync.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, _) => Center(child: Text('Error loading stats: $e')),
+            data: (stats) => _StatsBody(stats: stats),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary

- **Daemon**: `GET /stats?repos=org/repo1,org/repo2` — all SQL aggregations scoped by repo filter. Empty = global (backwards compatible).
- **Flutter**: Org/repo multi-select filter bar on Stats tab (same UX pattern as Activity filters).

## Changes

| File | Change |
|---|---|
| `daemon/internal/store/store.go` | `ComputeStats(repos []string)` with conditional WHERE clauses |
| `daemon/internal/server/handlers.go` | Parse `?repos=` query param |
| `flutter_app/lib/features/stats/stats_filters.dart` | New: StatsFilters model + provider |
| `flutter_app/lib/features/stats/stats_filter_bar.dart` | New: filter bar widget |
| `flutter_app/lib/features/stats/stats_screen.dart` | Add filter bar, derive repo list from PRs+Issues |
| `flutter_app/lib/features/dashboard/dashboard_providers.dart` | statsProvider reads filters, passes ?repos= |
| `flutter_app/lib/core/api/api_client.dart` | fetchStats accepts optional repos param |

## Test Plan
- [x] `go test ./... -race` — all pass
- [x] `flutter analyze` — no issues
- [ ] Manual: filter by org → stats update
- [ ] Manual: filter by repo → stats update
- [ ] Manual: reset → global stats restored

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)