### PR TITLE
feat: PR/issue state tracking, persistent filters, grid view

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1325,12 +1325,17 @@ func (a *tier2Adapter) CheckItem(ctx context.Context, item *scheduler.WatchItem)
 			return false, err
 		}
 		if prState != "open" {
+			// Only publish SSE on the first detection — check stored state first.
+			existing, _ := a.store.GetPRByGithubID(item.GithubID)
+			wasOpen := existing != nil && existing.State == "open"
 			a.store.UpdatePRStateByGithubID(item.GithubID, "closed")
-			a.broker.Publish(sse.Event{
-				Type: sse.EventPRStateChanged,
-				Data: fmt.Sprintf(`{"pr_id":%d,"state":"closed"}`, item.GithubID),
-			})
-			slog.Info("tier3: PR closed/merged", "repo", item.Repo, "number", item.Number)
+			if wasOpen {
+				a.broker.Publish(sse.Event{
+					Type: sse.EventPRStateChanged,
+					Data: fmt.Sprintf(`{"pr_id":%d,"state":"closed"}`, item.GithubID),
+				})
+				slog.Info("tier3: PR closed/merged", "repo", item.Repo, "number", item.Number)
+			}
 			return false, nil // closed — don't trigger HandleChange
 		}
 		return updatedAt.After(item.LastSeen), nil
@@ -1342,12 +1347,16 @@ func (a *tier2Adapter) CheckItem(ctx context.Context, item *scheduler.WatchItem)
 		return false, err
 	}
 	if issue.State != "open" {
+		existing, _ := a.store.GetIssueByGithubID(item.GithubID)
+		wasOpen := existing != nil && existing.State == "open"
 		a.store.UpdateIssueStateByGithubID(item.GithubID, "closed")
-		a.broker.Publish(sse.Event{
-			Type: sse.EventIssueStateChanged,
-			Data: fmt.Sprintf(`{"issue_id":%d,"state":"closed"}`, item.GithubID),
-		})
-		slog.Info("tier3: issue closed", "repo", item.Repo, "number", item.Number)
+		if wasOpen {
+			a.broker.Publish(sse.Event{
+				Type: sse.EventIssueStateChanged,
+				Data: fmt.Sprintf(`{"issue_id":%d,"state":"closed"}`, item.GithubID),
+			})
+			slog.Info("tier3: issue closed", "repo", item.Repo, "number", item.Number)
+		}
 		return false, nil // closed — don't trigger HandleChange
 	}
 	return issue.UpdatedAt.After(item.LastSeen), nil

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1318,43 +1318,39 @@ func (a *tier2Adapter) PRAlreadyReviewed(githubID int64, updatedAt time.Time) bo
 
 // CheckItem implements scheduler.Tier3ItemChecker.
 func (a *tier2Adapter) CheckItem(ctx context.Context, item *scheduler.WatchItem) (bool, error) {
-	// Use the GitHub Issues API — works for both issues and PRs.
-	issue, err := a.ghClient.GetIssue(item.Repo, item.Number)
-	if err != nil {
-		return false, err
-	}
-
-	// State reconciliation: detect open → closed transitions.
-	// Store updates are idempotent; SSE publishes fire-and-forget.
-	// Closed items remain in the watch queue and are eventually evicted by
-	// the backoff/EvictStale mechanism — no interface changes required.
 	if item.Type == "pr" {
-		prState, err := a.ghClient.GetPRState(item.Repo, item.Number)
+		// Single API call: /pulls/{n} gives state + merged_at + updated_at.
+		prState, updatedAt, err := a.ghClient.GetPRStateAndUpdatedAt(item.Repo, item.Number)
 		if err != nil {
-			slog.Warn("tier3: could not fetch PR state", "repo", item.Repo, "number", item.Number, "err", err)
-		} else if prState != "open" {
-			if err := a.store.UpdatePRStateByGithubID(item.GithubID, "closed"); err != nil {
-				slog.Warn("tier3: update PR state failed", "err", err)
-			}
+			return false, err
+		}
+		if prState != "open" {
+			a.store.UpdatePRStateByGithubID(item.GithubID, "closed")
 			a.broker.Publish(sse.Event{
 				Type: sse.EventPRStateChanged,
 				Data: fmt.Sprintf(`{"pr_id":%d,"state":"closed"}`, item.GithubID),
 			})
 			slog.Info("tier3: PR closed/merged", "repo", item.Repo, "number", item.Number)
+			return false, nil // closed — don't trigger HandleChange
 		}
-	} else if issue.State != "open" {
-		if err := a.store.UpdateIssueStateByGithubID(item.GithubID, "closed"); err != nil {
-			slog.Warn("tier3: update issue state failed", "err", err)
-		}
+		return updatedAt.After(item.LastSeen), nil
+	}
+
+	// Issues: GetIssue returns state + updated_at in one call.
+	issue, err := a.ghClient.GetIssue(item.Repo, item.Number)
+	if err != nil {
+		return false, err
+	}
+	if issue.State != "open" {
+		a.store.UpdateIssueStateByGithubID(item.GithubID, "closed")
 		a.broker.Publish(sse.Event{
 			Type: sse.EventIssueStateChanged,
 			Data: fmt.Sprintf(`{"issue_id":%d,"state":"closed"}`, item.GithubID),
 		})
 		slog.Info("tier3: issue closed", "repo", item.Repo, "number", item.Number)
+		return false, nil // closed — don't trigger HandleChange
 	}
-
-	changed := issue.UpdatedAt.After(item.LastSeen)
-	return changed, nil
+	return issue.UpdatedAt.After(item.LastSeen), nil
 }
 
 // HandleChange implements scheduler.Tier3ItemChecker.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1323,6 +1323,36 @@ func (a *tier2Adapter) CheckItem(ctx context.Context, item *scheduler.WatchItem)
 	if err != nil {
 		return false, err
 	}
+
+	// State reconciliation: detect open → closed transitions.
+	// Store updates are idempotent; SSE publishes fire-and-forget.
+	// Closed items remain in the watch queue and are eventually evicted by
+	// the backoff/EvictStale mechanism — no interface changes required.
+	if item.Type == "pr" {
+		prState, err := a.ghClient.GetPRState(item.Repo, item.Number)
+		if err != nil {
+			slog.Warn("tier3: could not fetch PR state", "repo", item.Repo, "number", item.Number, "err", err)
+		} else if prState != "open" {
+			if err := a.store.UpdatePRStateByGithubID(item.GithubID, "closed"); err != nil {
+				slog.Warn("tier3: update PR state failed", "err", err)
+			}
+			a.broker.Publish(sse.Event{
+				Type: sse.EventPRStateChanged,
+				Data: fmt.Sprintf(`{"pr_id":%d,"state":"closed"}`, item.GithubID),
+			})
+			slog.Info("tier3: PR closed/merged", "repo", item.Repo, "number", item.Number)
+		}
+	} else if issue.State != "open" {
+		if err := a.store.UpdateIssueStateByGithubID(item.GithubID, "closed"); err != nil {
+			slog.Warn("tier3: update issue state failed", "err", err)
+		}
+		a.broker.Publish(sse.Event{
+			Type: sse.EventIssueStateChanged,
+			Data: fmt.Sprintf(`{"issue_id":%d,"state":"closed"}`, item.GithubID),
+		})
+		slog.Info("tier3: issue closed", "repo", item.Repo, "number", item.Number)
+	}
+
 	changed := issue.UpdatedAt.After(item.LastSeen)
 	return changed, nil
 }

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -398,30 +398,33 @@ func (c *Client) GetPRHeadSHA(repo string, number int) (string, error) {
 	return pr.Head.SHA, nil
 }
 
-// GetPRState returns the effective state of a PR: "open" or "closed".
-// Uses the Pulls API to detect merged PRs (merged_at != null → "closed").
-func (c *Client) GetPRState(repo string, number int) (string, error) {
+// GetPRStateAndUpdatedAt returns the effective state ("open" or "closed") and
+// the updated_at timestamp of a PR. Uses the Pulls API to detect merged PRs
+// (merged_at != null → "closed"). Combines state + freshness in one API call
+// so callers don't need a separate GetIssue call for PRs.
+func (c *Client) GetPRStateAndUpdatedAt(repo string, number int) (state string, updatedAt time.Time, err error) {
 	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)
 	resp, err := c.do("GET", path, "application/vnd.github+json")
 	if err != nil {
-		return "", fmt.Errorf("github: get PR state %s#%d: %w", repo, number, err)
+		return "", time.Time{}, fmt.Errorf("github: get PR %s#%d: %w", repo, number, err)
 	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("github: get PR state %s#%d: status %d", repo, number, resp.StatusCode)
+		return "", time.Time{}, fmt.Errorf("github: get PR %s#%d: status %d", repo, number, resp.StatusCode)
 	}
 	var pr struct {
-		State    string  `json:"state"`
-		MergedAt *string `json:"merged_at"`
+		State     string    `json:"state"`
+		MergedAt  *string   `json:"merged_at"`
+		UpdatedAt time.Time `json:"updated_at"`
 	}
 	if err := json.Unmarshal(body, &pr); err != nil {
-		return "", fmt.Errorf("github: decode PR state %s#%d: %w", repo, number, err)
+		return "", time.Time{}, fmt.Errorf("github: decode PR %s#%d: %w", repo, number, err)
 	}
 	if pr.MergedAt != nil {
-		return "closed", nil
+		return "closed", pr.UpdatedAt, nil
 	}
-	return pr.State, nil
+	return pr.State, pr.UpdatedAt, nil
 }
 
 // FetchDiff returns the unified diff for a PR.

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -398,6 +398,32 @@ func (c *Client) GetPRHeadSHA(repo string, number int) (string, error) {
 	return pr.Head.SHA, nil
 }
 
