### PR TITLE
feat(nats): PR poll → NATS publisher (#303)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -475,6 +475,7 @@ func main() {
 			JS:             js,
 			PRFetcher:      adapter,
 			PRProcessor:    adapter,
+			PRPublisher:    bus.NewPRReviewPublisher(eventBus.JetStream()),
 			IssueProcessor: adapter,
 			Promoter:       adapter,
 			Store:          adapter,

--- a/daemon/internal/bus/publisher.go
+++ b/daemon/internal/bus/publisher.go
@@ -30,3 +30,33 @@ func (p *RepoPublisher) PublishRepos(ctx context.Context, repos []string) error 
 	}
 	return nil
 }
+
+// PRReviewPublisher publishes PR review requests to NATS JetStream.
+// Implements scheduler.Tier2PRPublisher.
+type PRReviewPublisher struct {
+	js jetstream.JetStream
+}
+
+// NewPRReviewPublisher creates a publisher that writes to SubjPRReview.
+func NewPRReviewPublisher(js jetstream.JetStream) *PRReviewPublisher {
+	return &PRReviewPublisher{js: js}
+}
+
+// PublishPRReview publishes a single PR review request with dedup via Nats-Msg-Id.
+func (p *PRReviewPublisher) PublishPRReview(ctx context.Context, repo string, number int, githubID int64, headSHA string) error {
+	data, err := Encode(PRReviewMsg{
+		Repo:     repo,
+		Number:   number,
+		GithubID: githubID,
+		HeadSHA:  headSHA,
+	})
+	if err != nil {
+		return fmt.Errorf("bus: encode pr review: %w", err)
+	}
+	msgID := fmt.Sprintf("%d:%s", githubID, headSHA)
+	_, err = p.js.Publish(ctx, SubjPRReview, data, jetstream.WithMsgID(msgID))
+	if err != nil {
+		return fmt.Errorf("bus: publish pr review: %w", err)
+	}
+	return nil
+}

--- a/daemon/internal/bus/publisher.go
+++ b/daemon/internal/bus/publisher.go
@@ -43,7 +43,11 @@ func NewPRReviewPublisher(js jetstream.JetStream) *PRReviewPublisher {
 }
 
 // PublishPRReview publishes a single PR review request with dedup via Nats-Msg-Id.
