### PR TITLE
feat(nats): SSE bridge over NATS — removes 10-subscriber limit (#309)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -145,6 +145,25 @@ func main() {
 	broker := sse.NewBroker()
 	broker.Start()
 
+	// ── Bridge: SSE broker → NATS events ────────────────────────────────
+	// Re-publishes every broker event to NATS so the SSE handler (which
+	// now reads from NATS) receives events from all existing publishers.
+	// This bridge is interim — Task 12 will have workers publish directly
+	// to NATS events subjects, removing the need for the broker entirely.
+	bridgeCh := broker.Subscribe()
+	if bridgeCh != nil {
+		go func() {
+			for event := range bridgeCh {
+				subj := "heimdallm.events." + event.Type
+				if err := eventBus.Conn().Publish(subj, []byte(event.Data)); err != nil {
+					slog.Warn("sse-bridge: publish to NATS failed", "type", event.Type, "err", err)
+				}
+			}
+		}()
+	} else {
+		slog.Warn("sse-bridge: broker subscriber cap reached, SSE bridge disabled")
+	}
+
 	// ActivityRecorder subscribes to the broker and writes a row into
 	// activity_log for every significant event. Disabled → not constructed.
 	// A nil broker subscription (subscriber cap reached) is a warning, not
@@ -213,6 +232,7 @@ func main() {
 	}
 	issueFetcher := issuepipeline.NewFetcher(ghClient, ghClient, s, issuePipe)
 	srv := server.New(s, broker, p, apiToken)
+	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)
 
 	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -25,12 +25,14 @@ import (
 	"github.com/heimdallm/daemon/internal/pipeline"
 	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
+	"github.com/nats-io/nats.go"
 )
 
 // Server holds the HTTP router, SSE broker, store, and optional pipeline.
 type Server struct {
 	store           *store.Store
 	broker          *sse.Broker
+	natsConn        *nats.Conn // when set, handleSSE reads from NATS instead of broker
 	pipeline        *pipeline.Pipeline
 	router          chi.Router
 	httpServer      *http.Server
@@ -86,6 +88,12 @@ func NewWithOptions(s *store.Store, broker *sse.Broker, p *pipeline.Pipeline, ap
 	}
 	srv.router = srv.buildRouter()
 	return srv
+}
+
+// SetNATSConn enables NATS-based SSE. When set, handleSSE subscribes to
+// NATS events instead of the in-memory broker, removing the 10-subscriber limit.
+func (srv *Server) SetNATSConn(conn *nats.Conn) {
+	srv.natsConn = conn
 }
 
 // sensitiveGETPaths lists GET paths that require authentication even though they
