### PR TITLE
fix: dedup PR reviews by HEAD commit SHA

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -367,6 +367,29 @@ func (c *Client) fetchReposForOrg(topic, org string) ([]string, error) {
 	return repos, nil
 }
 
+// GetPRHeadSHA returns the PR's current HEAD commit SHA via the Pulls API.
+// The Search Issues API used by FetchPRsToReview does not populate head.sha,
+// so the pipeline needs this lookup to deduplicate reviews by commit rather
+// than by the PR's updated_at (which any peer reviewer bumps on every review).
+func (c *Client) GetPRHeadSHA(repo string, number int) (string, error) {
+	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)
+	resp, err := c.do("GET", path, "application/vnd.github+json")
+	if err != nil {
+		return "", fmt.Errorf("github: get PR head sha: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if resp.StatusCode != http.StatusOK {
+		errBody := safeTruncate(string(body), maxErrBodyLen)
+		return "", fmt.Errorf("github: get PR head sha (%s #%d): status %d: %s", repo, number, resp.StatusCode, errBody)
+	}
+	var pr PullRequest
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return "", fmt.Errorf("github: get PR head sha: unmarshal: %w", err)
+	}
+	return pr.Head.SHA, nil
+}
+
 // FetchDiff returns the unified diff for a PR.
 func (c *Client) FetchDiff(repo string, number int) (string, error) {
 	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)