+// Returns an error if headSHA is empty to prevent dedup key collisions.
 func (p *PRReviewPublisher) PublishPRReview(ctx context.Context, repo string, number int, githubID int64, headSHA string) error {
+	if headSHA == "" {
+		return fmt.Errorf("bus: publish pr review: empty headSHA for %s #%d", repo, number)
+	}
 	data, err := Encode(PRReviewMsg{
 		Repo:     repo,
 		Number:   number,

--- a/daemon/internal/bus/publisher_test.go
+++ b/daemon/internal/bus/publisher_test.go
@@ -43,3 +43,65 @@ func TestRepoPublisher_PublishRepos(t *testing.T) {
 		t.Errorf("unexpected repos: %v", got.Repos)
 	}
 }
+
+func TestPRReviewPublisher_Publish(t *testing.T) {
+	b := newTestBus(t)
+	ctx := context.Background()
+
+	pub := bus.NewPRReviewPublisher(b.JetStream())
+
+	err := pub.PublishPRReview(ctx, "org/repo", 42, 12345, "abc123")
+	if err != nil {
+		t.Fatalf("PublishPRReview: %v", err)
+	}
+
+	cons, err := b.JetStream().Consumer(ctx, bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		t.Fatalf("consumer: %v", err)
+	}
+	msgs, err := cons.Fetch(1, jetstream.FetchMaxWait(2*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	var got bus.PRReviewMsg
+	for m := range msgs.Messages() {
+		if err := bus.Decode(m.Data(), &got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		m.Ack()
+	}
+	if got.Repo != "org/repo" || got.Number != 42 || got.GithubID != 12345 || got.HeadSHA != "abc123" {
+		t.Errorf("unexpected payload: %+v", got)
+	}
+}
+
+func TestPRReviewPublisher_Dedup(t *testing.T) {
+	b := newTestBus(t)
+	ctx := context.Background()
+
+	pub := bus.NewPRReviewPublisher(b.JetStream())
+
+	if err := pub.PublishPRReview(ctx, "org/repo", 1, 100, "sha1"); err != nil {
+		t.Fatalf("publish 1: %v", err)
+	}
+	if err := pub.PublishPRReview(ctx, "org/repo", 1, 100, "sha1"); err != nil {
+		t.Fatalf("publish 2: %v", err)
+	}
+
+	cons, err := b.JetStream().Consumer(ctx, bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		t.Fatalf("consumer: %v", err)
+	}
+	msgs, err := cons.Fetch(2, jetstream.FetchMaxWait(1*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	count := 0
+	for m := range msgs.Messages() {
+		count++
+		m.Ack()
+	}
+	if count != 1 {
+		t.Errorf("expected 1 (dedup), got %d", count)
+	}
+}

--- a/daemon/internal/scheduler/bridge_test.go
+++ b/daemon/internal/scheduler/bridge_test.go
@@ -32,6 +32,7 @@ func TestBridgeDiscovery_ForwardsRepos(t *testing.T) {
 		JS:             b.JetStream(),
 		PRFetcher:      &noopPRFetcher{},
 		PRProcessor:    &noopPRProcessor{},
+		PRPublisher:    &noopPRPublisher{},
 		IssueProcessor: &noopIssueProcessor{},
 		Store:          &noopStore{},
 		Tier2ConfigFn:  func() []string { return nil },
@@ -79,6 +80,12 @@ func (n *noopPRProcessor) PublishPending()                                      
 type noopIssueProcessor struct{}
 
 func (n *noopIssueProcessor) ProcessRepo(_ context.Context, _ string) (int, error) { return 0, nil }
+
+type noopPRPublisher struct{}
+
+func (n *noopPRPublisher) PublishPRReview(_ context.Context, _ string, _ int, _ int64, _ string) error {
+	return nil
+}
 
 type noopStore struct{}
 

--- a/daemon/internal/scheduler/pipeline.go
+++ b/daemon/internal/scheduler/pipeline.go
@@ -32,6 +32,7 @@ type PipelineDeps struct {
 	// Tier 2
 	PRFetcher      Tier2PRFetcher
 	PRProcessor    Tier2PRProcessor
+	PRPublisher    Tier2PRPublisher // publishes PR review requests to NATS
 	IssueProcessor Tier2IssueProcessor
 	Promoter       Tier2Promoter
 	Store          Tier2Store
@@ -131,6 +132,7 @@ func (p *Pipeline) Start(parentCtx context.Context, coldStart bool) {
 			WatchQueue:     p.queue,
 			PRFetcher:      p.deps.PRFetcher,
 			PRProcessor:    p.deps.PRProcessor,
+			PRPublisher:    p.deps.PRPublisher,
 			IssueProcessor: p.deps.IssueProcessor,
 			Promoter:       p.deps.Promoter,
 			Store:          p.deps.Store,

--- a/daemon/internal/scheduler/tier2.go
+++ b/daemon/internal/scheduler/tier2.go
@@ -56,6 +56,11 @@ type Tier2Promoter interface {
 	PromoteReady(ctx context.Context, repos []string) (int, error)
 }
 
+// Tier2PRPublisher publishes PR review requests to NATS.
+type Tier2PRPublisher interface {
+	PublishPRReview(ctx context.Context, repo string, number int, githubID int64, headSHA string) error
+}
+
 // Tier2Store checks if a PR has already been reviewed recently.
 type Tier2Store interface {
 	PRAlreadyReviewed(githubID int64, updatedAt time.Time) bool
@@ -67,6 +72,7 @@ type Tier2Deps struct {
 	WatchQueue     *WatchQueue
 	PRFetcher      Tier2PRFetcher
 	PRProcessor    Tier2PRProcessor
+	PRPublisher    Tier2PRPublisher
 	IssueProcessor Tier2IssueProcessor
 	Promoter       Tier2Promoter
 	Store          Tier2Store
@@ -142,15 +148,9 @@ func RunTier2(ctx context.Context, deps Tier2Deps, reposChan <-chan []string, co
 				if deps.Store.PRAlreadyReviewed(pr.ID, pr.UpdatedAt) {
 					continue
 				}
-				go func(p Tier2PR) {
-					if err := deps.PRProcessor.ProcessPR(ctx, p); err != nil {
-						slog.Error("tier2: PR pipeline", "repo", p.Repo, "pr", p.Number, "err", err)
-					}
-					// Enqueue to Tier 3 watch
-					deps.WatchQueue.Push(&WatchItem{
-						Type: "pr", Repo: p.Repo, Number: p.Number, GithubID: p.ID,
-					})
-				}(pr)
+				if err := deps.PRPublisher.PublishPRReview(ctx, pr.Repo, pr.Number, pr.ID, pr.HeadSHA); err != nil {
+					slog.Error("tier2: publish PR review", "repo", pr.Repo, "pr", pr.Number, "err", err)
+				}
 			}
 		}
 

--- a/daemon/internal/scheduler/tier2.go
+++ b/daemon/internal/scheduler/tier2.go
@@ -148,6 +148,8 @@ func RunTier2(ctx context.Context, deps Tier2Deps, reposChan <-chan []string, co
 				if deps.Store.PRAlreadyReviewed(pr.ID, pr.UpdatedAt) {
 					continue
 				}
+				// On publish failure the PR is not marked reviewed in the store,
+				// so the next poll cycle will re-detect and retry it.
 				if err := deps.PRPublisher.PublishPRReview(ctx, pr.Repo, pr.Number, pr.ID, pr.HeadSHA); err != nil {
 					slog.Error("tier2: publish PR review", "repo", pr.Repo, "pr", pr.Number, "err", err)
 				}

--- a/daemon/internal/scheduler/tier2_test.go
+++ b/daemon/internal/scheduler/tier2_test.go
@@ -1,0 +1,97 @@
+package scheduler_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/scheduler"
+)
+
+// mockPRPublisher records PublishPRReview calls.
+type mockPRPublisher struct {
+	mu    sync.Mutex
+	calls []publishedPR
+}
+
+type publishedPR struct {
+	Repo     string
+	Number   int
+	GithubID int64
+	HeadSHA  string
+}
+
+func (m *mockPRPublisher) PublishPRReview(_ context.Context, repo string, number int, githubID int64, headSHA string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, publishedPR{Repo: repo, Number: number, GithubID: githubID, HeadSHA: headSHA})
+	return nil
+}
+
+func (m *mockPRPublisher) getCalls() []publishedPR {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]publishedPR, len(m.calls))
+	copy(cp, m.calls)
+	return cp
+}
+
+// mockPRFetcher returns a fixed list of PRs.
+type mockPRFetcher struct {
+	prs []scheduler.Tier2PR
+}
+
+func (m *mockPRFetcher) FetchPRsToReview() ([]scheduler.Tier2PR, error) {
+	return m.prs, nil
+}
+
+// mockStore controls which PRs are "already reviewed".
+type mockStore struct {
+	reviewed map[int64]bool
+}
+
+func (m *mockStore) PRAlreadyReviewed(githubID int64, _ time.Time) bool {
+	return m.reviewed[githubID]
+}
+
+func TestRunTier2_PublishesPRsToNATS(t *testing.T) {
+	prPub := &mockPRPublisher{}
+	fetcher := &mockPRFetcher{prs: []scheduler.Tier2PR{
+		{ID: 1, Number: 10, Repo: "org/repo1", HeadSHA: "sha1", UpdatedAt: time.Now()},
+		{ID: 2, Number: 20, Repo: "org/repo2", HeadSHA: "sha2", UpdatedAt: time.Now()},
+		{ID: 3, Number: 30, Repo: "org/other", HeadSHA: "sha3", UpdatedAt: time.Now()},
+	}}
+	store := &mockStore{reviewed: map[int64]bool{2: true}}
+
+	reposChan := make(chan []string, 1)
+	reposChan <- []string{"org/repo1", "org/repo2"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go scheduler.RunTier2(ctx, scheduler.Tier2Deps{
+		Limiter:        scheduler.NewRateLimiter(100),
+		WatchQueue:     scheduler.NewWatchQueue(),
+		PRFetcher:      fetcher,
+		PRProcessor:    &noopPRProcessor{},
+		PRPublisher:    prPub,
+		IssueProcessor: &noopIssueProcessor{},
+		Store:          store,
+		ConfigFn:       func() []string { return nil },
+		Interval:       10 * time.Second, // long interval so only the cold-start tick fires
+	}, reposChan, true)
+
+	// RunTier2 waits 2s for Tier 1's first batch before firing processTick,
+	// so we need to wait >2s for the cold-start tick to execute.
+	time.Sleep(3 * time.Second)
+	cancel()
+
+	calls := prPub.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 published PR, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].GithubID != 1 || calls[0].HeadSHA != "sha1" {
+		t.Errorf("unexpected PR published: %+v", calls[0])
+	}
+}

--- a/daemon/internal/scheduler/tier2_test.go
+++ b/daemon/internal/scheduler/tier2_test.go
@@ -55,6 +55,11 @@ func (m *mockStore) PRAlreadyReviewed(githubID int64, _ time.Time) bool {
 	return m.reviewed[githubID]
 }
 
+// noopPromoter satisfies Tier2Promoter for tests that don't exercise promotion.
+type noopPromoter struct{}
+
+func (n *noopPromoter) PromoteReady(_ context.Context, _ []string) (int, error) { return 0, nil }
+
 func TestRunTier2_PublishesPRsToNATS(t *testing.T) {
 	prPub := &mockPRPublisher{}
 	fetcher := &mockPRFetcher{prs: []scheduler.Tier2PR{
@@ -67,7 +72,7 @@ func TestRunTier2_PublishesPRsToNATS(t *testing.T) {
 	reposChan := make(chan []string, 1)
 	reposChan <- []string{"org/repo1", "org/repo2"}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	go scheduler.RunTier2(ctx, scheduler.Tier2Deps{
@@ -77,21 +82,30 @@ func TestRunTier2_PublishesPRsToNATS(t *testing.T) {
 		PRProcessor:    &noopPRProcessor{},
 		PRPublisher:    prPub,
 		IssueProcessor: &noopIssueProcessor{},
+		Promoter:       &noopPromoter{},
 		Store:          store,
 		ConfigFn:       func() []string { return nil },
-		Interval:       10 * time.Second, // long interval so only the cold-start tick fires
+		Interval:       10 * time.Second,
 	}, reposChan, true)
 
-	// RunTier2 waits 2s for Tier 1's first batch before firing processTick,
-	// so we need to wait >2s for the cold-start tick to execute.
-	time.Sleep(3 * time.Second)
-	cancel()
-
-	calls := prPub.getCalls()
-	if len(calls) != 1 {
-		t.Fatalf("expected 1 published PR, got %d: %+v", len(calls), calls)
-	}
-	if calls[0].GithubID != 1 || calls[0].HeadSHA != "sha1" {
-		t.Errorf("unexpected PR published: %+v", calls[0])
+	// Poll until the cold-start processTick publishes (RunTier2 waits 2s
+	// for Tier 1's first batch before firing). Bounded by ctx timeout.
+	deadline := time.After(5 * time.Second)
+	for {
+		calls := prPub.getCalls()
+		if len(calls) > 0 {
+			if len(calls) != 1 {
+				t.Fatalf("expected 1 published PR, got %d: %+v", len(calls), calls)
+			}
+			if calls[0].GithubID != 1 || calls[0].HeadSHA != "sha1" {
+				t.Errorf("unexpected PR published: %+v", calls[0])
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for PublishPRReview call")
+		case <-time.After(100 * time.Millisecond):
+		}
 	}
 }

--- a/daemon/internal/scheduler/tier2_test.go
+++ b/daemon/internal/scheduler/tier2_test.go
@@ -72,7 +72,7 @@ func TestRunTier2_PublishesPRsToNATS(t *testing.T) {
 	reposChan := make(chan []string, 1)
 	reposChan <- []string{"org/repo1", "org/repo2"}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	go scheduler.RunTier2(ctx, scheduler.Tier2Deps{
@@ -90,7 +90,7 @@ func TestRunTier2_PublishesPRsToNATS(t *testing.T) {
 
 	// Poll until the cold-start processTick publishes (RunTier2 waits 2s
 	// for Tier 1's first batch before firing). Bounded by ctx timeout.
-	deadline := time.After(5 * time.Second)
+	deadline := time.After(3 * time.Second)
 	for {
 		calls := prPub.getCalls()
 		if len(calls) > 0 {

--- a/docs/superpowers/plans/2026-04-23-pr-poll-nats.md
+++ b/docs/superpowers/plans/2026-04-23-pr-poll-nats.md
@@ -1,0 +1,493 @@
+# PR Poll → NATS Publisher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the unbounded goroutine-per-PR pattern in Tier 2 with a NATS JetStream publish, with dedup via `Nats-Msg-Id`.
+
+**Architecture:** New `Tier2PRPublisher` interface in scheduler, implemented by `PRReviewPublisher` in bus/publisher.go. Tier 2's `processTick` publishes to NATS instead of spawning goroutines. Task 5 (consumer) will handle the actual review execution.
+
+**Tech Stack:** Go, NATS JetStream (embedded, `daemon/internal/bus/`)
+
+**Spec:** `docs/superpowers/specs/2026-04-23-pr-poll-nats-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `daemon/internal/bus/publisher.go` | Add PRReviewPublisher |
+| Modify | `daemon/internal/bus/publisher_test.go` | Add PRReviewPublisher round-trip + dedup test |
+| Modify | `daemon/internal/scheduler/tier2.go` | Add Tier2PRPublisher interface/field, replace goroutine with publish |
+| Create | `daemon/internal/scheduler/tier2_test.go` | Tier 2 unit test with mock publisher |
+| Modify | `daemon/internal/scheduler/pipeline.go` | Add PRPublisher to PipelineDeps |
+| Modify | `daemon/cmd/heimdallm/main.go` | Wire PRPublisher |
+
+---
+
+### Task 1: PRReviewPublisher
+
+**Files:**
+- Modify: `daemon/internal/bus/publisher.go`
+- Modify: `daemon/internal/bus/publisher_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `daemon/internal/bus/publisher_test.go`:
+
+```go
+func TestPRReviewPublisher_Publish(t *testing.T) {
+	b := newTestBus(t)
+	ctx := context.Background()
+
+	pub := bus.NewPRReviewPublisher(b.JetStream())
+
+	err := pub.PublishPRReview(ctx, "org/repo", 42, 12345, "abc123")
+	if err != nil {
+		t.Fatalf("PublishPRReview: %v", err)
+	}
+
+	cons, err := b.JetStream().Consumer(ctx, bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		t.Fatalf("consumer: %v", err)
+	}
+	msgs, err := cons.Fetch(1, jetstream.FetchMaxWait(2*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	var got bus.PRReviewMsg
+	for m := range msgs.Messages() {
+		if err := bus.Decode(m.Data(), &got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		m.Ack()
+	}
+	if got.Repo != "org/repo" || got.Number != 42 || got.GithubID != 12345 || got.HeadSHA != "abc123" {
+		t.Errorf("unexpected payload: %+v", got)
+	}
+}
+
+func TestPRReviewPublisher_Dedup(t *testing.T) {
+	b := newTestBus(t)
+	ctx := context.Background()
+
+	pub := bus.NewPRReviewPublisher(b.JetStream())
+
+	// Publish same PR+SHA twice
+	if err := pub.PublishPRReview(ctx, "org/repo", 1, 100, "sha1"); err != nil {
+		t.Fatalf("publish 1: %v", err)
+	}
+	if err := pub.PublishPRReview(ctx, "org/repo", 1, 100, "sha1"); err != nil {
+		t.Fatalf("publish 2: %v", err)
+	}
+
+	cons, err := b.JetStream().Consumer(ctx, bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		t.Fatalf("consumer: %v", err)
+	}
+	msgs, err := cons.Fetch(2, jetstream.FetchMaxWait(1*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	count := 0
+	for m := range msgs.Messages() {
+		count++
+		m.Ack()
+	}
+	if count != 1 {
+		t.Errorf("expected 1 (dedup), got %d", count)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go test ./internal/bus/ -run "TestPRReviewPublisher" -v
+```
+
+Expected: FAIL — `bus.NewPRReviewPublisher` undefined.
+
+- [ ] **Step 3: Add PRReviewPublisher to publisher.go**
+
+Append to `daemon/internal/bus/publisher.go`:
+
+```go
+// PRReviewPublisher publishes PR review requests to NATS JetStream.
+// Implements scheduler.Tier2PRPublisher.
+type PRReviewPublisher struct {
+	js jetstream.JetStream
+}
+
+// NewPRReviewPublisher creates a publisher that writes to SubjPRReview.
+func NewPRReviewPublisher(js jetstream.JetStream) *PRReviewPublisher {
+	return &PRReviewPublisher{js: js}
+}
+
+// PublishPRReview publishes a single PR review request with dedup via Nats-Msg-Id.
+func (p *PRReviewPublisher) PublishPRReview(ctx context.Context, repo string, number int, githubID int64, headSHA string) error {
+	data, err := Encode(PRReviewMsg{
+		Repo:     repo,
+		Number:   number,
+		GithubID: githubID,
+		HeadSHA:  headSHA,
+	})
+	if err != nil {
+		return fmt.Errorf("bus: encode pr review: %w", err)
+	}
+	msgID := fmt.Sprintf("%d:%s", githubID, headSHA)
+	_, err = p.js.Publish(ctx, SubjPRReview, data, jetstream.WithMsgID(msgID))
+	if err != nil {
+		return fmt.Errorf("bus: publish pr review: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go test ./internal/bus/ -run "TestPRReviewPublisher" -v
+```
+
+Expected: Both tests PASS.
+
+- [ ] **Step 5: Run full bus test suite**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go test ./internal/bus/ -v -count=1
+```
+
+Expected: All tests pass (18 existing + 2 new = 20).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+git add internal/bus/publisher.go internal/bus/publisher_test.go
+git commit -m "feat(bus): add PRReviewPublisher with dedup via Nats-Msg-Id (#303)"
+```
+
+---
+
+### Task 2: Tier2PRPublisher interface and refactor processTick
+
+**Files:**
+- Modify: `daemon/internal/scheduler/tier2.go`
+- Create: `daemon/internal/scheduler/tier2_test.go`
+- Modify: `daemon/internal/scheduler/pipeline.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `daemon/internal/scheduler/tier2_test.go`:
+
+```go
+package scheduler_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/scheduler"
+)
+
+// mockPRPublisher records PublishPRReview calls.
+type mockPRPublisher struct {
+	mu    sync.Mutex
+	calls []publishedPR
+}
+
+type publishedPR struct {
+	Repo     string
+	Number   int
+	GithubID int64
+	HeadSHA  string
+}
+
+func (m *mockPRPublisher) PublishPRReview(_ context.Context, repo string, number int, githubID int64, headSHA string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, publishedPR{Repo: repo, Number: number, GithubID: githubID, HeadSHA: headSHA})
+	return nil
+}
+
+func (m *mockPRPublisher) getCalls() []publishedPR {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]publishedPR, len(m.calls))
+	copy(cp, m.calls)
+	return cp
+}
+
+// mockPRFetcher returns a fixed list of PRs.
+type mockPRFetcher struct {
+	prs []scheduler.Tier2PR
+}
+
+func (m *mockPRFetcher) FetchPRsToReview() ([]scheduler.Tier2PR, error) {
+	return m.prs, nil
+}
+
+// mockStore controls which PRs are "already reviewed".
+type mockStore struct {
+	reviewed map[int64]bool
+}
+
+func (m *mockStore) PRAlreadyReviewed(githubID int64, _ time.Time) bool {
+	return m.reviewed[githubID]
+}
+
+func TestRunTier2_PublishesPRsToNATS(t *testing.T) {
+	prPub := &mockPRPublisher{}
+	fetcher := &mockPRFetcher{prs: []scheduler.Tier2PR{
+		{ID: 1, Number: 10, Repo: "org/repo1", HeadSHA: "sha1", UpdatedAt: time.Now()},
+		{ID: 2, Number: 20, Repo: "org/repo2", HeadSHA: "sha2", UpdatedAt: time.Now()},
+		{ID: 3, Number: 30, Repo: "org/other", HeadSHA: "sha3", UpdatedAt: time.Now()},
+	}}
+	store := &mockStore{reviewed: map[int64]bool{2: true}} // PR 2 already reviewed
+
+	reposChan := make(chan []string, 1)
+	reposChan <- []string{"org/repo1", "org/repo2"} // org/other not monitored
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go scheduler.RunTier2(ctx, scheduler.Tier2Deps{
+		Limiter:        scheduler.NewRateLimiter(100),
+		WatchQueue:     scheduler.NewWatchQueue(),
+		PRFetcher:      fetcher,
+		PRProcessor:    &noopPRProcessor{},
+		PRPublisher:    prPub,
+		IssueProcessor: &noopIssueProcessor{},
+		Store:          store,
+		ConfigFn:       func() []string { return nil },
+		Interval:       50 * time.Millisecond,
+	}, reposChan, true)
+
+	// Wait for the cold-start processTick to run
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	calls := prPub.getCalls()
+
+	// Only PR 1 should be published:
+	//   PR 2 is already reviewed (skipped by store)
+	//   PR 3 is not in monitored repos (skipped by monitoredSet)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 published PR, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].GithubID != 1 || calls[0].HeadSHA != "sha1" {
+		t.Errorf("unexpected PR published: %+v", calls[0])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go test ./internal/scheduler/ -run TestRunTier2_PublishesPRs -v
+```
+
+Expected: FAIL — `scheduler.Tier2Deps` has no field `PRPublisher`.
+
+- [ ] **Step 3: Add Tier2PRPublisher interface and field to tier2.go**
+
+In `daemon/internal/scheduler/tier2.go`, add the interface after the existing `Tier2Store` interface (around line 62):
+
+```go
+// Tier2PRPublisher publishes PR review requests to NATS.
+type Tier2PRPublisher interface {
+	PublishPRReview(ctx context.Context, repo string, number int, githubID int64, headSHA string) error
+}
+```
+
+Add `PRPublisher` field to `Tier2Deps` (around line 65):
+
+```go
+type Tier2Deps struct {
+	Limiter        *RateLimiter
+	WatchQueue     *WatchQueue
+	PRFetcher      Tier2PRFetcher
+	PRProcessor    Tier2PRProcessor
+	PRPublisher    Tier2PRPublisher
+	IssueProcessor Tier2IssueProcessor
+	Promoter       Tier2Promoter
+	Store          Tier2Store
+	ConfigFn       func() []string // returns monitored repos for PR filtering
+	Interval       time.Duration
+}
+```
+
+- [ ] **Step 4: Replace goroutine spawn with NATS publish in processTick**
+
+In `daemon/internal/scheduler/tier2.go`, in the `processTick` closure, replace the PR processing block. Change from:
+
+```go
+				for _, pr := range prs {
+					if _, ok := monitoredSet[pr.Repo]; !ok {
+						continue
+					}
+					if deps.Store.PRAlreadyReviewed(pr.ID, pr.UpdatedAt) {
+						continue
+					}
+					go func(p Tier2PR) {
+						if err := deps.PRProcessor.ProcessPR(ctx, p); err != nil {
+							slog.Error("tier2: PR pipeline", "repo", p.Repo, "pr", p.Number, "err", err)
+						}
+						// Enqueue to Tier 3 watch
+						deps.WatchQueue.Push(&WatchItem{
+							Type: "pr", Repo: p.Repo, Number: p.Number, GithubID: p.ID,
+						})
+					}(pr)
+				}
+```
+
+To:
+
+```go
+				for _, pr := range prs {
+					if _, ok := monitoredSet[pr.Repo]; !ok {
+						continue
+					}
+					if deps.Store.PRAlreadyReviewed(pr.ID, pr.UpdatedAt) {
+						continue
+					}
+					if err := deps.PRPublisher.PublishPRReview(ctx, pr.Repo, pr.Number, pr.ID, pr.HeadSHA); err != nil {
+						slog.Error("tier2: publish PR review", "repo", pr.Repo, "pr", pr.Number, "err", err)
+					}
+				}
+```
+
+- [ ] **Step 5: Run tier2 test**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go test ./internal/scheduler/ -run TestRunTier2_PublishesPRs -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Add PRPublisher to PipelineDeps in pipeline.go**
+
+In `daemon/internal/scheduler/pipeline.go`, add `PRPublisher` to the `PipelineDeps` struct. After the `JS` field:
+
+```go
+	// Tier 2
+	PRFetcher      Tier2PRFetcher
+	PRProcessor    Tier2PRProcessor
+	PRPublisher    Tier2PRPublisher  // publishes PR review requests to NATS
+	IssueProcessor Tier2IssueProcessor
+```
+
+And in `Start()`, update the `Tier2Deps` construction in the RunTier2 goroutine to include it. Add after `PRProcessor`:
+
+```go
+			PRPublisher:    p.deps.PRPublisher,
+```
+
+- [ ] **Step 7: Verify full scheduler build + tests**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go build ./internal/scheduler/
+go test ./internal/scheduler/ -v -count=1
+```
+
+Expected: Build clean, all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+git add internal/scheduler/tier2.go internal/scheduler/tier2_test.go internal/scheduler/pipeline.go
+git commit -m "feat(scheduler): replace goroutine spawn with NATS publish in Tier 2 (#303)"
+```
+
+---
+
+### Task 3: Wire into main.go
+
+**Files:**
+- Modify: `daemon/cmd/heimdallm/main.go`
+
+- [ ] **Step 1: Add PRPublisher to PipelineDeps in main.go**
+
+In `daemon/cmd/heimdallm/main.go`, find the `scheduler.PipelineDeps{` struct literal (around line 456). After the `JS:` line, add:
+
+```go
+			PRPublisher:    bus.NewPRReviewPublisher(eventBus.JetStream()),
+```
+
+The section should look like:
+
+```go
+			Publisher:      bus.NewRepoPublisher(eventBus.JetStream()),
+			JS:             eventBus.JetStream(),
+			PRPublisher:    bus.NewPRReviewPublisher(eventBus.JetStream()),
+			PRFetcher:      adapter,
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go build ./cmd/heimdallm/
+```
+
+Expected: Clean build.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go test ./... -count=1
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+git add cmd/heimdallm/main.go
+git commit -m "feat: wire PR review NATS publisher into daemon (#303)"
+```
+
+---
+
+### Task 4: Final validation
+
+- [ ] **Step 1: Run affected packages with race detector**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go test ./internal/bus/ ./internal/scheduler/ ./cmd/heimdallm/ -race -count=1
+```
+
+Expected: All pass (except pre-existing tier3 race).
+
+- [ ] **Step 2: Build the binary**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go build -o bin/heimdallm ./cmd/heimdallm/
+```
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+HEIMDALLM_DATA_DIR=$(mktemp -d) HEIMDALLM_AI_PRIMARY=claude-code timeout 5 ./bin/heimdallm 2>&1 | head -15
+```
+
+Expected: Daemon starts, NATS started, Tier 1 discovers repos, Tier 2 receives repo list. PRs that pass filters should be published to NATS (visible in logs if a review-eligible PR exists). Since there is no consumer yet (Task 5), the messages sit in the HEIMDALLM_WORK stream — this is expected.
+
+- [ ] **Step 4: Commit if adjustments needed**
+
+Skip if no changes.

--- a/docs/superpowers/plans/2026-04-23-pr-poll-nats.md
+++ b/docs/superpowers/plans/2026-04-23-pr-poll-nats.md
@@ -103,7 +103,7 @@ func TestPRReviewPublisher_Dedup(t *testing.T) {
 - [ ] **Step 2: Run test to verify it fails**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go test ./internal/bus/ -run "TestPRReviewPublisher" -v
 ```
 
@@ -148,7 +148,7 @@ func (p *PRReviewPublisher) PublishPRReview(ctx context.Context, repo string, nu
 - [ ] **Step 4: Run tests to verify they pass**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go test ./internal/bus/ -run "TestPRReviewPublisher" -v
 ```
 
@@ -157,7 +157,7 @@ Expected: Both tests PASS.
 - [ ] **Step 5: Run full bus test suite**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go test ./internal/bus/ -v -count=1
 ```
 
@@ -166,7 +166,7 @@ Expected: All tests pass (18 existing + 2 new = 20).
 - [ ] **Step 6: Commit**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 git add internal/bus/publisher.go internal/bus/publisher_test.go
 git commit -m "feat(bus): add PRReviewPublisher with dedup via Nats-Msg-Id (#303)"
 ```
@@ -290,7 +290,7 @@ func TestRunTier2_PublishesPRsToNATS(t *testing.T) {
 - [ ] **Step 2: Run test to verify it fails**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go test ./internal/scheduler/ -run TestRunTier2_PublishesPRs -v
 ```
 
@@ -367,7 +367,7 @@ To:
 - [ ] **Step 5: Run tier2 test**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go test ./internal/scheduler/ -run TestRunTier2_PublishesPRs -v
 ```
 
@@ -394,7 +394,7 @@ And in `Start()`, update the `Tier2Deps` construction in the RunTier2 goroutine 
 - [ ] **Step 7: Verify full scheduler build + tests**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go build ./internal/scheduler/
 go test ./internal/scheduler/ -v -count=1
 ```
@@ -404,7 +404,7 @@ Expected: Build clean, all tests pass.
 - [ ] **Step 8: Commit**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 git add internal/scheduler/tier2.go internal/scheduler/tier2_test.go internal/scheduler/pipeline.go
 git commit -m "feat(scheduler): replace goroutine spawn with NATS publish in Tier 2 (#303)"
 ```
@@ -436,7 +436,7 @@ The section should look like:
 - [ ] **Step 2: Verify build**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go build ./cmd/heimdallm/
 ```
 
@@ -445,7 +445,7 @@ Expected: Clean build.
 - [ ] **Step 3: Run full test suite**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go test ./... -count=1
 ```
 
@@ -454,7 +454,7 @@ Expected: All tests pass.
 - [ ] **Step 4: Commit**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 git add cmd/heimdallm/main.go
 git commit -m "feat: wire PR review NATS publisher into daemon (#303)"
 ```
@@ -466,7 +466,7 @@ git commit -m "feat: wire PR review NATS publisher into daemon (#303)"
 - [ ] **Step 1: Run affected packages with race detector**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go test ./internal/bus/ ./internal/scheduler/ ./cmd/heimdallm/ -race -count=1
 ```
 
@@ -475,14 +475,14 @@ Expected: All pass (except pre-existing tier3 race).
 - [ ] **Step 2: Build the binary**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go build -o bin/heimdallm ./cmd/heimdallm/
 ```
 
 - [ ] **Step 3: Smoke test**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 HEIMDALLM_DATA_DIR=$(mktemp -d) HEIMDALLM_AI_PRIMARY=claude-code timeout 5 ./bin/heimdallm 2>&1 | head -15
 ```
 

--- a/docs/superpowers/specs/2026-04-23-pr-poll-nats-design.md
+++ b/docs/superpowers/specs/2026-04-23-pr-poll-nats-design.md
@@ -1,0 +1,90 @@
+# PR Poll → NATS Publisher Design
+
+**Issue:** #298 (epic), #303 (Task 4)  
+**Date:** 2026-04-23  
+**Scope:** Refactor Tier 2 PR fetching to publish to NATS instead of spawning goroutines  
+
+## Overview
+
+Tier 2 currently spawns an unbounded goroutine per eligible PR to run `ProcessPR` + `WatchQueue.Push`. This task replaces the goroutine spawn with a NATS JetStream publish on `heimdallm.pr.review`. The review consumer (Task 5) will handle ProcessPR + WatchQueue.Push. Dedup is achieved via `Nats-Msg-Id = {github_id}:{head_sha}` with the 2-minute dedup window on HEIMDALLM_WORK.
+
+## Changes
+
+### 1. Tier2PRPublisher interface
+
+New interface in `scheduler/tier2.go`:
+
+```go
+type Tier2PRPublisher interface {
+    PublishPRReview(ctx context.Context, repo string, number int, githubID int64, headSHA string) error
+}
+```
+
+Added to `Tier2Deps`. The interface uses primitive fields (not `Tier2PR` or `bus.PRReviewMsg`) so that the scheduler package has no dependency on the bus package.
+
+### 2. PRReviewPublisher (NATS implementation)
+
+Added to `daemon/internal/bus/publisher.go`:
+
+```go
+type PRReviewPublisher struct {
+    js jetstream.JetStream
+}
+
+func NewPRReviewPublisher(js jetstream.JetStream) *PRReviewPublisher
+func (p *PRReviewPublisher) PublishPRReview(ctx context.Context, repo string, number int, githubID int64, headSHA string) error
+```
+
+- Encodes `PRReviewMsg{Repo, Number, GithubID, HeadSHA}`
+- Publishes to `SubjPRReview` with `WithMsgID(fmt.Sprintf("%d:%s", githubID, headSHA))`
+- The 2-minute dedup window on HEIMDALLM_WORK prevents duplicate processing if two poll ticks detect the same PR+SHA
+
+### 3. Tier 2 processTick changes
+
+**Removed:**
+- `go func(p Tier2PR) { ProcessPR + WatchQueue.Push }(pr)` — the unbounded goroutine spawn
+- Direct calls to `PRProcessor.ProcessPR` inside the PR loop
+- Direct calls to `WatchQueue.Push` inside the PR loop
+
+**Replaced with:**
+```go
+if err := deps.PRPublisher.PublishPRReview(ctx, pr.Repo, pr.Number, pr.ID, pr.HeadSHA); err != nil {
+    slog.Error("tier2: publish PR review", "repo", pr.Repo, "pr", pr.Number, "err", err)
+}
+```
+
+**Unchanged:**
+- `PRProcessor.PublishPending()` at end of processTick — still called directly
+- Issue processing, promotion — no changes
+- `WatchQueue` in Tier2Deps — still used by Tier 3
+- `PRProcessor` in Tier2Deps — still used for `PublishPending()`
+
+### 4. main.go wiring
+
+```go
+PRPublisher: bus.NewPRReviewPublisher(eventBus.JetStream()),
+```
+
+Added to `PipelineDeps` construction.
+
+## Files Changed
+
+| Action | File | What |
+|--------|------|------|
+| Modify | `daemon/internal/bus/publisher.go` | Add PRReviewPublisher |
+| Modify | `daemon/internal/bus/publisher_test.go` | Add PRReviewPublisher publish + dedup test |
+| Modify | `daemon/internal/scheduler/tier2.go` | Add Tier2PRPublisher interface/field, replace goroutine with publish |
+| Create | `daemon/internal/scheduler/tier2_test.go` | Tier 2 unit test with mock publisher |
+| Modify | `daemon/internal/scheduler/pipeline.go` | Add PRPublisher to PipelineDeps |
+| Modify | `daemon/cmd/heimdallm/main.go` | Wire PRPublisher |
+
+## Testing
+
+1. **PRReviewPublisher test** — real NATS, publish via PublishPRReview, consume from review-worker, verify payload and Nats-Msg-Id dedup
+2. **Tier2 unit test** — mock PRPublisher, verify PublishPRReview called per eligible PR, verify skipped for non-monitored and already-reviewed PRs
+
+## Out of Scope
+
+- PR review consumer (Task 5)
+- WatchQueue.Push migration (Task 5 consumer handles it, Task 9 replaces WatchQueue)
+- Removing PRProcessor from Tier2Deps (still needed for PublishPending)


### PR DESCRIPTION
## Summary

- Replace unbounded goroutine-per-PR spawn in Tier 2 with NATS JetStream publish
- Add `Tier2PRPublisher` interface and `PRReviewPublisher` implementation with dedup via `Nats-Msg-Id` (`{github_id}:{head_sha}`)
- Eligible PRs are published to `heimdallm.pr.review` — the review consumer (Task 5) will handle actual processing
- Wire `PRPublisher` into `PipelineDeps` from `main.go`

**Part of:** #298 (epic: embed NATS in backend)  
**Closes:** #303

**Stacks on:** #315 (discovery poller → NATS)

## Test plan

- [ ] `go test ./internal/bus/ -run TestPRReviewPublisher -v` — publish + dedup tests pass
- [ ] `go test ./internal/scheduler/ -run TestRunTier2 -v` — tier2 publishes only eligible PRs
- [ ] `go test ./... -count=1` — full suite passes, no regressions
- [ ] Smoke test: daemon starts, PRs published to NATS (no consumer yet — messages queue in stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)