### PR TITLE
feat(nats): PR review worker — first NATS consumer (#304)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -32,8 +32,8 @@ import (
 	"github.com/heimdallm/daemon/internal/scheduler"
 	"github.com/heimdallm/daemon/internal/server"
 	"github.com/heimdallm/daemon/internal/sse"
-	"github.com/heimdallm/daemon/internal/worker"
 	"github.com/heimdallm/daemon/internal/store"
+	"github.com/heimdallm/daemon/internal/worker"
 	"github.com/heimdallm/daemon/launchagent"
 )
 
@@ -534,8 +534,10 @@ func main() {
 	}
 
 	reviewWorker := worker.NewReviewWorker(eventBus.JetStream(), reviewHandler)
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	defer workerCancel()
 	go func() {
-		if err := reviewWorker.Start(context.Background()); err != nil {
+		if err := reviewWorker.Start(workerCtx); err != nil {
 			slog.Error("review worker stopped", "err", err)
 		}
 	}()

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/heimdallm/daemon/internal/scheduler"
 	"github.com/heimdallm/daemon/internal/server"
 	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/worker"
 	"github.com/heimdallm/daemon/internal/store"
 	"github.com/heimdallm/daemon/launchagent"
 )
@@ -493,6 +494,52 @@ func main() {
 	// immediately; operators see polling activity without waiting an entire
 	// PollInterval. The reload path below passes false.
 	pipe.Start(context.Background(), true)
+
+	// ── NATS PR review worker ───────────────────────────────────────────
+	// Consumes PR review requests published by Tier 2 and runs the
+	// existing review pipeline. This replaces the goroutine-per-PR
+	// pattern that Tier 2 used to use.
+	reviewHandler := func(ctx context.Context, msg bus.PRReviewMsg) {
+		pr, err := ghClient.GetPR(msg.Repo, msg.Number)
+		if err != nil {
+			slog.Error("review-worker: fetch PR from GitHub",
+				"repo", msg.Repo, "pr", msg.Number, "err", err)
+			return
+		}
+		// Stale message guard: if HEAD SHA changed since publish, skip.
+		// The next poll cycle will publish a new message with the updated SHA.
+		if msg.HeadSHA != "" && pr.Head.SHA != msg.HeadSHA {
+			slog.Info("review-worker: stale message (HEAD SHA changed), skipping",
+				"repo", msg.Repo, "pr", msg.Number,
+				"msg_sha", msg.HeadSHA, "current_sha", pr.Head.SHA)
+			return
+		}
+
+		cfgMu.Lock()
+		c := *cfg
+		aiCfg := c.AIForRepo(pr.Repo)
+		localDirBase := c.GitHub.LocalDirBase
+		cfgMu.Unlock()
+		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo, localDirBase)
+
+		runReview(pr, aiCfg)
+
+		// Maintain Tier 3 watching (Task 9 replaces WatchQueue entirely).
+		cfgMu.Lock()
+		q := pipe.Queue()
+		cfgMu.Unlock()
+		q.Push(&scheduler.WatchItem{
+			Type: "pr", Repo: pr.Repo, Number: pr.Number, GithubID: pr.ID,
+		})
+	}
+
+	reviewWorker := worker.NewReviewWorker(eventBus.JetStream(), reviewHandler)
+	go func() {
+		if err := reviewWorker.Start(context.Background()); err != nil {
+			slog.Error("review worker stopped", "err", err)
+		}
+	}()
+
 	// Use a closure so the defer reads the current pipe variable at shutdown
 	// time, not the initial pointer captured at defer-statement time. After a
 	// reload, pipe points to a new pipeline — the bare defer would stop the

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -441,6 +441,33 @@ func (c *Client) GetPRSnapshot(repo string, number int) (*PRSnapshot, error) {
 	}, nil
 }
 
+// GetPR returns the full PullRequest struct for a single PR via the Pulls API.
+// Used by the NATS review worker to hydrate a PRReviewMsg into a full PR.
+func (c *Client) GetPR(repo string, number int) (*PullRequest, error) {
+	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)
+	resp, err := c.do("GET", path, "application/vnd.github+json")
+	if err != nil {
+		return nil, fmt.Errorf("github: get PR: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if resp.StatusCode != http.StatusOK {
+		errBody := safeTruncate(string(body), maxErrBodyLen)
+		return nil, fmt.Errorf("github: get PR (%s #%d): status %d: %s", repo, number, resp.StatusCode, errBody)
+	}
+	var pr PullRequest
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return nil, fmt.Errorf("github: get PR: unmarshal: %w", err)
+	}
+	// Populate the Repo field the same way FetchPRs does.
+	if pr.Head.Repo.FullName != "" {
+		pr.Repo = pr.Head.Repo.FullName
+	} else {
+		pr.Repo = repo
+	}
+	return &pr, nil
+}
+
 // FetchDiff returns the unified diff for a PR.
 func (c *Client) FetchDiff(repo string, number int) (string, error) {
 	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)

