### PR TITLE
feat(nats): issue implement worker (#307)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -716,6 +716,84 @@ func main() {
 		}
 	}()
 
+	// ── NATS issue implement worker ─────────────────────────────────────
+	// Consumes implement requests published by the Fetcher when it classifies
+	// an issue as develop. Same config resolution as triage, different mode.
+	implementHandler := func(ctx context.Context, msg bus.IssueMsg) {
+		ghIssue, err := ghClient.GetIssue(msg.Repo, msg.Number)
+		if err != nil {
+			slog.Error("implement-worker: fetch issue from GitHub",
+				"repo", msg.Repo, "number", msg.Number, "err", err)
+			return
+		}
+		ghIssue.Mode = config.IssueModeDevelop
+
+		cfgMu.Lock()
+		c := *cfg
+		aiCfg := c.AIForRepo(msg.Repo)
+		if aiCfg.Primary == "" {
+			aiCfg.Primary = c.AI.Primary
+		}
+		agentCfg := c.AgentConfigFor(aiCfg.Primary)
+		localDirBase := c.GitHub.LocalDirBase
+		globalTimeout := c.AI.ExecutionTimeout
+		cfgMu.Unlock()
+		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, msg.Repo, localDirBase)
+
+		extraFlags := agentCfg.ExtraFlags
+		if extraFlags != "" {
+			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+				slog.Warn("implement-worker: extra_flags rejected", "err", err)
+				extraFlags = ""
+			}
+		}
+
+		issuePrompt, issueInstructions := resolveIssuePrompt(s, aiCfg.IssuePrompt, agentCfg.PromptID)
+		implPrompt, implInstructions := resolveImplementPrompt(s, aiCfg.ImplementPrompt, agentCfg.PromptID)
+
+		opts := issuepipeline.RunOptions{
+			GitHubToken: token,
+			Primary:     aiCfg.Primary,
+			Fallback:    aiCfg.Fallback,
+			ExecOpts: executor.ExecOptions{
+				Model:                agentCfg.Model,
+				MaxTurns:             agentCfg.MaxTurns,
+				ApprovalMode:         agentCfg.ApprovalMode,
+				ExtraFlags:           extraFlags,
+				WorkDir:              aiCfg.LocalDir,
+				Effort:               agentCfg.Effort,
+				PermissionMode:       agentCfg.PermissionMode,
+				Bare:                 agentCfg.Bare,
+				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
+				NoSessionPersistence: agentCfg.NoSessionPersistence,
+				Timeout:              resolveExecutionTimeout(globalTimeout, agentCfg.ExecutionTimeout),
+			},
+			IssuePromptOverride:     issuePrompt,
+			IssueInstructions:       issueInstructions,
+			ImplementPromptOverride: implPrompt,
+			ImplementInstructions:   implInstructions,
+			PRReviewers:             aiCfg.PRReviewers,
+			PRAssignee:              aiCfg.PRAssignee,
+			PRLabels:                aiCfg.PRLabels,
+			PRDraft:                 aiCfg.PRDraft != nil && *aiCfg.PRDraft,
+			GeneratePRDescription:   aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+		}
+
+		if _, err := issuePipe.Run(ctx, ghIssue, opts); err != nil {
+			slog.Error("implement-worker: pipeline run failed",
+				"repo", msg.Repo, "number", msg.Number, "err", err)
+		}
+	}
+
+	implementW := worker.NewImplementWorker(js, implementHandler)
+	implementWCtx, implementWCancel := context.WithCancel(context.Background())
+	defer implementWCancel()
+	go func() {
+		if err := implementW.Start(implementWCtx); err != nil {
+			slog.Error("implement worker stopped", "err", err)
+		}
+	}()
+
 	// Use a closure so the defer reads the current pipe variable at shutdown
 	// time, not the initial pointer captured at defer-statement time. After a
 	// reload, pipe points to a new pipeline — the bare defer would stop the

