### PR TITLE
feat(nats): PR publish worker with ack/nak retry (#305)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -275,7 +275,7 @@ func main() {
 		}
 	}
 
-	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) {
+	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) *store.Review {
 		// Persistent in-flight claim: survives daemon restart and config reload.
 		// Keyed on (pr_id, head_sha) so a new commit on the same PR is not
 		// gated by a stale in-flight row from a prior HEAD. See
@@ -318,7 +318,7 @@ func main() {
 			} else if !ok {
 				slog.Info("runReview: already in flight (persistent), skipping",
 					"pr", pr.Number, "repo", pr.Repo, "head_sha", pr.Head.SHA)
-				return
+				return nil
 			} else {
 				claimed = true
 				claimPRID = stored.ID
@@ -385,7 +385,7 @@ func main() {
 			})
 			slog.Info("runReview: skipping PR",
 				"repo", pr.Repo, "pr", pr.Number, "reason", string(reason))
-			return
+			return nil
 		}
 
 		// Safety check: log exactly what we're about to review
@@ -407,16 +407,16 @@ func main() {
 						"reason":    cbErr.Reason,
 					}),
 				})
-				return
+				return nil
 			}
 			broker.Publish(sse.Event{Type: sse.EventReviewError, Data: sseData(map[string]any{"pr_number": pr.Number, "repo": pr.Repo, "error": err.Error()})})
-			return
+			return nil
 		}
 		if rev == nil {
 			// Defense-in-depth gate in pipeline.Run rejected this PR. Callers are
 			// expected to filter upstream, so this is the safety net — exit quietly
 			// without emitting a completed/error event.
-			return
+			return nil
 		}
 		slog.Info("pipeline: review done",
 			"repo", pr.Repo, "number", pr.Number, "severity", rev.Severity,
@@ -427,9 +427,13 @@ func main() {
 			"pr_id":     rev.PRID,
 			"severity":  rev.Severity,
 		})})
+		return rev
 	}
 
 	// ── Multi-tier Pipeline ──────────────────────────────────────────────
