### PR TITLE
feat(config): make AI CLI execution timeout configurable

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -203,6 +203,7 @@ func main() {
 		}
 		cfgMu.Lock()
 		agentCfg := cfg.AgentConfigFor(cli)
+		globalTimeout := cfg.AI.ExecutionTimeout
 		cfgMu.Unlock()
 		extraFlags := agentCfg.ExtraFlags
 		if extraFlags != "" {
@@ -228,6 +229,7 @@ func main() {
 				Bare:                 agentCfg.Bare,
 				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
 				NoSessionPersistence: agentCfg.NoSessionPersistence,
+				Timeout:              resolveExecutionTimeout(globalTimeout, agentCfg.ExecutionTimeout),
 			},
 		}
 	}
@@ -631,6 +633,7 @@ func main() {
 		}
 		agentCfg := cfg.AgentConfigFor(aiCfg.Primary)
 		localDirBase := cfg.GitHub.LocalDirBase
+		globalTimeout := cfg.AI.ExecutionTimeout
 		cfgMu.Unlock()
 		// /repos/<short-name> fallback when local_dir is unset (stat-based,
 		// keep outside the mutex).
@@ -680,6 +683,7 @@ func main() {
 				Bare:                 agentCfg.Bare,
 				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
 				NoSessionPersistence: agentCfg.NoSessionPersistence,
+				Timeout:              resolveExecutionTimeout(globalTimeout, agentCfg.ExecutionTimeout),
 			},
 			IssuePromptOverride:     issuePrompt,
 			IssueInstructions:       issueInstructions,
@@ -844,6 +848,26 @@ func parseWatchInterval(s string) time.Duration {
 		return minWatch
 	}
 	return d
+}
+
+// resolveExecutionTimeout returns the effective execution timeout for the CLI
+// process. Per-agent timeout wins over the global timeout; zero means "use
+// executor default (5m)".
+func resolveExecutionTimeout(globalTimeout, agentTimeout string) time.Duration {
+	// Per-agent wins
+	if agentTimeout != "" {
+		if d, err := time.ParseDuration(agentTimeout); err == nil && d > 0 {
+			return d
+		}
+	}
+	// Global fallback
+	if globalTimeout != "" {
+		if d, err := time.ParseDuration(globalTimeout); err == nil && d > 0 {
+			return d
+		}
+	}
+	// Zero = executor uses its default (5m)
+	return 0
 }
 
 // upsertDiscoveredRepos adds PRs' repos to the monitored (or non-monitored)
@@ -1117,6 +1141,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 		}
 		agentCfg := c.AgentConfigFor(aiCfg.Primary)
 		localDirBase := c.GitHub.LocalDirBase
+		globalTimeout := c.AI.ExecutionTimeout
 		a.cfgMu.Unlock()
 		// /repos/<short-name> fallback when local_dir is unset (stat-based,
 		// keep outside the mutex).
@@ -1148,6 +1173,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 				Bare:                 agentCfg.Bare,
 				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
 				NoSessionPersistence: agentCfg.NoSessionPersistence,
