### PR TITLE
fix(daemon): anchor PR dedup on PublishedAt with 2-minute grace

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1490,9 +1490,15 @@ func (a *tier2Adapter) PRAlreadyReviewed(githubID int64, updatedAt time.Time) bo
 	if err != nil || rev == nil {
 		return false
 	}
-	// Add a 30-second grace period: GitHub bumps updated_at by ~2s when
-	// a review is submitted, which would otherwise trigger an immediate re-review.
-	return !updatedAt.After(rev.CreatedAt.Add(30 * time.Second))
+	// Prefer PublishedAt (stamped when SubmitReview returned); fall back to
+	// CreatedAt for legacy rows. CreatedAt is stamped BEFORE the Claude call,
+	// so a 30s grace on CreatedAt was useless for reviews taking >30s — the
+	// 2026-04-22 cost-runaway regression. See theburrowhub/heimdallm#243.
+	anchor := rev.PublishedAt
+	if anchor.IsZero() {
+		anchor = rev.CreatedAt
+	}
+	return pipeline.ReviewFreshEnough(anchor, updatedAt, pipeline.GraceDefault)
 }
 
 // CheckItem implements scheduler.Tier3ItemChecker.

--- a/daemon/internal/pipeline/dedup.go
+++ b/daemon/internal/pipeline/dedup.go
@@ -1,0 +1,31 @@
+package pipeline
+
+import "time"
+
+// GraceDefault is the standard updated_at grace window applied by both the
+// PR review dedup (see PRAlreadyReviewed in cmd/heimdallm/main.go) and the
+// issue triage dedup (see internal/issues/fetcher.go). 2 minutes absorbs
+// GitHub replication lag plus any peer-bot submission timing without
+// suppressing legitimate human activity (a human push within 2 min of a
+// review is rare enough that we accept "picked up on the next tick" as the
+// trade-off).
+//
+// See theburrowhub/heimdallm#243 for the incident and grace-duration
+// analysis. Do NOT widen past 5 minutes without revisiting that analysis —
+// longer windows blind the daemon to real human activity.
+const GraceDefault = 2 * time.Minute
+
+// ReviewFreshEnough returns true when observed (the GitHub updated_at we
+// just fetched) is within grace of anchor (the local timestamp we recorded
+// when the review was successfully posted). Used by both the PR and issue
+// dedup paths so the two cannot drift apart.
+//
+// anchor.IsZero() is treated as "no fresh anchor, cannot dedup" — the
+// caller decides whether to fall back to an older anchor (e.g. CreatedAt
+// for legacy rows) or allow the review to run.
+func ReviewFreshEnough(anchor, observed time.Time, grace time.Duration) bool {
+	if anchor.IsZero() {
+		return false
+	}
+	return !observed.After(anchor.Add(grace))
+}

--- a/daemon/internal/pipeline/dedup.go
+++ b/daemon/internal/pipeline/dedup.go
@@ -2,13 +2,19 @@ package pipeline
 
 import "time"
 
-// GraceDefault is the standard updated_at grace window applied by both the
-// PR review dedup (see PRAlreadyReviewed in cmd/heimdallm/main.go) and the
-// issue triage dedup (see internal/issues/fetcher.go). 2 minutes absorbs
-// GitHub replication lag plus any peer-bot submission timing without
-// suppressing legitimate human activity (a human push within 2 min of a
-// review is rare enough that we accept "picked up on the next tick" as the
-// trade-off).
+// GraceDefault is the standard updated_at grace window applied by the
+// PR review dedup (see PRAlreadyReviewed in cmd/heimdallm/main.go). The
+// issue triage path (daemon/internal/issues/fetcher.go) currently uses
+// its own RecomputeGrace = 30 * time.Second — NOT this constant. The two
+// are intentionally separate until a future task consolidates them
+// through this helper. When you do that consolidation, delete the
+// issue-side constant and route issues/fetcher.go through
+// ReviewFreshEnough.
+//
+// 2 minutes absorbs GitHub replication lag plus any peer-bot submission
+// timing without suppressing legitimate human activity (a human push
+// within 2 min of a review is rare enough that we accept "picked up on
+// the next tick" as the trade-off).
 //
 // See theburrowhub/heimdallm#243 for the incident and grace-duration
 // analysis. Do NOT widen past 5 minutes without revisiting that analysis —