+	js := eventBus.JetStream()
+	publishPub := bus.NewPRPublishPublisher(js)
+
 	// tier2Adapter bridges main.go's concrete types to the Pipeline's
 	// Tier 2 / Tier 3 interfaces.
 	adapter := &tier2Adapter{
@@ -445,10 +449,9 @@ func main() {
 		loginMu:              &loginMu,
 		login:                &cachedLogin,
 		runReview:            runReview,
+		publishPub:           publishPub,
 		lastSkippedUpdatedAt: make(map[int64]time.Time),
 	}
-
-	js := eventBus.JetStream()
 
 	buildPipeline := func(c *config.Config) *scheduler.Pipeline {
 		return scheduler.NewPipeline(scheduler.PipelineConfig{
@@ -522,7 +525,16 @@ func main() {
 		cfgMu.Unlock()
 		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo, localDirBase)
 
-		runReview(pr, aiCfg)
+		rev := runReview(pr, aiCfg)
+
+		// If review succeeded but wasn't published to GitHub yet,
+		// enqueue for the publish worker.
+		if rev != nil && rev.GitHubReviewID == 0 {
+			if err := publishPub.PublishPRPublish(ctx, rev.ID); err != nil {
+				slog.Warn("review-worker: failed to enqueue publish",
+					"review_id", rev.ID, "err", err)
+			}
+		}
 
 		// Maintain Tier 3 watching (Task 9 replaces WatchQueue entirely).
 		cfgMu.Lock()
@@ -539,6 +551,76 @@ func main() {
 	go func() {
 		if err := reviewWorker.Start(workerCtx); err != nil {
 			slog.Error("review worker stopped", "err", err)
+		}
+	}()
+
+	// ── NATS PR publish worker ──────────────────────────────────────────
+	// Consumes publish requests and submits stored reviews to GitHub.
+	// Replaces the manual retry loop in PublishPending with NATS retry
+	// semantics (NakWithDelay for transient GitHub errors).
+	publishHandler := func(ctx context.Context, msg bus.PRPublishMsg) error {
+		rev, err := s.GetReview(msg.ReviewID)
+		if err != nil {
+			slog.Warn("publish-worker: review not found, skipping",
+				"review_id", msg.ReviewID, "err", err)
+			return nil // permanent — ack
+		}
+		if rev.GitHubReviewID != 0 {
+			slog.Info("publish-worker: already published, skipping",
+				"review_id", msg.ReviewID, "github_review_id", rev.GitHubReviewID)
+			return nil // idempotent — ack
+		}
+
+		pr, err := s.GetPR(rev.PRID)
+		if err != nil {
+			slog.Warn("publish-worker: PR not found, marking orphaned",
+				"review_id", msg.ReviewID, "pr_id", rev.PRID, "err", err)
+			_ = s.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
+			return nil // permanent — ack
+		}
+		if pr.Repo == "" {
+			slog.Info("publish-worker: PR has no repo, marking orphaned",
+				"review_id", msg.ReviewID)
+			_ = s.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
+			return nil // permanent — ack
+		}
+
+		// Rebuild ReviewResult from stored JSON
+		var issues []executor.Issue
+		json.Unmarshal([]byte(rev.Issues), &issues)
+		result := &executor.ReviewResult{
+			Summary:  rev.Summary,
+			Issues:   issues,
+			Severity: rev.Severity,
+		}
+
+		ghID, ghState, err := ghClient.SubmitReview(
+			pr.Repo, pr.Number,
+			pipeline.BuildGitHubBody(result),
+			pipeline.SeverityToEvent(rev.Severity, len(issues)),
+		)
+		if err != nil {
+			// Transient — nak for NATS retry
+			return fmt.Errorf("submit review to GitHub: %w", err)
+		}
+
+		publishedAt := time.Now().UTC()
+		if err := s.MarkReviewPublished(rev.ID, ghID, ghState, publishedAt); err != nil {
+			slog.Warn("publish-worker: failed to mark published",
+				"review_id", rev.ID, "err", err)
+		}
+		slog.Info("publish-worker: review published",
+			"review_id", rev.ID, "github_review_id", ghID,
+			"github_review_state", ghState)
+		return nil // success — ack
+	}
+
+	publishW := worker.NewPublishWorker(js, publishHandler)
+	publishWCtx, publishWCancel := context.WithCancel(context.Background())
+	defer publishWCancel()
+	go func() {
+		if err := publishW.Start(publishWCtx); err != nil {
+			slog.Error("publish worker stopped", "err", err)
 		}
 	}()
 
@@ -1249,7 +1331,8 @@ type tier2Adapter struct {
 	cfg       **config.Config
 	loginMu   *sync.Mutex
 	login     *string
-	runReview func(pr *gh.PullRequest, aiCfg config.RepoAI)
+	runReview  func(pr *gh.PullRequest, aiCfg config.RepoAI) *store.Review
+	publishPub *bus.PRPublishPublisher
 
 	// skipMu protects lastSkippedUpdatedAt, which deduplicates review_skipped
 	// SSE events across consecutive poll cycles for the same (PR ID, updated_at)
@@ -1551,13 +1634,21 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 		// allowing two concurrent reviews on the same PR (#243 pattern).
 		Head: gh.Branch{SHA: pr.HeadSHA},
 	}
-	a.runReview(ghPR, aiCfg)
+	_ = a.runReview(ghPR, aiCfg)
 	return nil
 }
 
 // PublishPending implements scheduler.Tier2PRProcessor.
 func (a *tier2Adapter) PublishPending() {
-	a.pipeline.PublishPending()
+	reviews, err := a.store.ListUnpublishedReviews()
+	if err != nil || len(reviews) == 0 {
+		return
+	}
+	for _, rev := range reviews {
+		if err := a.publishPub.PublishPRPublish(context.Background(), rev.ID); err != nil {
+			slog.Warn("publish-pending: enqueue failed", "review_id", rev.ID, "err", err)
+		}
+	}
 }
 
 // ProcessRepo implements scheduler.Tier2IssueProcessor.
@@ -1846,7 +1937,7 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 			ghPR.HTMLURL = stored.URL
 			ghPR.User = gh.User{Login: snap.Author}
 		}
-		a.runReview(ghPR, aiCfg)
+		_ = a.runReview(ghPR, aiCfg)
 		return nil
 	}
 	if item.Type == "issue" {

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -587,7 +587,11 @@ func main() {
 
 		// Rebuild ReviewResult from stored JSON
 		var issues []executor.Issue
-		json.Unmarshal([]byte(rev.Issues), &issues)
+		if err := json.Unmarshal([]byte(rev.Issues), &issues); err != nil {
+			slog.Error("publish-worker: corrupt issues JSON, skipping",
+				"review_id", msg.ReviewID, "err", err)
+			return nil // permanent — ack
+		}
 		result := &executor.ReviewResult{
 			Summary:  rev.Summary,
 			Issues:   issues,
@@ -600,7 +604,14 @@ func main() {
 			pipeline.SeverityToEvent(rev.Severity, len(issues)),
 		)
 		if err != nil {
-			// Transient — nak for NATS retry
+			errStr := err.Error()
+			// 4xx errors (except 429 rate limit) are permanent — no point retrying.
+			// 5xx and network errors are transient — nak for NATS retry.
+			if strings.Contains(errStr, "status 4") && !strings.Contains(errStr, "status 429") {
+				slog.Error("publish-worker: permanent GitHub error, skipping",
+					"review_id", msg.ReviewID, "err", err)
+				return nil // permanent — ack
+			}
 			return fmt.Errorf("submit review to GitHub: %w", err)
 		}
 
@@ -1634,7 +1645,12 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 		// allowing two concurrent reviews on the same PR (#243 pattern).
 		Head: gh.Branch{SHA: pr.HeadSHA},
 	}
-	_ = a.runReview(ghPR, aiCfg)
+	rev := a.runReview(ghPR, aiCfg)
+	if rev != nil && rev.GitHubReviewID == 0 && a.publishPub != nil {
+		if err := a.publishPub.PublishPRPublish(context.Background(), rev.ID); err != nil {
+			slog.Warn("ProcessPR: failed to enqueue publish", "review_id", rev.ID, "err", err)
+		}
+	}
 	return nil
 }
 
@@ -1937,7 +1953,12 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 			ghPR.HTMLURL = stored.URL
 			ghPR.User = gh.User{Login: snap.Author}
 		}
-		_ = a.runReview(ghPR, aiCfg)
+		rev := a.runReview(ghPR, aiCfg)
+		if rev != nil && rev.GitHubReviewID == 0 && a.publishPub != nil {
+			if err := a.publishPub.PublishPRPublish(context.Background(), rev.ID); err != nil {
+				slog.Warn("HandleChange: failed to enqueue publish", "review_id", rev.ID, "err", err)
+			}
+		}
 		return nil
 	}
 	if item.Type == "issue" {

--- a/daemon/cmd/heimdallm/main_inflight_plumb_test.go
+++ b/daemon/cmd/heimdallm/main_inflight_plumb_test.go
@@ -186,11 +186,12 @@ func TestTier2Adapter_ProcessPR_PlumbsHeadSHAIntoGhPR(t *testing.T) {
 		sawGhPR   *gh.PullRequest
 		callCount int
 	)
-	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) {
+	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) *store.Review {
 		mu.Lock()
 		defer mu.Unlock()
 		sawGhPR = pr
 		callCount++
+		return nil
 	}
 
 	s := newMemStore(t)
@@ -256,11 +257,12 @@ func TestTier2Adapter_HandleChange_PlumbsHeadSHAIntoGhPR(t *testing.T) {
 		sawGhPR   *gh.PullRequest
 		callCount int
 	)
-	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) {
+	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) *store.Review {
 		mu.Lock()
 		defer mu.Unlock()
 		sawGhPR = pr
 		callCount++
+		return nil
 	}
 
 	s := newMemStore(t)
@@ -378,7 +380,7 @@ func TestTier2Adapter_ProcessPR_ConcurrentCallsCollapseToOneReview(t *testing.T)
 	var claimSignaler sync.Once
 
 	var reviewBody int32
-	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) {
+	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) *store.Review {
 		// Mirror the production claim logic from runReview in main.go. If
 		// the caller forgot to set Head.SHA (the #264 bug) OR the PR is
 		// not yet upserted, we still return without running — matches the
@@ -387,7 +389,7 @@ func TestTier2Adapter_ProcessPR_ConcurrentCallsCollapseToOneReview(t *testing.T)
 		// that count.
 		storedPR, _ := s.GetPRByGithubID(pr.ID)
 		if storedPR == nil || pr.Head.SHA == "" {
-			return
+			return nil
 		}
 		ok, err := s.ClaimInFlightReview(storedPR.ID, pr.Head.SHA)
 		if err != nil || !ok {
@@ -395,7 +397,7 @@ func TestTier2Adapter_ProcessPR_ConcurrentCallsCollapseToOneReview(t *testing.T)
 			// this is the production "already in flight, skip" branch. Do
 			// NOT touch reviewBody; the whole point of the regression test
 			// is that this path runs exactly once across both goroutines.
-			return
+			return nil
 		}
 		defer func() { _ = s.ReleaseInFlightReview(storedPR.ID, pr.Head.SHA) }()
 
@@ -407,6 +409,7 @@ func TestTier2Adapter_ProcessPR_ConcurrentCallsCollapseToOneReview(t *testing.T)
 		// signal delivered exactly once so the test harness is robust).
 		claimSignaler.Do(func() { close(holdingClaim) })
 		<-release
+		return nil
 	}
 
 	broker := sse.NewBroker()

