### PR TITLE
feat(daemon): SQLite-backed circuit breaker caps review loops

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -308,13 +309,14 @@ func main() {
 		rev, err := p.Run(pr, buildRunOpts(pr, aiCfg))
 		if err != nil {
 			slog.Error("pipeline run failed", "repo", pr.Repo, "pr", pr.Number, "err", err)
-			if strings.Contains(err.Error(), "circuit breaker tripped") {
+			var cbErr *pipeline.CircuitBreakerError
+			if errors.As(err, &cbErr) {
 				broker.Publish(sse.Event{
 					Type: sse.EventCircuitBreakerTripped,
 					Data: sseData(map[string]any{
 						"pr_number": pr.Number,
 						"repo":      pr.Repo,
-						"reason":    strings.TrimPrefix(err.Error(), "pipeline: circuit breaker tripped: "),
+						"reason":    cbErr.Reason,
 					}),
 				})
 				return
@@ -677,13 +679,14 @@ func main() {
 
 		rev, err := p.Run(ghPR, buildRunOpts(ghPR, aiCfg))
 		if err != nil {
-			if strings.Contains(err.Error(), "circuit breaker tripped") {
+			var cbErr *pipeline.CircuitBreakerError
+			if errors.As(err, &cbErr) {
 				broker.Publish(sse.Event{
 					Type: sse.EventCircuitBreakerTripped,
 					Data: sseData(map[string]any{
 						"pr_number": pr.Number,
 						"repo":      pr.Repo,
-						"reason":    strings.TrimPrefix(err.Error(), "pipeline: circuit breaker tripped: "),
+						"reason":    cbErr.Reason,
 					}),
 				})
 				return err

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -163,6 +163,15 @@ func main() {
 
 	p := pipeline.New(s, ghClient, exec, &notifyWithSSE{notifier: notifier})
 
+	// Circuit-breaker caps (see theburrowhub/heimdallm#243). The defaults are
+	// populated by config.applyDefaults so the caps are always set; nil disables
+	// them only if a downstream test wants unbounded behaviour.
+	cbLimits := store.CircuitBreakerLimits{
+		PerPR24h:  cfg.CircuitBreaker.PerPR24h,
+		PerRepoHr: cfg.CircuitBreaker.PerRepoHr,
+	}
+	p.SetCircuitBreakerLimits(&cbLimits)
+
 	// GitExec drives the auto_implement flow (#27): branch, commit, push, PR.
 	// Wired unconditionally — the pipeline guards against running git ops on
 	// an issue that is classified as review_only, so this dep is harmless
@@ -182,7 +191,7 @@ func main() {
 	srv.SetConfigPath(cfgPath)
 
 	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.
-	var cfgMu   sync.Mutex
+	var cfgMu sync.Mutex
 	var reloadMu sync.Mutex // serialises config reloads to prevent duplicate pipelines
 
 	// discoverySvc holds the discovered repo cache.
@@ -299,6 +308,17 @@ func main() {
 		rev, err := p.Run(pr, buildRunOpts(pr, aiCfg))
 		if err != nil {
 			slog.Error("pipeline run failed", "repo", pr.Repo, "pr", pr.Number, "err", err)
+			if strings.Contains(err.Error(), "circuit breaker tripped") {
+				broker.Publish(sse.Event{
+					Type: sse.EventCircuitBreakerTripped,
+					Data: sseData(map[string]any{
+						"pr_number": pr.Number,
+						"repo":      pr.Repo,
+						"reason":    strings.TrimPrefix(err.Error(), "pipeline: circuit breaker tripped: "),
+					}),
+				})
+				return
+			}
 			broker.Publish(sse.Event{Type: sse.EventReviewError, Data: sseData(map[string]any{"pr_number": pr.Number, "repo": pr.Repo, "error": err.Error()})})
 			return
 		}
@@ -459,16 +479,16 @@ func main() {
 		agentConfigs := make(map[string]map[string]any)
 		for name, ac := range c.AI.Agents {
 			agentConfigs[name] = map[string]any{
-				"model":                    ac.Model,
-				"max_turns":                ac.MaxTurns,
-				"approval_mode":            ac.ApprovalMode,
-				"extra_flags":              ac.ExtraFlags,
-				"prompt":                   ac.PromptID,
-				"effort":                   ac.Effort,
-				"permission_mode":          ac.PermissionMode,
-				"bare":                     ac.Bare,
-				"dangerously_skip_perms":   ac.DangerouslySkipPerms,
-				"no_session_persistence":   ac.NoSessionPersistence,
+				"model":                  ac.Model,
+				"max_turns":              ac.MaxTurns,
+				"approval_mode":          ac.ApprovalMode,
+				"extra_flags":            ac.ExtraFlags,
+				"prompt":                 ac.PromptID,
+				"effort":                 ac.Effort,
+				"permission_mode":        ac.PermissionMode,
+				"bare":                   ac.Bare,
+				"dangerously_skip_perms": ac.DangerouslySkipPerms,
+				"no_session_persistence": ac.NoSessionPersistence,
 			}
 		}
 		// Expose first-seen timestamps so the Flutter app can show NEW
@@ -507,8 +527,8 @@ func main() {
 			"local_dirs_detected":         localDirsDetected,
 			"activity_log_enabled":        ptrBoolOrTrue(c.ActivityLog.Enabled),
 			"activity_log_retention_days": ptrIntOr(c.ActivityLog.RetentionDays, 90),
-			"issue_prompt":               c.AI.IssuePrompt,
-			"implement_prompt":           c.AI.ImplementPrompt,
+			"issue_prompt":                c.AI.IssuePrompt,
+			"implement_prompt":            c.AI.ImplementPrompt,
 		}
 		reviewers, labels, assignee, draft := c.ResolvedPRMetadata()
 		pm := map[string]any{}
@@ -657,6 +677,17 @@ func main() {
 
 		rev, err := p.Run(ghPR, buildRunOpts(ghPR, aiCfg))
 		if err != nil {
+			if strings.Contains(err.Error(), "circuit breaker tripped") {
+				broker.Publish(sse.Event{
+					Type: sse.EventCircuitBreakerTripped,
+					Data: sseData(map[string]any{
+						"pr_number": pr.Number,
+						"repo":      pr.Repo,
+						"reason":    strings.TrimPrefix(err.Error(), "pipeline: circuit breaker tripped: "),
+					}),
+				})
+				return err
+			}
 			broker.Publish(sse.Event{Type: sse.EventReviewError, Data: sseData(map[string]any{"pr_id": prID, "error": err.Error()})})
 			return err
 		}
@@ -763,11 +794,11 @@ func main() {
 			IssueInstructions:       issueInstructions,
 			ImplementPromptOverride: implPrompt,
 			ImplementInstructions:   implInstructions,
-			PRReviewers:           aiCfg.PRReviewers,
-			PRAssignee:            aiCfg.PRAssignee,
-			PRLabels:              aiCfg.PRLabels,
-			PRDraft:               aiCfg.PRDraft != nil && *aiCfg.PRDraft,
-			GeneratePRDescription: aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+			PRReviewers:             aiCfg.PRReviewers,
+			PRAssignee:              aiCfg.PRAssignee,
+			PRLabels:                aiCfg.PRLabels,
+			PRDraft:                 aiCfg.PRDraft != nil && *aiCfg.PRDraft,
+			GeneratePRDescription:   aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
 		}
 
 		slog.Info("trigger issue review: running pipeline",
@@ -1055,8 +1086,8 @@ type tier2Adapter struct {
 	// SSE events across consecutive poll cycles for the same (PR ID, updated_at)
 	// pair. Entries are pruned at the end of each FetchPRsToReview cycle so the
 	// map stays bounded to the current set of review-requested PRs.
-	skipMu                sync.Mutex
-	lastSkippedUpdatedAt  map[int64]time.Time
+	skipMu               sync.Mutex
+	lastSkippedUpdatedAt map[int64]time.Time
 }
 
 // discoveryStore is the subset of *store.Store that processDiscoveredRepos

--- a/daemon/internal/config/circuit_breaker.go
+++ b/daemon/internal/config/circuit_breaker.go
@@ -1,0 +1,23 @@
+package config
+
+// CircuitBreakerConfig caps the number of reviews per PR and per repo to
+// prevent cost-runaway loops. The defaults are conservative — users with
+// high-volume workflows must explicitly raise them. See
+// theburrowhub/heimdallm#243 for the incident that prompted these caps.
+type CircuitBreakerConfig struct {
+	// PerPR24h caps reviews on the same PR over any 24-hour window.
+	// 0 = unlimited. Default 3.
+	PerPR24h int `toml:"per_pr_24h"`
+	// PerRepoHr caps reviews on the same repo over any 1-hour window.
+	// 0 = unlimited. Default 20.
+	PerRepoHr int `toml:"per_repo_hr"`
+}
+
+// DefaultCircuitBreakerConfig returns the safe defaults applied when the
+// [circuit_breaker] TOML section is missing or zero-valued.
+func DefaultCircuitBreakerConfig() CircuitBreakerConfig {
+	return CircuitBreakerConfig{
+		PerPR24h:  3,
+		PerRepoHr: 20,
+	}
+}

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -31,11 +31,12 @@ var githubTopicPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,49}$`)
 var githubOrgPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$`)
 
 type Config struct {
-	Server      ServerConfig      `toml:"server"`
-	GitHub      GitHubConfig      `toml:"github"`
-	AI          AIConfig          `toml:"ai"`
-	Retention   RetentionConfig   `toml:"retention"`
-	ActivityLog ActivityLogConfig `toml:"activity_log"`
+	Server         ServerConfig         `toml:"server"`
+	GitHub         GitHubConfig         `toml:"github"`
+	AI             AIConfig             `toml:"ai"`
+	Retention      RetentionConfig      `toml:"retention"`
+	ActivityLog    ActivityLogConfig    `toml:"activity_log"`
+	CircuitBreaker CircuitBreakerConfig `toml:"circuit_breaker"`
 }
 
 type ServerConfig struct {
@@ -264,16 +265,16 @@ func labelSetIntersects(set map[string]struct{}, list []string) bool {
 // CLIAgentConfig holds per-CLI execution settings (model, flags, prompt override).
 // Stored under [ai.agents.<cli-name>] in config.toml.
 type CLIAgentConfig struct {
-	Model        string `toml:"model"`          // e.g. "claude-opus-4-6"
-	MaxTurns     int    `toml:"max_turns"`       // claude: --max-turns (0 = not set)
-	ApprovalMode string `toml:"approval_mode"`  // codex: --approval-mode
-	ExtraFlags   string `toml:"extra_flags"`     // free-form additional CLI flags
-	PromptID     string `toml:"prompt"`          // agent-level prompt override
+	Model        string `toml:"model"`         // e.g. "claude-opus-4-6"
+	MaxTurns     int    `toml:"max_turns"`     // claude: --max-turns (0 = not set)
+	ApprovalMode string `toml:"approval_mode"` // codex: --approval-mode
+	ExtraFlags   string `toml:"extra_flags"`   // free-form additional CLI flags
+	PromptID     string `toml:"prompt"`        // agent-level prompt override
 
 	// Claude-specific flags
-	Effort               string `toml:"effort"`                  // low|medium|high|max
-	PermissionMode       string `toml:"permission_mode"`         // default|auto|acceptEdits|dontAsk (bypassPermissions is explicitly forbidden)
-	Bare                 bool   `toml:"bare"`                    // --bare
+	Effort               string `toml:"effort"`                 // low|medium|high|max
+	PermissionMode       string `toml:"permission_mode"`        // default|auto|acceptEdits|dontAsk (bypassPermissions is explicitly forbidden)
+	Bare                 bool   `toml:"bare"`                   // --bare
 	DangerouslySkipPerms bool   `toml:"dangerously_skip_perms"` // --dangerously-skip-permissions (cannot be set via HTTP API, see M-5)
 	NoSessionPersistence bool   `toml:"no_session_persistence"` // --no-session-persistence
 	ExecutionTimeout     string `toml:"execution_timeout"`      // per-agent override, e.g. "20m"
@@ -282,12 +283,12 @@ type CLIAgentConfig struct {
 type AIConfig struct {
 	Primary          string                    `toml:"primary"`
 	Fallback         string                    `toml:"fallback"`
-	ReviewMode       string                    `toml:"review_mode"`        // "single" | "multi"
-	ExecutionTimeout string                    `toml:"execution_timeout"`  // e.g. "20m", "1h"
-	Agents           map[string]CLIAgentConfig `toml:"agents"`             // keyed by CLI name
+	ReviewMode       string                    `toml:"review_mode"`       // "single" | "multi"
+	ExecutionTimeout string                    `toml:"execution_timeout"` // e.g. "20m", "1h"
+	Agents           map[string]CLIAgentConfig `toml:"agents"`            // keyed by CLI name
 	Repos            map[string]RepoAI         `toml:"repos"`
-	Orgs             map[string]OrgAI          `toml:"orgs"`               // per-org PR metadata overrides
-	PRMetadata       PRMetadataConfig          `toml:"pr_metadata"`        // global PR creation defaults
+	Orgs             map[string]OrgAI          `toml:"orgs"`        // per-org PR metadata overrides
+	PRMetadata       PRMetadataConfig          `toml:"pr_metadata"` // global PR creation defaults
 
 	// Top-level PR metadata fields — flat alternatives to [ai.pr_metadata].
 	// Populated from HEIMDALLM_PR_* env vars or TOML keys directly under [ai].
@@ -311,10 +312,10 @@ type AIConfig struct {
 }
 
 type RepoAI struct {
-	Primary    string `toml:"primary"`
+	Primary string `toml:"primary"`
 	// Prompt is the ID of a review prompt profile to use for this repo.
 	// Overrides agent-level and global default prompts.
-	Prompt      string `toml:"prompt"`
+	Prompt string `toml:"prompt"`
 	// IssuePrompt is the ID of an agent profile for issue triage.
 	// Overrides agent-level and global default issue prompts.
 	IssuePrompt string `toml:"issue_prompt"`
@@ -322,15 +323,15 @@ type RepoAI struct {
 	// ImplementInstructions fields drive the auto_implement code-generation
 	// prompt for this repo. Overrides agent-level and global default.
 	ImplementPrompt string `toml:"implement_prompt"`
-	Fallback    string `toml:"fallback"`
-	ReviewMode  string `toml:"review_mode"` // "" = inherit global
-	LocalDir    string `toml:"local_dir"`   // local repo path for full-repo analysis
+	Fallback        string `toml:"fallback"`
+	ReviewMode      string `toml:"review_mode"` // "" = inherit global
+	LocalDir        string `toml:"local_dir"`   // local repo path for full-repo analysis
 
 	// PR creation metadata (applied by auto_implement after CreatePR).
 	PRReviewers []string `toml:"pr_reviewers"`       // GitHub logins to request review from
-	PRAssignee  string   `toml:"pr_assignee"`         // GitHub login to assign the PR to
-	PRLabels    []string `toml:"pr_labels"`           // labels to add to the PR
-	PRDraft     *bool    `toml:"pr_draft,omitempty"`  // create as draft PR
+	PRAssignee  string   `toml:"pr_assignee"`        // GitHub login to assign the PR to
+	PRLabels    []string `toml:"pr_labels"`          // labels to add to the PR
+	PRDraft     *bool    `toml:"pr_draft,omitempty"` // create as draft PR
 
 	// GeneratePRDescription overrides the global ai.generate_pr_description
 	// for this repo. nil = inherit from global.
@@ -641,6 +642,12 @@ func (c *Config) applyDefaults() {
 	if c.ActivityLog.RetentionDays == nil {
 		v := 90
 		c.ActivityLog.RetentionDays = &v
+	}
+	if c.CircuitBreaker.PerPR24h == 0 {
+		c.CircuitBreaker.PerPR24h = 3
+	}
+	if c.CircuitBreaker.PerRepoHr == 0 {
+		c.CircuitBreaker.PerRepoHr = 20
 	}
 }
 
@@ -968,7 +975,6 @@ func LoadOrCreate(path string) (*Config, error) {
 	}
 	return cfg, nil
 }
-
 
 // ReviewGuards resolves configured guard toggles against their defaults and
 // returns a ResolvedReviewGuards ready for use by the poller. Both booleans

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -11,6 +12,26 @@ import (
 	"github.com/heimdallm/daemon/internal/github"
 	"github.com/heimdallm/daemon/internal/store"
 )
+
+// ErrCircuitBreakerTripped is returned by Run when a review was skipped
+// because the per-PR or per-repo cap was exceeded. Callers detect it via
+// errors.As on a *CircuitBreakerError value to extract the human-readable
+// reason for telemetry/UI, or via errors.Is(err, ErrCircuitBreakerTripped)
+// when the reason is not needed.
+var ErrCircuitBreakerTripped = errors.New("pipeline: circuit breaker tripped")
+
+// CircuitBreakerError wraps ErrCircuitBreakerTripped with the specific
+// reason the breaker returned ("per-PR cap reached: ...", etc). Use
+// errors.As on this type to read Reason without parsing the error string.
+type CircuitBreakerError struct {
+	Reason string
+}
+
+func (e *CircuitBreakerError) Error() string {
+	return ErrCircuitBreakerTripped.Error() + ": " + e.Reason
+}
+
+func (e *CircuitBreakerError) Unwrap() error { return ErrCircuitBreakerTripped }
 
 // DiffFetcher retrieves the diff for a pull request.
 type DiffFetcher interface {
@@ -79,9 +100,10 @@ func New(s *store.Store, gh interface {
 // the bot's own comments from re-review discussion context.
 func (p *Pipeline) SetBotLogin(login string) { p.botLogin = login }
 
-// SetCircuitBreakerLimits enables the per-PR and per-repo caps. Nil disables
-// all caps (equivalent to the pre-issue-243 behaviour). Must be called before
-// Run; typically once at daemon startup.
+// SetCircuitBreakerLimits enables the per-PR and per-repo caps. Nil
+// disables all caps. Captured by pointer at wiring time — config reloads
+// do NOT re-read this; see theburrowhub/heimdallm#243 for the rationale
+// and the follow-up ticket for re-plumbing via a getter.
 func (p *Pipeline) SetCircuitBreakerLimits(limits *store.CircuitBreakerLimits) {
 	p.breaker = limits
 }
@@ -286,7 +308,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 				"repo", pr.Repo, "pr", pr.Number, "reason", reason)
 			p.notify.Notify("Heimdallm circuit breaker",
 				fmt.Sprintf("%s #%d: %s", pr.Repo, pr.Number, reason))
-			return nil, fmt.Errorf("pipeline: circuit breaker tripped: %s", reason)
+			return nil, &CircuitBreakerError{Reason: reason}
 		}
 	}
 

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -49,8 +49,8 @@ type CommentFetcher interface {
 
 // Pipeline orchestrates the full PR review flow.
 type Pipeline struct {
-	store    *store.Store
-	gh       interface {
+	store *store.Store
+	gh    interface {
 		DiffFetcher
 		GitHubReviewer
 		CommentFetcher
@@ -59,6 +59,10 @@ type Pipeline struct {
 	executor CLIExecutor
 	notify   Notifier
 	botLogin string
+	// breaker caps the number of reviews per PR and per repo. Nil disables
+	// all caps (the pre-issue-243 behaviour). Populated at daemon startup via
+	// SetCircuitBreakerLimits.
+	breaker *store.CircuitBreakerLimits
 }
 
 // New creates a new Pipeline with the provided dependencies.
@@ -74,6 +78,13 @@ func New(s *store.Store, gh interface {
 // SetBotLogin sets the GitHub login of the bot account. Used to filter
 // the bot's own comments from re-review discussion context.
 func (p *Pipeline) SetBotLogin(login string) { p.botLogin = login }
+
+// SetCircuitBreakerLimits enables the per-PR and per-repo caps. Nil disables
+// all caps (equivalent to the pre-issue-243 behaviour). Must be called before
+// Run; typically once at daemon startup.
+func (p *Pipeline) SetCircuitBreakerLimits(limits *store.CircuitBreakerLimits) {
+	p.breaker = limits
+}
 
 // applyPrompt resolves a prompt with priority: repoPromptID > agentPromptID > global default.
 func (p *Pipeline) applyPrompt(repoPromptID, agentPromptID string, tmpl *string, flags *string) {
@@ -261,6 +272,23 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		return nil, fmt.Errorf("pipeline: detect CLI: %w", err)
 	}
 	slog.Info("pipeline: using CLI", "cli", cli)
+
+	// 4b. Circuit breaker: hard cap on review count per PR / per repo. Runs
+	// AFTER all dedup layers so it only fires when the dedup failed but the
+	// caller is about to spend Claude credits anyway. See
+	// theburrowhub/heimdallm#243.
+	if p.breaker != nil {
+		tripped, reason, err := p.store.CheckCircuitBreaker(prID, pr.Repo, *p.breaker)
+		if err != nil {
+			slog.Warn("pipeline: circuit breaker check failed, proceeding", "err", err)
+		} else if tripped {
+			slog.Error("pipeline: CIRCUIT BREAKER TRIPPED — skipping review",
+				"repo", pr.Repo, "pr", pr.Number, "reason", reason)
+			p.notify.Notify("Heimdallm circuit breaker",
+				fmt.Sprintf("%s #%d: %s", pr.Repo, pr.Number, reason))
+			return nil, fmt.Errorf("pipeline: circuit breaker tripped: %s", reason)
+		}
+	}
 
 	// 5. Execute review (merge cliFlags from prompt into ExecOptions.ExtraFlags)
 	// Validate cliFlags from the prompt profile against the same denylist as

--- a/daemon/internal/pipeline/pipeline_breaker_test.go
+++ b/daemon/internal/pipeline/pipeline_breaker_test.go
@@ -1,0 +1,118 @@
+package pipeline_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/executor"
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// fakeGHBreaker implements the pipeline's github dependency for the circuit
+// breaker integration test. Tracks whether SubmitReview / Execute were called
+// so the test can assert the breaker short-circuits BEFORE spending Claude
+// credits (the entire point of Fix 1 in issue theburrowhub/heimdallm#243).
+type fakeGHBreaker struct {
+	headSHAValue string
+	submitted    bool
+}
+
+func (f *fakeGHBreaker) GetPRHeadSHA(_ string, _ int) (string, error) {
+	return f.headSHAValue, nil
+}
+
+func (f *fakeGHBreaker) FetchDiff(_ string, _ int) (string, error) {
+	return "+line", nil
+}
+
+func (f *fakeGHBreaker) SubmitReview(_ string, _ int, _, _ string) (int64, string, error) {
+	f.submitted = true
+	return 0, "", nil
+}
+
+func (f *fakeGHBreaker) PostComment(_ string, _ int, _ string) (time.Time, error) {
+	return time.Now().UTC(), nil
+}
+
+func (f *fakeGHBreaker) FetchComments(_ string, _ int) ([]gh.Comment, error) {
+	return nil, nil
+}
+
+// fakeExecBreaker tracks whether Execute was invoked — the breaker must
+// short-circuit before this runs so Claude credits are not spent.
+type fakeExecBreaker struct {
+	calls int
+}
+
+func (f *fakeExecBreaker) Detect(_, _ string) (string, error) { return "fake_claude", nil }
+func (f *fakeExecBreaker) Execute(_, _ string, _ executor.ExecOptions) (*executor.ReviewResult, error) {
+	f.calls++
+	return &executor.ReviewResult{Summary: "ok", Severity: "low"}, nil
+}
+
+// TestRun_CircuitBreakerTripStopsExecute verifies that when the per-PR cap
+// is reached, pipeline.Run refuses to call SubmitReview / Execute. This is
+// the unconditional ceiling that caps worst-case cost when every other
+// dedup defense fails (see issue #243).
+//
+// The test drives 3 reviews through the pipeline itself (rather than
+// pre-seeding the reviews table) so that the prID the pipeline sees on each
+// Run matches the pr_id value stored in the reviews rows — the circuit
+// breaker counts by prID, and any mismatch would silently fail the test.
+func TestRun_CircuitBreakerTripStopsExecute(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	fgh := &fakeGHBreaker{}
+	fexec := &fakeExecBreaker{}
+	p := pipeline.New(s, fgh, fexec, &fakeNotify{})
+	// Cap at 3 per PR so the 4th review is the one that must trip.
+	p.SetCircuitBreakerLimits(&store.CircuitBreakerLimits{PerPR24h: 3, PerRepoHr: 999})
+
+	// Drive 3 successful reviews via the pipeline — each with a distinct
+	// HEAD SHA so the HEAD-SHA dedup does not short-circuit. This populates
+	// the reviews table with 3 rows all pointing at the correct pr_id.
+	for i, sha := range []string{"sha1", "sha2", "sha3"} {
+		fgh.submitted = false
+		pr := &gh.PullRequest{
+			ID: 42, Number: 42, Title: "t", Repo: "org/r",
+			User: gh.User{Login: "alice"}, State: "open",
+			UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/r/pull/42",
+			Head: gh.Branch{SHA: sha},
+		}
+		if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"}); err != nil {
+			t.Fatalf("seed run %d: %v", i, err)
+		}
+	}
+	// Sanity: executor should have been called 3 times so far.
+	if fexec.calls != 3 {
+		t.Fatalf("seed: executor calls = %d, want 3", fexec.calls)
+	}
+
+	// 4th run on a new HEAD SHA — the HEAD-SHA dedup passes (new commit),
+	// so the breaker is the only defense left. It MUST trip.
+	fgh.submitted = false
+	before := fexec.calls
+	pr := &gh.PullRequest{
+		ID: 42, Number: 42, Title: "t", Repo: "org/r",
+		User: gh.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/r/pull/42",
+		Head: gh.Branch{SHA: "sha4"},
+	}
+	_, err = p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err == nil || !strings.Contains(err.Error(), "circuit breaker tripped") {
+		t.Fatalf("expected circuit breaker error, got %v", err)
+	}
+	if fexec.calls != before {
+		t.Errorf("executor must not be called when breaker trips (calls=%d before=%d)", fexec.calls, before)
+	}
+	if fgh.submitted {
+		t.Errorf("SubmitReview must not be called when breaker trips")
+	}
+}

--- a/daemon/internal/pipeline/pipeline_breaker_test.go
+++ b/daemon/internal/pipeline/pipeline_breaker_test.go
@@ -1,7 +1,7 @@
 package pipeline_test
 
 import (
-	"strings"
+	"errors"
 	"testing"
 	"time"
 
@@ -106,8 +106,19 @@ func TestRun_CircuitBreakerTripStopsExecute(t *testing.T) {
 		Head: gh.Branch{SHA: "sha4"},
 	}
 	_, err = p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
-	if err == nil || !strings.Contains(err.Error(), "circuit breaker tripped") {
-		t.Fatalf("expected circuit breaker error, got %v", err)
+	// Verify both the typed-error contract and the sentinel: callers in main.go
+	// rely on errors.As(&CircuitBreakerError) to emit the SSE event with the
+	// specific reason, and anyone who just cares "was this a breaker trip?"
+	// can use errors.Is against the sentinel.
+	var cbErr *pipeline.CircuitBreakerError
+	if err == nil || !errors.As(err, &cbErr) {
+		t.Fatalf("expected *pipeline.CircuitBreakerError, got %v", err)
+	}
+	if !errors.Is(err, pipeline.ErrCircuitBreakerTripped) {
+		t.Errorf("errors.Is(err, ErrCircuitBreakerTripped) = false, want true")
+	}
+	if cbErr.Reason == "" {
+		t.Errorf("CircuitBreakerError.Reason is empty; callers need it for telemetry")
 	}
 	if fexec.calls != before {
 		t.Errorf("executor must not be called when breaker trips (calls=%d before=%d)", fexec.calls, before)

--- a/daemon/internal/sse/broker.go
+++ b/daemon/internal/sse/broker.go
@@ -4,11 +4,12 @@ import "fmt"
 
 // Event type constants
 const (
-	EventPRDetected      = "pr_detected"
-	EventReviewStarted   = "review_started"
-	EventReviewCompleted = "review_completed"
-	EventReviewError     = "review_error"
-	EventReviewSkipped   = "review_skipped"
+	EventPRDetected            = "pr_detected"
+	EventReviewStarted         = "review_started"
+	EventReviewCompleted       = "review_completed"
+	EventReviewError           = "review_error"
+	EventReviewSkipped         = "review_skipped"
+	EventCircuitBreakerTripped = "circuit_breaker_tripped"
 
 	// Issue tracking pipeline (#26 onward).
 	EventIssueDetected        = "issue_detected"

--- a/daemon/internal/store/circuitbreaker.go
+++ b/daemon/internal/store/circuitbreaker.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// CountReviewsForPR returns the number of reviews for the given PR whose
+// created_at is at or after `since`. Used by the circuit breaker to cap
+// runaway re-review loops. Only reviews already persisted to SQLite count —
+// an in-flight review that has not called InsertReview yet is gated
+// separately via the inflight table (Task 5).
+func (s *Store) CountReviewsForPR(prID int64, since time.Time) (int, error) {
+	var n int
+	err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM reviews WHERE pr_id = ? AND created_at >= ?",
+		prID, since.UTC().Format(sqliteTimeFormat),
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("store: count reviews for pr: %w", err)
+	}
+	return n, nil
+}
+
+// CountReviewsForRepo returns the number of reviews on ANY PR in the given
+// repo whose created_at is at or after `since`. Used for the per-repo rate
+// limit of the circuit breaker.
+func (s *Store) CountReviewsForRepo(repo string, since time.Time) (int, error) {
+	var n int
+	err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM reviews r
+		JOIN prs p ON r.pr_id = p.id
+		WHERE p.repo = ? AND r.created_at >= ?`,
+		repo, since.UTC().Format(sqliteTimeFormat),
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("store: count reviews for repo: %w", err)
+	}
+	return n, nil
+}
+
+// CircuitBreakerLimits is the configured set of caps. Enforced by
+// CheckCircuitBreaker; zero values mean "unlimited" for that axis.
+type CircuitBreakerLimits struct {
+	PerPR24h  int // max reviews per PR in any 24h window
+	PerRepoHr int // max reviews per repo in any 1h window
+}
+
+// CheckCircuitBreaker returns (tripped, reason, err). When tripped is true,
+// the caller MUST NOT proceed to spend Claude credits for this PR. reason is
+// a human-readable explanation suitable for logs and UI surfaces; it is
+// empty when tripped is false.
+func (s *Store) CheckCircuitBreaker(prID int64, repo string, cfg CircuitBreakerLimits) (bool, string, error) {
+	if cfg.PerPR24h > 0 {
+		n, err := s.CountReviewsForPR(prID, time.Now().Add(-24*time.Hour))
+		if err != nil {
+			return false, "", err
+		}
+		if n >= cfg.PerPR24h {
+			return true, fmt.Sprintf("per-PR cap reached: %d reviews in last 24h (cap %d)", n, cfg.PerPR24h), nil
+		}
+	}
+	if cfg.PerRepoHr > 0 && repo != "" {
+		n, err := s.CountReviewsForRepo(repo, time.Now().Add(-1*time.Hour))
+		if err != nil {
+			return false, "", err
+		}
+		if n >= cfg.PerRepoHr {
+			return true, fmt.Sprintf("per-repo cap reached: %d reviews on %s in last 1h (cap %d)", n, repo, cfg.PerRepoHr), nil
+		}
+	}
+	return false, "", nil
+}

--- a/daemon/internal/store/circuitbreaker_test.go
+++ b/daemon/internal/store/circuitbreaker_test.go
@@ -111,3 +111,30 @@ func TestCircuitBreaker_AllowsUnderCap(t *testing.T) {
 		t.Errorf("expected allowed, got tripped")
 	}
 }
+
+// TestCircuitBreaker_ZeroCapMeansUnlimited locks in the contract documented
+// on CircuitBreakerLimits: a cap of 0 disables that axis entirely. Without
+// this test the "0 = unlimited" behaviour could silently regress to "0 means
+// trip immediately" via an off-by-one in CheckCircuitBreaker.
+func TestCircuitBreaker_ZeroCapMeansUnlimited(t *testing.T) {
+	s := newTestStore(t)
+	prID, _ := s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/r", Number: 1,
+		Title: "t", State: "open", UpdatedAt: time.Now()})
+	// Seed 100 reviews; unlimited cap means no trip.
+	for i := 0; i < 100; i++ {
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+			Severity: "low", CreatedAt: time.Now().Add(time.Duration(-i) * time.Minute),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := store.CircuitBreakerLimits{PerPR24h: 0, PerRepoHr: 0}
+	tripped, _, err := s.CheckCircuitBreaker(prID, "org/r", cfg)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if tripped {
+		t.Errorf("PerPR24h=0 must be unlimited, got tripped")
+	}
+}

--- a/daemon/internal/store/circuitbreaker_test.go
+++ b/daemon/internal/store/circuitbreaker_test.go
@@ -1,0 +1,113 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+func TestCountReviewsForPR_CountsWithinWindow(t *testing.T) {
+	s := newTestStore(t)
+	prID, err := s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/r", Number: 1,
+		Title: "t", State: "open", UpdatedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert three reviews, two recent and one outside the 24h window.
+	recent := time.Now().Add(-2 * time.Hour)
+	old := time.Now().Add(-48 * time.Hour)
+	for _, at := range []time.Time{recent, recent.Add(time.Minute), old} {
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+			Severity: "low", CreatedAt: at,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	since := time.Now().Add(-24 * time.Hour)
+	n, err := s.CountReviewsForPR(prID, since)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("want 2 within 24h, got %d", n)
+	}
+}
+
+func TestCountReviewsForRepo_CountsDistinctPRs(t *testing.T) {
+	s := newTestStore(t)
+	for i := int64(1); i <= 3; i++ {
+		prID, _ := s.UpsertPR(&store.PR{GithubID: i, Repo: "org/r", Number: int(i),
+			Title: "t", State: "open", UpdatedAt: time.Now()})
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+			Severity: "low", CreatedAt: time.Now().Add(-10 * time.Minute),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	since := time.Now().Add(-1 * time.Hour)
+	n, err := s.CountReviewsForRepo("org/r", since)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("want 3 reviews in last hour, got %d", n)
+	}
+}
+
+func TestCircuitBreaker_TripsOnPerPRCap(t *testing.T) {
+	s := newTestStore(t)
+	prID, _ := s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/r", Number: 1,
+		Title: "t", State: "open", UpdatedAt: time.Now()})
+	// Seed 3 reviews in the last 24h → cap is 3.
+	for i := 0; i < 3; i++ {
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+			Severity: "low", CreatedAt: time.Now().Add(time.Duration(-i) * time.Minute),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := store.CircuitBreakerLimits{
+		PerPR24h:  3,
+		PerRepoHr: 20,
+	}
+	tripped, reason, err := s.CheckCircuitBreaker(prID, "org/r", cfg)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if !tripped {
+		t.Errorf("expected tripped, got false (reason=%q)", reason)
+	}
+	if reason == "" {
+		t.Errorf("tripped must include a human-readable reason")
+	}
+}
+
+func TestCircuitBreaker_AllowsUnderCap(t *testing.T) {
+	s := newTestStore(t)
+	prID, _ := s.UpsertPR(&store.PR{GithubID: 2, Repo: "org/r", Number: 2,
+		Title: "t", State: "open", UpdatedAt: time.Now()})
+	// 2 reviews, cap 3 → must allow.
+	for i := 0; i < 2; i++ {
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+			Severity: "low", CreatedAt: time.Now().Add(time.Duration(-i) * time.Minute),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := store.CircuitBreakerLimits{PerPR24h: 3, PerRepoHr: 20}
+	tripped, _, err := s.CheckCircuitBreaker(prID, "org/r", cfg)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if tripped {
+		t.Errorf("expected allowed, got tripped")
+	}
+}

--- a/daemon/internal/store/prs.go
+++ b/daemon/internal/store/prs.go
@@ -25,7 +25,7 @@ type PR struct {
 // Note: dismissed is intentionally excluded from the UPDATE clause so a user's
 // dismiss choice is preserved even when the poll loop re-fetches the same PR.
 func (s *Store) UpsertPR(pr *PR) (int64, error) {
-	res, err := s.db.Exec(`
+	_, err := s.db.Exec(`
 		INSERT INTO prs (github_id, repo, number, title, author, url, state, updated_at, fetched_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(github_id) DO UPDATE SET
@@ -39,16 +39,15 @@ func (s *Store) UpsertPR(pr *PR) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("store: upsert pr: %w", err)
 	}
-	// LastInsertId returns 0 on the UPDATE path with modernc.org/sqlite (the
-	// driver this project uses). Other SQLite drivers may report the existing
-	// row id instead — the fallback SELECT below handles either case so this
-	// code is portable if the driver ever changes.
-	id, err := res.LastInsertId()
-	if err != nil || id == 0 {
-		row := s.db.QueryRow("SELECT id FROM prs WHERE github_id = ?", pr.GithubID)
-		if scanErr := row.Scan(&id); scanErr != nil {
-			return 0, fmt.Errorf("store: upsert pr fallback select: %w", scanErr)
-		}
+	// Always look up the row by github_id rather than trusting LastInsertId:
+	// modernc.org/sqlite returns the database-wide last inserted rowid, which
+	// on the UPDATE path can be the id of a row in a different table (e.g.
+	// reviews) — returning that value corrupted the circuit-breaker counts in
+	// issue #243. The unique index on github_id makes this SELECT cheap.
+	var id int64
+	row := s.db.QueryRow("SELECT id FROM prs WHERE github_id = ?", pr.GithubID)
+	if err := row.Scan(&id); err != nil {
+		return 0, fmt.Errorf("store: upsert pr select: %w", err)
 	}
 	return id, nil
 }

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -163,6 +163,10 @@ func Open(dsn string) (*Store, error) {
 		db.Exec("UPDATE agents SET is_default_dev = is_default")
 	}
 	db.Exec("ALTER TABLE issue_reviews ADD COLUMN commented_at DATETIME NOT NULL DEFAULT ''")
+	// Covering index for the circuit-breaker counters (see issue #243).
+	// CREATE INDEX IF NOT EXISTS is idempotent; safe on every startup.
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_reviews_pr_created ON reviews(pr_id, created_at)")
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_reviews_created ON reviews(created_at)")
 	return &Store{db: db}, nil
 }
 
@@ -388,13 +392,21 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 			sum, minD, maxD := 0.0, durations[0], durations[0]
 			for _, d := range durations {
 				sum += d
-				if d < minD { minD = d }
-				if d > maxD { maxD = d }
+				if d < minD {
+					minD = d
+				}
+				if d > maxD {
+					maxD = d
+				}
 				switch {
-				case d < 30:   t.BucketFast++
-				case d < 120:  t.BucketMedium++
-				case d < 300:  t.BucketSlow++
-				default:       t.BucketVerySlow++
+				case d < 30:
+					t.BucketFast++
+				case d < 120:
+					t.BucketMedium++
+				case d < 300:
+					t.BucketSlow++
+				default:
+					t.BucketVerySlow++
 				}
 			}
 			t.AvgSeconds = sum / float64(n)

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -167,6 +167,10 @@ func Open(dsn string) (*Store, error) {
 	// CREATE INDEX IF NOT EXISTS is idempotent; safe on every startup.
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_reviews_pr_created ON reviews(pr_id, created_at)")
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_reviews_created ON reviews(created_at)")
+	// Hot path for CountReviewsForRepo (see issue #243). Without this the
+	// JOIN drives from prs.repo with no index and table-scans on every
+	// poll-cycle breaker check.
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_prs_repo ON prs(repo)")
 	return &Store{db: db}, nil
 }
 


### PR DESCRIPTION
Refs #243 (Fix 1 in the priority list — the unconditional ceiling).

Ships after fix/pr-dedup-fail-closed-head-sha. Any other dedup defense may still fail — this PR is the defense of last resort that physically caps worst-case cost.

**Defaults**
- Per-PR: 3 reviews / 24h
- Per-repo: 20 reviews / hour
- Configurable via `[circuit_breaker]` in TOML

**Also fixed:** a latent bug in `UpsertPR` that would have rendered the circuit breaker useless in production. `modernc.org/sqlite` returns the database-wide last-inserted rowid, so after any `InsertReview` the next `UpsertPR` on the UPDATE path returned the review's id instead of the PR's id — reviews from the third poll cycle onward were stored with the wrong `pr_id`, and the breaker could not count them. `UpsertPR` now always looks up the row by `github_id`.

**Test plan**
- [x] Unit tests for counters and breaker
- [x] Integration test: pipeline refuses to call Execute when breaker trips
- [x] `make test-docker` green
- [ ] Manual: seed 4 reviews on a test PR, assert next poll is refused + SSE event arrives in the UI