### PR TITLE
feat(nats): rate limiter integration with NATS workers (#310)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -525,6 +525,14 @@ func main() {
 	// existing review pipeline. This replaces the goroutine-per-PR
 	// pattern that Tier 2 used to use.
 	reviewHandler := func(ctx context.Context, msg bus.PRReviewMsg) {
+		cfgMu.Lock()
+		limiter := pipe.Limiter()
+		cfgMu.Unlock()
+		if err := limiter.Acquire(ctx, scheduler.TierRepo); err != nil {
+			slog.Warn("review-worker: rate limit cancelled", "err", err)
+			return
+		}
+
 		pr, err := ghClient.GetPR(msg.Repo, msg.Number)
 		if err != nil {
 			slog.Error("review-worker: fetch PR from GitHub",
@@ -616,6 +624,13 @@ func main() {
 			Summary:  rev.Summary,
 			Issues:   issues,
 			Severity: rev.Severity,
+		}
+
+		cfgMu.Lock()
+		limiter := pipe.Limiter()
+		cfgMu.Unlock()
+		if err := limiter.Acquire(ctx, scheduler.TierRepo); err != nil {
+			return fmt.Errorf("rate limit cancelled: %w", err)
 		}
 
 		ghID, ghState, err := ghClient.SubmitReview(
@@ -868,6 +883,13 @@ func main() {
 		} else {
 			slog.Warn("state-handler: KV get failed, using zero LastSeen",
 				"key", key, "err", err)
+		}
+
+		cfgMu.Lock()
+		limiter := pipe.Limiter()
+		cfgMu.Unlock()
+		if err := limiter.Acquire(ctx, scheduler.TierWatch); err != nil {
+			return false, fmt.Errorf("rate limit cancelled: %w", err)
 		}
 
 		changed, snap, err := adapter.CheckItem(ctx, item)

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -528,8 +528,10 @@ func main() {
 		cfgMu.Lock()
 		limiter := pipe.Limiter()
 		cfgMu.Unlock()
+		// Acquire returns only ctx.Err() (shutdown). On cancellation the
+		// message is acked without processing — acceptable because the
+		// daemon is shutting down and the PR will be re-detected next startup.
 		if err := limiter.Acquire(ctx, scheduler.TierRepo); err != nil {
-			slog.Warn("review-worker: rate limit cancelled", "err", err)
 			return
 		}
 
@@ -867,6 +869,15 @@ func main() {
 	// Consumes state check requests, calls GitHub API, updates KV backoff.
 	// Reuses the existing CheckItem/HandleChange logic from tier2Adapter.
 	stateHandler := func(ctx context.Context, msg bus.StateCheckMsg) (bool, error) {
+		// Rate limit before any GitHub API call. TierWatch (50ms) matches
+		// the old Tier 3 priority — state checks are lightweight and high-priority.
+		cfgMu.Lock()
+		limiter := pipe.Limiter()
+		cfgMu.Unlock()
+		if err := limiter.Acquire(ctx, scheduler.TierWatch); err != nil {
+			return false, fmt.Errorf("rate limit cancelled: %w", err)
+		}
+
 		item := &scheduler.WatchItem{
 			Type:     msg.Type,
 			Repo:     msg.Repo,
@@ -883,13 +894,6 @@ func main() {
 		} else {
 			slog.Warn("state-handler: KV get failed, using zero LastSeen",
 				"key", key, "err", err)
-		}
-
-		cfgMu.Lock()
-		limiter := pipe.Limiter()
-		cfgMu.Unlock()
-		if err := limiter.Acquire(ctx, scheduler.TierWatch); err != nil {
-			return false, fmt.Errorf("rate limit cancelled: %w", err)
 		}
 
 		changed, snap, err := adapter.CheckItem(ctx, item)

--- a/daemon/internal/scheduler/pipeline.go
+++ b/daemon/internal/scheduler/pipeline.go
@@ -248,3 +248,8 @@ func (p *Pipeline) Stop() {
 func (p *Pipeline) Queue() *WatchQueue {
 	return p.queue
 }
+
+// Limiter returns the shared rate limiter for external callers (e.g. NATS workers).
+func (p *Pipeline) Limiter() *RateLimiter {
+	return p.limiter
+}

--- a/docs/superpowers/specs/2026-04-24-rate-limiter-nats-design.md
+++ b/docs/superpowers/specs/2026-04-24-rate-limiter-nats-design.md
@@ -12,30 +12,29 @@ NATS `MaxAckPending` controls concurrency (how many workers run simultaneously).
 
 ## Changes
 
-### 1. Expose rate limiter to workers
+### 1. Expose rate limiter via Pipeline.Limiter()
 
-The `RateLimiter` is currently created inside `Pipeline.NewPipeline()`. For workers to use it, create a shared limiter in main.go and pass it to both the pipeline and the workers.
+Add a `Limiter() *RateLimiter` accessor to `Pipeline` (same pattern as `Queue()`). Workers access the shared limiter via `pipe.Limiter()` under `cfgMu` to handle config reloads.
 
 ### 2. Add Acquire to worker handlers
 
-In each worker handler closure in main.go, call `limiter.Acquire(ctx, scheduler.TierRepo)` before the GitHub API call:
+In each worker handler closure in main.go, call `limiter.Acquire()` at the top before any GitHub API call:
 
-- **reviewHandler**: before `ghClient.GetPR()`
-- **publishHandler**: before `ghClient.SubmitReview()`
-- **stateHandler**: before `adapter.CheckItem()`
+- **reviewHandler**: `TierRepo` (200ms) before `ghClient.GetPR()`
+- **publishHandler**: `TierRepo` (200ms) before `ghClient.SubmitReview()`
+- **stateHandler**: `TierWatch` (50ms) before `adapter.CheckItem()` — matches old Tier 3 priority since state checks are lightweight and high-priority
 
-Use `TierRepo` priority for all workers — they're equivalent to Tier 2 processing.
-
-### 3. Share limiter between pipeline and workers
-
-Create the limiter in main.go before `buildPipeline`, pass it to the pipeline config. Workers use the same instance.
+`Acquire` only returns `ctx.Err()` (shutdown). On cancellation:
+- reviewHandler: returns silently (ack — daemon shutting down, PR re-detected next startup)
+- publishHandler: returns wrapped error (nak — transient retry)
+- stateHandler: returns `(false, error)` (nak — backoff increased)
 
 ## Files Changed
 
 | Action | File | What |
 |--------|------|------|
-| Modify | `daemon/internal/scheduler/pipeline.go` | Accept external limiter in PipelineConfig |
-| Modify | `daemon/cmd/heimdallm/main.go` | Create shared limiter, pass to pipeline + workers |
+| Modify | `daemon/internal/scheduler/pipeline.go` | Add Limiter() accessor |
+| Modify | `daemon/cmd/heimdallm/main.go` | Add Acquire calls to 3 worker handlers |
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-04-24-rate-limiter-nats-design.md
+++ b/docs/superpowers/specs/2026-04-24-rate-limiter-nats-design.md
@@ -1,0 +1,43 @@
+# Rate Limiter Integration with NATS Design
+
+**Issue:** #298 (epic), #310 (Task 11)  
+**Date:** 2026-04-24  
+**Scope:** Add rate limiter to NATS workers that make GitHub API calls  
+
+## Overview
+
+Keep the existing token-bucket rate limiter as middleware. The pollers (Tier 1+2) already use it. Add it to the NATS worker handlers that make GitHub API calls: review worker (GetPR), publish worker (SubmitReview), and state worker (CheckItem).
+
+NATS `MaxAckPending` controls concurrency (how many workers run simultaneously). The rate limiter controls API call rate (how many GitHub calls per hour). They complement each other.
+
+## Changes
+
+### 1. Expose rate limiter to workers
+
+The `RateLimiter` is currently created inside `Pipeline.NewPipeline()`. For workers to use it, create a shared limiter in main.go and pass it to both the pipeline and the workers.
+
+### 2. Add Acquire to worker handlers
+
+In each worker handler closure in main.go, call `limiter.Acquire(ctx, scheduler.TierRepo)` before the GitHub API call:
+
+- **reviewHandler**: before `ghClient.GetPR()`
+- **publishHandler**: before `ghClient.SubmitReview()`
+- **stateHandler**: before `adapter.CheckItem()`
+
+Use `TierRepo` priority for all workers — they're equivalent to Tier 2 processing.
+
+### 3. Share limiter between pipeline and workers
+
+Create the limiter in main.go before `buildPipeline`, pass it to the pipeline config. Workers use the same instance.
+
+## Files Changed
+
+| Action | File | What |
+|--------|------|------|
+| Modify | `daemon/internal/scheduler/pipeline.go` | Accept external limiter in PipelineConfig |
+| Modify | `daemon/cmd/heimdallm/main.go` | Create shared limiter, pass to pipeline + workers |
+
+## Out of Scope
+
+- Replacing the token bucket with NATS-native rate limiting
+- Per-worker rate limit configuration


### PR DESCRIPTION
## Summary

- Add `Pipeline.Limiter()` accessor to expose the shared rate limiter
- Add `Acquire()` calls in NATS worker handlers before GitHub API calls:
  - **reviewHandler**: `TierRepo` before `GetPR()`
  - **publishHandler**: `TierRepo` before `SubmitReview()`
  - **stateHandler**: `TierWatch` before `CheckItem()`
- Limiter read under `cfgMu` to handle config reloads safely
- NATS `MaxAckPending` controls concurrency, rate limiter controls API call rate — they complement each other

**Part of:** #298 (epic: embed NATS in backend)  
**Closes:** #310

## Test plan

- [ ] `go test ./... -count=1` — full suite passes
- [ ] Smoke test: workers respect rate limit under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)