--- a/daemon/cmd/heimdallm/main_tier3_guards_test.go
+++ b/daemon/cmd/heimdallm/main_tier3_guards_test.go
@@ -13,6 +13,7 @@ import (
 	gh "github.com/heimdallm/daemon/internal/github"
 	"github.com/heimdallm/daemon/internal/scheduler"
 	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
 )
 
 // TestTier3Adapter_HandleChange_SkipsClosedPR verifies the Tier 3 correctness
@@ -38,8 +39,9 @@ func TestTier3Adapter_HandleChange_SkipsClosedPR(t *testing.T) {
 	)
 
 	runReviewCalls := 0
-	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) {
+	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) *store.Review {
 		runReviewCalls++
+		return nil
 	}
 
 	a := &tier2Adapter{

--- a/daemon/internal/bus/publisher.go
+++ b/daemon/internal/bus/publisher.go
@@ -64,3 +64,29 @@ func (p *PRReviewPublisher) PublishPRReview(ctx context.Context, repo string, nu
 	}
 	return nil
 }
+
+// PRPublishPublisher publishes review publish requests to NATS JetStream.
+type PRPublishPublisher struct {
+	js jetstream.JetStream
+}
+
+// NewPRPublishPublisher creates a publisher that writes to SubjPRPublish.
+func NewPRPublishPublisher(js jetstream.JetStream) *PRPublishPublisher {
+	return &PRPublishPublisher{js: js}
+}
+
+// PublishPRPublish enqueues a review for GitHub publication.
+// Dedup via Nats-Msg-Id prevents the scanner and review worker from
+// double-publishing the same review.
+func (p *PRPublishPublisher) PublishPRPublish(ctx context.Context, reviewID int64) error {
+	data, err := Encode(PRPublishMsg{ReviewID: reviewID})
+	if err != nil {
+		return fmt.Errorf("bus: encode pr publish: %w", err)
+	}
+	msgID := fmt.Sprintf("rev:%d", reviewID)
+	_, err = p.js.Publish(ctx, SubjPRPublish, data, jetstream.WithMsgID(msgID))
+	if err != nil {
+		return fmt.Errorf("bus: publish pr publish: %w", err)
+	}
+	return nil
+}

--- a/daemon/internal/bus/publisher_test.go
+++ b/daemon/internal/bus/publisher_test.go
@@ -105,3 +105,64 @@ func TestPRReviewPublisher_Dedup(t *testing.T) {
 		t.Errorf("expected 1 (dedup), got %d", count)
 	}
 }
