### PR TITLE
fix(daemon): mark review orphan on permanent submit failure (closes #325)

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -192,6 +192,49 @@ func (c *Client) fetchByQualifier(username, qualifier string, repos []string) ([
 	return result.Items, nil
 }
 
+// PermanentSubmitError signals that SubmitReview hit a state from
+// which no retry will recover — e.g. the PR's conversation is locked,
+// the PR has been deleted, or the repo was archived. Callers should
+// mark the local review row as orphaned (via the same sentinel as
+// the no-repo path in pipeline.PublishPending) instead of retrying
+// every poll cycle. See theburrowhub/heimdallm#325.
+type PermanentSubmitError struct {
+	StatusCode int    // HTTP status code returned by GitHub (always 422 today)
+	Reason     string // short human-readable label, e.g. "pr_locked"
+	Body       string // safe-truncated response body for diagnostics
+}
+
+func (e *PermanentSubmitError) Error() string {
+	return fmt.Sprintf("github: submit review permanent failure (status %d, reason %s): %s",
+		e.StatusCode, e.Reason, e.Body)
+}
+
+// classifyPermanentSubmit422 inspects an HTTP 422 response body and
+// returns (reason, true) when the failure is known to be permanent for
+// the daemon — i.e. no future retry can succeed without operator
+// intervention. Returns ("", false) for transient or unknown 422s so
+// the caller falls back to the existing retry path.
+//
+// Currently classified as permanent:
+//   - "lock prevents review" — PR conversation is locked. Unlocking
+//     requires the operator to use the GitHub UI; the daemon cannot
+//     recover on its own.
+//
+// Extend with care: a false positive here marks a recoverable review
+// as orphan and loses it permanently. When in doubt, leave the case
+// out and let the retry loop run — it is rate-limited by the poll
+// interval and only burns 1 GitHub API call per cycle.
+func classifyPermanentSubmit422(status int, body []byte) (string, bool) {
+	if status != http.StatusUnprocessableEntity {
+		return "", false
+	}
+	lower := strings.ToLower(string(body))
+	if strings.Contains(lower, "lock prevents review") || strings.Contains(lower, "pull request is locked") {
+		return "pr_locked", true
+	}
+	return "", false
+}
+
 // SubmitReview posts an AI-generated review to GitHub as a PR review.
 // event should be "REQUEST_CHANGES", "COMMENT", or "APPROVE".
 // Returns the GitHub review ID and the review state reported by the API —
@@ -199,6 +242,12 @@ func (c *Client) fetchByQualifier(username, qualifier string, repos []string) ([
 // event and on GitHub's server-side rules. We pass the state through to the
 // store so the web UI can show a review-decision badge sourced from GitHub
 // rather than derived locally from severity.
+//
+// On HTTP 422 with a body that indicates the PR is in a state from which
+// no retry can recover (e.g. the conversation has been locked), returns
+// a *PermanentSubmitError so the caller can mark the local review row
+// as orphaned instead of retrying every poll cycle. See
+// theburrowhub/heimdallm#325.
 func (c *Client) SubmitReview(repo string, number int, body, event string) (int64, string, error) {
 	path := fmt.Sprintf("/repos/%s/pulls/%d/reviews", repo, number)
 
@@ -225,6 +274,13 @@ func (c *Client) SubmitReview(repo string, number int, body, event string) (int6
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != 200 {
 		errBody := safeTruncate(string(respBody), maxErrBodyLen)
+		if reason, ok := classifyPermanentSubmit422(resp.StatusCode, respBody); ok {
+			return 0, "", &PermanentSubmitError{
+				StatusCode: resp.StatusCode,
+				Reason:     reason,
+				Body:       errBody,
+			}
+		}
 		return 0, "", fmt.Errorf("github: submit review: status %d: %s", resp.StatusCode, errBody)
 	}
 

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -275,10 +275,14 @@ func (c *Client) SubmitReview(repo string, number int, body, event string) (int6
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != 200 {
 		errBody := safeTruncate(string(respBody), maxErrBodyLen)
 		if reason, ok := classifyPermanentSubmit422(resp.StatusCode, respBody); ok {
+			// Body carries the FULL response (not safe-truncated) so an
+			// operator inspecting *PermanentSubmitError can see the full
+			// GitHub error payload — the reason substring may live past
+			// the maxErrBodyLen cutoff that the generic-error path uses.
 			return 0, "", &PermanentSubmitError{
 				StatusCode: resp.StatusCode,
 				Reason:     reason,
-				Body:       errBody,
+				Body:       string(respBody),
 			}
 		}
 		return 0, "", fmt.Errorf("github: submit review: status %d: %s", resp.StatusCode, errBody)

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -358,5 +359,33 @@ func TestSubmitReview_422WithoutLockIsNotPermanent(t *testing.T) {
 	var permErr *gh.PermanentSubmitError
 	if errors.As(err, &permErr) {
 		t.Errorf("422 without lock body must NOT classify as PermanentSubmitError, got %+v", permErr)
+	}
+}
+
+// TestSubmitReview_LockedPRBodyIsNotTruncated covers the
+// post-review-feedback fix to #325: when SubmitReview returns a
+// *PermanentSubmitError, the Body field must carry the FULL response
+// body (not safe-truncated) so an operator inspecting the error can
+// see the complete GitHub payload — the lock substring may live past
+// the maxErrBodyLen cutoff used by the generic-error path.
+func TestSubmitReview_LockedPRBodyIsNotTruncated(t *testing.T) {
+	// Build a body where the lock substring sits well past 200 bytes
+	// (maxErrBodyLen) so a truncation regression would lose it.
+	padding := strings.Repeat("x", 500)
+	bigBody := `{"message":"Validation Failed","padding":"` + padding + `","errors":[{"message":"lock prevents review"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(bigBody))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	_, _, err := client.SubmitReview("org/repo", 1, "body", "COMMENT")
+	var permErr *gh.PermanentSubmitError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected PermanentSubmitError on big locked body, got %v", err)
+	}
+	if !strings.Contains(permErr.Body, "lock prevents review") {
+		t.Errorf("permErr.Body lost the lock substring (truncated at boundary?); body=%q", permErr.Body)
 	}
 }

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -2,6 +2,7 @@ package github_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -279,4 +280,83 @@ func mustTime(s string) time.Time {
 		panic(err)
 	}
 	return t
+}
+
+// TestSubmitReview_LockedPRReturnsPermanentSubmitError locks in the
+// fix from theburrowhub/heimdallm#325: when GitHub returns 422 with a
+// "lock prevents review" body, the daemon must surface a typed
+// *PermanentSubmitError so PublishPending can mark the row orphan
+// instead of retrying every poll cycle forever.
+func TestSubmitReview_LockedPRReturnsPermanentSubmitError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/org/repo/pulls/1/reviews" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"unprocessable","message":"lock prevents review"}]}`))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	_, _, err := client.SubmitReview("org/repo", 1, "body", "COMMENT")
+	if err == nil {
+		t.Fatal("expected PermanentSubmitError, got nil")
+	}
+	var permErr *gh.PermanentSubmitError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected *PermanentSubmitError, got %T: %v", err, err)
+	}
+	if permErr.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("StatusCode = %d, want 422", permErr.StatusCode)
+	}
+	if permErr.Reason != "pr_locked" {
+		t.Errorf("Reason = %q, want pr_locked", permErr.Reason)
+	}
+	if permErr.Body == "" {
+		t.Errorf("Body should carry the truncated response for diagnostics, got empty")
+	}
+}
+
+// TestSubmitReview_TransientErrorIsNotPermanent guards against
+// over-classification: a 5xx (or any non-422 status) MUST keep the
+// generic-error path so the retry loop still runs. Otherwise a
+// transient outage would wipe legitimate reviews.
+func TestSubmitReview_TransientErrorIsNotPermanent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"upstream"}`, http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	_, _, err := client.SubmitReview("org/repo", 1, "body", "COMMENT")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var permErr *gh.PermanentSubmitError
+	if errors.As(err, &permErr) {
+		t.Errorf("503 must NOT classify as PermanentSubmitError, got %+v", permErr)
+	}
+}
+
+// TestSubmitReview_422WithoutLockIsNotPermanent ensures we don't
+// classify every 422 as permanent — only the specific lock-related
+// substrings. A 422 from a malformed body or wrong event value should
+// still surface as a generic error so callers can iterate.
+func TestSubmitReview_422WithoutLockIsNotPermanent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"message":"Validation Failed","errors":[{"code":"invalid","field":"event"}]}`))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	_, _, err := client.SubmitReview("org/repo", 1, "body", "BAD_EVENT")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var permErr *gh.PermanentSubmitError
+	if errors.As(err, &permErr) {
+		t.Errorf("422 without lock body must NOT classify as PermanentSubmitError, got %+v", permErr)
+	}
 }

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -586,9 +586,26 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		severityToEvent(result.Severity, len(result.Issues)),
 	)
 	if publishErr != nil {
-		// Review saved locally; will retry on next poll (GitHubReviewID == 0 check)
-		slog.Warn("pipeline: failed to publish to GitHub, will retry",
-			"pr", pr.Number, "err", publishErr)
+		// Permanent submit failure (PR locked etc.): mark the freshly
+		// stored row as orphaned right now so it never enters the
+		// PublishPending retry loop — the row would otherwise burn
+		// one GitHub API call per poll cycle indefinitely. Same
+		// (-1, "") sentinel as the no-repo path in PublishPending.
+		// See theburrowhub/heimdallm#325.
+		var permErr *github.PermanentSubmitError
+		if errors.As(publishErr, &permErr) {
+			if mErr := p.store.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC()); mErr != nil {
+				slog.Warn("pipeline: failed to mark orphaned review on initial publish, will fall through to PublishPending",
+					"review_id", rev.ID, "reason", permErr.Reason, "err", mErr)
+			} else {
+				slog.Info("pipeline: review marked orphan on initial publish (permanent submit failure)",
+					"review_id", rev.ID, "reason", permErr.Reason, "status", permErr.StatusCode)
+			}
+		} else {
+			// Transient — review saved locally; will retry on next poll (GitHubReviewID == 0 check)
+			slog.Warn("pipeline: failed to publish to GitHub, will retry",
+				"pr", pr.Number, "err", publishErr)
+		}
 	} else {
 		// Stamp PublishedAt immediately after the API returned success — this
 		// is the anchor the dedup window uses. Anchoring on CreatedAt (set
@@ -661,6 +678,25 @@ func (p *Pipeline) PublishPending() {
 			severityToEvent(rev.Severity, len(issues)),
 		)
 		if err != nil {
+			// Permanent submit failures (currently HTTP 422 with a
+			// "lock prevents review" body) cannot be recovered by
+			// retrying — the PR's conversation has been locked or
+			// otherwise put in a state requiring operator
+			// intervention. Mark the row as orphaned via the same
+			// (-1, "") sentinel we use for PRs with no repo so the
+			// retry loop stops burning one GitHub API call per poll
+			// cycle. See theburrowhub/heimdallm#325.
+			var permErr *github.PermanentSubmitError
+			if errors.As(err, &permErr) {
+				if mErr := p.store.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC()); mErr != nil {
+					slog.Warn("pipeline: failed to mark orphaned review, will retry next tick",
+						"review_id", rev.ID, "reason", permErr.Reason, "err", mErr)
+					continue
+				}
+				slog.Info("pipeline: review marked orphan (permanent submit failure, will not retry)",
+					"review_id", rev.ID, "reason", permErr.Reason, "status", permErr.StatusCode)
+				continue
+			}
 			slog.Warn("pipeline: retry publish failed", "review_id", rev.ID, "err", err)
 			continue
 		}

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -588,20 +588,12 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	if publishErr != nil {
 		// Permanent submit failure (PR locked etc.): mark the freshly
 		// stored row as orphaned right now so it never enters the
-		// PublishPending retry loop — the row would otherwise burn
-		// one GitHub API call per poll cycle indefinitely. Same
-		// (-1, "") sentinel as the no-repo path in PublishPending.
-		// See theburrowhub/heimdallm#325.
-		var permErr *github.PermanentSubmitError
-		if errors.As(publishErr, &permErr) {
-			if mErr := p.store.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC()); mErr != nil {
-				slog.Warn("pipeline: failed to mark orphaned review on initial publish, will fall through to PublishPending",
-					"review_id", rev.ID, "reason", permErr.Reason, "err", mErr)
-			} else {
-				slog.Info("pipeline: review marked orphan on initial publish (permanent submit failure)",
-					"review_id", rev.ID, "reason", permErr.Reason, "status", permErr.StatusCode)
-			}
-		} else {
+		// PublishPending retry loop. Transient errors fall through to
+		// the existing retry path. The orphan-marking pattern is
+		// shared with PublishPending via markOrphanIfPermanent so
+		// both sites stay in sync if the sentinel convention or
+		// logging shape ever changes. See theburrowhub/heimdallm#325.
+		if !p.markOrphanIfPermanent(rev.ID, publishErr, "initial publish") {
 			// Transient — review saved locally; will retry on next poll (GitHubReviewID == 0 check)
 			slog.Warn("pipeline: failed to publish to GitHub, will retry",
 				"pr", pr.Number, "err", publishErr)
@@ -643,6 +635,34 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	return rev, nil
 }
 
+// markOrphanIfPermanent inspects the error returned by SubmitReview and,
+// when it is a *github.PermanentSubmitError, marks the local review row
+// as orphaned via the (-1, "") sentinel that PublishPending also uses
+// for PRs with no repo. Returns true when the error was permanent and
+// the orphan-marking attempt was made (regardless of whether
+// MarkReviewPublished itself succeeded — a store failure here is logged
+// at Warn so the retry loop can re-attempt next tick).
+//
+// Returns false for transient or unknown errors so the caller falls
+// back to its existing retry logging. Centralising this keeps the Run
+// and PublishPending paths in lockstep — without the helper a future
+// edit to the sentinel convention or log shape would silently drift
+// between the two sites. See theburrowhub/heimdallm#325 review.
+func (p *Pipeline) markOrphanIfPermanent(reviewID int64, submitErr error, source string) bool {
+	var permErr *github.PermanentSubmitError
+	if !errors.As(submitErr, &permErr) {
+		return false
+	}
+	if mErr := p.store.MarkReviewPublished(reviewID, -1, "", time.Now().UTC()); mErr != nil {
+		slog.Warn("pipeline: failed to mark orphaned review, will retry next tick",
+			"review_id", reviewID, "source", source, "reason", permErr.Reason, "err", mErr)
+		return true
+	}
+	slog.Info("pipeline: review marked orphan (permanent submit failure, will not retry)",
+		"review_id", reviewID, "source", source, "reason", permErr.Reason, "status", permErr.StatusCode)
+	return true
+}
+
 // PublishPending re-submits locally stored reviews that failed to publish to GitHub.
 // Call this on scheduler ticks to retry failed publications.
 func (p *Pipeline) PublishPending() {
@@ -678,23 +698,12 @@ func (p *Pipeline) PublishPending() {
 			severityToEvent(rev.Severity, len(issues)),
 		)
 		if err != nil {
-			// Permanent submit failures (currently HTTP 422 with a
-			// "lock prevents review" body) cannot be recovered by
-			// retrying — the PR's conversation has been locked or
-			// otherwise put in a state requiring operator
-			// intervention. Mark the row as orphaned via the same
-			// (-1, "") sentinel we use for PRs with no repo so the
-			// retry loop stops burning one GitHub API call per poll
-			// cycle. See theburrowhub/heimdallm#325.
-			var permErr *github.PermanentSubmitError
-			if errors.As(err, &permErr) {
-				if mErr := p.store.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC()); mErr != nil {
-					slog.Warn("pipeline: failed to mark orphaned review, will retry next tick",
-						"review_id", rev.ID, "reason", permErr.Reason, "err", mErr)
-					continue
-				}
-				slog.Info("pipeline: review marked orphan (permanent submit failure, will not retry)",
-					"review_id", rev.ID, "reason", permErr.Reason, "status", permErr.StatusCode)
+			// Permanent submit failures (currently HTTP 422 "lock
+			// prevents review") are routed through the shared helper so
+			// both the Run path and this retry path apply the same
+			// orphan-marker, sentinel value and log shape. See
+			// theburrowhub/heimdallm#325.
+			if p.markOrphanIfPermanent(rev.ID, err, "retry publish") {
 				continue
 			}
 			slog.Warn("pipeline: retry publish failed", "review_id", rev.ID, "err", err)

--- a/daemon/internal/pipeline/pipeline_orphan_test.go
+++ b/daemon/internal/pipeline/pipeline_orphan_test.go
@@ -1,0 +1,213 @@
+package pipeline_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/executor"
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// fakeGHLockedSubmit is a github dependency stub whose SubmitReview
+// returns *gh.PermanentSubmitError on every call, simulating a PR
+// whose conversation has been locked by an operator. Used by the
+// #325 regression tests to assert the pipeline marks the row orphan
+// instead of looping the retry forever.
+type fakeGHLockedSubmit struct {
+	submitCalls int
+	headSHA     string
+}
+
+func (f *fakeGHLockedSubmit) FetchDiff(_ string, _ int) (string, error) { return "+line", nil }
+func (f *fakeGHLockedSubmit) SubmitReview(_ string, _ int, _, _ string) (int64, string, error) {
+	f.submitCalls++
+	return 0, "", &gh.PermanentSubmitError{
+		StatusCode: 422,
+		Reason:     "pr_locked",
+		Body:       "lock prevents review",
+	}
+}
+func (f *fakeGHLockedSubmit) PostComment(_ string, _ int, _ string) (time.Time, error) {
+	return time.Now().UTC(), nil
+}
+func (f *fakeGHLockedSubmit) FetchComments(_ string, _ int) ([]gh.Comment, error) {
+	return nil, nil
+}
+func (f *fakeGHLockedSubmit) GetPRHeadSHA(_ string, _ int) (string, error) { return f.headSHA, nil }
+
+// fakeExecOrphan mirrors fakeExecCounter but lives in this file so the
+// orphan tests are self-contained.
+type fakeExecOrphan struct{ calls int }
+
+func (f *fakeExecOrphan) Detect(_, _ string) (string, error) { return "fake_claude", nil }
+func (f *fakeExecOrphan) Execute(_, _ string, _ executor.ExecOptions) (*executor.ReviewResult, error) {
+	f.calls++
+	return &executor.ReviewResult{Summary: "ok", Severity: "low"}, nil
+}
+
+// TestRun_LockedPRMarksReviewOrphanImmediately covers the initial
+// publish path: a 422 lock during the first SubmitReview call must
+// mark the freshly inserted row as orphaned in-place, so it never
+// enters the PublishPending retry loop. Without this, every locked
+// PR burns one GitHub API call per poll cycle indefinitely. See
+// theburrowhub/heimdallm#325.
+func TestRun_LockedPRMarksReviewOrphanImmediately(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	fgh := &fakeGHLockedSubmit{headSHA: "deadbeef"}
+	p := pipeline.New(s, fgh, &fakeExecOrphan{}, &fakeNotify{})
+
+	pr := &gh.PullRequest{
+		ID: 1, Number: 1, Title: "t", Repo: "org/repo",
+		User: gh.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/1",
+		Head: gh.Branch{SHA: "deadbeef"},
+	}
+	rev, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev == nil {
+		t.Fatalf("expected stored review, got nil")
+	}
+
+	// The row must be present in the unpublished-reviews query before
+	// MarkReviewPublished runs — but afterwards it MUST NOT be.
+	unpub, err := s.ListUnpublishedReviews()
+	if err != nil {
+		t.Fatalf("list unpublished: %v", err)
+	}
+	if len(unpub) != 0 {
+		t.Errorf("expected 0 unpublished reviews after lock-orphan marking, got %d (the retry loop would burn API calls): %+v", len(unpub), unpub)
+	}
+
+	// Sanity: only one SubmitReview attempt — the orphan-marker stops the loop.
+	if fgh.submitCalls != 1 {
+		t.Errorf("SubmitReview attempts = %d, want 1 (orphan marker should stop the cycle)", fgh.submitCalls)
+	}
+
+	// PublishPending should now be a no-op for this row.
+	p.PublishPending()
+	if fgh.submitCalls != 1 {
+		t.Errorf("PublishPending re-attempted SubmitReview on orphaned row: calls=%d", fgh.submitCalls)
+	}
+}
+
+// TestPublishPending_LockedPRStopsRetrying covers the retry-loop
+// path: a row already in the unpublished queue (e.g. inserted by an
+// older daemon version, or by a transient publish failure that has
+// since transitioned to a permanent lock) must be marked orphan on
+// the very first PublishPending tick that observes the
+// PermanentSubmitError. The next tick must not re-attempt.
+func TestPublishPending_LockedPRStopsRetrying(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	// Seed a PR + an unpublished review row directly, mirroring the
+	// state PublishPending iterates over on every tick.
+	prID, err := s.UpsertPR(&store.PR{
+		GithubID: 100, Repo: "org/repo", Number: 7, Title: "t", Author: "alice",
+		State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	if _, err := s.InsertReview(&store.Review{
+		PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+		Severity: "low", CreatedAt: time.Now(),
+		HeadSHA:        "abc",
+		GitHubReviewID: 0, // marks it as unpublished
+	}); err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+
+	fgh := &fakeGHLockedSubmit{}
+	p := pipeline.New(s, fgh, &fakeExecOrphan{}, &fakeNotify{})
+
+	// First PublishPending tick: SubmitReview returns PermanentSubmitError,
+	// pipeline marks the row orphan.
+	p.PublishPending()
+	if fgh.submitCalls != 1 {
+		t.Fatalf("first tick SubmitReview calls = %d, want 1", fgh.submitCalls)
+	}
+	unpub, _ := s.ListUnpublishedReviews()
+	if len(unpub) != 0 {
+		t.Errorf("expected 0 unpublished reviews after orphan marking, got %d", len(unpub))
+	}
+
+	// Subsequent ticks must NOT re-attempt SubmitReview — that's the
+	// regression we're guarding against.
+	for i := 0; i < 3; i++ {
+		p.PublishPending()
+	}
+	if fgh.submitCalls != 1 {
+		t.Errorf("PublishPending re-attempted on orphaned row across %d extra ticks: total calls=%d, want 1", 3, fgh.submitCalls)
+	}
+}
+
+// TestPublishPending_TransientErrorStillRetries makes sure we did NOT
+// over-rotate: a transient (non-permanent) error must still leave the
+// row in the unpublished queue so the next tick retries. Mirrors the
+// fail-closed posture of #245 — a 5xx outage cannot wipe legitimate
+// reviews.
+func TestPublishPending_TransientErrorStillRetries(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	prID, _ := s.UpsertPR(&store.PR{
+		GithubID: 200, Repo: "org/repo", Number: 8, Title: "t", Author: "alice",
+		State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now(),
+	})
+	if _, err := s.InsertReview(&store.Review{
+		PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+		Severity: "low", CreatedAt: time.Now(),
+		HeadSHA: "def", GitHubReviewID: 0,
+	}); err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+
+	fgh := &fakeGHTransientSubmit{}
+	p := pipeline.New(s, fgh, &fakeExecOrphan{}, &fakeNotify{})
+
+	// Two ticks — both should attempt SubmitReview, both should leave
+	// the row in the queue (no orphan-marking on transient errors).
+	p.PublishPending()
+	p.PublishPending()
+	if fgh.submitCalls != 2 {
+		t.Errorf("transient SubmitReview attempts = %d, want 2 (must keep retrying)", fgh.submitCalls)
+	}
+	unpub, _ := s.ListUnpublishedReviews()
+	if len(unpub) != 1 {
+		t.Errorf("expected 1 unpublished review (transient must NOT mark orphan), got %d", len(unpub))
+	}
+}
+
+// fakeGHTransientSubmit returns a generic non-permanent error so the
+// transient-keeps-retrying test can drive the negative path.
+type fakeGHTransientSubmit struct{ submitCalls int }
+
+func (f *fakeGHTransientSubmit) FetchDiff(_ string, _ int) (string, error) { return "+line", nil }
+func (f *fakeGHTransientSubmit) SubmitReview(_ string, _ int, _, _ string) (int64, string, error) {
+	f.submitCalls++
+	return 0, "", errors.New("github: submit review: status 503: upstream")
+}
+func (f *fakeGHTransientSubmit) PostComment(_ string, _ int, _ string) (time.Time, error) {
+	return time.Now().UTC(), nil
+}
+func (f *fakeGHTransientSubmit) FetchComments(_ string, _ int) ([]gh.Comment, error) {
+	return nil, nil
+}
+func (f *fakeGHTransientSubmit) GetPRHeadSHA(_ string, _ int) (string, error) { return "", nil }


### PR DESCRIPTION
## Summary

Closes #325. \`PublishPending\` and the initial publish path in \`Run\` treated every GitHub error as transient. HTTP 422 with \"lock prevents review\" body is permanent — the PR's conversation has been locked and no future retry will succeed without operator intervention. Pre-fix the unpublished review row stayed in SQLite forever and the daemon burned one GitHub API call per poll cycle per locked PR (observed in production logs as a continuous \`WARN pipeline: retry publish failed\` for \`review_id=681\`).

This was bug 1 of the original #322 quartet; the other three landed in #324.

## Approach

Typed error in the GitHub client + matching detection in both pipeline paths. Reuses the existing \`MarkReviewPublished(reviewID, -1, \"\", ...)\` sentinel that \`PublishPending\` already uses for PRs with no repo (see \`pipeline.go:643-647\`).

### Files

- **\`daemon/internal/github/client.go\`** — new \`*PermanentSubmitError\` struct (\`StatusCode\`, \`Reason\`, \`Body\`) plus a \`classifyPermanentSubmit422\` predicate that case-insensitively matches \`\"lock prevents review\"\` and \`\"pull request is locked\"\`. \`SubmitReview\` returns the typed error in the 422-lock case and keeps the generic \`fmt.Errorf\` for everything else (transient 5xx, unknown 422s) so the retry loop continues working there. Same fail-closed posture as #245.

- **\`daemon/internal/pipeline/pipeline.go\` (PublishPending)** — \`errors.As(&permErr)\` on the \`SubmitReview\` error; on hit, marks orphan via the existing sentinel and continues. \`slog.Info\` records \`reason\` and \`status\` so the operator log says \"orphaned because pr_locked\" rather than the previous \"retry publish failed\" loop.

- **\`daemon/internal/pipeline/pipeline.go\` (Run)** — same \`errors.As\` check on the initial publish error. A 422 lock during the first \`SubmitReview\` now marks orphan in-place, so the row never enters the PublishPending retry queue. Transient errors still take the existing retry path.

### Tests

3 new client tests:
- \`TestSubmitReview_LockedPRReturnsPermanentSubmitError\`: 422 + lock body → typed error with \`StatusCode=422, Reason=\"pr_locked\"\`, body populated.
- \`TestSubmitReview_TransientErrorIsNotPermanent\`: 503 stays as generic error so retries continue.
- \`TestSubmitReview_422WithoutLockIsNotPermanent\`: 422 with malformed-body error message is NOT classified (guards against over-rotation).

3 new pipeline tests (\`pipeline_orphan_test.go\`):
- \`TestRun_LockedPRMarksReviewOrphanImmediately\`: \`Run\` with a locked PR → row marked orphan in-place, \`ListUnpublishedReviews\` returns empty, subsequent \`PublishPending\` is a no-op.
- \`TestPublishPending_LockedPRStopsRetrying\`: pre-seeded unpublished row → first tick marks orphan, next 3 ticks must NOT re-attempt \`SubmitReview\`.
- \`TestPublishPending_TransientErrorStillRetries\`: 5xx error keeps the row in the queue and \`SubmitReview\` is attempted on every tick (regression guard against over-rotation).

## Test plan

- [x] \`make test-docker\` green across all daemon packages
- [x] All 6 new tests pass
- [ ] Live verification post-merge: tail daemon logs against a real locked PR; expect one \"review marked orphan\" \`INFO\` line and zero subsequent \"retry publish failed\" warnings for that \`review_id\`.

## References

- Closes #325
- Original bug-1 spec from #322 (closed by #324, where the other 3 bugs landed)
- Same \`(-1, \"\")\` orphan sentinel: \`pipeline.go:643-647\` (PRs with no repo)
- Same fail-closed-on-unknown-error posture: #245 / #246 / #258 / #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)