### PR TITLE
fix(daemon): silence PR SHA-skip side effects + respect re-request review (closes #322 bugs 3-5)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -191,6 +191,13 @@ func main() {
 	}
 	p.SetCircuitBreakerLimits(&cbLimits)
 
+	// Wire the GitHub client as the timeline fetcher so the SHA-skip
+	// path can detect explicit re-request review actions and bypass the
+	// dedup. See theburrowhub/heimdallm#322 Bug 5. Requires the bot
+	// login resolved below; the pipeline no-ops the bypass if either
+	// p.timeline or p.botLogin is unset.
+	p.SetTimelineFetcher(ghClient)
+
 	// Issue-side circuit-breaker caps (theburrowhub/heimdallm#292) — mirrors
 	// the PR-side defenses against runaway triage loops.
 	issueCBLimits := store.IssueCircuitBreakerLimits{

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -198,6 +198,14 @@ func main() {
 	// p.timeline or p.botLogin is unset.
 	p.SetTimelineFetcher(ghClient)
 
+	// Wire the SSE broker as the lifecycle publisher so Run emits
+	// pr_detected / review_started / review_completed / review_skipped
+	// at the correct semantic point (after the SHA-skip + gate
+	// decisions). The caller used to publish these blindly at function
+	// entry, leaving Flutter spinners colgados on every SHA-skip and
+	// firing phantom desktop notifications. See #322 Bugs 3+4.
+	p.SetPublisher(broker)
+
 	// Issue-side circuit-breaker caps (theburrowhub/heimdallm#292) — mirrors
 	// the PR-side defenses against runaway triage loops.
 	issueCBLimits := store.IssueCircuitBreakerLimits{
@@ -401,8 +409,13 @@ func main() {
 		slog.Info("pipeline: reviewing PR",
 			"repo", pr.Repo, "number", pr.Number, "github_id", pr.ID, "title", pr.Title)
 
-		broker.Publish(sse.Event{Type: sse.EventPRDetected, Data: sseData(map[string]any{"pr_number": pr.Number, "repo": pr.Repo})})
-		broker.Publish(sse.Event{Type: sse.EventReviewStarted, Data: sseData(map[string]any{"pr_number": pr.Number, "repo": pr.Repo})})
+		// Lifecycle SSEs (pr_detected, review_started, review_completed,
+		// review_skipped) are published from within p.Run via its
+		// Publisher dependency — this caller only handles the error
+		// paths because they need contextual error data the pipeline
+		// doesn't pre-shape (the err.Error() string and the
+		// CircuitBreakerError discriminant). See theburrowhub/heimdallm#322
+		// Bugs 3+4 for the regression that made emitting from here unsafe.
 		rev, err := p.Run(pr, buildRunOpts(pr, aiCfg))
 		if err != nil {
 			slog.Error("pipeline run failed", "repo", pr.Repo, "pr", pr.Number, "err", err)
@@ -422,20 +435,15 @@ func main() {
 			return
 		}
 		if rev == nil {
-			// Defense-in-depth gate in pipeline.Run rejected this PR. Callers are
-			// expected to filter upstream, so this is the safety net — exit quietly
-			// without emitting a completed/error event.
+			// Pipeline took a skip path and already emitted
+			// EventReviewSkipped with the correct reason
+			// (sha_unchanged / legacy_backfill / not_open / draft /
+			// self_authored). Nothing else to do.
 			return
 		}
 		slog.Info("pipeline: review done",
 			"repo", pr.Repo, "number", pr.Number, "severity", rev.Severity,
 			"github_review_id", rev.GitHubReviewID)
-		broker.Publish(sse.Event{Type: sse.EventReviewCompleted, Data: sseData(map[string]any{
-			"pr_number": pr.Number,
-			"repo":      pr.Repo,
-			"pr_id":     rev.PRID,
-			"severity":  rev.Severity,
-		})})
 	}
 
 	// ── Multi-tier Pipeline ──────────────────────────────────────────────
@@ -799,6 +807,13 @@ func main() {
 			}
 		}()
 
+		// Lifecycle SSEs (pr_detected, review_started, review_completed,
+		// review_skipped with the actual reason) are published by p.Run
+		// via its Publisher dependency. Trigger only owns error paths so
+		// it can attach the err.Error() string the caller surfaces.
+		// Pre-#322 the trigger fabricated review_skipped(not_open) on
+		// every nil return — that lied for SHA-skip / legacy-backfill
+		// paths added in #322 Bug 4.
 		rev, err := p.Run(ghPR, buildRunOpts(ghPR, aiCfg))
 		if err != nil {
 			var cbErr *pipeline.CircuitBreakerError
@@ -816,28 +831,10 @@ func main() {
 			broker.Publish(sse.Event{Type: sse.EventReviewError, Data: sseData(map[string]any{"pr_id": prID, "error": err.Error()})})
 			return err
 		}
-		if rev == nil {
-			// pipeline.Run's defense-in-depth gate rejected this PR (e.g. an
-			// operator triggered a re-review on a closed/merged PR). Emit a
-			// review_skipped event so the UI can surface the reason instead of
-			// leaving the request hanging silently.
-			broker.Publish(sse.Event{
-				Type: sse.EventReviewSkipped,
-				Data: sseData(map[string]any{
-					"repo":      pr.Repo,
-					"pr_number": pr.Number,
-					"pr_title":  pr.Title,
-					"reason":    string(pipeline.SkipReasonNotOpen),
-				}),
-			})
-			return nil
-		}
-		broker.Publish(sse.Event{Type: sse.EventReviewCompleted, Data: sseData(map[string]any{
-			"pr_number": pr.Number,
-			"repo":      pr.Repo,
-			"pr_id":     prID,
-			"severity":  rev.Severity,
-		})})
+		// rev == nil → pipeline already emitted EventReviewSkipped with
+		// the actual reason. rev != nil → pipeline already emitted
+		// EventReviewCompleted. Either way, nothing else to do here.
+		_ = rev
 		return nil
 	})
 

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -833,7 +833,10 @@ func main() {
 		}
 		// rev == nil → pipeline already emitted EventReviewSkipped with
 		// the actual reason. rev != nil → pipeline already emitted
-		// EventReviewCompleted. Either way, nothing else to do here.
+		// EventReviewCompleted. Either way the trigger callback only
+		// has to report success/failure (its signature is
+		// `func(prID int64) error`, see SetTriggerReviewFn) so the
+		// review payload itself is not needed here.
 		_ = rev
 		return nil
 	})

--- a/daemon/internal/activity/recorder.go
+++ b/daemon/internal/activity/recorder.go
@@ -214,6 +214,20 @@ func (r *Recorder) recordIssueReviewError(ev sse.Event) error {
 	return err
 }
 