@@ -688,6 +696,13 @@ func (srv *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
+	// When NATS is available, subscribe directly — no subscriber limit.
+	if srv.natsConn != nil {
+		srv.handleSSEViaNATS(w, r, flusher)
+		return
+	}
+
+	// Fallback: use the in-memory broker (legacy path, max 10 subscribers).
 	ch := srv.broker.Subscribe()
 	if ch == nil {
 		http.Error(w, "too many SSE connections", http.StatusServiceUnavailable)
@@ -705,6 +720,37 @@ func (srv *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			fmt.Fprint(w, event.Format())
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+func (srv *Server) handleSSEViaNATS(w http.ResponseWriter, r *http.Request, flusher http.Flusher) {
+	// Core NATS subscription (not JetStream) — ephemeral fan-out, no persistence.
+	ch := make(chan *nats.Msg, 64)
+	sub, err := srv.natsConn.ChanSubscribe("heimdallm.events.>", ch)
+	if err != nil {
+		slog.Error("SSE: NATS subscribe failed", "err", err)
+		http.Error(w, "SSE subscription failed", http.StatusInternalServerError)
+		return
+	}
+	defer sub.Unsubscribe()
+
+	fmt.Fprintf(w, ": connected\n\n")
+	flusher.Flush()
+
+	for {
+		select {
+		case msg := <-ch:
+			// Extract event type from subject: "heimdallm.events.review_completed" → "review_completed"
+			eventType := msg.Subject
+			if idx := len("heimdallm.events."); idx < len(eventType) {
+				eventType = eventType[idx:]
+			}
+			// Format as SSE: the message data is the JSON payload
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, string(msg.Data))
 			flusher.Flush()
 		case <-r.Context().Done():
 			return

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -741,16 +741,18 @@ func (srv *Server) handleSSEViaNATS(w http.ResponseWriter, r *http.Request, flus
 	fmt.Fprintf(w, ": connected\n\n")
 	flusher.Flush()
 
+	// Keep-alive ticker prevents proxies/load balancers from closing idle connections.
+	keepAlive := time.NewTicker(20 * time.Second)
+	defer keepAlive.Stop()
+
 	for {
 		select {
 		case msg := <-ch:
-			// Extract event type from subject: "heimdallm.events.review_completed" → "review_completed"
-			eventType := msg.Subject
-			if idx := len("heimdallm.events."); idx < len(eventType) {
-				eventType = eventType[idx:]
-			}
-			// Format as SSE: the message data is the JSON payload
+			eventType := strings.TrimPrefix(msg.Subject, "heimdallm.events.")
 			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, string(msg.Data))
+			flusher.Flush()
+		case <-keepAlive.C:
+			fmt.Fprintf(w, ": ping\n\n")
 			flusher.Flush()
 		case <-r.Context().Done():
 			return

--- a/docs/superpowers/specs/2026-04-24-sse-bridge-nats-design.md
+++ b/docs/superpowers/specs/2026-04-24-sse-bridge-nats-design.md
@@ -1,0 +1,62 @@
+# SSE Bridge over NATS Design
+
+**Issue:** #298 (epic), #309 (Task 10)  
+**Date:** 2026-04-24  
+**Scope:** Route SSE events through NATS — bridge broker→NATS + SSE handler reads from NATS  
+
+## Overview
+
+Replace the direct broker→SSE handler path with NATS as intermediary. A bridge goroutine subscribes to the existing SSE broker and re-publishes every event to `heimdallm.events.*` subjects in NATS. The HTTP SSE handler (`/events`) subscribes to NATS `heimdallm.events.>` via core NATS (not JetStream) for fan-out. This removes the 10-subscriber limit (NATS handles fan-out natively) and fixes #286 (zombie connections).
+
+## Architecture
+
+```
+Workers → broker.Publish(event)
+              ↓
+SSE Broker (existing, unchanged)
+              ↓ bridge goroutine
+NATS core (heimdallm.events.{type})
+              ↓ subscribe per HTTP client
+handleSSE → SSE wire format → HTTP response
+```
+
+## Changes
+
+### 1. Bridge: broker → NATS
+
+Goroutine in main.go that subscribes to the broker and re-publishes to NATS:
+
+- Subscribes via `broker.Subscribe()` (uses one of the 10 broker slots)
+- For each event, publishes to `heimdallm.events.{event.Type}` via core NATS `conn.Publish`
+- The event data is published as-is (already JSON string from `sseData()`)
+- Uses core NATS (not JetStream) — events are ephemeral, no persistence needed
+
+### 2. SSE handler reads from NATS
+
+`handleSSE` changes from reading a broker channel to subscribing to NATS:
+
+- Creates a core NATS subscription on `heimdallm.events.>`
+- Each incoming NATS message is formatted as SSE and flushed to the HTTP client
+- When the HTTP client disconnects (`r.Context().Done()`), the subscription is cleaned up
+- No subscriber limit — NATS handles unlimited fan-out
+
+### 3. Server gets NATS connection
+
+The `Server` struct receives a `*nats.Conn` (or nil for backward compat in tests). When conn is set, `handleSSE` uses NATS. When nil, falls back to the broker (existing behavior).
+
+## Files Changed
+
+| Action | File | What |
+|--------|------|------|
+| Modify | `daemon/internal/server/handlers.go` | Add conn field, handleSSE reads from NATS |
+| Modify | `daemon/cmd/heimdallm/main.go` | Bridge goroutine, pass conn to server |
+
+## Testing
+
+1. Server test with mock NATS — publish event, verify SSE output
+2. Smoke test — Flutter UI receives events in real-time
+
+## Out of Scope
+
+- Removing the SSE broker entirely (Task 12 — still used by ActivityRecorder)
+- Removing broker.Publish calls from workers (Task 12)


### PR DESCRIPTION
## Summary

- Bridge goroutine re-publishes SSE broker events to NATS `heimdallm.events.*` subjects
- `handleSSE` reads from NATS via core `ChanSubscribe("heimdallm.events.>")` when conn is set
- No subscriber limit — NATS handles unlimited fan-out (fixes #286)
- Backward compatible: falls back to broker when NATS conn is nil (tests unaffected)
- `Server.SetNATSConn()` setter for injecting the NATS connection

**Part of:** #298 (epic: embed NATS in backend)  
**Closes:** #309  
**Fixes:** #286

## Test plan

- [ ] `go test ./internal/server/ -count=1` — all existing tests pass (broker fallback)
- [ ] `go test ./... -count=1` — full suite passes
- [ ] Smoke test: daemon starts, SSE events flow through NATS bridge to clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)