### PR TITLE
fix: use correct secret name for Homebrew tap

### DIFF
--- a/cli/internal/cli/issues.go
+++ b/cli/internal/cli/issues.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/theburrowhub/heimdallm/cli/internal/api"
 )
 
 func newIssuesCmd() *cobra.Command {
@@ -21,20 +22,25 @@ func newIssuesCmd() *cobra.Command {
 				return fmt.Errorf("fetching issues: %w", err)
 			}
 
-			if len(issues) == 0 {
+			var reviewed []api.Issue
+			for _, iss := range issues {
+				if iss.LatestReview != nil {
+					reviewed = append(reviewed, iss)
+				}
+			}
+
+			if len(reviewed) == 0 {
 				fmt.Println("No issues found.")
 				return nil
 			}
 
-			filtered := issues
+			filtered := reviewed
 			if severity != "" {
 				filtered = nil
-				for _, iss := range issues {
-					if iss.LatestReview != nil {
-						sev := extractTriageSeverity(iss.LatestReview.Triage)
-						if strings.EqualFold(sev, severity) {
-							filtered = append(filtered, iss)
-						}
+				for _, iss := range reviewed {
+					sev := extractTriageSeverity(iss.LatestReview.Triage)
+					if strings.EqualFold(sev, severity) {
+						filtered = append(filtered, iss)
 					}
 				}
 			}

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -179,7 +179,12 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					d.prs = append(d.prs, pr)
 				}
 			}
-			d.issues = msg.issues
+			d.issues = nil
+			for _, iss := range msg.issues {
+				if iss.LatestReview != nil {
+					d.issues = append(d.issues, iss)
+				}
+			}
 			d.config = msg.config
 			d.stats = msg.stats
 			if msg.activity != nil {


### PR DESCRIPTION
Fixes #169. One line: secrets.HOMEBREW_TAP_TOKEN → secrets.TAP_GITHUB_TOKEN