### PR TITLE
feat: add Homebrew tap to GoReleaser config

### DIFF
--- a/cli/.goreleaser.yml
+++ b/cli/.goreleaser.yml
@@ -37,6 +37,18 @@ changelog:
       - "^test:"
       - "^chore:"
 
+brews:
+  - repository:
+      owner: theburrowhub
+      name: homebrew-tap
+    homepage: https://github.com/theburrowhub/heimdallm
+    description: "CLI client for Heimdallm — monitor PRs, issues, and activity from the terminal"
+    license: MIT
+    install: |
+      bin.install "heimdallm-cli"
+    test: |
+      system "#{bin}/heimdallm-cli", "--help"
+
 release:
   github:
     owner: theburrowhub


### PR DESCRIPTION
## Summary

Add `brews` section to `cli/.goreleaser.yml` so each release automatically publishes a Homebrew formula to `theburrowhub/homebrew-tap`.

## Usage after merge

```bash
brew tap theburrowhub/tap
brew install heimdallm-cli
```

## Changes

One file: `cli/.goreleaser.yml` — added `brews` section with repository, homepage, description, install and test blocks.

## Test plan

- [ ] Next release creates `Formula/heimdallm-cli.rb` in `theburrowhub/homebrew-tap`
- [ ] `brew install theburrowhub/tap/heimdallm-cli` works
- [ ] `heimdallm-cli --help` runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)