### PR TITLE
feat(config): add local_dir_base as list for multi-group workspace support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ docker/.env.local
 docker/.env.swp
 docker/.env.swo
 docker/config/
+daemon/heimdallm

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -840,11 +840,12 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 	a.cfgMu.Lock()
 	c := *a.cfg
 	aiCfg := c.AIForRepo(pr.Repo)
+	localDirBase := c.GitHub.LocalDirBase
 	a.cfgMu.Unlock()
 	// /repos/<short-name> fallback when local_dir is unset (stat-based,
 	// keep outside the mutex). Lets HEIMDALLM_REPOS_DIR give every
 	// monitored repo full-repo context without a per-repo override.
-	aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo, c.GitHub.LocalDirBase)
+	aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo, localDirBase)
 
 	ghPR := &gh.PullRequest{
 		ID:        pr.ID,
@@ -907,10 +908,11 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 			aiCfg.Primary = c.AI.Primary
 		}
 		agentCfg := c.AgentConfigFor(aiCfg.Primary)
+		localDirBase := c.GitHub.LocalDirBase
 		a.cfgMu.Unlock()
 		// /repos/<short-name> fallback when local_dir is unset (stat-based,
 		// keep outside the mutex).
-		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, issue.Repo, c.GitHub.LocalDirBase)
+		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, issue.Repo, localDirBase)
 
 		extraFlags := agentCfg.ExtraFlags
 		if extraFlags != "" {

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -371,7 +371,7 @@ func main() {
 				return
 			}
 			seenRepo[repo] = true
-			if d := config.ResolveLocalDir("", repo); d != "" {
+			if d := config.ResolveLocalDir("", repo, c.GitHub.LocalDirBase); d != "" {
 				localDirsDetected[repo] = d
 			}
 		}
@@ -507,10 +507,11 @@ func main() {
 		}
 		cfgMu.Lock()
 		aiCfg := cfg.AIForRepo(pr.Repo)
+		localDirBase := cfg.GitHub.LocalDirBase
 		cfgMu.Unlock()
 		// /repos/<short-name> fallback when local_dir is unset (stat-based,
 		// keep outside the mutex).
-		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo)
+		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo, localDirBase)
 
 		// Construct github.PullRequest from stored data
 		ghPR := &gh.PullRequest{
@@ -576,10 +577,11 @@ func main() {
 			aiCfg.Primary = cfg.AI.Primary
 		}
 		agentCfg := cfg.AgentConfigFor(aiCfg.Primary)
+		localDirBase := cfg.GitHub.LocalDirBase
 		cfgMu.Unlock()
 		// /repos/<short-name> fallback when local_dir is unset (stat-based,
 		// keep outside the mutex).
-		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, iss.Repo)
+		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, iss.Repo, localDirBase)
 
 		// Reconstruct github.Issue from store data for the pipeline
 		ghIssue := &gh.Issue{
@@ -842,7 +844,7 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 	// /repos/<short-name> fallback when local_dir is unset (stat-based,
 	// keep outside the mutex). Lets HEIMDALLM_REPOS_DIR give every
 	// monitored repo full-repo context without a per-repo override.
-	aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo)
+	aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo, c.GitHub.LocalDirBase)
 
 	ghPR := &gh.PullRequest{
 		ID:        pr.ID,
@@ -908,7 +910,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 		a.cfgMu.Unlock()
 		// /repos/<short-name> fallback when local_dir is unset (stat-based,
 		// keep outside the mutex).
-		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, issue.Repo)
+		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, issue.Repo, c.GitHub.LocalDirBase)
 
 		extraFlags := agentCfg.ExtraFlags
 		if extraFlags != "" {

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -69,6 +69,13 @@ type GitHubConfig struct {
 	// changes (label updates, new comments, merge/close). Defaults to "1m".
 	WatchInterval string `toml:"watch_interval"`
 
+	// LocalDirBase is a list of base directories for auto-resolving local_dir
+	// per repo. ResolveLocalDir checks each path in order, looking for
+	// {base}/{repo-name}, before falling back to /repos/{repo-name}.
+	// This supports multiple workspace groups (e.g. ai-platform in one dir,
+	// another team's repos in another). Put more specific paths first.
+	LocalDirBase []string `toml:"local_dir_base"`
+
 	// IssueTracking turns the issue-tracking pipeline (fase-2) on and off and
 	// governs how issues are filtered and classified. The pipeline itself
 	// lives in downstream issues (#25 onward); this struct is the
@@ -312,29 +319,42 @@ func ShortRepoName(repo string) string {
 // should run in for a given repo, using this precedence:
 //
 //  1. The explicit `local_dir` from config (the `configured` argument).
-//  2. `DefaultReposMountPath/<short-name>` when that directory exists —
+//  2. Each path in `localDirBases` checked in order — first match wins.
+//     Supports multiple workspace groups (e.g. ai-platform repos in one
+//     dir, another team in another) without per-repo local_dir entries.
+//  3. `DefaultReposMountPath/<short-name>` when that directory exists —
 //     lets an operator drop a single HEIMDALLM_REPOS_DIR into
 //     docker/.env and have every monitored repo picked up without also
 //     touching the per-repo override in the UI.
-//  3. Empty string — the agent runs in its default CWD (diff-only mode).
+//  4. Empty string — the agent runs in its default CWD (diff-only mode).
 //
 // Calls `os.Stat` on the candidate path, so callers should invoke it
 // outside any config-mutex critical section. The result is not cached;
 // re-invocation picks up newly-mounted repos on the next review cycle.
-func ResolveLocalDir(configured, repo string) string {
+func ResolveLocalDir(configured, repo string, localDirBases []string) string {
 	if configured != "" {
 		return configured
-	}
-	if DefaultReposMountPath == "" {
-		return ""
 	}
 	short := ShortRepoName(repo)
 	if short == "" {
 		return ""
 	}
-	candidate := filepath.Join(DefaultReposMountPath, short)
-	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-		return candidate
+	// 1. Check each local_dir_base in order (first match wins)
+	for _, base := range localDirBases {
+		if base == "" {
+			continue
+		}
+		candidate := filepath.Join(base, short)
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+	}
+	// 2. Fallback to default mount path (/repos/{short-name})
+	if DefaultReposMountPath != "" {
+		candidate := filepath.Join(DefaultReposMountPath, short)
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
 	}
 	return ""
 }
@@ -522,6 +542,18 @@ func (c *Config) applyEnvOverrides() {
 	}
 	if v := os.Getenv("HEIMDALLM_WATCH_INTERVAL"); v != "" {
 		c.GitHub.WatchInterval = v
+	}
+	if v := os.Getenv("HEIMDALLM_LOCAL_DIR_BASE"); v != "" {
+		paths := strings.Split(v, ",")
+		cleaned := make([]string, 0, len(paths))
+		for _, p := range paths {
+			if s := strings.TrimSpace(p); s != "" {
+				cleaned = append(cleaned, s)
+			}
+		}
+		if len(cleaned) > 0 {
+			c.GitHub.LocalDirBase = cleaned
+		}
 	}
 	c.applyIssueTrackingEnv()
 	c.applyPRMetadataEnv()

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -1102,7 +1102,7 @@ func TestResolveLocalDir_PrefersConfigured(t *testing.T) {
 	DefaultReposMountPath = tmp
 	t.Cleanup(func() { DefaultReposMountPath = old })
 
-	if got := ResolveLocalDir("/explicit/path", "org/name"); got != "/explicit/path" {
+	if got := ResolveLocalDir("/explicit/path", "org/name", nil); got != "/explicit/path" {
 		t.Errorf("got %q, want /explicit/path", got)
 	}
 }
@@ -1117,7 +1117,7 @@ func TestResolveLocalDir_AutoDetectFromMount(t *testing.T) {
 	DefaultReposMountPath = tmp
 	t.Cleanup(func() { DefaultReposMountPath = old })
 
-	if got := ResolveLocalDir("", "org/name"); got != repoDir {
+	if got := ResolveLocalDir("", "org/name", nil); got != repoDir {
 		t.Errorf("got %q, want %q", got, repoDir)
 	}
 }
@@ -1130,7 +1130,7 @@ func TestResolveLocalDir_NoFallbackWhenDirMissing(t *testing.T) {
 	DefaultReposMountPath = tmp
 	t.Cleanup(func() { DefaultReposMountPath = old })
 
-	if got := ResolveLocalDir("", "org/name"); got != "" {
+	if got := ResolveLocalDir("", "org/name", nil); got != "" {
 		t.Errorf("got %q, want empty", got)
 	}
 }
@@ -1145,7 +1145,7 @@ func TestResolveLocalDir_IgnoresFiles(t *testing.T) {
 	DefaultReposMountPath = tmp
 	t.Cleanup(func() { DefaultReposMountPath = old })
 
-	if got := ResolveLocalDir("", "org/name"); got != "" {
+	if got := ResolveLocalDir("", "org/name", nil); got != "" {
 		t.Errorf("got %q, want empty (file, not dir)", got)
 	}
 }
@@ -1155,7 +1155,7 @@ func TestResolveLocalDir_EmptyReposMountPath(t *testing.T) {
 	DefaultReposMountPath = ""
 	t.Cleanup(func() { DefaultReposMountPath = old })
 
-	if got := ResolveLocalDir("", "org/name"); got != "" {
+	if got := ResolveLocalDir("", "org/name", nil); got != "" {
 		t.Errorf("got %q, want empty (mount path disabled)", got)
 	}
 }
@@ -1169,8 +1169,102 @@ func TestResolveLocalDir_EmptyRepo(t *testing.T) {
 	DefaultReposMountPath = tmp
 	t.Cleanup(func() { DefaultReposMountPath = old })
 
-	if got := ResolveLocalDir("", ""); got != "" {
+	if got := ResolveLocalDir("", "", nil); got != "" {
 		t.Errorf("got %q, want empty", got)
+	}
+}
+
+// ── ResolveLocalDir with LocalDirBase ────────────────────────────────────────
+
+func TestResolveLocalDir_LocalDirBase(t *testing.T) {
+	// Create temp dirs simulating workspace
+	base := t.TempDir()
+	repoDir := filepath.Join(base, "my-repo")
+	os.MkdirAll(repoDir, 0755)
+
+	got := ResolveLocalDir("", "org/my-repo", []string{base})
+	if got != repoDir {
+		t.Errorf("ResolveLocalDir = %q, want %q", got, repoDir)
+	}
+}
+
+func TestResolveLocalDir_OverrideTakesPrecedence(t *testing.T) {
+	got := ResolveLocalDir("/custom/path", "org/repo", []string{"/some/base"})
+	if got != "/custom/path" {
+		t.Errorf("ResolveLocalDir = %q, want /custom/path", got)
+	}
+}
+
+func TestResolveLocalDir_BaseBeforeDefault(t *testing.T) {
+	base := t.TempDir()
+	defaultPath := t.TempDir()
+	repoDir := filepath.Join(base, "repo")
+	os.MkdirAll(repoDir, 0755)
+	defaultRepoDir := filepath.Join(defaultPath, "repo")
+	os.MkdirAll(defaultRepoDir, 0755)
+
+	old := DefaultReposMountPath
+	DefaultReposMountPath = defaultPath
+	defer func() { DefaultReposMountPath = old }()
+
+	got := ResolveLocalDir("", "org/repo", []string{base})
+	if got != repoDir {
+		t.Errorf("ResolveLocalDir = %q, want base path %q (not default)", got, repoDir)
+	}
+}
+
+func TestResolveLocalDir_FallbackToDefault(t *testing.T) {
+	defaultPath := t.TempDir()
+	repoDir := filepath.Join(defaultPath, "repo")
+	os.MkdirAll(repoDir, 0755)
+
+	old := DefaultReposMountPath
+	DefaultReposMountPath = defaultPath
+	defer func() { DefaultReposMountPath = old }()
+
+	got := ResolveLocalDir("", "org/repo", nil) // empty base
+	if got != repoDir {
+		t.Errorf("ResolveLocalDir = %q, want default %q", got, repoDir)
+	}
+}
+
+func TestApplyEnvOverrides_LocalDirBase(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	t.Setenv("HEIMDALLM_LOCAL_DIR_BASE", "/workspace/group1, /workspace/group2")
+	cfg.applyEnvOverrides()
+	if len(cfg.GitHub.LocalDirBase) != 2 {
+		t.Fatalf("LocalDirBase = %v, want 2 items", cfg.GitHub.LocalDirBase)
+	}
+	if cfg.GitHub.LocalDirBase[0] != "/workspace/group1" {
+		t.Errorf("LocalDirBase[0] = %q, want /workspace/group1", cfg.GitHub.LocalDirBase[0])
+	}
+	if cfg.GitHub.LocalDirBase[1] != "/workspace/group2" {
+		t.Errorf("LocalDirBase[1] = %q, want /workspace/group2", cfg.GitHub.LocalDirBase[1])
+	}
+}
+
+func TestResolveLocalDir_MultipleBases(t *testing.T) {
+	group1 := t.TempDir()
+	group2 := t.TempDir()
+	// repo-a only in group1
+	os.MkdirAll(filepath.Join(group1, "repo-a"), 0755)
+	// repo-b only in group2
+	os.MkdirAll(filepath.Join(group2, "repo-b"), 0755)
+
+	bases := []string{group1, group2}
+
+	gotA := ResolveLocalDir("", "org/repo-a", bases)
+	if gotA != filepath.Join(group1, "repo-a") {
+		t.Errorf("repo-a = %q, want %q", gotA, filepath.Join(group1, "repo-a"))
+	}
+	gotB := ResolveLocalDir("", "org/repo-b", bases)
+	if gotB != filepath.Join(group2, "repo-b") {
+		t.Errorf("repo-b = %q, want %q", gotB, filepath.Join(group2, "repo-b"))
+	}
+	gotC := ResolveLocalDir("", "org/repo-c", bases)
+	if gotC != "" {
+		t.Errorf("repo-c = %q, want empty (not in any base)", gotC)
 	}
 }
 

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -1222,7 +1222,9 @@ func TestResolveLocalDir_BaseBeforeDefault(t *testing.T) {
 func TestResolveLocalDir_FallbackToDefault(t *testing.T) {
 	defaultPath := t.TempDir()
 	repoDir := filepath.Join(defaultPath, "repo")
-	os.MkdirAll(repoDir, 0755)
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 
 	old := DefaultReposMountPath
 	DefaultReposMountPath = defaultPath

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -1180,7 +1180,9 @@ func TestResolveLocalDir_LocalDirBase(t *testing.T) {
 	// Create temp dirs simulating workspace
 	base := t.TempDir()
 	repoDir := filepath.Join(base, "my-repo")
-	os.MkdirAll(repoDir, 0755)
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 
 	got := ResolveLocalDir("", "org/my-repo", []string{base})
 	if got != repoDir {
@@ -1199,9 +1201,13 @@ func TestResolveLocalDir_BaseBeforeDefault(t *testing.T) {
 	base := t.TempDir()
 	defaultPath := t.TempDir()
 	repoDir := filepath.Join(base, "repo")
-	os.MkdirAll(repoDir, 0755)
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 	defaultRepoDir := filepath.Join(defaultPath, "repo")
-	os.MkdirAll(defaultRepoDir, 0755)
+	if err := os.MkdirAll(defaultRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 
 	old := DefaultReposMountPath
 	DefaultReposMountPath = defaultPath
@@ -1248,9 +1254,13 @@ func TestResolveLocalDir_MultipleBases(t *testing.T) {
 	group1 := t.TempDir()
 	group2 := t.TempDir()
 	// repo-a only in group1
-	os.MkdirAll(filepath.Join(group1, "repo-a"), 0755)
+	if err := os.MkdirAll(filepath.Join(group1, "repo-a"), 0755); err != nil {
+		t.Fatal(err)
+	}
 	// repo-b only in group2
-	os.MkdirAll(filepath.Join(group2, "repo-b"), 0755)
+	if err := os.MkdirAll(filepath.Join(group2, "repo-b"), 0755); err != nil {
+		t.Fatal(err)
+	}
 
 	bases := []string{group1, group2}
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -32,6 +32,12 @@ HEIMDALLM_REPOSITORIES=
 # Defaults to 15m when HEIMDALLM_DISCOVERY_TOPIC is set.
 # HEIMDALLM_DISCOVERY_INTERVAL=15m
 
+# ── Local directory bases (optional) ────────────────────────────────────────
+# Comma-separated list of base directories for auto-resolving local_dir.
+# Each {base}/{repo-name} is checked in order. Supports multiple workspace groups.
+# Per-repo local_dir overrides this.
+# HEIMDALLM_LOCAL_DIR_BASE=/repos/ai-platform-workspace/workspace,/repos
+
 # ── Issue tracking pipeline (optional, fase-2) ──────────────────────────────
 # Enables the daemon to fetch, classify and process GitHub issues in the
 # monitored repos. Label classification precedence:

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -19,6 +19,10 @@ repositories = ["org/repo1", "org/repo2"]
 # discovery_orgs     = ["your-org", "your-other-org"]   # required when discovery_topic is set
 # discovery_interval = "15m"                             # any Go duration; defaults to 15m
 
+# Base directories for auto-resolving local_dir per repo (list).
+# Each {base}/{repo-name} is checked in order. Supports multiple workspace groups.
+# local_dir_base = ["/repos/ai-platform-workspace/workspace", "/repos"]
+
 # Issue tracking pipeline (fase-2).
 # When enabled, the daemon fetches open issues from the monitored repos,
 # classifies them by label, and — depending on the mode — posts an AI


### PR DESCRIPTION
Closes #130

## Summary

`local_dir_base` is now a **list** of base directories. ResolveLocalDir checks each path in order, supporting multiple workspace groups without per-repo config.

## Example

```toml
[github]
local_dir_base = [
  "/repos/ai-platform-workspace/workspace",
  "/repos"
]
```

```env
HEIMDALLM_LOCAL_DIR_BASE=/repos/ai-platform-workspace/workspace,/repos
```

With this config:
- `freepik-company/ai-bumblebee-proxy` → `/repos/ai-platform-workspace/workspace/ai-bumblebee-proxy`
- `theburrowhub/heimdallm` → `/repos/heimdallr` (fallback to second base)
- Unknown repo → falls back to `/repos/{name}` default mount

## Resolution priority

1. Per-repo `local_dir` override (highest)
2. Each `local_dir_base` path/{repo-name} in order (first match wins)
3. `/repos/{repo-name}` (existing default mount)
4. Empty (diff-only mode)

## Changes

- `config.go` — `LocalDirBase` changed from `string` to `[]string`, env var parses comma-separated list, `ResolveLocalDir` iterates bases
- `main.go` — all 5 call sites updated to pass `[]string`
- `config_test.go` — 12 tests including `TestResolveLocalDir_MultipleBases`
- `.env.example` + `config.example.toml` — docs updated

## Test plan

- [ ] `go test ./internal/config/ -run ResolveLocalDir -v` — 12 tests pass
- [ ] Single base: same behavior as before
- [ ] Multiple bases: first match wins
- [ ] Empty bases: falls back to `/repos/{name}` default
- [ ] Env var with commas: parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)