+// GetPRState returns the effective state of a PR: "open" or "closed".
+// Uses the Pulls API to detect merged PRs (merged_at != null → "closed").
+func (c *Client) GetPRState(repo string, number int) (string, error) {
+	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)
+	resp, err := c.do("GET", path, "application/vnd.github+json")
+	if err != nil {
+		return "", fmt.Errorf("github: get PR state %s#%d: %w", repo, number, err)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github: get PR state %s#%d: status %d", repo, number, resp.StatusCode)
+	}
+	var pr struct {
+		State    string  `json:"state"`
+		MergedAt *string `json:"merged_at"`
+	}
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return "", fmt.Errorf("github: decode PR state %s#%d: %w", repo, number, err)
+	}
+	if pr.MergedAt != nil {
+		return "closed", nil
+	}
+	return pr.State, nil
+}
+
 // FetchDiff returns the unified diff for a PR.
 func (c *Client) FetchDiff(repo string, number int) (string, error) {
 	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -274,7 +274,11 @@ func (srv *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (srv *Server) handleListPRs(w http.ResponseWriter, r *http.Request) {
-	prs, err := srv.store.ListPRs()
+	var states []string
+	if s := r.URL.Query().Get("state"); s != "" {
+		states = strings.Split(s, ",")
+	}
+	prs, err := srv.store.ListPRs(states...)
 	if err != nil {
 		slog.Error("handleListPRs: store error", "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -842,7 +846,11 @@ func toIssueReviewResponse(r *store.IssueReview) *issueReviewResponse {
 }
 
 func (srv *Server) handleListIssues(w http.ResponseWriter, r *http.Request) {
-	issues, err := srv.store.ListIssues()
+	var states []string
+	if s := r.URL.Query().Get("state"); s != "" {
+		states = strings.Split(s, ",")
+	}
+	issues, err := srv.store.ListIssues(states...)
 	if err != nil {
 		slog.Error("handleListIssues: store error", "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1302,3 +1302,123 @@ func TestHandleDeleteRepoField_Idempotent(t *testing.T) {
 		t.Fatalf("expected 200 (idempotent), got %d (body: %s)", w.Code, w.Body.String())
 	}
 }
+
+func TestHandleListPRs_StateFilter(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	broker := sse.NewBroker()
+	broker.Start()
+	t.Cleanup(broker.Stop)
+	srv := server.New(s, broker, nil, "test-token")
+
+	now := time.Now()
+	s.UpsertPR(&store.PR{GithubID: 10, Repo: "org/r", Number: 10, Title: "open pr", Author: "a", URL: "u", State: "open", UpdatedAt: now, FetchedAt: now})
+	s.UpsertPR(&store.PR{GithubID: 11, Repo: "org/r", Number: 11, Title: "closed pr", Author: "a", URL: "u", State: "closed", UpdatedAt: now, FetchedAt: now})
+
+	doReq := func(path string) []map[string]any {
+		t.Helper()
+		req := httptest.NewRequest("GET", path, nil)
+		req.Header.Set("X-Heimdallm-Token", "test-token")
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET %s: status %d, body: %s", path, w.Code, w.Body.String())
+		}
+		var prs []map[string]any
+		if err := json.NewDecoder(w.Body).Decode(&prs); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return prs
+	}
+
+	// No filter → both PRs returned
+	if got := doReq("/prs"); len(got) != 2 {
+		t.Errorf("GET /prs: expected 2, got %d", len(got))
+	}
+
+	// state=open → only the open PR
+	if got := doReq("/prs?state=open"); len(got) != 1 {
+		t.Errorf("GET /prs?state=open: expected 1, got %d", len(got))
+	} else if got[0]["state"] != "open" {
+		t.Errorf("GET /prs?state=open: got state %v", got[0]["state"])
+	}
+
+	// state=closed → only the closed PR
+	if got := doReq("/prs?state=closed"); len(got) != 1 {
+		t.Errorf("GET /prs?state=closed: expected 1, got %d", len(got))
+	} else if got[0]["state"] != "closed" {
+		t.Errorf("GET /prs?state=closed: got state %v", got[0]["state"])
+	}
+
+	// state=open,closed → both PRs
+	if got := doReq("/prs?state=open,closed"); len(got) != 2 {
+		t.Errorf("GET /prs?state=open,closed: expected 2, got %d", len(got))
+	}
+}
+
+func TestHandleListIssues_StateFilter(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	broker := sse.NewBroker()
+	broker.Start()
+	t.Cleanup(broker.Stop)
+	srv := server.New(s, broker, nil, "test-token")
+
+	now := time.Now()
+	s.UpsertIssue(&store.Issue{
+		GithubID: 20, Repo: "org/r", Number: 20, Title: "open issue",
+		Body: "b", Author: "a", Assignees: `[]`, Labels: `[]`,
+		State: "open", CreatedAt: now, FetchedAt: now,
+	})
+	s.UpsertIssue(&store.Issue{
+		GithubID: 21, Repo: "org/r", Number: 21, Title: "closed issue",
+		Body: "b", Author: "a", Assignees: `[]`, Labels: `[]`,
+		State: "closed", CreatedAt: now, FetchedAt: now,
+	})
+
+	doReq := func(path string) []map[string]any {
+		t.Helper()
+		req := httptest.NewRequest("GET", path, nil)
+		req.Header.Set("X-Heimdallm-Token", "test-token")
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET %s: status %d, body: %s", path, w.Code, w.Body.String())
+		}
+		var issues []map[string]any
+		if err := json.NewDecoder(w.Body).Decode(&issues); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return issues
+	}
+
+	// No filter → both issues returned
+	if got := doReq("/issues"); len(got) != 2 {
+		t.Errorf("GET /issues: expected 2, got %d", len(got))
+	}
+
+	// state=open → only the open issue
+	if got := doReq("/issues?state=open"); len(got) != 1 {
+		t.Errorf("GET /issues?state=open: expected 1, got %d", len(got))
+	} else if got[0]["state"] != "open" {
+		t.Errorf("GET /issues?state=open: got state %v", got[0]["state"])
+	}
+
+	// state=closed → only the closed issue
+	if got := doReq("/issues?state=closed"); len(got) != 1 {
+		t.Errorf("GET /issues?state=closed: expected 1, got %d", len(got))
+	} else if got[0]["state"] != "closed" {
+		t.Errorf("GET /issues?state=closed: got state %v", got[0]["state"])
+	}
+
+	// state=open,closed → both issues
+	if got := doReq("/issues?state=open,closed"); len(got) != 2 {
+		t.Errorf("GET /issues?state=open,closed: expected 2, got %d", len(got))
+	}
+}

--- a/daemon/internal/sse/broker.go
+++ b/daemon/internal/sse/broker.go
@@ -20,6 +20,9 @@ const (
 	// EventRepoDiscovered fires when the poll cycle sees a PR whose repo
 	// is not yet in monitored or non-monitored. Payload: {"repo": "org/name"}.
 	EventRepoDiscovered = "repo_discovered"
+
+	EventPRStateChanged    = "pr_state_changed"
+	EventIssueStateChanged = "issue_state_changed"
 )
 
 // maxSubscribers limits the number of concurrent SSE connections to prevent

--- a/daemon/internal/store/issues.go
+++ b/daemon/internal/store/issues.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -101,12 +102,22 @@ func (s *Store) GetIssueByGithubID(githubID int64) (*Issue, error) {
 }
 
 // ListIssues returns all non-dismissed issues ordered by fetched_at descending.
-func (s *Store) ListIssues() ([]*Issue, error) {
-	rows, err := s.db.Query(
-		`SELECT id, github_id, repo, number, title, body, author, assignees, labels,
-		        state, created_at, fetched_at, dismissed FROM issues
-		 WHERE dismissed = 0 ORDER BY fetched_at DESC`,
-	)
+// An optional list of states (e.g. "open", "closed") filters the result;
+// when no states are provided all non-dismissed issues are returned.
+func (s *Store) ListIssues(states ...string) ([]*Issue, error) {
+	query := `SELECT id, github_id, repo, number, title, body, author, assignees, labels,
+		        state, created_at, fetched_at, dismissed FROM issues WHERE dismissed = 0`
+	var args []any
+	if len(states) > 0 {
+		placeholders := strings.Repeat("?,", len(states))
+		placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+		query += " AND state IN (" + placeholders + ")"
+		for _, st := range states {
+			args = append(args, st)
+		}
+	}
+	query += " ORDER BY fetched_at DESC"
+	rows, err := s.db.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("store: list issues: %w", err)
 	}
@@ -120,6 +131,31 @@ func (s *Store) ListIssues() ([]*Issue, error) {
 		issues = append(issues, i)
 	}
 	return issues, rows.Err()
+}
+
+// ListOpenIssues is a convenience wrapper that returns only non-dismissed
+// issues with state "open".
+func (s *Store) ListOpenIssues() ([]*Issue, error) {
+	return s.ListIssues("open")
+}
+
+// UpdateIssueState updates the state of an issue by its local row ID.
+func (s *Store) UpdateIssueState(id int64, state string) error {
+	_, err := s.db.Exec("UPDATE issues SET state = ? WHERE id = ?", state, id)
+	if err != nil {
+		return fmt.Errorf("store: update issue state %d: %w", id, err)
+	}
+	return nil
+}
+
+// UpdateIssueStateByGithubID updates the state of an issue by its GitHub ID.
+// This is used by Tier 3 which supplies a github_id rather than the local id.
+func (s *Store) UpdateIssueStateByGithubID(githubID int64, state string) error {
+	_, err := s.db.Exec("UPDATE issues SET state = ? WHERE github_id = ?", state, githubID)
+	if err != nil {
+		return fmt.Errorf("store: update issue state by github_id %d: %w", githubID, err)
+	}
+	return nil
 }
 
 // DismissIssue hides an issue from the dashboard and opts it out of future

--- a/daemon/internal/store/prs.go
+++ b/daemon/internal/store/prs.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -69,10 +70,21 @@ func (s *Store) GetPRByGithubID(githubID int64) (*PR, error) {
 }
 
 // ListPRs returns all non-dismissed PRs ordered by updated_at descending.
-func (s *Store) ListPRs() ([]*PR, error) {
-	rows, err := s.db.Query(
-		"SELECT id, github_id, repo, number, title, author, url, state, updated_at, fetched_at, dismissed FROM prs WHERE dismissed = 0 ORDER BY updated_at DESC",
-	)
+// An optional list of states (e.g. "open", "closed") filters the result;
+// when no states are provided all non-dismissed PRs are returned.
+func (s *Store) ListPRs(states ...string) ([]*PR, error) {
+	query := "SELECT id, github_id, repo, number, title, author, url, state, updated_at, fetched_at, dismissed FROM prs WHERE dismissed = 0"
+	var args []any
+	if len(states) > 0 {
+		placeholders := strings.Repeat("?,", len(states))
+		placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+		query += " AND state IN (" + placeholders + ")"
+		for _, st := range states {
+			args = append(args, st)
+		}
+	}
+	query += " ORDER BY updated_at DESC"
+	rows, err := s.db.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("store: list prs: %w", err)
 	}
@@ -86,6 +98,31 @@ func (s *Store) ListPRs() ([]*PR, error) {
 		prs = append(prs, pr)
 	}
 	return prs, rows.Err()
+}
+
+// ListOpenPRs is a convenience wrapper that returns only non-dismissed PRs
+// with state "open".
+func (s *Store) ListOpenPRs() ([]*PR, error) {
+	return s.ListPRs("open")
+}
+
+// UpdatePRState updates the state of a PR by its local row ID.
+func (s *Store) UpdatePRState(id int64, state string) error {
+	_, err := s.db.Exec("UPDATE prs SET state = ? WHERE id = ?", state, id)
+	if err != nil {
+		return fmt.Errorf("store: update pr state %d: %w", id, err)
+	}
+	return nil
+}
+
+// UpdatePRStateByGithubID updates the state of a PR by its GitHub PR ID.
+// This is used by Tier 3 which supplies a github_id rather than the local id.
+func (s *Store) UpdatePRStateByGithubID(githubID int64, state string) error {
+	_, err := s.db.Exec("UPDATE prs SET state = ? WHERE github_id = ?", state, githubID)
+	if err != nil {
+		return fmt.Errorf("store: update pr state by github_id %d: %w", githubID, err)
+	}
+	return nil
 }
 
 // DismissPR marks a PR as dismissed so it no longer appears in the dashboard

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -427,3 +427,200 @@ func TestStore_DefaultAgentFor_ReturnsPerCategoryAgent(t *testing.T) {
 		t.Errorf("DefaultAgentFor(dev) = %+v, want error for no-match", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// State-filter tests for PRs
+// ---------------------------------------------------------------------------
+
+func TestListPRs_StateFilter(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err := s.UpsertPR(&store.PR{GithubID: 301, Repo: "org/r", Number: 301, Title: "open PR", Author: "a", URL: "u", State: "open", UpdatedAt: now, FetchedAt: now})
+	if err != nil {
+		t.Fatalf("upsert open: %v", err)
+	}
+	_, err = s.UpsertPR(&store.PR{GithubID: 302, Repo: "org/r", Number: 302, Title: "closed PR", Author: "a", URL: "u", State: "closed", UpdatedAt: now, FetchedAt: now})
+	if err != nil {
+		t.Fatalf("upsert closed: %v", err)
+	}
+
+	all, err := s.ListPRs()
+	if err != nil {
+		t.Fatalf("ListPRs() all: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("ListPRs() = %d, want 2", len(all))
+	}
+
+	open, err := s.ListPRs("open")
+	if err != nil {
+		t.Fatalf("ListPRs(open): %v", err)
+	}
+	if len(open) != 1 {
+		t.Errorf("ListPRs(open) = %d, want 1", len(open))
+	}
+	if open[0].State != "open" {
+		t.Errorf("ListPRs(open)[0].State = %q, want open", open[0].State)
+	}
+
+	closed, err := s.ListPRs("closed")
+	if err != nil {
+		t.Fatalf("ListPRs(closed): %v", err)
+	}
+	if len(closed) != 1 {
+		t.Errorf("ListPRs(closed) = %d, want 1", len(closed))
+	}
+	if closed[0].State != "closed" {
+		t.Errorf("ListPRs(closed)[0].State = %q, want closed", closed[0].State)
+	}
+}
+
+func TestUpdatePRState(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	id, err := s.UpsertPR(&store.PR{GithubID: 303, Repo: "org/r", Number: 303, Title: "t", Author: "a", URL: "u", State: "open", UpdatedAt: now, FetchedAt: now})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	if err := s.UpdatePRState(id, "closed"); err != nil {
+		t.Fatalf("UpdatePRState: %v", err)
+	}
+
+	closed, err := s.ListPRs("closed")
+	if err != nil {
+		t.Fatalf("ListPRs(closed): %v", err)
+	}
+	if len(closed) != 1 || closed[0].ID != id {
+		t.Errorf("expected 1 closed PR with id=%d, got %v", id, closed)
+	}
+	if closed[0].State != "closed" {
+		t.Errorf("State = %q, want closed", closed[0].State)
+	}
+}
+
+func TestUpdatePRStateByGithubID(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	id, err := s.UpsertPR(&store.PR{GithubID: 304, Repo: "org/r", Number: 304, Title: "t", Author: "a", URL: "u", State: "open", UpdatedAt: now, FetchedAt: now})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	if err := s.UpdatePRStateByGithubID(304, "closed"); err != nil {
+		t.Fatalf("UpdatePRStateByGithubID: %v", err)
+	}
+
+	closed, err := s.ListPRs("closed")
+	if err != nil {
+		t.Fatalf("ListPRs(closed): %v", err)
+	}
+	if len(closed) != 1 || closed[0].ID != id {
+		t.Errorf("expected 1 closed PR with id=%d, got %v", id, closed)
+	}
+	if closed[0].GithubID != 304 {
+		t.Errorf("GithubID = %d, want 304", closed[0].GithubID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// State-filter tests for Issues
+// ---------------------------------------------------------------------------
+
+func TestListIssues_StateFilter(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	openIssue := &store.Issue{GithubID: 401, Repo: "org/r", Number: 401, Title: "open issue", Author: "a", State: "open", CreatedAt: now, FetchedAt: now}
+	closedIssue := &store.Issue{GithubID: 402, Repo: "org/r", Number: 402, Title: "closed issue", Author: "a", State: "closed", CreatedAt: now, FetchedAt: now}
+
+	if _, err := s.UpsertIssue(openIssue); err != nil {
+		t.Fatalf("upsert open: %v", err)
+	}
+	if _, err := s.UpsertIssue(closedIssue); err != nil {
+		t.Fatalf("upsert closed: %v", err)
+	}
+
+	all, err := s.ListIssues()
+	if err != nil {
+		t.Fatalf("ListIssues() all: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("ListIssues() = %d, want 2", len(all))
+	}
+
+	open, err := s.ListIssues("open")
+	if err != nil {
+		t.Fatalf("ListIssues(open): %v", err)
+	}
+	if len(open) != 1 {
+		t.Errorf("ListIssues(open) = %d, want 1", len(open))
+	}
+	if open[0].State != "open" {
+		t.Errorf("ListIssues(open)[0].State = %q, want open", open[0].State)
+	}
+
+	closed, err := s.ListIssues("closed")
+	if err != nil {
+		t.Fatalf("ListIssues(closed): %v", err)
+	}
+	if len(closed) != 1 {
+		t.Errorf("ListIssues(closed) = %d, want 1", len(closed))
+	}
+	if closed[0].State != "closed" {
+		t.Errorf("ListIssues(closed)[0].State = %q, want closed", closed[0].State)
+	}
+}
+
+func TestUpdateIssueState(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	id, err := s.UpsertIssue(&store.Issue{GithubID: 403, Repo: "org/r", Number: 403, Title: "t", Author: "a", State: "open", CreatedAt: now, FetchedAt: now})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	if err := s.UpdateIssueState(id, "closed"); err != nil {
+		t.Fatalf("UpdateIssueState: %v", err)
+	}
+
+	closed, err := s.ListIssues("closed")
+	if err != nil {
+		t.Fatalf("ListIssues(closed): %v", err)
+	}
+	if len(closed) != 1 || closed[0].ID != id {
+		t.Errorf("expected 1 closed issue with id=%d, got %v", id, closed)
+	}
+	if closed[0].State != "closed" {
+		t.Errorf("State = %q, want closed", closed[0].State)
+	}
+}
+
+func TestUpdateIssueStateByGithubID(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	id, err := s.UpsertIssue(&store.Issue{GithubID: 404, Repo: "org/r", Number: 404, Title: "t", Author: "a", State: "open", CreatedAt: now, FetchedAt: now})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	if err := s.UpdateIssueStateByGithubID(404, "closed"); err != nil {
+		t.Fatalf("UpdateIssueStateByGithubID: %v", err)
+	}
+
+	closed, err := s.ListIssues("closed")
+	if err != nil {
+		t.Fatalf("ListIssues(closed): %v", err)
+	}
+	if len(closed) != 1 || closed[0].ID != id {
+		t.Errorf("expected 1 closed issue with id=%d, got %v", id, closed)
+	}
+	if closed[0].GithubID != 404 {
+		t.Errorf("GithubID = %d, want 404", closed[0].GithubID)
+	}
+}

--- a/docs/superpowers/plans/2026-04-22-state-tracking-filters.md
+++ b/docs/superpowers/plans/2026-04-22-state-tracking-filters.md
@@ -1,0 +1,857 @@
+# State Tracking & Filterable Views Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track open/closed state of PRs and issues, filter by state in the Activity view, persist all filters across sessions, and add list/grid view modes.
+
+**Architecture:** The Tier 3 watch cycle already fetches each item from GitHub via `GetIssue` — we piggyback state reconciliation on that existing call. Closed items are excluded from future polling. The API gains a `?state=` query param. Flutter persists all activity filters in SharedPreferences and adds state chips + grid/list toggle.
+
+**Tech Stack:** Go (SQLite store, chi router, SSE), Dart/Flutter (Riverpod, SharedPreferences)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `daemon/internal/store/prs.go` | Modify | `ListPRs(states)`, `UpdatePRState` |
+| `daemon/internal/store/issues.go` | Modify | `ListIssues(states)`, `UpdateIssueState` |
+| `daemon/internal/store/prs_test.go` | Modify | Tests for state filter and update |
+| `daemon/internal/store/issues_test.go` | Modify | Tests for state filter and update |
+| `daemon/internal/sse/broker.go` | Modify | Add `EventPRStateChanged`, `EventIssueStateChanged` |
+| `daemon/cmd/heimdallm/main.go` | Modify | State reconciliation in `CheckItem`, exclude closed from Tier 2 |
+| `daemon/internal/server/handlers.go` | Modify | Parse `?state=` on GET /prs and GET /issues |
+| `daemon/internal/server/handlers_test.go` | Modify | Tests for state filter param |
+| `flutter_app/lib/shared/widgets/state_badge.dart` | Create | Open/Closed badge widget |
+| `flutter_app/lib/features/dashboard/activity_filters.dart` | Modify | Add `states`, `viewMode` fields; persistence |
+| `flutter_app/lib/features/dashboard/dashboard_providers.dart` | Modify | Persist filters; pass state to API |
+| `flutter_app/lib/features/dashboard/activity_filter_bar.dart` | Modify | State chips + grid/list toggle |
+| `flutter_app/lib/features/dashboard/dashboard_screen.dart` | Modify | Grid view builder; state badge; SSE state listener; opacity for closed |
+| `flutter_app/lib/core/api/api_client.dart` | Modify | Pass `?state=` param on fetchPRs/fetchIssues |
+
+---
+
+### Task 1: Store — State Filter and Update Methods
+
+**Files:**
+- Modify: `daemon/internal/store/prs.go`
+- Modify: `daemon/internal/store/issues.go`
+- Modify: `daemon/internal/store/prs_test.go` (if exists) or `daemon/internal/store/store_test.go`
+
+- [ ] **Step 1: Add `UpdatePRState` method**
+
+Add to `daemon/internal/store/prs.go`:
+
+```go
+// UpdatePRState sets the state of a PR by its store ID.
+func (s *Store) UpdatePRState(id int64, state string) error {
+	_, err := s.db.Exec("UPDATE prs SET state = ? WHERE id = ?", state, id)
+	return err
+}
+```
+
+- [ ] **Step 2: Modify `ListPRs` to accept state filter**
+
+Change the signature and SQL in `daemon/internal/store/prs.go`. The current `ListPRs()` has no params. Change to:
+
+```go
+// ListPRs returns non-dismissed PRs, optionally filtered by state.
+// If no states are provided, all non-dismissed PRs are returned.
+func (s *Store) ListPRs(states ...string) ([]*PR, error) {
+	query := `SELECT id, github_id, repo, number, title, author, url, state, updated_at, fetched_at, dismissed
+		FROM prs WHERE dismissed = 0`
+	var args []any
+	if len(states) > 0 {
+		placeholders := make([]string, len(states))
+		for i, st := range states {
+			placeholders[i] = "?"
+			args = append(args, st)
+		}
+		query += " AND state IN (" + strings.Join(placeholders, ",") + ")"
+	}
+	query += " ORDER BY updated_at DESC"
+	rows, err := s.db.Query(query, args...)
+	// ... rest unchanged (scan loop)
+```
+
+Add `"strings"` to imports if not present.
+
+- [ ] **Step 3: Add `ListOpenPRs` convenience method**
+
+```go
+// ListOpenPRs returns all non-dismissed PRs with state="open".
+// Used by state reconciliation to know which items need checking.
+func (s *Store) ListOpenPRs() ([]*PR, error) {
+	return s.ListPRs("open")
+}
+```
+
+- [ ] **Step 4: Add `UpdateIssueState` method**
+
+Add to `daemon/internal/store/issues.go`:
+
+```go
+// UpdateIssueState sets the state of an issue by its store ID.
+func (s *Store) UpdateIssueState(id int64, state string) error {
+	_, err := s.db.Exec("UPDATE issues SET state = ? WHERE id = ?", state, id)
+	return err
+}
+```
+
+- [ ] **Step 5: Modify `ListIssues` to accept state filter**
+
+Same pattern as `ListPRs`:
+
+```go
+func (s *Store) ListIssues(states ...string) ([]*Issue, error) {
+	query := `SELECT id, github_id, repo, number, title, body, author, assignees, labels,
+		state, created_at, fetched_at, dismissed
+		FROM issues WHERE dismissed = 0`
+	var args []any
+	if len(states) > 0 {
+		placeholders := make([]string, len(states))
+		for i, st := range states {
+			placeholders[i] = "?"
+			args = append(args, st)
+		}
+		query += " AND state IN (" + strings.Join(placeholders, ",") + ")"
+	}
+	query += " ORDER BY fetched_at DESC"
+	rows, err := s.db.Query(query, args...)
+	// ... rest unchanged (scan loop)
+```
+
+- [ ] **Step 6: Add `ListOpenIssues` convenience method**
+
+```go
+func (s *Store) ListOpenIssues() ([]*Issue, error) {
+	return s.ListIssues("open")
+}
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `cd daemon && go test ./internal/store/ -v -count=1`
+Expected: all existing tests pass (the no-arg `ListPRs()` call still works because `states` is variadic)
+
+- [ ] **Step 8: Write tests for new methods**
+
+Add to the store test file:
+
+```go
+func TestListPRs_StateFilter(t *testing.T) {
+	s := setupTestStore(t)
+	// Insert two PRs with different states
+	s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/a", Number: 1, State: "open", UpdatedAt: time.Now()})
+	s.UpsertPR(&store.PR{GithubID: 2, Repo: "org/a", Number: 2, State: "closed", UpdatedAt: time.Now()})
+
+	all, _ := s.ListPRs()
+	assert(len(all) == 2)
+
+	open, _ := s.ListPRs("open")
+	assert(len(open) == 1 && open[0].Number == 1)
+
+	closed, _ := s.ListPRs("closed")
+	assert(len(closed) == 1 && closed[0].Number == 2)
+}
+
+func TestUpdatePRState(t *testing.T) {
+	s := setupTestStore(t)
+	id, _ := s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/a", Number: 1, State: "open", UpdatedAt: time.Now()})
+	s.UpdatePRState(id, "closed")
+	prs, _ := s.ListPRs("closed")
+	assert(len(prs) == 1 && prs[0].State == "closed")
+}
+```
+
+Adapt to match existing test patterns in the file. Same pattern for issues.
+
+- [ ] **Step 9: Run all tests and commit**
+
+Run: `cd daemon && go test ./... -count=1`
+
+```bash
+git add daemon/internal/store/
+git commit -m "feat(store): add state filter to ListPRs/ListIssues, add UpdatePRState/UpdateIssueState"
+```
+
+---
+
+### Task 2: SSE Events + GitHub PR State
+
+**Files:**
+- Modify: `daemon/internal/sse/broker.go`
+- Modify: `daemon/internal/github/client.go`
+
+- [ ] **Step 1: Add SSE event type constants**
+
+Add to `daemon/internal/sse/broker.go` after the existing constants:
+
+```go
+EventPRStateChanged    = "pr_state_changed"
+EventIssueStateChanged = "issue_state_changed"
+```
+
+- [ ] **Step 2: Add `GetPRState` to GitHub client**
+
+The `GetIssue` method works for both PRs and issues (GitHub's Issues API handles both), but for PRs it returns "open"/"closed" — not "merged". To detect merged, we need the Pulls API. Add to `daemon/internal/github/client.go`:
+
+```go
+// GetPRState returns the state of a PR: "open", "closed", or "merged".
+// Uses the Pulls API which distinguishes merged from closed.
+func (c *Client) GetPRState(repo string, number int) (string, error) {
+	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)
+	resp, err := c.do("GET", path, "application/vnd.github+json")
+	if err != nil {
+		return "", fmt.Errorf("github: get PR state %s#%d: %w", repo, number, err)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github: get PR state %s#%d: status %d", repo, number, resp.StatusCode)
+	}
+	var pr struct {
+		State    string `json:"state"`
+		MergedAt *string `json:"merged_at"`
+	}
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return "", fmt.Errorf("github: decode PR state %s#%d: %w", repo, number, err)
+	}
+	// GitHub PR state is "open" or "closed"; merged is inferred from merged_at
+	if pr.MergedAt != nil {
+		return "closed", nil // Unified: merged → closed per spec
+	}
+	return pr.State, nil
+}
+```
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `cd daemon && go build ./...`
+
+```bash
+git add daemon/internal/sse/broker.go daemon/internal/github/client.go
+git commit -m "feat: add SSE state change events and GetPRState helper"
+```
+
+---
+
+### Task 3: State Reconciliation in Tier 3
+
+**Files:**
+- Modify: `daemon/cmd/heimdallm/main.go`
+
+- [ ] **Step 1: Modify `CheckItem` to detect state changes**
+
+The current `CheckItem` in `tier2Adapter` (main.go ~line 1320) fetches the issue from GitHub and checks `UpdatedAt`. Extend it to also detect state changes and update the store:
+
+```go
+func (a *tier2Adapter) CheckItem(ctx context.Context, item *scheduler.WatchItem) (bool, error) {
+	issue, err := a.ghClient.GetIssue(item.Repo, item.Number)
+	if err != nil {
+		return false, err
+	}
+
+	// State reconciliation: detect open → closed transitions.
+	// For PRs, use the Pulls API to distinguish merged from closed.
+	if item.Type == "pr" {
+		prState, err := a.ghClient.GetPRState(item.Repo, item.Number)
+		if err != nil {
+			slog.Warn("tier3: could not fetch PR state", "repo", item.Repo, "number", item.Number, "err", err)
+		} else if prState != "open" {
+			// PR was closed or merged — update store, emit SSE, exclude from future polling.
+			if err := a.store.UpdatePRState(item.GithubID, "closed"); err != nil {
+				slog.Warn("tier3: update PR state failed", "err", err)
+			}
+			a.broker.Publish(sse.Event{
+				Type: sse.EventPRStateChanged,
+				Data: fmt.Sprintf(`{"pr_id":%d,"state":"closed"}`, item.GithubID),
+			})
+			slog.Info("tier3: PR state changed to closed", "repo", item.Repo, "number", item.Number)
+			// Don't re-enqueue — item drops out of the watch queue.
+			return false, nil
+		}
+	} else {
+		// Issue state from the Issues API response.
+		if issue.State != "open" {
+			if err := a.store.UpdateIssueState(item.GithubID, "closed"); err != nil {
+				slog.Warn("tier3: update issue state failed", "err", err)
+			}
+			a.broker.Publish(sse.Event{
+				Type: sse.EventIssueStateChanged,
+				Data: fmt.Sprintf(`{"issue_id":%d,"state":"closed"}`, item.GithubID),
+			})
+			slog.Info("tier3: issue state changed to closed", "repo", item.Repo, "number", item.Number)
+			return false, nil
+		}
+	}
+
+	changed := issue.UpdatedAt.After(item.LastSeen)
+	return changed, nil
+}
+```
+
+**IMPORTANT:** The `return false, nil` for closed items means Tier 3 won't call `HandleChange` and the item won't be re-enqueued — it naturally drops out of the watch queue.
+
+**IMPORTANT:** `item.GithubID` is the GitHub ID used as the PR/issue store key. Verify that `UpdatePRState` and `UpdateIssueState` use the correct ID column. If the store uses the local `id` (auto-increment) instead of `github_id`, we need a different method. Check the store's `GetPR(githubID)` pattern — if it exists, use it to resolve the local ID first. Otherwise, add `UpdatePRStateByGithubID`:
+
+```go
+func (s *Store) UpdatePRStateByGithubID(githubID int64, state string) error {
+	_, err := s.db.Exec("UPDATE prs SET state = ? WHERE github_id = ?", state, githubID)
+	return err
+}
+```
+
+Same for issues. Use the `ByGithubID` variants in `CheckItem`.
+
+- [ ] **Step 2: Verify and commit**
+
+Run: `cd daemon && go build ./... && go test ./... -count=1`
+
+```bash
+git add daemon/cmd/heimdallm/main.go daemon/internal/store/prs.go daemon/internal/store/issues.go
+git commit -m "feat: state reconciliation in Tier 3 — detect closed PRs/issues, emit SSE events"
+```
+
+---
+
+### Task 4: API Handlers — State Query Param
+
+**Files:**
+- Modify: `daemon/internal/server/handlers.go`
+- Modify: `daemon/internal/server/handlers_test.go`
+
+- [ ] **Step 1: Modify `handleListPRs` to parse `?state=`**
+
+```go
+func (srv *Server) handleListPRs(w http.ResponseWriter, r *http.Request) {
+	var states []string
+	if s := r.URL.Query().Get("state"); s != "" {
+		states = strings.Split(s, ",")
+	}
+	prs, err := srv.store.ListPRs(states...)
+	// ... rest unchanged
+```
+
+- [ ] **Step 2: Modify `handleListIssues` to parse `?state=`**
+
+Same pattern:
+
+```go
+func (srv *Server) handleListIssues(w http.ResponseWriter, r *http.Request) {
+	var states []string
+	if s := r.URL.Query().Get("state"); s != "" {
+		states = strings.Split(s, ",")
+	}
+	issues, err := srv.store.ListIssues(states...)
+	// ... rest unchanged
+```
+
+- [ ] **Step 3: Write integration tests**
+
+```go
+func TestHandleListPRs_StateFilter(t *testing.T) {
+	s := setupTestStore(t)
+	s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/a", Number: 1, State: "open", ...})
+	s.UpsertPR(&store.PR{GithubID: 2, Repo: "org/a", Number: 2, State: "closed", ...})
+
+	srv := server.New(s, sse.NewBroker(), nil, "test-token")
+
+	// No filter → all
+	req := httptest.NewRequest("GET", "/prs", nil)
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	// assert 2 items
+
+	// Filter open
+	req = httptest.NewRequest("GET", "/prs?state=open", nil)
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	// assert 1 item, state=open
+
+	// Filter closed
+	req = httptest.NewRequest("GET", "/prs?state=closed", nil)
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	// assert 1 item, state=closed
+}
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `cd daemon && go test ./... -count=1`
+
+```bash
+git add daemon/internal/server/handlers.go daemon/internal/server/handlers_test.go
+git commit -m "feat(api): add ?state= query param to GET /prs and GET /issues"
+```
+
+---
+
+### Task 5: Flutter — State Badge Widget
+
+**Files:**
+- Create: `flutter_app/lib/shared/widgets/state_badge.dart`
+
+- [ ] **Step 1: Create the widget**
+
+```dart
+import 'package:flutter/material.dart';
+
+class StateBadge extends StatelessWidget {
+  final String state;
+  const StateBadge({super.key, required this.state});
+
+  bool get _isOpen => state == 'open';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: _isOpen ? Colors.green.shade700 : Colors.grey.shade600,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            _isOpen ? Icons.circle_outlined : Icons.check_circle,
+            size: 12,
+            color: Colors.white,
+          ),
+          const SizedBox(width: 4),
+          Text(
+            _isOpen ? 'Open' : 'Closed',
+            style: const TextStyle(color: Colors.white, fontSize: 10, fontWeight: FontWeight.w600),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Verify and commit**
+
+Run: `cd flutter_app && flutter analyze --no-fatal-infos`
+
+```bash
+git add flutter_app/lib/shared/widgets/state_badge.dart
+git commit -m "feat(flutter): add StateBadge widget (Open/Closed)"
+```
+
+---
+
+### Task 6: Flutter — API Client State Param
+
+**Files:**
+- Modify: `flutter_app/lib/core/api/api_client.dart`
+
+- [ ] **Step 1: Modify `fetchPRs` to accept state filter**
+
+Change `fetchPRs` to accept optional states:
+
+```dart
+Future<List<PR>> fetchPRs({List<String> states = const []}) async {
+  var path = '/prs';
+  if (states.isNotEmpty) {
+    path += '?state=${states.join(',')}';
+  }
+  final resp = await _client.get(_uri(path), headers: await _authHeaders());
+  // ... rest unchanged
+}
+```
+
+- [ ] **Step 2: Modify `fetchIssues` to accept state filter**
+
+Same pattern for `fetchIssues`.
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `cd flutter_app && flutter analyze --no-fatal-infos`
+
+```bash
+git add flutter_app/lib/core/api/api_client.dart
+git commit -m "feat(flutter): pass ?state= param on fetchPRs/fetchIssues"
+```
+
+---
+
+### Task 7: Flutter — Persistent Activity Filters
+
+**Files:**
+- Modify: `flutter_app/lib/features/dashboard/activity_filters.dart`
+- Modify: `flutter_app/lib/features/dashboard/dashboard_providers.dart`
+
+- [ ] **Step 1: Extend `ActivityFilters` with states and viewMode**
+
+```dart
+class ActivityFilters {
+  final Set<String> types;
+  final Set<String> orgs;
+  final Set<String> repos;
+  final Set<String> states;    // 'open', 'closed' — empty = all
+  final String search;
+  final String viewMode;       // 'list' or 'grid'
+
+  const ActivityFilters({
+    this.types = const {},
+    this.orgs = const {},
+    this.repos = const {},
+    this.states = const {'open'},  // default: only open
+    this.search = '',
+    this.viewMode = 'list',
+  });
+
+  ActivityFilters copyWith({
+    Set<String>? types, Set<String>? orgs, Set<String>? repos,
+    Set<String>? states, String? search, String? viewMode,
+  }) => ActivityFilters(
+    types: types ?? this.types,
+    orgs: orgs ?? this.orgs,
+    repos: repos ?? this.repos,
+    states: states ?? this.states,
+    search: search ?? this.search,
+    viewMode: viewMode ?? this.viewMode,
+  );
+
+  bool get hasFilters =>
+    types.isNotEmpty || orgs.isNotEmpty || repos.isNotEmpty ||
+    states != const {'open'} || search.isNotEmpty;
+}
+```
+
+- [ ] **Step 2: Create persistent `ActivityFiltersNotifier`**
+
+Replace the `StateProvider` with a `Notifier` that persists to SharedPreferences. Add to `dashboard_providers.dart`:
+
+```dart
+class ActivityFiltersNotifier extends Notifier<ActivityFilters> {
+  static const _typesKey = 'activity_type_filter';
+  static const _orgsKey = 'activity_org_filter';
+  static const _reposKey = 'activity_repo_filter';
+  static const _statesKey = 'activity_state_filter';
+  static const _viewModeKey = 'activity_view_mode';
+
+  @override
+  ActivityFilters build() {
+    _loadAsync();
+    return const ActivityFilters(); // default until prefs load
+  }
+
+  Future<void> _loadAsync() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = ActivityFilters(
+      types: _loadSet(prefs, _typesKey),
+      orgs: _loadSet(prefs, _orgsKey),
+      repos: _loadSet(prefs, _reposKey),
+      states: _loadSet(prefs, _statesKey, defaultVal: {'open'}),
+      viewMode: prefs.getString(_viewModeKey) ?? 'list',
+    );
+  }
+
+  Set<String> _loadSet(SharedPreferences p, String key, {Set<String>? defaultVal}) {
+    final v = p.getString(key);
+    if (v == null || v.isEmpty) return defaultVal ?? {};
+    return v.split(',').toSet();
+  }
+
+  void update(ActivityFilters filters) {
+    state = filters;
+    _saveAsync(filters);
+  }
+
+  Future<void> _saveAsync(ActivityFilters f) async {
+    final prefs = await SharedPreferences.getInstance();
+    prefs.setString(_typesKey, f.types.join(','));
+    prefs.setString(_orgsKey, f.orgs.join(','));
+    prefs.setString(_reposKey, f.repos.join(','));
+    prefs.setString(_statesKey, f.states.join(','));
+    prefs.setString(_viewModeKey, f.viewMode);
+  }
+}
+
+final activityFiltersProvider =
+    NotifierProvider<ActivityFiltersNotifier, ActivityFilters>(
+        ActivityFiltersNotifier.new);
+```
+
+- [ ] **Step 3: Update `prsProvider` and `issuesProvider` to pass state filter**
+
+In `dashboard_providers.dart`, modify the providers to read the state filter and pass it to the API:
+
+```dart
+final prsProvider = FutureProvider<List<PR>>((ref) async {
+  ref.watch(prListRefreshProvider);
+  ref.watch(meProvider);
+  final filters = ref.watch(activityFiltersProvider);
+  final api = ref.watch(apiClientProvider);
+  final prs = await api.fetchPRs(states: filters.states.toList());
+  // ... rest unchanged
+});
+```
+
+Same for `issuesProvider`.
+
+- [ ] **Step 4: Update all filter consumers**
+
+Replace `ref.read(activityFiltersProvider.notifier).state = ...` with `ref.read(activityFiltersProvider.notifier).update(...)` in `activity_filter_bar.dart` and `dashboard_screen.dart`.
+
+- [ ] **Step 5: Verify and commit**
+
+Run: `cd flutter_app && flutter analyze --no-fatal-infos`
+
+```bash
+git add flutter_app/lib/features/dashboard/
+git commit -m "feat(flutter): persistent activity filters with state and viewMode"
+```
+
+---
+
+### Task 8: Flutter — Activity Filter Bar Extensions
+
+**Files:**
+- Modify: `flutter_app/lib/features/dashboard/activity_filter_bar.dart`
+
+- [ ] **Step 1: Add state chips**
+
+After the type chips (PR/IT/DEV), add Open/Closed chips:
+
+```dart
+const SizedBox(width: 8),
+_stateChip('Open', 'open', Colors.green),
+_stateChip('Closed', 'closed', Colors.grey),
+```
+
+Where `_stateChip` follows the same pattern as `_typeChip`:
+
+```dart
+Widget _stateChip(String label, String value, Color color) {
+  final filters = ref.watch(activityFiltersProvider);
+  final selected = filters.states.contains(value);
+  return FilterChip(
+    label: Text(label, style: TextStyle(fontSize: 11, color: selected ? Colors.white : null)),
+    selected: selected,
+    selectedColor: color,
+    checkmarkColor: Colors.white,
+    onSelected: (v) {
+      final current = Set<String>.from(filters.states);
+      v ? current.add(value) : current.remove(value);
+      ref.read(activityFiltersProvider.notifier).update(
+        filters.copyWith(states: current),
+      );
+    },
+  );
+}
+```
+
+- [ ] **Step 2: Add list/grid toggle**
+
+At the right end of the filter bar:
+
+```dart
+const Spacer(),
+_ViewToggleButton(
+  icon: Icons.view_list,
+  active: filters.viewMode == 'list',
+  onTap: () => ref.read(activityFiltersProvider.notifier).update(
+    filters.copyWith(viewMode: 'list'),
+  ),
+),
+_ViewToggleButton(
+  icon: Icons.grid_view,
+  active: filters.viewMode == 'grid',
+  onTap: () => ref.read(activityFiltersProvider.notifier).update(
+    filters.copyWith(viewMode: 'grid'),
+  ),
+),
+```
+
+Copy `_ViewToggleButton` from `repos_screen.dart` (it's a small styled `IconButton`).
+
+- [ ] **Step 3: Verify and commit**
+
+Run: `cd flutter_app && flutter analyze --no-fatal-infos`
+
+```bash
+git add flutter_app/lib/features/dashboard/activity_filter_bar.dart
+git commit -m "feat(flutter): state chips (Open/Closed) and list/grid toggle in Activity filter bar"
+```
+
+---
+
+### Task 9: Flutter — Grid View and State Badge in Activity Tab
+
+**Files:**
+- Modify: `flutter_app/lib/features/dashboard/dashboard_screen.dart`
+
+- [ ] **Step 1: Add StateBadge to `_PRTile`**
+
+Import `state_badge.dart`. In the `_PRTile` build method, add the `StateBadge` next to the type badge:
+
+```dart
+// After the existing type badge:
+const SizedBox(width: 4),
+StateBadge(state: widget.pr.state),
+```
+
+Apply reduced opacity for closed items — wrap the tile's Card in an `Opacity` widget:
+
+```dart
+Opacity(
+  opacity: widget.pr.state == 'open' ? 1.0 : 0.6,
+  child: Card(... existing tile ...),
+)
+```
+
+- [ ] **Step 2: Add StateBadge to `_IssueActivityTile`**
+
+Same pattern — add `StateBadge` and opacity wrapper.
+
+- [ ] **Step 3: Create `_ActivityGridTile` widget**
+
+A compact card for the grid view:
+
+```dart
+class _ActivityGridTile extends StatelessWidget {
+  final _ActivityItem item;
+  const _ActivityGridTile({required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    final (type, color, state, title, subtitle, severity, timestamp) = switch (item) {
+      _PRItem(:final pr) => ('PR', Colors.blue, pr.state, pr.title,
+          '${pr.repo} #${pr.number} · ${pr.author}',
+          pr.latestReview?.severity, pr.updatedAt),
+      _IssueItem(:final issue) => (
+          issue.latestReview?.actionTaken == 'auto_implement' ? 'DEV' : 'IT',
+          issue.latestReview?.actionTaken == 'auto_implement' ? Colors.green : Colors.orange,
+          issue.state, issue.title,
+          '${issue.repo} #${issue.number} · ${issue.author}',
+          issue.latestReview?.severity, issue.fetchedAt),
+    };
+    return Opacity(
+      opacity: state == 'open' ? 1.0 : 0.6,
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+                  decoration: BoxDecoration(color: color, borderRadius: BorderRadius.circular(3)),
+                  child: Text(type, style: const TextStyle(color: Colors.white, fontSize: 9, fontWeight: FontWeight.bold)),
+                ),
+                const Spacer(),
+                StateBadge(state: state),
+              ]),
+              const SizedBox(height: 6),
+              Text(title, maxLines: 2, overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500)),
+              const SizedBox(height: 4),
+              Text(subtitle, style: TextStyle(fontSize: 10, color: Colors.grey.shade500)),
+              const Spacer(),
+              Row(children: [
+                if (severity != null)
+                  SeverityBadge(severity: severity),
+                const Spacer(),
+                Text(_timeAgo(timestamp), style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+              ]),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Switch between list and grid in `_ActivityTab.build`**
+
+Replace the current item rendering with a view mode switch:
+
+```dart
+final viewMode = filters.viewMode;
+if (viewMode == 'grid')
+  SliverGrid(
+    gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+      maxCrossAxisExtent: 280,
+      childAspectRatio: 1.6,
+      crossAxisSpacing: 8,
+      mainAxisSpacing: 8,
+    ),
+    delegate: SliverChildBuilderDelegate(
+      (ctx, i) => _ActivityGridTile(item: filtered[i]),
+      childCount: filtered.length,
+    ),
+  )
+else
+  SliverList(
+    delegate: SliverChildBuilderDelegate(
+      (ctx, i) => switch (filtered[i]) {
+        _PRItem(:final pr) => _PRTile(pr: pr),
+        _IssueItem(:final issue) => _IssueActivityTile(issue: issue),
+      },
+      childCount: filtered.length,
+    ),
+  )
+```
+
+Note: this may require converting the current `Column` + `ListView` to a `CustomScrollView` with `SliverList`/`SliverGrid`. Follow the pattern from `repos_screen.dart` which already does this.
+
+- [ ] **Step 5: Add SSE listener for state changes**
+
+In the `_ActivityTab`, add listeners for the new SSE events:
+
+```dart
+ref.listen(sseStreamProvider, (_, next) {
+  next.whenData((event) {
+    if (event.type == 'pr_state_changed' || event.type == 'issue_state_changed') {
+      // Refresh the lists to pick up the state change
+      ref.invalidate(prsProvider);
+      ref.invalidate(issuesProvider);
+    }
+  });
+});
+```
+
+- [ ] **Step 6: Verify and commit**
+
+Run: `cd flutter_app && flutter analyze --no-fatal-infos && flutter test`
+
+```bash
+git add flutter_app/lib/features/dashboard/dashboard_screen.dart flutter_app/lib/shared/widgets/state_badge.dart
+git commit -m "feat(flutter): grid view, state badges, opacity for closed items, SSE state listener"
+```
+
+---
+
+### Task 10: End-to-End Verification
+
+**Files:** None (testing only)
+
+- [ ] **Step 1: Run all daemon tests**
+
+Run: `cd daemon && go test ./... -count=1`
+Expected: all pass
+
+- [ ] **Step 2: Run Flutter analysis and tests**
+
+Run: `cd flutter_app && flutter analyze --no-fatal-infos && flutter test`
+Expected: no issues, all tests pass
+
+- [ ] **Step 3: Build daemon binary**
+
+Run: `cd daemon && go build -o bin/heimdallm ./cmd/heimdallm`
+Expected: clean build
+
+- [ ] **Step 4: Build Flutter app**
+
+Run: `cd flutter_app && flutter build macos --release`
+Expected: clean build

--- a/docs/superpowers/specs/2026-04-22-state-tracking-filters-design.md
+++ b/docs/superpowers/specs/2026-04-22-state-tracking-filters-design.md
@@ -1,0 +1,162 @@
+# PR & Issue State Tracking with Filterable Views
+
+**Date**: 2026-04-22
+**Status**: Design approved
+
+## Problem
+
+Heimdallm only fetches open PRs/issues from GitHub (`state=open`). Once a PR is merged or an issue is closed, there's no record of the state change — the item stays as "open" in the DB forever. The Activity view has no state filter, no list/grid toggle, and filters reset on every app restart.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| State check process | Integrated in Tier 3 watch cycle | No new config, reuses existing infrastructure (1min cycle) |
+| Filter persistence | SharedPreferences (Flutter-only) | Simple, each client has its own filters |
+| View modes | Lista/mosaico in unified Activity tab | PRs + issues together, badge indicates type (PR/IT/DEV) |
+| State values | Open / Closed (merged → closed) | Unified for PRs and issues, simpler UI |
+
+## Daemon — State Reconciliation in Tier 3
+
+### Watch cycle state refresh
+
+Each Tier 3 cycle (~1min) adds a state reconciliation step before processing changes:
+
+For each PR in DB with `state="open"`:
+1. `GET /repos/{owner}/{repo}/pulls/{number}` → read current state
+2. If state changed (closed/merged) → `UPDATE prs SET state='closed' WHERE id=<id>`
+3. Merged PRs are stored as `state="closed"` (unified per design decision)
+
+For each issue in DB with `state="open"`:
+1. `GET /repos/{owner}/{repo}/issues/{number}` → read current state
+2. If state changed → `UPDATE issues SET state='closed' WHERE id=<id>`
+
+### Polling exclusion
+
+Items with `state != "open"` are excluded from:
+- Tier 2 (PR review triggering) — don't review closed PRs
+- Tier 3 (watch cycle) — don't re-check items already closed
+- Issue fetcher — don't re-process closed issues
+
+### Rate limit protection
+
+- Only verify items with `state="open"` and `fetched_at` older than 5 minutes
+- Maximum 50 items per cycle (oldest first, round-robin)
+- Uses the existing rate limiter accounting
+
+### SSE events for real-time UI updates
+
+When state changes are detected, the daemon emits:
+- `pr_state_changed` with `{pr_id, state}`
+- `issue_state_changed` with `{issue_id, state}`
+
+## API — State Filter
+
+### GET /prs and GET /issues — `state` query parameter
+
+```
+GET /prs?state=open          → only open
+GET /prs?state=closed        → only closed
+GET /prs                     → all (no filter)
+GET /issues?state=open,closed → explicit multi-value
+```
+
+### Store layer
+
+```go
+func (s *Store) ListPRs(states ...string) ([]*PR, error)
+func (s *Store) ListIssues(states ...string) ([]*TrackedIssue, error)
+```
+
+Empty `states` returns all. Non-empty filters with `WHERE state IN (?)`. Dismissed items remain excluded by default: `WHERE dismissed = 0 AND state IN (?)`.
+
+## Flutter — Persistent Filters and List/Grid View
+
+### Extended Activity filter bar
+
+The existing `ActivityFilterBar` gains:
+
+1. **State chips**: `Open` / `Closed` — multi-select (both active = all). Default: `Open` active.
+2. **View toggle**: list/grid icons at the right end of the bar (same pattern as Repos tab).
+
+Bar layout: `[Sort] [Type chips: PR/IT/DEV] [State chips: Open/Closed] [Org] [Repo] [Search] [List/Grid toggle]`
+
+### Persistence (SharedPreferences)
+
+New keys:
+- `activity_state_filter` → `"open"`, `"closed"`, `"open,closed"` (default: `"open"`)
+- `activity_view_mode` → `"list"` or `"grid"` (default: `"list"`)
+
+Existing ephemeral filters migrate to SharedPreferences:
+- `activity_type_filter` → `"pr,it,dev"` (default: empty = all)
+- `activity_org_filter` → `"org1,org2"` (default: empty = all)
+- `activity_repo_filter` → `"org/repo1,org/repo2"` (default: empty = all)
+
+All loaded on build, saved on every change.
+
+### Grid mode (mosaic)
+
+Each grid item is a compact card:
+- Type badge (PR/IT/DEV) with color — top left
+- State badge (Open/Closed) — top right
+- Title (truncated to 2 lines)
+- `repo#number` + author
+- Severity badge if review exists
+- Relative timestamp
+
+### List mode
+
+Current list tiles gain a state badge (Open/Closed) inline next to the existing type badge.
+
+### State badge styling
+
+- **Open**: green background, white text, open circle icon
+- **Closed**: grey/purple background, white text, check icon
+
+### Closed items visual treatment
+
+- Items with `state=closed` render at **reduced opacity** (0.6) in both modes
+- Action buttons (Review, Promote, Dismiss) remain available on closed items
+- Default filter is `Open` — user must activate `Closed` chip to see them
+
+### Real-time state updates
+
+Flutter listens for `pr_state_changed` and `issue_state_changed` SSE events and updates the tile inline without reloading the entire list.
+
+## Files Affected
+
+### Daemon (Go)
+
+| File | Change |
+|------|--------|
+| `daemon/internal/pipeline/pipeline.go` | State reconciliation in Tier 3 watch cycle; exclude closed from polling |
+| `daemon/internal/github/client.go` | Add `FetchPRState(repo, number)` and `FetchIssueState(repo, number)` helpers |
+| `daemon/internal/store/prs.go` | `ListPRs(states ...string)` with optional WHERE clause; `UpdatePRState(id, state)` |
+| `daemon/internal/store/issues.go` | `ListIssues(states ...string)` with optional WHERE clause; `UpdateIssueState(id, state)` |
+| `daemon/internal/server/handlers.go` | Parse `?state=` query param on GET /prs and GET /issues |
+| `daemon/internal/sse/broker.go` | Add `EventPRStateChanged` and `EventIssueStateChanged` event types |
+
+### Flutter (Dart)
+
+| File | Change |
+|------|--------|
+| `flutter_app/lib/features/dashboard/dashboard_providers.dart` | Persist all filters to SharedPreferences; add state filter and view mode providers |
+| `flutter_app/lib/features/dashboard/activity_filter_bar.dart` | Add state chips (Open/Closed) and list/grid toggle |
+| `flutter_app/lib/features/dashboard/activity_filters.dart` | Add `states` and `viewMode` fields to `ActivityFilters` |
+| `flutter_app/lib/features/dashboard/dashboard_screen.dart` | Grid view builder; state badge on tiles; SSE listener for state changes; opacity for closed items |
+| `flutter_app/lib/shared/widgets/state_badge.dart` | New widget: Open/Closed badge with icon + color |
+| `flutter_app/lib/core/api/api_client.dart` | Pass `?state=` param on fetchPRs and fetchIssues |
+
+## Testing Strategy
+
+### Daemon
+- Unit test for state reconciliation: mock GitHub returning closed/merged → verify DB updated
+- Unit test for `ListPRs(states...)`: verify SQL WHERE clause
+- Unit test for polling exclusion: closed items skipped in Tier 2/3
+- Integration test for GET /prs?state=open: only open returned
+
+### Flutter
+- Unit test for filter persistence: save/load SharedPreferences round-trip
+- Widget test for state chips: toggle, verify filter updates
+- Widget test for grid/list toggle: verify view mode changes
+- Widget test for state badge: correct color/icon for open vs closed

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -43,8 +43,12 @@ class ApiClient {
     }
   }
 
-  Future<List<PR>> fetchPRs() async {
-    final resp = await _client.get(_uri('/prs'), headers: await _authHeaders());
+  Future<List<PR>> fetchPRs({List<String> states = const []}) async {
+    var path = '/prs';
+    if (states.isNotEmpty) {
+      path += '?state=${states.join(',')}';
+    }
+    final resp = await _client.get(_uri(path), headers: await _authHeaders());
     if (resp.statusCode != 200) {
       throw ApiException('GET /prs failed: ${resp.statusCode}');
     }
@@ -250,8 +254,12 @@ class ApiClient {
 
   // ── Issues ────────────────────────────────────────────────────────────
 
-  Future<List<TrackedIssue>> fetchIssues() async {
-    final resp = await _client.get(_uri('/issues'), headers: await _authHeaders());
+  Future<List<TrackedIssue>> fetchIssues({List<String> states = const []}) async {
+    var path = '/issues';
+    if (states.isNotEmpty) {
+      path += '?state=${states.join(',')}';
+    }
+    final resp = await _client.get(_uri(path), headers: await _authHeaders());
     if (resp.statusCode != 200) {
       throw ApiException('GET /issues failed: ${resp.statusCode}');
     }

--- a/flutter_app/lib/features/dashboard/activity_filter_bar.dart
+++ b/flutter_app/lib/features/dashboard/activity_filter_bar.dart
@@ -92,7 +92,7 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
                     return orgs.contains(org);
                   }).toSet();
                 }
-                notifier.state = filters.copyWith(orgs: orgs, repos: repos);
+                notifier.update(filters.copyWith(orgs: orgs, repos: repos));
               },
             ),
 
@@ -106,7 +106,7 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
               displayFn: (v) => v.contains('/') ? v.split('/').last : v,
               onChanged: (repos) => ref
                   .read(activityFiltersProvider.notifier)
-                  .state = filters.copyWith(repos: repos),
+                  .update(filters.copyWith(repos: repos)),
             ),
 
           // ── Search field ────────────────────────────────────────────
@@ -136,7 +136,7 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
               ),
               onChanged: (v) => ref
                   .read(activityFiltersProvider.notifier)
-                  .state = filters.copyWith(search: v),
+                  .update(filters.copyWith(search: v)),
             ),
           ),
 
@@ -144,8 +144,8 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
           if (filters.hasFilters)
             GestureDetector(
               onTap: () {
-                ref.read(activityFiltersProvider.notifier).state =
-                    const ActivityFilters();
+                ref.read(activityFiltersProvider.notifier).update(
+                    const ActivityFilters());
                 _searchController.clear();
               },
               child: Chip(
@@ -212,8 +212,8 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
       onSelected: (_) {
         final types = Set<String>.from(filters.types);
         selected ? types.remove(type) : types.add(type);
-        ref.read(activityFiltersProvider.notifier).state =
-            filters.copyWith(types: types);
+        ref.read(activityFiltersProvider.notifier).update(
+            filters.copyWith(types: types));
       },
     );
   }

--- a/flutter_app/lib/features/dashboard/activity_filter_bar.dart
+++ b/flutter_app/lib/features/dashboard/activity_filter_bar.dart
@@ -164,7 +164,6 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
             ),
 
           // ── View toggle ─────────────────────────────────────────────
-          const Spacer(),
           IconButton(
             icon: const Icon(Icons.view_list, size: 18),
             color: filters.viewMode == 'list'

--- a/flutter_app/lib/features/dashboard/activity_filter_bar.dart
+++ b/flutter_app/lib/features/dashboard/activity_filter_bar.dart
@@ -75,6 +75,12 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
           _typeChip('it', 'IT', Colors.orange, filters),
           _typeChip('dev', 'DEV', Colors.green, filters),
 
+          const SizedBox(width: 8),
+          // ── State chips ─────────────────────────────────────────────
+          _stateChip('Open', 'open', Colors.green),
+          const SizedBox(width: 4),
+          _stateChip('Closed', 'closed', Colors.grey),
+
           // ── Org multi-select ────────────────────────────────────────
           if (_allOrgs.isNotEmpty)
             _multiSelectPopup(
@@ -156,6 +162,31 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
                 side: BorderSide(color: Colors.red.shade400.withValues(alpha: 0.4)),
               ),
             ),
+
+          // ── View toggle ─────────────────────────────────────────────
+          const Spacer(),
+          IconButton(
+            icon: const Icon(Icons.view_list, size: 18),
+            color: filters.viewMode == 'list'
+                ? Theme.of(context).colorScheme.primary
+                : Colors.grey,
+            visualDensity: VisualDensity.compact,
+            tooltip: 'List view',
+            onPressed: () => ref
+                .read(activityFiltersProvider.notifier)
+                .update(filters.copyWith(viewMode: 'list')),
+          ),
+          IconButton(
+            icon: const Icon(Icons.grid_view, size: 18),
+            color: filters.viewMode == 'grid'
+                ? Theme.of(context).colorScheme.primary
+                : Colors.grey,
+            visualDensity: VisualDensity.compact,
+            tooltip: 'Grid view',
+            onPressed: () => ref
+                .read(activityFiltersProvider.notifier)
+                .update(filters.copyWith(viewMode: 'grid')),
+          ),
         ],
       ),
     );
@@ -214,6 +245,28 @@ class _ActivityFilterBarState extends ConsumerState<ActivityFilterBar> {
         selected ? types.remove(type) : types.add(type);
         ref.read(activityFiltersProvider.notifier).update(
             filters.copyWith(types: types));
+      },
+    );
+  }
+
+  // ── State chip ──────────────────────────────────────────────────────────────
+
+  Widget _stateChip(String label, String value, Color color) {
+    final filters = ref.watch(activityFiltersProvider);
+    final selected = filters.states.contains(value);
+    return FilterChip(
+      label: Text(label,
+          style: TextStyle(fontSize: 11, color: selected ? Colors.white : null)),
+      selected: selected,
+      selectedColor: color,
+      checkmarkColor: Colors.white,
+      visualDensity: VisualDensity.compact,
+      onSelected: (v) {
+        final current = Set<String>.from(filters.states);
+        v ? current.add(value) : current.remove(value);
+        ref.read(activityFiltersProvider.notifier).update(
+              filters.copyWith(states: current),
+            );
       },
     );
   }