--- a/daemon/internal/worker/implement.go
+++ b/daemon/internal/worker/implement.go
@@ -1,0 +1,79 @@
+// daemon/internal/worker/implement.go
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// ImplementWorker consumes issue implement requests from NATS and delegates
+// to a handler that runs the issue pipeline in Develop mode.
+type ImplementWorker struct {
+	js      jetstream.JetStream
+	handler func(ctx context.Context, msg bus.IssueMsg)
+}
+
+// NewImplementWorker creates a worker that consumes from the implement-worker
+// durable consumer.
+func NewImplementWorker(js jetstream.JetStream, handler func(context.Context, bus.IssueMsg)) *ImplementWorker {
+	return &ImplementWorker{js: js, handler: handler}
+}
+
+// Start begins consuming. Blocks until ctx is cancelled.
+// Always acks messages — errors are logged inside the handler.
+func (w *ImplementWorker) Start(ctx context.Context) error {
+	cons, err := w.js.Consumer(ctx, bus.StreamWork, bus.ConsumerImplement)
+	if err != nil {
+		return err
+	}
+
+	iter, err := cons.Messages(jetstream.PullMaxMessages(1))
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		<-ctx.Done()
+		iter.Stop()
+	}()
+
+	for {
+		msg, err := iter.Next()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, jetstream.ErrMsgIteratorClosed) {
+				return nil
+			}
+			return fmt.Errorf("implement-worker: iter.Next: %w", err)
+		}
+
+		var issueMsg bus.IssueMsg
+		if err := bus.Decode(msg.Data(), &issueMsg); err != nil {
+			slog.Error("implement-worker: decode message", "err", err)
+			msg.Ack()
+			continue
+		}
+
+		slog.Info("implement-worker: processing",
+			"repo", issueMsg.Repo, "number", issueMsg.Number, "github_id", issueMsg.GithubID)
+
+		w.safeHandle(ctx, issueMsg)
+		msg.Ack()
+	}
+}
+
+func (w *ImplementWorker) safeHandle(ctx context.Context, msg bus.IssueMsg) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("implement-worker: handler panic",
+				"repo", msg.Repo, "number", msg.Number, "panic", r,
+				"stack", string(debug.Stack()))
+		}
+	}()
+	w.handler(ctx, msg)
+}

--- a/daemon/internal/worker/implement_test.go
+++ b/daemon/internal/worker/implement_test.go
@@ -1,0 +1,50 @@
+// daemon/internal/worker/implement_test.go
+package worker_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/heimdallm/daemon/internal/worker"
+)
+
+func TestImplementWorker_ConsumesAndCallsHandler(t *testing.T) {
+	b := newTestBus(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var (
+		mu       sync.Mutex
+		received []bus.IssueMsg
+	)
+	handler := func(_ context.Context, msg bus.IssueMsg) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, msg)
+	}
+
+	w := worker.NewImplementWorker(b.JetStream(), handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+
+	pub := bus.NewIssuePublisher(b.JetStream())
+	if err := pub.PublishIssueImplement(ctx, "org/repo", 77, 99999); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("expected 1, got %d", len(received))
+	}
+	msg := received[0]
+	if msg.Repo != "org/repo" || msg.Number != 77 || msg.GithubID != 99999 {
+		t.Errorf("unexpected: %+v", msg)
+	}
+}

--- a/docs/superpowers/specs/2026-04-24-issue-implement-worker-design.md
+++ b/docs/superpowers/specs/2026-04-24-issue-implement-worker-design.md
@@ -1,0 +1,40 @@
+# Issue Implement Worker (NATS Consumer) Design
+
+**Issue:** #298 (epic), #307 (Task 8)  
+**Date:** 2026-04-24  
+**Scope:** NATS consumer for heimdallm.issue.implement — runs issue pipeline in Develop mode  
+
+## Overview
+
+Mirror of the TriageWorker (Task 7) but for `develop` issues. Consumes from `implement-worker` durable consumer on `HEIMDALLM_WORK`. The Fetcher already publishes to `heimdallm.issue.implement` for issues classified as `develop` (added in Task 7). This task adds the consumer side.
+
+## Changes
+
+### 1. ImplementWorker (worker/implement.go)
+
+Same pattern as TriageWorker:
+
+```go
+type ImplementWorker struct {
+    js      jetstream.JetStream
+    handler func(ctx context.Context, msg bus.IssueMsg)
+}
+```
+
+Consumes from `implement-worker` consumer. Always acks. Panic recovery via safeHandle.
+
+### 2. Handler closure (main.go)
+
+Same as triageHandler but with `Mode = config.IssueModeDevelop`. The `RunOptions` are identical — the mode determines the pipeline behavior (triage posts a comment, implement creates a branch + PR).
+
+## Files Changed
+
+| Action | File | What |
+|--------|------|------|
+| Create | `daemon/internal/worker/implement.go` | ImplementWorker consumer |
+| Create | `daemon/internal/worker/implement_test.go` | Test |
+| Modify | `daemon/cmd/heimdallm/main.go` | implementHandler + ImplementWorker startup |
+
+## Out of Scope
+
+- NATS events for issue completion (Task 10)


### PR DESCRIPTION
## Summary

- Create `ImplementWorker` NATS consumer for `heimdallm.issue.implement`
- Handler fetches issue from GitHub, sets Mode=Develop, resolves per-repo config, runs `issuePipe.Run`
- Same pattern as TriageWorker (Task 7) — panic recovery, always-ack, cancellable context
- Wire implementHandler + ImplementWorker startup in main.go

**Part of:** #298 (epic: embed NATS in backend)  
**Closes:** #307

**Stacks on:** #319 (issue triage worker)

## Test plan

- [ ] `go test ./internal/worker/ -run TestImplementWorker -v` — consumer test passes
- [ ] `go test ./... -count=1` — full suite passes
- [ ] Smoke test: develop-labeled issues trigger `implement-worker: processing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)