### PR TITLE
chore: add @Muriano and @vbuenog as default CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default owners for all files in the repository.
 # These users will be requested for review on all PRs.
-* @sergiotejon
+* @sergiotejon @Muriano @vbuenog


### PR DESCRIPTION
Closes #205.

## Summary

- `.github/CODEOWNERS` now lists `* @sergiotejon @Muriano @vbuenog` so every PR auto-requests all three as reviewers instead of just @sergiotejon.

## Username note

User asked for "vbueno" but that GitHub handle belongs to an empty, unrelated account from 2012. The actual contributor is Víctor Bueno whose handle is **vbuenog** (confirmed via git log on this repo — e.g. PR #109 Activity View). Using `@vbuenog` here. Flag if the intended target is different.

## Test plan

- [ ] Once merged, open a test PR and verify all three accounts appear in the "Reviewers" list automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)