+// dedupSkipReasons are review_skipped reasons that fire on routine
+// poll cycles rather than user-visible policy decisions, and therefore
+// should NOT produce activity_log rows. Recording them would spam the
+// activity feed with one row per poll for every stable PR — exactly the
+// regression theburrowhub/heimdallm#322 Bug 4 was meant to close (the
+// pre-fix path emitted EventReviewCompleted on those skips, which was
+// then routed here). Keep policy skips (not_open / draft /
+// self_authored) recorded — those reflect the bot deciding not to
+// review and are useful in the audit trail.
+var dedupSkipReasons = map[string]bool{
+	"sha_unchanged":   true,
+	"legacy_backfill": true,
+}
+
 func (r *Recorder) recordReviewSkipped(ev sse.Event) error {
 	var p struct {
 		Repo     string `json:"repo"`
@@ -223,6 +237,11 @@ func (r *Recorder) recordReviewSkipped(ev sse.Event) error {
 	}
 	if err := decode(ev.Data, &p); err != nil {
 		return err
+	}
+	if dedupSkipReasons[p.Reason] {
+		// Routine dedup skip — UI still gets the SSE so the spinner can
+		// clear, but the activity log stays free of poll-cycle noise.
+		return nil
 	}
 	_, err := r.store.InsertActivity(time.Now(), orgOf(p.Repo), p.Repo, "pr",
 		p.PRNumber, p.PRTitle, "review_skipped", p.Reason, map[string]any{

--- a/daemon/internal/activity/recorder_test.go
+++ b/daemon/internal/activity/recorder_test.go
@@ -304,6 +304,29 @@ func TestRecorder_ReviewSkipped(t *testing.T) {
 	}
 }
 
+// TestRecorder_ReviewSkippedDedupReasonsAreNotRecorded locks in the
+// fix from theburrowhub/heimdallm#322 review feedback: dedup-flavoured
+// skips (sha_unchanged, legacy_backfill) MUST NOT generate activity_log
+// rows even though they fire as review_skipped SSE events. They run on
+// every poll cycle on stable PRs — recording them would produce one
+// spam row per minute per stable PR, which is the activity-log spam
+// regression Bug 4 was supposed to close.
+func TestRecorder_ReviewSkippedDedupReasonsAreNotRecorded(t *testing.T) {
+	_, fs, events := newTestRecorder(t)
+
+	for _, reason := range []string{"sha_unchanged", "legacy_backfill"} {
+		events <- sse.Event{
+			Type: sse.EventReviewSkipped,
+			Data: `{"repo":"org/name","pr_number":42,"pr_title":"Fix X","reason":"` + reason + `"}`,
+		}
+	}
+	// Give the recorder a beat to drain any rows it might have inserted.
+	time.Sleep(50 * time.Millisecond)
+	if got := fs.count(); got != 0 {
+		t.Errorf("dedup skips should NOT produce activity_log rows; got %d rows", got)
+	}
+}
+
 func TestRecorder_StoreFailureIsLoggedAndDropped(t *testing.T) {
 	_, fs, events := newTestRecorder(t)
 	fs.setFailNext(true)

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -510,6 +510,103 @@ func (c *Client) FetchIssueCommentsOnly(repo string, number int) ([]Comment, err
 	return c.fetchIssueComments(repo, number)
 }
 
+// TimelineEvent is a slim view of a GitHub PR timeline entry. Only the
+// two events the pipeline needs are surfaced: review_requested (someone
+// asked the reviewer for a review) and review_dismissed (someone
+// dismissed the reviewer's prior review). Other event types in the
+// timeline (commits, labels, comments, assignments…) are filtered out
+// at fetch time so callers don't have to reason about them.
+type TimelineEvent struct {
+	Event     string    // "review_requested" or "review_dismissed"
+	Actor     string    // login of the user who triggered the event
+	CreatedAt time.Time
+}
+
+// GetPRTimelineEventsForReviewer returns the review_requested and
+// review_dismissed events on a PR that target the given reviewer login,
+// sorted ascending by created_at. Used by the pipeline to detect
+// explicit re-request review actions on PRs whose HEAD SHA hasn't
+// changed (theburrowhub/heimdallm#322 Bug 5): a re-request bumps
+// updated_at and re-adds the bot to requested_reviewers, but the SHA
+// fail-closed dedup (#245) would otherwise silently skip the review
+// regardless of the user's explicit intent.
+//
+// Returns an empty slice (not nil) when no relevant events exist —
+// callers can range over the result without a nil guard.
+func (c *Client) GetPRTimelineEventsForReviewer(repo string, number int, login string) ([]TimelineEvent, error) {
+	if login == "" {
+		return nil, fmt.Errorf("github: GetPRTimelineEventsForReviewer: empty login")
+	}
+	out := []TimelineEvent{}
+	page := 1
+	for {
+		path := fmt.Sprintf("/repos/%s/issues/%d/timeline?per_page=100&page=%d", repo, number, page)
+		resp, err := c.do("GET", path, "application/vnd.github+json")
+		if err != nil {
+			return nil, fmt.Errorf("github: fetch timeline: %w", err)
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			errBody := safeTruncate(string(body), maxErrBodyLen)
+			return nil, fmt.Errorf("github: fetch timeline: status %d: %s", resp.StatusCode, errBody)
+		}
+		var raw []struct {
+			Event     string    `json:"event"`
+			CreatedAt time.Time `json:"created_at"`
+			Actor     struct {
+				Login string `json:"login"`
+			} `json:"actor"`
+			RequestedReviewer *struct {
+				Login string `json:"login"`
+			} `json:"requested_reviewer,omitempty"`
+			DismissedReview *struct {
+				User struct {
+					Login string `json:"login"`
+				} `json:"user"`
+			} `json:"dismissed_review,omitempty"`
+		}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, fmt.Errorf("github: decode timeline: %w", err)
+		}
+		for _, ev := range raw {
+			switch ev.Event {
+			case "review_requested":
+				if ev.RequestedReviewer != nil && strings.EqualFold(ev.RequestedReviewer.Login, login) {
+					out = append(out, TimelineEvent{
+						Event:     ev.Event,
+						Actor:     ev.Actor.Login,
+						CreatedAt: ev.CreatedAt,
+					})
+				}
+			case "review_dismissed":
+				if ev.DismissedReview != nil && strings.EqualFold(ev.DismissedReview.User.Login, login) {
+					out = append(out, TimelineEvent{
+						Event:     ev.Event,
+						Actor:     ev.Actor.Login,
+						CreatedAt: ev.CreatedAt,
+					})
+				}
+			}
+		}
+		// Stop paging when we get a short page (under per_page=100).
+		if len(raw) < 100 {
+			break
+		}
+		page++
+		// Hard cap so a misbehaving server can't make us iterate forever.
+		if page > 50 {
+			slog.Warn("github: timeline pagination cap hit, returning partial results",
+				"repo", repo, "pr", number, "pages", page)
+			break
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+	return out, nil
+}
+
 func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error) {
 	path := fmt.Sprintf("/repos/%s/pulls/%d/comments", repo, number)
 	resp, err := c.do("GET", path, "application/vnd.github+json")

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -601,6 +601,13 @@ func (c *Client) GetPRTimelineEventsForReviewer(repo string, number int, login s
 			break
 		}
 	}
+	// Defensive re-sort: GitHub's timeline API documents ascending
+	// chronological order, but the contract is not load-bearing for us
+	// — pipeline.shouldBypassSHASkipForReReview relies on the slice
+	// being sorted to walk it backward in O(1) for the common case.
+	// A single sort here is cheap (events is filtered down to just
+	// review_requested / review_dismissed for one login) and immunises
+	// the caller against an undocumented re-ordering on GitHub's side.
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].CreatedAt.Before(out[j].CreatedAt)
 	})

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	gh "github.com/heimdallm/daemon/internal/github"
 )
@@ -199,4 +200,83 @@ func TestFetchIssueCommentsOnly_PropagatesRealErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 500 from issues endpoint, got nil")
 	}
+}
+
+// TestGetPRTimelineEventsForReviewer_FiltersByLogin locks in the
+// behaviour the SHA-skip bypass in #322 Bug 5 depends on: the method
+// must only return events that target the given reviewer login. Mixed
+// payload exercises (a) a review_requested for the bot, (b) a
+// review_requested for a different user (must be ignored), (c) a
+// review_dismissed for the bot, and (d) an unrelated event type
+// (commented).
+func TestGetPRTimelineEventsForReviewer_FiltersByLogin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/org/repo/issues/7/timeline" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"event":      "review_requested",
+				"created_at": "2026-04-24T07:00:00Z",
+				"actor":      map[string]string{"login": "alice"},
+				"requested_reviewer": map[string]string{"login": "heimdallm-bot"},
+			},
+			{
+				"event":      "review_requested",
+				"created_at": "2026-04-24T07:01:00Z",
+				"actor":      map[string]string{"login": "alice"},
+				"requested_reviewer": map[string]string{"login": "someone-else"},
+			},
+			{
+				"event":      "review_dismissed",
+				"created_at": "2026-04-24T07:02:00Z",
+				"actor":      map[string]string{"login": "alice"},
+				"dismissed_review": map[string]any{
+					"user": map[string]string{"login": "heimdallm-bot"},
+				},
+			},
+			{
+				"event":      "commented",
+				"created_at": "2026-04-24T07:03:00Z",
+				"actor":      map[string]string{"login": "alice"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	events, err := client.GetPRTimelineEventsForReviewer("org/repo", 7, "heimdallm-bot")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events for heimdallm-bot, got %d: %+v", len(events), events)
+	}
+	if events[0].Event != "review_requested" || !events[0].CreatedAt.Equal(mustTime("2026-04-24T07:00:00Z")) {
+		t.Errorf("event[0] mismatch: %+v", events[0])
+	}
+	if events[1].Event != "review_dismissed" || !events[1].CreatedAt.Equal(mustTime("2026-04-24T07:02:00Z")) {
+		t.Errorf("event[1] mismatch: %+v", events[1])
+	}
+}
+
+// TestGetPRTimelineEventsForReviewer_RejectsEmptyLogin guards against
+// callers that forget to set the bot login: without a target login the
+// filter would let through every review_requested / review_dismissed in
+// the timeline, defeating the point.
+func TestGetPRTimelineEventsForReviewer_RejectsEmptyLogin(t *testing.T) {
+	client := gh.NewClient("fake-token", gh.WithBaseURL("http://invalid"))
+	_, err := client.GetPRTimelineEventsForReviewer("org/repo", 7, "")
+	if err == nil {
+		t.Fatal("expected error on empty login, got nil")
+	}
+}
+
+func mustTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
 }

--- a/daemon/internal/pipeline/guards.go
+++ b/daemon/internal/pipeline/guards.go
@@ -9,6 +9,18 @@ const (
 	SkipReasonNotOpen      SkipReason = "not_open"
 	SkipReasonDraft        SkipReason = "draft"
 	SkipReasonSelfAuthored SkipReason = "self_authored"
+	// SkipReasonSHAUnchanged is emitted when pipeline.Run short-circuits
+	// because the previous review row already covers the current HEAD
+	// commit (the #245 fail-closed dedup) and no explicit re-request was
+	// detected (#322 Bug 5). Surfaced via EventReviewSkipped so the UI
+	// can stop the spinner and the activity log can record a real
+	// reason rather than fabricating "not_open".
+	SkipReasonSHAUnchanged SkipReason = "sha_unchanged"
+	// SkipReasonLegacyBackfill is emitted when pipeline.Run skips a
+	// review on a legacy row that had no head_sha column populated and
+	// is now backfilled from the current snapshot. The user must trigger
+	// a re-review manually to score that exact commit.
+	SkipReasonLegacyBackfill SkipReason = "legacy_backfill"
 )
 
 // PRGate is the minimal PR view the guard evaluator needs. Callers synthesize

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/heimdallm/daemon/internal/executor"
 	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
 )
 