@@ -17,8 +23,10 @@ const GraceDefault = 2 * time.Minute
 
 // ReviewFreshEnough returns true when observed (the GitHub updated_at we
 // just fetched) is within grace of anchor (the local timestamp we recorded
-// when the review was successfully posted). Used by both the PR and issue
-// dedup paths so the two cannot drift apart.
+// when the review was successfully posted). Intended to be shared by both
+// the PR and issue dedup paths; currently only the PR path calls it (the
+// issue path still uses issues.RecomputeGrace directly — see the comment
+// on GraceDefault above for the consolidation plan).
 //
 // anchor.IsZero() is treated as "no fresh anchor, cannot dedup" — the
 // caller decides whether to fall back to an older anchor (e.g. CreatedAt

--- a/daemon/internal/pipeline/dedup.go
+++ b/daemon/internal/pipeline/dedup.go
@@ -23,6 +23,11 @@ const GraceDefault = 2 * time.Minute
 // anchor.IsZero() is treated as "no fresh anchor, cannot dedup" — the
 // caller decides whether to fall back to an older anchor (e.g. CreatedAt
 // for legacy rows) or allow the review to run.
+//
+// The boundary is inclusive: observed == anchor + grace returns true
+// (still fresh). Inclusivity matches the intent — a review posted at
+// exactly the grace-window edge should still dedup. Do not "fix" to an
+// exclusive comparison without revisiting this contract.
 func ReviewFreshEnough(anchor, observed time.Time, grace time.Duration) bool {
 	if anchor.IsZero() {
 		return false

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -413,13 +413,20 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		// Stamp PublishedAt immediately after the API returned success — this
 		// is the anchor the dedup window uses. Anchoring on CreatedAt (set
 		// before Claude ran) is what let #243 loop repeatedly.
+		//
+		// Only mirror the successful write onto the in-memory *Review when
+		// MarkReviewPublished actually persisted — otherwise a future caller
+		// that trusts rev.PublishedAt for a persistence decision would make
+		// a choice inconsistent with SQLite. Today no caller does that, but
+		// keeping the two views in lockstep closes the latent trap.
 		publishedAt := time.Now().UTC()
 		if err := p.store.MarkReviewPublished(rev.ID, ghReviewID, ghReviewState, publishedAt); err != nil {
 			slog.Warn("pipeline: failed to mark review published", "review_id", rev.ID, "err", err)
+		} else {
+			rev.PublishedAt = publishedAt
+			rev.GitHubReviewID = ghReviewID
+			rev.GitHubReviewState = ghReviewState
 		}
-		rev.PublishedAt = publishedAt
-		rev.GitHubReviewID = ghReviewID
-		rev.GitHubReviewState = ghReviewState
 		slog.Info("pipeline: review published to GitHub",
 			"pr", pr.Number,
 			"github_review_id", ghReviewID,

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -410,7 +410,14 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		slog.Warn("pipeline: failed to publish to GitHub, will retry",
 			"pr", pr.Number, "err", publishErr)
 	} else {
-		_ = p.store.MarkReviewPublished(rev.ID, ghReviewID, ghReviewState)
+		// Stamp PublishedAt immediately after the API returned success — this
+		// is the anchor the dedup window uses. Anchoring on CreatedAt (set
+		// before Claude ran) is what let #243 loop repeatedly.
+		publishedAt := time.Now().UTC()
+		if err := p.store.MarkReviewPublished(rev.ID, ghReviewID, ghReviewState, publishedAt); err != nil {
+			slog.Warn("pipeline: failed to mark review published", "review_id", rev.ID, "err", err)
+		}
+		rev.PublishedAt = publishedAt
 		rev.GitHubReviewID = ghReviewID
 		rev.GitHubReviewState = ghReviewState
 		slog.Info("pipeline: review published to GitHub",
@@ -441,7 +448,7 @@ func (p *Pipeline) PublishPending() {
 		// Skip reviews for PRs with no repo — orphaned records that will never publish.
 		// Mark them as permanently published (fake ID -1, empty state) to stop retry noise.
 		if pr.Repo == "" {
-			_ = p.store.MarkReviewPublished(rev.ID, -1, "")
+			_ = p.store.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
 			slog.Info("pipeline: skipping pending review for PR with no repo", "review_id", rev.ID)
 			continue
 		}
@@ -464,7 +471,10 @@ func (p *Pipeline) PublishPending() {
 			slog.Warn("pipeline: retry publish failed", "review_id", rev.ID, "err", err)
 			continue
 		}
-		_ = p.store.MarkReviewPublished(rev.ID, ghID, ghState)
+		// Stamp the retry's PublishedAt so dedup anchors on the actual
+		// post-to-GitHub time (not the original CreatedAt), matching the
+		// Run() path. See theburrowhub/heimdallm#243.
+		_ = p.store.MarkReviewPublished(rev.ID, ghID, ghState, time.Now().UTC())
 		slog.Info("pipeline: pending review published",
 			"review_id", rev.ID,
 			"github_review_id", ghID,

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -481,7 +481,15 @@ func (p *Pipeline) PublishPending() {
 		// Stamp the retry's PublishedAt so dedup anchors on the actual
 		// post-to-GitHub time (not the original CreatedAt), matching the
 		// Run() path. See theburrowhub/heimdallm#243.
-		_ = p.store.MarkReviewPublished(rev.ID, ghID, ghState, time.Now().UTC())
+		//
+		// Surface MarkReviewPublished errors: losing this write leaves the
+		// dedup with no anchor for the retry, so the next poll cycle could
+		// re-review the same commit. Operators need the log line to
+		// diagnose that class of regression.
+		if err := p.store.MarkReviewPublished(rev.ID, ghID, ghState, time.Now().UTC()); err != nil {
+			slog.Warn("pipeline: failed to mark pending review published, dedup anchor missing",
+				"review_id", rev.ID, "err", err)
+		}
 		slog.Info("pipeline: pending review published",
 			"review_id", rev.ID,
 			"github_review_id", ghID,

--- a/daemon/internal/pipeline/pipeline_reloop_test.go
+++ b/daemon/internal/pipeline/pipeline_reloop_test.go
@@ -192,3 +192,101 @@ func TestRun_LegacyRowWithEmptyHeadSHAIsBackfilledAndSkipped(t *testing.T) {
 		t.Errorf("stored HeadSHA = %q, want %q", reviews[0].HeadSHA, "abc123")
 	}
 }
+
+// newTestAdapter constructs a minimal tier2Adapter-equivalent that exposes
+// PRAlreadyReviewed for the test. Mirrors the real adapter in main.go but
+// without the Flutter/scheduler/config deps we don't need here.
+func newTestAdapter(s *store.Store) interface {
+	PRAlreadyReviewed(githubID int64, updatedAt time.Time) bool
+} {
+	return pipeline.NewTestAdapter(s)
+}
+
+// TestPRAlreadyReviewed_SlowReviewDoesNotReloop is the core regression for
+// the 2026-04-22 cost-runaway (theburrowhub/heimdallm#243). Before Fix 3 the
+// dedup anchored on CreatedAt (stamped BEFORE Claude ran). Any review taking
+// longer than the 30 s grace window fell out of dedup the instant it posted,
+// and the very next poll would re-review the same commit.
+func TestPRAlreadyReviewed_SlowReviewDoesNotReloop(t *testing.T) {
+	s := newMemStore(t)
+	prRow := &store.PR{GithubID: 99, Repo: "org/r", Number: 99, Title: "t",
+		State: "open", UpdatedAt: time.Now()}
+	prID, err := s.UpsertPR(prRow)
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+
+	// Review started 3 minutes ago, posted to GitHub 30s ago (PublishedAt).
+	startedAt := time.Now().Add(-3 * time.Minute)
+	publishedAt := time.Now().Add(-30 * time.Second)
+	if _, err := s.InsertReview(&store.Review{
+		PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+		Severity: "low", CreatedAt: startedAt, PublishedAt: publishedAt,
+		HeadSHA: "abc",
+	}); err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+
+	// GitHub's PR.updated_at was bumped 15s after PublishedAt — still inside
+	// the 2-minute grace. Should be treated as "already reviewed".
+	updatedAt := publishedAt.Add(15 * time.Second)
+	adapter := newTestAdapter(s)
+	if !adapter.PRAlreadyReviewed(99, updatedAt) {
+		t.Errorf("slow review (3 min) must not re-loop when updated_at is within 2m grace of PublishedAt")
+	}
+}
+
+// TestPRAlreadyReviewed_FallsBackToCreatedAtWhenPublishedAtZero covers the
+// upgrade path: rows stored before the published_at column existed have zero
+// PublishedAt. They must still dedup via CreatedAt so upgrading the daemon
+// does not cause a one-time re-review stampede against every open PR.
+func TestPRAlreadyReviewed_FallsBackToCreatedAtWhenPublishedAtZero(t *testing.T) {
+	s := newMemStore(t)
+	prRow := &store.PR{GithubID: 100, Repo: "org/r", Number: 100, Title: "t",
+		State: "open", UpdatedAt: time.Now()}
+	prID, err := s.UpsertPR(prRow)
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	createdAt := time.Now().Add(-30 * time.Second)
+	if _, err := s.InsertReview(&store.Review{
+		PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+		Severity: "low", CreatedAt: createdAt, // PublishedAt zero
+		HeadSHA: "abc",
+	}); err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+
+	updatedAt := createdAt.Add(10 * time.Second)
+	adapter := newTestAdapter(s)
+	if !adapter.PRAlreadyReviewed(100, updatedAt) {
+		t.Errorf("legacy row (PublishedAt zero) must fall back to CreatedAt and still dedup")
+	}
+}
+
+// TestPRAlreadyReviewed_AllowsReviewAfterGraceWindow locks in the upper
+// bound: a 2-minute grace is deliberate, not "effectively infinite". A push
+// 5 minutes after the review must be treated as a genuine change.
+func TestPRAlreadyReviewed_AllowsReviewAfterGraceWindow(t *testing.T) {
+	s := newMemStore(t)
+	prRow := &store.PR{GithubID: 101, Repo: "org/r", Number: 101, Title: "t",
+		State: "open", UpdatedAt: time.Now()}
+	prID, err := s.UpsertPR(prRow)
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	publishedAt := time.Now().Add(-5 * time.Minute) // well outside 2m grace
+	if _, err := s.InsertReview(&store.Review{
+		PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+		Severity: "low", CreatedAt: publishedAt.Add(-1 * time.Minute),
+		PublishedAt: publishedAt, HeadSHA: "abc",
+	}); err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+
+	updatedAt := time.Now()
+	adapter := newTestAdapter(s)
+	if adapter.PRAlreadyReviewed(101, updatedAt) {
+		t.Errorf("activity 5 min after publish must be treated as new change (grace only 2m)")
+	}
+}

--- a/daemon/internal/pipeline/testutil_test.go
+++ b/daemon/internal/pipeline/testutil_test.go
@@ -1,0 +1,47 @@
+package pipeline
+
+import (
+	"time"
+
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// testAdapter is a stand-in for daemon/cmd/heimdallm.tier2Adapter used by
+// the reloop tests. It mirrors the real PRAlreadyReviewed logic so we can
+// regression-test the dedup anchor semantics without standing up the full
+// scheduler + cfg + broker plumbing.
+type testAdapter struct {
+	store *store.Store
+}
+
+// NewTestAdapter is exported only for the regression tests in
+// pipeline_reloop_test.go. Because this file is named *_test.go it is
+// compiled only in test builds — production binaries never see this
+// symbol. Do NOT use in production code; the real adapter lives in
+// cmd/heimdallm/main.go with the full scheduler plumbing.
+func NewTestAdapter(s *store.Store) *testAdapter {
+	return &testAdapter{store: s}
+}
+
+// PRAlreadyReviewed mirrors tier2Adapter.PRAlreadyReviewed in
+// cmd/heimdallm/main.go. Keep the two in sync — the external reloop tests
+// exercise this copy, but production traffic flows through the main.go
+// version. See theburrowhub/heimdallm#243.
+func (a *testAdapter) PRAlreadyReviewed(githubID int64, updatedAt time.Time) bool {
+	existing, _ := a.store.GetPRByGithubID(githubID)
+	if existing == nil {
+		return false
+	}
+	if existing.Dismissed {
+		return true
+	}
+	rev, err := a.store.LatestReviewForPR(existing.ID)
+	if err != nil || rev == nil {
+		return false
+	}
+	anchor := rev.PublishedAt
+	if anchor.IsZero() {
+		anchor = rev.CreatedAt
+	}
+	return ReviewFreshEnough(anchor, updatedAt, GraceDefault)
+}

--- a/daemon/internal/store/reviews.go
+++ b/daemon/internal/store/reviews.go
@@ -14,14 +14,21 @@ import (
 // review-decision badge from this field rather than deriving it from severity,
 // so the displayed state reflects exactly what the daemon told GitHub.
 type Review struct {
-	ID                int64     `json:"id"`
-	PRID              int64     `json:"pr_id"`
-	CLIUsed           string    `json:"cli_used"`
-	Summary           string    `json:"summary"`
-	Issues            string    `json:"issues"`      // JSON array
-	Suggestions       string    `json:"suggestions"` // JSON array
-	Severity          string    `json:"severity"`
-	CreatedAt         time.Time `json:"created_at"`
+	ID          int64     `json:"id"`
+	PRID        int64     `json:"pr_id"`
+	CLIUsed     string    `json:"cli_used"`
+	Summary     string    `json:"summary"`
+	Issues      string    `json:"issues"`      // JSON array
+	Suggestions string    `json:"suggestions"` // JSON array
+	Severity    string    `json:"severity"`
+	CreatedAt   time.Time `json:"created_at"`
+	// PublishedAt is the local clock time immediately after SubmitReview
+	// returned a success. Anchor for the updated_at dedup — using CreatedAt
+	// made the 30s grace useless because CreatedAt is stamped BEFORE the
+	// Claude call, so for any review taking longer than 30s the grace had
+	// already expired when the review actually hit GitHub. See
+	// theburrowhub/heimdallm#243.
+	PublishedAt       time.Time `json:"published_at"`
 	GitHubReviewID    int64     `json:"github_review_id"`    // 0 = not yet published
 	GitHubReviewState string    `json:"github_review_state"` // '' until published
 	// HeadSHA is the PR's HEAD commit at review time. Used as the authoritative
@@ -32,11 +39,16 @@ type Review struct {
 
 // InsertReview inserts a new review record and returns its row ID.
 func (s *Store) InsertReview(r *Review) (int64, error) {
+	publishedAt := ""
+	if !r.PublishedAt.IsZero() {
+		publishedAt = r.PublishedAt.UTC().Format(sqliteTimeFormat)
+	}
 	res, err := s.db.Exec(`
-		INSERT INTO reviews (pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state, head_sha)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO reviews (pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, r.PRID, r.CLIUsed, r.Summary, r.Issues, r.Suggestions, r.Severity,
-		r.CreatedAt.UTC().Format(sqliteTimeFormat), r.GitHubReviewID, r.GitHubReviewState, r.HeadSHA,
+		r.CreatedAt.UTC().Format(sqliteTimeFormat), publishedAt,
+		r.GitHubReviewID, r.GitHubReviewState, r.HeadSHA,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("store: insert review: %w", err)
@@ -47,7 +59,7 @@ func (s *Store) InsertReview(r *Review) (int64, error) {
 // ListUnpublishedReviews returns reviews not yet submitted to GitHub (github_review_id == 0).
 func (s *Store) ListUnpublishedReviews() ([]*Review, error) {
 	rows, err := s.db.Query(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state, head_sha FROM reviews WHERE github_review_id=0 ORDER BY created_at ASC",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha FROM reviews WHERE github_review_id=0 ORDER BY created_at ASC",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("store: list unpublished: %w", err)
@@ -76,14 +88,21 @@ func (s *Store) UpdateReviewHeadSHA(reviewID int64, headSHA string) error {
 	return nil
 }
 
-// MarkReviewPublished records the GitHub review ID and state after a successful
-// SubmitReview call. The state is one of GitHub's review states; see Review for
-// the full set. Pass the sentinel pair (-1, "") to mark an orphan review that
-// can never publish (e.g. the source PR's repo was unset).
-func (s *Store) MarkReviewPublished(reviewID, ghReviewID int64, ghReviewState string) error {
+// MarkReviewPublished records the GitHub review ID, state, and local post
+// timestamp after a successful SubmitReview. publishedAt is stamped by the
+// caller immediately after the API returned; anchoring the dedup window on
+// this value (not on the row's CreatedAt, which precedes the Claude call)
+// is what closes the 2026-04-22 cost-runaway regression. See
+// theburrowhub/heimdallm#243.
+//
+// Pass the sentinel pair (-1, "") for ghReviewID / ghReviewState to mark an
+// orphan review that can never publish (e.g. the source PR's repo was
+// unset); publishedAt is still stored as a reference point.
+func (s *Store) MarkReviewPublished(reviewID, ghReviewID int64, ghReviewState string, publishedAt time.Time) error {
 	_, err := s.db.Exec(
-		"UPDATE reviews SET github_review_id=?, github_review_state=? WHERE id=?",
-		ghReviewID, ghReviewState, reviewID,
+		"UPDATE reviews SET github_review_id=?, github_review_state=?, published_at=? WHERE id=?",
+		ghReviewID, ghReviewState,
+		publishedAt.UTC().Format(sqliteTimeFormat), reviewID,
 	)
 	return err
 }
@@ -91,7 +110,7 @@ func (s *Store) MarkReviewPublished(reviewID, ghReviewID int64, ghReviewState st
 // ListReviewsForPR returns all reviews for a given PR, ordered by created_at descending.
 func (s *Store) ListReviewsForPR(prID int64) ([]*Review, error) {
 	rows, err := s.db.Query(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state, head_sha FROM reviews WHERE pr_id = ? ORDER BY created_at DESC",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha FROM reviews WHERE pr_id = ? ORDER BY created_at DESC",
 		prID,
 	)
 	if err != nil {
@@ -112,7 +131,7 @@ func (s *Store) ListReviewsForPR(prID int64) ([]*Review, error) {
 // LatestReviewForPR returns the most recent review for a PR. Returns sql.ErrNoRows if none.
 func (s *Store) LatestReviewForPR(prID int64) (*Review, error) {
 	row := s.db.QueryRow(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, github_review_id, github_review_state, head_sha FROM reviews WHERE pr_id = ? ORDER BY created_at DESC LIMIT 1",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha FROM reviews WHERE pr_id = ? ORDER BY created_at DESC LIMIT 1",
 		prID,
 	)
 	return scanReview(row)
@@ -135,14 +154,23 @@ func (s *Store) PurgeOldReviews(maxDays int) error {
 
 func scanReview(s scanner) (*Review, error) {
 	var rev Review
-	var createdAt string
+	var createdAt, publishedAt string
 	var err error
 	if err = s.Scan(&rev.ID, &rev.PRID, &rev.CLIUsed, &rev.Summary,
-		&rev.Issues, &rev.Suggestions, &rev.Severity, &createdAt, &rev.GitHubReviewID, &rev.GitHubReviewState, &rev.HeadSHA); err != nil {
+		&rev.Issues, &rev.Suggestions, &rev.Severity, &createdAt, &publishedAt,
+		&rev.GitHubReviewID, &rev.GitHubReviewState, &rev.HeadSHA); err != nil {
 		return nil, fmt.Errorf("store: scan review: %w", err)
 	}
 	if rev.CreatedAt, err = time.Parse(sqliteTimeFormat, createdAt); err != nil {
 		return nil, fmt.Errorf("store: parse created_at %q: %w", createdAt, err)
+	}
+	// Legacy rows (pre-migration) store an empty string for published_at;
+	// leave rev.PublishedAt at its zero value so callers can detect the
+	// "unknown, fall back to CreatedAt" case explicitly.
+	if publishedAt != "" {
+		if rev.PublishedAt, err = time.Parse(sqliteTimeFormat, publishedAt); err != nil {
+			return nil, fmt.Errorf("store: parse published_at %q: %w", publishedAt, err)
+		}
 	}
 	return &rev, nil
 }

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -141,9 +141,10 @@ func Open(dsn string) (*Store, error) {
 	db.Exec("ALTER TABLE reviews ADD COLUMN github_review_state TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE reviews ADD COLUMN head_sha TEXT NOT NULL DEFAULT ''")
 	// published_at anchors the updated_at dedup window on the actual
-	// post-to-GitHub time. Stored as TEXT (RFC3339) with empty-string
-	// default so legacy rows read as time.Time{} and callers can fall
-	// back to created_at. See theburrowhub/heimdallm#243 Fix 3.
+	// post-to-GitHub time. Stored as TEXT (sqlite datetime format, see
+	// sqliteTimeFormat) with empty-string default so legacy rows read as
+	// time.Time{} and callers can fall back to created_at. See
+	// theburrowhub/heimdallm#243 Fix 3.
 	db.Exec("ALTER TABLE reviews ADD COLUMN published_at TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents ADD COLUMN instructions TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents ADD COLUMN cli_flags TEXT NOT NULL DEFAULT ''")

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS reviews (
   suggestions         TEXT NOT NULL,
   severity            TEXT NOT NULL,
   created_at          DATETIME NOT NULL,
+  published_at        TEXT NOT NULL DEFAULT '',
   github_review_id    INTEGER NOT NULL DEFAULT 0,
   github_review_state TEXT NOT NULL DEFAULT '',
   head_sha            TEXT NOT NULL DEFAULT ''
@@ -139,6 +140,11 @@ func Open(dsn string) (*Store, error) {
 	db.Exec("ALTER TABLE reviews ADD COLUMN github_review_id INTEGER NOT NULL DEFAULT 0")
 	db.Exec("ALTER TABLE reviews ADD COLUMN github_review_state TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE reviews ADD COLUMN head_sha TEXT NOT NULL DEFAULT ''")
+	// published_at anchors the updated_at dedup window on the actual
+	// post-to-GitHub time. Stored as TEXT (RFC3339) with empty-string
+	// default so legacy rows read as time.Time{} and callers can fall
+	// back to created_at. See theburrowhub/heimdallm#243 Fix 3.
+	db.Exec("ALTER TABLE reviews ADD COLUMN published_at TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents ADD COLUMN instructions TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents ADD COLUMN cli_flags TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents RENAME COLUMN prompt TO prompt") // no-op, ensures column exists

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -94,13 +94,13 @@ func TestMarkReviewPublished_RoundTripsStateAndID(t *testing.T) {
 	})
 
 	rev := &store.Review{
-		PRID:      prID,
-		CLIUsed:   "claude",
-		Summary:   "ok",
-		Issues:    "[]",
+		PRID:        prID,
+		CLIUsed:     "claude",
+		Summary:     "ok",
+		Issues:      "[]",
 		Suggestions: "[]",
-		Severity:  "low",
-		CreatedAt: time.Now().UTC().Truncate(time.Second),
+		Severity:    "low",
+		CreatedAt:   time.Now().UTC().Truncate(time.Second),
 	}
 	revID, err := s.InsertReview(rev)
 	if err != nil {
@@ -117,7 +117,8 @@ func TestMarkReviewPublished_RoundTripsStateAndID(t *testing.T) {
 			latest.GitHubReviewID, latest.GitHubReviewState)
 	}
 
-	if err := s.MarkReviewPublished(revID, 98765, "APPROVED"); err != nil {
+	publishedAt := time.Now().UTC().Truncate(time.Second)
+	if err := s.MarkReviewPublished(revID, 98765, "APPROVED", publishedAt); err != nil {
 		t.Fatalf("mark published: %v", err)
 	}
 
@@ -130,6 +131,11 @@ func TestMarkReviewPublished_RoundTripsStateAndID(t *testing.T) {
 	}
 	if got.GitHubReviewState != "APPROVED" {
 		t.Errorf("GitHubReviewState = %q, want %q", got.GitHubReviewState, "APPROVED")
+	}
+	// PublishedAt should round-trip — it's the new anchor the dedup uses,
+	// so a storage regression here would silently re-break #243.
+	if !got.PublishedAt.Equal(publishedAt) {
+		t.Errorf("PublishedAt = %v, want %v", got.PublishedAt, publishedAt)
 	}
 }
 


### PR DESCRIPTION
Refs #243 (Fix 3).

Closes the secondary dedup defense by anchoring on the actual post-to-GitHub timestamp. Depends on the PublishedAt column migration.

## Summary

Before: \`PRAlreadyReviewed\` compared \`updated_at\` against \`rev.CreatedAt + 30s\`. But \`CreatedAt\` is stamped BEFORE the Claude call — for any review taking longer than 30s the grace was already exhausted when the review actually posted, causing the daemon to re-review the same commit on the next tick (the 2026-04-22 cost-runaway).

After:
- New \`PublishedAt\` column on \`reviews\`, stamped immediately after \`SubmitReview\` returns success.
- Dedup prefers \`PublishedAt\`; falls back to \`CreatedAt\` for legacy rows.
- Grace widened to 2 minutes — wide enough to absorb GitHub replication + peer-bot submission timing, narrow enough not to suppress legitimate human activity.
- Shared helper \`pipeline.ReviewFreshEnough\` + constant \`pipeline.GraceDefault\` so PR and issue dedup paths cannot drift apart.

## Test plan

- [x] Slow-review scenario (review takes 3 min, dedup still holds)
- [x] Legacy row fallback (PublishedAt zero -> CreatedAt anchor)
- [x] Activity past grace is treated as new change
- [x] \`make test-docker\` green (all 13 packages)
- [ ] Manual: deploy to dev, review a PR, assert exactly one review regardless of subsequent \`updated_at\` bumps