### PR TITLE
feat(cli): dismiss-issue and undismiss-issue commands

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -264,6 +264,18 @@ func (c *Client) TriggerIssueReview(id int64) error {
 	return err
 }
 
+// DismissIssue hides an issue from the pipeline, stopping retries until undismissed.
+func (c *Client) DismissIssue(id int64) error {
+	_, err := c.do("POST", fmt.Sprintf("/issues/%d/dismiss", id))
+	return err
+}
+
+// UndismissIssue restores a previously dismissed issue, allowing the pipeline to retry it.
+func (c *Client) UndismissIssue(id int64) error {
+	_, err := c.do("POST", fmt.Sprintf("/issues/%d/undismiss", id))
+	return err
+}
+
 // StreamEvents opens an SSE connection and sends events to the provided channel.
 // It blocks until the context is cancelled, the connection is closed, or an error occurs.
 func (c *Client) StreamEvents(ctx context.Context, events chan<- SSEEvent) error {

--- a/cli/internal/cli/review.go
+++ b/cli/internal/cli/review.go
@@ -46,3 +46,45 @@ func newReviewIssueCmd() *cobra.Command {
 		},
 	}
 }
+
+func newDismissIssueCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "dismiss-issue <id>",
+		Short: "Dismiss an issue, stopping the daemon from retrying it",
+		Long: "Marks an issue as dismissed so the pipeline skips it on future polls.\n" +
+			"Use undismiss-issue to restore it.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := clientFromContext(cmd.Context())
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid issue ID: %w", err)
+			}
+			if err := c.DismissIssue(id); err != nil {
+				return fmt.Errorf("dismissing issue: %w", err)
+			}
+			fmt.Printf("Issue %d dismissed.\n", id)
+			return nil
+		},
+	}
+}
+
+func newUndismissIssueCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "undismiss-issue <id>",
+		Short: "Restore a dismissed issue so the pipeline can retry it",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := clientFromContext(cmd.Context())
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid issue ID: %w", err)
+			}
+			if err := c.UndismissIssue(id); err != nil {
+				return fmt.Errorf("undismissing issue: %w", err)
+			}
+			fmt.Printf("Issue %d undismissed.\n", id)
+			return nil
+		},
+	}
+}

--- a/cli/internal/cli/root.go
+++ b/cli/internal/cli/root.go
@@ -84,6 +84,8 @@ func NewRootCmd() *cobra.Command {
 		newFollowCmd(),
 		newReviewPRCmd(),
 		newReviewIssueCmd(),
+		newDismissIssueCmd(),
+		newUndismissIssueCmd(),
 		newConfigCmd(),
 		newStatsCmd(),
 		newDashboardCmd(),


### PR DESCRIPTION
## Summary

Closes #224.

The daemon endpoints (`POST /issues/{id}/dismiss`, `POST /issues/{id}/undismiss`), the pipeline guard in `fetcher.go` (`alreadyProcessed` checks `row.Dismissed`), the Flutter UI buttons (issues list tile and issue detail AppBar), and the Flutter API client methods were all already implemented. The only missing piece was the **CLI path**.

This PR adds:

- `heimdallm-cli dismiss-issue <id>` — stops the daemon from retrying a stuck issue (IT triage or DEV auto-implement)
- `heimdallm-cli undismiss-issue <id>` — restores a dismissed issue so the pipeline retries it
- `DismissIssue(id int64) error` and `UndismissIssue(id int64) error` methods on the CLI API client

## Test plan

- [x] `go build ./...` passes in `cli/`
- [x] `go test ./... -count=1` passes in `cli/`
- [x] `go test ./... -count=1` passes in `daemon/`
- [x] `flutter analyze --no-fatal-infos` passes in `flutter_app/`
- [x] `heimdallm-cli dismiss-issue --help` shows correct usage
- [x] `heimdallm-cli undismiss-issue --help` shows correct usage
- [x] Existing daemon tests for `handleDismissIssue` / `handleUndismissIssue` pass (`TestHandlerDismissIssue`, `TestHandlerUndismissIssue`)
- [x] Existing fetcher test for dismissed issues passes (`TestFetcher_SkipsDismissedIssues`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)