+
+func TestPRPublishPublisher_Publish(t *testing.T) {
+	b := newTestBus(t)
+	ctx := context.Background()
+
+	pub := bus.NewPRPublishPublisher(b.JetStream())
+
+	if err := pub.PublishPRPublish(ctx, 42); err != nil {
+		t.Fatalf("PublishPRPublish: %v", err)
+	}
+
+	cons, err := b.JetStream().Consumer(ctx, bus.StreamWork, bus.ConsumerPublish)
+	if err != nil {
+		t.Fatalf("consumer: %v", err)
+	}
+	msgs, err := cons.Fetch(1, jetstream.FetchMaxWait(2*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	var got bus.PRPublishMsg
+	for m := range msgs.Messages() {
+		if err := bus.Decode(m.Data(), &got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		m.Ack()
+	}
+	if got.ReviewID != 42 {
+		t.Errorf("ReviewID = %d, want 42", got.ReviewID)
+	}
+}
+
+func TestPRPublishPublisher_Dedup(t *testing.T) {
+	b := newTestBus(t)
+	ctx := context.Background()
+
+	pub := bus.NewPRPublishPublisher(b.JetStream())
+
+	if err := pub.PublishPRPublish(ctx, 42); err != nil {
+		t.Fatalf("publish 1: %v", err)
+	}
+	if err := pub.PublishPRPublish(ctx, 42); err != nil {
+		t.Fatalf("publish 2: %v", err)
+	}
+
+	cons, err := b.JetStream().Consumer(ctx, bus.StreamWork, bus.ConsumerPublish)
+	if err != nil {
+		t.Fatalf("consumer: %v", err)
+	}
+	msgs, err := cons.Fetch(2, jetstream.FetchMaxWait(1*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	count := 0
+	for m := range msgs.Messages() {
+		count++
+		m.Ack()
+	}
+	if count != 1 {
+		t.Errorf("expected 1 (dedup), got %d", count)
+	}
+}

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -397,13 +397,13 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		}
 		reviewBody = buildMultiSummaryBody(result)
 	} else {
-		reviewBody = buildGitHubBody(result)
+		reviewBody = BuildGitHubBody(result)
 	}
 
 	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
 		pr.Repo, pr.Number,
 		reviewBody,
-		severityToEvent(result.Severity, len(result.Issues)),
+		SeverityToEvent(result.Severity, len(result.Issues)),
 	)
 	if publishErr != nil {
 		// Review saved locally; will retry on next poll (GitHubReviewID == 0 check)
@@ -471,8 +471,8 @@ func (p *Pipeline) PublishPending() {
 		// already posted when the review first ran; we only retry the formal review).
 		ghID, ghState, err := p.gh.SubmitReview(
 			pr.Repo, pr.Number,
-			buildGitHubBody(result),
-			severityToEvent(rev.Severity, len(issues)),
+			BuildGitHubBody(result),
+			SeverityToEvent(rev.Severity, len(issues)),
 		)
 		if err != nil {
 			slog.Warn("pipeline: retry publish failed", "review_id", rev.ID, "err", err)
@@ -546,8 +546,8 @@ func buildMultiSummaryBody(r *executor.ReviewResult) string {
 	return sb.String()
 }
 
-// buildGitHubBody formats the AI review as a GitHub-flavored markdown review body.
-func buildGitHubBody(r *executor.ReviewResult) string {
+// BuildGitHubBody formats the AI review as a GitHub-flavored markdown review body.
+func BuildGitHubBody(r *executor.ReviewResult) string {
 	var sb strings.Builder
 	sb.WriteString("## 🤖 Heimdallm AI Review\n\n")
 	sb.WriteString(r.Summary)
@@ -581,10 +581,10 @@ func buildGitHubBody(r *executor.ReviewResult) string {
 	return sb.String()
 }
 
-// severityToEvent maps severity to a GitHub review event type.
+// SeverityToEvent maps severity to a GitHub review event type.
 // Only high-severity issues block a PR — Heimdallm must not be a blocker
 // for medium/low issues. Those are left as informational comments with an APPROVE.
-func severityToEvent(severity string, _ int) string {
+func SeverityToEvent(severity string, _ int) string {
 	if severity == "high" {
 		return "REQUEST_CHANGES"
 	}

--- a/daemon/internal/store/reviews.go
+++ b/daemon/internal/store/reviews.go
@@ -76,6 +76,15 @@ func (s *Store) ListUnpublishedReviews() ([]*Review, error) {
 	return reviews, rows.Err()
 }
 
+// GetReview returns a single review by its local row ID.
+func (s *Store) GetReview(id int64) (*Review, error) {
+	row := s.db.QueryRow(
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha FROM reviews WHERE id = ?",
+		id,
+	)
+	return scanReview(row)
+}
+
 // UpdateReviewHeadSHA backfills the head_sha column on a legacy review row.
 // Used by the pipeline's fail-closed dedup: if a previous review had no SHA
 // (from before the column was populated), we populate it from the current

--- a/daemon/internal/worker/publish.go
+++ b/daemon/internal/worker/publish.go
@@ -1,0 +1,89 @@
+// daemon/internal/worker/publish.go
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// PublishWorker consumes PR publish requests from NATS and delegates
+// to a handler that submits the review to GitHub.
+//
+// Unlike ReviewWorker, the handler returns an error to control ack/nak:
+//   - nil → Ack (success or permanent failure, no retry)
+//   - non-nil → NakWithDelay(30s) for NATS retry on transient failures
+type PublishWorker struct {
+	js      jetstream.JetStream
+	handler func(ctx context.Context, msg bus.PRPublishMsg) error
+}
+
+// NewPublishWorker creates a worker that consumes from the publish-worker
+// durable consumer.
+func NewPublishWorker(js jetstream.JetStream, handler func(context.Context, bus.PRPublishMsg) error) *PublishWorker {
+	return &PublishWorker{js: js, handler: handler}
+}
+
+// Start begins consuming. Blocks until ctx is cancelled.
+func (w *PublishWorker) Start(ctx context.Context) error {
+	cons, err := w.js.Consumer(ctx, bus.StreamWork, bus.ConsumerPublish)
+	if err != nil {
+		return err
+	}
+
+	iter, err := cons.Messages(jetstream.PullMaxMessages(1))
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		<-ctx.Done()
+		iter.Stop()
+	}()
+
+	for {
+		msg, err := iter.Next()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, jetstream.ErrMsgIteratorClosed) {
+				return nil
+			}
+			return fmt.Errorf("publish-worker: iter.Next: %w", err)
+		}
+
+		var pubMsg bus.PRPublishMsg
+		if err := bus.Decode(msg.Data(), &pubMsg); err != nil {
+			slog.Error("publish-worker: decode message", "err", err)
+			msg.Ack()
+			continue
+		}
+
+		slog.Info("publish-worker: processing", "review_id", pubMsg.ReviewID)
+
+		if err := w.safeHandle(ctx, pubMsg); err != nil {
+			slog.Warn("publish-worker: transient error, will retry",
+				"review_id", pubMsg.ReviewID, "err", err)
+			msg.NakWithDelay(30 * time.Second)
+		} else {
+			msg.Ack()
+		}
+	}
+}
+
+// safeHandle calls the handler with panic recovery.
+func (w *PublishWorker) safeHandle(ctx context.Context, msg bus.PRPublishMsg) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("publish-worker: handler panic",
+				"review_id", msg.ReviewID, "panic", r,
+				"stack", string(debug.Stack()))
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+	return w.handler(ctx, msg)
+}

--- a/daemon/internal/worker/publish_test.go
+++ b/daemon/internal/worker/publish_test.go
@@ -1,0 +1,127 @@
+// daemon/internal/worker/publish_test.go
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/heimdallm/daemon/internal/worker"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestPublishWorker_AcksOnSuccess(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	called := make(chan int64, 1)
+	handler := func(_ context.Context, msg bus.PRPublishMsg) error {
+		called <- msg.ReviewID
+		return nil
+	}
+
+	w := worker.NewPublishWorker(b.JetStream(), handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+
+	pub := bus.NewPRPublishPublisher(b.JetStream())
+	if err := pub.PublishPRPublish(ctx, 42); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case id := <-called:
+		if id != 42 {
+			t.Errorf("ReviewID = %d, want 42", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not called")
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	cons, err := b.JetStream().Consumer(context.Background(), bus.StreamWork, bus.ConsumerPublish)
+	if err != nil {
+		t.Fatalf("get consumer: %v", err)
+	}
+	info, err := cons.Info(context.Background())
+	if err != nil {
+		t.Fatalf("consumer info: %v", err)
+	}
+	if info.NumAckPending > 0 {
+		t.Errorf("expected 0 ack-pending, got %d", info.NumAckPending)
+	}
+}
+
+func TestPublishWorker_NaksOnError(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var mu sync.Mutex
+	callCount := 0
+	handler := func(_ context.Context, msg bus.PRPublishMsg) error {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		return errors.New("transient error")
+	}
+
+	w := worker.NewPublishWorker(b.JetStream(), handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+
+	data, _ := bus.Encode(bus.PRPublishMsg{ReviewID: 99})
+	_, err := b.JetStream().Publish(ctx, bus.SubjPRPublish, data, jetstream.WithMsgID("rev:99"))
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	// Wait for at least the first call
+	time.Sleep(1 * time.Second)
+	cancel()
+
+	mu.Lock()
+	n := callCount
+	mu.Unlock()
+	if n < 1 {
+		t.Fatalf("expected handler to be called at least once, got %d", n)
+	}
+}
+
+func TestPublishWorker_NaksOnPanic(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	panicked := make(chan struct{}, 1)
+	handler := func(_ context.Context, _ bus.PRPublishMsg) error {
+		panicked <- struct{}{}
+		panic("simulated publish panic")
+	}
+
+	w := worker.NewPublishWorker(b.JetStream(), handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+
+	data, _ := bus.Encode(bus.PRPublishMsg{ReviewID: 77})
+	_, err := b.JetStream().Publish(ctx, bus.SubjPRPublish, data, jetstream.WithMsgID("rev:77"))
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case <-panicked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not called")
+	}
+
+	// Panic → safeHandle returns error → NakWithDelay (not ack)
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+}

--- a/docs/superpowers/plans/2026-04-23-pr-publish-worker.md
+++ b/docs/superpowers/plans/2026-04-23-pr-publish-worker.md
@@ -1,0 +1,675 @@
+# PR Publish Worker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a NATS consumer that publishes stored reviews to GitHub, replacing the manual PublishPending retry loop with NATS retry semantics (NakWithDelay).
+
+**Architecture:** PublishWorker consumes `PRPublishMsg` from the `publish-worker` consumer. Two sources publish messages: the review worker (happy path after successful review) and a simplified PublishPending scanner (catch-up). The handler returns an error to control ack/nak — nil means ack, non-nil means NakWithDelay for NATS retry.
+
+**Tech Stack:** Go, NATS JetStream (embedded), existing pipeline/store packages
+
+**Spec:** `docs/superpowers/specs/2026-04-23-pr-publish-worker-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `daemon/internal/store/reviews.go` | Add GetReview(id) method |
+| Modify | `daemon/internal/bus/publisher.go` | Add PRPublishPublisher |
+| Modify | `daemon/internal/bus/publisher_test.go` | Test PRPublishPublisher |
+| Create | `daemon/internal/worker/publish.go` | PublishWorker with ack/nak logic |
+| Create | `daemon/internal/worker/publish_test.go` | Tests for PublishWorker |
+| Modify | `daemon/cmd/heimdallm/main.go` | runReview returns *Review, publishHandler, PublishWorker startup, reviewHandler publishes PRPublishMsg, simplify PublishPending |
+
+---
+
+### Task 1: store.GetReview
+
+**Files:**
+- Modify: `daemon/internal/store/reviews.go`
+
+- [ ] **Step 1: Add GetReview method**
+
+In `daemon/internal/store/reviews.go`, after the `ListUnpublishedReviews` method (around line 77), add:
+
+```go
+// GetReview returns a single review by its local row ID.
+func (s *Store) GetReview(id int64) (*Review, error) {
+	row := s.db.QueryRow(
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha FROM reviews WHERE id = ?",
+		id,
+	)
+	return scanReview(row)
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd daemon
+go build ./internal/store/
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/store/reviews.go
+git commit -m "feat(store): add GetReview method (#305)"
+```
+
+---
+
+### Task 2: PRPublishPublisher
+
+**Files:**
+- Modify: `daemon/internal/bus/publisher.go`
+- Modify: `daemon/internal/bus/publisher_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `daemon/internal/bus/publisher_test.go`:
+
+```go
+func TestPRPublishPublisher_Publish(t *testing.T) {
+	b := newTestBus(t)
+	ctx := context.Background()
+
+	pub := bus.NewPRPublishPublisher(b.JetStream())
+
+	if err := pub.PublishPRPublish(ctx, 42); err != nil {
+		t.Fatalf("PublishPRPublish: %v", err)
+	}
+
+	cons, err := b.JetStream().Consumer(ctx, bus.StreamWork, bus.ConsumerPublish)
+	if err != nil {
+		t.Fatalf("consumer: %v", err)
+	}
+	msgs, err := cons.Fetch(1, jetstream.FetchMaxWait(2*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	var got bus.PRPublishMsg
+	for m := range msgs.Messages() {
+		if err := bus.Decode(m.Data(), &got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		m.Ack()
+	}
+	if got.ReviewID != 42 {
+		t.Errorf("ReviewID = %d, want 42", got.ReviewID)
+	}
+}
+
+func TestPRPublishPublisher_Dedup(t *testing.T) {
+	b := newTestBus(t)
+	ctx := context.Background()
+
+	pub := bus.NewPRPublishPublisher(b.JetStream())
+
+	if err := pub.PublishPRPublish(ctx, 42); err != nil {
+		t.Fatalf("publish 1: %v", err)
+	}
+	if err := pub.PublishPRPublish(ctx, 42); err != nil {
+		t.Fatalf("publish 2: %v", err)
+	}
+
+	cons, err := b.JetStream().Consumer(ctx, bus.StreamWork, bus.ConsumerPublish)
+	if err != nil {
+		t.Fatalf("consumer: %v", err)
+	}
+	msgs, err := cons.Fetch(2, jetstream.FetchMaxWait(1*time.Second))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	count := 0
+	for m := range msgs.Messages() {
+		count++
+		m.Ack()
+	}
+	if count != 1 {
+		t.Errorf("expected 1 (dedup), got %d", count)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd daemon
+go test ./internal/bus/ -run TestPRPublishPublisher -v
+```
+
+Expected: FAIL — `bus.NewPRPublishPublisher` undefined.
+
+- [ ] **Step 3: Add PRPublishPublisher to publisher.go**
+
+Append to `daemon/internal/bus/publisher.go`:
+
+```go
+// PRPublishPublisher publishes review publish requests to NATS JetStream.
+type PRPublishPublisher struct {
+	js jetstream.JetStream
+}
+
+// NewPRPublishPublisher creates a publisher that writes to SubjPRPublish.
+func NewPRPublishPublisher(js jetstream.JetStream) *PRPublishPublisher {
+	return &PRPublishPublisher{js: js}
+}
+
+// PublishPRPublish enqueues a review for GitHub publication.
+// Dedup via Nats-Msg-Id prevents the scanner and review worker from
+// double-publishing the same review.
+func (p *PRPublishPublisher) PublishPRPublish(ctx context.Context, reviewID int64) error {
+	data, err := Encode(PRPublishMsg{ReviewID: reviewID})
+	if err != nil {
+		return fmt.Errorf("bus: encode pr publish: %w", err)
+	}
+	msgID := fmt.Sprintf("rev:%d", reviewID)
+	_, err = p.js.Publish(ctx, SubjPRPublish, data, jetstream.WithMsgID(msgID))
+	if err != nil {
+		return fmt.Errorf("bus: publish pr publish: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd daemon
+go test ./internal/bus/ -run TestPRPublishPublisher -v
+```
+
+Expected: Both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/bus/publisher.go internal/bus/publisher_test.go
+git commit -m "feat(bus): add PRPublishPublisher with dedup by review ID (#305)"
+```
+
+---
+
+### Task 3: PublishWorker
+
+**Files:**
+- Create: `daemon/internal/worker/publish.go`
+- Create: `daemon/internal/worker/publish_test.go`
+
+- [ ] **Step 1: Create publish.go**
+
+```go
+// daemon/internal/worker/publish.go
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// PublishWorker consumes PR publish requests from NATS and delegates
+// to a handler that submits the review to GitHub.
+//
+// Unlike ReviewWorker, the handler returns an error to control ack/nak:
+//   - nil → Ack (success or permanent failure, no retry)
+//   - non-nil → NakWithDelay(30s) for NATS retry on transient failures
+type PublishWorker struct {
+	js      jetstream.JetStream
+	handler func(ctx context.Context, msg bus.PRPublishMsg) error
+}
+
+// NewPublishWorker creates a worker that consumes from the publish-worker
+// durable consumer.
+func NewPublishWorker(js jetstream.JetStream, handler func(context.Context, bus.PRPublishMsg) error) *PublishWorker {
+	return &PublishWorker{js: js, handler: handler}
+}
+
+// Start begins consuming. Blocks until ctx is cancelled.
+func (w *PublishWorker) Start(ctx context.Context) error {
+	cons, err := w.js.Consumer(ctx, bus.StreamWork, bus.ConsumerPublish)
+	if err != nil {
+		return err
+	}
+
+	iter, err := cons.Messages(jetstream.PullMaxMessages(1))
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		<-ctx.Done()
+		iter.Stop()
+	}()
+
+	for {
+		msg, err := iter.Next()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, jetstream.ErrMsgIteratorClosed) {
+				return nil
+			}
+			return fmt.Errorf("publish-worker: iter.Next: %w", err)
+		}
+
+		var pubMsg bus.PRPublishMsg
+		if err := bus.Decode(msg.Data(), &pubMsg); err != nil {
+			slog.Error("publish-worker: decode message", "err", err)
+			msg.Ack()
+			continue
+		}
+
+		slog.Info("publish-worker: processing", "review_id", pubMsg.ReviewID)
+
+		if err := w.safeHandle(ctx, pubMsg); err != nil {
+			slog.Warn("publish-worker: transient error, will retry",
+				"review_id", pubMsg.ReviewID, "err", err)
+			msg.NakWithDelay(30 * time.Second)
+		} else {
+			msg.Ack()
+		}
+	}
+}
+
+// safeHandle calls the handler with panic recovery.
+func (w *PublishWorker) safeHandle(ctx context.Context, msg bus.PRPublishMsg) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("publish-worker: handler panic",
+				"review_id", msg.ReviewID, "panic", r,
+				"stack", string(debug.Stack()))
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+	return w.handler(ctx, msg)
+}
+```
+
+- [ ] **Step 2: Create publish_test.go**
+
+```go
+// daemon/internal/worker/publish_test.go
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/heimdallm/daemon/internal/worker"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestPublishWorker_AcksOnSuccess(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	called := make(chan int64, 1)
+	handler := func(_ context.Context, msg bus.PRPublishMsg) error {
+		called <- msg.ReviewID
+		return nil
+	}
+
+	w := worker.NewPublishWorker(b.JetStream(), handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+
+	pub := bus.NewPRPublishPublisher(b.JetStream())
+	if err := pub.PublishPRPublish(ctx, 42); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case id := <-called:
+		if id != 42 {
+			t.Errorf("ReviewID = %d, want 42", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not called")
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	cons, err := b.JetStream().Consumer(context.Background(), bus.StreamWork, bus.ConsumerPublish)
+	if err != nil {
+		t.Fatalf("get consumer: %v", err)
+	}
+	info, err := cons.Info(context.Background())
+	if err != nil {
+		t.Fatalf("consumer info: %v", err)
+	}
+	if info.NumAckPending > 0 {
+		t.Errorf("expected 0 ack-pending, got %d", info.NumAckPending)
+	}
+}
+
+func TestPublishWorker_NaksOnError(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var mu sync.Mutex
+	callCount := 0
+	handler := func(_ context.Context, msg bus.PRPublishMsg) error {
+		mu.Lock()
+		callCount++
+		n := callCount
+		mu.Unlock()
+		if n <= 2 {
+			return errors.New("transient error")
+		}
+		return nil // succeed on 3rd attempt
+	}
+
+	w := worker.NewPublishWorker(b.JetStream(), handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+
+	// Publish directly with short NakWithDelay for test speed.
+	// The worker uses 30s delay, but for testing we publish and just
+	// verify the handler is called multiple times (redelivery).
+	data, _ := bus.Encode(bus.PRPublishMsg{ReviewID: 99})
+	_, err := b.JetStream().Publish(ctx, bus.SubjPRPublish, data, jetstream.WithMsgID("rev:99"))
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	// Wait enough time for at least the first call + nak
+	// NakWithDelay is 30s in production, but NATS may redeliver sooner in tests.
+	// We just verify the handler was called at least once.
+	time.Sleep(1 * time.Second)
+	cancel()
+
+	mu.Lock()
+	n := callCount
+	mu.Unlock()
+	if n < 1 {
+		t.Fatalf("expected handler to be called at least once, got %d", n)
+	}
+}
+
+func TestPublishWorker_AcksOnPanic(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	panicked := make(chan struct{}, 1)
+	handler := func(_ context.Context, _ bus.PRPublishMsg) error {
+		panicked <- struct{}{}
+		panic("simulated publish panic")
+	}
+
+	w := worker.NewPublishWorker(b.JetStream(), handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+
+	data, _ := bus.Encode(bus.PRPublishMsg{ReviewID: 77})
+	_, err := b.JetStream().Publish(ctx, bus.SubjPRPublish, data, jetstream.WithMsgID("rev:77"))
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case <-panicked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not called")
+	}
+
+	// Panic returns error from safeHandle → NakWithDelay (not ack).
+	// This is correct — a panic is treated as transient.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd daemon
+go test ./internal/worker/ -v -count=1
+```
+
+Expected: All worker tests pass (3 review + 3 publish).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/worker/publish.go internal/worker/publish_test.go
+git commit -m "feat(worker): add PublishWorker with ack/nak error handling (#305)"
+```
+
+---
+
+### Task 4: Wire into main.go
+
+**Files:**
+- Modify: `daemon/cmd/heimdallm/main.go`
+
+This is the most complex task — several changes:
+
+- [ ] **Step 1: Change runReview signature to return *store.Review**
+
+In `daemon/cmd/heimdallm/main.go`, find `runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) {` (around line 278). Change to:
+
+```go
+	runReview := func(pr *gh.PullRequest, aiCfg config.RepoAI) *store.Review {
+```
+
+At the end of the function (around line 429, before the closing `}`), the `broker.Publish(sse.Event{Type: sse.EventReviewCompleted, ...})` block is the success path. After it, add `return rev`. For all early-return paths (errors, skips), change `return` to `return nil`.
+
+Specifically:
+- Line ~319 (`return` after "already in flight") → `return nil`
+- Line ~349 (`return` after review guards skip) → `return nil`
+- Line ~373 (`return` after circuit breaker) → `return nil`
+- Line ~375 (`return` after review error) → `return nil`
+- Line ~381 (`return` after rev == nil) → `return nil`
+- Line ~429 (after EventReviewCompleted publish) → add `return rev`
+
+- [ ] **Step 2: Update callers of runReview**
+
+Find all callers:
+- `a.runReview(ghPR, aiCfg)` in `ProcessPR` (around line 1554) → change to `_ = a.runReview(ghPR, aiCfg)`
+- `a.runReview(ghPR, aiCfg)` in `HandleChange` (around line 1849) → change to `_ = a.runReview(ghPR, aiCfg)`
+
+Also update the `tier2Adapter` struct field:
+- `runReview func(pr *gh.PullRequest, aiCfg config.RepoAI)` → `runReview func(pr *gh.PullRequest, aiCfg config.RepoAI) *store.Review`
+
+- [ ] **Step 3: Create publishPub and publishHandler**
+
+After the `reviewWorker` startup block (around line 543), add:
+
+```go
+	// ── NATS PR publish worker ──────────────────────────────────────────
+	publishPub := bus.NewPRPublishPublisher(js)
+
+	publishHandler := func(ctx context.Context, msg bus.PRPublishMsg) error {
+		rev, err := s.GetReview(msg.ReviewID)
+		if err != nil {
+			slog.Warn("publish-worker: review not found, skipping",
+				"review_id", msg.ReviewID, "err", err)
+			return nil // permanent — ack
+		}
+		if rev.GitHubReviewID != 0 {
+			slog.Info("publish-worker: already published, skipping",
+				"review_id", msg.ReviewID, "github_review_id", rev.GitHubReviewID)
+			return nil // idempotent — ack
+		}
+
+		pr, err := s.GetPR(rev.PRID)
+		if err != nil {
+			slog.Warn("publish-worker: PR not found, marking orphaned",
+				"review_id", msg.ReviewID, "pr_id", rev.PRID, "err", err)
+			_ = s.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
+			return nil // permanent — ack
+		}
+		if pr.Repo == "" {
+			slog.Info("publish-worker: PR has no repo, marking orphaned",
+				"review_id", msg.ReviewID)
+			_ = s.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
+			return nil // permanent — ack
+		}
+
+		// Rebuild ReviewResult from stored JSON
+		var issues []executor.Issue
+		json.Unmarshal([]byte(rev.Issues), &issues)
+		result := &executor.ReviewResult{
+			Summary:  rev.Summary,
+			Issues:   issues,
+			Severity: rev.Severity,
+		}
+
+		ghID, ghState, err := p.SubmitReviewToGitHub(
+			pr.Repo, pr.Number,
+			pipeline.BuildGitHubBody(result),
+			pipeline.SeverityToEvent(rev.Severity, len(issues)),
+		)
+		if err != nil {
+			// Transient — nak for NATS retry
+			return fmt.Errorf("submit review to GitHub: %w", err)
+		}
+
+		publishedAt := time.Now().UTC()
+		if err := s.MarkReviewPublished(rev.ID, ghID, ghState, publishedAt); err != nil {
+			slog.Warn("publish-worker: failed to mark published",
+				"review_id", rev.ID, "err", err)
+		}
+		slog.Info("publish-worker: review published",
+			"review_id", rev.ID, "github_review_id", ghID,
+			"github_review_state", ghState)
+		return nil // success — ack
+	}
+
+	publishWorker := worker.NewPublishWorker(js, publishHandler)
+	publishWorkerCtx, publishWorkerCancel := context.WithCancel(context.Background())
+	defer publishWorkerCancel()
+	go func() {
+		if err := publishWorker.Start(publishWorkerCtx); err != nil {
+			slog.Error("publish worker stopped", "err", err)
+		}
+	}()
+```
+
+**IMPORTANT:** The handler uses `p.SubmitReviewToGitHub()` — but this is actually `ghClient.SubmitReview()` since `p` is `*pipeline.Pipeline`. Check if `SubmitReview` is accessible. Actually, looking at the existing `PublishPending()`, it uses `p.gh.SubmitReview()` where `p.gh` is the GitHub client interface. Since we're in main.go, use `ghClient.SubmitReview()` directly.
+
+Also, `buildGitHubBody` and `severityToEvent` are unexported in the pipeline package. We need to either:
+a) Export them (`BuildGitHubBody`, `SeverityToEvent`)
+b) Duplicate the logic in main.go
+c) Add a method on pipeline.Pipeline that wraps the publish logic
+
+Option (a) is cleanest — export the two helpers. They're pure functions with no dependencies.
+
+- [ ] **Step 4: Export buildGitHubBody and severityToEvent**
+
+In `daemon/internal/pipeline/pipeline.go`, rename:
+- `buildGitHubBody` → `BuildGitHubBody`
+- `severityToEvent` → `SeverityToEvent`
+
+Update all internal callers in the same file. Search for `buildGitHubBody(` and `severityToEvent(` — they appear in `Run()` (around line 400-401) and `PublishPending()` (around lines 472-476).
+
+- [ ] **Step 5: Modify reviewHandler to publish PRPublishMsg**
+
+In the `reviewHandler` closure (around line 502), change the `runReview` call and add PRPublishMsg publish:
+
+```go
+		rev := runReview(pr, aiCfg)
+
+		// If review succeeded but wasn't published to GitHub yet,
+		// enqueue for the publish worker.
+		if rev != nil && rev.GitHubReviewID == 0 {
+			if err := publishPub.PublishPRPublish(ctx, rev.ID); err != nil {
+				slog.Warn("review-worker: failed to enqueue publish",
+					"review_id", rev.ID, "err", err)
+			}
+		}
+
+		// Maintain Tier 3 watching ...
+```
+
+- [ ] **Step 6: Simplify PublishPending in tier2Adapter**
+
+The `PublishPending()` method on `tier2Adapter` (around line 1508) currently calls `a.pipeline.PublishPending()`. Replace with a version that enqueues via NATS:
+
+First, add `publishPub *bus.PRPublishPublisher` to the `tier2Adapter` struct and wire it in the `adapter := &tier2Adapter{...}` constructor.
+
+Then change `PublishPending()`:
+
+```go
+func (a *tier2Adapter) PublishPending() {
+	reviews, err := a.store.ListUnpublishedReviews()
+	if err != nil || len(reviews) == 0 {
+		return
+	}
+	for _, rev := range reviews {
+		if err := a.publishPub.PublishPRPublish(context.Background(), rev.ID); err != nil {
+			slog.Warn("publish-pending: enqueue failed", "review_id", rev.ID, "err", err)
+		}
+	}
+}
+```
+
+- [ ] **Step 7: Verify build**
+
+```bash
+cd daemon
+go build ./cmd/heimdallm/
+```
+
+- [ ] **Step 8: Run full test suite**
+
+```bash
+cd daemon
+go test ./... -count=1
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cmd/heimdallm/main.go internal/pipeline/pipeline.go
+git commit -m "feat: wire PR publish worker into daemon (#305)"
+```
+
+---
+
+### Task 5: Final validation
+
+- [ ] **Step 1: Run affected packages with race detector**
+
+```bash
+cd daemon
+go test ./internal/worker/ ./internal/bus/ ./internal/store/ ./cmd/heimdallm/ -race -count=1
+```
+
+- [ ] **Step 2: Build binary**
+
+```bash
+cd daemon
+go build -o bin/heimdallm ./cmd/heimdallm/
+```
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+cd daemon
+HEIMDALLM_DATA_DIR=$(mktemp -d) HEIMDALLM_AI_PRIMARY=claude-code timeout 8 ./bin/heimdallm 2>&1 | head -20
+```
+
+Expected: Daemon starts. If a PR review completes, the publish worker should pick up any unpublished reviews.
+
+- [ ] **Step 4: Commit if adjustments needed**
+
+Skip if no changes.

--- a/docs/superpowers/specs/2026-04-23-pr-publish-worker-design.md
+++ b/docs/superpowers/specs/2026-04-23-pr-publish-worker-design.md
@@ -1,0 +1,132 @@
+# PR Publish Worker (NATS Consumer) Design
+
+**Issue:** #298 (epic), #305 (Task 6)  
+**Date:** 2026-04-23  
+**Scope:** NATS consumer for publishing stored reviews to GitHub, replacing PublishPending() retry loop  
+
+## Overview
+
+The publish worker consumes `PRPublishMsg{ReviewID}` from `heimdallm.pr.publish` and submits the stored review to GitHub. Two sources publish to this subject: (1) the review worker after a successful review (happy path), and (2) a simplified publish-pending scanner that catches up on reviews that failed initial publication. NATS retry semantics (`NakWithDelay`) replace the manual retry loop in `PublishPending()`.
+
+## Architecture
+
+```
+Review Worker → PRPublishMsg → NATS (pr.publish) → PublishWorker → GitHub SubmitReview
+                                      ↑
+PublishPending scanner (periodic) ─────┘  (catch-up for failed publishes)
+```
+
+## Changes
+
+### 1. PublishWorker (worker/publish.go)
+
+Same pattern as ReviewWorker:
+
+```go
+type PublishWorker struct {
+    js      jetstream.JetStream
+    handler func(ctx context.Context, msg bus.PRPublishMsg) error
+}
+```
+
+Key difference from ReviewWorker: the handler **returns an error**. This controls ack/nak behavior:
+- `nil` → `msg.Ack()` (success or permanent failure)
+- Non-nil error → `msg.NakWithDelay(30s)` (transient failure, retry via NATS)
+
+`MaxDeliver=5` on the `publish-worker` consumer means 5 attempts before the message is dropped.
+
+### 2. Handler closure (main.go)
+
+```go
+publishHandler := func(ctx context.Context, msg bus.PRPublishMsg) error {
+    rev, err := s.GetReview(msg.ReviewID)
+    // not found → return nil (ack, permanent)
+    // already published (GitHubReviewID != 0) → return nil (ack, idempotent)
+
+    pr, err := s.GetPR(rev.PRID)
+    // not found or empty repo → mark orphaned, return nil
+
+    // Rebuild ReviewResult from stored JSON
+    // SubmitReview to GitHub
+    // If 5xx/rate-limit → return error (nak, transient)
+    // If success → MarkReviewPublished, return nil
+}
+```
+
+### 3. PRPublishPublisher (bus/publisher.go)
+
+```go
+type PRPublishPublisher struct { js jetstream.JetStream }
+
+func (p *PRPublishPublisher) PublishPRPublish(ctx context.Context, reviewID int64) error
+```
+
+Publishes to `SubjPRPublish` with `Nats-Msg-Id = fmt.Sprintf("rev:%d", reviewID)` for dedup. The 2-minute dedup window prevents the scanner and review worker from double-publishing the same review.
+
+### 4. Review worker publishes PRPublishMsg
+
+In the review handler in main.go, after `runReview` succeeds:
+
+```go
+if rev != nil && rev.GitHubReviewID == 0 {
+    publishPub.PublishPRPublish(ctx, rev.ID)
+}
+```
+
+`rev` is returned by `p.Run()` — it has `rev.ID` set (from `InsertReview`) and `GitHubReviewID == 0` when the initial GitHub submit failed.
+
+Note: if `GitHubReviewID != 0`, the review was already published to GitHub during `p.Run()` and doesn't need the publish worker.
+
+### 5. PublishPending scanner simplified
+
+The existing `PublishPending()` in `pipeline.go` is simplified to just enqueue:
+
+```go
+func (p *Pipeline) PublishPending() {
+    reviews, _ := p.store.ListUnpublishedReviews()
+    for _, rev := range reviews {
+        p.publishPub.PublishPRPublish(ctx, rev.ID)
+    }
+}
+```
+
+This still runs at the end of each Tier 2 `processTick`. Dedup by review_id means overlap with the review worker is harmless.
+
+### 6. Store: GetReview method
+
+Need to verify if `store.GetReview(id)` exists. If not, add it — it's a simple `SELECT ... WHERE id = ?`.
+
+### 7. Error handling
+
+| Error | Action | Reason |
+|-------|--------|--------|
+| Review not found | Ack | Permanent — review was deleted |
+| Already published (GitHubReviewID != 0) | Ack | Idempotent — already done |
+| PR not found / empty repo | Ack + mark orphaned | Permanent — PR record lost |
+| GitHub 5xx / rate limit | NakWithDelay(30s) | Transient — retry |
+| GitHub 404 (PR deleted) | Ack | Permanent — PR no longer exists |
+| Other GitHub error | NakWithDelay(30s) | Assume transient |
+
+## Files Changed
+
+| Action | File | What |
+|--------|------|------|
+| Create | `daemon/internal/worker/publish.go` | PublishWorker consumer with ack/nak logic |
+| Create | `daemon/internal/worker/publish_test.go` | Tests with mock handler |
+| Modify | `daemon/internal/bus/publisher.go` | Add PRPublishPublisher |
+| Modify | `daemon/internal/bus/publisher_test.go` | Test for PRPublishPublisher |
+| Modify | `daemon/internal/pipeline/pipeline.go` | Simplify PublishPending to enqueue via NATS |
+| Modify | `daemon/cmd/heimdallm/main.go` | publishHandler + PublishWorker startup + review handler publishes PRPublishMsg |
+| Possibly | `daemon/internal/store/reviews.go` | Add GetReview(id) if not exists |
+
+## Testing
+
+1. **PublishWorker test** — mock handler, verify ack on nil return, verify nak on error return
+2. **PRPublishPublisher test** — publish + consume roundtrip with dedup
+3. **Smoke test** — review completes → publish message → publish worker logs activity
+
+## Out of Scope
+
+- Removing `PublishPending()` entirely (it stays as catch-up scanner)
+- NATS events (Task 10)
+- Metrics/alerting on publish failures


### PR DESCRIPTION
## Summary

- Create `PublishWorker` NATS consumer with ack/nak error handling:
  - `nil` return → Ack (success or permanent failure)
  - Non-nil error → NakWithDelay(30s) for NATS retry on transient GitHub errors
  - Panic recovery via safeHandle (panic → nak, not crash)
- Add `PRPublishPublisher` with dedup by review ID
- Review worker now publishes `PRPublishMsg` after successful review (happy path)
- Simplified `PublishPending()` to enqueue via NATS instead of direct GitHub submit (catch-up scanner)
- Export `BuildGitHubBody` and `SeverityToEvent` from pipeline package
- Change `runReview` to return `*store.Review` for publish message creation
- Add `store.GetReview(id)` method

**Part of:** #298 (epic: embed NATS in backend)  
**Closes:** #305

## Test plan

- [ ] `go test ./internal/worker/ -v` — 6 tests pass (3 review + 3 publish: ack/nak/panic)
- [ ] `go test ./internal/bus/ -run TestPRPublishPublisher -v` — publish + dedup tests pass
- [ ] `go test ./... -count=1` — full suite passes, no regressions
- [ ] Smoke test: review completes → publish worker enqueues → GitHub submit via NATS

🤖 Generated with [Claude Code](https://claude.com/claude-code)