### PR TITLE
fix: issue re-triage loop + locked PR publish retry (#322)

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -513,14 +513,20 @@ func (c *Client) FetchComments(repo string, number int) ([]Comment, error) {
 
 	r1 := <-reviewCh
 	r2 := <-issueCh
-	if r1.err != nil {
+	// Review comments (pulls API) return 404 for issues — this is expected.
+	// Treat as empty rather than fatal so issue marker scanning works.
+	if r1.err != nil && !strings.Contains(r1.err.Error(), "status 404") {
 		return nil, r1.err
 	}
 	if r2.err != nil {
 		return nil, r2.err
 	}
 
-	all := append(r1.comments, r2.comments...)
+	var all []Comment
+	if r1.err == nil {
+		all = append(all, r1.comments...)
+	}
+	all = append(all, r2.comments...)
 	sort.Slice(all, func(i, j int) bool {
 		return all[i].CreatedAt.Before(all[j].CreatedAt)
 	})

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -475,6 +475,15 @@ func (p *Pipeline) PublishPending() {
 			SeverityToEvent(rev.Severity, len(issues)),
 		)
 		if err != nil {
+			errStr := err.Error()
+			// 422 "lock prevents review" and other 4xx (except 429 rate limit)
+			// are permanent — mark as orphaned to stop infinite retry.
+			if strings.Contains(errStr, "status 4") && !strings.Contains(errStr, "status 429") {
+				slog.Warn("pipeline: permanent publish failure, marking orphaned",
+					"review_id", rev.ID, "err", err)
+				_ = p.store.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
+				continue
+			}
 			slog.Warn("pipeline: retry publish failed", "review_id", rev.ID, "err", err)
 			continue
 		}


### PR DESCRIPTION
## Summary

Fixes two infinite-loop bugs observed in production logs:

**Bug 1: Issue #144 re-triaged every poll cycle**
- `FetchComments` called the pulls review-comments API (`/pulls/N/comments`) which returns 404 for issues (not PRs)
- The 404 killed the marker scanner, falling through to dedup checks that couldn't catch the re-triage
- **Fix:** Treat 404 from review-comments as empty (no review comments on issues is expected)

**Bug 2: Review #681 PublishPending retried 422 indefinitely**
- `PublishPending()` treated all GitHub errors as transient, retrying every poll cycle
- 422 "lock prevents review" is permanent — the PR's conversation is locked
- **Fix:** Treat 4xx (except 429 rate limit) as permanent failures, mark review as orphaned

**Closes:** #322

## Test plan

- [ ] `go test ./internal/github/ ./internal/pipeline/ -count=1` — tests pass
- [ ] `go test ./... -count=1` — full suite passes
- [ ] Smoke test: issue #144 no longer re-triages every cycle, review #681 stops retrying

🤖 Generated with [Claude Code](https://claude.com/claude-code)