### PR TITLE
fix: add git to Docker runtime image for auto_implement

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /heimdallm ./cmd/heimd
 # ─── Stage 2: Runtime with AI CLIs ───────────────────────────────────────────
 FROM node:20-alpine
 
-RUN apk add --no-cache ca-certificates tzdata bash curl coreutils
+RUN apk add --no-cache ca-certificates tzdata bash curl coreutils git
 
 # ── Install AI CLI tools ──────────────────────────────────────────────────────
 # Claude Code CLI (Anthropic) — requires ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN at runtime


### PR DESCRIPTION
Fixes #143

## Problem

auto_implement fails with `exec: "git": executable file not found in $PATH`. Git is in the builder stage but not the runtime stage of the Dockerfile.

## Fix

One line: add `git` to the runtime `apk add` in `docker/Dockerfile` line 16.

## Test plan

- [ ] `docker build -f docker/Dockerfile .` succeeds
- [ ] `docker exec heimdallm git --version` returns a version
- [ ] auto_implement no longer fails with missing git

🤖 Generated with [Claude Code](https://claude.com/claude-code)