### PR TITLE
fix: pass GitHubToken to issue pipeline RunOptions

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -276,6 +276,7 @@ func main() {
 	// Tier 2 / Tier 3 interfaces.
 	adapter := &tier2Adapter{
 		ghClient:  ghClient,
+		ghToken:   token,
 		pipeline:  p,
 		issuePipe: issuePipe,
 		fetcher:   issueFetcher,
@@ -613,8 +614,9 @@ func main() {
 		implPrompt, implInstructions := resolveImplementPrompt(s, aiCfg.ImplementPrompt, agentCfg.PromptID)
 
 		opts := issuepipeline.RunOptions{
-			Primary:  aiCfg.Primary,
-			Fallback: aiCfg.Fallback,
+			GitHubToken: token,
+			Primary:     aiCfg.Primary,
+			Fallback:    aiCfg.Fallback,
 			ExecOpts: executor.ExecOptions{
 				Model:                agentCfg.Model,
 				MaxTurns:             agentCfg.MaxTurns,
@@ -796,6 +798,7 @@ func parseWatchInterval(s string) time.Duration {
 
 type tier2Adapter struct {
 	ghClient  *gh.Client
+	ghToken   string
 	pipeline  *pipeline.Pipeline
 	issuePipe *issuepipeline.Pipeline
 	fetcher   *issuepipeline.Fetcher
@@ -966,8 +969,9 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 		implPrompt, implInstructions := resolveImplementPrompt(a.store, aiCfg.ImplementPrompt, agentCfg.PromptID)
 
 		return issuepipeline.RunOptions{
-			Primary:  aiCfg.Primary,
-			Fallback: aiCfg.Fallback,
+			GitHubToken: a.ghToken,
+			Primary:     aiCfg.Primary,
+			Fallback:    aiCfg.Fallback,
 			ExecOpts: executor.ExecOptions{
 				Model:                agentCfg.Model,
 				MaxTurns:             agentCfg.MaxTurns,


### PR DESCRIPTION
Fixes #141

## Problem

`auto_implement` always fails with `empty GitHubToken`. The token is loaded at startup but never passed to `issuepipeline.RunOptions`.

## Fix

Two changes in `daemon/cmd/heimdallm/main.go`:

1. **Trigger-review handler** (line ~615): Added `GitHubToken: token`
2. **tier2Adapter poll path** (line ~969): Added `ghToken` field to struct, wired at construction, passed as `GitHubToken: a.ghToken`

## Test plan

- [ ] `go build ./cmd/heimdallm` compiles
- [ ] Deploy with `auto_implement` issue → no longer fails with empty token
- [ ] `review_only` mode unaffected (token field is ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)