@@ -80,6 +81,27 @@ type TimelineFetcher interface {
 	GetPRTimelineEventsForReviewer(repo string, number int, login string) ([]github.TimelineEvent, error)
 }
 
+// Publisher is the broker subset the pipeline uses to emit lifecycle
+// events. *sse.Broker satisfies it directly so main.go can wire the
+// production broker as the publisher with no adapter.
+//
+// Why the pipeline (not the caller) emits these events: the caller
+// cannot know which path Run will take (real review, SHA-skip,
+// legacy-backfill, gate-skip) until Run returns, but the UI/notify
+// stack consumes review_started the instant it lands. Emitting from
+// the caller before Run produced phantom "reviewing" spinners in
+// Flutter and a desktop notification per poll cycle on stable PRs —
+// exactly the regression Bug 3 was supposed to fix. Centralising the
+// emission inside Run keeps the lifecycle SSEs honest. See
+// theburrowhub/heimdallm#322 Bugs 3 and 4.
+//
+// Optional dependency: when not set (nil), the pipeline emits no
+// lifecycle events and the caller is responsible (legacy contract,
+// preserved so existing tests don't need a stub publisher each).
+type Publisher interface {
+	Publish(e sse.Event)
+}
+
 // Pipeline orchestrates the full PR review flow.
 type Pipeline struct {
 	store *store.Store
@@ -100,6 +122,10 @@ type Pipeline struct {
 	// SHA-skip path on explicit re-request review actions. Nil keeps the
 	// pre-#322 behaviour (skip on SHA match regardless of user intent).
 	timeline TimelineFetcher
+	// publisher emits lifecycle SSE events (pr_detected, review_started,
+	// review_completed, review_skipped) at the same semantic point Run
+	// makes the actual decision. Nil disables emission (legacy contract).
+	publisher Publisher
 }
 
 // New creates a new Pipeline with the provided dependencies.
@@ -130,6 +156,41 @@ func (p *Pipeline) SetCircuitBreakerLimits(limits *store.CircuitBreakerLimits) {
 // here at daemon startup.
 func (p *Pipeline) SetTimelineFetcher(t TimelineFetcher) {
 	p.timeline = t
+}
+
+// SetPublisher wires the SSE broker so Run can emit lifecycle events
+// at the correct semantic point (after the SHA-skip / gate decisions
+// rather than blindly at function entry). Nil disables emission and
+// callers must handle lifecycle themselves — legacy contract.
+func (p *Pipeline) SetPublisher(pub Publisher) {
+	p.publisher = pub
+}
+
+// publish emits an SSE lifecycle event with the given payload. No-op
+// when no publisher is wired or the payload fails to marshal — these
+// events are observability, not load-bearing for correctness.
+func (p *Pipeline) publish(eventType string, data map[string]any) {
+	if p.publisher == nil {
+		return
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+	p.publisher.Publish(sse.Event{Type: eventType, Data: string(b)})
+}
+
+// publishSkipped is a small helper for the four skip paths in Run that
+// need to emit EventReviewSkipped with the same shape: repo, pr_number,
+// pr_title, reason. Centralised so changes to the payload schema only
+// touch one site.
+func (p *Pipeline) publishSkipped(pr *github.PullRequest, reason SkipReason) {
+	p.publish(sse.EventReviewSkipped, map[string]any{
+		"repo":      pr.Repo,
+		"pr_number": pr.Number,
+		"pr_title":  pr.Title,
+		"reason":    string(reason),
+	})
 }
 
 // shouldBypassSHASkipForReReview returns true iff the operator
@@ -269,8 +330,10 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	}
 
 	// Defense-in-depth: refuse to run the CLI if the gate rejects this PR.
-	// Callers publish the skip event themselves — we only log here so a
-	// missed caller-side check is visible in daemon logs.
+	// Callers usually pre-filter with pipeline.Evaluate; the warn log on
+	// reaching this branch flags missed caller-side checks. Emit the skip
+	// SSE here too (with the actual reason, not a fabricated one) so the
+	// UI lifecycle stays honest if a caller forgets to publish its own.
 	if reason := Evaluate(PRGate{
 		State:  pr.State,
 		Draft:  pr.Draft,
@@ -278,6 +341,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	}, opts.Guards); reason != SkipReasonNone {
 		slog.Warn("pipeline: gate skip (caller did not filter)",
 			"repo", pr.Repo, "pr", pr.Number, "reason", string(reason))
+		p.publishSkipped(pr, reason)
 		return nil, nil
 	}
 
@@ -338,6 +402,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 			slog.Warn("pipeline: failed to backfill HeadSHA",
 				"review_id", prevReview.ID, "err", err)
 		}
+		p.publishSkipped(pr, SkipReasonLegacyBackfill)
 		return nil, nil
 	}
 	if prevReview != nil && pr.Head.SHA != "" && prevReview.HeadSHA == pr.Head.SHA {
@@ -362,17 +427,30 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		} else {
 			slog.Info("pipeline: skipping re-review, HEAD SHA unchanged",
 				"repo", pr.Repo, "pr", pr.Number, "head_sha", pr.Head.SHA)
+			p.publishSkipped(pr, SkipReasonSHAUnchanged)
 			return nil, nil
 		}
 	}
 
 	// All early-exit paths above are exhausted: from this point we are
-	// committed to running the CLI and posting a real review. Notify here
-	// (not at the top of Run) so the desktop notification only fires when a
-	// review is actually about to happen. Fixes #322 Bug 3 — a SHA-skip path
-	// would otherwise spam "PR Review Started" once per poll cycle on stable
-	// PRs whose updated_at keeps getting bumped by CI bots / cross-refs.
+	// committed to running the CLI and posting a real review. Both the
+	// desktop notification AND the lifecycle SSEs (pr_detected /
+	// review_started) fire here, NOT at the top of Run, because the UI
+	// stack consumes review_started the instant it lands — the Flutter
+	// dashboard marks the PR as "reviewing" and triggers a desktop
+	// notification of its own (see #322 Bug 3). Emitting at function
+	// entry on a SHA-skipped PR would leave a phantom spinner forever
+	// (no terminal event ever follows) and spam notifications once per
+	// poll cycle.
 	p.notify.Notify("PR Review Started", fmt.Sprintf("%s #%d", pr.Repo, pr.Number))
+	p.publish(sse.EventPRDetected, map[string]any{
+		"pr_number": pr.Number,
+		"repo":      pr.Repo,
+	})
+	p.publish(sse.EventReviewStarted, map[string]any{
+		"pr_number": pr.Number,
+		"repo":      pr.Repo,
+	})
 
 	// 2b. Fetch PR comments for context (non-fatal: proceed without if unavailable)
 	prComments, err := p.gh.FetchComments(pr.Repo, pr.Number)
@@ -532,6 +610,12 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		fmt.Sprintf("%s #%d — severity: %s", pr.Repo, pr.Number, result.Severity))
 
 	slog.Info("pipeline: review complete", "pr", pr.Number, "severity", result.Severity)
+	p.publish(sse.EventReviewCompleted, map[string]any{
+		"pr_number": pr.Number,
+		"repo":      pr.Repo,
+		"pr_id":     rev.PRID,
+		"severity":  rev.Severity,
+	})
 	return rev, nil
 }
 

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -167,14 +167,19 @@ func (p *Pipeline) SetPublisher(pub Publisher) {
 }
 
 // publish emits an SSE lifecycle event with the given payload. No-op
-// when no publisher is wired or the payload fails to marshal — these
-// events are observability, not load-bearing for correctness.
+// when no publisher is wired. A marshal failure on a map[string]any
+// of basic types should not happen in practice (every payload site
+// uses string / int / int64 / float64), but if it ever does we log
+// at Warn level rather than swallow silently — debugging a missing
+// SSE event without that breadcrumb is painful.
 func (p *Pipeline) publish(eventType string, data map[string]any) {
 	if p.publisher == nil {
 		return
 	}
 	b, err := json.Marshal(data)
 	if err != nil {
+		slog.Warn("pipeline: failed to marshal SSE payload, dropping event",
+			"event", eventType, "err", err)
 		return
 	}
 	p.publisher.Publish(sse.Event{Type: eventType, Data: string(b)})
@@ -211,24 +216,23 @@ func (p *Pipeline) shouldBypassSHASkipForReReview(pr *github.PullRequest, prevRe
 			"repo", pr.Repo, "pr", pr.Number, "err", err)
 		return false
 	}
