### PR TITLE
feat: Repositories view — filters, auto-discover, grid toggle (#112)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -837,36 +837,35 @@ func (a *tier2Adapter) FetchPRsToReview() ([]scheduler.Tier2PR, error) {
 		})
 	}
 
-	// Auto-discovery: add repos seen in PRs that aren't in the config yet.
+	// Auto-discovery: check + append under a single lock to avoid TOCTOU.
+	var updated []string
+	var newRepos []string
 	a.cfgMu.Lock()
 	c := *a.cfg
-	known := make(map[string]struct{}, len(c.GitHub.Repositories))
+	known := make(map[string]struct{}, len(c.GitHub.Repositories)+len(c.GitHub.NonMonitored))
 	for _, r := range c.GitHub.Repositories {
 		known[r] = struct{}{}
 	}
-	// Also consider non-monitored repos as "known" — don't re-add blacklisted repos.
 	for _, r := range c.GitHub.NonMonitored {
 		known[r] = struct{}{}
 	}
-	a.cfgMu.Unlock()
-
-	var newRepos []string
 	for repo := range seenRepos {
 		if _, ok := known[repo]; !ok {
 			newRepos = append(newRepos, repo)
 		}
 	}
 	if len(newRepos) > 0 {
-		a.cfgMu.Lock()
-		c = *a.cfg
-		updated := append(append([]string(nil), c.GitHub.Repositories...), newRepos...)
+		updated = append(append([]string(nil), c.GitHub.Repositories...), newRepos...)
 		c.GitHub.Repositories = updated
 		*a.cfg = c
-		a.cfgMu.Unlock()
+	}
+	a.cfgMu.Unlock()
 
