### PR TITLE
feat: implement #222 — bug: triage loop — RecomputeGrace too short for slow triages

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -240,13 +240,15 @@ func (c *Client) SubmitReview(repo string, number int, body, event string) (int6
 
 // PostComment posts a general comment on a PR (issue comment).
 // Used in multi-feedback mode to post one comment per issue before the formal review.
-func (c *Client) PostComment(repo string, number int, body string) error {
+// Returns the comment's creation timestamp as reported by GitHub so callers
+// can record when the comment actually landed (see issue #222).
+func (c *Client) PostComment(repo string, number int, body string) (time.Time, error) {
 	path := fmt.Sprintf("/repos/%s/issues/%d/comments", repo, number)
 	payload := map[string]any{"body": body}
 	data, _ := json.Marshal(payload)
 	req, err := http.NewRequest("POST", c.baseURL+path, strings.NewReader(string(data)))
 	if err != nil {
-		return fmt.Errorf("github: post comment: %w", err)
+		return time.Time{}, fmt.Errorf("github: post comment: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Accept", "application/vnd.github+json")
@@ -254,15 +256,21 @@ func (c *Client) PostComment(repo string, number int, body string) error {
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return fmt.Errorf("github: post comment: %w", err)
+		return time.Time{}, fmt.Errorf("github: post comment: %w", err)
 	}
 	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if resp.StatusCode != http.StatusCreated {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 		errBody := safeTruncate(string(respBody), maxErrBodyLen)
-		return fmt.Errorf("github: post comment: status %d: %s", resp.StatusCode, errBody)
+		return time.Time{}, fmt.Errorf("github: post comment: status %d: %s", resp.StatusCode, errBody)
 	}
-	return nil
+	var result struct {
+		CreatedAt time.Time `json:"created_at"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return time.Now().UTC(), nil
+	}
+	return result.CreatedAt, nil
 }
 
 // maxDiscoveryPages bounds the number of Search API pages consumed per org.

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -156,7 +156,11 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 		return true, "already implemented (PR created)", nil
 	}
 
-	cutoff := latest.CreatedAt.Add(RecomputeGrace)
+	ref := latest.CommentedAt
+	if ref.IsZero() {
+		ref = latest.CreatedAt
+	}
+	cutoff := ref.Add(RecomputeGrace)
 	if !issue.UpdatedAt.After(cutoff) {
 		return true, "no new activity since last review", nil
 	}

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -155,11 +155,12 @@ func TestFetcher_SkipsDismissedIssues(t *testing.T) {
 
 func TestFetcher_SkipsIssueAlreadyReviewedWithoutNewActivity(t *testing.T) {
 	reviewedAt := time.Now().Add(-1 * time.Hour)
-	issue := fixture(1, reviewedAt.Add(5*time.Second)) // within 30s grace
+	commentedAt := reviewedAt.Add(10 * time.Second)
+	issue := fixture(1, commentedAt.Add(5*time.Second)) // within 30s grace of commentedAt
 	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
 		issue.ID: {
 			row:    &store.Issue{ID: 10, GithubID: issue.ID},
-			review: &store.IssueReview{IssueID: 10, CreatedAt: reviewedAt},
+			review: &store.IssueReview{IssueID: 10, CreatedAt: reviewedAt, CommentedAt: commentedAt},
 		},
 	}}
 	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, &fakePipeline{})
@@ -172,11 +173,12 @@ func TestFetcher_SkipsIssueAlreadyReviewedWithoutNewActivity(t *testing.T) {
 
 func TestFetcher_RerunsIssueWithNewActivityAfterGrace(t *testing.T) {
 	reviewedAt := time.Now().Add(-1 * time.Hour)
-	issue := fixture(1, reviewedAt.Add(5*time.Minute)) // well past the 30s grace
+	commentedAt := reviewedAt.Add(10 * time.Second)
+	issue := fixture(1, commentedAt.Add(5*time.Minute)) // well past the 30s grace
 	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
 		issue.ID: {
 			row:    &store.Issue{ID: 10, GithubID: issue.ID},
-			review: &store.IssueReview{IssueID: 10, CreatedAt: reviewedAt},
+			review: &store.IssueReview{IssueID: 10, CreatedAt: reviewedAt, CommentedAt: commentedAt},
 		},
 	}}
 	p := &fakePipeline{}
@@ -185,6 +187,42 @@ func TestFetcher_RerunsIssueWithNewActivityAfterGrace(t *testing.T) {
 	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if processed != 1 {
 		t.Errorf("new activity past grace should re-run, got processed=%d calls=%v", processed, p.calls)
+	}
+}
+
+func TestFetcher_SlowTriageDoesNotReloop(t *testing.T) {
+	createdAt := time.Now().Add(-2 * time.Minute)
+	commentedAt := createdAt.Add(45 * time.Second) // triage took 45s
+	// UpdatedAt is after createdAt+30s (old cutoff) but before commentedAt+30s (new cutoff).
+	issue := fixture(1, commentedAt.Add(5*time.Second))
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row:    &store.Issue{ID: 10, GithubID: issue.ID},
+			review: &store.IssueReview{IssueID: 10, CreatedAt: createdAt, CommentedAt: commentedAt},
+		},
+	}}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, &fakePipeline{})
+
+	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 0 {
+		t.Errorf("slow triage should not re-loop, got processed=%d", processed)
+	}
+}
+
+func TestFetcher_FallsBackToCreatedAtWhenCommentedAtZero(t *testing.T) {
+	reviewedAt := time.Now().Add(-1 * time.Hour)
+	issue := fixture(1, reviewedAt.Add(5*time.Second)) // within 30s grace of createdAt
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row:    &store.Issue{ID: 10, GithubID: issue.ID},
+			review: &store.IssueReview{IssueID: 10, CreatedAt: reviewedAt}, // CommentedAt zero
+		},
+	}}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, &fakePipeline{})
+
+	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 0 {
+		t.Errorf("zero CommentedAt should fall back to CreatedAt, got processed=%d", processed)
 	}
 }
 

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -52,7 +52,7 @@ func sanitizeTitle(s string) string {
 // IssueCommenter posts a comment on an issue. Same method GitHub exposes for
 // PR comments — both routes share `/repos/{owner}/{repo}/issues/{n}/comments`.
 type IssueCommenter interface {
-	PostComment(repo string, number int, body string) error
+	PostComment(repo string, number int, body string) (time.Time, error)
 }
 
 // IssueCommentFetcher fetches the existing discussion for an issue so the
@@ -319,7 +319,7 @@ func (p *Pipeline) runReviewOnly(ctx context.Context, issue *github.Issue, issue
 	// the review is still persisted locally with a zero pr_created so
 	// operators can re-drive it manually without losing the LLM output.
 	body := BuildMarkdownComment(result)
-	postErr := p.gh.PostComment(issue.Repo, issue.Number, body)
+	commentedAt, postErr := p.gh.PostComment(issue.Repo, issue.Number, body)
 	if postErr != nil {
 		slog.Warn("issues pipeline: PostComment failed, review will be stored locally only",
 			"repo", issue.Repo, "number", issue.Number, "err", postErr)
@@ -341,6 +341,7 @@ func (p *Pipeline) runReviewOnly(ctx context.Context, issue *github.Issue, issue
 		Suggestions: string(suggestionsJSON),
 		ActionTaken: string(config.IssueModeReviewOnly),
 		CreatedAt:   time.Now().UTC(),
+		CommentedAt: commentedAt,
 	}
 	revID, err := p.store.InsertIssueReview(rev)
 	if err != nil {
@@ -516,9 +517,10 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 	// on failure — the PR is already public and the review row carries the
 	// number, so a missed comment does not lose information.
 	linkBackBody := fmt.Sprintf("Implementation PR: #%d", prNumber)
-	if err := p.gh.PostComment(issue.Repo, issue.Number, linkBackBody); err != nil {
+	commentedAt, linkErr := p.gh.PostComment(issue.Repo, issue.Number, linkBackBody)
+	if linkErr != nil {
 		slog.Warn("issues pipeline: link-back comment failed",
-			"repo", issue.Repo, "number", issue.Number, "err", err)
+			"repo", issue.Repo, "number", issue.Number, "err", linkErr)
 	}
 
 	rev := &store.IssueReview{
@@ -530,6 +532,7 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 		ActionTaken: string(config.IssueModeDevelop),
 		PRCreated:   prNumber,
 		CreatedAt:   time.Now().UTC(),
+		CommentedAt: commentedAt,
 	}
 	revID, err := p.store.InsertIssueReview(rev)
 	if err != nil {
@@ -563,7 +566,7 @@ func (p *Pipeline) autoImplementNoChangesFallback(issue *github.Issue, issueID i
 			"---\n*auto_implement → review_only fallback · Heimdallm*",
 		issue.Number,
 	)
-	postErr := p.gh.PostComment(issue.Repo, issue.Number, body)
+	commentedAt, postErr := p.gh.PostComment(issue.Repo, issue.Number, body)
 	if postErr != nil {
 		slog.Warn("issues pipeline: auto_implement fallback PostComment failed",
 			"repo", issue.Repo, "number", issue.Number, "err", postErr)
@@ -580,6 +583,7 @@ func (p *Pipeline) autoImplementNoChangesFallback(issue *github.Issue, issueID i
 		// develop-without-local_dir fallback.
 		ActionTaken: string(config.IssueModeReviewOnly),
 		CreatedAt:   time.Now().UTC(),
+		CommentedAt: commentedAt,
 	}
 	revID, err := p.store.InsertIssueReview(rev)
 	if err != nil {

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -97,9 +97,9 @@ type prCall struct {
 	Draft                         bool
 }
 
-func (f *fakeGH) PostComment(repo string, number int, body string) error {
+func (f *fakeGH) PostComment(repo string, number int, body string) (time.Time, error) {
 	f.postCalls = append(f.postCalls, postCall{Repo: repo, Number: number, Body: body})
-	return f.postErr
+	return time.Now().UTC(), f.postErr
 }
 
 func (f *fakeGH) FetchComments(repo string, number int) ([]github.Comment, error) {

--- a/daemon/internal/issues/promoter.go
+++ b/daemon/internal/issues/promoter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/heimdallm/daemon/internal/config"
 	"github.com/heimdallm/daemon/internal/github"
@@ -20,7 +21,7 @@ type PromoteIssueClient interface {
 	GetIssue(repo string, number int) (*github.Issue, error)
 	AddLabels(repo string, number int, labels []string) error
 	RemoveLabels(repo string, number int, labels []string) error
-	PostComment(repo string, number int, body string) error
+	PostComment(repo string, number int, body string) (time.Time, error)
 }
 
 // PromoteReady scans every monitored repo for open issues carrying a
@@ -228,7 +229,7 @@ func applyPromotion(c PromoteIssueClient, issue *github.Issue, blockedLabels []s
 		}
 		return fmt.Errorf("add promote-to: %w", err)
 	}
-	if err := c.PostComment(issue.Repo, issue.Number, auditCommentBody(promoteTo, states)); err != nil {
+	if _, err := c.PostComment(issue.Repo, issue.Number, auditCommentBody(promoteTo, states)); err != nil {
 		// Comment failure is non-fatal — labels already flipped, the
 		// next poll cycle will process the issue normally. Log only.
 		slog.Warn("issues promote: audit comment failed (labels already flipped)",

--- a/daemon/internal/issues/promoter_test.go
+++ b/daemon/internal/issues/promoter_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/heimdallm/daemon/internal/config"
 	"github.com/heimdallm/daemon/internal/github"
@@ -78,12 +79,12 @@ func (f *fakePromoteClient) RemoveLabels(repo string, n int, labels []string) er
 	f.removed = append(f.removed, struct{ Repo string; N int; Labels []string }{repo, n, labels})
 	return nil
 }
-func (f *fakePromoteClient) PostComment(repo string, n int, body string) error {
+func (f *fakePromoteClient) PostComment(repo string, n int, body string) (time.Time, error) {
 	if f.commentErr != nil {
-		return f.commentErr
+		return time.Time{}, f.commentErr
 	}
 	f.comments = append(f.comments, struct{ Repo string; N int; Body string }{repo, n, body})
-	return nil
+	return time.Now().UTC(), nil
 }
 
 func mkIssue(repo string, number int, state, body string, labels ...string) *github.Issue {
@@ -292,7 +293,7 @@ func (f *failingPromoteClient) AddLabels(repo string, n int, ls []string) error 
 func (f *failingPromoteClient) RemoveLabels(repo string, n int, ls []string) error {
 	return f.inner.RemoveLabels(repo, n, ls)
 }
-func (f *failingPromoteClient) PostComment(repo string, n int, body string) error {
+func (f *failingPromoteClient) PostComment(repo string, n int, body string) (time.Time, error) {
 	return f.inner.PostComment(repo, n, body)
 }
 
@@ -490,7 +491,7 @@ func (c *countingPromoteClient) AddLabels(repo string, n int, ls []string) error
 func (c *countingPromoteClient) RemoveLabels(repo string, n int, ls []string) error {
 	return c.inner.RemoveLabels(repo, n, ls)
 }
-func (c *countingPromoteClient) PostComment(repo string, n int, body string) error {
+func (c *countingPromoteClient) PostComment(repo string, n int, body string) (time.Time, error) {
 	return c.inner.PostComment(repo, n, body)
 }
 

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -39,7 +39,7 @@ type Notifier interface {
 type GitHubReviewer interface {
 	SubmitReview(repo string, number int, body, event string) (int64, string, error)
 	// PostComment posts a general PR comment (used in multi-feedback mode).
-	PostComment(repo string, number int, body string) error
+	PostComment(repo string, number int, body string) (time.Time, error)
 }
 
 // CommentFetcher retrieves PR comments for context injection into the AI prompt.
@@ -285,7 +285,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	if reviewMode == "multi" && len(result.Issues) > 0 {
 		// Post one comment per issue (best-effort — failures are logged but don't abort)
 		for _, issue := range result.Issues {
-			if err := p.gh.PostComment(pr.Repo, pr.Number, buildIssueComment(issue)); err != nil {
+			if _, err := p.gh.PostComment(pr.Repo, pr.Number, buildIssueComment(issue)); err != nil {
 				slog.Warn("pipeline: failed to post issue comment", "pr", pr.Number, "err", err)
 			}
 		}

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -36,8 +36,8 @@ func (f *fakeGH) SubmitReview(repo string, number int, body, event string) (int6
 	return 12345, state, nil
 }
 
-func (f *fakeGH) PostComment(repo string, number int, body string) error {
-	return nil
+func (f *fakeGH) PostComment(repo string, number int, body string) (time.Time, error) {
+	return time.Now().UTC(), nil
 }
 
 func (f *fakeGH) FetchComments(repo string, number int) ([]github.Comment, error) {
@@ -136,8 +136,8 @@ func (f *fakeGHCommentsError) SubmitReview(repo string, number int, body, event 
 	return 1, "COMMENTED", nil
 }
 
-func (f *fakeGHCommentsError) PostComment(repo string, number int, body string) error {
-	return nil
+func (f *fakeGHCommentsError) PostComment(repo string, number int, body string) (time.Time, error) {
+	return time.Now().UTC(), nil
 }
 
 func (f *fakeGHCommentsError) FetchComments(repo string, number int) ([]github.Comment, error) {
@@ -218,7 +218,7 @@ func (f *fakeGHWithHeadSHA) SubmitReview(repo string, number int, body, event st
 	f.submits++
 	return 1, "COMMENTED", nil
 }
-func (f *fakeGHWithHeadSHA) PostComment(repo string, number int, body string) error { return nil }
+func (f *fakeGHWithHeadSHA) PostComment(repo string, number int, body string) (time.Time, error) { return time.Now().UTC(), nil }
 func (f *fakeGHWithHeadSHA) FetchComments(repo string, number int) ([]github.Comment, error) {
 	return nil, nil
 }
@@ -300,7 +300,7 @@ func (f *fakeGHCounter) SubmitReview(repo string, number int, body, event string
 	f.submits++
 	return 1, "COMMENTED", nil
 }
-func (f *fakeGHCounter) PostComment(repo string, number int, body string) error { return nil }
+func (f *fakeGHCounter) PostComment(repo string, number int, body string) (time.Time, error) { return time.Now().UTC(), nil }
 func (f *fakeGHCounter) FetchComments(repo string, number int) ([]github.Comment, error) { return nil, nil }
 func (f *fakeGHCounter) GetPRHeadSHA(repo string, number int) (string, error)            { return "", nil }
 

--- a/daemon/internal/store/issues.go
+++ b/daemon/internal/store/issues.go
@@ -40,6 +40,7 @@ type IssueReview struct {
 	ActionTaken string    `json:"action_taken"`
 	PRCreated   int       `json:"pr_created"`
 	CreatedAt   time.Time `json:"created_at"`
+	CommentedAt time.Time `json:"commented_at"`
 }
 
 // UpsertIssue inserts or updates an issue keyed on github_id. The dismissed
@@ -154,11 +155,16 @@ func (s *Store) InsertIssueReview(r *IssueReview) (int64, error) {
 	if r.ActionTaken == "" {
 		r.ActionTaken = "review_only"
 	}
+	commentedAt := ""
+	if !r.CommentedAt.IsZero() {
+		commentedAt = r.CommentedAt.UTC().Format(sqliteTimeFormat)
+	}
 	res, err := s.db.Exec(`
-		INSERT INTO issue_reviews (issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO issue_reviews (issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at, commented_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, r.IssueID, r.CLIUsed, r.Summary, r.Triage, r.Suggestions, r.ActionTaken, r.PRCreated,
 		r.CreatedAt.UTC().Format(sqliteTimeFormat),
+		commentedAt,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("store: insert issue review: %w", err)
@@ -169,7 +175,7 @@ func (s *Store) InsertIssueReview(r *IssueReview) (int64, error) {
 // ListIssueReviews returns every review for an issue, newest first.
 func (s *Store) ListIssueReviews(issueID int64) ([]*IssueReview, error) {
 	rows, err := s.db.Query(
-		`SELECT id, issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at
+		`SELECT id, issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at, COALESCE(commented_at,'')
 		 FROM issue_reviews WHERE issue_id = ? ORDER BY created_at DESC`,
 		issueID,
 	)
@@ -192,7 +198,7 @@ func (s *Store) ListIssueReviews(issueID int64) ([]*IssueReview, error) {
 // sql.ErrNoRows if none exists yet.
 func (s *Store) LatestIssueReview(issueID int64) (*IssueReview, error) {
 	row := s.db.QueryRow(
-		`SELECT id, issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at
+		`SELECT id, issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at, COALESCE(commented_at,'')
 		 FROM issue_reviews WHERE issue_id = ? ORDER BY created_at DESC LIMIT 1`,
 		issueID,
 	)
@@ -220,14 +226,19 @@ func scanIssue(s scanner) (*Issue, error) {
 
 func scanIssueReview(s scanner) (*IssueReview, error) {
 	var r IssueReview
-	var createdAt string
+	var createdAt, commentedAt string
 	if err := s.Scan(&r.ID, &r.IssueID, &r.CLIUsed, &r.Summary, &r.Triage,
-		&r.Suggestions, &r.ActionTaken, &r.PRCreated, &createdAt); err != nil {
+		&r.Suggestions, &r.ActionTaken, &r.PRCreated, &createdAt, &commentedAt); err != nil {
 		return nil, fmt.Errorf("store: scan issue review: %w", err)
 	}
 	var err error
 	if r.CreatedAt, err = time.Parse(sqliteTimeFormat, createdAt); err != nil {
 		return nil, fmt.Errorf("store: parse issue review created_at %q: %w", createdAt, err)
+	}
+	if commentedAt != "" {
+		if r.CommentedAt, err = time.Parse(sqliteTimeFormat, commentedAt); err != nil {
+			return nil, fmt.Errorf("store: parse issue review commented_at %q: %w", commentedAt, err)
+		}
 	}
 	return &r, nil
 }

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -162,6 +162,7 @@ func Open(dsn string) (*Store, error) {
 	if _, err := db.Exec("ALTER TABLE agents ADD COLUMN is_default_dev INTEGER NOT NULL DEFAULT 0"); err == nil {
 		db.Exec("UPDATE agents SET is_default_dev = is_default")
 	}
+	db.Exec("ALTER TABLE issue_reviews ADD COLUMN commented_at DATETIME NOT NULL DEFAULT ''")
 	return &Store{db: db}, nil
 }
 


### PR DESCRIPTION
Auto-generated by Heimdallm in response to #222.

Closes #222