--- a/flutter_app/lib/features/dashboard/activity_filters.dart
+++ b/flutter_app/lib/features/dashboard/activity_filters.dart
@@ -1,41 +1,98 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Filter state for the unified Activity view.
 class ActivityFilters {
   final Set<String> types; // 'pr', 'it', 'dev' -- empty = show all
   final Set<String> orgs; // empty = all orgs
   final Set<String> repos; // empty = all repos
+  final Set<String> states; // 'open', 'closed' — empty = all
   final String search; // free text search
+  final String viewMode; // 'list' or 'grid'
 
   const ActivityFilters({
     this.types = const {},
     this.orgs = const {},
     this.repos = const {},
+    this.states = const {'open'}, // default: only open
     this.search = '',
+    this.viewMode = 'list',
   });
 
   ActivityFilters copyWith({
     Set<String>? types,
     Set<String>? orgs,
     Set<String>? repos,
+    Set<String>? states,
     String? search,
+    String? viewMode,
   }) =>
       ActivityFilters(
         types: types ?? this.types,
         orgs: orgs ?? this.orgs,
         repos: repos ?? this.repos,
+        states: states ?? this.states,
         search: search ?? this.search,
+        viewMode: viewMode ?? this.viewMode,
       );
 
   bool get hasFilters =>
       types.isNotEmpty ||
       orgs.isNotEmpty ||
       repos.isNotEmpty ||
+      !(states.length == 1 && states.contains('open')) ||
       search.isNotEmpty;
 }
 