-	// events is sorted ascending by CreatedAt. Walk it to find the most
-	// recent event whose timestamp is strictly newer than prevReview.CreatedAt.
-	// If that event is a review_requested → bypass; if it's a
-	// review_dismissed (or none qualify) → keep the skip. We only honour
-	// events that came AFTER the existing review because earlier
-	// requests are by definition already satisfied.
-	var latestRelevant *github.TimelineEvent
-	for i := range events {
+	// events is sorted ascending by CreatedAt. We need the LAST event
+	// whose timestamp is strictly newer than prevReview.CreatedAt — by
+	// definition the tail of the slice — so iterate backward and stop
+	// at the first qualifying entry. Marginally faster than a forward
+	// walk for active PRs (which is exactly when this runs hot) and
+	// reads more clearly: "is the most recent re-review-relevant event
+	// still a request?".
+	for i := len(events) - 1; i >= 0; i-- {
 		ev := &events[i]
 		if !ev.CreatedAt.After(prevReview.CreatedAt) {
-			continue
+			// Past the cutoff: everything earlier is already-satisfied
+			// (events are sorted ascending), so no need to continue.
+			return false
 		}
-		latestRelevant = ev
+		return ev.Event == "review_requested"
 	}
-	if latestRelevant == nil {
-		return false
-	}
-	return latestRelevant.Event == "review_requested"
+	return false
 }
 
 // applyPrompt resolves a prompt with priority: repoPromptID > agentPromptID > global default.
@@ -432,26 +436,6 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		}
 	}
 
-	// All early-exit paths above are exhausted: from this point we are
-	// committed to running the CLI and posting a real review. Both the
-	// desktop notification AND the lifecycle SSEs (pr_detected /
-	// review_started) fire here, NOT at the top of Run, because the UI
-	// stack consumes review_started the instant it lands — the Flutter
-	// dashboard marks the PR as "reviewing" and triggers a desktop
-	// notification of its own (see #322 Bug 3). Emitting at function
-	// entry on a SHA-skipped PR would leave a phantom spinner forever
-	// (no terminal event ever follows) and spam notifications once per
-	// poll cycle.
-	p.notify.Notify("PR Review Started", fmt.Sprintf("%s #%d", pr.Repo, pr.Number))
-	p.publish(sse.EventPRDetected, map[string]any{
-		"pr_number": pr.Number,
-		"repo":      pr.Repo,
-	})
-	p.publish(sse.EventReviewStarted, map[string]any{
-		"pr_number": pr.Number,
-		"repo":      pr.Repo,
-	})
-
 	// 2b. Fetch PR comments for context (non-fatal: proceed without if unavailable)
 	prComments, err := p.gh.FetchComments(pr.Repo, pr.Number)
 	if err != nil {
@@ -512,6 +496,29 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 			return nil, &CircuitBreakerError{Reason: reason}
 		}
 	}
+
+	// All early-exit paths above are exhausted (gate, SHA-skip,
+	// legacy-backfill, circuit breaker): from this point we are committed
+	// to running the CLI and posting a real review. Both the desktop
+	// notification AND the lifecycle SSEs (pr_detected / review_started)
+	// fire here, NOT at the top of Run and NOT before the breaker check,
+	// because the UI stack consumes review_started the instant it lands
+	// — the Flutter dashboard marks the PR as "reviewing" and triggers a
+	// desktop notification of its own (see #322 Bugs 3+4). Emitting on
+	// any path that does NOT proceed to Execute would leave a phantom
+	// spinner and a phantom desktop notification per poll cycle. Caller
+	// already wraps the CircuitBreakerError into its own SSE event, so
+	// the breaker-trip path remains observable without a bogus
+	// review_started preceding it.
+	p.notify.Notify("PR Review Started", fmt.Sprintf("%s #%d", pr.Repo, pr.Number))
+	p.publish(sse.EventPRDetected, map[string]any{
+		"pr_number": pr.Number,
+		"repo":      pr.Repo,
+	})
+	p.publish(sse.EventReviewStarted, map[string]any{
+		"pr_number": pr.Number,
+		"repo":      pr.Repo,
+	})
 
 	// 5. Execute review (merge cliFlags from prompt into ExecOptions.ExtraFlags)
 	// Validate cliFlags from the prompt profile against the same denylist as

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -68,6 +68,18 @@ type CommentFetcher interface {
 	FetchComments(repo string, number int) ([]github.Comment, error)
 }
 
+// TimelineFetcher returns the review_requested / review_dismissed events
+// targeting a specific reviewer login on a PR. Used by the SHA-skip
+// path to detect explicit re-request review actions that the user
+// performed via the GitHub UI even though the HEAD SHA is unchanged.
+// See theburrowhub/heimdallm#322 Bug 5.
+//
+// Optional dependency: when not set (nil), the pipeline falls back to
+// the previous behaviour (skip on SHA match regardless of timeline).
+type TimelineFetcher interface {
+	GetPRTimelineEventsForReviewer(repo string, number int, login string) ([]github.TimelineEvent, error)
+}
+
 // Pipeline orchestrates the full PR review flow.
 type Pipeline struct {
 	store *store.Store
@@ -84,6 +96,10 @@ type Pipeline struct {
 	// all caps (the pre-issue-243 behaviour). Populated at daemon startup via
 	// SetCircuitBreakerLimits.
 	breaker *store.CircuitBreakerLimits
+	// timeline is the optional event-history fetcher used to bypass the
+	// SHA-skip path on explicit re-request review actions. Nil keeps the
+	// pre-#322 behaviour (skip on SHA match regardless of user intent).
+	timeline TimelineFetcher
 }
 
 // New creates a new Pipeline with the provided dependencies.
@@ -106,6 +122,52 @@ func (p *Pipeline) SetBotLogin(login string) { p.botLogin = login }
 // and the follow-up ticket for re-plumbing via a getter.
 func (p *Pipeline) SetCircuitBreakerLimits(limits *store.CircuitBreakerLimits) {
 	p.breaker = limits
+}
+
+// SetTimelineFetcher enables the explicit-re-request-review bypass for
+// the SHA-skip path. Nil keeps the pre-#322 behaviour (skip on SHA
+// match regardless of user intent). Production wires the *github.Client
+// here at daemon startup.
+func (p *Pipeline) SetTimelineFetcher(t TimelineFetcher) {
+	p.timeline = t
+}
+
+// shouldBypassSHASkipForReReview returns true iff the operator
+// explicitly re-requested a review on this PR after the previous
+// review's CreatedAt and that re-request is still in effect (not
+// superseded by a later dismissal). All preconditions fail closed:
+// missing dependencies (nil timeline / empty bot login / nil
+// prevReview) or a timeline API error keep the SHA skip in place so a
+// transient outage cannot widen the cost surface. See
+// theburrowhub/heimdallm#322 Bug 5.
+func (p *Pipeline) shouldBypassSHASkipForReReview(pr *github.PullRequest, prevReview *store.Review) bool {
+	if p.timeline == nil || p.botLogin == "" || prevReview == nil {
+		return false
+	}
+	events, err := p.timeline.GetPRTimelineEventsForReviewer(pr.Repo, pr.Number, p.botLogin)
+	if err != nil {
+		slog.Warn("pipeline: re-request timeline lookup failed, keeping SHA skip (fail-closed)",
+			"repo", pr.Repo, "pr", pr.Number, "err", err)
+		return false
+	}
+	// events is sorted ascending by CreatedAt. Walk it to find the most
+	// recent event whose timestamp is strictly newer than prevReview.CreatedAt.
+	// If that event is a review_requested → bypass; if it's a
+	// review_dismissed (or none qualify) → keep the skip. We only honour
+	// events that came AFTER the existing review because earlier
+	// requests are by definition already satisfied.
+	var latestRelevant *github.TimelineEvent
+	for i := range events {
+		ev := &events[i]
+		if !ev.CreatedAt.After(prevReview.CreatedAt) {
+			continue
+		}
+		latestRelevant = ev
+	}
+	if latestRelevant == nil {
+		return false
+	}
+	return latestRelevant.Event == "review_requested"
 }
 
 // applyPrompt resolves a prompt with priority: repoPromptID > agentPromptID > global default.
@@ -279,9 +341,29 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		return nil, nil
 	}
 	if prevReview != nil && pr.Head.SHA != "" && prevReview.HeadSHA == pr.Head.SHA {
-		slog.Info("pipeline: skipping re-review, HEAD SHA unchanged",
-			"repo", pr.Repo, "pr", pr.Number, "head_sha", pr.Head.SHA)
-		return nil, nil
+		// Before honouring the SHA-skip, check whether the operator
+		// explicitly re-requested a review via the GitHub UI on this same
+		// commit. The fail-closed SHA dedup (#245) was designed to ignore
+		// updated_at bumps from CI bots and cross-references, but it
+		// should NOT swallow a deliberate human action. See
+		// theburrowhub/heimdallm#322 Bug 5.
+		//
+		// Decision rule: bypass the skip iff the most recent
+		// review_requested or review_dismissed event for the bot login is
+		// a review_requested newer than prevReview.CreatedAt. A later
+		// review_dismissed (or any other state) cancels the bypass —
+		// dismiss-then-no-new-request means the operator no longer wants
+		// our review. Same fail-closed posture as #245: a timeline API
+		// error keeps the original skip in place rather than widening
+		// the cost surface on a transient outage.
+		if p.shouldBypassSHASkipForReReview(pr, prevReview) {
+			slog.Info("pipeline: SHA unchanged but explicit re-request detected — proceeding with review",
+				"repo", pr.Repo, "pr", pr.Number, "head_sha", pr.Head.SHA)
+		} else {
+			slog.Info("pipeline: skipping re-review, HEAD SHA unchanged",
+				"repo", pr.Repo, "pr", pr.Number, "head_sha", pr.Head.SHA)
+			return nil, nil
+		}
 	}
 
 	// All early-exit paths above are exhausted: from this point we are

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -219,8 +219,6 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		return nil, nil
 	}
 
