### PR TITLE
fix: global settings parity — missing fields, broken develop switch

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -462,14 +462,21 @@ func main() {
 			"activity_log_enabled":        ptrBoolOrTrue(c.ActivityLog.Enabled),
 			"activity_log_retention_days": ptrIntOr(c.ActivityLog.RetentionDays, 90),
 		}
-		if len(c.AI.PRMetadata.Reviewers) > 0 || len(c.AI.PRMetadata.Labels) > 0 {
-			pm := map[string]any{}
-			if len(c.AI.PRMetadata.Reviewers) > 0 {
-				pm["reviewers"] = c.AI.PRMetadata.Reviewers
-			}
-			if len(c.AI.PRMetadata.Labels) > 0 {
-				pm["labels"] = c.AI.PRMetadata.Labels
-			}
+		reviewers, labels, assignee, draft := c.ResolvedPRMetadata()
+		pm := map[string]any{}
+		if len(reviewers) > 0 {
+			pm["reviewers"] = reviewers
+		}
+		if len(labels) > 0 {
+			pm["labels"] = labels
+		}
+		if assignee != "" {
+			pm["pr_assignee"] = assignee
+		}
+		if draft != nil {
+			pm["pr_draft"] = *draft
+		}
+		if len(pm) > 0 {
 			result["pr_metadata"] = pm
 		}
 		return result

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -461,6 +461,8 @@ func main() {
 			"local_dirs_detected":         localDirsDetected,
 			"activity_log_enabled":        ptrBoolOrTrue(c.ActivityLog.Enabled),
 			"activity_log_retention_days": ptrIntOr(c.ActivityLog.RetentionDays, 90),
+			"issue_prompt":               c.AI.IssuePrompt,
+			"implement_prompt":           c.AI.ImplementPrompt,
 		}
 		reviewers, labels, assignee, draft := c.ResolvedPRMetadata()
 		pm := map[string]any{}

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -409,7 +409,7 @@ func repoOrg(repo string) string {
 // flat [ai] fields on top of [ai.pr_metadata]. Flat fields win when set,
 // matching the contract that HEIMDALLM_PR_* env vars populate the flat
 // fields and should override the nested section.
-func (c *Config) resolvedPRMetadata() (reviewers, labels []string, assignee string, draft *bool) {
+func (c *Config) ResolvedPRMetadata() (reviewers, labels []string, assignee string, draft *bool) {
 	reviewers = c.AI.PRMetadata.Reviewers
 	labels = c.AI.PRMetadata.Labels
 	assignee = c.AI.PRMetadata.Assignee
@@ -435,7 +435,7 @@ func (c *Config) resolvedPRMetadata() (reviewers, labels []string, assignee stri
 // three levels: per-repo > per-org > global defaults. Each PR metadata
 // field resolves independently.
 func (c *Config) AIForRepo(repo string) RepoAI {
-	gReviewers, gLabels, gAssignee, gDraft := c.resolvedPRMetadata()
+	gReviewers, gLabels, gAssignee, gDraft := c.ResolvedPRMetadata()
 
 	// Org-level layer: start from global, overlay org-level fields.
 	orgReviewers, orgLabels, orgAssignee, orgDraft := gReviewers, gLabels, gAssignee, gDraft

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -255,6 +255,13 @@ type AIConfig struct {
 	PRAssignee  string   `toml:"pr_assignee"`
 	PRDraft     *bool    `toml:"pr_draft,omitempty"`
 
+	// IssuePrompt is the global default agent profile ID for issue triage.
+	// Per-repo overrides in [ai.repos.<name>] take precedence.
+	IssuePrompt string `toml:"issue_prompt"`
+	// ImplementPrompt is the global default agent profile ID for auto-implement.
+	// Per-repo overrides in [ai.repos.<name>] take precedence.
+	ImplementPrompt string `toml:"implement_prompt"`
+
 	// GeneratePRDescription enables LLM-generated PR titles and descriptions
 	// for auto_implement PRs. When true, after the implementation commit,
 	// a second LLM call generates a rich PR description from the diff.

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -341,6 +341,8 @@ class AppConfig {
   final List<String> globalPRLabels;
   final String globalPRAssignee;
   final bool globalPRDraft;
+  final String globalIssuePrompt;
+  final String globalImplementPrompt;
   /// Host paths the daemon scans (in order) when a repo has no explicit
   /// `local_dir` set — first match at `{base}/{short-repo-name}` wins.
   final List<String> localDirBase;
@@ -367,6 +369,8 @@ class AppConfig {
     this.globalPRLabels = const [],
     this.globalPRAssignee = '',
     this.globalPRDraft = false,
+    this.globalIssuePrompt = '',
+    this.globalImplementPrompt = '',
     this.localDirBase = const [],
     this.localDirsDetected = const {},
   });
@@ -393,6 +397,8 @@ class AppConfig {
     List<String>? globalPRLabels,
     String? globalPRAssignee,
     bool? globalPRDraft,
+    String? globalIssuePrompt,
+    String? globalImplementPrompt,
     List<String>? localDirBase,
     Map<String, String>? localDirsDetected,
   }) {
@@ -408,10 +414,12 @@ class AppConfig {
       issueTracking:     issueTracking     ?? this.issueTracking,
       globalPRReviewers: globalPRReviewers ?? this.globalPRReviewers,
       globalPRLabels:    globalPRLabels    ?? this.globalPRLabels,
-      globalPRAssignee:  globalPRAssignee  ?? this.globalPRAssignee,
-      globalPRDraft:     globalPRDraft     ?? this.globalPRDraft,
-      localDirBase:      localDirBase      ?? this.localDirBase,
-      localDirsDetected: localDirsDetected ?? this.localDirsDetected,
+      globalPRAssignee:       globalPRAssignee       ?? this.globalPRAssignee,
+      globalPRDraft:          globalPRDraft          ?? this.globalPRDraft,
+      globalIssuePrompt:     globalIssuePrompt     ?? this.globalIssuePrompt,
+      globalImplementPrompt: globalImplementPrompt ?? this.globalImplementPrompt,
+      localDirBase:           localDirBase           ?? this.localDirBase,
+      localDirsDetected:     localDirsDetected     ?? this.localDirsDetected,
     );
   }
 
@@ -515,9 +523,11 @@ class AppConfig {
       issueTracking:     issueTracking,
       globalPRReviewers: _parseStringList((json['pr_metadata'] as Map<String, dynamic>?)?['reviewers']),
       globalPRLabels:    _parseStringList((json['pr_metadata'] as Map<String, dynamic>?)?['labels']),
-      globalPRAssignee:  (json['pr_metadata'] as Map<String, dynamic>?)?['pr_assignee'] as String? ?? '',
-      globalPRDraft:     (json['pr_metadata'] as Map<String, dynamic>?)?['pr_draft'] as bool? ?? false,
-      localDirBase:      _parseStringList(json['local_dir_base']),
+      globalPRAssignee:       (json['pr_metadata'] as Map<String, dynamic>?)?['pr_assignee'] as String? ?? '',
+      globalPRDraft:          (json['pr_metadata'] as Map<String, dynamic>?)?['pr_draft'] as bool? ?? false,
+      globalIssuePrompt:     (json['issue_prompt'] as String?) ?? '',
+      globalImplementPrompt: (json['implement_prompt'] as String?) ?? '',
+      localDirBase:           _parseStringList(json['local_dir_base']),
       localDirsDetected: localDirsDetected,
     );
   }

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -339,11 +339,10 @@ class AppConfig {
   final IssueTrackingConfig issueTracking;
   final List<String> globalPRReviewers;
   final List<String> globalPRLabels;
+  final String globalPRAssignee;
+  final bool globalPRDraft;
   /// Host paths the daemon scans (in order) when a repo has no explicit
   /// `local_dir` set — first match at `{base}/{short-repo-name}` wins.
-  /// Written to the `[github].local_dir_base` TOML key. Unknown to early
-  /// `writeConfig` revisions; fielded here so a Flutter save preserves
-  /// the value instead of silently dropping it on the floor.
   final List<String> localDirBase;
   /// Auto-detected `local_dir` per repo, populated by the daemon when the
   /// repo is visible at `/home/heimdallm/repos/<short-name>` in the
@@ -366,6 +365,8 @@ class AppConfig {
     this.issueTracking = const IssueTrackingConfig(),
     this.globalPRReviewers = const [],
     this.globalPRLabels = const [],
+    this.globalPRAssignee = '',
+    this.globalPRDraft = false,
     this.localDirBase = const [],
     this.localDirsDetected = const {},
   });
@@ -390,6 +391,8 @@ class AppConfig {
     IssueTrackingConfig? issueTracking,
     List<String>? globalPRReviewers,
     List<String>? globalPRLabels,
+    String? globalPRAssignee,
+    bool? globalPRDraft,
     List<String>? localDirBase,
     Map<String, String>? localDirsDetected,
   }) {
@@ -405,6 +408,8 @@ class AppConfig {
       issueTracking:     issueTracking     ?? this.issueTracking,
       globalPRReviewers: globalPRReviewers ?? this.globalPRReviewers,
       globalPRLabels:    globalPRLabels    ?? this.globalPRLabels,
+      globalPRAssignee:  globalPRAssignee  ?? this.globalPRAssignee,
+      globalPRDraft:     globalPRDraft     ?? this.globalPRDraft,
       localDirBase:      localDirBase      ?? this.localDirBase,
       localDirsDetected: localDirsDetected ?? this.localDirsDetected,
     );
@@ -510,6 +515,8 @@ class AppConfig {
       issueTracking:     issueTracking,
       globalPRReviewers: _parseStringList((json['pr_metadata'] as Map<String, dynamic>?)?['reviewers']),
       globalPRLabels:    _parseStringList((json['pr_metadata'] as Map<String, dynamic>?)?['labels']),
+      globalPRAssignee:  (json['pr_metadata'] as Map<String, dynamic>?)?['pr_assignee'] as String? ?? '',
+      globalPRDraft:     (json['pr_metadata'] as Map<String, dynamic>?)?['pr_draft'] as bool? ?? false,
       localDirBase:      _parseStringList(json['local_dir_base']),
       localDirsDetected: localDirsDetected,
     );

--- a/flutter_app/lib/core/setup/first_run_setup.dart
+++ b/flutter_app/lib/core/setup/first_run_setup.dart
@@ -238,13 +238,20 @@ class FirstRunSetup {
     buf.writeln();
 
     // Global PR metadata defaults
-    if (config.globalPRReviewers.isNotEmpty || config.globalPRLabels.isNotEmpty) {
+    if (config.globalPRReviewers.isNotEmpty || config.globalPRLabels.isNotEmpty ||
+        config.globalPRAssignee.isNotEmpty || config.globalPRDraft) {
       buf.writeln('[ai.pr_metadata]');
       if (config.globalPRReviewers.isNotEmpty) {
         buf.writeln('reviewers = [${config.globalPRReviewers.map((r) => '"${_tomlEscapeString(r)}"').join(', ')}]');
       }
       if (config.globalPRLabels.isNotEmpty) {
         buf.writeln('labels = [${config.globalPRLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+      }
+      if (config.globalPRAssignee.isNotEmpty) {
+        buf.writeln('pr_assignee = "${_tomlEscapeString(config.globalPRAssignee)}"');
+      }
+      if (config.globalPRDraft) {
+        buf.writeln('pr_draft = true');
       }
       buf.writeln();
     }

--- a/flutter_app/lib/core/setup/first_run_setup.dart
+++ b/flutter_app/lib/core/setup/first_run_setup.dart
@@ -235,6 +235,12 @@ class FirstRunSetup {
       buf.writeln('fallback = "${_tomlEscapeString(config.aiFallback)}"');
     }
     buf.writeln('review_mode = "${_tomlEscapeString(config.reviewMode)}"');
+    if (config.globalIssuePrompt.isNotEmpty) {
+      buf.writeln('issue_prompt = "${_tomlEscapeString(config.globalIssuePrompt)}"');
+    }
+    if (config.globalImplementPrompt.isNotEmpty) {
+      buf.writeln('implement_prompt = "${_tomlEscapeString(config.globalImplementPrompt)}"');
+    }
     buf.writeln();
 
     // Global PR metadata defaults

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -122,6 +122,13 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
   }
   if (prMeta.isNotEmpty) aiDiff['pr_metadata'] = prMeta;
 
+  if (old.globalIssuePrompt != updated.globalIssuePrompt) {
+    aiDiff['issue_prompt'] = updated.globalIssuePrompt;
+  }
+  if (old.globalImplementPrompt != updated.globalImplementPrompt) {
+    aiDiff['implement_prompt'] = updated.globalImplementPrompt;
+  }
+
   if (aiDiff.isNotEmpty) diff['ai'] = aiDiff;
 
   // GitHub section

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -114,6 +114,12 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
   if (_listsDiffer(old.globalPRLabels, updated.globalPRLabels)) {
     prMeta['labels'] = updated.globalPRLabels;
   }
+  if (old.globalPRAssignee != updated.globalPRAssignee) {
+    prMeta['pr_assignee'] = updated.globalPRAssignee;
+  }
+  if (old.globalPRDraft != updated.globalPRDraft) {
+    prMeta['pr_draft'] = updated.globalPRDraft;
+  }
   if (prMeta.isNotEmpty) aiDiff['pr_metadata'] = prMeta;
 
   if (aiDiff.isNotEmpty) diff['ai'] = aiDiff;

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -5,6 +5,7 @@ import '../../core/models/config_model.dart';
 import '../../core/platform/platform_services_provider.dart';
 import '../../shared/widgets/autocomplete_chip_field.dart';
 import '../../shared/widgets/toast.dart';
+import '../agents/agents_screen.dart' show agentsProvider;
 import '../dashboard/dashboard_providers.dart';
 import 'config_providers.dart';
 
@@ -25,6 +26,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   String _pollInterval = '5m';
   int _retentionDays = 90;
   IssueTrackingConfig _issueTracking = const IssueTrackingConfig();
+  String? _issuePromptId;
+  String? _developPromptId;
 
   // All known repos. Key = "org/repo", Value = per-repo settings.
   Map<String, RepoConfig> _repoConfigs = {};
@@ -73,6 +76,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     _retentionDays = config.retentionDays;
     _repoConfigs = Map.from(config.repoConfigs);
     _issueTracking = config.issueTracking;
+    _issuePromptId = config.globalIssuePrompt.isEmpty ? null : config.globalIssuePrompt;
+    _developPromptId = config.globalImplementPrompt.isEmpty ? null : config.globalImplementPrompt;
   }
 
   /// Auto-discovers repos from the user's PRs. Runs silently on init.
@@ -451,6 +456,13 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             _issueTracking = _issueTracking.copyWith(assignees: v ?? []);
           }),
         ),
+        const SizedBox(height: 10),
+        _agentDropdown(
+          label: 'Issue Prompt',
+          helper: 'Agent profile for issue triage',
+          value: _issuePromptId,
+          onChanged: (v) => setState(() => _issuePromptId = v),
+        ),
       ],
     ]);
   }
