### PR TITLE
feat: implement #289 — bug: Homebrew formula not updated by GoReleaser — manual formula blocks auto-generation

### DIFF
--- a/cli/.goreleaser.yml
+++ b/cli/.goreleaser.yml
@@ -40,6 +40,7 @@ brews:
       owner: theburrowhub
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
     homepage: https://github.com/theburrowhub/heimdallm
     description: "CLI client for Heimdallm — monitor PRs, issues, and activity from the terminal"
     license: MIT


### PR DESCRIPTION
Auto-generated by Heimdallm in response to #289.

Closes #289