### PR TITLE
fix: add HOMEBREW_TAP_TOKEN for GoReleaser Homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -513,4 +513,5 @@ jobs:
           workdir: cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ needs.release-please.outputs.tag_name }}

--- a/cli/.goreleaser.yml
+++ b/cli/.goreleaser.yml
@@ -37,6 +37,22 @@ changelog:
       - "^test:"
       - "^chore:"
 
+brews:
+  - name: heimdallm-cli
+    repository:
+      owner: theburrowhub
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    skip_upload: auto
+    directory: Formula
+    homepage: https://github.com/theburrowhub/heimdallm
+    description: "CLI client for Heimdallm — monitor PRs, issues, and activity from the terminal"
+    license: MIT
+    install: |
+      bin.install "heimdallm-cli"
+    test: |
+      system "#{bin}/heimdallm-cli", "--help"
+
 release:
   github:
     owner: theburrowhub


### PR DESCRIPTION
Fixes #169

## Problem

GoReleaser fails to publish Homebrew formula: `401 Bad credentials` on `homebrew-tap` repo. The CI `GITHUB_TOKEN` only has access to `heimdallm`.

## Fix

Same pattern as krakenv/cherry-go/git-gone:
1. `cli/.goreleaser.yml` — added `token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"` to brews section
2. `.github/workflows/release.yml` — passes `HOMEBREW_TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}`

## Required manual step

Add `TAP_GITHUB_TOKEN` secret to https://github.com/theburrowhub/heimdallm/settings/secrets/actions — same token used by the other theburrowhub projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)