### PR TITLE
fix: enroll all processed items in watch_state (#352)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -512,6 +512,7 @@ func main() {
 		login:                &cachedLogin,
 		runReview:            runReview,
 		publishPub:           publishPub,
+		watchStore:           watchStore,
 		lastSkippedUpdatedAt: make(map[int64]time.Time),
 	}
 
@@ -836,6 +837,12 @@ func main() {
 			slog.Error("triage-worker: pipeline run failed",
 				"repo", msg.Repo, "number", msg.Number, "err", err)
 		}
+
+		// Enroll for state watching so closed/resolved issues update in the UI.
+		if err := watchStore.Enroll(ctx, "issue", msg.Repo, msg.Number, msg.GithubID); err != nil {
+			slog.Warn("triage-worker: failed to enroll watch",
+				"repo", msg.Repo, "number", msg.Number, "err", err)
+		}
 	}
 
 	triageW := worker.NewTriageWorker(conn, maxWorkers, triageHandler)
@@ -912,6 +919,12 @@ func main() {
 
 		if _, err := issuePipe.Run(ctx, ghIssue, opts); err != nil {
 			slog.Error("implement-worker: pipeline run failed",
+				"repo", msg.Repo, "number", msg.Number, "err", err)
+		}
+
+		// Enroll for state watching so closed/resolved issues update in the UI.
+		if err := watchStore.Enroll(ctx, "issue", msg.Repo, msg.Number, msg.GithubID); err != nil {
+			slog.Warn("implement-worker: failed to enroll watch",
 				"repo", msg.Repo, "number", msg.Number, "err", err)
 		}
 	}
@@ -1904,6 +1917,7 @@ type tier2Adapter struct {
 	login     *string
 	runReview  func(pr *gh.PullRequest, aiCfg config.RepoAI) *store.Review
 	publishPub *bus.PRPublishPublisher
+	watchStore *bus.WatchStore
 
 	// skipMu protects lastSkippedUpdatedAt, which deduplicates review_skipped
 	// SSE events across consecutive poll cycles for the same (PR ID, updated_at)
@@ -2210,6 +2224,9 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 		if err := a.publishPub.PublishPRPublish(context.Background(), rev.ID); err != nil {
 			slog.Warn("ProcessPR: failed to enqueue publish", "review_id", rev.ID, "err", err)
 		}
+	}
+	if a.watchStore != nil {
+		a.watchStore.Enroll(context.Background(), "pr", pr.Repo, pr.Number, pr.ID)
 	}
 	return nil
 }
@@ -2518,6 +2535,9 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 			if err := a.publishPub.PublishPRPublish(context.Background(), rev.ID); err != nil {
 				slog.Warn("HandleChange: failed to enqueue publish", "review_id", rev.ID, "err", err)
 			}
+		}
+		if a.watchStore != nil {
+			a.watchStore.Enroll(context.Background(), "pr", item.Repo, item.Number, item.GithubID)
 		}
 		return nil
 	}

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2226,7 +2226,9 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 		}
 	}
 	if a.watchStore != nil {
-		a.watchStore.Enroll(context.Background(), "pr", pr.Repo, pr.Number, pr.ID)
+		if err := a.watchStore.Enroll(ctx, "pr", pr.Repo, pr.Number, pr.ID); err != nil {
+			slog.Warn("ProcessPR: failed to enroll watch", "repo", pr.Repo, "pr", pr.Number, "err", err)
+		}
 	}
 	return nil
 }
@@ -2537,7 +2539,9 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 			}
 		}
 		if a.watchStore != nil {
-			a.watchStore.Enroll(context.Background(), "pr", item.Repo, item.Number, item.GithubID)
+			if err := a.watchStore.Enroll(ctx, "pr", item.Repo, item.Number, item.GithubID); err != nil {
+				slog.Warn("HandleChange: failed to enroll watch", "repo", item.Repo, "pr", item.Number, "err", err)
+			}
 		}
 		return nil
 	}

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -839,6 +839,8 @@ func main() {
 		}
 
 		// Enroll for state watching so closed/resolved issues update in the UI.
+		// Runs even after pipeline failure — state tracking is independent of
+		// pipeline success, and we want the UI to reflect closures regardless.
 		if err := watchStore.Enroll(ctx, "issue", msg.Repo, msg.Number, msg.GithubID); err != nil {
 			slog.Warn("triage-worker: failed to enroll watch",
 				"repo", msg.Repo, "number", msg.Number, "err", err)
@@ -923,6 +925,8 @@ func main() {
 		}
 
 		// Enroll for state watching so closed/resolved issues update in the UI.
+		// Runs even after pipeline failure — state tracking is independent of
+		// pipeline success, and we want the UI to reflect closures regardless.
 		if err := watchStore.Enroll(ctx, "issue", msg.Repo, msg.Number, msg.GithubID); err != nil {
 			slog.Warn("implement-worker: failed to enroll watch",
 				"repo", msg.Repo, "number", msg.Number, "err", err)


### PR DESCRIPTION
## Summary

All processed items (PRs and issues) now get enrolled in watch_state so the state poller detects closures/merges.

Previously only the NATS review worker enrolled PRs. Issues were never enrolled — their state stayed `open` forever in the UI.

**Added enrollment in:**
- triageHandler (issues after triage)
- implementHandler (issues after implement)
- ProcessPR (PRs from Tier 2 path)
- HandleChange (PRs from state check re-review)

**Closes:** #352

## Test plan

- [ ] `go test ./... -count=1` — passes
- [ ] After deploy: closed issues update in the Activity tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)