### PR TITLE
feat: promote issue from IT (triage) to DEV (auto-implement) from the UI (#225)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -721,6 +721,98 @@ func main() {
 		return nil
 	})
 
+	// Wire the promote callback: runs the auto_implement pipeline for a review_only issue,
+	// effectively reclassifying it to develop from the UI without needing a GitHub label change.
+	srv.SetTriggerPromoteFn(func(issueID int64) error {
+		publishIssueErr := func(msg string) {
+			broker.Publish(sse.Event{
+				Type: sse.EventIssueReviewError,
+				Data: sseData(map[string]any{"issue_id": issueID, "error": msg}),
+			})
+		}
+
+		iss, err := s.GetIssue(issueID)
+		if err != nil {
+			publishIssueErr(fmt.Sprintf("Issue not found: %v", err))
+			return fmt.Errorf("promote issue: get issue %d: %w", issueID, err)
+		}
+
+		cfgMu.Lock()
+		aiCfg := cfg.AIForRepo(iss.Repo)
+		if aiCfg.Primary == "" {
+			aiCfg.Primary = cfg.AI.Primary
+		}
+		agentCfg := cfg.AgentConfigFor(aiCfg.Primary)
+		localDirBase := cfg.GitHub.LocalDirBase
+		globalTimeout := cfg.AI.ExecutionTimeout
+		cfgMu.Unlock()
+		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, iss.Repo, localDirBase)
+
+		// Reconstruct github.Issue from store data and force develop mode.
+		ghIssue := &gh.Issue{
+			ID:      iss.GithubID,
+			Number:  iss.Number,
+			Title:   iss.Title,
+			Body:    iss.Body,
+			State:   iss.State,
+			Repo:    iss.Repo,
+			HTMLURL: fmt.Sprintf("https://github.com/%s/issues/%d", iss.Repo, iss.Number),
+		}
+		ghIssue.User.Login = iss.Author
+		ghIssue.Mode = config.IssueModeDevelop // promote: always run auto_implement
+
+		extraFlags := agentCfg.ExtraFlags
+		if extraFlags != "" {
+			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+				slog.Warn("promoteIssue: extra_flags rejected", "err", err)
+				extraFlags = ""
+			}
+		}
+
+		issuePrompt, issueInstructions := resolveIssuePrompt(s, aiCfg.IssuePrompt, agentCfg.PromptID)
+		implPrompt, implInstructions := resolveImplementPrompt(s, aiCfg.ImplementPrompt, agentCfg.PromptID)
+
+		opts := issuepipeline.RunOptions{
+			GitHubToken: token,
+			Primary:     aiCfg.Primary,
+			Fallback:    aiCfg.Fallback,
+			ExecOpts: executor.ExecOptions{
+				Model:                agentCfg.Model,
+				MaxTurns:             agentCfg.MaxTurns,
+				ApprovalMode:         agentCfg.ApprovalMode,
+				ExtraFlags:           extraFlags,
+				WorkDir:              aiCfg.LocalDir,
+				Effort:               agentCfg.Effort,
+				PermissionMode:       agentCfg.PermissionMode,
+				Bare:                 agentCfg.Bare,
+				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
+				NoSessionPersistence: agentCfg.NoSessionPersistence,
+				Timeout:              resolveExecutionTimeout(globalTimeout, agentCfg.ExecutionTimeout),
+			},
+			IssuePromptOverride:     issuePrompt,
+			IssueInstructions:       issueInstructions,
+			ImplementPromptOverride: implPrompt,
+			ImplementInstructions:   implInstructions,
+			PRReviewers:           aiCfg.PRReviewers,
+			PRAssignee:            aiCfg.PRAssignee,
+			PRLabels:              aiCfg.PRLabels,
+			PRDraft:               aiCfg.PRDraft != nil && *aiCfg.PRDraft,
+			GeneratePRDescription: aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+		}
+
+		slog.Info("promote issue: running auto_implement pipeline",
+			"store_issue_id", issueID, "repo", iss.Repo, "number", iss.Number)
+
+		_, err = issuePipe.Run(context.Background(), ghIssue, opts)
+		if err != nil {
+			broker.Publish(sse.Event{Type: sse.EventIssueReviewError, Data: sseData(map[string]any{
+				"issue_id": issueID, "repo": iss.Repo, "error": err.Error(),
+			})})
+			return err
+		}
+		return nil
+	})
+
 	go func() {
 		slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
 		if err := srv.Start(cfg.Server.Port, cfg.Server.BindAddr); err != nil {

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -37,6 +37,7 @@ type Server struct {
 	reloadFn        func() error
 	triggerReviewFn      func(prID int64) error
 	triggerIssueReviewFn func(issueID int64) error
+	triggerPromoteFn     func(issueID int64) error
 	meFn                 func() (string, error)
 	// configFn returns the current running config as a JSON-serializable map.
 	configFn func() map[string]any
@@ -148,6 +149,13 @@ func (srv *Server) SetTriggerIssueReviewFn(fn func(issueID int64) error) {
 	srv.triggerIssueReviewFn = fn
 }
 
+// SetTriggerPromoteFn wires the promote callback called by POST /issues/{id}/promote.
+// The callback must run the auto_implement pipeline for the given issue regardless
+// of its current classification (review_only → develop promotion).
+func (srv *Server) SetTriggerPromoteFn(fn func(issueID int64) error) {
+	srv.triggerPromoteFn = fn
+}
+
 // SetMeFn wires the authenticated-user callback called by GET /me.
 func (srv *Server) SetMeFn(fn func() (string, error)) { srv.meFn = fn }
 
@@ -234,6 +242,7 @@ func (srv *Server) buildRouter() chi.Router {
 	r.Get("/issues", srv.handleListIssues)
 	r.Get("/issues/{id}", srv.handleGetIssue)
 	r.Post("/issues/{id}/review", srv.handleTriggerIssueReview)
+	r.Post("/issues/{id}/promote", srv.handlePromoteIssue)
 	r.Post("/issues/{id}/dismiss", srv.handleDismissIssue)
 	r.Post("/issues/{id}/undismiss", srv.handleUndismissIssue)
 	r.Get("/repos/{name}/labels", srv.handleRepoLabels)
@@ -921,6 +930,35 @@ func (srv *Server) handleTriggerIssueReview(w http.ResponseWriter, r *http.Reque
 		}
 	}()
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "review queued"})
+}
+
+// handlePromoteIssue promotes a review_only-classified issue to auto_implement,
+// triggering the full develop pipeline immediately without waiting for a label
+// change on GitHub. It shares the same semaphore as review and triage so total
+// concurrent AI processes stay bounded.
+func (srv *Server) handlePromoteIssue(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	if srv.triggerPromoteFn == nil {
+		http.Error(w, "promote trigger not configured", http.StatusServiceUnavailable)
+		return
+	}
+	select {
+	case srv.reviewSem <- struct{}{}:
+	default:
+		http.Error(w, `{"error":"too many concurrent reviews — try again later"}`, http.StatusTooManyRequests)
+		return
+	}
+	go func() {
+		defer func() { <-srv.reviewSem }()
+		if err := srv.triggerPromoteFn(id); err != nil {
+			slog.Error("promote issue failed", "issue_id", id, "err", err)
+		}
+	}()
+	writeJSON(w, http.StatusAccepted, map[string]string{"status": "promote queued"})
 }
 
 func (srv *Server) handleRepoLabels(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -472,6 +472,60 @@ func TestHandlerTriggerIssueReview_NotConfigured(t *testing.T) {
 	}
 }
 