-	p.notify.Notify("PR Review Started", fmt.Sprintf("%s #%d", pr.Repo, pr.Number))
-
 	// 2. Fetch diff
 	diff, err := p.gh.FetchDiff(pr.Repo, pr.Number)
 	if err != nil {
@@ -262,22 +260,37 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	// current snapshot and skip. The user can trigger a re-review manually if
 	// they want one, but we never spend Claude credits on a legacy row whose
 	// dedup state is ambiguous.
+	// Both skip paths return (nil, nil) — the same contract the gate-skip
+	// branch above uses. Returning prevReview here was the source of the
+	// activity-log spam observed in #322 (Bug 4): the caller in
+	// cmd/heimdallm/main.go has a defensive `if rev == nil { return }` that
+	// suppresses the EventReviewCompleted SSE / "review done" log /
+	// activity_log row when Run does not produce a fresh review. Returning a
+	// non-nil prevReview bypassed that filter and made every poll cycle on a
+	// stable PR look like a brand-new review in every UI surface, even though
+	// no Claude credits were spent.
 	if prevReview != nil && prevReview.HeadSHA == "" && pr.Head.SHA != "" {
 		slog.Info("pipeline: backfilling empty HeadSHA on legacy review row, skipping re-review",
 			"repo", pr.Repo, "pr", pr.Number, "review_id", prevReview.ID, "head_sha", pr.Head.SHA)
 		if err := p.store.UpdateReviewHeadSHA(prevReview.ID, pr.Head.SHA); err != nil {
 			slog.Warn("pipeline: failed to backfill HeadSHA",
 				"review_id", prevReview.ID, "err", err)
-		} else {
-			prevReview.HeadSHA = pr.Head.SHA
 		}
-		return prevReview, nil
+		return nil, nil
 	}
 	if prevReview != nil && pr.Head.SHA != "" && prevReview.HeadSHA == pr.Head.SHA {
 		slog.Info("pipeline: skipping re-review, HEAD SHA unchanged",
 			"repo", pr.Repo, "pr", pr.Number, "head_sha", pr.Head.SHA)
-		return prevReview, nil
+		return nil, nil
 	}
+
+	// All early-exit paths above are exhausted: from this point we are
+	// committed to running the CLI and posting a real review. Notify here
+	// (not at the top of Run) so the desktop notification only fires when a
+	// review is actually about to happen. Fixes #322 Bug 3 — a SHA-skip path
+	// would otherwise spam "PR Review Started" once per poll cycle on stable
+	// PRs whose updated_at keeps getting bumped by CI bots / cross-refs.
+	p.notify.Notify("PR Review Started", fmt.Sprintf("%s #%d", pr.Repo, pr.Number))
 
 	// 2b. Fetch PR comments for context (non-fatal: proceed without if unavailable)
 	prComments, err := p.gh.FetchComments(pr.Repo, pr.Number)

--- a/daemon/internal/pipeline/pipeline_breaker_test.go
+++ b/daemon/internal/pipeline/pipeline_breaker_test.go
@@ -71,7 +71,10 @@ func TestRun_CircuitBreakerTripStopsExecute(t *testing.T) {
 
 	fgh := &fakeGHBreaker{}
 	fexec := &fakeExecBreaker{}
-	p := pipeline.New(s, fgh, fexec, &fakeNotify{})
+	notify := &fakeNotify{}
+	pub := &fakePublisher{}
+	p := pipeline.New(s, fgh, fexec, notify)
+	p.SetPublisher(pub)
 	// Cap at 3 per PR so the 4th review is the one that must trip.
 	p.SetCircuitBreakerLimits(&store.CircuitBreakerLimits{PerPR24h: 3, PerRepoHr: 999})
 
@@ -125,5 +128,24 @@ func TestRun_CircuitBreakerTripStopsExecute(t *testing.T) {
 	}
 	if fgh.submitted {
 		t.Errorf("SubmitReview must not be called when breaker trips")
+	}
+
+	// #322 review feedback: notify "PR Review Started" and the
+	// EventReviewStarted SSE must NOT fire on a breaker-trip path.
+	// Pre-fix, both lived above the breaker check, leaving Flutter with a
+	// phantom spinner and the operator with a phantom desktop notification
+	// every time the cap clamped down.
+	startedNotifies := countNotify(notify.events, "PR Review Started")
+	if startedNotifies != 3 {
+		t.Errorf("notify(\"PR Review Started\"): got %d, want 3 (one per real review, none on breaker trip)", startedNotifies)
+	}
+	startedSSEs := 0
+	for _, ev := range pub.types() {
+		if ev == "review_started" {
+			startedSSEs++
+		}
+	}
+	if startedSSEs != 3 {
+		t.Errorf("EventReviewStarted: got %d, want 3 (one per real review, none on breaker trip)", startedSSEs)
 	}
 }

--- a/daemon/internal/pipeline/pipeline_reloop_test.go
+++ b/daemon/internal/pipeline/pipeline_reloop_test.go
@@ -166,11 +166,13 @@ func TestRun_LegacyRowWithEmptyHeadSHAIsBackfilledAndSkipped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if rev == nil {
-		t.Fatalf("expected returned review, got nil")
-	}
-	if rev.HeadSHA != "abc123" {
-		t.Errorf("expected legacy row backfilled to abc123, got %q", rev.HeadSHA)
+	// Contract change for #322 Bug 4: legacy-backfill is now a silent skip
+	// (returns nil) — same shape as the gate-skip and SHA-skip paths — so
+	// the caller's defensive `if rev == nil { return }` filter suppresses
+	// the false EventReviewCompleted / activity_log row. The backfill side
+	// effect on issue_reviews still happens; assert it via the store below.
+	if rev != nil {
+		t.Errorf("expected nil review on legacy-backfill skip, got %+v", rev)
 	}
 	if fexec.calls != 0 {
 		t.Errorf("executor must not be called when backfilling legacy row (calls=%d)", fexec.calls)

--- a/daemon/internal/pipeline/pipeline_reloop_test.go
+++ b/daemon/internal/pipeline/pipeline_reloop_test.go
@@ -170,7 +170,7 @@ func TestRun_LegacyRowWithEmptyHeadSHAIsBackfilledAndSkipped(t *testing.T) {
 	// (returns nil) — same shape as the gate-skip and SHA-skip paths — so
 	// the caller's defensive `if rev == nil { return }` filter suppresses
 	// the false EventReviewCompleted / activity_log row. The backfill side
-	// effect on issue_reviews still happens; assert it via the store below.
+	// effect on the reviews table still happens; assert it via the store below.
 	if rev != nil {
 		t.Errorf("expected nil review on legacy-backfill skip, got %+v", rev)
 	}

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -562,9 +562,14 @@ func TestPipeline_Run_RespectsExplicitReReviewOnSameSHA(t *testing.T) {
 	}
 
 	// Operator hits "Re-request review" — timeline records a
-	// review_requested event newer than the existing review.
+	// review_requested event clearly after the existing review's
+	// CreatedAt. The +1 minute offset is deliberate: prevReview.CreatedAt
+	// was sealed during runFirstReview a few microseconds ago, and the
+	// bypass decision uses .After() (strict greater-than). A naked
+	// time.Now() here would race with that sealed timestamp on fast
+	// machines — pinning the offset keeps the test deterministic.
 	tl := &fakeTimeline{events: []github.TimelineEvent{
-		{Event: "review_requested", Actor: "alice", CreatedAt: time.Now()},
+		{Event: "review_requested", Actor: "alice", CreatedAt: time.Now().Add(1 * time.Minute)},
 	}}
 	p.SetTimelineFetcher(tl)
 

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/heimdallm/daemon/internal/executor"
 	"github.com/heimdallm/daemon/internal/github"
 	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
 )
 
@@ -99,6 +101,42 @@ func (f *fakeTimeline) GetPRTimelineEventsForReviewer(_ string, _ int, _ string)
 		return nil, f.err
 	}
 	return f.events, nil
+}
+
+// fakePublisher records every SSE event the pipeline emits so lifecycle
+// tests can assert the exact (event_type, payload) pairs that hit the
+// broker. Mirrors the *sse.Broker contract via duck-typing — no need to
+// stand up a real broker for assertions. See #322 Bugs 3+4.
+type fakePublisher struct {
+	mu     sync.Mutex
+	events []sse.Event
+}
+
+func (f *fakePublisher) Publish(e sse.Event) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, e)
+}
+
+func (f *fakePublisher) types() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.events))
+	for i, e := range f.events {
+		out[i] = e.Type
+	}
+	return out
+}
+
+func (f *fakePublisher) firstOf(eventType string) (sse.Event, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, e := range f.events {
+		if e.Type == eventType {
+			return e, true
+		}
+	}
+	return sse.Event{}, false
 }
 
 func TestPipeline_Run(t *testing.T) {
@@ -706,4 +744,186 @@ func TestPipeline_Run_TimelineErrorKeepsSkip(t *testing.T) {
 	if tl.calls == 0 {
 		t.Errorf("timeline was not consulted")
 	}
+}
+
+// ── #322 Bugs 3+4: pipeline-owned lifecycle SSEs ──────────────────────
+
+// TestPipeline_Run_SHASkipEmitsReviewSkipped is the regression guard
+// for the spinner-colgado UI bug from #322 Bug 3+4 review feedback:
+// when Run short-circuits on an unchanged HEAD SHA, the publisher
+// must receive a single review_skipped event (with reason
+// sha_unchanged) and NOTHING ELSE — no review_started, no
+// review_completed. The Flutter dashboard relies on review_skipped to
+// stop the spinner and remove the PR from reviewingPRsProvider.
+func TestPipeline_Run_SHASkipEmitsReviewSkipped(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	exec := &fakeExecCounter{}
+	gh := &fakeGHCounter{diff: "+line"}
+	pub := &fakePublisher{}
+	p := pipeline.New(s, gh, exec, &fakeNotify{})
+	p.SetPublisher(pub)
+
+	pr := &github.PullRequest{
+		ID: 42, Number: 42, Title: "t", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/42",
+		Head: github.Branch{SHA: "deadbeef"},
+	}
+	// First run: real review. Pipeline should emit pr_detected,
+	// review_started, review_completed (in that order).
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	wantFirst := []string{"pr_detected", "review_started", "review_completed"}
+	if got := pub.types(); !equalStringSlices(got, wantFirst) {
+		t.Fatalf("first run events: got %v, want %v", got, wantFirst)
+	}
+
+	// Second run: same SHA → skip path. Pipeline must emit ONE
+	// review_skipped event (with reason sha_unchanged) and nothing
+	// else. No review_started → no phantom Flutter spinner.
+	pub.events = nil
+	pr.UpdatedAt = time.Now().Add(5 * time.Minute)
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if got := pub.types(); !equalStringSlices(got, []string{"review_skipped"}) {
+		t.Fatalf("second-run events: got %v, want exactly [review_skipped]", got)
+	}
+	ev, _ := pub.firstOf("review_skipped")
+	wantReason := `"reason":"sha_unchanged"`
+	if !strings.Contains(ev.Data, wantReason) {
+		t.Errorf("review_skipped payload missing %s, got %q", wantReason, ev.Data)
+	}
+}
+
+// TestPipeline_Run_LegacyBackfillEmitsReviewSkipped covers the
+// legacy-row backfill branch: a previous review row with empty
+// HeadSHA is backfilled and the run skips. Must emit
+// review_skipped(legacy_backfill), nothing else.
+func TestPipeline_Run_LegacyBackfillEmitsReviewSkipped(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	prRow := &store.PR{
+		GithubID: 100, Repo: "org/repo", Number: 2, Title: "t",
+		Author: "alice", State: "open",
+		UpdatedAt: time.Now(), FetchedAt: time.Now(),
+	}
+	prID, _ := s.UpsertPR(prRow)
+	if _, err := s.InsertReview(&store.Review{
+		PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+		Severity: "low", CreatedAt: time.Now().Add(-1 * time.Hour),
+		HeadSHA: "", // legacy row
+	}); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+
+	pub := &fakePublisher{}
+	p := pipeline.New(s, &fakeGHCounter{diff: "+line"}, &fakeExecCounter{}, &fakeNotify{})
+	p.SetPublisher(pub)
+
+	pr := &github.PullRequest{
+		ID: 100, Number: 2, Title: "t", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/2",
+		Head: github.Branch{SHA: "abc123"},
+	}
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := pub.types(); !equalStringSlices(got, []string{"review_skipped"}) {
+		t.Fatalf("events: got %v, want [review_skipped]", got)
+	}
+	ev, _ := pub.firstOf("review_skipped")
+	if !strings.Contains(ev.Data, `"reason":"legacy_backfill"`) {
+		t.Errorf("review_skipped payload missing legacy_backfill reason, got %q", ev.Data)
+	}
+}
+
+// TestPipeline_Run_GateSkipEmitsReviewSkipped covers the
+// defense-in-depth Evaluate skip: a closed/draft/self-authored PR
+// must surface a review_skipped event with the actual reason from
+// the gate, not a fabricated one. Pre-#322 the trigger handler
+// invented "not_open" for every nil return — now the pipeline owns
+// the truth.
+func TestPipeline_Run_GateSkipEmitsReviewSkipped(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	pub := &fakePublisher{}
+	p := pipeline.New(s, &fakeGHCounter{diff: "+line"}, &fakeExecCounter{}, &fakeNotify{})
+	p.SetPublisher(pub)
+
+	pr := &github.PullRequest{
+		ID: 200, Number: 200, Title: "t", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "closed", // not_open
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/200",
+		Head: github.Branch{SHA: "abc"},
+	}
+	opts := pipeline.RunOptions{
+		Primary: "claude",
+		Guards:  pipeline.GateConfig{SkipDrafts: true, SkipSelfAuthor: true, BotLogin: "heimdallm-bot"},
+	}
+	if _, err := p.Run(pr, opts); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := pub.types(); !equalStringSlices(got, []string{"review_skipped"}) {
+		t.Fatalf("events: got %v, want [review_skipped]", got)
+	}
+	ev, _ := pub.firstOf("review_skipped")
+	if !strings.Contains(ev.Data, `"reason":"not_open"`) {
+		t.Errorf("review_skipped payload missing not_open reason, got %q", ev.Data)
+	}
+}
+
+// TestPipeline_Run_NilPublisherIsNoop guards the legacy contract: a
+// pipeline with no publisher wired (every existing test that doesn't
+// care about SSEs) must not panic on emit. Quietly drops events.
+func TestPipeline_Run_NilPublisherIsNoop(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	p := pipeline.New(s, &fakeGHCounter{diff: "+line"}, &fakeExecCounter{}, &fakeNotify{})
+	// No SetPublisher call — publisher stays nil.
+
+	pr := &github.PullRequest{
+		ID: 300, Number: 300, Title: "t", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/300",
+		Head: github.Branch{SHA: "abc"},
+	}
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("run with nil publisher: %v", err)
+	}
+}
+
+// equalStringSlices is a tiny helper for ordered slice equality used by
+// the lifecycle SSE tests above. Keeps the assertions readable without
+// pulling in reflect.DeepEqual (which obscures element-level mismatches
+// on failure).
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -2,6 +2,7 @@ package pipeline_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -81,6 +82,23 @@ func countNotify(events []string, title string) int {
 		}
 	}
 	return n