+class ActivityFiltersNotifier extends Notifier<ActivityFilters> {
+  static const _typesKey = 'activity_type_filter';
+  static const _orgsKey = 'activity_org_filter';
+  static const _reposKey = 'activity_repo_filter';
+  static const _statesKey = 'activity_state_filter';
+  static const _viewModeKey = 'activity_view_mode';
+
+  @override
+  ActivityFilters build() {
+    _loadAsync();
+    return const ActivityFilters();
+  }
+
+  Future<void> _loadAsync() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = ActivityFilters(
+      types: _loadSet(prefs, _typesKey),
+      orgs: _loadSet(prefs, _orgsKey),
+      repos: _loadSet(prefs, _reposKey),
+      states: _loadSet(prefs, _statesKey, defaultVal: {'open'}),
+      viewMode: prefs.getString(_viewModeKey) ?? 'list',
+    );
+  }
+
+  Set<String> _loadSet(SharedPreferences p, String key,
+      {Set<String>? defaultVal}) {
+    final v = p.getString(key);
+    if (v == null || v.isEmpty) return defaultVal ?? {};
+    return v.split(',').toSet();
+  }
+
+  void update(ActivityFilters filters) {
+    state = filters;
+    _saveAsync(filters);
+  }
+
+  Future<void> _saveAsync(ActivityFilters f) async {
+    final prefs = await SharedPreferences.getInstance();
+    prefs.setString(_typesKey, f.types.join(','));
+    prefs.setString(_orgsKey, f.orgs.join(','));
+    prefs.setString(_reposKey, f.repos.join(','));
+    prefs.setString(_statesKey, f.states.join(','));
+    prefs.setString(_viewModeKey, f.viewMode);
+  }
+}
+
 final activityFiltersProvider =
