### PR TITLE
fix: startup scan enrolls open PRs/issues in watch_state

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2777,17 +2777,25 @@ func enrollOpenItems(s *store.Store, ws *bus.WatchStore) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("query open prs: %w", err)
 	}
-	defer rows.Close()
 	for rows.Next() {
 		var ghID int64
 		var repo string
 		var number int
 		if err := rows.Scan(&ghID, &repo, &number); err != nil {
+			slog.Warn("startup-enroll: scan PR failed", "err", err)
 			continue
 		}
-		if added, err := ws.EnrollIfAbsent(ctx, "pr", repo, number, ghID); err == nil && added {
+		added, err := ws.EnrollIfAbsent(ctx, "pr", repo, number, ghID)
+		if err != nil {
+			slog.Warn("startup-enroll: enroll PR failed", "repo", repo, "number", number, "err", err)
+			continue
+		}
+		if added {
 			enrolled++
 		}
+	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("startup-enroll: PR iteration error", "err", err)
 	}
 	rows.Close()
 
@@ -2796,18 +2804,27 @@ func enrollOpenItems(s *store.Store, ws *bus.WatchStore) (int, error) {
 	if err != nil {
 		return enrolled, fmt.Errorf("query open issues: %w", err)
 	}
-	defer rows2.Close()
 	for rows2.Next() {
 		var ghID int64
 		var repo string
 		var number int
 		if err := rows2.Scan(&ghID, &repo, &number); err != nil {
+			slog.Warn("startup-enroll: scan issue failed", "err", err)
 			continue
 		}
-		if added, err := ws.EnrollIfAbsent(ctx, "issue", repo, number, ghID); err == nil && added {
+		added, err := ws.EnrollIfAbsent(ctx, "issue", repo, number, ghID)
+		if err != nil {
+			slog.Warn("startup-enroll: enroll issue failed", "repo", repo, "number", number, "err", err)
+			continue
+		}
+		if added {
 			enrolled++
 		}
 	}
+	if err := rows2.Err(); err != nil {
+		slog.Warn("startup-enroll: issue iteration error", "err", err)
+	}
+	rows2.Close()
 
 	return enrolled, nil
 }

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -156,6 +156,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Enroll any open PRs/issues not yet in watch_state so the state
+	// poller picks them up. Covers items processed before the NATS
+	// migration that were never enrolled.
+	if enrolled, err := enrollOpenItems(s, watchStore); err != nil {
+		slog.Warn("startup: enroll open items failed", "err", err)
+	} else if enrolled > 0 {
+		slog.Info("startup: enrolled open items into watch_state", "count", enrolled)
+	}
+
 	broker := sse.NewBroker()
 	broker.Start()
 
@@ -2754,4 +2763,51 @@ func ptrIntOr(p *int, defaultV int) int {
 		return defaultV
 	}
 	return *p
+}
+
+// enrollOpenItems scans all open PRs and issues in the store and enrolls
+// them in watch_state if not already present. This backfills items that
+// were processed before the NATS migration introduced watch_state.
+func enrollOpenItems(s *store.Store, ws *bus.WatchStore) (int, error) {
+	ctx := context.Background()
+	enrolled := 0
+
+	// Open PRs
+	rows, err := s.DB().Query("SELECT github_id, repo, number FROM prs WHERE state='open'")
+	if err != nil {
+		return 0, fmt.Errorf("query open prs: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var ghID int64
+		var repo string
+		var number int
+		if err := rows.Scan(&ghID, &repo, &number); err != nil {
+			continue
+		}
+		if added, err := ws.EnrollIfAbsent(ctx, "pr", repo, number, ghID); err == nil && added {
+			enrolled++
+		}
+	}
+	rows.Close()
+
+	// Open issues
+	rows2, err := s.DB().Query("SELECT github_id, repo, number FROM issues WHERE state='open'")
+	if err != nil {
+		return enrolled, fmt.Errorf("query open issues: %w", err)
+	}
+	defer rows2.Close()
+	for rows2.Next() {
+		var ghID int64
+		var repo string
+		var number int
+		if err := rows2.Scan(&ghID, &repo, &number); err != nil {
+			continue
+		}
+		if added, err := ws.EnrollIfAbsent(ctx, "issue", repo, number, ghID); err == nil && added {
+			enrolled++
+		}
+	}
+
+	return enrolled, nil
 }

--- a/daemon/internal/bus/watch.go
+++ b/daemon/internal/bus/watch.go
@@ -84,6 +84,25 @@ func (w *WatchStore) Enroll(_ context.Context, typ, repo string, number int, git
 	return nil
 }
 
+// EnrollIfAbsent adds an item only if it's not already in the watch list.
+// Returns true if enrolled, false if already present.
+func (w *WatchStore) EnrollIfAbsent(_ context.Context, typ, repo string, number int, githubID int64) (bool, error) {
+	key := fmt.Sprintf("%s.%d", typ, githubID)
+	now := time.Now()
+	nextCheck := now.Add(InitialBackoff)
+	res, err := w.db.Exec(`
+		INSERT OR IGNORE INTO watch_state (key, type, repo, number, github_id, next_check, backoff_ns, last_seen)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		key, typ, repo, number, githubID,
+		nextCheck.Format(timeFormat), int64(InitialBackoff), now.Format(timeFormat),
+	)
+	if err != nil {
+		return false, fmt.Errorf("watch: enroll-if-absent %s: %w", key, err)
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
 // Get retrieves a single watch entry by key.
 func (w *WatchStore) Get(_ context.Context, key string) (*WatchEntry, error) {
 	var entry WatchEntry


### PR DESCRIPTION
## Summary

On daemon startup, scans all PRs and issues with `state=open` in the store and enrolls them in `watch_state` using `INSERT OR IGNORE` — items already enrolled are not touched.

This backfills items processed before the NATS migration that were never enrolled in watch_state, so the state poller detects when they close on GitHub and updates the UI.

### Changes
- `WatchStore.EnrollIfAbsent()` — new method, `INSERT OR IGNORE` (doesn't reset backoff on existing items)
- `enrollOpenItems()` in main.go — startup scan, runs after watch store init

## Test plan

- [ ] `go test ./... -count=1` — passes
- [ ] On startup with stale open items: log shows `"enrolled open items into watch_state" count=N`
- [ ] After 30s (state poller tick): stale items get checked and updated to closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)