+				Timeout:              resolveExecutionTimeout(globalTimeout, agentCfg.ExecutionTimeout),
 			},
 			IssuePromptOverride:     issuePrompt,
 			IssueInstructions:       issueInstructions,

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -235,15 +235,17 @@ type CLIAgentConfig struct {
 	Bare                 bool   `toml:"bare"`                    // --bare
 	DangerouslySkipPerms bool   `toml:"dangerously_skip_perms"` // --dangerously-skip-permissions (cannot be set via HTTP API, see M-5)
 	NoSessionPersistence bool   `toml:"no_session_persistence"` // --no-session-persistence
+	ExecutionTimeout     string `toml:"execution_timeout"`      // per-agent override, e.g. "20m"
 }
 
 type AIConfig struct {
-	Primary    string                      `toml:"primary"`
-	Fallback   string                      `toml:"fallback"`
-	ReviewMode string                      `toml:"review_mode"` // "single" | "multi"
-	Agents     map[string]CLIAgentConfig   `toml:"agents"`      // keyed by CLI name
-	Repos      map[string]RepoAI           `toml:"repos"`
-	PRMetadata PRMetadataConfig            `toml:"pr_metadata"` // global PR creation defaults
+	Primary          string                    `toml:"primary"`
+	Fallback         string                    `toml:"fallback"`
+	ReviewMode       string                    `toml:"review_mode"`        // "single" | "multi"
+	ExecutionTimeout string                    `toml:"execution_timeout"`  // e.g. "20m", "1h"
+	Agents           map[string]CLIAgentConfig `toml:"agents"`             // keyed by CLI name
+	Repos            map[string]RepoAI         `toml:"repos"`
+	PRMetadata       PRMetadataConfig          `toml:"pr_metadata"`        // global PR creation defaults
 }
 
 type RepoAI struct {
@@ -529,6 +531,9 @@ func (c *Config) applyEnvOverrides() {
 	}
 	if v := os.Getenv("HEIMDALLM_REVIEW_MODE"); v != "" {
 		c.AI.ReviewMode = v
+	}
+	if v := os.Getenv("HEIMDALLM_EXECUTION_TIMEOUT"); v != "" {
+		c.AI.ExecutionTimeout = v
 	}
 	if v := os.Getenv("HEIMDALLM_RETENTION_DAYS"); v != "" {
 		if d, err := strconv.Atoi(v); err == nil {

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -1419,6 +1419,16 @@ retention_days = 0
 
 // ── AutoEnablePRForDiscovery ────────────────────────────────────────────────
 
+func TestApplyEnvOverrides_ExecutionTimeout(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	t.Setenv("HEIMDALLM_EXECUTION_TIMEOUT", "20m")
+	cfg.applyEnvOverrides()
+	if cfg.AI.ExecutionTimeout != "20m" {
+		t.Errorf("ExecutionTimeout = %q, want 20m", cfg.AI.ExecutionTimeout)
+	}
+}
+
 func TestAutoEnablePRForDiscovery_Default(t *testing.T) {
 	cfg := &GitHubConfig{}
 	if !cfg.AutoEnablePRForDiscovery() {

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -57,6 +57,10 @@ type ExecOptions struct {
 	// (CLIAgentConfig.DangerouslySkipPerms) which requires local file access.
 	DangerouslySkipPerms bool // --dangerously-skip-permissions
 	NoSessionPersistence bool // --no-session-persistence
+
+	// Timeout overrides the default execution timeout for the CLI process.
+	// Zero = use default (5 minutes).
+	Timeout time.Duration
 }
 
 // Executor runs AI CLI tools for code review.
@@ -345,7 +349,11 @@ func (e *Executor) Execute(cli, prompt string, opts ExecOptions) (*ReviewResult,
 // output, etc.). Callers should pass the bytes through StripToJSON before
 // json.Unmarshal — CLIs routinely wrap JSON in code fences or surrounding text.
 func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), executionTimeout)
+	timeout := executionTimeout
+	if opts.Timeout > 0 {
+		timeout = opts.Timeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	// Resolve full path — uses login shell to find binaries in Homebrew/npm/etc.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -162,3 +162,6 @@ HEIMDALLM_PORT=7842
 # take precedence.
 # HEIMDALLM_PR_REVIEWERS=muriano,ivanmunozruiz
 # HEIMDALLM_PR_LABELS=auto-generated,heimdallm
+
+# AI CLI execution timeout (default: 5m). Increase for complex auto_implement tasks.
+# HEIMDALLM_EXECUTION_TIMEOUT=20m

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -46,6 +46,7 @@ repositories = ["org/repo1", "org/repo2"]
 primary = "claude"
 # fallback = "gemini"
 review_mode = "single"   # "single" or "multi"
+# execution_timeout = "20m"   # default: 5m; increase for complex auto_implement
 
 # Per-CLI settings (optional)
 # [ai.agents.claude]


### PR DESCRIPTION
Closes #155

## Problem

Execution timeout hardcoded to 5 minutes. Complex auto_implement tasks get killed mid-implementation.

## Fix

`execution_timeout` configurable at 3 levels:

```toml
[ai]
execution_timeout = "20m"          # global

[ai.agents.claude]
execution_timeout = "30m"          # per-agent (wins)
```

```env
HEIMDALLM_EXECUTION_TIMEOUT=20m   # env var
```

Resolution: per-agent > global > env > default (5m). Zero change for existing users.

## Changes

- `executor.go` — `Timeout` field in `ExecOptions`, used when > 0
- `config.go` — `ExecutionTimeout` in `AIConfig` + `CLIAgentConfig` + env var
- `main.go` — `resolveExecutionTimeout()` helper, all 3 ExecOptions sites updated
- Tests + docs

## Test plan

- [ ] `go test ./...` passes
- [ ] Default (no config): 5m timeout unchanged
- [ ] `execution_timeout = "20m"` in TOML: uses 20m
- [ ] Per-agent override wins over global

🤖 Generated with [Claude Code](https://claude.com/claude-code)