--- a/daemon/internal/worker/review.go
+++ b/daemon/internal/worker/review.go
@@ -1,0 +1,66 @@
+// daemon/internal/worker/review.go
+package worker
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// ReviewWorker consumes PR review requests from NATS and delegates
+// to a handler function that runs the actual review pipeline.
+type ReviewWorker struct {
+	js      jetstream.JetStream
+	handler func(ctx context.Context, msg bus.PRReviewMsg)
+}
+
+// NewReviewWorker creates a worker that consumes from the review-worker
+// durable consumer. The handler is called for each message and should
+// contain the full review logic (fetch PR, run pipeline, push to watch queue).
+func NewReviewWorker(js jetstream.JetStream, handler func(context.Context, bus.PRReviewMsg)) *ReviewWorker {
+	return &ReviewWorker{js: js, handler: handler}
+}
+
+// Start begins consuming from the NATS review-worker consumer.
+// Blocks until ctx is cancelled. Always acks messages — errors are
+// logged inside the handler, not retried via NATS redelivery.
+func (w *ReviewWorker) Start(ctx context.Context) error {
+	cons, err := w.js.Consumer(ctx, bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		return err
+	}
+
+	iter, err := cons.Messages(jetstream.PullMaxMessages(1))
+	if err != nil {
+		return err
+	}
+
+	// Stop the iterator when context is cancelled so iter.Next() unblocks.
+	go func() {
+		<-ctx.Done()
+		iter.Stop()
+	}()
+
+	for {
+		msg, err := iter.Next()
+		if err != nil {
+			// Context cancelled or iterator stopped — clean exit.
+			return nil
+		}
+
+		var prMsg bus.PRReviewMsg
+		if err := bus.Decode(msg.Data(), &prMsg); err != nil {
+			slog.Error("review-worker: decode message", "err", err)
+			msg.Ack()
+			continue
+		}
+
+		slog.Info("review-worker: processing",
+			"repo", prMsg.Repo, "pr", prMsg.Number, "github_id", prMsg.GithubID)
+
+		w.handler(ctx, prMsg)
+		msg.Ack()
+	}
+}