-    StateProvider<ActivityFilters>((ref) => const ActivityFilters());
+    NotifierProvider<ActivityFiltersNotifier, ActivityFilters>(
+        ActivityFiltersNotifier.new);
 
 /// Sort mode for the Activity view — shared between dashboard_screen
 /// and activity_filter_bar to avoid duplication.

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -8,6 +8,7 @@ import '../../core/platform/platform_services_provider.dart';
 import '../../main.dart' show sendPRNotification;
 import '../issues/issues_providers.dart';
 import '../stats/stats_filters.dart';
+import 'activity_filters.dart';
 
 final apiClientProvider = Provider<ApiClient>((ref) {
   return ApiClient(platform: ref.watch(platformServicesProvider));
@@ -154,8 +155,9 @@ final prsProvider = FutureProvider<List<PR>>((ref) async {
   // Watch meProvider so the tray is rebuilt (with correct author filter)
   // as soon as the username loads after startup.
   ref.watch(meProvider);
+  final filters = ref.watch(activityFiltersProvider);
   final api = ref.watch(apiClientProvider);
-  final prs = await api.fetchPRs();
+  final prs = await api.fetchPRs(states: filters.states.toList());
   _rebuildTray(ref, prs);
   _reconcileReviewingPRs(ref, prs);
   return prs;

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/models/pr.dart';
 import '../../core/models/tracked_issue.dart';
 import '../../shared/widgets/severity_badge.dart';
+import '../../shared/widgets/state_badge.dart';
 import '../../shared/widgets/toast.dart';
 import '../../shared/widgets/type_badge.dart';
 import '../activity/activity_screen.dart';
@@ -182,6 +183,11 @@ int _itemPriorityKey(_ActivityItem item) => switch (item) {
         },
 };
 
+String _itemState(_ActivityItem item) => switch (item) {
+  _PRItem(:final pr)       => pr.state,
+  _IssueItem(:final issue) => issue.state,
+};
+
 bool _matchesFilters(_ActivityItem item, ActivityFilters filters) {
   // Type filter
   if (filters.types.isNotEmpty) {
@@ -197,6 +203,10 @@ bool _matchesFilters(_ActivityItem item, ActivityFilters filters) {
   // Repo filter
   if (filters.repos.isNotEmpty) {
     if (!filters.repos.contains(_itemRepo(item))) return false;
+  }
+  // State filter
+  if (filters.states.isNotEmpty) {
+    if (!filters.states.contains(_itemState(item))) return false;
   }
   // Search
   if (filters.search.isNotEmpty) {
@@ -234,6 +244,16 @@ class _ActivityTab extends ConsumerStatefulWidget {
 class _ActivityTabState extends ConsumerState<_ActivityTab> {
   @override
   Widget build(BuildContext context) {
+    // SSE listener for state changes (open/closed transitions)
+    ref.listen(sseStreamProvider, (_, next) {
+      next.whenData((event) {
+        if (event.type == 'pr_state_changed' || event.type == 'issue_state_changed') {
+          ref.invalidate(prsProvider);
+          ref.invalidate(issuesProvider);
+        }
+      });
+    });
+
     final prsAsync    = ref.watch(prsProvider);
     final issuesAsync = ref.watch(issuesProvider);
     final sort        = ref.watch(reviewsSortProvider);
@@ -272,34 +292,66 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
       return const Center(child: Text('No activity yet'));
     }
 
+    final viewMode = filters.viewMode;
+
+    // Build filter bar + count header (shared between list and grid)
+    final header = [
+      ActivityFilterBar(
+        allRepos: allRepos,
+        sort: sort,
+        onSortChanged: (mode) => ref.read(reviewsSortProvider.notifier).set(mode),
+      ),
+      if (filters.hasFilters)
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+          child: Text(
+            '${filtered.length} item${filtered.length == 1 ? '' : 's'}',
+            style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+          ),
+        ),
+    ];
+
+    if (filtered.isEmpty && filters.hasFilters) {
+      return Column(
+        children: [
+          ...header,
+          const Expanded(
+            child: Center(child: Text('No items match the current filters.')),
+          ),
+        ],
+      );
+    }
+
+    if (viewMode == 'grid') {
+      return Column(
+        children: [
+          ...header,
+          Expanded(
+            child: GridView.builder(
+              padding: const EdgeInsets.all(8),
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 300,
+                childAspectRatio: 1.6,
+                crossAxisSpacing: 8,
+                mainAxisSpacing: 8,
+              ),
+              itemCount: filtered.length,
+              itemBuilder: (ctx, i) => _ActivityGridTile(item: filtered[i]),
+            ),
+          ),
+        ],
+      );
+    }
+
+    // Default: list mode
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 8),
       children: [
-        // Sort + Filter bar — single unified row
-        ActivityFilterBar(
-          allRepos: allRepos,
-          sort: sort,
-          onSortChanged: (mode) => ref.read(reviewsSortProvider.notifier).set(mode),
-        ),
-        // Filtered count when filters are active
-        if (filters.hasFilters)
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
-            child: Text(
-              '${filtered.length} item${filtered.length == 1 ? '' : 's'}',
-              style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
-            ),
-          ),
-        if (filtered.isEmpty && filters.hasFilters)
-          const Padding(
-            padding: EdgeInsets.symmetric(vertical: 32),
-            child: Center(child: Text('No items match the current filters.')),
-          )
-        else
-          ...filtered.map((item) => switch (item) {
-            _PRItem(:final pr) => _PRTile(pr: pr),
-            _IssueItem(:final issue) => _IssueActivityTile(issue: issue),
-          }),
+        ...header,
+        ...filtered.map((item) => switch (item) {
+          _PRItem(:final pr) => _PRTile(pr: pr),
+          _IssueItem(:final issue) => _IssueActivityTile(issue: issue),
+        }),
       ],
     );
   }
@@ -396,7 +448,9 @@ class _PRTileState extends ConsumerState<_PRTile> {
     final reviewed = pr.latestReview != null;
     final isReviewing = ref.watch(reviewingPRsProvider).containsKey(_reviewKey);
 
-    return Card(
+    return Opacity(
+      opacity: pr.state == 'open' ? 1.0 : 0.6,
+      child: Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
@@ -418,11 +472,14 @@ class _PRTileState extends ConsumerState<_PRTile> {
                   borderRadius: BorderRadius.circular(2),
                 ),
               ),
-              // Type badge
+              // Type badge + state badge
               const Padding(
-                padding: EdgeInsets.only(right: 10),
+                padding: EdgeInsets.only(right: 6),
                 child: TypeBadge(type: 'pr'),
               ),
+              const SizedBox(width: 4),
+              StateBadge(state: pr.state),
+              const SizedBox(width: 4),
               // Title + subtitle
               Expanded(
                 child: Column(
@@ -483,6 +540,7 @@ class _PRTileState extends ConsumerState<_PRTile> {
           ),
         ),
       ),
+      ),
     );
   }
 
@@ -514,7 +572,9 @@ class _IssueActivityTile extends StatelessWidget {
     final reviewed = issue.latestReview != null;
     final severity = issue.latestReview?.severity ?? '';
 
-    return Card(
+    return Opacity(
+      opacity: issue.state == 'open' ? 1.0 : 0.6,
+      child: Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
@@ -531,11 +591,14 @@ class _IssueActivityTile extends StatelessWidget {
                   borderRadius: BorderRadius.circular(2),
                 ),
               ),
-              // Type badge
+              // Type badge + state badge
               Padding(
-                padding: const EdgeInsets.only(right: 10),
+                padding: const EdgeInsets.only(right: 6),
                 child: TypeBadge(type: _type),
               ),
+              const SizedBox(width: 4),
+              StateBadge(state: issue.state),
+              const SizedBox(width: 4),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -567,6 +630,7 @@ class _IssueActivityTile extends StatelessWidget {
           ),
         ),
       ),
+      ),
     );
   }
 
