### PR TITLE
feat: implement #238 — feat: comment-based control markers + pre-push state check to prevent duplicate processing

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -177,7 +177,7 @@ func main() {
 	} else {
 		slog.Warn("could not resolve bot login for re-review context", "err", err)
 	}
-	issueFetcher := issuepipeline.NewFetcher(ghClient, s, issuePipe)
+	issueFetcher := issuepipeline.NewFetcher(ghClient, ghClient, s, issuePipe)
 	srv := server.New(s, broker, p, apiToken)
 	srv.SetConfigPath(cfgPath)
 

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -56,6 +56,12 @@ type issueDedupStore interface {
 	CountFailedAutoImplement(issueID int64) (int, error)
 }
 
+// issueMarkerFetcher fetches comments for an issue so the fetcher can scan
+// for control markers (done/skip/retry) during the dedup check.
+type issueMarkerFetcher interface {
+	FetchComments(repo string, number int) ([]github.Comment, error)
+}
+
 // OptionsFn lets the caller map each classified issue to its RunOptions.
 // In production main.go resolves per-repo AI config here; tests can return a
 // constant.
@@ -65,14 +71,17 @@ type OptionsFn func(issue *github.Issue) RunOptions
 // without new activity, dispatch the rest to the pipeline.
 type Fetcher struct {
 	client   IssuesFetcher
+	comments issueMarkerFetcher
 	store    issueDedupStore
 	pipeline PipelineRunner
 }
 
 // NewFetcher wires the orchestrator. All dependencies are interfaces so
-// tests inject lightweight fakes.
-func NewFetcher(client IssuesFetcher, s issueDedupStore, p PipelineRunner) *Fetcher {
-	return &Fetcher{client: client, store: s, pipeline: p}
+// tests inject lightweight fakes. The comments parameter provides comment
+// fetching for control-marker scanning (#238); pass the same *github.Client
+// used for issue fetching.
+func NewFetcher(client IssuesFetcher, comments issueMarkerFetcher, s issueDedupStore, p PipelineRunner) *Fetcher {
+	return &Fetcher{client: client, comments: comments, store: s, pipeline: p}
 }
 
 // ProcessRepo fetches every eligible issue for one repo and dispatches it to
@@ -150,6 +159,28 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 		}
 		return false, "", err
 	}
