### PR TITLE
feat: heimdallm-cli auto-discover token + config file

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,6 +3,7 @@ module github.com/theburrowhub/heimdallm/cli
 go 1.21
 
 require (
+	github.com/BurntSushi/toml v1.3.2
 	github.com/charmbracelet/bubbletea v1.2.4
 	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/spf13/cobra v1.8.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbletea v1.2.4 h1:KN8aCViA0eps9SCOThb2/XPIlea3ANJLUkv3KnQRNCE=

--- a/cli/internal/cli/cliconfig.go
+++ b/cli/internal/cli/cliconfig.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+type cliConfig struct {
+	Host  string `toml:"host,omitempty"`
+	Token string `toml:"token,omitempty"`
+}
+
+func configDir() string {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return filepath.Join(dir, "heimdallm")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".config", "heimdallm")
+	}
+	return filepath.Join(home, ".config", "heimdallm")
+}
+
+func configPath() string {
+	return filepath.Join(configDir(), "cli.toml")
+}
+
+func loadCLIConfig() (*cliConfig, error) {
+	var cfg cliConfig
+	if _, err := toml.DecodeFile(configPath(), &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func saveCLIConfig(cfg *cliConfig) error {
+	dir := configDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(cfg); err != nil {
+		return fmt.Errorf("encoding config: %w", err)
+	}
+
+	if err := os.WriteFile(configPath(), buf.Bytes(), 0600); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+	return nil
+}
+
+func discoverDockerToken() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "docker", "exec", "heimdallm", "cat", "/data/api_token").Output()
+	if err != nil {
+		return "", fmt.Errorf("docker discovery failed: %w", err)
+	}
+
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return "", fmt.Errorf("empty token from container")
+	}
+	return token, nil
+}

--- a/cli/internal/cli/cliconfig_test.go
+++ b/cli/internal/cli/cliconfig_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigDirDefault(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+	want := filepath.Join(home, ".config", "heimdallm")
+	if got := configDir(); got != want {
+		t.Errorf("configDir() = %q, want %q", got, want)
+	}
+}
+
+func TestConfigDirXDG(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg-test")
+	want := "/tmp/xdg-test/heimdallm"
+	if got := configDir(); got != want {
+		t.Errorf("configDir() = %q, want %q", got, want)
+	}
+}
+
+func TestSaveAndLoadCLIConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	cfg := &cliConfig{
+		Host:  "http://myhost:9999",
+		Token: "abc123def456",
+	}
+
+	if err := saveCLIConfig(cfg); err != nil {
+		t.Fatalf("saveCLIConfig: %v", err)
+	}
+
+	loaded, err := loadCLIConfig()
+	if err != nil {
+		t.Fatalf("loadCLIConfig: %v", err)
+	}
+
+	if loaded.Host != cfg.Host {
+		t.Errorf("Host = %q, want %q", loaded.Host, cfg.Host)
+	}
+	if loaded.Token != cfg.Token {
+		t.Errorf("Token = %q, want %q", loaded.Token, cfg.Token)
+	}
+}
+
+func TestSaveCLIConfigPermissions(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	cfg := &cliConfig{Host: "http://localhost:7842", Token: "secret"}
+	if err := saveCLIConfig(cfg); err != nil {
+		t.Fatalf("saveCLIConfig: %v", err)
+	}
+
+	info, err := os.Stat(configPath())
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm != 0600 {
+		t.Errorf("config permissions = %04o, want 0600", perm)
+	}
+}
+
+func TestSaveCLIConfigDirPermissions(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	cfg := &cliConfig{Host: "http://localhost:7842", Token: "secret"}
+	if err := saveCLIConfig(cfg); err != nil {
+		t.Fatalf("saveCLIConfig: %v", err)
+	}
+
+	info, err := os.Stat(configDir())
+	if err != nil {
+		t.Fatalf("stat config dir: %v", err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm != 0700 {
+		t.Errorf("config dir permissions = %04o, want 0700", perm)
+	}
+}
+
+func TestLoadCLIConfigMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	_, err := loadCLIConfig()
+	if err == nil {
+		t.Error("loadCLIConfig should fail when file is missing")
+	}
+}
+
+func TestSaveAndLoadPartialConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	cfg := &cliConfig{Host: "http://example.com:8080"}
+	if err := saveCLIConfig(cfg); err != nil {
+		t.Fatalf("saveCLIConfig: %v", err)
+	}
+
+	loaded, err := loadCLIConfig()
+	if err != nil {
+		t.Fatalf("loadCLIConfig: %v", err)
+	}
+
+	if loaded.Host != cfg.Host {
+		t.Errorf("Host = %q, want %q", loaded.Host, cfg.Host)
+	}
+	if loaded.Token != "" {
+		t.Errorf("Token = %q, want empty", loaded.Token)
+	}
+}