@@ -577,5 +641,86 @@ class _IssueActivityTile extends StatelessWidget {
       case 'medium':   return Colors.orange.shade700;
       default:         return Colors.green.shade700;
     }
+  }
+}
+
+// ── Grid tile ─────────────────────────────────────────────────────────────────
+
+class _ActivityGridTile extends StatelessWidget {
+  final _ActivityItem item;
+  const _ActivityGridTile({required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    final String type;
+    final Color color;
+    final String state;
+    final String title;
+    final String subtitle;
+    final String? severity;
+    final DateTime timestamp;
+
+    switch (item) {
+      case _PRItem(:final pr):
+        type = 'PR';
+        color = Colors.blue;
+        state = pr.state;
+        title = pr.title;
+        subtitle = '${pr.repo} #${pr.number} · ${pr.author}';
+        severity = pr.latestReview?.severity;
+        timestamp = pr.updatedAt;
+      case _IssueItem(:final issue):
+        final isDev = issue.latestReview?.actionTaken == 'auto_implement';
+        type = isDev ? 'DEV' : 'IT';
+        color = isDev ? Colors.green : Colors.orange;
+        state = issue.state;
+        title = issue.title;
+        subtitle = '${issue.repo} #${issue.number} · ${issue.author}';
+        severity = issue.latestReview?.severity;
+        timestamp = issue.fetchedAt;
+    }
+
+    return Opacity(
+      opacity: state == 'open' ? 1.0 : 0.6,
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+                  decoration: BoxDecoration(color: color, borderRadius: BorderRadius.circular(3)),
+                  child: Text(type, style: const TextStyle(color: Colors.white, fontSize: 9, fontWeight: FontWeight.bold)),
+                ),
+                const Spacer(),
+                StateBadge(state: state),
+              ]),
+              const SizedBox(height: 6),
+              Text(title, maxLines: 2, overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500)),
+              const SizedBox(height: 4),
+              Text(subtitle, style: TextStyle(fontSize: 10, color: Colors.grey.shade500),
+                  maxLines: 1, overflow: TextOverflow.ellipsis),
+              const Spacer(),
+              Row(children: [
+                if (severity != null)
+                  SeverityBadge(severity: severity),
+                const Spacer(),
+                Text(_timeAgo(timestamp), style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+              ]),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _timeAgo(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
   }
 }

