### PR TITLE
fix(issues): break re-triage loop by detecting bot own comments (closes #362)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -260,7 +260,9 @@ func main() {
 	issuePipe.SetCircuitBreakerLimits(&issueCBLimits)
 
 	// Resolve bot login for re-review / re-triage context filtering.
+	var resolvedBotLogin string
 	if login, err := ghClient.AuthenticatedUser(); err == nil {
+		resolvedBotLogin = login
 		p.SetBotLogin(login)
 		issuePipe.SetBotLogin(login)
 		slog.Info("bot login resolved", "login", login)
@@ -268,6 +270,7 @@ func main() {
 		slog.Warn("could not resolve bot login for re-review context", "err", err)
 	}
 	issueFetcher := issuepipeline.NewFetcher(ghClient, ghClient, s, issuePipe)
+	issueFetcher.SetBotLogin(resolvedBotLogin) // break re-triage loop (#362)
 	srv := server.New(s, broker, p, apiToken)
 	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/heimdallm/daemon/internal/config"
@@ -89,6 +90,7 @@ type Fetcher struct {
 	store     issueDedupStore
 	pipeline  PipelineRunner
 	publisher IssuePublisher // optional — when set, publishes to NATS instead of running pipeline
+	botLogin  string         // GitHub login of the bot — used to ignore self-triggered updated_at bumps
 }
 
 // NewFetcher wires the orchestrator. All dependencies are interfaces so
@@ -103,6 +105,13 @@ func NewFetcher(client IssuesFetcher, comments issueMarkerFetcher, s issueDedupS
 // classified issues to NATS instead of calling pipeline.Run directly.
 func (f *Fetcher) SetPublisher(p IssuePublisher) {
 	f.publisher = p
+}
+
+// SetBotLogin sets the GitHub login of the bot account. When set, the
+// dedup check ignores updated_at bumps caused by the bot's own comments,
+// breaking the re-triage loop described in #362.
+func (f *Fetcher) SetBotLogin(login string) {
+	f.botLogin = login
 }
 
 // ProcessRepo fetches every eligible issue for one repo and dispatches it to
@@ -217,6 +226,17 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 				return true, "skip marker", nil
 			case MarkerResultDone:
 				return true, "done marker", nil
+			}
+
+			// If the most recent comment is from the bot itself, the
+			// updated_at bump was self-triggered and does not represent
+			// genuine new activity. Skip reprocessing regardless of the
+			// grace window. This breaks the re-triage loop (#362).
+			if f.botLogin != "" && len(comments) > 0 {
+				last := comments[len(comments)-1]
+				if strings.EqualFold(last.Author, f.botLogin) {
+					return true, "last comment is from bot (self-triggered update)", nil
+				}
 			}
 		}
 	}

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -475,3 +475,84 @@ func TestFetcher_NilMarkerFetcherSkipsMarkerCheck(t *testing.T) {
 		t.Errorf("nil marker fetcher should skip marker check and process, got processed=%d", processed)
 	}
 }
+
+// TestFetcher_BotCommentSkipsReprocess verifies that when the most recent
+// comment on an issue is from the bot itself, the fetcher skips reprocessing
+// — breaking the re-triage loop described in #362.
+func TestFetcher_BotCommentSkipsReprocess(t *testing.T) {
+	now := time.Now()
+	issue := fixture(1, now)
+
+	// The issue has a previous review with CommentedAt 2 minutes ago.
+	// updated_at (now) is well past the 30s grace window, so without the
+	// bot-comment check it would be reprocessed.
+	commentedAt := now.Add(-2 * time.Minute)
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row:    &store.Issue{ID: 10, GithubID: issue.ID},
+			review: &store.IssueReview{CommentedAt: commentedAt},
+		},
+	}}
+
+	// The latest comment is from the bot.
+	mf := &fakeMarkerFetcher{
+		commentsByKey: map[string][]github.Comment{
+			"org/repo#1": {
+				{Author: "some-user", Body: "please triage this"},
+				{Author: "heimdallm-bot", Body: "## Triage\n..."},
+			},
+		},
+	}
+
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
+	f.SetBotLogin("heimdallm-bot")
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 0 {
+		t.Errorf("bot's own comment should prevent reprocessing, got processed=%d", processed)
+	}
+	if len(p.calls) != 0 {
+		t.Errorf("pipeline should not have been called, got %d calls", len(p.calls))
+	}
+}
+
+// TestFetcher_HumanCommentAfterBotAllowsReprocess verifies that when a
+// human comments after the bot, the issue IS reprocessed.
+func TestFetcher_HumanCommentAfterBotAllowsReprocess(t *testing.T) {
+	now := time.Now()
+	issue := fixture(1, now)
+
+	commentedAt := now.Add(-2 * time.Minute)
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row:    &store.Issue{ID: 10, GithubID: issue.ID},
+			review: &store.IssueReview{CommentedAt: commentedAt},
+		},
+	}}
+
+	// Bot commented, then a human replied — should reprocess.
+	mf := &fakeMarkerFetcher{
+		commentsByKey: map[string][]github.Comment{
+			"org/repo#1": {
+				{Author: "heimdallm-bot", Body: "## Triage\n..."},
+				{Author: "some-user", Body: "I disagree with this analysis"},
+			},
+		},
+	}
+
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
+	f.SetBotLogin("heimdallm-bot")
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 1 {
+		t.Errorf("human comment after bot should allow reprocessing, got processed=%d", processed)
+	}
+}


### PR DESCRIPTION
## Summary
- The 30s `RecomputeGrace` window is shorter than the 1m `poll_interval`, so after the bot posts a triage comment, the `updated_at` bump exceeds the grace on the next cycle — causing infinite re-triage
- Add bot-comment detection in `alreadyProcessed()`: if the most recent comment is from the bot itself, skip reprocessing
- A human comment after the bot still triggers re-triage as expected
- Wire `SetBotLogin` on the Fetcher from `main.go`

## Tests
- `TestFetcher_BotCommentSkipsReprocess` — bot's last comment prevents reprocessing
- `TestFetcher_HumanCommentAfterBotAllowsReprocess` — human reply after bot allows reprocessing

## Impact
Prevents duplicate triage comments. Real-world case: `overmind-swarm/dev#317` received 3 duplicate triages in 3 minutes on 2026-04-25.

Closes #362