-		// Persist to store so the repos survive a daemon restart.
-		reposJSON, _ := json.Marshal(updated)
-		if _, err := a.store.SetConfig("repositories", string(reposJSON)); err != nil {
+	if len(newRepos) > 0 {
+		reposJSON, err := json.Marshal(updated)
+		if err != nil {
+			slog.Error("auto-discovery: failed to marshal repos", "err", err)
+		} else if _, err := a.store.SetConfig("repositories", string(reposJSON)); err != nil {
 			slog.Warn("auto-discovery: failed to persist repos", "err", err)
 		} else {
 			slog.Info("auto-discovery: added repos from PRs", "repos", newRepos)

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -809,18 +809,22 @@ type tier2Adapter struct {
 }
 
 // FetchPRsToReview implements scheduler.Tier2PRFetcher.
+// After fetching, any repos not yet in the config are auto-discovered and
+// persisted — the daemon never silently skips unknown repos again.
 func (a *tier2Adapter) FetchPRsToReview() ([]scheduler.Tier2PR, error) {
 	prs, err := a.ghClient.FetchPRsToReview()
 	if err != nil {
 		return nil, err
 	}
 	out := make([]scheduler.Tier2PR, 0, len(prs))
+	seenRepos := make(map[string]struct{})
 	for _, pr := range prs {
 		pr.ResolveRepo()
 		if pr.Repo == "" {
 			slog.Warn("adapter: skipping PR with empty repo", "pr_number", pr.Number)
 			continue
 		}
+		seenRepos[pr.Repo] = struct{}{}
 		out = append(out, scheduler.Tier2PR{
 			ID:        pr.ID,
 			Number:    pr.Number,
@@ -832,6 +836,43 @@ func (a *tier2Adapter) FetchPRsToReview() ([]scheduler.Tier2PR, error) {
 			UpdatedAt: pr.UpdatedAt,
 		})
 	}
+
+	// Auto-discovery: add repos seen in PRs that aren't in the config yet.
+	a.cfgMu.Lock()
+	c := *a.cfg
+	known := make(map[string]struct{}, len(c.GitHub.Repositories))
+	for _, r := range c.GitHub.Repositories {
+		known[r] = struct{}{}
+	}
+	// Also consider non-monitored repos as "known" — don't re-add blacklisted repos.
+	for _, r := range c.GitHub.NonMonitored {
+		known[r] = struct{}{}
+	}
+	a.cfgMu.Unlock()
+
+	var newRepos []string
+	for repo := range seenRepos {
+		if _, ok := known[repo]; !ok {
+			newRepos = append(newRepos, repo)
+		}
+	}
+	if len(newRepos) > 0 {
+		a.cfgMu.Lock()
+		c = *a.cfg
+		updated := append(append([]string(nil), c.GitHub.Repositories...), newRepos...)
+		c.GitHub.Repositories = updated
+		*a.cfg = c
+		a.cfgMu.Unlock()
+
+		// Persist to store so the repos survive a daemon restart.
+		reposJSON, _ := json.Marshal(updated)
+		if _, err := a.store.SetConfig("repositories", string(reposJSON)); err != nil {
+			slog.Warn("auto-discovery: failed to persist repos", "err", err)
+		} else {
+			slog.Info("auto-discovery: added repos from PRs", "repos", newRepos)
+		}
+	}
+
 	return out, nil
 }
 

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -778,7 +778,7 @@ func (srv *Server) handleRepoCollaborators(w http.ResponseWriter, r *http.Reques
 }
 
 func (srv *Server) handleStats(w http.ResponseWriter, r *http.Request) {
-	var repos []string
+	var repos, orgs []string
 	if raw := r.URL.Query().Get("repos"); raw != "" {
 		for _, s := range strings.Split(raw, ",") {
 			if s = strings.TrimSpace(s); s != "" {
@@ -786,7 +786,14 @@ func (srv *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	stats, err := srv.store.ComputeStats(repos)
+	if raw := r.URL.Query().Get("orgs"); raw != "" {
+		for _, s := range strings.Split(raw, ",") {
+			if s = strings.TrimSpace(s); s != "" {
+				orgs = append(orgs, s)
+			}
+		}
+	}
+	stats, err := srv.store.ComputeStats(repos, orgs)
 	if err != nil {
 		slog.Error("handleStats: store error", "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -227,16 +227,20 @@ type DayCount struct {
 }
 
 // ComputeStats aggregates statistics from the reviews and prs tables.
-// When repos is non-empty, results are scoped to reviews of PRs in those repos.
-func (s *Store) ComputeStats(repos []string) (*Stats, error) {
+// When repos is non-empty, results are scoped to PRs in those repos.
+// When orgs is non-empty, results are scoped to PRs whose repo starts
+// with "org/" (i.e. belongs to one of the given GitHub organizations).
+// repos takes precedence over orgs; both empty = global stats.
+func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 	stats := &Stats{
 		BySeverity: make(map[string]int),
 		ByCLI:      make(map[string]int),
 	}
 
-	// Build reusable filter clauses for the given repos.
+	// Build reusable filter clauses.
 	// repoFilter: for queries on reviews only (uses subquery on prs table).
-	// repoFilterJoined: for queries that already JOIN prs p (direct p.repo IN).
+	// repoFilterJoined: for queries that already JOIN prs p.
+	// Both use the same repoArgs since the placeholder count matches.
 	var repoFilter, repoFilterJoined string
 	var repoArgs []any
 	if len(repos) > 0 {
@@ -248,6 +252,17 @@ func (s *Store) ComputeStats(repos []string) (*Stats, error) {
 		inClause := strings.Join(placeholders, ",")
 		repoFilter = " AND r.pr_id IN (SELECT id FROM prs WHERE repo IN (" + inClause + "))"
 		repoFilterJoined = " AND p.repo IN (" + inClause + ")"
+	} else if len(orgs) > 0 {
+		// Org filter: match repos starting with "org/" using LIKE.
+		// Both clauses use the same args (org + "/%") so repoArgs is shared.
+		var conditions, conditionsJ []string
+		for _, org := range orgs {
+			conditions = append(conditions, "repo LIKE ?")
+			conditionsJ = append(conditionsJ, "p.repo LIKE ?")
+			repoArgs = append(repoArgs, org+"/%")
+		}
+		repoFilter = " AND r.pr_id IN (SELECT id FROM prs WHERE " + strings.Join(conditions, " OR ") + ")"
+		repoFilterJoined = " AND (" + strings.Join(conditionsJ, " OR ") + ")"
 	}
 
 	// Total reviews

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -254,12 +254,14 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 		repoFilterJoined = " AND p.repo IN (" + inClause + ")"
 	} else if len(orgs) > 0 {
 		// Org filter: match repos starting with "org/" using LIKE.
-		// Both clauses use the same args (org + "/%") so repoArgs is shared.
+		// Escape SQL LIKE wildcards in org names to prevent unintended matches
+		// (e.g. org "my_team" matching "myXteam/repo" via unescaped _).
+		likeEscaper := strings.NewReplacer("%", "\\%", "_", "\\_")
 		var conditions, conditionsJ []string
 		for _, org := range orgs {
-			conditions = append(conditions, "repo LIKE ?")
-			conditionsJ = append(conditionsJ, "p.repo LIKE ?")
-			repoArgs = append(repoArgs, org+"/%")
+			conditions = append(conditions, "repo LIKE ? ESCAPE '\\'")
+			conditionsJ = append(conditionsJ, "p.repo LIKE ? ESCAPE '\\'")
+			repoArgs = append(repoArgs, likeEscaper.Replace(org)+"/%")
 		}
 		repoFilter = " AND r.pr_id IN (SELECT id FROM prs WHERE " + strings.Join(conditions, " OR ") + ")"
 		repoFilterJoined = " AND (" + strings.Join(conditionsJ, " OR ") + ")"

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -155,12 +155,15 @@ class ApiClient {
     return body['login'] as String? ?? '';
   }
 
-  Future<Map<String, dynamic>> fetchStats({List<String> repos = const []}) async {
-    var path = '/stats';
-    if (repos.isNotEmpty) {
-      path += '?repos=${Uri.encodeQueryComponent(repos.join(','))}';
-    }
-    final resp = await _client.get(_uri(path), headers: await _authHeaders());
+  Future<Map<String, dynamic>> fetchStats({
+    List<String> repos = const [],
+    List<String> orgs = const [],
+  }) async {
+    final params = <String, String>{};
+    if (repos.isNotEmpty) params['repos'] = repos.join(',');
+    if (orgs.isNotEmpty) params['orgs'] = orgs.join(',');
+    final uri = _uri('/stats').replace(queryParameters: params.isNotEmpty ? params : null);
+    final resp = await _client.get(uri, headers: await _authHeaders());
     if (resp.statusCode != 200) throw ApiException('GET /stats failed: ${resp.statusCode}');
     return jsonDecode(resp.body) as Map<String, dynamic>;
   }

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -144,28 +144,10 @@ final statsProvider = FutureProvider<Map<String, dynamic>>((ref) async {
   ref.watch(prListRefreshProvider); // refresh stats when reviews complete
   final filters = ref.watch(statsFiltersProvider);
   final api = ref.watch(apiClientProvider);
-
-  // Effective repos: explicit repo selection takes priority. If only orgs
-  // are selected, derive the repo list from known PRs + issues so the
-  // org filter actually scopes the stats.
-  List<String> repos;
-  if (filters.repos.isNotEmpty) {
-    repos = filters.repos.toList();
-  } else if (filters.orgs.isNotEmpty) {
-    final prs = ref.watch(prsProvider).valueOrNull ?? [];
-    final issues = ref.watch(issuesProvider).valueOrNull ?? [];
-    final allRepos = <String>{
-      ...prs.map((p) => p.repo),
-      ...issues.map((i) => i.repo),
-    }..remove('');
-    repos = allRepos.where((r) {
-      final org = r.contains('/') ? r.split('/').first : r;
-      return filters.orgs.contains(org);
-    }).toList();
-  } else {
-    repos = [];
-  }
-  return api.fetchStats(repos: repos);
+  return api.fetchStats(
+    repos: filters.repos.toList(),
+    orgs: filters.orgs.toList(),
+  );
 });
 
 void _rebuildTray(Ref ref, List<PR> prs) {

--- a/flutter_app/lib/features/repositories/repos_screen.dart
+++ b/flutter_app/lib/features/repositories/repos_screen.dart
@@ -22,6 +22,7 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
   Map<String, RepoConfig> _repoConfigs = {};
   bool _initialized = false;
   String _search = '';
+  String _orgFilter = ''; // empty = all orgs
   _SyncStatus _syncStatus = _SyncStatus.idle;
   _FilterMode _filterMode = _FilterMode.all;
   _ViewMode _viewMode = _ViewMode.list;
@@ -107,10 +108,24 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
             return a.compareTo(b);
           });
 
+        // Derive all orgs for the org filter dropdown
+        final allOrgs = _repoConfigs.keys
+            .map((r) => r.contains('/') ? r.split('/').first : r)
+            .toSet()
+            .toList()..sort();
+
         // Apply text search
         var filtered = _search.isEmpty
             ? allRepos
             : allRepos.where((r) => r.toLowerCase().contains(_search.toLowerCase())).toList();
+
+        // Apply org filter
+        if (_orgFilter.isNotEmpty) {
+          filtered = filtered.where((r) {
+            final org = r.contains('/') ? r.split('/').first : r;
+            return org == _orgFilter;
+          }).toList();
+        }
 
         // Apply monitored/not-monitored filter
         if (_filterMode == _FilterMode.monitored) {
@@ -124,24 +139,52 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
 
         return Column(
           children: [
-            // Toolbar
+            // Single-line toolbar: search + filters + view toggle + status
             Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+              padding: const EdgeInsets.fromLTRB(16, 10, 16, 6),
               child: Row(
                 children: [
-                  Expanded(
+                  // Compact search
+                  SizedBox(
+                    width: 160,
                     child: TextField(
                       decoration: const InputDecoration(
-                        hintText: 'Filter repos…',
-                        prefixIcon: Icon(Icons.search, size: 18),
+                        hintText: 'Search…',
+                        prefixIcon: Icon(Icons.search, size: 16),
                         isDense: true,
                         border: OutlineInputBorder(),
-                        contentPadding: EdgeInsets.symmetric(vertical: 8),
+                        contentPadding: EdgeInsets.symmetric(vertical: 6),
                       ),
+                      style: const TextStyle(fontSize: 13),
                       onChanged: (v) => setState(() => _search = v),
                     ),
                   ),
                   const SizedBox(width: 8),
+                  // Monitored filter chips
+                  _filterChip('All', _repoConfigs.length, _FilterMode.all),
+                  const SizedBox(width: 4),
+                  _filterChip('Monitored', monitoredCount, _FilterMode.monitored),
+                  const SizedBox(width: 4),
+                  _filterChip('Not mon.', notMonitoredCount, _FilterMode.notMonitored),
+                  const SizedBox(width: 8),
+                  // Org dropdown
+                  if (allOrgs.length > 1)
+                    SizedBox(
+                      height: 32,
+                      child: DropdownButton<String>(
+                        value: _orgFilter.isEmpty ? null : _orgFilter,
+                        hint: const Text('Org', style: TextStyle(fontSize: 12)),
+                        style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurface),
+                        isDense: true,
+                        underline: const SizedBox.shrink(),
+                        items: [
+                          const DropdownMenuItem(value: '', child: Text('All orgs')),
+                          ...allOrgs.map((o) => DropdownMenuItem(value: o, child: Text(o))),
+                        ],
+                        onChanged: (v) => setState(() => _orgFilter = v ?? ''),
+                      ),
+                    ),
+                  const Spacer(),
                   // View toggle
                   SegmentedButton<_ViewMode>(
                     segments: const [
@@ -156,7 +199,7 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
                       tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     ),
                   ),
-                  const SizedBox(width: 8),
+                  const SizedBox(width: 6),
                   // Auto-save status
                   SizedBox(
                     width: 22, height: 22,
@@ -167,19 +210,6 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
                       _SyncStatus.idle   => const SizedBox.shrink(),
                     },
                   ),
-                ],
-              ),
-            ),
-            // Filter chips
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
-              child: Row(
-                children: [
-                  _filterChip('All', _repoConfigs.length, _FilterMode.all),
-                  const SizedBox(width: 6),
-                  _filterChip('Monitored', monitoredCount, _FilterMode.monitored),
-                  const SizedBox(width: 6),
-                  _filterChip('Not monitored', notMonitoredCount, _FilterMode.notMonitored),
                 ],
               ),
             ),
@@ -249,7 +279,7 @@ class _RepoGrid extends StatelessWidget {
             crossAxisCount: crossCount,
             mainAxisSpacing: 8,
             crossAxisSpacing: 8,
-            childAspectRatio: 2.2,
+            childAspectRatio: 2.0,
           ),
           itemCount: repos.length,
           itemBuilder: (context, i) {
@@ -257,6 +287,11 @@ class _RepoGrid extends StatelessWidget {
             final config = configs[repo]!;
             final shortName = repo.contains('/') ? repo.split('/').last : repo;
             final org = repo.contains('/') ? repo.split('/').first : '';
+            final configuredDir = (config.localDir ?? '').isNotEmpty ? config.localDir : null;
+            final detectedDir = appConfig.localDirsDetected[repo];
+            final effectiveDir = configuredDir ?? detectedDir;
+            final hasDirMapping = effectiveDir != null && effectiveDir.isNotEmpty;
+            final isAutoDetected = configuredDir == null && detectedDir != null;
 
             return Card(
               child: InkWell(
@@ -281,7 +316,7 @@ class _RepoGrid extends StatelessWidget {
                           ),
                           const SizedBox(width: 3),
                           _Led(
-                            status: config.devLedStatus(appConfig.issueTracking.enabled, false),
+                            status: config.devLedStatus(appConfig.issueTracking.enabled, hasDirMapping),
                             tooltip: 'Dev',
                           ),
                           const Spacer(),
@@ -302,6 +337,34 @@ class _RepoGrid extends StatelessWidget {
                             style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis),
+                      const SizedBox(height: 2),
+                      Row(children: [
+                        Icon(
+                          hasDirMapping ? Icons.folder : Icons.folder_off_outlined,
+                          size: 11,
+                          color: hasDirMapping
+                              ? (isAutoDetected ? Colors.blue.shade400 : Colors.green.shade500)
+                              : Colors.grey.shade600,
+                        ),
+                        const SizedBox(width: 3),
+                        Expanded(
+                          child: Text(
+                            hasDirMapping
+                                ? (isAutoDetected
+                                    ? 'Auto: ${effectiveDir.split('/').last}'
+                                    : effectiveDir.split('/').last)
+                                : 'No local dir',
+                            style: TextStyle(
+                              fontSize: 10,
+                              color: hasDirMapping
+                                  ? (isAutoDetected ? Colors.blue.shade400 : Colors.green.shade500)
+                                  : Colors.grey.shade600,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ]),
                     ],
                   ),
                 ),

--- a/flutter_app/lib/features/repositories/repos_screen.dart
+++ b/flutter_app/lib/features/repositories/repos_screen.dart
@@ -22,7 +22,7 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
   Map<String, RepoConfig> _repoConfigs = {};
   bool _initialized = false;
   String _search = '';
-  String _orgFilter = ''; // empty = all orgs
+  Set<String> _orgFilter = {}; // empty = all orgs
   _SyncStatus _syncStatus = _SyncStatus.idle;
   _FilterMode _filterMode = _FilterMode.all;
   _ViewMode _viewMode = _ViewMode.list;
@@ -123,7 +123,7 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
         if (_orgFilter.isNotEmpty) {
           filtered = filtered.where((r) {
             final org = r.contains('/') ? r.split('/').first : r;
-            return org == _orgFilter;
+            return _orgFilter.contains(org);
           }).toList();
         }
 
@@ -167,23 +167,48 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
                   const SizedBox(width: 4),
                   _filterChip('Not mon.', notMonitoredCount, _FilterMode.notMonitored),
                   const SizedBox(width: 8),
-                  // Org dropdown
+                  // Org multi-select (dialog, same UX as Activity)
                   if (allOrgs.length > 1)
-                    SizedBox(
-                      height: 32,
-                      child: DropdownButton<String>(
-                        value: _orgFilter.isEmpty ? null : _orgFilter,
-                        hint: const Text('Org', style: TextStyle(fontSize: 12)),
-                        style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurface),
-                        isDense: true,
-                        underline: const SizedBox.shrink(),
-                        items: [
-                          const DropdownMenuItem(value: '', child: Text('All orgs')),
-                          ...allOrgs.map((o) => DropdownMenuItem(value: o, child: Text(o))),
-                        ],
-                        onChanged: (v) => setState(() => _orgFilter = v ?? ''),
+                    GestureDetector(
+                      onTap: () async {
+                        final result = await showDialog<Set<String>>(
+                          context: context,
+                          builder: (_) => _MultiSelectDialog(
+                            title: 'Filter by Org',
+                            items: allOrgs,
+                            selected: _orgFilter,
+                          ),
+                        );
+                        if (result != null) setState(() => _orgFilter = result);
+                      },
+                      child: Chip(
+                        avatar: Icon(Icons.business, size: 14,
+                            color: _orgFilter.isNotEmpty
+                                ? Theme.of(context).colorScheme.primary
+                                : Colors.grey),
+                        label: Text(
+                          _orgFilter.isNotEmpty ? 'Org (${_orgFilter.length})' : 'Org',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: _orgFilter.isNotEmpty
+                                ? Theme.of(context).colorScheme.primary
+                                : null,
+                          ),
+                        ),
+                        visualDensity: VisualDensity.compact,
+                        side: _orgFilter.isNotEmpty
+                            ? BorderSide(color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5))
+                            : const BorderSide(color: Colors.transparent),
                       ),
                     ),
+                  // Reset org filter
+                  if (_orgFilter.isNotEmpty) ...[
+                    const SizedBox(width: 4),
+                    GestureDetector(
+                      onTap: () => setState(() => _orgFilter = {}),
+                      child: const Icon(Icons.clear, size: 16, color: Colors.grey),
+                    ),
+                  ],
                   const Spacer(),
                   // View toggle
                   SegmentedButton<_ViewMode>(
@@ -625,6 +650,75 @@ class _RepoTile extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+// ── Multi-select dialog (same pattern as Stats filter) ───────────────────
+
+class _MultiSelectDialog extends StatefulWidget {
+  final String title;
+  final List<String> items;
+  final Set<String> selected;
+
+  const _MultiSelectDialog({
+    required this.title,
+    required this.items,
+    required this.selected,
+  });
+
+  @override
+  State<_MultiSelectDialog> createState() => _MultiSelectDialogState();
+}
+
+class _MultiSelectDialogState extends State<_MultiSelectDialog> {
+  late Set<String> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = Set<String>.from(widget.selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.title, style: const TextStyle(fontSize: 16)),
+      contentPadding: const EdgeInsets.only(top: 12),
+      content: SizedBox(
+        width: 300,
+        child: ListView.builder(
+          shrinkWrap: true,
+          itemCount: widget.items.length,
+          itemBuilder: (_, i) {
+            final item = widget.items[i];
+            return CheckboxListTile(
+              dense: true,
+              title: Text(item, style: const TextStyle(fontSize: 13)),
+              value: _selected.contains(item),
+              onChanged: (val) {
+                setState(() {
+                  if (val == true) {
+                    _selected.add(item);
+                  } else {
+                    _selected.remove(item);
+                  }
+                });
+              },
+            );
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, null),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, _selected),
+          child: const Text('Apply'),
+        ),
+      ],
     );
   }
 }

--- a/flutter_app/lib/features/repositories/repos_screen.dart
+++ b/flutter_app/lib/features/repositories/repos_screen.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/models/config_model.dart';
-import '../../core/platform/platform_services_provider.dart';
 import '../../shared/widgets/toast.dart';
 import '../config/config_providers.dart';
 
@@ -15,16 +15,24 @@ class ReposScreen extends ConsumerStatefulWidget {
 }
 
 enum _SyncStatus { idle, saving, saved }
+enum _FilterMode { all, monitored, notMonitored }
+enum _ViewMode { list, grid }
 
 class _ReposScreenState extends ConsumerState<ReposScreen> {
   Map<String, RepoConfig> _repoConfigs = {};
   bool _initialized = false;
-  bool _discovering = false;
-  String? _discoverError;
   String _search = '';
   _SyncStatus _syncStatus = _SyncStatus.idle;
+  _FilterMode _filterMode = _FilterMode.all;
+  _ViewMode _viewMode = _ViewMode.list;
   Timer? _debounce;
   Timer? _savedResetTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadViewPreference();
+  }
 
   @override
   void dispose() {
@@ -33,38 +41,31 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
     super.dispose();
   }
 
+  void _loadViewPreference() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final value = prefs.getString('repos_view_mode');
+      if (value == 'grid' && mounted) setState(() => _viewMode = _ViewMode.grid);
+    } catch (_) {}
+  }
+
+  void _setViewMode(_ViewMode mode) {
+    setState(() => _viewMode = mode);
+    SharedPreferences.getInstance().then((prefs) {
+      prefs.setString('repos_view_mode', mode.name);
+    }).catchError((_) {});
+  }
+
   void _initFrom(AppConfig config) {
     if (_initialized) return;
     _initialized = true;
     _repoConfigs = Map.from(config.repoConfigs);
   }
 
-  /// Called whenever a repo config changes — schedules an auto-save.
   void _onChange(String repo, RepoConfig rc) {
     setState(() => _repoConfigs[repo] = rc);
     _debounce?.cancel();
     _debounce = Timer(const Duration(milliseconds: 800), _autoSave);
-  }
-
-  Future<void> _discover() async {
-    setState(() { _discovering = true; _discoverError = null; });
-    try {
-      final token = await ref.read(platformServicesProvider).detectGitHubToken();
-      final discovered = await ref.read(platformServicesProvider).discoverReposFromPRs(token ?? '');
-      if (!mounted) return;
-      setState(() {
-        for (final repo in discovered) {
-          _repoConfigs.putIfAbsent(repo, () => const RepoConfig(prEnabled: true));
-        }
-        _discovering = false;
-        if (discovered.isEmpty) _discoverError = 'No active PRs found.';
-      });
-      _debounce?.cancel();
-      _debounce = Timer(const Duration(milliseconds: 400), _autoSave);
-    } catch (e) {
-      if (!mounted) return;
-      setState(() { _discovering = false; _discoverError = '$e'; });
-    }
   }
 
   Future<void> _autoSave() async {
@@ -97,7 +98,7 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
       data: (config) {
         _initFrom(config);
 
-        // Monitored first, disabled last; both groups sorted alphabetically
+        // Sort: monitored first, then alphabetical
         final allRepos = _repoConfigs.keys.toList()
           ..sort((a, b) {
             final ma = _repoConfigs[a]!.isMonitored ? 0 : 1;
@@ -105,9 +106,21 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
             if (ma != mb) return ma.compareTo(mb);
             return a.compareTo(b);
           });
-        final filtered = _search.isEmpty
+
+        // Apply text search
+        var filtered = _search.isEmpty
             ? allRepos
             : allRepos.where((r) => r.toLowerCase().contains(_search.toLowerCase())).toList();
+
+        // Apply monitored/not-monitored filter
+        if (_filterMode == _FilterMode.monitored) {
+          filtered = filtered.where((r) => _repoConfigs[r]!.isMonitored).toList();
+        } else if (_filterMode == _FilterMode.notMonitored) {
+          filtered = filtered.where((r) => !_repoConfigs[r]!.isMonitored).toList();
+        }
+
+        final monitoredCount = _repoConfigs.values.where((c) => c.isMonitored).length;
+        final notMonitoredCount = _repoConfigs.length - monitoredCount;
 
         return Column(
           children: [
@@ -129,16 +142,22 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
                     ),
                   ),
                   const SizedBox(width: 8),
-                  FilledButton.tonalIcon(
-                    icon: _discovering
-                        ? const SizedBox(width: 14, height: 14,
-                            child: CircularProgressIndicator(strokeWidth: 2))
-                        : const Icon(Icons.sync, size: 16),
-                    label: const Text('Discover'),
-                    onPressed: _discovering ? null : _discover,
+                  // View toggle
+                  SegmentedButton<_ViewMode>(
+                    segments: const [
+                      ButtonSegment(value: _ViewMode.list, icon: Icon(Icons.view_list, size: 16)),
+                      ButtonSegment(value: _ViewMode.grid, icon: Icon(Icons.grid_view, size: 16)),
+                    ],
+                    selected: {_viewMode},
+                    onSelectionChanged: (s) => _setViewMode(s.first),
+                    showSelectedIcon: false,
+                    style: const ButtonStyle(
+                      visualDensity: VisualDensity.compact,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
                   ),
-                  const SizedBox(width: 12),
-                  // Auto-save status indicator
+                  const SizedBox(width: 8),
+                  // Auto-save status
                   SizedBox(
                     width: 22, height: 22,
                     child: switch (_syncStatus) {
@@ -151,23 +170,144 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
                 ],
               ),
             ),
-            if (_discoverError != null)
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-                child: Text(_discoverError!, style: const TextStyle(color: Colors.orange)),
+            // Filter chips
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
+              child: Row(
+                children: [
+                  _filterChip('All', _repoConfigs.length, _FilterMode.all),
+                  const SizedBox(width: 6),
+                  _filterChip('Monitored', monitoredCount, _FilterMode.monitored),
+                  const SizedBox(width: 6),
+                  _filterChip('Not monitored', notMonitoredCount, _FilterMode.notMonitored),
+                ],
               ),
-            // Repo list with section dividers
+            ),
+            // Content
             Expanded(
               child: filtered.isEmpty
-                  ? const Center(child: Text('No repos yet. Tap Discover.'))
-                  : _RepoListWithSections(
-                      repos: filtered,
-                      configs: _repoConfigs,
-                      appConfig: config,
-                      onChanged: _onChange,
-                    ),
+                  ? Center(child: Text(
+                      _repoConfigs.isEmpty
+                          ? 'No repos yet — the daemon auto-discovers repos from your PRs.'
+                          : 'No repos match the current filter.',
+                      style: TextStyle(color: Colors.grey.shade500),
+                    ))
+                  : _viewMode == _ViewMode.list
+                      ? _RepoListWithSections(
+                          repos: filtered,
+                          configs: _repoConfigs,
+                          appConfig: config,
+                          onChanged: _onChange,
+                        )
+                      : _RepoGrid(
+                          repos: filtered,
+                          configs: _repoConfigs,
+                          appConfig: config,
+                        ),
             ),
           ],
+        );
+      },
+    );
+  }
+
+  Widget _filterChip(String label, int count, _FilterMode mode) {
+    final active = _filterMode == mode;
+    return FilterChip(
+      label: Text('$label ($count)', style: const TextStyle(fontSize: 12)),
+      selected: active,
+      onSelected: (_) => setState(() => _filterMode = mode),
+      visualDensity: VisualDensity.compact,
+      showCheckmark: false,
+    );
+  }
+}
+
+// ── Grid view ────────────────────────────────────────────────────────────────
+
+class _RepoGrid extends StatelessWidget {
+  final List<String> repos;
+  final Map<String, RepoConfig> configs;
+  final AppConfig appConfig;
+
+  const _RepoGrid({
+    required this.repos,
+    required this.configs,
+    required this.appConfig,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final crossCount = constraints.maxWidth > 900 ? 4
+            : constraints.maxWidth > 600 ? 3
+            : 2;
+        return GridView.builder(
+          padding: const EdgeInsets.all(12),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossCount,
+            mainAxisSpacing: 8,
+            crossAxisSpacing: 8,
+            childAspectRatio: 2.2,
+          ),
+          itemCount: repos.length,
+          itemBuilder: (context, i) {
+            final repo = repos[i];
+            final config = configs[repo]!;
+            final shortName = repo.contains('/') ? repo.split('/').last : repo;
+            final org = repo.contains('/') ? repo.split('/').first : '';
+
+            return Card(
+              child: InkWell(
+                borderRadius: BorderRadius.circular(12),
+                onTap: () => context.push('/repos/${Uri.encodeComponent(repo)}'),
+                child: Padding(
+                  padding: const EdgeInsets.all(10),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Row(
+                        children: [
+                          _Led(
+                            status: config.prLedStatus(appConfig.repositories.contains(repo)),
+                            tooltip: 'PR',
+                          ),
+                          const SizedBox(width: 3),
+                          _Led(
+                            status: config.itLedStatus(appConfig.issueTracking.enabled),
+                            tooltip: 'IT',
+                          ),
+                          const SizedBox(width: 3),
+                          _Led(
+                            status: config.devLedStatus(appConfig.issueTracking.enabled, false),
+                            tooltip: 'Dev',
+                          ),
+                          const Spacer(),
+                          Icon(Icons.chevron_right, size: 14, color: Colors.grey.shade600),
+                        ],
+                      ),
+                      const SizedBox(height: 6),
+                      Text(shortName,
+                          style: TextStyle(
+                            fontSize: 13,
+                            fontWeight: config.isMonitored ? FontWeight.w600 : FontWeight.normal,
+                            color: config.isMonitored ? null : Colors.grey,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis),
+                      if (org.isNotEmpty)
+                        Text(org,
+                            style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
         );
       },
     );
@@ -195,26 +335,21 @@ class _RepoListWithSections extends ConsumerStatefulWidget {
 }
 
 class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
-  // Collapse state per "section:org" key — default expanded
   final _expanded = <String, bool>{};
 
   bool _isExpanded(String key) => _expanded[key] ?? true;
-
   void _toggle(String key) =>
       setState(() => _expanded[key] = !_isExpanded(key));
 
-  /// Groups repos by the org part ("org" in "org/repo") and sorts within each org.
   Map<String, List<String>> _groupByOrg(List<String> repos) {
     final groups = <String, List<String>>{};
     for (final r in repos) {
       final org = r.contains('/') ? r.split('/').first : r;
       groups.putIfAbsent(org, () => []).add(r);
     }
-    // Sort repos within each org alphabetically
     for (final list in groups.values) {
       list.sort();
     }
-    // Return sorted by org name
     return Map.fromEntries(
         groups.entries.toList()..sort((a, b) => a.key.compareTo(b.key)));
   }
@@ -230,38 +365,20 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
       padding: const EdgeInsets.symmetric(vertical: 4),
       children: [
         if (monitored.isNotEmpty) ...[
-          _sectionHeader(
-            context,
-            'Monitored — auto-review enabled',
-            monitored.length,
-            Colors.green.shade700,
-          ),
+          _sectionHeader(context, 'Monitored — auto-review enabled',
+              monitored.length, Colors.green.shade700),
           ..._buildOrgGroups('monitored', monitored),
         ],
-        _sectionHeader(
-          context,
-          'Not monitored — PRs visible, no auto-review',
-          disabled.length,
-          Colors.grey.shade600,
-        ),
-        if (disabled.isEmpty)
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
-            child: Text(
-              'No repos disabled. Toggle the switch on any repo above to stop auto-reviewing it.',
-              style: TextStyle(fontSize: 12, color: Colors.grey.shade500),
-            ),
-          )
-        else
+        if (disabled.isNotEmpty) ...[
+          _sectionHeader(context, 'Not monitored — PRs visible, no auto-review',
+              disabled.length, Colors.grey.shade600),
           ..._buildOrgGroups('disabled', disabled),
+        ],
       ],
     );
   }
 
-  List<Widget> _buildOrgGroups(
-    String section,
-    List<String> repos,
-  ) {
+  List<Widget> _buildOrgGroups(String section, List<String> repos) {
     final groups = _groupByOrg(repos);
     final items = <Widget>[];
     for (final entry in groups.entries) {
@@ -284,21 +401,17 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
     return items;
   }
 
-  Widget _sectionHeader(
-      BuildContext ctx, String label, int count, Color color) {
+  Widget _sectionHeader(BuildContext ctx, String label, int count, Color color) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 14, 16, 4),
       child: Row(children: [
         Container(
-            width: 8,
-            height: 8,
+            width: 8, height: 8,
             decoration: BoxDecoration(color: color, shape: BoxShape.circle)),
         const SizedBox(width: 6),
         Text(label,
             style: TextStyle(
-                fontSize: 12,
-                color: Colors.grey.shade400,
-                fontWeight: FontWeight.w600)),
+                fontSize: 12, color: Colors.grey.shade400, fontWeight: FontWeight.w600)),
         const SizedBox(width: 6),
         Text('$count',
             style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
@@ -306,24 +419,18 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
     );
   }
 
-  Widget _orgHeader(
-      String org, int count, bool expanded, VoidCallback onTap) {
+  Widget _orgHeader(String org, int count, bool expanded, VoidCallback onTap) {
     return InkWell(
       onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.fromLTRB(24, 6, 16, 2),
         child: Row(children: [
-          Icon(
-            expanded ? Icons.expand_less : Icons.expand_more,
-            size: 16,
-            color: Colors.grey.shade500,
-          ),
+          Icon(expanded ? Icons.expand_less : Icons.expand_more,
+              size: 16, color: Colors.grey.shade500),
           const SizedBox(width: 4),
           Text(org,
               style: TextStyle(
-                  fontSize: 12,
-                  color: Colors.grey.shade400,
-                  fontWeight: FontWeight.w500)),
+                  fontSize: 12, color: Colors.grey.shade400, fontWeight: FontWeight.w500)),
           const SizedBox(width: 6),
           Text('$count',
               style: TextStyle(fontSize: 11, color: Colors.grey.shade600)),
@@ -336,7 +443,7 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
 // ── LED indicator ────────────────────────────────────────────────────────────
 
 class _Led extends StatelessWidget {
-  final String status; // 'off', 'global', 'repo'
+  final String status;
   final String tooltip;
   const _Led({required this.status, required this.tooltip});
 
@@ -381,12 +488,7 @@ class _RepoTile extends StatelessWidget {
     final configuredDir = (config.localDir ?? '').isNotEmpty ? config.localDir : null;
     final detectedDir = appConfig.localDirsDetected[repo];
     final effectiveDir = configuredDir ?? detectedDir;
-    // Full-repo analysis is available as long as *either* the user
-    // configured a path *or* the daemon detected one under /repos.
     final hasDirMapping = effectiveDir != null && effectiveDir.isNotEmpty;
-    // Distinguish configured vs auto-detected in the label/colour so the
-    // operator can tell at a glance whether they set it themselves or the
-    // bind-mount convention kicked in.
     final isAutoDetected = configuredDir == null && detectedDir != null;
 
     return Card(
@@ -434,9 +536,7 @@ class _RepoTile extends StatelessWidget {
                         hasDirMapping ? Icons.folder : Icons.folder_off_outlined,
                         size: 13,
                         color: hasDirMapping
-                            ? (isAutoDetected
-                                ? Colors.blue.shade400
-                                : Colors.green.shade500)
+                            ? (isAutoDetected ? Colors.blue.shade400 : Colors.green.shade500)
                             : Colors.grey.shade600,
                       ),
                       const SizedBox(width: 4),
@@ -449,9 +549,7 @@ class _RepoTile extends StatelessWidget {
                         style: TextStyle(
                           fontSize: 11,
                           color: hasDirMapping
-                              ? (isAutoDetected
-                                  ? Colors.blue.shade400
-                                  : Colors.green.shade500)
+                              ? (isAutoDetected ? Colors.blue.shade400 : Colors.green.shade500)
                               : Colors.grey.shade600,
                         ),
                       ),


### PR DESCRIPTION
## Summary

- **Daemon**: auto-discovers repos from PR fetch — repos seen in `review-requested:@me` are persisted to config automatically (additive, respects non_monitored blacklist)
- **Flutter**: removed manual Discover button, added monitored/not-monitored filter chips, added list/grid view toggle with persistence

## Changes

| Component | Change |
|---|---|
| `daemon/cmd/heimdallm/main.go` | `FetchPRsToReview` auto-upserts unknown repos to config store |
| `flutter_app/.../repos_screen.dart` | Filter chips, grid view, view toggle, removed Discover button |

## Test Plan
- [x] `go test ./... -race` — all pass
- [x] `flutter analyze` — no issues
- [ ] Manual: verify new repos appear automatically after daemon poll
- [ ] Manual: filter by Monitored / Not monitored
- [ ] Manual: toggle list ↔ grid, close and reopen — preference persists

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)