--- a/flutter_app/lib/features/issues/issues_providers.dart
+++ b/flutter_app/lib/features/issues/issues_providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/tracked_issue.dart';
+import '../dashboard/activity_filters.dart';
 import '../dashboard/dashboard_providers.dart';
 
 /// Counter incremented by SSE events to trigger issue list refresh.
@@ -13,8 +14,9 @@ final promotingIssuesProvider = StateProvider<Set<String>>((ref) => const {});
 
 final issuesProvider = FutureProvider<List<TrackedIssue>>((ref) async {
   ref.watch(issueListRefreshProvider);
+  final filters = ref.watch(activityFiltersProvider);
   final api = ref.watch(apiClientProvider);
-  return api.fetchIssues();
+  return api.fetchIssues(states: filters.states.toList());
 });
 
 final issueDetailProvider =

--- a/flutter_app/lib/shared/widgets/state_badge.dart
+++ b/flutter_app/lib/shared/widgets/state_badge.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class StateBadge extends StatelessWidget {
+  final String state;
+  const StateBadge({super.key, required this.state});
+
+  bool get _isOpen => state == 'open';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: _isOpen ? Colors.green.shade700 : Colors.grey.shade600,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            _isOpen ? Icons.circle_outlined : Icons.check_circle,
+            size: 12,
+            color: Colors.white,
+          ),
+          const SizedBox(width: 4),
+          Text(
+            _isOpen ? 'Open' : 'Closed',
+            style: const TextStyle(color: Colors.white, fontSize: 10, fontWeight: FontWeight.w600),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- **Daemon**: Tier 3 watch cycle detects closed/merged PRs and issues, updates DB state, emits SSE events. Closed items naturally drop out of polling via backoff+eviction.
- **API**: `GET /prs?state=open` and `GET /issues?state=closed` — optional comma-separated state filter.
- **Flutter**: Persistent activity filters (SharedPreferences), Open/Closed state chips, list/grid view toggle, StateBadge widget, grid tile layout, reduced opacity for closed items, real-time SSE state updates.

## Test plan

- [ ] `cd daemon && go test ./... -count=1` — all pass
- [ ] `flutter analyze --no-fatal-infos` — no issues
- [ ] `flutter test` — 120 tests pass
- [ ] Toggle Open/Closed chips → list filters correctly
- [ ] Switch list/grid → both modes render with state badges
- [ ] Filters persist across tab changes and app restart
- [ ] Closed items show at 0.6 opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)