@@ -544,8 +556,47 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           value: _globalPRDraft,
           onChanged: (v) => setState(() => _globalPRDraft = v),
         ),
+        const SizedBox(height: 10),
+        _agentDropdown(
+          label: 'Develop Prompt',
+          helper: 'Agent profile for auto-implementation',
+          value: _developPromptId,
+          onChanged: (v) => setState(() => _developPromptId = v),
+        ),
       ],
     ]);
+  }
+
+  Widget _agentDropdown({
+    required String label,
+    required String helper,
+    required String? value,
+    required ValueChanged<String?> onChanged,
+  }) {
+    final agents = ref.watch(agentsProvider).valueOrNull ?? [];
+    final options = agents.map((a) => a.id).toList();
+    final effective = (value != null && options.contains(value)) ? value : null;
+    return DropdownButtonFormField<String?>(
+      key: ValueKey('$label-$effective'),
+      initialValue: effective,
+      decoration: InputDecoration(
+        labelText: label,
+        helperText: helper,
+        border: const OutlineInputBorder(),
+        isDense: true,
+      ),
+      items: [
+        const DropdownMenuItem<String?>(
+          value: null,
+          child: Text('default', style: TextStyle(fontSize: 12)),
+        ),
+        ...options.map((id) => DropdownMenuItem<String?>(
+              value: id,
+              child: Text(id, style: const TextStyle(fontSize: 12)),
+            )),
+      ],
+      onChanged: onChanged,
+    );
   }
 
   Widget _settingsCard(String title, List<Widget> children) {
@@ -644,6 +695,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     globalPRLabels: _globalPRLabels,
     globalPRAssignee: _globalPRAssignee,
     globalPRDraft: _globalPRDraft,
+    globalIssuePrompt: _issuePromptId ?? '',
+    globalImplementPrompt: _developPromptId ?? '',
     // aiPrimary, aiFallback, reviewMode, agentConfigs managed in Agents tab
   );
 

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -515,15 +515,14 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           }),
         ),
         const SizedBox(height: 10),
