### PR TITLE
feat: implement #169 — bug: GoReleaser fails to publish Homebrew formula to homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -513,4 +513,5 @@ jobs:
           workdir: cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ needs.release-please.outputs.tag_name }}

--- a/cli/.goreleaser.yml
+++ b/cli/.goreleaser.yml
@@ -41,6 +41,7 @@ brews:
   - repository:
       owner: theburrowhub
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: https://github.com/theburrowhub/heimdallm
     description: "CLI client for Heimdallm — monitor PRs, issues, and activity from the terminal"
     license: MIT


### PR DESCRIPTION
Auto-generated by Heimdallm in response to #169.

Closes #169