--- a/cli/internal/cli/configure.go
+++ b/cli/internal/cli/configure.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newConfigureCmd() *cobra.Command {
+	var auto bool
+
+	cmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Save daemon connection settings to config file",
+		Long: `Save host and token to ~/.config/heimdallm/cli.toml.
+
+Use --auto to auto-discover the token from a local Docker container named 'heimdallm'.
+Without --auto, you will be prompted for host and token interactively.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, _ := loadCLIConfig()
+			if cfg == nil {
+				cfg = &cliConfig{}
+			}
+
+			if auto {
+				return configureAuto(cfg)
+			}
+			return configureInteractive(cmd, cfg)
+		},
+	}
+
+	cmd.Flags().BoolVar(&auto, "auto", false, "auto-discover token from local Docker container")
+	return cmd
+}
+
+func configureAuto(cfg *cliConfig) error {
+	if cfg.Host == "" {
+		cfg.Host = "http://localhost:7842"
+	}
+
+	fmt.Println("Detecting Docker container 'heimdallm'...")
+	token, err := discoverDockerToken()
+	if err != nil {
+		return fmt.Errorf("auto-discovery failed: %w\nIs the heimdallm container running? Try: docker ps | grep heimdallm", err)
+	}
+
+	cfg.Token = token
+	fmt.Println("Token retrieved from container")
+
+	if err := saveCLIConfig(cfg); err != nil {
+		return err
+	}
+	fmt.Printf("Saved to %s\n", configPath())
+	return nil
+}
+
+func configureInteractive(cmd *cobra.Command, cfg *cliConfig) error {
+	scanner := bufio.NewScanner(cmd.InOrStdin())
+
+	defaultHost := cfg.Host
+	if defaultHost == "" {
+		defaultHost = "http://localhost:7842"
+	}
+
+	fmt.Printf("Host [%s]: ", defaultHost)
+	if scanner.Scan() {
+		if h := strings.TrimSpace(scanner.Text()); h != "" {
+			cfg.Host = h
+		} else {
+			cfg.Host = defaultHost
+		}
+	}
+
+	fmt.Print("Token: ")
+	if scanner.Scan() {
+		if t := strings.TrimSpace(scanner.Text()); t != "" {
+			cfg.Token = t
+		}
+	}
+
+	if err := saveCLIConfig(cfg); err != nil {
+		return err
+	}
+	fmt.Printf("Saved to %s\n", configPath())
+	return nil
+}

--- a/cli/internal/cli/configure_test.go
+++ b/cli/internal/cli/configure_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestConfigureInteractiveDefaults(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	input := "\nmytoken123\n"
+	cmd := newConfigureCmd()
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+
+	cfg, err := loadCLIConfig()
+	if err != nil {
+		t.Fatalf("loadCLIConfig: %v", err)
+	}
+
+	if cfg.Host != "http://localhost:7842" {
+		t.Errorf("Host = %q, want default", cfg.Host)
+	}
+	if cfg.Token != "mytoken123" {
+		t.Errorf("Token = %q, want %q", cfg.Token, "mytoken123")
+	}
+}
+
+func TestConfigureInteractiveCustomHost(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	input := "http://remote:9999\nsecrettoken\n"
+	cmd := newConfigureCmd()
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+
+	cfg, err := loadCLIConfig()
+	if err != nil {
+		t.Fatalf("loadCLIConfig: %v", err)
+	}
+
+	if cfg.Host != "http://remote:9999" {
+		t.Errorf("Host = %q, want %q", cfg.Host, "http://remote:9999")
+	}
+	if cfg.Token != "secrettoken" {
+		t.Errorf("Token = %q, want %q", cfg.Token, "secrettoken")
+	}
+}
+
+func TestConfigurePreservesExistingValues(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	initial := &cliConfig{Host: "http://old:1234", Token: "oldtoken"}
+	if err := saveCLIConfig(initial); err != nil {
+		t.Fatalf("saveCLIConfig: %v", err)
+	}
+
+	input := "\nnewtoken\n"
+	cmd := newConfigureCmd()
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+
+	cfg, err := loadCLIConfig()
+	if err != nil {
+		t.Fatalf("loadCLIConfig: %v", err)
+	}
+
+	if cfg.Host != "http://old:1234" {
+		t.Errorf("Host = %q, want preserved %q", cfg.Host, "http://old:1234")
+	}
+	if cfg.Token != "newtoken" {
+		t.Errorf("Token = %q, want %q", cfg.Token, "newtoken")
+	}
+}

--- a/cli/internal/cli/root.go
+++ b/cli/internal/cli/root.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/theburrowhub/heimdallm/cli/internal/api"
@@ -31,12 +32,42 @@ func NewRootCmd() *cobra.Command {
 		Short: "CLI client for the Heimdallm daemon",
 		Long:  "Monitor and interact with the Heimdallm daemon from the terminal.",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// Resolution priority:
+			// 1. --token / --host flags (already in flagToken/flagHost)
+			// 2. Environment variables
 			if flagHost == "" {
 				flagHost = os.Getenv("HEIMDALLM_HOST")
 			}
 			if flagToken == "" {
 				flagToken = os.Getenv("HEIMDALLM_TOKEN")
 			}
+
+			// 3. Config file (~/.config/heimdallm/cli.toml)
+			if flagHost == "" || flagToken == "" {
+				if cfg, err := loadCLIConfig(); err == nil {
+					if flagHost == "" && cfg.Host != "" {
+						flagHost = cfg.Host
+					}
+					if flagToken == "" && cfg.Token != "" {
+						flagToken = cfg.Token
+					}
+				}
+			}
+
+			// 4. Auto-discover from Docker (if localhost and no token yet).
+			//    Skipped for the configure command to avoid unnecessary latency.
+			if flagToken == "" && cmd.Name() != "configure" {
+				host := flagHost
+				if host == "" {
+					host = api.DefaultHost
+				}
+				if isLocalhost(host) {
+					if token, err := discoverDockerToken(); err == nil {
+						flagToken = token
+					}
+				}
+			}
+
 			c := api.New(flagHost, flagToken)
 			cmd.SetContext(context.WithValue(cmd.Context(), clientKey, c))
 		},
@@ -56,7 +87,17 @@ func NewRootCmd() *cobra.Command {
 		newConfigCmd(),
 		newStatsCmd(),
 		newDashboardCmd(),
+		newConfigureCmd(),
 	)
 
 	return root
+}
+
+func isLocalhost(host string) bool {
+	u, err := url.Parse(host)
+	if err != nil {
+		return false
+	}
+	h := u.Hostname()
+	return h == "localhost" || h == "127.0.0.1" || h == "::1"
 }

--- a/cli/internal/cli/root_test.go
+++ b/cli/internal/cli/root_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import "testing"
+
+func TestIsLocalhost(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"http://localhost:7842", true},
+		{"http://127.0.0.1:7842", true},
+		{"http://[::1]:7842", true},
+		{"http://localhost", true},
+		{"https://localhost:443", true},
+		{"http://example.com:7842", false},
+		{"http://192.168.1.10:7842", false},
+		{"not-a-url", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			if got := isLocalhost(tt.host); got != tt.want {
+				t.Errorf("isLocalhost(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #170

Rebased version of #175 (same code, clean history).

## Summary

CLI auto-discovers daemon token and supports config file for persistent settings.

- `heimdallm-cli configure` — saves host + token to `~/.config/heimdallm/cli.toml`
- `heimdallm-cli configure --auto` — reads token from Docker container automatically
- Resolution: --token flag > HEIMDALLM_TOKEN env > config file > auto-discover

🤖 Generated with [Claude Code](https://claude.com/claude-code)