-        TextFormField(
-          initialValue: _globalPRAssignee,
-          decoration: const InputDecoration(
-            labelText: 'PR Assignee',
-            helperText: 'GitHub username to assign PRs to',
-            border: OutlineInputBorder(),
-            isDense: true,
-          ),
-          onChanged: (v) => setState(() => _globalPRAssignee = v.trim()),
+        AutocompleteChipField(
+          label: 'PR Assignee',
+          helper: 'GitHub username to assign PRs to',
+          selectedValues: _globalPRAssignee.isEmpty ? [] : [_globalPRAssignee],
+          availableOptions: const [],
+          onChanged: (v) => setState(() {
+            _globalPRAssignee = (v != null && v.isNotEmpty) ? v.first : '';
+          }),
         ),
         const SizedBox(height: 10),
         AutocompleteChipField(

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -457,6 +457,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
 
   List<String> _globalPRReviewers = [];
   List<String> _globalPRLabels = [];
+  String _globalPRAssignee = '';
+  bool _globalPRDraft = false;
   bool _developInitialized = false;
 
   void _initDevelopFromConfig(AppConfig config) {
@@ -464,6 +466,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     _developInitialized = true;
     _globalPRReviewers = List.from(config.globalPRReviewers);
     _globalPRLabels = List.from(config.globalPRLabels);
+    _globalPRAssignee = config.globalPRAssignee;
+    _globalPRDraft = config.globalPRDraft;
   }
 
   Widget _developSection(AppConfig config) {
@@ -479,41 +483,69 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         contentPadding: EdgeInsets.zero,
         value: hasLabels,
         onChanged: (v) => setState(() {
-          if (!v) {
+          if (v) {
+            // Give it a default label so the section stays enabled
+            if (_issueTracking.developLabels.isEmpty) {
+              _issueTracking = _issueTracking.copyWith(developLabels: ['develop']);
+            }
+          } else {
             _issueTracking = _issueTracking.copyWith(developLabels: []);
           }
         }),
       ),
-      const SizedBox(height: 6),
-      AutocompleteChipField(
-        label: 'Develop labels',
-        helper: 'Issues with these labels get a branch + PR',
-        selectedValues: _issueTracking.developLabels,
-        availableOptions: const [],
-        onChanged: (v) => setState(() {
-          _issueTracking = _issueTracking.copyWith(developLabels: v ?? []);
-        }),
-      ),
-      const SizedBox(height: 10),
-      AutocompleteChipField(
-        label: 'PR Reviewers',
-        helper: 'GitHub usernames to request review',
-        selectedValues: _globalPRReviewers,
-        availableOptions: const [],
-        onChanged: (v) => setState(() {
-          _globalPRReviewers = v ?? [];
-        }),
-      ),
-      const SizedBox(height: 10),
-      AutocompleteChipField(
-        label: 'PR Labels',
-        helper: 'Labels to add to PRs',
-        selectedValues: _globalPRLabels,
-        availableOptions: const [],
-        onChanged: (v) => setState(() {
-          _globalPRLabels = v ?? [];
-        }),
-      ),
+      if (hasLabels) ...[
+        const SizedBox(height: 6),
+        AutocompleteChipField(
+          label: 'Develop labels',
+          helper: 'Issues with these labels get a branch + PR',
+          selectedValues: _issueTracking.developLabels,
+          availableOptions: const [],
+          onChanged: (v) => setState(() {
+            _issueTracking = _issueTracking.copyWith(developLabels: v ?? []);
+          }),
+        ),
+        const SizedBox(height: 10),
+        AutocompleteChipField(
+          label: 'PR Reviewers',
+          helper: 'GitHub usernames to request review',
+          selectedValues: _globalPRReviewers,
+          availableOptions: const [],
+          onChanged: (v) => setState(() {
+            _globalPRReviewers = v ?? [];
+          }),
+        ),
+        const SizedBox(height: 10),
+        TextFormField(
+          initialValue: _globalPRAssignee,
+          decoration: const InputDecoration(
+            labelText: 'PR Assignee',
+            helperText: 'GitHub username to assign PRs to',
+            border: OutlineInputBorder(),
+            isDense: true,
+          ),
+          onChanged: (v) => setState(() => _globalPRAssignee = v.trim()),
+        ),
+        const SizedBox(height: 10),
+        AutocompleteChipField(
+          label: 'PR Labels',
+          helper: 'Labels to add to PRs',
+          selectedValues: _globalPRLabels,
+          availableOptions: const [],
+          onChanged: (v) => setState(() {
+            _globalPRLabels = v ?? [];
+          }),
+        ),
+        const SizedBox(height: 10),
+        SwitchListTile(
+          title: const Text('Create as draft', style: TextStyle(fontSize: 13)),
+          subtitle: const Text('PRs are created as drafts by default',
+              style: TextStyle(fontSize: 11)),
+          dense: true,
+          contentPadding: EdgeInsets.zero,
+          value: _globalPRDraft,
+          onChanged: (v) => setState(() => _globalPRDraft = v),
+        ),
+      ],
     ]);
   }
 
@@ -611,6 +643,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     issueTracking: _issueTracking,
     globalPRReviewers: _globalPRReviewers,
     globalPRLabels: _globalPRLabels,
+    globalPRAssignee: _globalPRAssignee,
+    globalPRDraft: _globalPRDraft,
     // aiPrimary, aiFallback, reviewMode, agentConfigs managed in Agents tab
   );
 


### PR DESCRIPTION
## Summary

- Daemon exposes `pr_assignee`, `pr_draft`, `issue_prompt`, `implement_prompt` in GET /config
- Flutter: PR Assignee (chip field), Draft switch, Issue Prompt dropdown, Develop Prompt dropdown added to global settings
- Develop switch fixed: enabling now sets default "develop" label (was no-op before)
- Develop sub-fields hidden when switch is off

## Closes

Resolves field parity gap between global settings and per-repo detail screen.

## Test plan

- [ ] `cd daemon && go test ./... -count=1` — all pass
- [ ] `flutter analyze --no-fatal-infos` — no issues
- [ ] Manual: toggle develop switch on → label "develop" appears, fields shown
- [ ] Manual: toggle develop switch off → fields hidden
- [ ] Manual: select agent profile in Issue Prompt / Develop Prompt dropdowns → persisted on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)