--- a/daemon/internal/github/models.go
+++ b/daemon/internal/github/models.go
@@ -82,7 +82,8 @@ type Repo struct {
 }
 
 type Branch struct {
-	Repo Repo `json:"repo"`
+	Repo Repo   `json:"repo"`
+	SHA  string `json:"sha"`
 }
 
 type PullRequest struct {

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -17,6 +17,13 @@ type DiffFetcher interface {
 	FetchDiff(repo string, number int) (string, error)
 }
 
+// HeadSHAResolver fetches a PR's current HEAD commit SHA. The Search Issues
+// API (used by Tier 2 to discover review requests) does not populate head.sha,
+// so the pipeline needs an explicit lookup before it can dedup by commit.
+type HeadSHAResolver interface {
+	GetPRHeadSHA(repo string, number int) (string, error)
+}
+
 // CLIExecutor detects and runs an AI CLI tool.
 type CLIExecutor interface {
 	Detect(primary, fallback string) (string, error)
@@ -47,6 +54,7 @@ type Pipeline struct {
 		DiffFetcher
 		GitHubReviewer
 		CommentFetcher
+		HeadSHAResolver
 	}
 	executor CLIExecutor
 	notify   Notifier
@@ -58,6 +66,7 @@ func New(s *store.Store, gh interface {
 	DiffFetcher
 	GitHubReviewer
 	CommentFetcher
+	HeadSHAResolver
 }, exec CLIExecutor, n Notifier) *Pipeline {
 	return &Pipeline{store: s, gh: gh, executor: exec, notify: n}
 }
@@ -156,6 +165,30 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		return nil, fmt.Errorf("pipeline: fetch diff: %w", err)
 	}
 
+	// 2a. Authoritative dedup by HEAD commit SHA. The Tier 2/3 dedup uses
+	// updated_at — but any peer reviewer submitting a review (human or another
+	// heimdallm instance) bumps updated_at, which would otherwise cause us to
+	// re-review the same commit indefinitely (see theburrowhub/heimdallm#139).
+	// If the last stored review is for the same HEAD SHA, return it unchanged.
+	//
+	// The Search Issues API used by Tier 2 does not populate head.sha, so we
+	// resolve it on-demand. Resolver failure degrades gracefully — we fall
+	// through and run the review rather than block on a transient API error.
+	if pr.Head.SHA == "" {
+		if sha, err := p.gh.GetPRHeadSHA(pr.Repo, pr.Number); err != nil {
+			slog.Warn("pipeline: could not resolve HEAD SHA, skipping dedup guard",
+				"repo", pr.Repo, "pr", pr.Number, "err", err)
+		} else {
+			pr.Head.SHA = sha
+		}
+	}
+	prevReview, _ := p.store.LatestReviewForPR(prID)
+	if prevReview != nil && pr.Head.SHA != "" && prevReview.HeadSHA == pr.Head.SHA {
+		slog.Info("pipeline: skipping re-review, HEAD SHA unchanged",
+			"repo", pr.Repo, "pr", pr.Number, "head_sha", pr.Head.SHA)
+		return prevReview, nil
+	}
+
 	// 2b. Fetch PR comments for context (non-fatal: proceed without if unavailable)
 	prComments, err := p.gh.FetchComments(pr.Repo, pr.Number)
 	if err != nil {
@@ -166,7 +199,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 
 	// 2c. Build re-review context if a previous review exists for this PR.
 	var reviewCtx string
-	if prevReview, err := p.store.LatestReviewForPR(prID); err == nil && prevReview != nil {
+	if prevReview != nil {
 		reviewCtx = buildReviewContext(
 			prevReview.Issues,
 			prevReview.Severity,
@@ -238,6 +271,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		Severity:       result.Severity,
 		CreatedAt:      time.Now().UTC(),
 		GitHubReviewID: 0, // will be set after GitHub publish
+		HeadSHA:        pr.Head.SHA,
 	}
 	rev.ID, err = p.store.InsertReview(rev)
 	if err != nil {

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -44,6 +44,8 @@ func (f *fakeGH) FetchComments(repo string, number int) ([]github.Comment, error
 	return f.comments, nil
 }
 
+func (f *fakeGH) GetPRHeadSHA(repo string, number int) (string, error) { return "", nil }
+
 type fakeExec struct{}
 
 func (f *fakeExec) Detect(primary, fallback string) (string, error) {
@@ -142,6 +144,8 @@ func (f *fakeGHCommentsError) FetchComments(repo string, number int) ([]github.C
 	return nil, fmt.Errorf("network error")
 }
 
+func (f *fakeGHCommentsError) GetPRHeadSHA(repo string, number int) (string, error) { return "", nil }
+
 func TestPipeline_Run_CommentsInjectedIntoPrompt(t *testing.T) {
 	s, err := store.Open(":memory:")
 	if err != nil {
@@ -191,5 +195,184 @@ func TestPipeline_Run_CommentsFetchErrorIsNonFatal(t *testing.T) {
 	_, err = p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
 	if err != nil {
 		t.Fatalf("expected pipeline to succeed despite comments fetch error, got: %v", err)
+	}
+}
+
+// fakeGHWithHeadSHA resolves a HEAD SHA via GetPRHeadSHA, simulating the
+// real GitHub client — the Search Issues API used by Tier 2 does not return
+// head.sha, so the pipeline must hydrate it before the dedup guard can fire.
+type fakeGHWithHeadSHA struct {
+	diff   string
+	sha    string
+	shaErr error
+	// calls tracks GetPRHeadSHA invocations so tests can assert hydration
+	// only happens when pr.Head.SHA is empty.
+	shaCalls int
+	submits  int
+}
+
+func (f *fakeGHWithHeadSHA) FetchDiff(repo string, number int) (string, error) {
+	return f.diff, nil
+}
+func (f *fakeGHWithHeadSHA) SubmitReview(repo string, number int, body, event string) (int64, string, error) {
+	f.submits++
+	return 1, "COMMENTED", nil
+}
+func (f *fakeGHWithHeadSHA) PostComment(repo string, number int, body string) error { return nil }
+func (f *fakeGHWithHeadSHA) FetchComments(repo string, number int) ([]github.Comment, error) {
+	return nil, nil
+}
+func (f *fakeGHWithHeadSHA) GetPRHeadSHA(repo string, number int) (string, error) {
+	f.shaCalls++
+	return f.sha, f.shaErr
+}
+
+// TestPipeline_Run_HydratesHeadSHAWhenMissing covers the production path: the
+// Search Issues API doesn't populate head.sha, so Tier 2 hands the pipeline a
+// PR with Head.SHA == "". The pipeline must fetch it so the dedup guard and
+// the stored review row both record the correct SHA.
+func TestPipeline_Run_HydratesHeadSHAWhenMissing(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	gh := &fakeGHWithHeadSHA{diff: "+line", sha: "abc123"}
+	p := pipeline.New(s, gh, &fakeExec{}, &fakeNotify{})
+
+	pr := &github.PullRequest{
+		ID: 7, Number: 7, Title: "t", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/7",
+		// Head.SHA intentionally empty — mirrors Search API payload.
+	}
+	rev, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if gh.shaCalls != 1 {
+		t.Errorf("expected 1 GetPRHeadSHA call, got %d", gh.shaCalls)
+	}
+	if rev.HeadSHA != "abc123" {
+		t.Errorf("stored HeadSHA = %q, want %q", rev.HeadSHA, "abc123")
+	}
+
+	// Second run: the PR now has the SHA inline (as if hydrated upstream).
+	// Pipeline must NOT call GetPRHeadSHA again, and must skip on SHA match.
+	pr.Head.SHA = "abc123"
+	_, err = p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if gh.shaCalls != 1 {
+		t.Errorf("GetPRHeadSHA called redundantly: %d", gh.shaCalls)
+	}
+	if gh.submits != 1 {
+		t.Errorf("SubmitReview called on same SHA: %d", gh.submits)
+	}
+}
+
+// fakeExecCounter records how many times Execute was called so tests can
+// assert whether the pipeline short-circuited before invoking the CLI.
+type fakeExecCounter struct {
+	calls int
+}
+
+func (f *fakeExecCounter) Detect(primary, fallback string) (string, error) {
+	return "fake_claude", nil
+}
+
+func (f *fakeExecCounter) Execute(cli, prompt string, _ executor.ExecOptions) (*executor.ReviewResult, error) {
+	f.calls++
+	return &executor.ReviewResult{Summary: "ok", Severity: "low"}, nil
+}
+
+// fakeGHCounter records SubmitReview calls so tests can verify no publish
+// happens on a skipped re-review.
+type fakeGHCounter struct {
+	diff     string
+	submits  int
+}
+
+func (f *fakeGHCounter) FetchDiff(repo string, number int) (string, error) { return f.diff, nil }
+func (f *fakeGHCounter) SubmitReview(repo string, number int, body, event string) (int64, string, error) {
+	f.submits++
+	return 1, "COMMENTED", nil
+}
+func (f *fakeGHCounter) PostComment(repo string, number int, body string) error { return nil }
+func (f *fakeGHCounter) FetchComments(repo string, number int) ([]github.Comment, error) { return nil, nil }
+func (f *fakeGHCounter) GetPRHeadSHA(repo string, number int) (string, error)            { return "", nil }
+
+// TestPipeline_Run_SkipsReviewOnSameHeadSHA is the regression guard for the
+// bot-feedback loop bug seen on theburrowhub/heimdallm#139: any review
+// submission bumps the PR's updated_at, so the timestamp-based dedup let
+// multiple bots re-review the same commit over and over. The authoritative
+// guard must be the HEAD commit SHA — if we've already reviewed this exact
+// commit, the pipeline must not run the CLI or publish a new review.
+func TestPipeline_Run_SkipsReviewOnSameHeadSHA(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	exec := &fakeExecCounter{}
+	gh := &fakeGHCounter{diff: "+line"}
+	p := pipeline.New(s, gh, exec, &fakeNotify{})
+
+	pr := &github.PullRequest{
+		ID: 42, Number: 42, Title: "Feature", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/42",
+		Head: github.Branch{SHA: "deadbeef"},
+	}
+
+	// First run — produces the initial review on commit deadbeef.
+	rev1, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if rev1 == nil || rev1.HeadSHA != "deadbeef" {
+		t.Fatalf("first review HeadSHA = %q, want %q", func() string { if rev1 == nil { return "<nil>" }; return rev1.HeadSHA }(), "deadbeef")
+	}
+	if exec.calls != 1 || gh.submits != 1 {
+		t.Fatalf("first run: exec=%d submits=%d, want 1/1", exec.calls, gh.submits)
+	}
+
+	// Simulate another bot posting a review, bumping updated_at. HEAD SHA unchanged.
+	pr.UpdatedAt = time.Now().Add(5 * time.Minute)
+
+	// Second run on the same HEAD SHA — must short-circuit. No CLI call, no
+	// publish, no new review row.
+	rev2, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if exec.calls != 1 {
+		t.Errorf("executor called again on same SHA: calls=%d", exec.calls)
+	}
+	if gh.submits != 1 {
+		t.Errorf("SubmitReview called again on same SHA: submits=%d", gh.submits)
+	}
+	reviews, _ := s.ListReviewsForPR(rev1.PRID)
+	if len(reviews) != 1 {
+		t.Errorf("duplicate review row inserted on same SHA: got %d reviews", len(reviews))
+	}
+	if rev2 == nil || rev2.ID != rev1.ID {
+		t.Errorf("expected Run to return the existing review on same SHA; got rev2=%+v", rev2)
+	}
+
+	// Third run with a new HEAD SHA — must proceed normally.
+	pr.Head.SHA = "cafef00d"
+	_, err = p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("third run: %v", err)
+	}
+	if exec.calls != 2 {
+		t.Errorf("executor not invoked on new SHA: calls=%d", exec.calls)
+	}
+	if gh.submits != 2 {
+		t.Errorf("SubmitReview not invoked on new SHA: submits=%d", gh.submits)
 	}
 }

--- a/daemon/internal/store/reviews.go
+++ b/daemon/internal/store/reviews.go
@@ -24,15 +24,19 @@ type Review struct {
 	CreatedAt         time.Time `json:"created_at"`
 	GitHubReviewID    int64     `json:"github_review_id"`    // 0 = not yet published
 	GitHubReviewState string    `json:"github_review_state"` // '' until published
+	// HeadSHA is the PR's HEAD commit at review time. Used as the authoritative
+	// dedup key: if we've already reviewed this SHA, peer-bot review submissions
+	// bumping the PR's updated_at must not trigger a re-review.
+	HeadSHA string `json:"head_sha"`
 }
 
 // InsertReview inserts a new review record and returns its row ID.
 func (s *Store) InsertReview(r *Review) (int64, error) {
 	res, err := s.db.Exec(`
-		INSERT INTO reviews (pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO reviews (pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state, head_sha)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, r.PRID, r.CLIUsed, r.Summary, r.Issues, r.Suggestions, r.Severity,
-		r.CreatedAt.UTC().Format(sqliteTimeFormat), r.GitHubReviewID, r.GitHubReviewState,
+		r.CreatedAt.UTC().Format(sqliteTimeFormat), r.GitHubReviewID, r.GitHubReviewState, r.HeadSHA,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("store: insert review: %w", err)
@@ -43,7 +47,7 @@ func (s *Store) InsertReview(r *Review) (int64, error) {
 // ListUnpublishedReviews returns reviews not yet submitted to GitHub (github_review_id == 0).
 func (s *Store) ListUnpublishedReviews() ([]*Review, error) {
 	rows, err := s.db.Query(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state FROM reviews WHERE github_review_id=0 ORDER BY created_at ASC",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state, head_sha FROM reviews WHERE github_review_id=0 ORDER BY created_at ASC",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("store: list unpublished: %w", err)
@@ -75,7 +79,7 @@ func (s *Store) MarkReviewPublished(reviewID, ghReviewID int64, ghReviewState st
 // ListReviewsForPR returns all reviews for a given PR, ordered by created_at descending.
 func (s *Store) ListReviewsForPR(prID int64) ([]*Review, error) {
 	rows, err := s.db.Query(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state FROM reviews WHERE pr_id = ? ORDER BY created_at DESC",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state, head_sha FROM reviews WHERE pr_id = ? ORDER BY created_at DESC",
 		prID,
 	)
 	if err != nil {
@@ -96,7 +100,7 @@ func (s *Store) ListReviewsForPR(prID int64) ([]*Review, error) {
 // LatestReviewForPR returns the most recent review for a PR. Returns sql.ErrNoRows if none.
 func (s *Store) LatestReviewForPR(prID int64) (*Review, error) {
 	row := s.db.QueryRow(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state FROM reviews WHERE pr_id = ? ORDER BY created_at DESC LIMIT 1",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state, head_sha FROM reviews WHERE pr_id = ? ORDER BY created_at DESC LIMIT 1",
 		prID,
 	)
 	return scanReview(row)
@@ -122,7 +126,7 @@ func scanReview(s scanner) (*Review, error) {
 	var createdAt string
 	var err error
 	if err = s.Scan(&rev.ID, &rev.PRID, &rev.CLIUsed, &rev.Summary,
-		&rev.Issues, &rev.Suggestions, &rev.Severity, &createdAt, &rev.GitHubReviewID, &rev.GitHubReviewState); err != nil {
+		&rev.Issues, &rev.Suggestions, &rev.Severity, &createdAt, &rev.GitHubReviewID, &rev.GitHubReviewState, &rev.HeadSHA); err != nil {
 		return nil, fmt.Errorf("store: scan review: %w", err)
 	}
 	if rev.CreatedAt, err = time.Parse(sqliteTimeFormat, createdAt); err != nil {

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -46,7 +46,8 @@ CREATE TABLE IF NOT EXISTS reviews (
   severity            TEXT NOT NULL,
   created_at          DATETIME NOT NULL,
   github_review_id    INTEGER NOT NULL DEFAULT 0,
-  github_review_state TEXT NOT NULL DEFAULT ''
+  github_review_state TEXT NOT NULL DEFAULT '',
+  head_sha            TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS configs (
@@ -131,6 +132,7 @@ func Open(dsn string) (*Store, error) {
 	// Migrate existing DBs (ALTER TABLE ignores "duplicate column" errors silently)
 	db.Exec("ALTER TABLE reviews ADD COLUMN github_review_id INTEGER NOT NULL DEFAULT 0")
 	db.Exec("ALTER TABLE reviews ADD COLUMN github_review_state TEXT NOT NULL DEFAULT ''")
+	db.Exec("ALTER TABLE reviews ADD COLUMN head_sha TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents ADD COLUMN instructions TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents ADD COLUMN cli_flags TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents RENAME COLUMN prompt TO prompt") // no-op, ensures column exists

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -131,6 +131,36 @@ func TestMarkReviewPublished_RoundTripsStateAndID(t *testing.T) {
 	}
 }
 
+// TestReview_HeadSHARoundTrip covers the field added to deduplicate re-reviews
+// by HEAD commit SHA instead of the PR's updated_at (which is bumped every time
+// any reviewer — including a peer bot — submits a review, causing bot-feedback
+// loops on the same commit).
+func TestReview_HeadSHARoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	prID, _ := s.UpsertPR(&store.PR{
+		GithubID: 1, Repo: "org/r", Number: 1, Title: "t", Author: "a",
+		URL: "u", State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now(),
+	})
+
+	rev := &store.Review{
+		PRID: prID, CLIUsed: "claude", Summary: "ok",
+		Issues: "[]", Suggestions: "[]", Severity: "low",
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+		HeadSHA:   "deadbeefcafef00d",
+	}
+	if _, err := s.InsertReview(rev); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	got, err := s.LatestReviewForPR(prID)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	if got.HeadSHA != "deadbeefcafef00d" {
+		t.Errorf("HeadSHA = %q, want %q", got.HeadSHA, "deadbeefcafef00d")
+	}
+}
+
 func TestPR_ListAll(t *testing.T) {
 	s := newTestStore(t)
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
## Summary
- Replaces the `updated_at`-based dedup (which any peer review bumps) with a HEAD-SHA dedup inside the pipeline — reviews short-circuit when the last stored review's `head_sha` matches the PR's current HEAD commit.
- Adds `Review.head_sha` column (ALTER migration, empty default for legacy rows) and a `GetPRHeadSHA` client method to hydrate SHAs missing from the Search Issues API payload.
- Keeps the existing Tier 2 / Tier 3 `updated_at` check as a cheap pre-filter; the pipeline guard is the authoritative stop.

## Why
Observed on #139: two heimdallm instances (each a distinct reviewer account) ended up re-reviewing the same commit 11+ times in ~30 minutes. Root cause — each review submission bumps the PR's `updated_at`, defeating the 30s grace window in `PRAlreadyReviewed`, so every peer reply triggered another re-review on the same commit. The SHA-based guard only releases on a genuine `git push`.

## Test plan
- [x] `make test` — full daemon suite green, including 3 new TDD tests:
  - `TestReview_HeadSHARoundTrip` — `head_sha` round-trips through the store
  - `TestPipeline_Run_SkipsReviewOnSameHeadSHA` — executor + `SubmitReview` not invoked when HEAD SHA matches last review; new SHA proceeds normally
  - `TestPipeline_Run_HydratesHeadSHAWhenMissing` — pipeline resolves SHA on-demand when missing, skips the resolver when already populated
- [x] `make lint` clean
- [x] `make build` clean
- [ ] Manual: verify a bot's own follow-up doesn't trigger a re-review by watching a PR that has both a human and a heimdallm reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)