### PR TITLE
feat: implement #222 — bug: triage loop — RecomputeGrace too short for slow triages

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -111,6 +111,7 @@ type IssueReview struct {
 	ActionTaken string          `json:"action_taken"`
 	PRCreated   int             `json:"pr_created"`
 	CreatedAt   time.Time       `json:"created_at"`
+	CommentedAt time.Time       `json:"commented_at"`
 }
 
 type Issue struct {

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -292,12 +292,16 @@ func (p *Pipeline) runReviewOnly(ctx context.Context, issue *github.Issue, issue
 	var triageCtx string
 	prevReview, _ := p.store.LatestIssueReview(issueID)
 	if prevReview != nil {
+		lastTriageRef := prevReview.CommentedAt
+		if lastTriageRef.IsZero() {
+			lastTriageRef = prevReview.CreatedAt
+		}
 		triageCtx = buildTriageContext(
 			prevReview.Triage,
 			prevReview.Suggestions,
 			prevReview.Summary,
 			extractSeverity(prevReview.Triage),
-			prevReview.CreatedAt,
+			lastTriageRef,
 			comments,
 			p.botLogin,
 		)
@@ -445,12 +449,16 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 	var triageCtx string
 	prevReview, _ := p.store.LatestIssueReview(issueID)
 	if prevReview != nil {
+		lastTriageRef := prevReview.CommentedAt
+		if lastTriageRef.IsZero() {
+			lastTriageRef = prevReview.CreatedAt
+		}
 		triageCtx = buildTriageContext(
 			prevReview.Triage,
 			prevReview.Suggestions,
 			prevReview.Summary,
 			extractSeverity(prevReview.Triage),
-			prevReview.CreatedAt,
+			lastTriageRef,
 			comments,
 			p.botLogin,
 		)

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -105,7 +105,8 @@ CREATE TABLE IF NOT EXISTS issue_reviews (
   suggestions  TEXT NOT NULL DEFAULT '[]',
   action_taken TEXT NOT NULL DEFAULT 'review_only',
   pr_created   INTEGER NOT NULL DEFAULT 0,
-  created_at   DATETIME NOT NULL
+  created_at   DATETIME NOT NULL,
+  commented_at DATETIME NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS activity_log (


### PR DESCRIPTION
Auto-generated by Heimdallm in response to #222.

Closes #222