### PR TITLE
fix: auto-dismiss legacy items with empty repo from watch_state

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -988,7 +988,9 @@ func main() {
 		// Auto-dismiss legacy items with missing data — they can never be checked.
 		if msg.Repo == "" {
 			key := fmt.Sprintf("%s.%d", msg.Type, msg.GithubID)
-			watchStore.Delete(ctx, key)
+			if err := watchStore.Delete(ctx, key); err != nil {
+				slog.Warn("state-handler: failed to delete legacy item", "key", key, "err", err)
+			}
 			slog.Info("state-handler: auto-dismissed legacy item with empty repo",
 				"type", msg.Type, "number", msg.Number, "github_id", msg.GithubID)
 			return false, nil
@@ -1022,7 +1024,9 @@ func main() {
 			// 404 means the repo/PR was deleted or we don't have access.
 			// Remove from watch to stop retrying.
 			if strings.Contains(err.Error(), "status 404") {
-				watchStore.Delete(ctx, key)
+				if delErr := watchStore.Delete(ctx, key); delErr != nil {
+					slog.Warn("state-handler: failed to delete unreachable item", "key", key, "err", delErr)
+				}
 				slog.Info("state-handler: removed unreachable item from watch",
 					"type", msg.Type, "repo", msg.Repo, "number", msg.Number)
 				return false, nil
@@ -2806,9 +2810,13 @@ func enrollOpenItems(s *store.Store, ws *bus.WatchStore) {
 		for rows.Next() {
 			var it item
 			if err := rows.Scan(&it.ghID, &it.repo, &it.number); err != nil {
+				slog.Warn("state-poller: backfill scan failed", "type", q.typ, "err", err)
 				continue
 			}
 			batch = append(batch, it)
+		}
+		if err := rows.Err(); err != nil {
+			slog.Warn("state-poller: backfill iteration error", "type", q.typ, "err", err)
 		}
 		rows.Close() // close before writing to avoid SQLite lock contention
 

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -958,7 +958,7 @@ func main() {
 			case <-ticker.C:
 				// Gradually enroll one open item not yet in watch_state per tick.
 				// Backfills items from before the NATS migration without blocking startup.
-				enrollOneOpenItem(s, watchStore)
+				enrollOpenItems(s, watchStore)
 
 				if evicted, err := watchStore.EvictStale(statePollerCtx); err != nil {
 					slog.Warn("state-poller: evict failed", "err", err)
@@ -985,6 +985,15 @@ func main() {
 	// Consumes state check requests, calls GitHub API, updates KV backoff.
 	// Reuses the existing CheckItem/HandleChange logic from tier2Adapter.
 	stateHandler := func(ctx context.Context, msg bus.StateCheckMsg) (bool, error) {
+		// Auto-dismiss legacy items with missing data — they can never be checked.
+		if msg.Repo == "" {
+			key := fmt.Sprintf("%s.%d", msg.Type, msg.GithubID)
+			watchStore.Delete(ctx, key)
+			slog.Info("state-handler: auto-dismissed legacy item with empty repo",
+				"type", msg.Type, "number", msg.Number, "github_id", msg.GithubID)
+			return false, nil
+		}
+
 		// Rate limit before any GitHub API call. TierWatch (50ms) matches
 		// the old Tier 3 priority — state checks are lightweight and high-priority.
 		if err := limiter.Acquire(ctx, scheduler.TierWatch); err != nil {
@@ -999,7 +1008,6 @@ func main() {
 		}
 
 		// Read LastSeen from KV for the dedup check inside CheckItem.
-		// Key separator is "." (NATS KV doesn't allow ":").
 		key := fmt.Sprintf("%s.%d", msg.Type, msg.GithubID)
 		entry, err := watchStore.Get(ctx, key)
 		if err == nil {
@@ -1011,6 +1019,14 @@ func main() {
 
 		changed, snap, err := adapter.CheckItem(ctx, item)
 		if err != nil {
+			// 404 means the repo/PR was deleted or we don't have access.
+			// Remove from watch to stop retrying.
+			if strings.Contains(err.Error(), "status 404") {
+				watchStore.Delete(ctx, key)
+				slog.Info("state-handler: removed unreachable item from watch",
+					"type", msg.Type, "repo", msg.Repo, "number", msg.Number)
+				return false, nil
+			}
 			return false, err
 		}
 		if !changed {
@@ -2760,11 +2776,11 @@ func ptrIntOr(p *int, defaultV int) int {
 	return *p
 }
 
-// enrollOneOpenItem finds one open PR or issue not yet in watch_state and
-// enrolls it. Called once per state-poller tick (every 30s) to gradually
-// backfill items from before the NATS migration without blocking startup.
-// Uses a single query with LEFT JOIN to avoid holding a read lock while writing.
-func enrollOneOpenItem(s *store.Store, ws *bus.WatchStore) {
+// enrollOpenItems enrolls up to 10 open PRs/issues not yet in watch_state.
+// Called once per state-poller tick (every 30s) to gradually backfill items
+// from before the NATS migration. Uses a batch query with LEFT JOIN to find
+// unenrolled items without holding a read lock during writes.
+func enrollOpenItems(s *store.Store, ws *bus.WatchStore) {
 	ctx := context.Background()
 	for _, q := range []struct {
 		typ   string
@@ -2772,23 +2788,38 @@ func enrollOneOpenItem(s *store.Store, ws *bus.WatchStore) {
 	}{
 		{"pr", `SELECT p.github_id, p.repo, p.number FROM prs p
 			LEFT JOIN watch_state w ON w.key = 'pr.' || p.github_id
-			WHERE p.state='open' AND w.key IS NULL LIMIT 1`},
+			WHERE p.state='open' AND p.repo != '' AND w.key IS NULL LIMIT 10`},
 		{"issue", `SELECT i.github_id, i.repo, i.number FROM issues i
 			LEFT JOIN watch_state w ON w.key = 'issue.' || i.github_id
-			WHERE i.state='open' AND w.key IS NULL LIMIT 1`},
+			WHERE i.state='open' AND i.repo != '' AND w.key IS NULL LIMIT 10`},
 	} {
-		var ghID int64
-		var repo string
-		var number int
-		err := s.DB().QueryRow(q.query).Scan(&ghID, &repo, &number)
+		rows, err := s.DB().Query(q.query)
 		if err != nil {
-			continue // no rows or error — try next type
+			continue
 		}
-		if err := ws.Enroll(ctx, q.typ, repo, number, ghID); err != nil {
-			slog.Warn("state-poller: backfill enroll failed", "type", q.typ, "repo", repo, "number", number, "err", err)
-			return
+		type item struct {
+			ghID   int64
+			repo   string
+			number int
 		}
-		slog.Debug("state-poller: backfill enrolled", "type", q.typ, "repo", repo, "number", number)
-		return
+		var batch []item
+		for rows.Next() {
+			var it item
+			if err := rows.Scan(&it.ghID, &it.repo, &it.number); err != nil {
+				continue
+			}
+			batch = append(batch, it)
+		}
+		rows.Close() // close before writing to avoid SQLite lock contention
+
+		for _, it := range batch {
+			if err := ws.Enroll(ctx, q.typ, it.repo, it.number, it.ghID); err != nil {
+				slog.Warn("state-poller: backfill enroll failed", "type", q.typ, "repo", it.repo, "number", it.number, "err", err)
+				return
+			}
+		}
+		if len(batch) > 0 {
+			slog.Debug("state-poller: backfill enrolled", "type", q.typ, "count", len(batch))
+		}
 	}
 }

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -958,7 +958,7 @@ func main() {
 			case <-ticker.C:
 				// Gradually enroll one open item not yet in watch_state per tick.
 				// Backfills items from before the NATS migration without blocking startup.
-				enrollOpenItems(s, watchStore)
+				enrollOpenItems(statePollerCtx, s, watchStore)
 
 				if evicted, err := watchStore.EvictStale(statePollerCtx); err != nil {
 					slog.Warn("state-poller: evict failed", "err", err)
@@ -1023,7 +1023,8 @@ func main() {
 		if err != nil {
 			// 404 means the repo/PR was deleted or we don't have access.
 			// Remove from watch to stop retrying.
-			if strings.Contains(err.Error(), "status 404") {
+			var apiErr *gh.APIError
+			if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
 				if delErr := watchStore.Delete(ctx, key); delErr != nil {
 					slog.Warn("state-handler: failed to delete unreachable item", "key", key, "err", delErr)
 				}
@@ -2784,8 +2785,7 @@ func ptrIntOr(p *int, defaultV int) int {
 // Called once per state-poller tick (every 30s) to gradually backfill items
 // from before the NATS migration. Uses a batch query with LEFT JOIN to find
 // unenrolled items without holding a read lock during writes.
-func enrollOpenItems(s *store.Store, ws *bus.WatchStore) {
-	ctx := context.Background()
+func enrollOpenItems(ctx context.Context, s *store.Store, ws *bus.WatchStore) {
 	for _, q := range []struct {
 		typ   string
 		query string
@@ -2823,7 +2823,7 @@ func enrollOpenItems(s *store.Store, ws *bus.WatchStore) {
 		for _, it := range batch {
 			if err := ws.Enroll(ctx, q.typ, it.repo, it.number, it.ghID); err != nil {
 				slog.Warn("state-poller: backfill enroll failed", "type", q.typ, "repo", it.repo, "number", it.number, "err", err)
-				return
+				break // skip rest of this type, try next type
 			}
 		}
 		if len(batch) > 0 {

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -192,6 +192,17 @@ func (c *Client) fetchByQualifier(username, qualifier string, repos []string) ([
 	return result.Items, nil
 }
 
+// APIError is an HTTP error from the GitHub API with a typed StatusCode.
+// Used by callers to detect specific error classes (e.g. 404 Not Found).
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("github: API error (status %d): %s", e.StatusCode, e.Body)
+}
+
 // PermanentSubmitError signals that SubmitReview hit a state from
 // which no retry will recover — e.g. the PR's conversation is locked,
 // the PR has been deleted, or the repo was archived. Callers should
@@ -486,7 +497,7 @@ func (c *Client) GetPRSnapshot(repo string, number int) (*PRSnapshot, error) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if resp.StatusCode != http.StatusOK {
 		errBody := safeTruncate(string(body), maxErrBodyLen)
-		return nil, fmt.Errorf("github: get PR snapshot (%s #%d): status %d: %s", repo, number, resp.StatusCode, errBody)
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: errBody}
 	}
 	var pr PullRequest
 	if err := json.Unmarshal(body, &pr); err != nil {

--- a/daemon/internal/github/repos.go
+++ b/daemon/internal/github/repos.go
@@ -191,7 +191,7 @@ func (c *Client) GetIssue(repo string, number int) (*Issue, error) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("github: get issue %s#%d: status %d: %s", repo, number, resp.StatusCode, safeTruncate(string(body), maxErrBodyLen))
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: safeTruncate(string(body), maxErrBodyLen)}
 	}
 	var issue Issue
 	if err := json.Unmarshal(body, &issue); err != nil {


### PR DESCRIPTION
## Summary

Legacy PRs with empty `repo` field were being enrolled into watch_state by the backfill process. The state worker tried to check them via GitHub API, got 404, and logged warnings every 30s indefinitely.

**Fixes:**
- `enrollOpenItems` query: `AND p.repo != ''` — skip items without repo
- State handler: auto-delete items with empty repo from watch_state
- State handler: remove items that return 404 from GitHub (deleted repos, revoked access)
- Fixed `enrollOneOpenItem` → `enrollOpenItems` function name mismatch

## Test plan

- [ ] `go test ./... -count=1` — passes
- [ ] No more 404 spam in logs for legacy items

🤖 Generated with [Claude Code](https://claude.com/claude-code)