### PR TITLE
feat: implement #162 — feat: integrate GoReleaser for CLI binaries in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -486,3 +486,31 @@ jobs:
           files: ${{ env.DMG_PATH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # CLI binaries — cross-platform via GoReleaser
+  # ═══════════════════════════════════════════════════════════════════════════
+  goreleaser-cli:
+    name: Build CLI binaries (GoReleaser)
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+          workdir: cli
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ needs.release-please.outputs.tag_name }}

--- a/cli/.goreleaser.yml
+++ b/cli/.goreleaser.yml
@@ -41,4 +41,5 @@ release:
   github:
     owner: theburrowhub
     name: heimdallm
+  mode: keep-existing
   extra_files: []


### PR DESCRIPTION
Auto-generated by Heimdallm in response to #162.

Closes #162