### PR TITLE
fix(issues): bot-comment check must allow mode transitions

### DIFF
--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -213,12 +213,17 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 	// dedup gates so a retry marker can override all of them. The API call
 	// is skipped when the comment fetcher is nil (legacy callers / tests
 	// that pre-date marker support).
+	// cachedComments holds the comments fetched during marker scanning,
+	// reused later for the bot-comment check to avoid a second API call.
+	var cachedComments []github.Comment
+
 	if f.comments != nil {
 		comments, cmErr := f.comments.FetchIssueCommentsOnly(issue.Repo, issue.Number)
 		if cmErr != nil {
 			slog.Warn("issues fetcher: marker scan failed, falling through to dedup checks",
 				"repo", issue.Repo, "number", issue.Number, "err", cmErr)
 		} else {
+			cachedComments = comments
 			switch ScanMarkers(comments) {
 			case MarkerResultRetry:
 				return false, "", nil // force reprocess
@@ -226,17 +231,6 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 				return true, "skip marker", nil
 			case MarkerResultDone:
 				return true, "done marker", nil
-			}
-
-			// If the most recent comment is from the bot itself, the
-			// updated_at bump was self-triggered and does not represent
-			// genuine new activity. Skip reprocessing regardless of the
-			// grace window. This breaks the re-triage loop (#362).
-			if f.botLogin != "" && len(comments) > 0 {
-				last := comments[len(comments)-1]
-				if strings.EqualFold(last.Author, f.botLogin) {
-					return true, "last comment is from bot (self-triggered update)", nil
-				}
 			}
 		}
 	}
@@ -260,6 +254,19 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 	// it to stop the pipeline from picking it up again.
 	if latest.ActionTaken == "auto_implement" && latest.PRCreated > 0 {
 		return true, "already implemented (PR created)", nil
+	}
+
+	// Bot-comment dedup: if the most recent comment is from the bot AND the
+	// issue's current mode matches what was already done (ActionTaken), the
+	// updated_at bump was self-triggered — skip. When the mode changed
+	// (e.g. review_only → develop after a label swap), reprocess even if
+	// the last comment is from the bot. This breaks the re-triage loop
+	// (#362) without blocking mode transitions.
+	if f.botLogin != "" && len(cachedComments) > 0 {
+		last := cachedComments[len(cachedComments)-1]
+		if strings.EqualFold(last.Author, f.botLogin) && latest.ActionTaken == string(issue.Mode) {
+			return true, "last comment is from bot, same mode (self-triggered update)", nil
+		}
 	}
 
 	// If the auto_implement push has failed too many times, stop retrying.

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -483,14 +483,14 @@ func TestFetcher_BotCommentSkipsReprocess(t *testing.T) {
 	now := time.Now()
 	issue := fixture(1, now)
 
-	// The issue has a previous review with CommentedAt 2 minutes ago.
+	// The issue has a previous review_only review with CommentedAt 2 minutes ago.
 	// updated_at (now) is well past the 30s grace window, so without the
 	// bot-comment check it would be reprocessed.
 	commentedAt := now.Add(-2 * time.Minute)
 	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
 		issue.ID: {
 			row:    &store.Issue{ID: 10, GithubID: issue.ID},
-			review: &store.IssueReview{CommentedAt: commentedAt},
+			review: &store.IssueReview{CommentedAt: commentedAt, ActionTaken: "review_only"},
 		},
 	}}
 
@@ -554,5 +554,51 @@ func TestFetcher_HumanCommentAfterBotAllowsReprocess(t *testing.T) {
 	}
 	if processed != 1 {
 		t.Errorf("human comment after bot should allow reprocessing, got processed=%d", processed)
+	}
+}
+
+// TestFetcher_ModeChangeBypassesBotCommentCheck verifies that when the issue
+// mode changed (e.g. label swapped from heimdallm-triage to heimdallm-develop),
+// the bot-comment check does NOT block reprocessing — even if the last comment
+// is from the bot (#362).
+func TestFetcher_ModeChangeBypassesBotCommentCheck(t *testing.T) {
+	now := time.Now()
+	// Issue now has develop mode (label changed).
+	issue := &github.Issue{
+		ID:        int64(1001),
+		Number:    1,
+		Repo:      "org/repo",
+		UpdatedAt: now,
+		Mode:      config.IssueModeDevelop,
+	}
+
+	// Previous review was review_only — mode has changed.
+	commentedAt := now.Add(-2 * time.Minute)
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row:    &store.Issue{ID: 10, GithubID: issue.ID},
+			review: &store.IssueReview{CommentedAt: commentedAt, ActionTaken: "review_only"},
+		},
+	}}
+
+	// Last comment is from the bot (triage comment).
+	mf := &fakeMarkerFetcher{
+		commentsByKey: map[string][]github.Comment{
+			"org/repo#1": {
+				{Author: "heimdallm-bot", Body: "## Triage\n..."},
+			},
+		},
+	}
+
+	p := &fakePipeline{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
+	f.SetBotLogin("heimdallm-bot")
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 1 {
+		t.Errorf("mode change should bypass bot-comment check, got processed=%d", processed)
 	}
 }


### PR DESCRIPTION
## Summary
- The bot-comment dedup from #363 was too aggressive: it blocked **all** reprocessing when the last comment was from the bot, even when the issue mode changed (e.g. `heimdallm-triage` → `heimdallm-develop`)
- Now only skips when `latest.ActionTaken == issue.Mode` — a mode change always allows reprocessing
- Added `TestFetcher_ModeChangeBypassesBotCommentCheck` test

## Impact
Without this fix, swapping a label from `heimdallm-triage` to `heimdallm-develop` on an already-triaged issue would silently do nothing.

Refs: #362