+
+	// Comment-based control markers (#238). Checked before the dismiss and
+	// dedup gates so a retry marker can override all of them. The API call
+	// is skipped when the comment fetcher is nil (legacy callers / tests
+	// that pre-date marker support).
+	if f.comments != nil {
+		comments, cmErr := f.comments.FetchComments(issue.Repo, issue.Number)
+		if cmErr != nil {
+			slog.Warn("issues fetcher: marker scan failed, falling through to dedup checks",
+				"repo", issue.Repo, "number", issue.Number, "err", cmErr)
+		} else {
+			switch ScanMarkers(comments) {
+			case MarkerResultRetry:
+				return false, "", nil // force reprocess
+			case MarkerResultSkip:
+				return true, "skip marker", nil
+			case MarkerResultDone:
+				return true, "done marker", nil
+			}
+		}
+	}
+
 	if row.Dismissed {
 		return true, "dismissed", nil
 	}

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,6 +19,19 @@ import (
 type fakeClient struct {
 	issues []*github.Issue
 	err    error
+}
+
+type fakeMarkerFetcher struct {
+	commentsByKey map[string][]github.Comment
+	err           error
+}
+
+func (f *fakeMarkerFetcher) FetchComments(repo string, number int) ([]github.Comment, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	key := fmt.Sprintf("%s#%d", repo, number)
+	return f.commentsByKey[key], nil
 }
 
 func (c *fakeClient) FetchIssues(repo string, cfg config.IssueTrackingConfig, authenticatedUser string) ([]*github.Issue, error) {
@@ -109,7 +123,7 @@ func enabledCfg() config.IssueTrackingConfig {
 func TestFetcher_NoOpWhenDisabled(t *testing.T) {
 	client := &fakeClient{issues: []*github.Issue{fixture(1, time.Now())}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(client, &fakeDedup{}, p)
+	f := issues.NewFetcher(client, nil, &fakeDedup{}, p)
 
 	processed, err := f.ProcessRepo(context.Background(), "org/repo", config.IssueTrackingConfig{Enabled: false}, "alice", noOpts)
 	if err != nil {
@@ -121,7 +135,7 @@ func TestFetcher_NoOpWhenDisabled(t *testing.T) {
 }
 
 func TestFetcher_NilOptionsFnIsError(t *testing.T) {
-	f := issues.NewFetcher(&fakeClient{}, &fakeDedup{}, &fakePipeline{})
+	f := issues.NewFetcher(&fakeClient{}, nil, &fakeDedup{}, &fakePipeline{})
 	_, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", nil)
 	if err == nil {
 		t.Fatal("expected error for nil OptionsFn")
@@ -130,7 +144,7 @@ func TestFetcher_NilOptionsFnIsError(t *testing.T) {
 
 func TestFetcher_FetchErrorIsFatalForThisRun(t *testing.T) {
 	client := &fakeClient{err: errors.New("github down")}
-	f := issues.NewFetcher(client, &fakeDedup{}, &fakePipeline{})
+	f := issues.NewFetcher(client, nil, &fakeDedup{}, &fakePipeline{})
 
 	_, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if err == nil {
@@ -141,7 +155,7 @@ func TestFetcher_FetchErrorIsFatalForThisRun(t *testing.T) {
 func TestFetcher_DispatchesUnprocessedIssues(t *testing.T) {
 	client := &fakeClient{issues: []*github.Issue{fixture(1, time.Now()), fixture(2, time.Now())}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(client, &fakeDedup{byGithubID: map[int64]dedupEntry{}}, p)
+	f := issues.NewFetcher(client, nil, &fakeDedup{byGithubID: map[int64]dedupEntry{}}, p)
 
 	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if err != nil {
@@ -159,7 +173,7 @@ func TestFetcher_SkipsDismissedIssues(t *testing.T) {
 	}}
 	client := &fakeClient{issues: []*github.Issue{issue}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(client, dedup, p)
+	f := issues.NewFetcher(client, nil, dedup, p)
 
 	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if processed != 0 || len(p.calls) != 0 {
@@ -177,7 +191,7 @@ func TestFetcher_SkipsIssueAlreadyReviewedWithoutNewActivity(t *testing.T) {
 			review: &store.IssueReview{IssueID: 10, CreatedAt: reviewedAt, CommentedAt: commentedAt},
 		},
 	}}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, &fakePipeline{})
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, &fakePipeline{})
 
 	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if processed != 0 {
@@ -196,7 +210,7 @@ func TestFetcher_RerunsIssueWithNewActivityAfterGrace(t *testing.T) {
 		},
 	}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, p)
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, p)
 
 	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if processed != 1 {
@@ -215,7 +229,7 @@ func TestFetcher_SlowTriageDoesNotReloop(t *testing.T) {
 			review: &store.IssueReview{IssueID: 10, CreatedAt: createdAt, CommentedAt: commentedAt},
 		},
 	}}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, &fakePipeline{})
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, &fakePipeline{})
 
 	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if processed != 0 {
@@ -232,7 +246,7 @@ func TestFetcher_FallsBackToCreatedAtWhenCommentedAtZero(t *testing.T) {
 			review: &store.IssueReview{IssueID: 10, CreatedAt: reviewedAt}, // CommentedAt zero
 		},
 	}}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, &fakePipeline{})
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, &fakePipeline{})
 
 	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if processed != 0 {
@@ -246,7 +260,7 @@ func TestFetcher_RunsFirstTimeIssueKnownButNeverReviewed(t *testing.T) {
 		issue.ID: {row: &store.Issue{ID: 10, GithubID: issue.ID}}, // no review yet
 	}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, p)
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, p)
 
 	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if processed != 1 {
@@ -261,7 +275,7 @@ func TestFetcher_PipelineErrorIsLoggedNotPropagated(t *testing.T) {
 	issue2 := fixture(2, time.Now())
 	client := &fakeClient{issues: []*github.Issue{issue1, issue2}}
 	p := &fakePipeline{runErr: errors.New("LLM timeout")}
-	f := issues.NewFetcher(client, &fakeDedup{byGithubID: map[int64]dedupEntry{}}, p)
+	f := issues.NewFetcher(client, nil, &fakeDedup{byGithubID: map[int64]dedupEntry{}}, p)
 
 	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if err != nil {
@@ -281,7 +295,7 @@ func TestFetcher_DedupLookupErrorTreatedAsUnprocessed(t *testing.T) {
 		issue.ID: {rowErr: errors.New("store unavailable")},
 	}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, p)
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, p)
 
 	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if processed != 1 {
@@ -307,7 +321,7 @@ func TestFetcher_SkipsIssueAfterMaxAutoImplementFailures(t *testing.T) {
 		},
 	}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, p)
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, p)
 
 	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if err != nil {
@@ -331,7 +345,7 @@ func TestFetcher_DoesNotSkipBelowMaxAutoImplementFailures(t *testing.T) {
 		},
 	}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, p)
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, p)
 
 	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if processed != 1 {
@@ -352,10 +366,112 @@ func TestFetcher_CountFailedAutoImplErrDoesNotSkip(t *testing.T) {
 		},
 	}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, dedup, p)
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, p)
 
 	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if processed != 1 {
 		t.Errorf("count error must not block the pipeline, got processed=%d", processed)
+	}
+}
+
+// ── comment-based control markers (#238) ────────────────────────────────────
+
+func TestFetcher_SkipsDoneMarker(t *testing.T) {
+	issue := fixture(1, time.Now())
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {row: &store.Issue{ID: 10, GithubID: issue.ID}},
+	}}
+	mf := &fakeMarkerFetcher{commentsByKey: map[string][]github.Comment{
+		"org/repo#1": {{Body: "<!-- heimdallm:done -->\n✅ done", CreatedAt: time.Now()}},
+	}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
+
+	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 0 || len(p.calls) != 0 {
+		t.Errorf("done marker should skip issue, got processed=%d calls=%v", processed, p.calls)
+	}
+}
+
+func TestFetcher_SkipsSkipMarker(t *testing.T) {
+	issue := fixture(1, time.Now())
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {row: &store.Issue{ID: 10, GithubID: issue.ID}},
+	}}
+	mf := &fakeMarkerFetcher{commentsByKey: map[string][]github.Comment{
+		"org/repo#1": {{Body: "<!-- heimdallm:skip -->", CreatedAt: time.Now()}},
+	}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
+
+	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 0 || len(p.calls) != 0 {
+		t.Errorf("skip marker should skip issue, got processed=%d calls=%v", processed, p.calls)
+	}
+}
+
+func TestFetcher_RetryMarkerOverridesDone(t *testing.T) {
+	issue := fixture(1, time.Now())
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {row: &store.Issue{ID: 10, GithubID: issue.ID}},
+	}}
+	mf := &fakeMarkerFetcher{commentsByKey: map[string][]github.Comment{
+		"org/repo#1": {
+			{Body: "<!-- heimdallm:done -->\n✅ done", CreatedAt: time.Now().Add(-10 * time.Minute)},
+			{Body: "<!-- heimdallm:retry -->", CreatedAt: time.Now()},
+		},
+	}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
+
+	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 1 || len(p.calls) != 1 {
+		t.Errorf("retry marker should force reprocess, got processed=%d calls=%v", processed, p.calls)
+	}
+}
+
+func TestFetcher_RetryMarkerOverridesDismissed(t *testing.T) {
+	issue := fixture(1, time.Now())
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {row: &store.Issue{ID: 10, GithubID: issue.ID, Dismissed: true}},
+	}}
+	mf := &fakeMarkerFetcher{commentsByKey: map[string][]github.Comment{
+		"org/repo#1": {{Body: "<!-- heimdallm:retry -->", CreatedAt: time.Now()}},
+	}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
+
+	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 1 {
+		t.Errorf("retry marker should override dismiss, got processed=%d", processed)
+	}
+}
+
+func TestFetcher_MarkerFetchErrorFallsThrough(t *testing.T) {
+	issue := fixture(1, time.Now())
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {row: &store.Issue{ID: 10, GithubID: issue.ID}},
+	}}
+	mf := &fakeMarkerFetcher{err: errors.New("comments API broken")}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
+
+	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 1 {
+		t.Errorf("marker fetch error should fall through to pipeline, got processed=%d", processed)
+	}
+}
+
+func TestFetcher_NilMarkerFetcherSkipsMarkerCheck(t *testing.T) {
+	issue := fixture(1, time.Now())
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {row: &store.Issue{ID: 10, GithubID: issue.ID}},
+	}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, p)
+
+	processed, _ := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if processed != 1 {
+		t.Errorf("nil marker fetcher should skip marker check and process, got processed=%d", processed)
 	}
 }