+}
+
+// fakeTimeline is a TimelineFetcher stub that returns a canned event
+// slice (or an error) so SHA-skip-bypass tests can drive the
+// re-request decision deterministically. Used by tests for #322 Bug 5.
+type fakeTimeline struct {
+	events []github.TimelineEvent
+	err    error
+	calls  int
+}
+
+func (f *fakeTimeline) GetPRTimelineEventsForReviewer(_ string, _ int, _ string) ([]github.TimelineEvent, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.events, nil
 }
 
 func TestPipeline_Run(t *testing.T) {
@@ -498,5 +516,189 @@ func TestPipeline_Run_Tier3PathSkipsOnSameHeadSHA(t *testing.T) {
 	// have produced one.
 	if startedCount := countNotify(notify.events, "PR Review Started"); startedCount != 1 {
 		t.Errorf("notify(\"PR Review Started\") fired %d times across 1 real review + 1 Tier 3 SHA-skip; want exactly 1", startedCount)
+	}
+}
+
+// ── #322 Bug 5: explicit re-request review bypasses the SHA skip ──────
+
+// runFirstReview is a small helper used by the Bug 5 tests below to seed
+// a previous review on the store via the real pipeline, so the second
+// Run hits the SHA-skip branch with a realistic prevReview row.
+func runFirstReview(t *testing.T, p *pipeline.Pipeline, pr *github.PullRequest) {
+	t.Helper()
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("seed first review: %v", err)
+	}
+}
+
+// TestPipeline_Run_RespectsExplicitReReviewOnSameSHA covers the
+// happy-path bypass: operator presses "Re-request review" in the
+// GitHub UI, the timeline records a review_requested newer than the
+// previous review, the pipeline must re-run the review on the same
+// HEAD SHA. Defends against the silent-skip behaviour observed on PR
+// freepik-company/ai-api-specs#557 on 2026-04-24.
+func TestPipeline_Run_RespectsExplicitReReviewOnSameSHA(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	exec := &fakeExecCounter{}
+	gh := &fakeGHCounter{diff: "+line"}
+	p := pipeline.New(s, gh, exec, &fakeNotify{})
+	p.SetBotLogin("heimdallm-bot")
+
+	pr := &github.PullRequest{
+		ID: 557, Number: 557, Title: "feat: x", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+		HTMLURL:   "https://github.com/org/repo/pull/557",
+		Head:      github.Branch{SHA: "c527a2e4"},
+	}
+	runFirstReview(t, p, pr)
+	if exec.calls != 1 {
+		t.Fatalf("seed: expected exec.calls=1, got %d", exec.calls)
+	}
+
+	// Operator hits "Re-request review" — timeline records a
+	// review_requested event newer than the existing review.
+	tl := &fakeTimeline{events: []github.TimelineEvent{
+		{Event: "review_requested", Actor: "alice", CreatedAt: time.Now()},
+	}}
+	p.SetTimelineFetcher(tl)
+
+	pr.UpdatedAt = time.Now()
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("re-request run: %v", err)
+	}
+	if exec.calls != 2 {
+		t.Errorf("re-request: expected exec.calls=2, got %d", exec.calls)
+	}
+	if gh.submits != 2 {
+		t.Errorf("re-request: expected gh.submits=2, got %d", gh.submits)
+	}
+	if tl.calls == 0 {
+		t.Errorf("timeline was not consulted on SHA-skip path")
+	}
+}
+
+// TestPipeline_Run_IgnoresStaleReviewRequest covers the negative case:
+// a review_requested whose timestamp predates the existing review is
+// already-satisfied and must NOT bypass the SHA skip. Otherwise every
+// PR that ever asked for the bot would re-review forever.
+func TestPipeline_Run_IgnoresStaleReviewRequest(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	exec := &fakeExecCounter{}
+	gh := &fakeGHCounter{diff: "+line"}
+	p := pipeline.New(s, gh, exec, &fakeNotify{})
+	p.SetBotLogin("heimdallm-bot")
+
+	pr := &github.PullRequest{
+		ID: 1, Number: 1, Title: "t", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+		HTMLURL:   "https://github.com/org/repo/pull/1",
+		Head:      github.Branch{SHA: "abc"},
+	}
+	runFirstReview(t, p, pr)
+
+	// Stale request: predates the review we just performed.
+	tl := &fakeTimeline{events: []github.TimelineEvent{
+		{Event: "review_requested", Actor: "alice", CreatedAt: time.Now().Add(-2 * time.Hour)},
+	}}
+	p.SetTimelineFetcher(tl)
+
+	pr.UpdatedAt = time.Now()
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if exec.calls != 1 {
+		t.Errorf("stale request must NOT trigger re-review, got exec.calls=%d", exec.calls)
+	}
+}
+
+// TestPipeline_Run_DismissAfterReRequestKeepsSkip covers the layered
+// case: re-request was followed by a dismiss, so the operator no
+// longer wants our review on this SHA. Newest event wins; skip stays.
+func TestPipeline_Run_DismissAfterReRequestKeepsSkip(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	exec := &fakeExecCounter{}
+	gh := &fakeGHCounter{diff: "+line"}
+	p := pipeline.New(s, gh, exec, &fakeNotify{})
+	p.SetBotLogin("heimdallm-bot")
+
+	pr := &github.PullRequest{
+		ID: 2, Number: 2, Title: "t", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+		HTMLURL:   "https://github.com/org/repo/pull/2",
+		Head:      github.Branch{SHA: "def"},
+	}
+	runFirstReview(t, p, pr)
+
+	now := time.Now()
+	tl := &fakeTimeline{events: []github.TimelineEvent{
+		{Event: "review_requested", Actor: "alice", CreatedAt: now.Add(-10 * time.Minute)},
+		{Event: "review_dismissed", Actor: "alice", CreatedAt: now.Add(-5 * time.Minute)},
+	}}
+	p.SetTimelineFetcher(tl)
+
+	pr.UpdatedAt = now
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if exec.calls != 1 {
+		t.Errorf("dismiss after re-request must keep the skip, got exec.calls=%d", exec.calls)
+	}
+}
+
+// TestPipeline_Run_TimelineErrorKeepsSkip enforces the fail-closed
+// posture: a transient timeline API error must NOT widen the cost
+// surface by suddenly bypassing the SHA skip. Same rule as the
+// HEAD-SHA resolver fail-closed in #245.
+func TestPipeline_Run_TimelineErrorKeepsSkip(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	exec := &fakeExecCounter{}
+	gh := &fakeGHCounter{diff: "+line"}
+	p := pipeline.New(s, gh, exec, &fakeNotify{})
+	p.SetBotLogin("heimdallm-bot")
+
+	pr := &github.PullRequest{
+		ID: 3, Number: 3, Title: "t", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+		HTMLURL:   "https://github.com/org/repo/pull/3",
+		Head:      github.Branch{SHA: "ghi"},
+	}
+	runFirstReview(t, p, pr)
+
+	tl := &fakeTimeline{err: errors.New("github: 503 service unavailable")}
+	p.SetTimelineFetcher(tl)
+
+	pr.UpdatedAt = time.Now()
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if exec.calls != 1 {
+		t.Errorf("timeline error must keep the skip (fail-closed), got exec.calls=%d", exec.calls)
+	}
+	if tl.calls == 0 {
+		t.Errorf("timeline was not consulted")
 	}
 }

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -69,6 +69,20 @@ func (f *fakeNotify) Notify(title, message string) {
 	f.events = append(f.events, title)
 }
 
