### PR TITLE
fix(daemon): fail-closed on HEAD SHA lookup for PR dedup

### DIFF
--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -201,17 +201,42 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	// If the last stored review is for the same HEAD SHA, return it unchanged.
 	//
 	// The Search Issues API used by Tier 2 does not populate head.sha, so we
-	// resolve it on-demand. Resolver failure degrades gracefully — we fall
-	// through and run the review rather than block on a transient API error.
+	// resolve it on-demand. We must NOT proceed to Execute when we cannot
+	// confirm the SHA, because a transient API failure would otherwise bypass
+	// the cross-instance dedup and let every peer bot run the review on top
+	// of the same commit. See theburrowhub/heimdallm#243.
 	if pr.Head.SHA == "" {
-		if sha, err := p.gh.GetPRHeadSHA(pr.Repo, pr.Number); err != nil {
-			slog.Warn("pipeline: could not resolve HEAD SHA, skipping dedup guard",
-				"repo", pr.Repo, "pr", pr.Number, "err", err)
-		} else {
-			pr.Head.SHA = sha
+		sha, err := p.gh.GetPRHeadSHA(pr.Repo, pr.Number)
+		if err != nil {
+			// One short retry absorbs rate-limit blips without turning the
+			// fail-closed stance into a permanent outage.
+			sha, err = p.gh.GetPRHeadSHA(pr.Repo, pr.Number)
 		}
+		if err != nil {
+			slog.Warn("pipeline: HEAD SHA unresolved — skipping review (fail-closed)",
+				"repo", pr.Repo, "pr", pr.Number, "err", err)
+			return nil, fmt.Errorf("pipeline: resolve HEAD SHA: %w", err)
+		}
+		pr.Head.SHA = sha
 	}
 	prevReview, _ := p.store.LatestReviewForPR(prID)
+	// Legacy rows (before the head_sha column was populated) have empty
+	// HeadSHA and would otherwise bypass the guard because "" never equals a
+	// real SHA. Treat as "cannot confirm safe" — backfill the column from the
+	// current snapshot and skip. The user can trigger a re-review manually if
+	// they want one, but we never spend Claude credits on a legacy row whose
+	// dedup state is ambiguous.
+	if prevReview != nil && prevReview.HeadSHA == "" && pr.Head.SHA != "" {
+		slog.Info("pipeline: backfilling empty HeadSHA on legacy review row, skipping re-review",
+			"repo", pr.Repo, "pr", pr.Number, "review_id", prevReview.ID, "head_sha", pr.Head.SHA)
+		if err := p.store.UpdateReviewHeadSHA(prevReview.ID, pr.Head.SHA); err != nil {
+			slog.Warn("pipeline: failed to backfill HeadSHA",
+				"review_id", prevReview.ID, "err", err)
+		} else {
+			prevReview.HeadSHA = pr.Head.SHA
+		}
+		return prevReview, nil
+	}
 	if prevReview != nil && pr.Head.SHA != "" && prevReview.HeadSHA == pr.Head.SHA {
 		slog.Info("pipeline: skipping re-review, HEAD SHA unchanged",
 			"repo", pr.Repo, "pr", pr.Number, "head_sha", pr.Head.SHA)

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -208,8 +208,11 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	if pr.Head.SHA == "" {
 		sha, err := p.gh.GetPRHeadSHA(pr.Repo, pr.Number)
 		if err != nil {
-			// One short retry absorbs rate-limit blips without turning the
-			// fail-closed stance into a permanent outage.
+			// Short backoff before the single retry — 0ms back-to-back retries
+			// are useless against 429s (the rate window is still active).
+			// #243's specific failure mode was rate-limit 429s, so the retry
+			// needs at least a small gap to have any chance of succeeding.
+			time.Sleep(500 * time.Millisecond)
 			sha, err = p.gh.GetPRHeadSHA(pr.Repo, pr.Number)
 		}
 		if err != nil {

--- a/daemon/internal/pipeline/pipeline_reloop_test.go
+++ b/daemon/internal/pipeline/pipeline_reloop_test.go
@@ -1,0 +1,188 @@
+package pipeline_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/executor"
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// newMemStore opens an in-memory SQLite store for tests. Callers get a
+// fully-migrated *store.Store; cleanup is registered via t.Cleanup.
+func newMemStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+// fakeGHReloop implements the subset of the pipeline's github dependency
+// needed to exercise the HEAD-SHA fail-closed path. It records whether the
+// diff/submit steps ran so tests can assert the pipeline short-circuits
+// before executing a review when the SHA resolver fails.
+type fakeGHReloop struct {
+	headSHAErr   error
+	headSHAValue string
+	headSHACalls int
+	submitted    bool
+	diffCalled   bool
+	execCalled   bool
+}
+
+func (f *fakeGHReloop) GetPRHeadSHA(_ string, _ int) (string, error) {
+	f.headSHACalls++
+	if f.headSHAErr != nil {
+		return "", f.headSHAErr
+	}
+	return f.headSHAValue, nil
+}
+
+func (f *fakeGHReloop) FetchDiff(_ string, _ int) (string, error) {
+	f.diffCalled = true
+	return "+line", nil
+}
+
+func (f *fakeGHReloop) SubmitReview(_ string, _ int, _, _ string) (int64, string, error) {
+	f.submitted = true
+	return 0, "", nil
+}
+
+func (f *fakeGHReloop) PostComment(_ string, _ int, _ string) (time.Time, error) {
+	return time.Now().UTC(), nil
+}
+
+func (f *fakeGHReloop) FetchComments(_ string, _ int) ([]gh.Comment, error) {
+	return nil, nil
+}
+
+// fakeExecReloop tracks whether the CLI executor was invoked — the fail-closed
+// guard must short-circuit before this runs so Claude credits are not spent.
+type fakeExecReloop struct {
+	calls int
+}
+
+func (f *fakeExecReloop) Detect(_, _ string) (string, error) { return "fake_claude", nil }
+func (f *fakeExecReloop) Execute(_, _ string, _ executor.ExecOptions) (*executor.ReviewResult, error) {
+	f.calls++
+	return &executor.ReviewResult{Summary: "ok", Severity: "low"}, nil
+}
+
+// TestRun_FailClosedWhenHeadSHALookupFails is the regression guard for the
+// 2026-04-22 cost-runaway (theburrowhub/heimdallm#243). When GetPRHeadSHA
+// returns a persistent error, the pipeline must NOT fall through to the
+// executor — doing so would let a transient API outage bypass the
+// cross-instance dedup and have every peer daemon spend Claude credits on
+// the same commit.
+func TestRun_FailClosedWhenHeadSHALookupFails(t *testing.T) {
+	s := newMemStore(t)
+	fgh := &fakeGHReloop{headSHAErr: errors.New("github: 503 service unavailable")}
+	fexec := &fakeExecReloop{}
+	p := pipeline.New(s, fgh, fexec, &fakeNotify{})
+
+	pr := &gh.PullRequest{
+		ID: 1, Number: 1, Title: "t", Repo: "org/repo",
+		User: gh.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/1",
+		Head: gh.Branch{SHA: ""}, // empty forces resolver path
+	}
+	_, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err == nil {
+		t.Fatalf("expected fail-closed error, got nil")
+	}
+	if fexec.calls != 0 {
+		t.Errorf("executor must not be called when HEAD SHA resolver fails (calls=%d)", fexec.calls)
+	}
+	if fgh.submitted {
+		t.Errorf("SubmitReview must not be called when HEAD SHA resolver fails")
+	}
+	// A single short retry is allowed to absorb rate-limit blips.
+	if fgh.headSHACalls > 2 {
+		t.Errorf("GetPRHeadSHA called more than twice (retries should stop at 1): %d", fgh.headSHACalls)
+	}
+}
+
+// TestRun_LegacyRowWithEmptyHeadSHAIsBackfilledAndSkipped covers the second
+// half of the fail-closed fix: rows stored before HeadSHA was populated carry
+// HeadSHA = "", which the old "prev.HeadSHA == pr.Head.SHA" check could never
+// match — so every legacy row would have bypassed the guard and re-run
+// Claude. Instead we backfill the column from the current snapshot and skip
+// the re-review; a user who wants a fresh review can trigger one manually.
+func TestRun_LegacyRowWithEmptyHeadSHAIsBackfilledAndSkipped(t *testing.T) {
+	s := newMemStore(t)
+
+	// Seed a "legacy" review row with head_sha = "".
+	prRow := &store.PR{
+		GithubID:  100,
+		Repo:      "org/repo",
+		Number:    2,
+		Title:     "t",
+		Author:    "alice",
+		State:     "open",
+		UpdatedAt: time.Now(),
+		FetchedAt: time.Now(),
+	}
+	prID, err := s.UpsertPR(prRow)
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	_, err = s.InsertReview(&store.Review{
+		PRID:      prID,
+		CLIUsed:   "claude",
+		Summary:   "",
+		Issues:    "[]",
+		Suggestions: "[]",
+		Severity:  "low",
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+		HeadSHA:   "",
+	})
+	if err != nil {
+		t.Fatalf("insert legacy review: %v", err)
+	}
+
+	fgh := &fakeGHReloop{headSHAValue: "abc123"}
+	fexec := &fakeExecReloop{}
+	p := pipeline.New(s, fgh, fexec, &fakeNotify{})
+
+	pr := &gh.PullRequest{
+		ID: 100, Number: 2, Title: "t", Repo: "org/repo",
+		User: gh.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/2",
+		Head: gh.Branch{SHA: ""},
+	}
+	rev, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev == nil {
+		t.Fatalf("expected returned review, got nil")
+	}
+	if rev.HeadSHA != "abc123" {
+		t.Errorf("expected legacy row backfilled to abc123, got %q", rev.HeadSHA)
+	}
+	if fexec.calls != 0 {
+		t.Errorf("executor must not be called when backfilling legacy row (calls=%d)", fexec.calls)
+	}
+	if fgh.submitted {
+		t.Errorf("SubmitReview must not be called when backfilling legacy row")
+	}
+
+	// Verify the row was actually persisted with the backfilled SHA so a
+	// subsequent Run hits the standard same-SHA skip branch.
+	reviews, err := s.ListReviewsForPR(prID)
+	if err != nil {
+		t.Fatalf("list reviews: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("expected 1 review after backfill, got %d", len(reviews))
+	}
+	if reviews[0].HeadSHA != "abc123" {
+		t.Errorf("stored HeadSHA = %q, want %q", reviews[0].HeadSHA, "abc123")
+	}
+}

--- a/daemon/internal/pipeline/pipeline_reloop_test.go
+++ b/daemon/internal/pipeline/pipeline_reloop_test.go
@@ -33,7 +33,6 @@ type fakeGHReloop struct {
 	headSHACalls int
 	submitted    bool
 	diffCalled   bool
-	execCalled   bool
 }
 
 func (f *fakeGHReloop) GetPRHeadSHA(_ string, _ int) (string, error) {
@@ -96,6 +95,13 @@ func TestRun_FailClosedWhenHeadSHALookupFails(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected fail-closed error, got nil")
 	}
+	// Cost-boundary contract: FetchDiff IS allowed to run (it happens before
+	// the SHA check at pipeline.go:192) — it's a cheap GitHub API call. What
+	// must NOT run is the Claude executor or the review submission, because
+	// those are the expensive steps that burned €1,300 in #243.
+	if !fgh.diffCalled {
+		t.Errorf("expected FetchDiff to run before the SHA check (documents cost boundary)")
+	}
 	if fexec.calls != 0 {
 		t.Errorf("executor must not be called when HEAD SHA resolver fails (calls=%d)", fexec.calls)
 	}
@@ -133,14 +139,14 @@ func TestRun_LegacyRowWithEmptyHeadSHAIsBackfilledAndSkipped(t *testing.T) {
 		t.Fatalf("upsert pr: %v", err)
 	}
 	_, err = s.InsertReview(&store.Review{
-		PRID:      prID,
-		CLIUsed:   "claude",
-		Summary:   "",
-		Issues:    "[]",
+		PRID:        prID,
+		CLIUsed:     "claude",
+		Summary:     "",
+		Issues:      "[]",
 		Suggestions: "[]",
-		Severity:  "low",
-		CreatedAt: time.Now().Add(-1 * time.Hour),
-		HeadSHA:   "",
+		Severity:    "low",
+		CreatedAt:   time.Now().Add(-1 * time.Hour),
+		HeadSHA:     "",
 	})
 	if err != nil {
 		t.Fatalf("insert legacy review: %v", err)

--- a/daemon/internal/store/reviews.go
+++ b/daemon/internal/store/reviews.go
@@ -64,6 +64,18 @@ func (s *Store) ListUnpublishedReviews() ([]*Review, error) {
 	return reviews, rows.Err()
 }
 
+// UpdateReviewHeadSHA backfills the head_sha column on a legacy review row.
+// Used by the pipeline's fail-closed dedup: if a previous review had no SHA
+// (from before the column was populated), we populate it from the current
+// snapshot instead of proceeding to a full re-review.
+func (s *Store) UpdateReviewHeadSHA(reviewID int64, headSHA string) error {
+	_, err := s.db.Exec("UPDATE reviews SET head_sha = ? WHERE id = ?", headSHA, reviewID)
+	if err != nil {
+		return fmt.Errorf("store: update review head_sha: %w", err)
+	}
+	return nil
+}
+
 // MarkReviewPublished records the GitHub review ID and state after a successful
 // SubmitReview call. The state is one of GitHub's review states; see Review for
 // the full set. Pass the sentinel pair (-1, "") to mark an orphan review that


### PR DESCRIPTION
Refs #243 (Fix 2 in the priority list).

Smallest-surface high-leverage change from the audit. Ships first so the probable proximate cause of the incident is closed while the rest of the plan lands.

## Summary

- `pipeline.Run` used to log a warning and fall through when `GetPRHeadSHA` errored, letting transient GitHub API failures bypass the cross-instance dedup and cost Claude credits on every peer daemon.
- Now retries once, then returns an error on persistent failure.
- Legacy review rows with empty `head_sha` (from before the column was populated) are backfilled from the current snapshot and the re-review is skipped, instead of silently bypassing the guard because `"" != "<real sha>"`.
- New store method `UpdateReviewHeadSHA`.

## Test plan

- [x] Regression tests for both failure modes (`TestRun_FailClosedWhenHeadSHALookupFails`, `TestRun_LegacyRowWithEmptyHeadSHAIsBackfilledAndSkipped`)
- [x] `make test-docker` green
- [ ] Manual: restart daemon, verify reviews still post on healthy PRs