--- a/daemon/internal/issues/integration_test.go
+++ b/daemon/internal/issues/integration_test.go
@@ -51,7 +51,7 @@ func TestIntegration_FetcherDrivesPipelineEndToEnd(t *testing.T) {
 	broker := &fakeBroker{}
 
 	pipe := issues.New(s, gh, exec, nil, broker, nil)
-	fetcher := issues.NewFetcher(client, s, pipe)
+	fetcher := issues.NewFetcher(client, gh, s, pipe)
 
 	processed, err := fetcher.ProcessRepo(
 		context.Background(),

--- a/daemon/internal/issues/markers.go
+++ b/daemon/internal/issues/markers.go
@@ -1,0 +1,42 @@
+package issues
+
+import (
+	"strings"
+
+	"github.com/heimdallm/daemon/internal/github"
+)
+
+const (
+	MarkerDone  = "<!-- heimdallm:done -->"
+	MarkerSkip  = "<!-- heimdallm:skip -->"
+	MarkerRetry = "<!-- heimdallm:retry -->"
+)
+
+// MarkerResult represents the effective control marker found in comments.
+type MarkerResult int
+
+const (
+	MarkerNone        MarkerResult = iota
+	MarkerResultDone               // issue processed, skip
+	MarkerResultSkip               // permanent skip
+	MarkerResultRetry              // force reprocess
+)
+
+// ScanMarkers scans a chronologically sorted comment slice for control markers
+// and returns the effective result. The latest marker wins: if a comment
+// contains retry after an earlier done or skip, the issue is reprocessed.
+// Within a single comment, priority is retry > skip > done.
+func ScanMarkers(comments []github.Comment) MarkerResult {
+	var latest MarkerResult
+	for _, c := range comments {
+		switch {
+		case strings.Contains(c.Body, MarkerRetry):
+			latest = MarkerResultRetry
+		case strings.Contains(c.Body, MarkerSkip):
+			latest = MarkerResultSkip
+		case strings.Contains(c.Body, MarkerDone):
+			latest = MarkerResultDone
+		}
+	}
+	return latest
+}

--- a/daemon/internal/issues/markers_test.go
+++ b/daemon/internal/issues/markers_test.go
@@ -1,0 +1,119 @@
+package issues_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/issues"
+)
+
+func comment(body string, minutesAgo int) github.Comment {
+	return github.Comment{
+		Author:    "someone",
+		Body:      body,
+		CreatedAt: time.Now().Add(-time.Duration(minutesAgo) * time.Minute),
+	}
+}
+
+func TestScanMarkers_NoMarkers(t *testing.T) {
+	comments := []github.Comment{
+		comment("Just a regular comment", 10),
+		comment("Another one", 5),
+	}
+	if got := issues.ScanMarkers(comments); got != issues.MarkerNone {
+		t.Errorf("ScanMarkers = %d, want MarkerNone", got)
+	}
+}
+
+func TestScanMarkers_EmptyComments(t *testing.T) {
+	if got := issues.ScanMarkers(nil); got != issues.MarkerNone {
+		t.Errorf("ScanMarkers(nil) = %d, want MarkerNone", got)
+	}
+}
+
+func TestScanMarkers_DoneMarker(t *testing.T) {
+	comments := []github.Comment{
+		comment("some discussion", 10),
+		comment("<!-- heimdallm:done -->\n✅ Implementation complete", 5),
+	}
+	if got := issues.ScanMarkers(comments); got != issues.MarkerResultDone {
+		t.Errorf("ScanMarkers = %d, want MarkerResultDone", got)
+	}
+}
+
+func TestScanMarkers_SkipMarker(t *testing.T) {
+	comments := []github.Comment{
+		comment("<!-- heimdallm:skip -->", 5),
+	}
+	if got := issues.ScanMarkers(comments); got != issues.MarkerResultSkip {
+		t.Errorf("ScanMarkers = %d, want MarkerResultSkip", got)
+	}
+}
+
+func TestScanMarkers_RetryMarker(t *testing.T) {
+	comments := []github.Comment{
+		comment("<!-- heimdallm:retry -->", 5),
+	}
+	if got := issues.ScanMarkers(comments); got != issues.MarkerResultRetry {
+		t.Errorf("ScanMarkers = %d, want MarkerResultRetry", got)
+	}
+}
+
+func TestScanMarkers_RetryOverridesDone(t *testing.T) {
+	comments := []github.Comment{
+		comment("<!-- heimdallm:done -->\n✅ done", 10),
+		comment("<!-- heimdallm:retry -->", 5),
+	}
+	if got := issues.ScanMarkers(comments); got != issues.MarkerResultRetry {
+		t.Errorf("ScanMarkers = %d, want MarkerResultRetry (overrides done)", got)
+	}
+}
+
+func TestScanMarkers_RetryOverridesSkip(t *testing.T) {
+	comments := []github.Comment{
+		comment("<!-- heimdallm:skip -->", 10),
+		comment("<!-- heimdallm:retry -->", 5),
+	}
+	if got := issues.ScanMarkers(comments); got != issues.MarkerResultRetry {
+		t.Errorf("ScanMarkers = %d, want MarkerResultRetry (overrides skip)", got)
+	}
+}
+
+func TestScanMarkers_DoneAfterRetrySkips(t *testing.T) {
+	comments := []github.Comment{
+		comment("<!-- heimdallm:retry -->", 10),
+		comment("<!-- heimdallm:done -->\n✅ new implementation", 5),
+	}
+	if got := issues.ScanMarkers(comments); got != issues.MarkerResultDone {
+		t.Errorf("ScanMarkers = %d, want MarkerResultDone (latest wins)", got)
+	}
+}
+
+func TestScanMarkers_SkipAfterDone(t *testing.T) {
+	comments := []github.Comment{
+		comment("<!-- heimdallm:done -->", 10),
+		comment("<!-- heimdallm:skip -->", 5),
+	}
+	if got := issues.ScanMarkers(comments); got != issues.MarkerResultSkip {
+		t.Errorf("ScanMarkers = %d, want MarkerResultSkip (latest wins)", got)
+	}
+}
+
+func TestScanMarkers_MarkerEmbeddedInLargerComment(t *testing.T) {
+	comments := []github.Comment{
+		comment("Hey, please skip this.\n<!-- heimdallm:skip -->\nThanks!", 5),
+	}
+	if got := issues.ScanMarkers(comments); got != issues.MarkerResultSkip {
+		t.Errorf("ScanMarkers = %d, want MarkerResultSkip (embedded marker)", got)
+	}
+}
+
+func TestScanMarkers_RetryPriorityWithinSingleComment(t *testing.T) {
+	comments := []github.Comment{
+		comment("<!-- heimdallm:done -->\n<!-- heimdallm:retry -->", 5),
+	}
+	if got := issues.ScanMarkers(comments); got != issues.MarkerResultRetry {
+		t.Errorf("ScanMarkers = %d, want MarkerResultRetry (retry wins within comment)", got)
+	}
+}

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -605,8 +605,8 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 	// Non-fatal on failure — the PR is already public and the review row
 	// carries the number, so a missed comment does not lose information.
 	linkBackBody := fmt.Sprintf(
-		"%s\n✅ Implementation complete — PR #%d created on branch `%s`.\nThis issue will not be reprocessed unless `%s` is added.",
-		MarkerDone, prNumber, branch, MarkerRetry,
+		"%s\n✅ Implementation complete — PR #%d created on branch `%s`.\nThis issue will not be reprocessed unless a retry marker is added.",
+		MarkerDone, prNumber, branch,
 	)
 	commentedAt, linkErr := p.gh.PostComment(issue.Repo, issue.Number, linkBackBody)
 	if linkErr != nil {

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -81,6 +81,13 @@ type PRMetadataApplier interface {
 	SetAssignees(repo string, number int, assignees []string) error
 }
 
+// IssueGetter fetches a single issue by repo + number. Used by the
+// auto_implement pre-push state check to verify the issue is still open
+// before creating a PR (#238).
+type IssueGetter interface {
+	GetIssue(repo string, number int) (*github.Issue, error)
+}
+
 // CLIExecutor runs an AI CLI. The pipeline uses ExecuteRaw because the
 // triage schema (Triage object) differs from the PR-review schema.
 type CLIExecutor interface {
@@ -198,6 +205,7 @@ type issueGitHub interface {
 	DefaultBrancher
 	PRCreator
 	PRMetadataApplier
+	IssueGetter
 }
 
 // New wires the pipeline. All dependencies are interfaces so tests can
@@ -501,6 +509,21 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 		p.publishError(issueID, issue, fmt.Errorf("commit: %w", err))
 		return nil, fmt.Errorf("issues pipeline: commit: %w", err)
 	}
+
+	// Pre-push state check (#238): verify the issue is still open. If it
+	// was closed during implementation (e.g. another PR merged), abort to
+	// avoid creating a duplicate PR. Non-fatal on API error — we proceed
+	// with the push rather than block on a transient failure.
+	freshIssue, stateErr := p.gh.GetIssue(issue.Repo, issue.Number)
+	if stateErr != nil {
+		slog.Warn("issues pipeline: pre-push state check failed, proceeding with push",
+			"repo", issue.Repo, "number", issue.Number, "err", stateErr)
+	} else if freshIssue.State != "open" {
+		slog.Info("issues pipeline: issue closed during implementation, aborting",
+			"repo", issue.Repo, "number", issue.Number, "state", freshIssue.State)
+		return nil, nil
+	}
+
 	if err := p.git.Push(ctx, workDir, issue.Repo, branch, opts.GitHubToken); err != nil {
 		// Record the push failure so the fetcher can enforce the
 		// MaxAutoImplementFailures retry cap (#223). Without this row the
@@ -577,11 +600,14 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 	// a metadata failure does not roll back the PR, which is already public.
 	applyPRMetadata(p.gh, issue.Repo, prNumber, opts)
 
-	// Post a short "Implementation PR: #N" comment on the issue so watchers
-	// of the issue (who might not watch the repo) see the PR land. Non-fatal
-	// on failure — the PR is already public and the review row carries the
-	// number, so a missed comment does not lose information.
-	linkBackBody := fmt.Sprintf("Implementation PR: #%d", prNumber)
+	// Post a done-marker comment on the issue so watchers see the PR land
+	// and the fetcher's marker scan skips the issue on future polls (#238).
+	// Non-fatal on failure — the PR is already public and the review row
+	// carries the number, so a missed comment does not lose information.
+	linkBackBody := fmt.Sprintf(
+		"%s\n✅ Implementation complete — PR #%d created on branch `%s`.\nThis issue will not be reprocessed unless `%s` is added.",
+		MarkerDone, prNumber, branch, MarkerRetry,
+	)
 	commentedAt, linkErr := p.gh.PostComment(issue.Repo, issue.Number, linkBackBody)
 	if linkErr != nil {
 		slog.Warn("issues pipeline: link-back comment failed",

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -94,6 +94,10 @@ type fakeGH struct {
 	reviewersCalls [][]string
 	labelsCalls    [][]string
 	assigneesCalls [][]string
+
+	// GetIssue stub for pre-push state check (#238).
+	getIssueState string // returned state; defaults to "open"
+	getIssueErr   error
 }
 
 type postCall struct {
@@ -149,6 +153,17 @@ func (f *fakeGH) CreatePR(repo, title, body, head, base string, draft bool) (*gi
 		htmlURL = fmt.Sprintf("https://github.com/%s/pull/%d", repo, num)
 	}
 	return &github.CreatedPR{Number: num, ID: id, HTMLURL: htmlURL}, nil
+}
+
+func (f *fakeGH) GetIssue(repo string, number int) (*github.Issue, error) {
+	if f.getIssueErr != nil {
+		return nil, f.getIssueErr
+	}
+	state := f.getIssueState
+	if state == "" {
+		state = "open"
+	}
+	return &github.Issue{Repo: repo, Number: number, State: state}, nil
 }
 
 func (f *fakeGH) SetPRReviewers(repo string, prNumber int, reviewers []string) error {
@@ -557,14 +572,16 @@ func TestPipeline_AutoImplementHappyPath(t *testing.T) {
 		t.Errorf("SSE sequence = %v, want %v", types, want)
 	}
 
-	// Exactly one PostComment: the link-back note pointing watchers of the
-	// issue at the newly-opened PR. This is NOT the review_only fallback
-	// comment — that one only fires on the no-changes path.
+	// Exactly one PostComment: the done-marker comment pointing watchers of
+	// the issue at the newly-opened PR and marking it processed (#238).
 	if len(gh.postCalls) != 1 {
-		t.Fatalf("auto_implement happy path should post the link-back comment, got %d", len(gh.postCalls))
+		t.Fatalf("auto_implement happy path should post the done-marker comment, got %d", len(gh.postCalls))
 	}
-	if !strings.Contains(gh.postCalls[0].Body, "Implementation PR: #123") {
-		t.Errorf("link-back comment body wrong: %q", gh.postCalls[0].Body)
+	if !strings.Contains(gh.postCalls[0].Body, issues.MarkerDone) {
+		t.Errorf("comment should contain done marker: %q", gh.postCalls[0].Body)
+	}
+	if !strings.Contains(gh.postCalls[0].Body, "PR #123") {
+		t.Errorf("comment should reference PR: %q", gh.postCalls[0].Body)
 	}
 
 	// Prompt was the implement flavour, not the triage JSON instruction.
@@ -1302,6 +1319,84 @@ func TestPipeline_AutoImplementDescriptionNotCalledWhenDisabled(t *testing.T) {
 	// No diff call.
 	if len(git.diffCalls) != 0 {
 		t.Errorf("Diff should not be called when disabled, got %v", git.diffCalls)
+	}
+}
+
+// ── pre-push state check (#238) ─────────────────────────────────────────────
+
+func TestPipeline_AutoImplementAbortsWhenIssueClosedDuringImplementation(t *testing.T) {
+	gh := &fakeGH{defaultBranch: "main", createPRNumber: 42, getIssueState: "closed"}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("done")}
+	git := &fakeGit{hasChanges: true}
+	broker := &fakeBroker{}
+	p := issues.New(&fakeStore{}, gh, exec, git, broker, nil)
+
+	rev, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions())
+	if err != nil {
+		t.Fatalf("expected nil error on closed-issue abort, got: %v", err)
+	}
+	if rev != nil {
+		t.Errorf("expected nil review on closed-issue abort, got: %+v", rev)
+	}
+	// Commit ran but push and PR must NOT have run.
+	if len(git.commitCalls) != 1 {
+		t.Errorf("commit should have run, got %d calls", len(git.commitCalls))
+	}
+	if len(git.pushCalls) != 0 {
+		t.Errorf("push must not run when issue is closed, got %d calls", len(git.pushCalls))
+	}
+	if len(gh.createPRCalls) != 0 {
+		t.Errorf("CreatePR must not run when issue is closed, got %d calls", len(gh.createPRCalls))
+	}
+}
+
+func TestPipeline_AutoImplementProceedsWhenStateCheckFails(t *testing.T) {
+	gh := &fakeGH{
+		defaultBranch: "main",
+		createPRNumber: 55,
+		getIssueErr:   errors.New("API timeout"),
+	}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("done")}
+	git := &fakeGit{hasChanges: true}
+	p := issues.New(&fakeStore{}, gh, exec, git, &fakeBroker{}, nil)
+
+	rev, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions())
+	if err != nil {
+		t.Fatalf("state check failure must not abort the pipeline: %v", err)
+	}
+	if rev == nil || rev.PRCreated != 55 {
+		t.Errorf("pipeline should proceed when state check fails, got rev=%+v", rev)
+	}
+}
+
+// ── done marker comment (#238) ──────────────────────────────────────────────
+
+func TestPipeline_AutoImplementPostsDoneMarkerComment(t *testing.T) {
+	gh := &fakeGH{defaultBranch: "main", createPRNumber: 157}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("done")}
+	git := &fakeGit{hasChanges: true}
+	p := issues.New(&fakeStore{}, gh, exec, git, &fakeBroker{}, nil)
+
+	_, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if len(gh.postCalls) != 1 {
+		t.Fatalf("expected 1 PostComment (done marker), got %d", len(gh.postCalls))
+	}
+	body := gh.postCalls[0].Body
+	if !strings.Contains(body, issues.MarkerDone) {
+		t.Errorf("comment should contain done marker, got: %q", body)
+	}
+	if !strings.Contains(body, "PR #157") {
+		t.Errorf("comment should reference PR number, got: %q", body)
+	}
+	if !strings.Contains(body, "heimdallm/issue-7") {
+		t.Errorf("comment should reference branch name, got: %q", body)
+	}
+	if !strings.Contains(body, issues.MarkerRetry) {
+		t.Errorf("comment should mention retry marker for human reference, got: %q", body)
 	}
 }
 

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -1395,8 +1395,8 @@ func TestPipeline_AutoImplementPostsDoneMarkerComment(t *testing.T) {
 	if !strings.Contains(body, "heimdallm/issue-7") {
 		t.Errorf("comment should reference branch name, got: %q", body)
 	}
-	if !strings.Contains(body, issues.MarkerRetry) {
-		t.Errorf("comment should mention retry marker for human reference, got: %q", body)
+	if !strings.Contains(body, "retry marker") {
+		t.Errorf("comment should mention retry for human reference, got: %q", body)
 	}
 }
 


### PR DESCRIPTION
Auto-generated by Heimdallm in response to #238.

Closes #238