### PR TITLE
fix(daemon): ResetBackoff stores observed updated_at, not wall clock

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1618,8 +1618,12 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 			return nil
 		}
 
-		// Mirror the existing Tier 2 updated_at dedup.
-		if a.PRAlreadyReviewed(item.GithubID, item.LastSeen) {
+		// Mirror the Tier 2 updated_at dedup against the freshly-observed
+		// GitHub snapshot timestamp, NOT item.LastSeen — the queue's
+		// LastSeen has already been overwritten by ResetBackoff on earlier
+		// ticks and is no longer a faithful representation of the PR's
+		// current updated_at.
+		if a.PRAlreadyReviewed(item.GithubID, snap.UpdatedAt) {
 			slog.Debug("tier3: PR already reviewed, skipping", "pr", item.Number, "repo", item.Repo)
 			return nil
 		}

--- a/daemon/internal/scheduler/queue.go
+++ b/daemon/internal/scheduler/queue.go
@@ -14,7 +14,7 @@ const (
 
 // WatchItem represents a PR or issue being actively watched for changes.
 type WatchItem struct {
-	Type      string        // "pr" | "issue"
+	Type      string // "pr" | "issue"
 	Repo      string
 	Number    int
 	GithubID  int64
@@ -103,17 +103,23 @@ func (q *WatchQueue) ReEnqueue(item *WatchItem) {
 	heap.Push(&q.items, item)
 }
 
-// ResetBackoff resets an item's backoff to initial and re-enqueues it.
-// Called when activity is detected on the item. Same concurrency contract
-// as ReEnqueue — caller must own the item exclusively.
-func (q *WatchQueue) ResetBackoff(item *WatchItem) {
+// ResetBackoff resets an item's backoff to initial and records the observed
+// GitHub updated_at as LastSeen. Called when activity is detected on the
+// item. Using observed (not time.Now()) is critical: if a Tier 3 check
+// discovered the change via GitHub's updated_at, storing time.Now() as
+// LastSeen would drift ahead of GitHub's clock and make subsequent ticks
+// spuriously re-detect the same change. See theburrowhub/heimdallm#243.
+//
+// Same concurrency contract as ReEnqueue — caller must own the item
+// exclusively.
+func (q *WatchQueue) ResetBackoff(item *WatchItem, observedUpdatedAt time.Time) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if q.seen[item.GithubID] {
 		return
 	}
 	item.Backoff = initialBackoff
-	item.LastSeen = time.Now()
+	item.LastSeen = observedUpdatedAt
 	item.NextCheck = time.Now().Add(initialBackoff)
 	q.seen[item.GithubID] = true
 	heap.Push(&q.items, item)

--- a/daemon/internal/scheduler/queue_test.go
+++ b/daemon/internal/scheduler/queue_test.go
@@ -98,9 +98,22 @@ func TestWatchQueue_BackoffCapped(t *testing.T) {
 func TestWatchQueue_ResetBackoff(t *testing.T) {
 	q := NewWatchQueue()
 	item := &WatchItem{Type: "pr", GithubID: 100, Backoff: 8 * time.Minute}
-	q.ResetBackoff(item)
+	q.ResetBackoff(item, time.Now())
 	if item.Backoff != initialBackoff {
 		t.Errorf("backoff = %v, want %v", item.Backoff, initialBackoff)
+	}
+}
+
+func TestWatchQueue_ResetBackoff_StoresObservedUpdatedAt(t *testing.T) {
+	q := NewWatchQueue()
+	observed := time.Now().Add(-5 * time.Minute)
+	item := &WatchItem{Type: "pr", GithubID: 100, Backoff: 8 * time.Minute}
+	q.ResetBackoff(item, observed)
+	if !item.LastSeen.Equal(observed) {
+		t.Errorf("LastSeen = %v, want observed = %v", item.LastSeen, observed)
+	}
+	if item.Backoff != initialBackoff {
+		t.Errorf("Backoff = %v, want initial = %v", item.Backoff, initialBackoff)
 	}
 }
 

--- a/daemon/internal/scheduler/tier3.go
+++ b/daemon/internal/scheduler/tier3.go
@@ -84,7 +84,14 @@ func RunTier3(ctx context.Context, deps Tier3Deps) {
 					if err := deps.Checker.HandleChange(ctx, item, snap); err != nil {
 						slog.Error("tier3: handle change", "err", err)
 					}
-					deps.Queue.ResetBackoff(item)
+					// Pass the observed timestamp so LastSeen matches
+					// GitHub-side time, not wall clock — see
+					// theburrowhub/heimdallm#243.
+					observed := time.Time{}
+					if snap != nil {
+						observed = snap.UpdatedAt
+					}
+					deps.Queue.ResetBackoff(item, observed)
 				} else {
 					deps.Queue.ReEnqueue(item)
 				}


### PR DESCRIPTION
Refs #243 (Fix 4). Small refactor that restores the Tier 3 change-detection defense.

**Draft** while controller runs through subagent review pipeline — will be marked ready after spec + code-quality reviews pass.

**Test plan**
- [x] Unit test on ResetBackoff signature
- [x] `make test-docker` green