### PR TITLE
fix: per-repo overrides lost on config save (#138)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -347,10 +347,14 @@ func main() {
 		repoOverrides := make(map[string]map[string]any)
 		for repo, ai := range c.AI.Repos {
 			ro := map[string]any{
-				"primary":     ai.Primary,
-				"fallback":    ai.Fallback,
-				"review_mode": ai.ReviewMode,
-				"local_dir":   ai.LocalDir,
+				"primary":      ai.Primary,
+				"fallback":     ai.Fallback,
+				"review_mode":  ai.ReviewMode,
+				"local_dir":    ai.LocalDir,
+				"pr_reviewers": ai.PRReviewers,
+				"pr_assignee":  ai.PRAssignee,
+				"pr_labels":    ai.PRLabels,
+				"pr_draft":     ai.PRDraft,
 			}
 			if ai.IssueTracking != nil {
 				ro["issue_tracking"] = ai.IssueTracking


### PR DESCRIPTION
## Summary

`GET /config` was missing `pr_reviewers`, `pr_assignee`, `pr_labels`, `pr_draft` from `repo_overrides`. Flutter parsed them as `null`, then `_autoSave` wrote TOML without them — silently erasing per-repo overrides on every save.

**1 file changed, 4 lines added.**

## Test Plan
- [x] `go build` + `go test` — pass
- [x] Manual: set Develop labels on a repo, edit another field, verify labels persist after reload

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)