### PR TITLE
feat(heimdallm): persist in-flight reviews + reload delay + multi-instance regression test + breaker banner

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -118,6 +118,16 @@ func main() {
 		slog.Warn("activity retention purge failed", "err", err)
 	}
 
+	// Clear in-flight review claims leaked by a daemon that crashed between
+	// claim and release. The 30-minute cutoff gives normal reviews (which
+	// finish in seconds-minutes) plenty of headroom while still cleaning up
+	// anything stuck from a previous process. See theburrowhub/heimdallm#243.
+	if n, err := s.ClearStaleInFlight(30 * time.Minute); err != nil {
+		slog.Warn("startup: clear stale inflight failed", "err", err)
+	} else if n > 0 {
+		slog.Info("startup: cleared stale inflight rows", "count", n)
+	}
+
 	broker := sse.NewBroker()
 	broker.Start()
 
@@ -203,11 +213,6 @@ func main() {
 	var loginMu sync.Mutex
 	var cachedLogin string
 
-	// reviewMu prevents concurrent pipeline runs for the same GitHub PR ID.
-	// Key: pr.ID (GitHub PR ID), Value: true while being reviewed.
-	var reviewMu sync.Mutex
-	inFlight := make(map[int64]bool)
-
 	buildRunOpts := func(pr *gh.PullRequest, aiCfg config.RepoAI) pipeline.RunOptions {
 		cli := aiCfg.Primary
 		if cli == "" {
@@ -257,19 +262,40 @@ func main() {
 	}
 
 	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) {
-		// Guard: skip if already being reviewed
-		reviewMu.Lock()
-		if inFlight[pr.ID] {
-			reviewMu.Unlock()
-			slog.Info("review already in flight, skipping", "pr", pr.Number, "repo", pr.Repo)
-			return
+		// Persistent in-flight claim: survives daemon restart and config reload.
+		// Keyed on (pr_id, head_sha) so a new commit on the same PR is not
+		// gated by a stale in-flight row from a prior HEAD. See
+		// theburrowhub/heimdallm#243.
+		//
+		// For early-stage PRs that have not yet been upserted, OR for PRs
+		// where the HEAD SHA is not yet known, skip the claim — the
+		// downstream SHA dedup in pipeline.Run (already fail-closed per
+		// Task 1) handles those paths.
+		stored, _ := s.GetPRByGithubID(pr.ID)
+		var claimed bool
+		var claimPRID int64
+		var claimSHA string
+		if stored != nil && pr.Head.SHA != "" {
+			ok, err := s.ClaimInFlightReview(stored.ID, pr.Head.SHA)
+			if err != nil {
+				slog.Warn("runReview: claim inflight failed, proceeding", "err", err)
+			} else if !ok {
+				slog.Info("runReview: already in flight (persistent), skipping",
+					"pr", pr.Number, "repo", pr.Repo, "head_sha", pr.Head.SHA)
+				return
+			} else {
+				claimed = true
+				claimPRID = stored.ID
+				claimSHA = pr.Head.SHA
+			}
 		}
-		inFlight[pr.ID] = true
-		reviewMu.Unlock()
 		defer func() {
-			reviewMu.Lock()
-			delete(inFlight, pr.ID)
-			reviewMu.Unlock()
+			if claimed {
+				if err := s.ReleaseInFlightReview(claimPRID, claimSHA); err != nil {
+					slog.Warn("runReview: release inflight failed", "err", err,
+						"pr_id", claimPRID, "head_sha", claimSHA)
+				}
+			}
 		}()
 
 		// Caller-side gate: evaluate review guards BEFORE announcing the review.
@@ -397,7 +423,10 @@ func main() {
 	}
 
 	pipe := buildPipeline(cfg)
-	pipe.Start(context.Background())
+	// Initial daemon start → coldStart=true so Tier 2 fires its first tick
+	// immediately; operators see polling activity without waiting an entire
+	// PollInterval. The reload path below passes false.
+	pipe.Start(context.Background(), true)
 	// Use a closure so the defer reads the current pipe variable at shutdown
 	// time, not the initial pointer captured at defer-statement time. After a
 	// reload, pipe points to a new pipeline — the bare defer would stop the
@@ -617,7 +646,11 @@ func main() {
 		pipe = newPipe
 		cfgMu.Unlock()
 
-		newPipe.Start(context.Background())
+		// Reload path → coldStart=false so Tier 2 waits one full PollInterval
+		// before its first tick. A UI config PATCH triggers this path; firing
+		// an immediate tick on every PATCH would fan out reviews across the
+		// whole fleet and amplify the cost-runaway loop #243 closed.
+		newPipe.Start(context.Background(), false)
 		return nil
 	})
 
@@ -663,18 +696,31 @@ func main() {
 		slog.Info("trigger review: running pipeline",
 			"store_pr_id", prID, "repo", pr.Repo, "number", pr.Number, "github_id", pr.GithubID)
 
-		// Use the same in-flight guard as the poll loop
-		reviewMu.Lock()
-		if inFlight[ghPR.ID] {
-			reviewMu.Unlock()
-			return fmt.Errorf("review already in progress for PR %d", ghPR.Number)
+		// Persistent in-flight claim: keyed on (store pr_id, head_sha).
+		// Triggered reviews are reconstructed from stored PR data which has no
+		// HEAD SHA populated; in that case we skip the claim and rely on the
+		// downstream SHA dedup inside pipeline.Run (Task 1, fail-closed) to
+		// prevent duplicate work. When the head SHA is known, claim/release
+		// using the same mechanism as the poll loop so both paths share the
+		// same persistent guard across daemon restart / config reload.
+		var triggerClaimed bool
+		if ghPR.Head.SHA != "" {
+			ok, err := s.ClaimInFlightReview(pr.ID, ghPR.Head.SHA)
+			if err != nil {
+				slog.Warn("trigger review: claim inflight failed, proceeding", "err", err)
+			} else if !ok {
+				return fmt.Errorf("review already in progress for PR %d", ghPR.Number)
+			} else {
+				triggerClaimed = true
+			}
 		}
-		inFlight[ghPR.ID] = true
-		reviewMu.Unlock()
 		defer func() {
-			reviewMu.Lock()
-			delete(inFlight, ghPR.ID)
-			reviewMu.Unlock()
+			if triggerClaimed {
+				if err := s.ReleaseInFlightReview(pr.ID, ghPR.Head.SHA); err != nil {
+					slog.Warn("trigger review: release inflight failed", "err", err,
+						"pr_id", pr.ID, "head_sha", ghPR.Head.SHA)
+				}
+			}
 		}()
 
 		rev, err := p.Run(ghPR, buildRunOpts(ghPR, aiCfg))

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -271,7 +272,29 @@ func main() {
 		// where the HEAD SHA is not yet known, skip the claim — the
 		// downstream SHA dedup in pipeline.Run (already fail-closed per
 		// Task 1) handles those paths.
-		stored, _ := s.GetPRByGithubID(pr.ID)
+		//
+		// On Claim error (transient SQLite blip, disk pressure), we log and
+		// proceed fail-open. This is safe because the downstream defenses
+		// ALREADY bound the worst-case cost of a slipped review:
+		//   1. pipeline.Run's HEAD-SHA guard is fail-closed (Task 1 / PR #245) —
+		//      a second daemon running the same SHA is rejected.
+		//   2. The SQLite-backed circuit breaker caps reviews at
+		//      3/PR/24h + 20/repo/hour (Task 2 / PR #246) — worst case is
+		//      a handful of reviews, not the €1,300 incident.
+		//   3. PRAlreadyReviewed uses PublishedAt + 2-min grace (Task 3 / PR #247) —
+		//      the common "bot bumped updated_at" case is still dedup'd even
+		//      without the persistent claim.
+		// Fail-closed here would block legitimate reviews on a transient DB
+		// error; the layered defenses make fail-open the right trade.
+		//
+		// sql.ErrNoRows is expected for PRs not yet upserted (early-stage);
+		// any other error is a real problem worth surfacing in logs.
+		stored, err := s.GetPRByGithubID(pr.ID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			slog.Warn("runReview: GetPRByGithubID failed, proceeding without persistent claim",
+				"pr_id", pr.ID, "repo", pr.Repo, "err", err)
+		}
+		// stored may be nil either way — downstream Claim guard handles that.
 		var claimed bool
 		var claimPRID int64
 		var claimSHA string
@@ -703,6 +726,11 @@ func main() {
 		// prevent duplicate work. When the head SHA is known, claim/release
 		// using the same mechanism as the poll loop so both paths share the
 		// same persistent guard across daemon restart / config reload.
+		//
+		// Fail-open on Claim error here for the same reason as the poll path —
+		// see runReview above for the full layered-defense rationale
+		// (HEAD-SHA guard + circuit breaker + PublishedAt dedup cap the
+		// worst case at <€30/PR).
 		var triggerClaimed bool
 		if ghPR.Head.SHA != "" {
 			ok, err := s.ClaimInFlightReview(pr.ID, ghPR.Head.SHA)

--- a/daemon/internal/pipeline/pipeline_reloop_test.go
+++ b/daemon/internal/pipeline/pipeline_reloop_test.go
@@ -264,6 +264,51 @@ func TestPRAlreadyReviewed_FallsBackToCreatedAtWhenPublishedAtZero(t *testing.T)
 	}
 }
 
+// TestRun_TwoInstancesSharingStoreDoNotDoubleReview simulates two team
+// members running Heimdallm daemons against the same repo and the same
+// SQLite store (e.g. a shared cache, a Dropbox-mounted .db, or two
+// daemons on the same machine). Instance A runs the review first and
+// persists the row; Instance B's next poll must see A's PublishedAt and
+// dedup against it rather than re-running Claude on the same commit.
+//
+// This is the "cannot recur" seal for the 2026-04-22 cost-runaway
+// (theburrowhub/heimdallm#243). Before Fix 3 the dedup was per-process,
+// so two daemons could each burn Claude credits on the same PR despite
+// sharing a store. The fix lives in PRAlreadyReviewed (anchored on
+// PublishedAt, which is persisted) — this test locks it in across
+// adapter instances.
+func TestRun_TwoInstancesSharingStoreDoNotDoubleReview(t *testing.T) {
+	// Two tier2Adapters sharing the same SQLite simulates two team members'
+	// daemons on the same repo. Instance A runs the review, persists the
+	// row. Instance B immediately checks PRAlreadyReviewed; the shared
+	// PublishedAt must dedup it.
+	s := newMemStore(t)
+	prRow := &store.PR{GithubID: 1234, Repo: "org/r", Number: 1234,
+		Title: "t", State: "open", UpdatedAt: time.Now()}
+	prID, err := s.UpsertPR(prRow)
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+
+	publishedAt := time.Now()
+	if _, err := s.InsertReview(&store.Review{
+		PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+		Severity: "low", CreatedAt: publishedAt.Add(-2 * time.Minute),
+		PublishedAt: publishedAt, HeadSHA: "abc",
+	}); err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+
+	// Simulate GitHub's updated_at bump from A's review submission.
+	updatedAt := publishedAt.Add(5 * time.Second)
+
+	// B is a fresh adapter instance on the same store.
+	adapterB := pipeline.NewTestAdapter(s)
+	if !adapterB.PRAlreadyReviewed(1234, updatedAt) {
+		t.Errorf("Instance B must dedup against Instance A's PublishedAt in the shared store")
+	}
+}
+
 // TestPRAlreadyReviewed_AllowsReviewAfterGraceWindow locks in the upper
 // bound: a 2-minute grace is deliberate, not "effectively infinite". A push
 // 5 minutes after the review must be treated as a genuine change.

--- a/daemon/internal/scheduler/pipeline.go
+++ b/daemon/internal/scheduler/pipeline.go
@@ -69,7 +69,13 @@ func NewPipeline(cfg PipelineConfig, deps PipelineDeps) *Pipeline {
 }
 
 // Start launches all 3 tiers and the rate limiter refill goroutine.
-func (p *Pipeline) Start(parentCtx context.Context) {
+//
+// coldStart controls whether Tier 2 runs its first processTick immediately.
+// Pass true on initial daemon startup, false on a pipeline reload triggered
+// by config change. See RunTier2 for the rationale — in short, a config
+// reload can come from a UI PATCH and firing Tier 2 before backoff state
+// settles would amplify any in-flight review loop.
+func (p *Pipeline) Start(parentCtx context.Context, coldStart bool) {
 	ctx, cancel := context.WithCancel(parentCtx)
 	p.cancel = cancel
 
@@ -119,7 +125,7 @@ func (p *Pipeline) Start(parentCtx context.Context) {
 			Store:          p.deps.Store,
 			ConfigFn:       p.deps.Tier2ConfigFn,
 			Interval:       p.cfg.PollInterval,
-		}, reposChan)
+		}, reposChan, coldStart)
 	}()
 
 	// Tier 3: Per-item watch

--- a/daemon/internal/scheduler/tier2.go
+++ b/daemon/internal/scheduler/tier2.go
@@ -62,9 +62,16 @@ type Tier2Deps struct {
 	Interval       time.Duration
 }
 
-// RunTier2 runs the per-repo processing tier. It consumes repos from
-// reposChan and runs PR + issue processing on each repo per tick.
-func RunTier2(ctx context.Context, deps Tier2Deps, reposChan <-chan []string) {
+// RunTier2 runs the review-requested polling tier.
+//
+// coldStart controls the behaviour of the very first tick:
+//   - true (initial daemon startup): fire processTick() immediately so the
+//     UI sees activity without waiting PollInterval.
+//   - false (pipeline reload): skip the immediate tick. A reload is often
+//     triggered by a UI config PATCH and firing the tick immediately would
+//     re-poll every repo before backoff state has settled, amplifying any
+//     in-flight review loop. See theburrowhub/heimdallm#243.
+func RunTier2(ctx context.Context, deps Tier2Deps, reposChan <-chan []string, coldStart bool) {
 	var (
 		mu    sync.Mutex
 		repos []string
@@ -166,8 +173,12 @@ func RunTier2(ctx context.Context, deps Tier2Deps, reposChan <-chan []string) {
 		deps.PRProcessor.PublishPending()
 	}
 
-	// Run immediately
-	processTick()
+	// Run immediately only on a cold start. On pipeline reload (coldStart
+	// == false) wait one full PollInterval before the first tick so a UI
+	// config PATCH cannot fan out to every repo the instant it lands.
+	if coldStart {
+		processTick()
+	}
 
 	for {
 		select {

--- a/daemon/internal/store/inflight.go
+++ b/daemon/internal/store/inflight.go
@@ -1,0 +1,74 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// ClaimInFlightReview inserts a row marking (prID, headSHA) as currently
+// being reviewed. Returns (true, nil) on successful claim, (false, nil) if
+// another daemon (or this one, pre-restart) already claimed it. Errors
+// surface real SQLite problems, not contention.
+//
+// headSHA is part of the composite key so a new commit on an in-flight PR
+// can be reviewed immediately; only the same commit is deduplicated.
+//
+// See theburrowhub/heimdallm#243 — this replaces the in-memory inFlight
+// map whose state was wiped by daemon restarts and config reloads.
+func (s *Store) ClaimInFlightReview(prID int64, headSHA string) (bool, error) {
+	res, err := s.db.Exec(
+		"INSERT OR IGNORE INTO reviews_in_flight (pr_id, head_sha, started_at) VALUES (?, ?, ?)",
+		prID, headSHA, time.Now().UTC().Format(sqliteTimeFormat),
+	)
+	if err != nil {
+		return false, fmt.Errorf("store: claim inflight: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("store: claim inflight rowsaffected: %w", err)
+	}
+	return n == 1, nil
+}
+
+// ReleaseInFlightReview removes the (prID, headSHA) row so the pair can be
+// re-claimed. Always call in a defer from the caller that successfully
+// claimed; no-op if the row doesn't exist.
+func (s *Store) ReleaseInFlightReview(prID int64, headSHA string) error {
+	_, err := s.db.Exec(
+		"DELETE FROM reviews_in_flight WHERE pr_id = ? AND head_sha = ?",
+		prID, headSHA,
+	)
+	if err != nil {
+		return fmt.Errorf("store: release inflight: %w", err)
+	}
+	return nil
+}
+
+// ClearStaleInFlight removes claims older than `maxAge`. Protects against
+// claims leaked by a daemon that crashed between claim and release. Safe to
+// call on every startup; returns the number of rows cleared.
+func (s *Store) ClearStaleInFlight(maxAge time.Duration) (int, error) {
+	cutoff := time.Now().Add(-maxAge).UTC().Format(sqliteTimeFormat)
+	res, err := s.db.Exec("DELETE FROM reviews_in_flight WHERE started_at < ?", cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("store: clear stale inflight: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("store: clear stale rowsaffected: %w", err)
+	}
+	return int(n), nil
+}
+
+// InsertStaleInFlight is test-only: seeds an in-flight row with a custom
+// started_at so ClearStaleInFlight can be exercised deterministically.
+func (s *Store) InsertStaleInFlight(prID int64, headSHA string, startedAt time.Time) error {
+	_, err := s.db.Exec(
+		"INSERT INTO reviews_in_flight (pr_id, head_sha, started_at) VALUES (?, ?, ?)",
+		prID, headSHA, startedAt.UTC().Format(sqliteTimeFormat),
+	)
+	if err != nil {
+		return fmt.Errorf("store: insert stale inflight: %w", err)
+	}
+	return nil
+}

--- a/daemon/internal/store/inflight.go
+++ b/daemon/internal/store/inflight.go
@@ -59,16 +59,3 @@ func (s *Store) ClearStaleInFlight(maxAge time.Duration) (int, error) {
 	}
 	return int(n), nil
 }
-
-// InsertStaleInFlight is test-only: seeds an in-flight row with a custom
-// started_at so ClearStaleInFlight can be exercised deterministically.
-func (s *Store) InsertStaleInFlight(prID int64, headSHA string, startedAt time.Time) error {
-	_, err := s.db.Exec(
-		"INSERT INTO reviews_in_flight (pr_id, head_sha, started_at) VALUES (?, ?, ?)",
-		prID, headSHA, startedAt.UTC().Format(sqliteTimeFormat),
-	)
-	if err != nil {
-		return fmt.Errorf("store: insert stale inflight: %w", err)
-	}
-	return nil
-}

--- a/daemon/internal/store/inflight_test.go
+++ b/daemon/internal/store/inflight_test.go
@@ -1,0 +1,67 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInFlight_ClaimAndRelease(t *testing.T) {
+	s := newTestStore(t)
+	claimed, err := s.ClaimInFlightReview(42, "abc123")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if !claimed {
+		t.Errorf("first claim should succeed")
+	}
+	// Second claim on the same (pr_id, head_sha) must fail.
+	claimed, err = s.ClaimInFlightReview(42, "abc123")
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if claimed {
+		t.Errorf("second claim on same (pr, sha) must return false")
+	}
+	// Different SHA on the same PR is allowed (new commit).
+	claimed, err = s.ClaimInFlightReview(42, "def456")
+	if err != nil {
+		t.Fatalf("new sha claim: %v", err)
+	}
+	if !claimed {
+		t.Errorf("claim for new SHA must succeed")
+	}
+	// Release the first claim; should allow a re-claim.
+	if err := s.ReleaseInFlightReview(42, "abc123"); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	claimed, err = s.ClaimInFlightReview(42, "abc123")
+	if err != nil {
+		t.Fatalf("re-claim: %v", err)
+	}
+	if !claimed {
+		t.Errorf("re-claim after release must succeed")
+	}
+}
+
+func TestInFlight_StaleEntriesAreCleared(t *testing.T) {
+	s := newTestStore(t)
+	// Simulate a stale row from a crashed daemon.
+	if err := s.InsertStaleInFlight(42, "abc123", time.Now().Add(-1*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	n, err := s.ClearStaleInFlight(30 * time.Minute)
+	if err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("want 1 stale row cleared, got %d", n)
+	}
+	// The row should now be claimable again.
+	claimed, err := s.ClaimInFlightReview(42, "abc123")
+	if err != nil {
+		t.Fatalf("claim after clear: %v", err)
+	}
+	if !claimed {
+		t.Errorf("claim after stale-clear must succeed")
+	}
+}

--- a/daemon/internal/store/inflight_test_helpers_test.go
+++ b/daemon/internal/store/inflight_test_helpers_test.go
@@ -1,0 +1,22 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// InsertStaleInFlight is a test-only helper that seeds an in-flight row
+// with a custom started_at so ClearStaleInFlight can be exercised
+// deterministically. Kept in a _test.go file so production code cannot
+// accidentally depend on it — external test packages (package store_test)
+// can still call it because it lives in package store and is exported.
+func (s *Store) InsertStaleInFlight(prID int64, headSHA string, startedAt time.Time) error {
+	_, err := s.db.Exec(
+		"INSERT INTO reviews_in_flight (pr_id, head_sha, started_at) VALUES (?, ?, ?)",
+		prID, headSHA, startedAt.UTC().Format(sqliteTimeFormat),
+	)
+	if err != nil {
+		return fmt.Errorf("store: insert stale inflight: %w", err)
+	}
+	return nil
+}

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -124,6 +124,13 @@ CREATE TABLE IF NOT EXISTS activity_log (
 );
 CREATE INDEX IF NOT EXISTS idx_activity_ts      ON activity_log(ts DESC);
 CREATE INDEX IF NOT EXISTS idx_activity_repo_ts ON activity_log(repo, ts DESC);
+
+CREATE TABLE IF NOT EXISTS reviews_in_flight (
+  pr_id       INTEGER NOT NULL,
+  head_sha    TEXT    NOT NULL,
+  started_at  DATETIME NOT NULL,
+  PRIMARY KEY (pr_id, head_sha)
+);
 `
 
 // Open opens (or creates) a SQLite database at dsn and applies the schema.
@@ -178,6 +185,14 @@ func Open(dsn string) (*Store, error) {
 	// JOIN drives from prs.repo with no index and table-scans on every
 	// poll-cycle breaker check.
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_prs_repo ON prs(repo)")
+	// Idempotent migration for existing DBs — new installs get the table
+	// from the schema constant above. Safe on every startup.
+	db.Exec(`CREATE TABLE IF NOT EXISTS reviews_in_flight (
+		pr_id       INTEGER NOT NULL,
+		head_sha    TEXT    NOT NULL,
+		started_at  DATETIME NOT NULL,
+		PRIMARY KEY (pr_id, head_sha)
+	)`)
 	return &Store{db: db}, nil
 }
 

--- a/flutter_app/lib/features/circuit_breaker/circuit_breaker_banner.dart
+++ b/flutter_app/lib/features/circuit_breaker/circuit_breaker_banner.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+/// Banner shown when the daemon's review circuit breaker has tripped.
+/// Dismiss is explicit — the user must acknowledge seeing the warning so
+/// they can't miss a cost event. The message is sourced from the SSE
+/// event payload.
+class CircuitBreakerBanner extends StatelessWidget {
+  final String message;
+  final VoidCallback onDismiss;
+  const CircuitBreakerBanner({
+    super.key,
+    required this.message,
+    required this.onDismiss,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialBanner(
+      backgroundColor: Colors.red.shade50,
+      leading: const Icon(Icons.warning_amber_rounded, color: Colors.red),
+      content: Text(
+        'Review circuit breaker tripped — $message',
+        style: const TextStyle(color: Colors.black87),
+      ),
+      actions: [TextButton(onPressed: onDismiss, child: const Text('Dismiss'))],
+    );
+  }
+}

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -24,6 +24,13 @@ final sseStreamProvider = StreamProvider<SseEvent>((ref) {
   return client.connect();
 });
 
+/// Latest circuit-breaker-tripped payload from the daemon. Null until the
+/// breaker fires or after the user dismisses the banner. Set by the
+/// `circuit_breaker_tripped` SSE handler and cleared by the dashboard's
+/// dismiss button — the user must acknowledge the event so cost spikes
+/// can't slip by silently (regression guard for the 2026-04-22 runaway).
+final circuitBreakerProvider = StateProvider<String?>((ref) => null);
+
 /// Tracks PRs currently being reviewed, keyed by "repo:prNumber". Used to
 /// show spinners in the tile list and detail view.
 ///
@@ -45,7 +52,8 @@ final StateProvider<int> prListRefreshProvider = StateProvider<int>((ref) {
     // to catch up on any events that arrived during the disconnection window.
     if (!(prev?.hasValue ?? false) && next.hasValue) {
       Future.microtask(
-          () => ref.read(prListRefreshProvider.notifier).update((s) => s + 1));
+        () => ref.read(prListRefreshProvider.notifier).update((s) => s + 1),
+      );
     }
     next.whenData((event) => _handleSseEvent(ref, event));
   });
@@ -58,12 +66,18 @@ void _handleSseEvent(Ref ref, SseEvent event) {
     final repo = data['repo'] as String? ?? '';
     final prNumber = (data['pr_number'] as num?)?.toInt();
     final prId = (data['pr_id'] as num?)?.toInt();
-    final key = (repo.isNotEmpty && prNumber != null) ? '$repo:$prNumber' : null;
+    final key = (repo.isNotEmpty && prNumber != null)
+        ? '$repo:$prNumber'
+        : null;
 
     switch (event.type) {
       case 'review_started':
         if (key != null) {
-          final baseline = _baselineReviewId(ref, repo: repo, prNumber: prNumber!);
+          final baseline = _baselineReviewId(
+            ref,
+            repo: repo,
+            prNumber: prNumber!,
+          );
           ref
               .read(reviewingPRsProvider.notifier)
               .update((s) => {...s, key: baseline});
@@ -119,7 +133,9 @@ void _handleSseEvent(Ref ref, SseEvent event) {
             ? '$repo:$issueNumber'
             : null;
         if (issueKey != null) {
-          ref.read(reviewingIssuesProvider.notifier).update((s) => {...s, issueKey});
+          ref
+              .read(reviewingIssuesProvider.notifier)
+              .update((s) => {...s, issueKey});
         }
 
       case 'issue_review_completed':
@@ -128,7 +144,9 @@ void _handleSseEvent(Ref ref, SseEvent event) {
             ? '$repo:$issueNumber'
             : null;
         if (issueKey != null) {
-          ref.read(reviewingIssuesProvider.notifier).update((s) => s.difference({issueKey}));
+          ref
+              .read(reviewingIssuesProvider.notifier)
+              .update((s) => s.difference({issueKey}));
         }
         ref.read(issueListRefreshProvider.notifier).update((s) => s + 1);
 
@@ -138,8 +156,18 @@ void _handleSseEvent(Ref ref, SseEvent event) {
             ? '$repo:$issueNumber'
             : null;
         if (issueKey != null) {
-          ref.read(reviewingIssuesProvider.notifier).update((s) => s.difference({issueKey}));
+          ref
+              .read(reviewingIssuesProvider.notifier)
+              .update((s) => s.difference({issueKey}));
         }
+
+      // ── Circuit breaker ────────────────────────────────────────────────
+      case 'circuit_breaker_tripped':
+        final repo = data['repo'] as String? ?? 'unknown';
+        final prNumber = (data['pr_number'] as num?)?.toInt() ?? 0;
+        final reason = data['reason'] as String? ?? '';
+        ref.read(circuitBreakerProvider.notifier).state =
+            '$repo #$prNumber — $reason';
     }
   } catch (_) {}
 }
@@ -242,8 +270,9 @@ void _rebuildTray(Ref ref, List<PR> prs) {
       // Don't build tray until we know the username — without it the
       // author filter falls back to '' and shows the user's own PRs.
       if (me == null || me.isEmpty) return;
-      await ref.read(platformServicesProvider).rebuildTrayMenu(prs: prs, me: me);
+      await ref
+          .read(platformServicesProvider)
+          .rebuildTrayMenu(prs: prs, me: me);
     } catch (_) {}
   });
 }
-

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -11,6 +11,7 @@ import '../../shared/widgets/type_badge.dart';
 import '../activity/activity_screen.dart';
 import '../activity/activity_providers.dart';
 import '../agents/agents_screen.dart';
+import '../circuit_breaker/circuit_breaker_banner.dart';
 import '../cli_agents/cli_agents_screen.dart';
 import '../issues/issues_providers.dart';
 import '../repositories/repos_screen.dart';
@@ -24,6 +25,7 @@ class DashboardScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final cbMessage = ref.watch(circuitBreakerProvider);
     return DefaultTabController(
       length: 6,
       child: Scaffold(
@@ -52,23 +54,35 @@ class DashboardScreen extends ConsumerWidget {
           ],
           bottom: const TabBar(
             tabs: [
-              Tab(icon: Icon(Icons.dashboard),       text: 'Activity'),
-              Tab(icon: Icon(Icons.timeline),        text: 'Activity log'),
+              Tab(icon: Icon(Icons.dashboard), text: 'Activity'),
+              Tab(icon: Icon(Icons.timeline), text: 'Activity log'),
               Tab(icon: Icon(Icons.folder_outlined), text: 'Repositories'),
-              Tab(icon: Icon(Icons.auto_awesome),    text: 'Prompts'),
-              Tab(icon: Icon(Icons.smart_toy),       text: 'Agents'),
-              Tab(icon: Icon(Icons.bar_chart),       text: 'Stats'),
+              Tab(icon: Icon(Icons.auto_awesome), text: 'Prompts'),
+              Tab(icon: Icon(Icons.smart_toy), text: 'Agents'),
+              Tab(icon: Icon(Icons.bar_chart), text: 'Stats'),
             ],
           ),
         ),
-        body: const TabBarView(
+        body: Column(
           children: [
-            _ActivityTab(),
-            ActivityScreen(),
-            ReposScreen(),
-            AgentsScreen(),
-            CLIAgentsScreen(),
-            StatsScreen(),
+            if (cbMessage != null)
+              CircuitBreakerBanner(
+                message: cbMessage,
+                onDismiss: () =>
+                    ref.read(circuitBreakerProvider.notifier).state = null,
+              ),
+            const Expanded(
+              child: TabBarView(
+                children: [
+                  _ActivityTab(),
+                  ActivityScreen(),
+                  ReposScreen(),
+                  AgentsScreen(),
+                  CLIAgentsScreen(),
+                  StatsScreen(),
+                ],
+              ),
+            ),
           ],
         ),
       ),
@@ -82,8 +96,9 @@ class DashboardScreen extends ConsumerWidget {
 
 const _sortPrefKey = 'activity_sort_mode';
 
-final reviewsSortProvider =
-    NotifierProvider<SortNotifier, SortMode>(SortNotifier.new);
+final reviewsSortProvider = NotifierProvider<SortNotifier, SortMode>(
+  SortNotifier.new,
+);
 
 class SortNotifier extends Notifier<SortMode> {
   @override
@@ -106,11 +121,13 @@ class SortNotifier extends Notifier<SortMode> {
 
   void set(SortMode mode) {
     state = mode;
-    SharedPreferences.getInstance().then((prefs) {
-      prefs.setString(_sortPrefKey, mode.name);
-    }).catchError((e) {
-      debugPrint('SortNotifier: failed to save preference: $e');
-    });
+    SharedPreferences.getInstance()
+        .then((prefs) {
+          prefs.setString(_sortPrefKey, mode.name);
+        })
+        .catchError((e) {
+          debugPrint('SortNotifier: failed to save preference: $e');
+        });
   }
 }
 
@@ -135,56 +152,58 @@ class _IssueItem extends _ActivityItem {
 String _itemType(_ActivityItem item) => switch (item) {
   _PRItem() => 'pr',
   _IssueItem(:final issue) =>
-      (issue.latestReview != null && issue.latestReview!.actionTaken == 'develop')
-          ? 'dev'
-          : 'it',
+    (issue.latestReview != null && issue.latestReview!.actionTaken == 'develop')
+        ? 'dev'
+        : 'it',
 };
 
 String _itemRepo(_ActivityItem item) => switch (item) {
-  _PRItem(:final pr)       => pr.repo,
+  _PRItem(:final pr) => pr.repo,
   _IssueItem(:final issue) => issue.repo,
 };
 
 String _itemTitle(_ActivityItem item) => switch (item) {
-  _PRItem(:final pr)       => pr.title,
+  _PRItem(:final pr) => pr.title,
   _IssueItem(:final issue) => issue.title,
 };
 
 int _itemNumber(_ActivityItem item) => switch (item) {
-  _PRItem(:final pr)       => pr.number,
+  _PRItem(:final pr) => pr.number,
   _IssueItem(:final issue) => issue.number,
 };
 
 String _itemAuthor(_ActivityItem item) => switch (item) {
-  _PRItem(:final pr)       => pr.author,
+  _PRItem(:final pr) => pr.author,
   _IssueItem(:final issue) => issue.author,
 };
 
 DateTime _itemDate(_ActivityItem item) => switch (item) {
-  _PRItem(:final pr)       => pr.updatedAt,
+  _PRItem(:final pr) => pr.updatedAt,
   _IssueItem(:final issue) => issue.latestReview?.createdAt ?? issue.fetchedAt,
 };
 
 int _itemPriorityKey(_ActivityItem item) => switch (item) {
-  _PRItem(:final pr) => pr.latestReview == null
-      ? 0
-      : switch (pr.latestReview!.severity.toLowerCase()) {
-          'high'   => 1,
-          'medium' => 2,
-          _        => 3,
-        },
-  _IssueItem(:final issue) => issue.latestReview == null
-      ? 0
-      : switch (issue.latestReview!.severity.toLowerCase()) {
-          'critical' => 0,
-          'high'     => 1,
-          'medium'   => 2,
-          _          => 3,
-        },
+  _PRItem(:final pr) =>
+    pr.latestReview == null
+        ? 0
+        : switch (pr.latestReview!.severity.toLowerCase()) {
+            'high' => 1,
+            'medium' => 2,
+            _ => 3,
+          },
+  _IssueItem(:final issue) =>
+    issue.latestReview == null
+        ? 0
+        : switch (issue.latestReview!.severity.toLowerCase()) {
+            'critical' => 0,
+            'high' => 1,
+            'medium' => 2,
+            _ => 3,
+          },
 };
 
 String _itemState(_ActivityItem item) => switch (item) {
-  _PRItem(:final pr)       => pr.state,
+  _PRItem(:final pr) => pr.state,
   _IssueItem(:final issue) => issue.state,
 };
 
@@ -211,11 +230,14 @@ bool _matchesFilters(_ActivityItem item, ActivityFilters filters) {
   // Search
   if (filters.search.isNotEmpty) {
     final q = filters.search.toLowerCase();
-    final title  = _itemTitle(item).toLowerCase();
-    final repo   = _itemRepo(item).toLowerCase();
+    final title = _itemTitle(item).toLowerCase();
+    final repo = _itemRepo(item).toLowerCase();
     final number = _itemNumber(item).toString();
     final author = _itemAuthor(item).toLowerCase();
-    if (!title.contains(q) && !repo.contains(q) && !number.contains(q) && !author.contains(q)) {
+    if (!title.contains(q) &&
+        !repo.contains(q) &&
+        !number.contains(q) &&
+        !author.contains(q)) {
       return false;
     }
   }
@@ -247,17 +269,18 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
     // SSE listener for state changes (open/closed transitions)
     ref.listen(sseStreamProvider, (_, next) {
       next.whenData((event) {
-        if (event.type == 'pr_state_changed' || event.type == 'issue_state_changed') {
+        if (event.type == 'pr_state_changed' ||
+            event.type == 'issue_state_changed') {
           ref.invalidate(prsProvider);
           ref.invalidate(issuesProvider);
         }
       });
     });
 
-    final prsAsync    = ref.watch(prsProvider);
+    final prsAsync = ref.watch(prsProvider);
     final issuesAsync = ref.watch(issuesProvider);
-    final sort        = ref.watch(reviewsSortProvider);
-    final filters     = ref.watch(activityFiltersProvider);
+    final sort = ref.watch(reviewsSortProvider);
+    final filters = ref.watch(activityFiltersProvider);
 
     // Combine loading states
     if (prsAsync.isLoading && issuesAsync.isLoading) {
@@ -267,7 +290,7 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
       return _errorView(context, prsAsync.error!);
     }
 
-    final prs    = prsAsync.valueOrNull ?? [];
+    final prs = prsAsync.valueOrNull ?? [];
     final issues = issuesAsync.valueOrNull ?? [];
 
     // Collect all known repos for the filter bar.
@@ -283,7 +306,9 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
     ];
 
     // Apply filters.
-    final filtered = items.where((item) => _matchesFilters(item, filters)).toList();
+    final filtered = items
+        .where((item) => _matchesFilters(item, filters))
+        .toList();
 
     // Sort.
     _sortItems(filtered, sort);
@@ -299,7 +324,8 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
       ActivityFilterBar(
         allRepos: allRepos,
         sort: sort,
-        onSortChanged: (mode) => ref.read(reviewsSortProvider.notifier).set(mode),
+        onSortChanged: (mode) =>
+            ref.read(reviewsSortProvider.notifier).set(mode),
       ),
       if (filters.hasFilters)
         Padding(
@@ -348,10 +374,12 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
       padding: const EdgeInsets.symmetric(vertical: 8),
       children: [
         ...header,
-        ...filtered.map((item) => switch (item) {
-          _PRItem(:final pr) => _PRTile(pr: pr),
-          _IssueItem(:final issue) => _IssueActivityTile(issue: issue),
-        }),
+        ...filtered.map(
+          (item) => switch (item) {
+            _PRItem(:final pr) => _PRTile(pr: pr),
+            _IssueItem(:final issue) => _IssueActivityTile(issue: issue),
+          },
+        ),
       ],
     );
   }
@@ -363,21 +391,26 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
         children: [
           const Icon(Icons.wifi_off, size: 48, color: Colors.grey),
           const SizedBox(height: 12),
-          const Text('Could not reach the Heimdallm daemon.',
-              style: TextStyle(fontWeight: FontWeight.w600)),
+          const Text(
+            'Could not reach the Heimdallm daemon.',
+            style: TextStyle(fontWeight: FontWeight.w600),
+          ),
           const SizedBox(height: 4),
-          const Text('Go to Settings to configure and start it.',
-              style: TextStyle(color: Colors.grey)),
+          const Text(
+            'Go to Settings to configure and start it.',
+            style: TextStyle(color: Colors.grey),
+          ),
           const SizedBox(height: 16),
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
               TextButton(
-                  onPressed: () {
-                    ref.invalidate(prsProvider);
-                    ref.invalidate(issuesProvider);
-                  },
-                  child: const Text('Retry')),
+                onPressed: () {
+                  ref.invalidate(prsProvider);
+                  ref.invalidate(issuesProvider);
+                },
+                child: const Text('Retry'),
+              ),
               const SizedBox(width: 8),
               FilledButton.icon(
                 icon: const Icon(Icons.settings, size: 16),
@@ -429,13 +462,16 @@ class _PRTileState extends ConsumerState<_PRTile> {
       await api.dismissPR(widget.pr.id);
       ref.invalidate(prsProvider);
       if (mounted) {
-        showToast(context, 'PR #${widget.pr.number} dismissed',
-            duration: const Duration(seconds: 5),
-            actionLabel: 'Undo',
-            onAction: () async {
-              await api.undismissPR(widget.pr.id);
-              ref.invalidate(prsProvider);
-            });
+        showToast(
+          context,
+          'PR #${widget.pr.number} dismissed',
+          duration: const Duration(seconds: 5),
+          actionLabel: 'Undo',
+          onAction: () async {
+            await api.undismissPR(widget.pr.id);
+            ref.invalidate(prsProvider);
+          },
+        );
       }
     } catch (e) {
       if (mounted) showToast(context, 'Error: $e', isError: true);
@@ -451,112 +487,132 @@ class _PRTileState extends ConsumerState<_PRTile> {
     return Opacity(
       opacity: pr.state == 'open' ? 1.0 : 0.6,
       child: Card(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: () => context.push('/prs/${pr.id}'),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            children: [
-              // Severity bar on the left
-              Container(
-                width: 4, height: 48,
-                margin: const EdgeInsets.only(right: 12),
-                decoration: BoxDecoration(
-                  color: isReviewing
-                      ? Theme.of(context).colorScheme.primary
-                      : reviewed
-                          ? _severityColor(pr.latestReview!.severity)
-                          : Colors.grey.shade600,
-                  borderRadius: BorderRadius.circular(2),
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: () => context.push('/prs/${pr.id}'),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                // Severity bar on the left
+                Container(
+                  width: 4,
+                  height: 48,
+                  margin: const EdgeInsets.only(right: 12),
+                  decoration: BoxDecoration(
+                    color: isReviewing
+                        ? Theme.of(context).colorScheme.primary
+                        : reviewed
+                        ? _severityColor(pr.latestReview!.severity)
+                        : Colors.grey.shade600,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
                 ),
-              ),
-              // Type badge + state badge
-              const Padding(
-                padding: EdgeInsets.only(right: 6),
-                child: TypeBadge(type: 'pr'),
-              ),
-              const SizedBox(width: 4),
-              StateBadge(state: pr.state),
-              const SizedBox(width: 4),
-              // Title + subtitle
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(pr.title,
+                // Type badge + state badge
+                const Padding(
+                  padding: EdgeInsets.only(right: 6),
+                  child: TypeBadge(type: 'pr'),
+                ),
+                const SizedBox(width: 4),
+                StateBadge(state: pr.state),
+                const SizedBox(width: 4),
+                // Title + subtitle
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        pr.title,
                         style: const TextStyle(fontWeight: FontWeight.w600),
-                        maxLines: 1, overflow: TextOverflow.ellipsis),
-                    const SizedBox(height: 4),
-                    Text('${pr.repo} · #${pr.number} · ${pr.author}',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        '${pr.repo} · #${pr.number} · ${pr.author}',
                         style: Theme.of(context).textTheme.bodySmall,
-                        maxLines: 1, overflow: TextOverflow.ellipsis),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                // Trailing: badge/spinner + Review + dismiss — all in one row
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    // Status indicator
+                    if (isReviewing)
+                      SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                      )
+                    else if (reviewed)
+                      SeverityBadge(severity: pr.latestReview!.severity)
+                    else
+                      _chip('PENDING', Colors.grey.shade700),
+                    const SizedBox(width: 8),
+                    // Review button (hidden while reviewing)
+                    if (!isReviewing)
+                      SizedBox(
+                        height: 28,
+                        child: ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(horizontal: 10),
+                            textStyle: const TextStyle(fontSize: 12),
+                          ),
+                          onPressed: _triggerReview,
+                          child: const Text('Review'),
+                        ),
+                      ),
+                    // Dismiss
+                    IconButton(
+                      icon: const Icon(Icons.close, size: 14),
+                      tooltip: 'Dismiss PR',
+                      color: Colors.grey.shade600,
+                      visualDensity: VisualDensity.compact,
+                      onPressed: _dismiss,
+                    ),
                   ],
                 ),
-              ),
-              const SizedBox(width: 12),
-              // Trailing: badge/spinner + Review + dismiss — all in one row
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Status indicator
-                  if (isReviewing)
-                    SizedBox(
-                      width: 18, height: 18,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                    )
-                  else if (reviewed)
-                    SeverityBadge(severity: pr.latestReview!.severity)
-                  else
-                    _chip('PENDING', Colors.grey.shade700),
-                  const SizedBox(width: 8),
-                  // Review button (hidden while reviewing)
-                  if (!isReviewing)
-                    SizedBox(
-                      height: 28,
-                      child: ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(horizontal: 10),
-                            textStyle: const TextStyle(fontSize: 12)),
-                        onPressed: _triggerReview,
-                        child: const Text('Review'),
-                      ),
-                    ),
-                  // Dismiss
-                  IconButton(
-                    icon: const Icon(Icons.close, size: 14),
-                    tooltip: 'Dismiss PR',
-                    color: Colors.grey.shade600,
-                    visualDensity: VisualDensity.compact,
-                    onPressed: _dismiss,
-                  ),
-                ],
-              ),
-            ],
+              ],
+            ),
           ),
         ),
-      ),
       ),
     );
   }
 
   Widget _chip(String label, Color color) => Container(
     padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-    decoration: BoxDecoration(color: color, borderRadius: BorderRadius.circular(4)),
-    child: Text(label,
-        style: const TextStyle(
-            color: Colors.white, fontSize: 11, fontWeight: FontWeight.w600)),
+    decoration: BoxDecoration(
+      color: color,
+      borderRadius: BorderRadius.circular(4),
+    ),
+    child: Text(
+      label,
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: 11,
+        fontWeight: FontWeight.w600,
+      ),
+    ),
   );
 
   Color _severityColor(String s) {
     switch (s.toLowerCase()) {
-      case 'high':   return Colors.red.shade700;
-      case 'medium': return Colors.orange.shade700;
-      default:       return Colors.green.shade700;
+      case 'high':
+        return Colors.red.shade700;
+      case 'medium':
+        return Colors.orange.shade700;
+      default:
+        return Colors.green.shade700;
     }
   }
 }
@@ -575,71 +631,93 @@ class _IssueActivityTile extends StatelessWidget {
     return Opacity(
       opacity: issue.state == 'open' ? 1.0 : 0.6,
       child: Card(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: () => context.push('/issues/${issue.id}'),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            children: [
-              Container(
-                width: 4, height: 48,
-                margin: const EdgeInsets.only(right: 12),
-                decoration: BoxDecoration(
-                  color: reviewed ? _severityColor(severity) : Colors.grey.shade600,
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-              // Type badge + state badge
-              Padding(
-                padding: const EdgeInsets.only(right: 6),
-                child: TypeBadge(type: _type),
-              ),
-              const SizedBox(width: 4),
-              StateBadge(state: issue.state),
-              const SizedBox(width: 4),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(issue.title,
-                        style: const TextStyle(fontWeight: FontWeight.w600),
-                        maxLines: 1, overflow: TextOverflow.ellipsis),
-                    const SizedBox(height: 4),
-                    Text('${issue.repo} · #${issue.number} · ${issue.author}',
-                        style: Theme.of(context).textTheme.bodySmall,
-                        maxLines: 1, overflow: TextOverflow.ellipsis),
-                  ],
-                ),
-              ),
-              const SizedBox(width: 12),
-              if (reviewed)
-                SeverityBadge(severity: severity)
-              else
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: () => context.push('/issues/${issue.id}'),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  width: 4,
+                  height: 48,
+                  margin: const EdgeInsets.only(right: 12),
                   decoration: BoxDecoration(
-                      color: Colors.grey.shade700,
-                      borderRadius: BorderRadius.circular(4)),
-                  child: const Text('PENDING',
-                      style: TextStyle(
-                          color: Colors.white, fontSize: 11, fontWeight: FontWeight.w600)),
+                    color: reviewed
+                        ? _severityColor(severity)
+                        : Colors.grey.shade600,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
                 ),
-            ],
+                // Type badge + state badge
+                Padding(
+                  padding: const EdgeInsets.only(right: 6),
+                  child: TypeBadge(type: _type),
+                ),
+                const SizedBox(width: 4),
+                StateBadge(state: issue.state),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        issue.title,
+                        style: const TextStyle(fontWeight: FontWeight.w600),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        '${issue.repo} · #${issue.number} · ${issue.author}',
+                        style: Theme.of(context).textTheme.bodySmall,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                if (reviewed)
+                  SeverityBadge(severity: severity)
+                else
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 3,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.grey.shade700,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: const Text(
+                      'PENDING',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
           ),
         ),
-      ),
       ),
     );
   }
 
   Color _severityColor(String s) {
     switch (s.toLowerCase()) {
-      case 'critical': return Colors.red.shade900;
-      case 'high':     return Colors.red.shade700;
-      case 'medium':   return Colors.orange.shade700;
-      default:         return Colors.green.shade700;
+      case 'critical':
+        return Colors.red.shade900;
+      case 'high':
+        return Colors.red.shade700;
+      case 'medium':
+        return Colors.orange.shade700;
+      default:
+        return Colors.green.shade700;
     }
   }
 }
@@ -688,28 +766,58 @@ class _ActivityGridTile extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(children: [
-                Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
-                  decoration: BoxDecoration(color: color, borderRadius: BorderRadius.circular(3)),
-                  child: Text(type, style: const TextStyle(color: Colors.white, fontSize: 9, fontWeight: FontWeight.bold)),
-                ),
-                const Spacer(),
-                StateBadge(state: state),
-              ]),
+              Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 5,
+                      vertical: 1,
+                    ),
+                    decoration: BoxDecoration(
+                      color: color,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                    child: Text(
+                      type,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 9,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  const Spacer(),
+                  StateBadge(state: state),
+                ],
+              ),
               const SizedBox(height: 6),
-              Text(title, maxLines: 2, overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500)),
+              Text(
+                title,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
               const SizedBox(height: 4),
-              Text(subtitle, style: TextStyle(fontSize: 10, color: Colors.grey.shade500),
-                  maxLines: 1, overflow: TextOverflow.ellipsis),
+              Text(
+                subtitle,
+                style: TextStyle(fontSize: 10, color: Colors.grey.shade500),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
               const Spacer(),
-              Row(children: [
-                if (severity != null)
-                  SeverityBadge(severity: severity),
-                const Spacer(),
-                Text(_timeAgo(timestamp), style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
-              ]),
+              Row(
+                children: [
+                  if (severity != null) SeverityBadge(severity: severity),
+                  const Spacer(),
+                  Text(
+                    _timeAgo(timestamp),
+                    style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+                  ),
+                ],
+              ),
             ],
           ),
         ),

--- a/flutter_app/test/features/circuit_breaker_banner_test.dart
+++ b/flutter_app/test/features/circuit_breaker_banner_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/features/circuit_breaker/circuit_breaker_banner.dart';
+
+void main() {
+  testWidgets('CircuitBreakerBanner shows the message and dismisses', (
+    tester,
+  ) async {
+    var dismissed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CircuitBreakerBanner(
+            message: 'org/r #42 — per-PR cap reached',
+            onDismiss: () => dismissed = true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('org/r #42'), findsOneWidget);
+    expect(find.textContaining('per-PR cap reached'), findsOneWidget);
+
+    await tester.tap(find.text('Dismiss'));
+    await tester.pumpAndSettle();
+    expect(dismissed, isTrue);
+  });
+}


### PR DESCRIPTION
Refs #243 (consolidated Task 5 + Task 6 per user instruction to minimise team review cycles).

## Task 5 — Restart / reload hardening

- Persistent `reviews_in_flight` table in SQLite keyed on (pr_id, head_sha); the previous in-memory map wiped on daemon restart / config reload.
- `ClaimInFlightReview` / `ReleaseInFlightReview` / `ClearStaleInFlight(30m)` (startup cleanup).
- `RunTier2` + `Pipeline.Start` gain `coldStart bool` — initial startup fires the first tick immediately for UX; reload waits one `PollInterval` so UI config PATCHes cannot re-trigger the whole fleet.

## Task 6 — Multi-instance regression test + UI banner

- `pipeline_reloop_test.go` adds `TestRun_TwoInstancesSharingStoreDoNotDoubleReview` — two adapters on the same SQLite; Instance B must dedup against Instance A's `PublishedAt`.
- Flutter: subscribe to the `circuit_breaker_tripped` SSE event (event constant landed with Task 2 in PR #246) and render a dismissible MaterialBanner. Cost events no longer slip by silently.
- `CircuitBreakerBanner` widget + widget test cover the show-and-dismiss contract.

## Test plan

- [x] Go: claim/release/clear-stale unit tests, multi-instance regression test, existing Tier 2 tests updated for new signature — all green via `make test-docker`
- [x] Flutter: widget test for banner + existing tests — all green
- [ ] Manual: kill daemon mid-review, restart, verify the review does not re-run (same SHA) and stale claims are cleared after 30 minutes
- [ ] Manual: PATCH /config, verify Tier 2 does not immediately re-poll every repo
- [ ] Manual: trip the circuit breaker (seed 3 reviews on a test PR), verify banner appears in Flutter and dismisses cleanly

## Why consolidated

Combining Task 5 and Task 6 into one PR rather than stacking two separate PRs — one review cycle from the team instead of two. The commits are logically grouped: Task 5's \`38ab91e\` is the daemon-side restart hardening, followed by Task 6's regression test + UI banner commits.