### PR TITLE
fix: config screen race condition + TOML tag mismatch + UI consistency

### DIFF
--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -305,8 +305,8 @@ type RepoAI struct {
 type PRMetadataConfig struct {
 	Reviewers []string `toml:"reviewers"`
 	Labels    []string `toml:"labels"`
-	Assignee  string   `toml:"assignee"`
-	Draft     *bool    `toml:"draft,omitempty"`
+	Assignee  string   `toml:"pr_assignee"`
+	Draft     *bool    `toml:"pr_draft,omitempty"`
 }
 
 // OrgAI holds per-organisation PR metadata overrides, applied to all repos

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -10,24 +10,16 @@ final daemonHealthProvider = FutureProvider<bool>((ref) async {
 
 final configProvider = FutureProvider<AppConfig>((ref) async {
   final api = ref.watch(apiClientProvider);
-  try {
-    final json = await api.fetchConfig();
-    return AppConfig.fromJson(json);
-  } catch (_) {
-    return const AppConfig();
-  }
+  final json = await api.fetchConfig();
+  return AppConfig.fromJson(json);
 });
 
 class ConfigNotifier extends AsyncNotifier<AppConfig> {
   @override
   Future<AppConfig> build() async {
     final api = ref.watch(apiClientProvider);
-    try {
-      final json = await api.fetchConfig();
-      return AppConfig.fromJson(json);
-    } catch (_) {
-      return const AppConfig();
-    }
+    final json = await api.fetchConfig();
+    return AppConfig.fromJson(json);
   }
 
   /// Replaces local state with fresh config from the daemon. Called after
@@ -38,6 +30,8 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
 
   /// Save global config changes by computing the diff and sending only
   /// changed fields to the daemon via PATCH.
+  /// Optimistic: updates UI state immediately, sends PATCH in background,
+  /// then reconciles with the daemon's authoritative response.
   Future<void> save(AppConfig updated) async {
     final current = state.valueOrNull;
     if (current == null) return;
@@ -47,6 +41,9 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
       state = AsyncValue.data(updated);
       return;
     }
+    // Optimistic update — UI reflects the change immediately
+    state = AsyncValue.data(updated);
+    // Reconcile with daemon response in background
     final freshJson = await api.patchConfig(diff);
     state = AsyncValue.data(AppConfig.fromJson(freshJson));
   }

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -560,14 +560,21 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           }),
         ),
         const SizedBox(height: 10),
-        SwitchListTile(
-          title: const Text('Create as draft', style: TextStyle(fontSize: 13)),
-          subtitle: const Text('PRs are created as drafts by default',
-              style: TextStyle(fontSize: 11)),
-          dense: true,
-          contentPadding: EdgeInsets.zero,
-          value: _globalPRDraft,
-          onChanged: (v) => setState(() => _globalPRDraft = v),
+        Container(
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+          child: SwitchListTile(
+            title: const Text('Create as draft', style: TextStyle(fontSize: 11)),
+            subtitle: Text('PRs are created as drafts by default',
+                style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+            dense: true,
+            contentPadding: EdgeInsets.zero,
+            value: _globalPRDraft,
+            onChanged: (v) => setState(() => _globalPRDraft = v),
+          ),
         ),
         const SizedBox(height: 10),
         _agentDropdown(
@@ -587,28 +594,53 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     required ValueChanged<String?> onChanged,
   }) {
     final agents = ref.watch(agentsProvider).valueOrNull ?? [];
-    final options = agents.map((a) => a.id).toList();
-    final effective = (value != null && options.contains(value)) ? value : null;
-    return DropdownButtonFormField<String?>(
-      key: ValueKey('$label-$effective'),
-      initialValue: effective,
-      decoration: InputDecoration(
-        labelText: label,
-        helperText: helper,
-        border: const OutlineInputBorder(),
-        isDense: true,
+    final effective = (value != null && agents.any((a) => a.id == value)) ? value : null;
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(6),
       ),
-      items: [
-        const DropdownMenuItem<String?>(
-          value: null,
-          child: Text('default', style: TextStyle(fontSize: 12)),
-        ),
-        ...options.map((id) => DropdownMenuItem<String?>(
-              value: id,
-              child: Text(id, style: const TextStyle(fontSize: 12)),
-            )),
-      ],
-      onChanged: onChanged,
+      padding: const EdgeInsets.all(10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(label, style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
+              const Spacer(),
+              Text('global', style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+            ],
+          ),
+          const SizedBox(height: 6),
+          DropdownButtonFormField<String?>(
+            key: ValueKey('$label-$effective'),
+            initialValue: effective,
+            decoration: const InputDecoration(
+              isDense: true,
+              border: OutlineInputBorder(),
+              contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+            ),
+            style: const TextStyle(fontSize: 12),
+            items: [
+              const DropdownMenuItem<String?>(
+                value: null,
+                child: Text('default', style: TextStyle(fontSize: 12)),
+              ),
+              ...agents.map((a) => DropdownMenuItem<String?>(
+                    value: a.id,
+                    child: Text(a.name.isNotEmpty ? a.name : a.id,
+                        style: const TextStyle(fontSize: 12)),
+                  )),
+            ],
+            onChanged: onChanged,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(helper,
+                style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+          ),
+        ],
+      ),
     );
   }
 

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -119,7 +119,20 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       ),
       body: configAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (_, __) => _buildForm(context, const AppConfig(), daemonRunning),
+        error: (e, __) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Could not load config: $e',
+                  style: TextStyle(color: Colors.red.shade400, fontSize: 13)),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => ref.invalidate(configNotifierProvider),
+                child: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
         data: (config) {
           _initFromConfig(config);
           return _buildForm(context, config, daemonRunning);


### PR DESCRIPTION
## Summary

- **Race condition fix**: `configProvider` and `ConfigNotifier.build()` no longer swallow errors — returning `const AppConfig()` on fetch failure locked the init guard with empty data, causing all subsequent saves to erase real config values
- **TOML tag fix**: `PRMetadataConfig` used `toml:"assignee"` / `toml:"draft"` but TOML and Flutter write `pr_assignee` / `pr_draft` — fields were silently ignored on load
- **UI consistency**: Prompt dropdowns show agent name (not ID), wrapped in same container style as other fields. Draft switch also wrapped consistently.
- **Optimistic save**: UI updates immediately on save, PATCH runs in background

## Test plan

- [ ] `cd daemon && go test ./... -count=1` — all pass
- [ ] `flutter analyze --no-fatal-infos` — no issues
- [ ] `flutter test` — all pass
- [ ] Kill daemon, open app → shows error + retry (not empty form)
- [ ] PR Assignee persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)