--- a/daemon/internal/worker/review.go
+++ b/daemon/internal/worker/review.go
@@ -3,6 +3,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -48,7 +49,7 @@ func (w *ReviewWorker) Start(ctx context.Context) error {
 	for {
 		msg, err := iter.Next()
 		if err != nil {
-			if ctx.Err() != nil {
+			if ctx.Err() != nil || errors.Is(err, jetstream.ErrMsgIteratorClosed) {
 				return nil // clean shutdown
 			}
 			return fmt.Errorf("review-worker: iter.Next: %w", err)

--- a/daemon/internal/worker/review.go
+++ b/daemon/internal/worker/review.go
@@ -3,7 +3,9 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"runtime/debug"
 
 	"github.com/heimdallm/daemon/internal/bus"
 	"github.com/nats-io/nats.go/jetstream"
@@ -46,8 +48,10 @@ func (w *ReviewWorker) Start(ctx context.Context) error {
 	for {
 		msg, err := iter.Next()
 		if err != nil {
-			// Context cancelled or iterator stopped — clean exit.
-			return nil
+			if ctx.Err() != nil {
+				return nil // clean shutdown
+			}
+			return fmt.Errorf("review-worker: iter.Next: %w", err)
 		}
 
 		var prMsg bus.PRReviewMsg
@@ -60,7 +64,20 @@ func (w *ReviewWorker) Start(ctx context.Context) error {
 		slog.Info("review-worker: processing",
 			"repo", prMsg.Repo, "pr", prMsg.Number, "github_id", prMsg.GithubID)
 
-		w.handler(ctx, prMsg)
+		w.safeHandle(ctx, prMsg)
 		msg.Ack()
 	}
+}
+
+// safeHandle calls the handler with panic recovery so a single bad PR
+// cannot kill the worker goroutine.
+func (w *ReviewWorker) safeHandle(ctx context.Context, msg bus.PRReviewMsg) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("review-worker: handler panic",
+				"repo", msg.Repo, "pr", msg.Number, "panic", r,
+				"stack", string(debug.Stack()))
+		}
+	}()
+	w.handler(ctx, msg)
 }

--- a/daemon/internal/worker/review_test.go
+++ b/daemon/internal/worker/review_test.go
@@ -1,0 +1,122 @@
+// daemon/internal/worker/review_test.go
+package worker_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/heimdallm/daemon/internal/worker"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func newTestBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	dir := t.TempDir()
+	b := bus.New(bus.Config{DataDir: dir, MaxConcurrentWorkers: 3})
+	if err := b.Start(context.Background()); err != nil {
+		t.Fatalf("bus start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+	return b
+}
+
+func TestReviewWorker_ConsumesAndCallsHandler(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var (
+		mu       sync.Mutex
+		received []bus.PRReviewMsg
+	)
+	handler := func(_ context.Context, msg bus.PRReviewMsg) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, msg)
+	}
+
+	w := worker.NewReviewWorker(b.JetStream(), handler)
+
+	go func() {
+		if err := w.Start(ctx); err != nil {
+			t.Errorf("worker start: %v", err)
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	pub := bus.NewPRReviewPublisher(b.JetStream())
+	if err := pub.PublishPRReview(ctx, "org/repo", 42, 12345, "abc123"); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("expected 1 message handled, got %d", len(received))
+	}
+	msg := received[0]
+	if msg.Repo != "org/repo" || msg.Number != 42 || msg.GithubID != 12345 || msg.HeadSHA != "abc123" {
+		t.Errorf("unexpected message: %+v", msg)
+	}
+
+	cons, err := b.JetStream().Consumer(context.Background(), bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		t.Fatalf("get consumer: %v", err)
+	}
+	info, err := cons.Info(context.Background())
+	if err != nil {
+		t.Fatalf("consumer info: %v", err)
+	}
+	if info.NumAckPending > 0 {
+		t.Errorf("expected 0 ack-pending, got %d", info.NumAckPending)
+	}
+}
+
+func TestReviewWorker_AcksOnHandlerReturn(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	called := make(chan struct{}, 1)
+	handler := func(_ context.Context, _ bus.PRReviewMsg) {
+		called <- struct{}{}
+	}
+
+	w := worker.NewReviewWorker(b.JetStream(), handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+
+	data, _ := bus.Encode(bus.PRReviewMsg{Repo: "a/b", Number: 1, GithubID: 1, HeadSHA: "s1"})
+	_, err := b.JetStream().Publish(ctx, bus.SubjPRReview, data, jetstream.WithMsgID("1:s1"))
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not called within timeout")
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	cons, err := b.JetStream().Consumer(context.Background(), bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		t.Fatalf("get consumer: %v", err)
+	}
+	info, err := cons.Info(context.Background())
+	if err != nil {
+		t.Fatalf("consumer info: %v", err)
+	}
+	if info.NumAckPending > 0 {
+		t.Errorf("message not acked after handler returned: ack-pending=%d", info.NumAckPending)
+	}
+}

--- a/daemon/internal/worker/review_test.go
+++ b/daemon/internal/worker/review_test.go
@@ -120,3 +120,46 @@ func TestReviewWorker_AcksAfterHandler(t *testing.T) {
 		t.Errorf("message not acked after handler returned: ack-pending=%d", info.NumAckPending)
 	}
 }
+
+func TestReviewWorker_AcksAfterHandlerPanic(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	panicked := make(chan struct{}, 1)
+	handler := func(_ context.Context, _ bus.PRReviewMsg) {
+		panicked <- struct{}{}
+		panic("simulated handler panic")
+	}
+
+	w := worker.NewReviewWorker(b.JetStream(), handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+
+	data, _ := bus.Encode(bus.PRReviewMsg{Repo: "a/b", Number: 1, GithubID: 1, HeadSHA: "p1"})
+	_, err := b.JetStream().Publish(ctx, bus.SubjPRReview, data, jetstream.WithMsgID("1:p1"))
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case <-panicked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not called within timeout")
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	// Message should still be acked despite handler panic
+	cons, err := b.JetStream().Consumer(context.Background(), bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		t.Fatalf("get consumer: %v", err)
+	}
+	info, err := cons.Info(context.Background())
+	if err != nil {
+		t.Fatalf("consumer info: %v", err)
+	}
+	if info.NumAckPending > 0 {
+		t.Errorf("message not acked after handler panic: ack-pending=%d", info.NumAckPending)
+	}
+}

--- a/daemon/internal/worker/review_test.go
+++ b/daemon/internal/worker/review_test.go
@@ -79,7 +79,7 @@ func TestReviewWorker_ConsumesAndCallsHandler(t *testing.T) {
 	}
 }
 
-func TestReviewWorker_AcksOnHandlerReturn(t *testing.T) {
+func TestReviewWorker_AcksAfterHandler(t *testing.T) {
 	b := newTestBus(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/docs/superpowers/plans/2026-04-23-pr-review-worker.md
+++ b/docs/superpowers/plans/2026-04-23-pr-review-worker.md
@@ -1,0 +1,477 @@
+# PR Review Worker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create the first NATS consumer — a review worker that subscribes to `heimdallm.pr.review`, fetches the full PR from GitHub, calls the existing review pipeline, and pushes to WatchQueue.
+
+**Architecture:** New `daemon/internal/worker/` package with `ReviewWorker` that handles NATS consumer plumbing. Business logic is injected via a handler closure from main.go that wraps the existing `runReview` function. A new `GetPR` method on the GitHub client provides full PR data from the API.
+
+**Tech Stack:** Go, NATS JetStream (embedded), existing pipeline/github packages
+
+**Spec:** `docs/superpowers/specs/2026-04-23-pr-review-worker-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `daemon/internal/github/client.go` | Add `GetPR(repo, number) (*PullRequest, error)` |
+| Create | `daemon/internal/worker/review.go` | ReviewWorker — NATS consumer with handler callback |
+| Create | `daemon/internal/worker/review_test.go` | ReviewWorker test with embedded NATS + mock handler |
+| Modify | `daemon/cmd/heimdallm/main.go` | Handler closure + ReviewWorker startup |
+
+---
+
+### Task 1: GetPR method on GitHub client
+
+**Files:**
+- Modify: `daemon/internal/github/client.go`
+
+- [ ] **Step 1: Add GetPR method**
+
+In `daemon/internal/github/client.go`, after the `GetPRSnapshot` method (around line 442), add:
+
+```go
+// GetPR returns the full PullRequest struct for a single PR via the Pulls API.
+// Used by the NATS review worker to hydrate a PRReviewMsg into a full PR.
+func (c *Client) GetPR(repo string, number int) (*PullRequest, error) {
+	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)
+	resp, err := c.do("GET", path, "application/vnd.github+json")
+	if err != nil {
+		return nil, fmt.Errorf("github: get PR: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if resp.StatusCode != http.StatusOK {
+		errBody := safeTruncate(string(body), maxErrBodyLen)
+		return nil, fmt.Errorf("github: get PR (%s #%d): status %d: %s", repo, number, resp.StatusCode, errBody)
+	}
+	var pr PullRequest
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return nil, fmt.Errorf("github: get PR: unmarshal: %w", err)
+	}
+	// Populate the Repo field the same way FetchPRs does.
+	if pr.Head.Repo.FullName != "" {
+		pr.Repo = pr.Head.Repo.FullName
+	} else {
+		pr.Repo = repo
+	}
+	return &pr, nil
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go build ./internal/github/
+```
+
+Expected: Clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+git add internal/github/client.go
+git commit -m "feat(github): add GetPR method for full PR fetch (#304)"
+```
+
+---
+
+### Task 2: ReviewWorker
+
+**Files:**
+- Create: `daemon/internal/worker/review.go`
+- Create: `daemon/internal/worker/review_test.go`
+
+- [ ] **Step 1: Create review.go**
+
+```go
+// daemon/internal/worker/review.go
+package worker
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// ReviewWorker consumes PR review requests from NATS and delegates
+// to a handler function that runs the actual review pipeline.
+type ReviewWorker struct {
+	js      jetstream.JetStream
+	handler func(ctx context.Context, msg bus.PRReviewMsg)
+}
+
+// NewReviewWorker creates a worker that consumes from the review-worker
+// durable consumer. The handler is called for each message and should
+// contain the full review logic (fetch PR, run pipeline, push to watch queue).
+func NewReviewWorker(js jetstream.JetStream, handler func(context.Context, bus.PRReviewMsg)) *ReviewWorker {
+	return &ReviewWorker{js: js, handler: handler}
+}
+
+// Start begins consuming from the NATS review-worker consumer.
+// Blocks until ctx is cancelled. Always acks messages — errors are
+// logged inside the handler, not retried via NATS redelivery.
+func (w *ReviewWorker) Start(ctx context.Context) error {
+	cons, err := w.js.Consumer(ctx, bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		return err
+	}
+
+	iter, err := cons.Messages(jetstream.PullMaxMessages(1))
+	if err != nil {
+		return err
+	}
+
+	// Stop the iterator when context is cancelled so iter.Next() unblocks.
+	go func() {
+		<-ctx.Done()
+		iter.Stop()
+	}()
+
+	for {
+		msg, err := iter.Next()
+		if err != nil {
+			// Context cancelled or iterator stopped — clean exit.
+			return nil
+		}
+
+		var prMsg bus.PRReviewMsg
+		if err := bus.Decode(msg.Data(), &prMsg); err != nil {
+			slog.Error("review-worker: decode message", "err", err)
+			msg.Ack()
+			continue
+		}
+
+		slog.Info("review-worker: processing",
+			"repo", prMsg.Repo, "pr", prMsg.Number, "github_id", prMsg.GithubID)
+
+		w.handler(ctx, prMsg)
+		msg.Ack()
+	}
+}
+```
+
+- [ ] **Step 2: Create review_test.go**
+
+```go
+// daemon/internal/worker/review_test.go
+package worker_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/heimdallm/daemon/internal/worker"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func newTestBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	dir := t.TempDir()
+	b := bus.New(bus.Config{DataDir: dir, MaxConcurrentWorkers: 3})
+	if err := b.Start(context.Background()); err != nil {
+		t.Fatalf("bus start: %v", err)
+	}
+	t.Cleanup(b.Stop)
+	return b
+}
+
+func TestReviewWorker_ConsumesAndCallsHandler(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var (
+		mu       sync.Mutex
+		received []bus.PRReviewMsg
+	)
+	handler := func(_ context.Context, msg bus.PRReviewMsg) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, msg)
+	}
+
+	w := worker.NewReviewWorker(b.JetStream(), handler)
+
+	// Start worker in background
+	go func() {
+		if err := w.Start(ctx); err != nil {
+			t.Errorf("worker start: %v", err)
+		}
+	}()
+
+	// Give the worker time to connect to the consumer
+	time.Sleep(200 * time.Millisecond)
+
+	// Publish a PR review message
+	pub := bus.NewPRReviewPublisher(b.JetStream())
+	if err := pub.PublishPRReview(ctx, "org/repo", 42, 12345, "abc123"); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	// Wait for handler to be called
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("expected 1 message handled, got %d", len(received))
+	}
+	msg := received[0]
+	if msg.Repo != "org/repo" || msg.Number != 42 || msg.GithubID != 12345 || msg.HeadSHA != "abc123" {
+		t.Errorf("unexpected message: %+v", msg)
+	}
+
+	// Verify message was acked (0 pending)
+	cons, err := b.JetStream().Consumer(context.Background(), bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		t.Fatalf("get consumer: %v", err)
+	}
+	info, err := cons.Info(context.Background())
+	if err != nil {
+		t.Fatalf("consumer info: %v", err)
+	}
+	if info.NumAckPending > 0 {
+		t.Errorf("expected 0 ack-pending, got %d", info.NumAckPending)
+	}
+}
+
+func TestReviewWorker_AcksOnHandlerError(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	called := make(chan struct{}, 1)
+	handler := func(_ context.Context, _ bus.PRReviewMsg) {
+		// Simulate handler that panics/errors — but we don't panic,
+		// the handler just returns. The worker should still ack.
+		called <- struct{}{}
+	}
+
+	w := worker.NewReviewWorker(b.JetStream(), handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+
+	// Publish
+	data, _ := bus.Encode(bus.PRReviewMsg{Repo: "a/b", Number: 1, GithubID: 1, HeadSHA: "s1"})
+	_, err := b.JetStream().Publish(ctx, bus.SubjPRReview, data, jetstream.WithMsgID("1:s1"))
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not called within timeout")
+	}
+
+	// Small delay for ack to propagate
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	cons, err := b.JetStream().Consumer(context.Background(), bus.StreamWork, bus.ConsumerReview)
+	if err != nil {
+		t.Fatalf("get consumer: %v", err)
+	}
+	info, err := cons.Info(context.Background())
+	if err != nil {
+		t.Fatalf("consumer info: %v", err)
+	}
+	if info.NumAckPending > 0 {
+		t.Errorf("message not acked after handler returned: ack-pending=%d", info.NumAckPending)
+	}
+}
+```
+
+- [ ] **Step 3: Verify it compiles and tests pass**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go test ./internal/worker/ -v -count=1
+```
+
+Expected: Both tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+git add internal/worker/review.go internal/worker/review_test.go
+git commit -m "feat(worker): add ReviewWorker NATS consumer (#304)"
+```
+
+---
+
+### Task 3: Wire ReviewWorker into main.go
+
+**Files:**
+- Modify: `daemon/cmd/heimdallm/main.go`
+
+- [ ] **Step 1: Add worker import**
+
+In `daemon/cmd/heimdallm/main.go`, add to the import block:
+
+```go
+"github.com/heimdallm/daemon/internal/worker"
+```
+
+- [ ] **Step 2: Add handler closure and worker startup**
+
+In main.go, after the `pipe.Start(context.Background(), true)` call (around line 490) and before the defer that stops the pipeline (around line 495), add:
+
+```go
+	// ── NATS PR review worker ───────────────────────────────────────────
+	// Consumes PR review requests published by Tier 2 and runs the
+	// existing review pipeline. This replaces the goroutine-per-PR
+	// pattern that Tier 2 used to use.
+	reviewHandler := func(ctx context.Context, msg bus.PRReviewMsg) {
+		pr, err := ghClient.GetPR(msg.Repo, msg.Number)
+		if err != nil {
+			slog.Error("review-worker: fetch PR from GitHub",
+				"repo", msg.Repo, "pr", msg.Number, "err", err)
+			return
+		}
+		// Stale message guard: if HEAD SHA changed since publish, skip.
+		// The next poll cycle will publish a new message with the updated SHA.
+		if msg.HeadSHA != "" && pr.Head.SHA != msg.HeadSHA {
+			slog.Info("review-worker: stale message (HEAD SHA changed), skipping",
+				"repo", msg.Repo, "pr", msg.Number,
+				"msg_sha", msg.HeadSHA, "current_sha", pr.Head.SHA)
+			return
+		}
+
+		cfgMu.Lock()
+		c := *cfg
+		aiCfg := c.AIForRepo(pr.Repo)
+		localDirBase := c.GitHub.LocalDirBase
+		cfgMu.Unlock()
+		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo, localDirBase)
+
+		runReview(pr, aiCfg)
+
+		// Maintain Tier 3 watching (Task 9 replaces WatchQueue entirely).
+		pipe.Queue().Push(&scheduler.WatchItem{
+			Type: "pr", Repo: pr.Repo, Number: pr.Number, GithubID: pr.ID,
+		})
+	}
+
+	reviewWorker := worker.NewReviewWorker(eventBus.JetStream(), reviewHandler)
+	go func() {
+		if err := reviewWorker.Start(context.Background()); err != nil {
+			slog.Error("review worker stopped", "err", err)
+		}
+	}()
+```
+
+**IMPORTANT:** The `pipe` variable is captured by the closure. On config reload, `pipe` is reassigned to a new pipeline. The closure always reads the current `pipe`, which is correct because the WatchQueue belongs to the active pipeline.
+
+However, `pipe` is reassigned under `cfgMu` during reload. The `pipe.Queue().Push(...)` call should also be under `cfgMu` to avoid a race. Update the handler to:
+
+```go
+		// Maintain Tier 3 watching (Task 9 replaces WatchQueue entirely).
+		cfgMu.Lock()
+		currentPipe := pipe
+		cfgMu.Unlock()
+		currentPipe.Queue().Push(&scheduler.WatchItem{
+			Type: "pr", Repo: pr.Repo, Number: pr.Number, GithubID: pr.ID,
+		})
+```
+
+Wait — `pipe` is NOT protected by `cfgMu` in the existing code. Let me check:
+
+Actually, looking at the existing code, `pipe` is a local variable in `main()` that is reassigned during reload. The reload path does:
+```go
+cfgMu.Lock()
+oldPipe := pipe
+cfgMu.Unlock()
+oldPipe.Stop()
+pipe = buildPipeline(cfg)
+pipe.Start(context.Background(), false)
+```
+
+So `pipe` assignment IS protected by `cfgMu` in the reload path. For the handler, reading `pipe` should also be under `cfgMu`. But this is a pre-existing pattern (the defer closure for shutdown also reads `pipe` without cfgMu). For consistency and safety, use:
+
+```go
+		cfgMu.Lock()
+		q := pipe.Queue()
+		cfgMu.Unlock()
+		q.Push(&scheduler.WatchItem{
+			Type: "pr", Repo: pr.Repo, Number: pr.Number, GithubID: pr.ID,
+		})
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go build ./cmd/heimdallm/
+```
+
+Expected: Clean build.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go test ./... -count=1
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+git add cmd/heimdallm/main.go
+git commit -m "feat: wire PR review NATS worker into daemon startup (#304)"
+```
+
+---
+
+### Task 4: Final validation
+
+- [ ] **Step 1: Run affected packages with race detector**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go test ./internal/worker/ ./internal/bus/ ./internal/github/ ./cmd/heimdallm/ -race -count=1
+```
+
+Expected: All pass.
+
+- [ ] **Step 2: Build binary**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+go build -o bin/heimdallm ./cmd/heimdallm/
+```
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+HEIMDALLM_DATA_DIR=$(mktemp -d) HEIMDALLM_AI_PRIMARY=claude-code timeout 8 ./bin/heimdallm 2>&1 | head -20
+```
+
+Expected: Daemon starts. Logs should show:
+1. `"bus: NATS started"` — NATS embeds
+2. `"tier1: discovery complete"` — Tier 1 publishes to NATS
+3. `"tier2: received repo list"` — bridge forwards to Tier 2
+4. `"review-worker: processing"` — worker consumes PR messages
+5. Review pipeline runs as before
+
+This is the first time the full NATS loop works end-to-end for PRs: publish → NATS → worker → pipeline.Run.
+
+- [ ] **Step 4: Commit if adjustments needed**
+
+Skip if no changes.

--- a/docs/superpowers/plans/2026-04-23-pr-review-worker.md
+++ b/docs/superpowers/plans/2026-04-23-pr-review-worker.md
@@ -64,7 +64,7 @@ func (c *Client) GetPR(repo string, number int) (*PullRequest, error) {
 - [ ] **Step 2: Verify it compiles**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go build ./internal/github/
 ```
 
@@ -73,7 +73,7 @@ Expected: Clean build.
 - [ ] **Step 3: Commit**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 git add internal/github/client.go
 git commit -m "feat(github): add GetPR method for full PR fetch (#304)"
 ```
@@ -296,7 +296,7 @@ func TestReviewWorker_AcksOnHandlerError(t *testing.T) {
 - [ ] **Step 3: Verify it compiles and tests pass**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go test ./internal/worker/ -v -count=1
 ```
 
@@ -305,7 +305,7 @@ Expected: Both tests PASS.
 - [ ] **Step 4: Commit**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 git add internal/worker/review.go internal/worker/review_test.go
 git commit -m "feat(worker): add ReviewWorker NATS consumer (#304)"
 ```
@@ -413,7 +413,7 @@ So `pipe` assignment IS protected by `cfgMu` in the reload path. For the handler
 - [ ] **Step 3: Verify build**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go build ./cmd/heimdallm/
 ```
 
@@ -422,7 +422,7 @@ Expected: Clean build.
 - [ ] **Step 4: Run full test suite**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go test ./... -count=1
 ```
 
@@ -431,7 +431,7 @@ Expected: All tests pass.
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 git add cmd/heimdallm/main.go
 git commit -m "feat: wire PR review NATS worker into daemon startup (#304)"
 ```
@@ -443,7 +443,7 @@ git commit -m "feat: wire PR review NATS worker into daemon startup (#304)"
 - [ ] **Step 1: Run affected packages with race detector**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go test ./internal/worker/ ./internal/bus/ ./internal/github/ ./cmd/heimdallm/ -race -count=1
 ```
 
@@ -452,14 +452,14 @@ Expected: All pass.
 - [ ] **Step 2: Build binary**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 go build -o bin/heimdallm ./cmd/heimdallm/
 ```
 
 - [ ] **Step 3: Smoke test**
 
 ```bash
-cd /Users/jamuriano/personal-workspace/auto-pr/daemon
+cd daemon
 HEIMDALLM_DATA_DIR=$(mktemp -d) HEIMDALLM_AI_PRIMARY=claude-code timeout 8 ./bin/heimdallm 2>&1 | head -20
 ```
 

--- a/docs/superpowers/specs/2026-04-23-pr-review-worker-design.md
+++ b/docs/superpowers/specs/2026-04-23-pr-review-worker-design.md
@@ -1,0 +1,98 @@
+# PR Review Worker (NATS Consumer) Design
+
+**Issue:** #298 (epic), #304 (Task 5)  
+**Date:** 2026-04-23  
+**Scope:** First NATS consumer — subscribes to heimdallm.pr.review, calls existing review pipeline  
+
+## Overview
+
+The PR review worker is a pull-based NATS consumer that reads from the `review-worker` durable consumer on `HEIMDALLM_WORK`. For each message, it fetches the full PR from GitHub, calls the existing `runReview` logic, and pushes to WatchQueue for Tier 3. Messages are always acked (errors are logged, not retried — the pipeline already has circuit breakers and SHA dedup).
+
+## Architecture
+
+```
+NATS (heimdallm.pr.review) → ReviewWorker → handler closure → runReview → pipeline.Run
+                                                              → WatchQueue.Push
+```
+
+### ReviewWorker (daemon/internal/worker/review.go)
+
+```go
+type ReviewWorker struct {
+    js      jetstream.JetStream
+    handler func(ctx context.Context, msg bus.PRReviewMsg)
+}
+
+func NewReviewWorker(js jetstream.JetStream, handler func(context.Context, bus.PRReviewMsg)) *ReviewWorker
+func (w *ReviewWorker) Start(ctx context.Context) error
+```
+
+`Start` gets the `review-worker` consumer, calls `cons.Messages()`, iterates:
+1. Deserialize `PRReviewMsg`
+2. Call `handler(ctx, msg)`
+3. Ack (always — handler logs errors internally)
+4. On context cancel, stop iterator and return
+
+### Handler closure (main.go)
+
+```go
+reviewHandler := func(ctx context.Context, msg bus.PRReviewMsg) {
+    // 1. Fetch full PR from GitHub via GetPR
+    // 2. Verify HeadSHA matches (stale message guard)
+    // 3. Resolve aiCfg for repo
+    // 4. Call existing runReview(pr, aiCfg)
+    // 5. WatchQueue.Push (maintain Tier 3)
+}
+```
+
+The handler reuses `runReview` exactly as-is — all claims, guards, SSE events, pipeline.Run logic stays intact.
+
+### GetPR (github/client.go)
+
+New method on `Client`:
+
+```go
+func (c *Client) GetPR(repo string, number int) (*PullRequest, error)
+```
+
+Same API call as `GetPRSnapshot` (`GET /repos/{repo}/pulls/{number}`) but returns the full `*PullRequest` instead of a reduced snapshot. Sets `pr.Repo` from `Head.Repo.FullName` (same pattern as `FetchPRs`).
+
+## Design Decisions
+
+### Always Ack
+Messages are always acked even on handler error. Rationale:
+- `MaxDeliver=3` with `AckWait=30m` means a failed message re-delivers after 30 min — too late to be useful
+- The pipeline has layered defenses: circuit breaker (3/PR/24h), SHA dedup (fail-closed), PublishedAt grace
+- Nak/retry would just hit the same defenses again
+- Errors are logged for operator visibility
+
+### No pr.publish or NATS events yet
+The epic spec says the worker should publish `pr.publish` + `events.review_completed`. These are deferred:
+- `pr.publish` has no consumer until Task 6
+- NATS events have no consumer until Task 10 (SSE bridge)
+- The SSE broker still handles UI events
+- Tasks 6 and 10 will add these publishes when they create the consumers
+
+### HeadSHA stale guard
+Between publish (Tier 2 poll) and consume (worker), the PR's HEAD may have changed. The handler fetches the fresh PR and compares `pr.Head.SHA` with `msg.HeadSHA`. If they differ, the message is stale — log and skip (a new message for the updated SHA will arrive from the next poll cycle).
+
+## Files Changed
+
+| Action | File | What |
+|--------|------|------|
+| Create | `daemon/internal/worker/review.go` | ReviewWorker struct with NATS consumer loop |
+| Create | `daemon/internal/worker/review_test.go` | Test with embedded NATS + mock handler |
+| Modify | `daemon/internal/github/client.go` | Add GetPR method |
+| Modify | `daemon/cmd/heimdallm/main.go` | Create handler closure, start ReviewWorker |
+
+## Testing
+
+1. **ReviewWorker test** — embedded NATS, publish PRReviewMsg, mock handler verifies it's called with correct data, consumer acks message
+2. **Smoke test** — binary starts, PR published to NATS by Tier 2, worker consumes and triggers review
+
+## Out of Scope
+
+- Publishing to `heimdallm.pr.publish` (Task 6)
+- Publishing to NATS events (Task 10)
+- Removing `PRProcessor.ProcessPR` from Tier2Deps (still used for `PublishPending`)
+- Replacing WatchQueue (Task 9)


### PR DESCRIPTION
## Summary

- Create first NATS consumer: `ReviewWorker` in new `daemon/internal/worker/` package
- Worker subscribes to `review-worker` durable consumer, deserializes `PRReviewMsg`, calls handler
- Handler closure in main.go: fetches full PR from GitHub, applies stale SHA guard, calls existing `runReview`, pushes to WatchQueue
- Add `GetPR(repo, number)` to GitHub client for full PR fetch
- Always-ack strategy: errors logged inside handler, not retried via NATS (pipeline has circuit breakers + SHA dedup)

**First end-to-end NATS loop:** Tier 2 publishes PR → NATS → ReviewWorker consumes → pipeline.Run

**Part of:** #298 (epic: embed NATS in backend)  
**Closes:** #304

**Stacks on:** #316 (PR poll → NATS)

## Test plan

- [ ] `go test ./internal/worker/ -v` — ReviewWorker consume + ack tests pass
- [ ] `go test ./... -count=1` — full suite passes, no regressions
- [ ] Smoke test: `review-worker: processing` appears in logs when a PR is eligible

🤖 Generated with [Claude Code](https://claude.com/claude-code)