+func TestHandlerPromoteIssue(t *testing.T) {
+	srv, s := setupServer(t)
+	now := time.Now()
+	id, _ := s.UpsertIssue(&store.Issue{
+		GithubID: 800, Repo: "org/r", Number: 20, Title: "t",
+		Body: "b", Author: "a", Assignees: `[]`, Labels: `[]`,
+		State: "open", CreatedAt: now, FetchedAt: now,
+	})
+
+	promoted := make(chan int64, 1)
+	srv.SetTriggerPromoteFn(func(issueID int64) error {
+		promoted <- issueID
+		return nil
+	})
+
+	req := httptest.NewRequest("POST", "/issues/"+itoa(id)+"/promote", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("promote issue: status %d, body: %s", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	json.NewDecoder(w.Body).Decode(&body)
+	if body["status"] != "promote queued" {
+		t.Errorf("promote issue: unexpected body %v", body)
+	}
+
+	select {
+	case got := <-promoted:
+		if got != id {
+			t.Errorf("promoted with issue_id %d, expected %d", got, id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("promote callback not called within 2s")
+	}
+}
+
+func TestHandlerPromoteIssue_NotConfigured(t *testing.T) {
+	srv, s := setupServer(t)
+	now := time.Now()
+	id, _ := s.UpsertIssue(&store.Issue{
+		GithubID: 801, Repo: "org/r", Number: 21, Title: "t",
+		Body: "b", Author: "a", Assignees: `[]`, Labels: `[]`,
+		State: "open", CreatedAt: now, FetchedAt: now,
+	})
+
+	req := httptest.NewRequest("POST", "/issues/"+itoa(id)+"/promote", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when promote not configured, got %d", w.Code)
+	}
+}
+
 func TestIssueEndpointsRequireAuthWhenTokenSet(t *testing.T) {
 	s, err := store.Open(":memory:")
 	if err != nil {
@@ -513,6 +567,7 @@ func TestIssueEndpointsRequireAuthWhenTokenSet(t *testing.T) {
 	// POST endpoints — protected via method-based auth (all POST requires token)
 	postPaths := []string{
 		"/issues/" + issueID + "/review",
+		"/issues/" + issueID + "/promote",
 		"/issues/" + issueID + "/dismiss",
 		"/issues/" + issueID + "/undismiss",
 	}

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -285,6 +285,16 @@ class ApiClient {
     }
   }
 
+  /// Promotes a review_only-classified issue to auto_implement, triggering the
+  /// full develop pipeline without requiring a GitHub label change.
+  Future<void> promoteIssue(int issueId) async {
+    final resp = await _client.post(_uri('/issues/$issueId/promote'),
+        headers: await _authHeaders());
+    if (resp.statusCode != 202) {
+      throw ApiException('POST /issues/$issueId/promote failed: ${resp.statusCode}');
+    }
+  }
+
   Future<void> dismissIssue(int issueId) async {
     final resp = await _client.post(_uri('/issues/$issueId/dismiss'),
         headers: await _authHeaders());

--- a/flutter_app/lib/features/issues/issues_providers.dart
+++ b/flutter_app/lib/features/issues/issues_providers.dart
@@ -8,6 +8,9 @@ final issueListRefreshProvider = StateProvider<int>((ref) => 0);
 /// Tracks issues currently being reviewed, keyed by "repo:issueNumber".
 final reviewingIssuesProvider = StateProvider<Set<String>>((ref) => const {});
 
+/// Tracks issues currently being promoted to develop, keyed by "repo:issueNumber".
+final promotingIssuesProvider = StateProvider<Set<String>>((ref) => const {});
+
 final issuesProvider = FutureProvider<List<TrackedIssue>>((ref) async {
   ref.watch(issueListRefreshProvider);
   final api = ref.watch(apiClientProvider);

--- a/flutter_app/lib/features/issues/issues_screen.dart
+++ b/flutter_app/lib/features/issues/issues_screen.dart
@@ -7,6 +7,8 @@ import '../../shared/widgets/toast.dart';
 import '../dashboard/dashboard_providers.dart';
 import 'issues_providers.dart';
 
+const _actionReviewOnly = 'review_only';
+
 /// Filter state for the issues list.
 final _repoFilterProvider = StateProvider<String?>((ref) => null);
 
@@ -108,6 +110,18 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
     }
   }
 
+  Future<void> _promote() async {
+    ref.read(promotingIssuesProvider.notifier).update((s) => {...s, _reviewKey});
+    try {
+      await ref.read(apiClientProvider).promoteIssue(widget.issue.id);
+      if (mounted) showToast(context, 'Promoted to Develop — pipeline queued');
+    } catch (e) {
+      if (mounted) showToast(context, 'Error: $e', isError: true);
+    } finally {
+      ref.read(promotingIssuesProvider.notifier).update((s) => s.difference({_reviewKey}));
+    }
+  }
+
   Future<void> _dismiss() async {
     final api = ref.read(apiClientProvider);
     try {
@@ -137,7 +151,14 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
     final issue = widget.issue;
     final reviewed = issue.latestReview != null;
     final isReviewing = ref.watch(reviewingIssuesProvider).contains(_reviewKey);
+    final isPromoting = ref.watch(promotingIssuesProvider).contains(_reviewKey);
     final severity = issue.latestReview?.severity ?? '';
+    // Show "Promote to Develop" only when the latest review action was review_only
+    // and not currently running either pipeline on this issue.
+    final canPromote = reviewed &&
+        issue.latestReview!.actionTaken == _actionReviewOnly &&
+        !isReviewing &&
+        !isPromoting;
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
@@ -200,12 +221,14 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  if (isReviewing)
+                  if (isReviewing || isPromoting)
                     SizedBox(
                       width: 18, height: 18,
                       child: CircularProgressIndicator(
                         strokeWidth: 2,
-                        color: Theme.of(context).colorScheme.primary,
+                        color: isPromoting
+                            ? Theme.of(context).colorScheme.secondary
+                            : Theme.of(context).colorScheme.primary,
                       ),
                     )
                   else if (reviewed)
@@ -213,7 +236,7 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
                   else
                     _chip('PENDING', Colors.grey.shade700),
                   const SizedBox(width: 8),
-                  if (!isReviewing)
+                  if (!isReviewing && !isPromoting) ...[
                     SizedBox(
                       height: 28,
                       child: ElevatedButton(
@@ -224,6 +247,22 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
                         child: const Text('Review'),
                       ),
                     ),
+                    if (canPromote) ...[
+                      const SizedBox(width: 6),
+                      SizedBox(
+                        height: 28,
+                        child: ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                              padding: const EdgeInsets.symmetric(horizontal: 10),
+                              textStyle: const TextStyle(fontSize: 12),
+                              backgroundColor: Theme.of(context).colorScheme.secondary,
+                              foregroundColor: Theme.of(context).colorScheme.onSecondary),
+                          onPressed: _promote,
+                          child: const Text('Promote to Dev'),
+                        ),
+                      ),
+                    ],
+                  ],
                   IconButton(
                     icon: const Icon(Icons.close, size: 14),
                     tooltip: 'Dismiss issue',


### PR DESCRIPTION
## Summary

- Add `POST /issues/{id}/promote` daemon endpoint that triggers the `auto_implement` pipeline for a `review_only`-classified issue, using the same pattern as `POST /issues/{id}/review`
- Add `promoteIssue(int issueId)` to `ApiClient` in the Flutter app
- Add a **Promote to Dev** button to the issues list that only appears on issues whose latest `action_taken` is `review_only`; button shows a distinct secondary-color spinner while the pipeline queues, and a toast on success/failure

## Test plan

- [ ] `cd daemon && go test ./... -count=1` — all pass (verified locally)
- [ ] `cd flutter_app && flutter analyze --no-fatal-infos` — no issues (verified locally)
- [ ] `TestHandlerPromoteIssue` and `TestHandlerPromoteIssue_NotConfigured` pass
- [ ] Promote button appears only on `review_only` issues in the UI
- [ ] Promote button is absent on `auto_implement` (already promoted) issues
- [ ] Calling `POST /issues/{id}/promote` without token returns 401 when token is configured
- [ ] Calling without the promote callback wired returns 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)