+// countNotify returns how many times `title` appears in the recorded
+// fakeNotify events. Used by SHA-skip regression tests to assert no
+// duplicate "PR Review Started" notifications fire when the pipeline
+// short-circuits on an unchanged HEAD SHA (#322 Bug 3).
+func countNotify(events []string, title string) int {
+	n := 0
+	for _, e := range events {
+		if e == title {
+			n++
+		}
+	}
+	return n
+}
+
 func TestPipeline_Run(t *testing.T) {
 	s, err := store.Open(":memory:")
 	if err != nil {
@@ -319,7 +333,8 @@ func TestPipeline_Run_SkipsReviewOnSameHeadSHA(t *testing.T) {
 
 	exec := &fakeExecCounter{}
 	gh := &fakeGHCounter{diff: "+line"}
-	p := pipeline.New(s, gh, exec, &fakeNotify{})
+	notify := &fakeNotify{}
+	p := pipeline.New(s, gh, exec, notify)
 
 	pr := &github.PullRequest{
 		ID: 42, Number: 42, Title: "Feature", Repo: "org/repo",
@@ -359,8 +374,21 @@ func TestPipeline_Run_SkipsReviewOnSameHeadSHA(t *testing.T) {
 	if len(reviews) != 1 {
 		t.Errorf("duplicate review row inserted on same SHA: got %d reviews", len(reviews))
 	}
-	if rev2 == nil || rev2.ID != rev1.ID {
-		t.Errorf("expected Run to return the existing review on same SHA; got rev2=%+v", rev2)
+	// Contract change for #322 Bug 4: SHA-skip now returns (nil, nil), the
+	// same shape the gate-skip path uses, so the caller's defensive
+	// `if rev == nil { return }` filter suppresses the false
+	// EventReviewCompleted / activity_log row / "review done" log. The skip
+	// itself stays visible via the slog.Info inside Run.
+	if rev2 != nil {
+		t.Errorf("expected nil review on SHA-skip (silent skip), got rev2=%+v", rev2)
+	}
+
+	// Regression for #322 Bug 3: the desktop notification must NOT fire on a
+	// SHA-skip. Only the first run (which actually dispatched a review)
+	// should have produced a "PR Review Started" / "PR Review Complete"
+	// pair. The second run skipped, so no extra notify events.
+	if startedCount := countNotify(notify.events, "PR Review Started"); startedCount != 1 {
+		t.Errorf("notify(\"PR Review Started\") fired %d times across 1 real review + 1 SHA-skip; want exactly 1", startedCount)
 	}
 
 	// Third run with a new HEAD SHA — must proceed normally.
@@ -431,7 +459,8 @@ func TestPipeline_Run_Tier3PathSkipsOnSameHeadSHA(t *testing.T) {
 
 	exec := &fakeExecCounter{}
 	gh := &fakeGHCounter{diff: "+line"}
-	p := pipeline.New(s, gh, exec, &fakeNotify{})
+	notify := &fakeNotify{}
+	p := pipeline.New(s, gh, exec, notify)
 
 	prT2 := &github.PullRequest{
 		ID: 900, Number: 900, Title: "t", Repo: "org/repo",
@@ -449,7 +478,8 @@ func TestPipeline_Run_Tier3PathSkipsOnSameHeadSHA(t *testing.T) {
 	// Tier 3 re-entry: same PR, same SHA, bumped updated_at.
 	prT3 := *prT2
 	prT3.UpdatedAt = prT2.UpdatedAt.Add(2 * time.Minute)
-	if _, err := p.Run(&prT3, pipeline.RunOptions{Primary: "claude"}); err != nil {
+	rev3, err := p.Run(&prT3, pipeline.RunOptions{Primary: "claude"})
+	if err != nil {
 		t.Fatalf("tier3 run: %v", err)
 	}
 	if exec.calls != 1 {
@@ -457,5 +487,16 @@ func TestPipeline_Run_Tier3PathSkipsOnSameHeadSHA(t *testing.T) {
 	}
 	if gh.submits != 1 {
 		t.Errorf("Tier 3 re-run submitted review on same SHA: submits=%d", gh.submits)
+	}
+	// #322 Bug 4: Tier 3 SHA-skip must return (nil, nil) so the activity
+	// recorder doesn't insert a fake review row each watch cycle.
+	if rev3 != nil {
+		t.Errorf("Tier 3 SHA-skip should return nil review, got %+v", rev3)
+	}
+	// #322 Bug 3: Tier 3 SHA-skip must not fire a fresh "PR Review Started"
+	// notification — only the first run (which actually dispatched) should
+	// have produced one.
+	if startedCount := countNotify(notify.events, "PR Review Started"); startedCount != 1 {
+		t.Errorf("notify(\"PR Review Started\") fired %d times across 1 real review + 1 Tier 3 SHA-skip; want exactly 1", startedCount)
 	}
 }

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -89,18 +89,31 @@ func countNotify(events []string, title string) int {
 // fakeTimeline is a TimelineFetcher stub that returns a canned event
 // slice (or an error) so SHA-skip-bypass tests can drive the
 // re-request decision deterministically. Used by tests for #322 Bug 5.
+//
+// `calls` is guarded by callsMu because future parallel-test usage (or a
+// regression that lets two goroutines reach Run concurrently) would
+// otherwise race on the increment — same posture as fakePublisher.
 type fakeTimeline struct {
-	events []github.TimelineEvent
-	err    error
-	calls  int
+	events  []github.TimelineEvent
+	err     error
+	callsMu sync.Mutex
+	calls   int
 }
 
 func (f *fakeTimeline) GetPRTimelineEventsForReviewer(_ string, _ int, _ string) ([]github.TimelineEvent, error) {
+	f.callsMu.Lock()
 	f.calls++
+	f.callsMu.Unlock()
 	if f.err != nil {
 		return nil, f.err
 	}
 	return f.events, nil
+}
+
+func (f *fakeTimeline) callCount() int {
+	f.callsMu.Lock()
+	defer f.callsMu.Unlock()
+	return f.calls
 }
 
 // fakePublisher records every SSE event the pipeline emits so lifecycle
@@ -621,7 +634,7 @@ func TestPipeline_Run_RespectsExplicitReReviewOnSameSHA(t *testing.T) {
 	if gh.submits != 2 {
 		t.Errorf("re-request: expected gh.submits=2, got %d", gh.submits)
 	}
-	if tl.calls == 0 {
+	if tl.callCount() == 0 {
 		t.Errorf("timeline was not consulted on SHA-skip path")
 	}
 }
@@ -741,7 +754,7 @@ func TestPipeline_Run_TimelineErrorKeepsSkip(t *testing.T) {
 	if exec.calls != 1 {
 		t.Errorf("timeline error must keep the skip (fail-closed), got exec.calls=%d", exec.calls)
 	}
-	if tl.calls == 0 {
+	if tl.callCount() == 0 {
 		t.Errorf("timeline was not consulted")
 	}
 }

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -123,6 +123,19 @@ void _handleSseEvent(Ref ref, SseEvent event) {
           }
         }
 
+      case 'review_skipped':
+        // Manual trigger on a PR with unchanged HEAD SHA (re-request,
+        // legacy backfill, or any policy gate) returns no real review,
+        // so the optimistic spinner that dashboard_screen sets must be
+        // cleared explicitly. Without this case the spinner stayed
+        // colgado after every trigger that hit a dedup branch — the
+        // regression flagged on theburrowhub/heimdallm#322.
+        if (key != null) {
+          ref
+              .read(reviewingPRsProvider.notifier)
+              .update((s) => Map.of(s)..remove(key));
+        }
+
       // ── Issue tracking events ──────────────────────────────────────────
       case 'issue_detected':
         ref.read(issueListRefreshProvider.notifier).update((s) => s + 1);


### PR DESCRIPTION
## Summary

Closes 3 of the 4 bugs tracked in #322 — the PR-side ones, all sharing the SHA-skip code site in \`pipeline.Run\`. Bug 1 (PublishPending 422 lock loop) lives in a different code path and stays in #322 for a separate PR.

| Bug | Symptom | Status in this PR |
|---|---|---|
| 3. Notify \"PR Review Started\" desktop spam every poll on stable PRs | Operator received a phantom desktop notification once per minute per stable PR | ✅ Fixed |
| 4. Activity log records false \"high review\" entries every poll on stable PRs | UI showed 10 fake reviews on PR #557 in 10 min — none were actually run | ✅ Fixed |
| 5. Re-request review explícito ignorado mientras HEAD SHA no cambie | The functional bug — daemon silently dropped the operator's explicit \"Re-request review\" action | ✅ Fixed |
| 1. PublishPending retries 422 \"lock prevents review\" forever | Independent code site (publish loop, not review loop) | Out of scope — left in #322 |

Self-assigned the issue to me before starting work.

## Commit 1 — \`11852b5\` Bugs 3 + 4

Two changes in \`pipeline.go\`:

1. **Move the unconditional notify out of the function entry.** \`p.notify.Notify(\"PR Review Started\", ...)\` was firing at the top of \`Run\`, before the SHA-skip dedup check. Moved to immediately AFTER the SHA-skip block so it only runs when a real review is about to be dispatched.
2. **Make SHA-skip and legacy-backfill paths return \`(nil, nil)\`** instead of \`(prevReview, nil)\`. The caller in \`cmd/heimdallm/main.go\` has a defensive \`if rev == nil { return }\` filter (line 417) that suppresses the \`EventReviewCompleted\` SSE / \`activity_log\` row / \`\"review done\"\` log line. Returning \`prevReview\` bypassed that filter — which is why the activity log on PR #557 showed 10 false \"high review\" entries in 10 minutes despite zero Claude credits being spent. The new contract matches the gate-skip path on line 219 (also \`(nil, nil)\`). The backfill side-effect (\`UpdateReviewHeadSHA\`) still runs.

Updated 3 existing tests for the new contract:
- \`TestPipeline_Run_SkipsReviewOnSameHeadSHA\`: now asserts \`rev2 == nil\` AND that \`fakeNotify\` events for \"PR Review Started\" total exactly 1 (one real review, one silent skip) — locks in Bug 3 and Bug 4.
- \`TestPipeline_Run_Tier3PathSkipsOnSameHeadSHA\`: same updated assertions for the Tier 3 watch path.
- \`TestRun_LegacyRowWithEmptyHeadSHAIsBackfilledAndSkipped\`: legacy backfill is now also a silent skip; verifies the side-effect via the store directly.

## Commit 2 — \`4cc9590\` Bug 5

The functional one. Adds an explicit-action bypass on top of the SHA fail-closed dedup.

**\`github/client.go\`**:
- New \`TimelineEvent\` type and \`GetPRTimelineEventsForReviewer(repo, number, login)\` method.
- Pages through \`GET /repos/:repo/issues/:n/timeline\`, filters to \`review_requested\` (where \`requested_reviewer.login == login\`) and \`review_dismissed\` (where \`dismissed_review.user.login == login\`), returns sorted ascending by created_at.
- 50-page hard cap to defend against malformed pagination responses.

**\`pipeline/pipeline.go\`**:
- Optional \`TimelineFetcher\` dependency on \`Pipeline\` + \`SetTimelineFetcher\` setter, mirroring \`SetCircuitBreakerLimits\`. Nil-safe — disables the bypass when unset, preserving pre-#322 behaviour for tests that don't care.
- New helper \`shouldBypassSHASkipForReReview\` encapsulates the decision: bypass iff the most recent timeline event for the bot login (newer than \`prevReview.CreatedAt\`) is a \`review_requested\`. A subsequent \`review_dismissed\` cancels the bypass (operator no longer wants our review).
- **Same fail-closed posture as #245**: a transient timeline API error keeps the SHA skip in place. The PR-side circuit breaker (\`#246\`, 3/PR/24h, 20/repo/h) still caps the worst case if a misbehaving operator presses re-request 50 times in a row.

**\`cmd/heimdallm/main.go\`**:
- Wires the production \`*github.Client\` as the \`TimelineFetcher\` at startup, right after \`SetCircuitBreakerLimits\`.

**Tests added**:
- 2 GitHub-client tests: filter-by-login behaviour with mixed payload + empty-login guard.
- 4 pipeline tests: happy-path bypass, stale-request rejection, dismiss-after-request rejection, fail-closed-on-timeline-error.

## Test plan

- [x] \`make test-docker\` green across all daemon packages
- [x] All 6 new tests pass; all 3 updated tests pass
- [ ] Live verification post-merge: re-request review on a stable PR → confirm fresh review is dispatched on next poll cycle. Bumps from CI bots / cross-refs alone (no re-request) → confirm no notify, no activity_log row, no Claude call.

## References

- Closes #322 bugs 3, 4, 5 (bug 1 left open for a separate PR)
- Builds on \`#245\` (HEAD SHA fail-closed dedup) — preserves the cost-runaway protection while honouring deliberate user actions
- Builds on \`#246\` (PR-side circuit breaker) — still the hard cap if re-request is abused
- Live evidence on PR \`freepik-company/ai-api-specs#557\` on 2026-04-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)