### PR TITLE
[codex] fix PR review dedup for mismatched GitHub IDs

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1813,7 +1813,7 @@ func runTier2(
 				if _, ok := monitoredSet[pr.Repo]; !ok {
 					continue
 				}
-				if adapter.PRAlreadyReviewed(pr.ID, pr.UpdatedAt) {
+				if adapter.PRAlreadyReviewed(pr.ID, pr.Repo, pr.Number, pr.UpdatedAt) {
 					continue
 				}
 				if err := prPublisher.PublishPRReview(ctx, pr.Repo, pr.Number, pr.ID, pr.HeadSHA); err != nil {
@@ -1908,17 +1908,17 @@ func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
 // ── tier2Adapter bridges main.go's concrete types to Pipeline interfaces ──
 
 type tier2Adapter struct {
-	ghClient  *gh.Client
-	ghToken   string
-	pipeline  *pipeline.Pipeline
-	issuePipe *issuepipeline.Pipeline
-	fetcher   *issuepipeline.Fetcher
-	store     *store.Store
-	broker    *sse.Broker
-	cfgMu     *sync.Mutex
-	cfg       **config.Config
-	loginMu   *sync.Mutex
-	login     *string
+	ghClient   *gh.Client
+	ghToken    string
+	pipeline   *pipeline.Pipeline
+	issuePipe  *issuepipeline.Pipeline
+	fetcher    *issuepipeline.Fetcher
+	store      *store.Store
+	broker     *sse.Broker
+	cfgMu      *sync.Mutex
+	cfg        **config.Config
+	loginMu    *sync.Mutex
+	login      *string
 	runReview  func(pr *gh.PullRequest, aiCfg config.RepoAI) *store.Review
 	publishPub *bus.PRPublishPublisher
 	watchStore *bus.WatchStore
@@ -2360,8 +2360,15 @@ func (a *tier2Adapter) PromoteReady(ctx context.Context, repos []string) (int, e
 }
 
 // PRAlreadyReviewed implements scheduler.Tier2Store.
-func (a *tier2Adapter) PRAlreadyReviewed(githubID int64, updatedAt time.Time) bool {
+func (a *tier2Adapter) PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time) bool {
 	existing, _ := a.store.GetPRByGithubID(githubID)
+	if existing == nil && repo != "" && number > 0 {
+		existing, _ = a.store.GetPRByRepoNumber(repo, number)
+		if existing != nil {
+			slog.Debug("pr dedup: matched stored PR by repo/number after github_id miss",
+				"repo", repo, "pr", number, "incoming_github_id", githubID, "stored_github_id", existing.GithubID)
+		}
+	}
 	if existing == nil {
 		return false
 	}
@@ -2511,7 +2518,7 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 		// LastSeen has already been overwritten by ResetBackoff on earlier
 		// ticks and is no longer a faithful representation of the PR's
 		// current updated_at.
-		if a.PRAlreadyReviewed(item.GithubID, snap.UpdatedAt) {
+		if a.PRAlreadyReviewed(item.GithubID, item.Repo, item.Number, snap.UpdatedAt) {
 			slog.Debug("tier3: PR already reviewed, skipping", "pr", item.Number, "repo", item.Repo)
 			return nil
 		}

--- a/daemon/internal/pipeline/pipeline_reloop_test.go
+++ b/daemon/internal/pipeline/pipeline_reloop_test.go
@@ -199,7 +199,7 @@ func TestRun_LegacyRowWithEmptyHeadSHAIsBackfilledAndSkipped(t *testing.T) {
 // PRAlreadyReviewed for the test. Mirrors the real adapter in main.go but
 // without the Flutter/scheduler/config deps we don't need here.
 func newTestAdapter(s *store.Store) interface {
-	PRAlreadyReviewed(githubID int64, updatedAt time.Time) bool
+	PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time) bool
 } {
 	return pipeline.NewTestAdapter(s)
 }
@@ -233,7 +233,7 @@ func TestPRAlreadyReviewed_SlowReviewDoesNotReloop(t *testing.T) {
 	// the 2-minute grace. Should be treated as "already reviewed".
 	updatedAt := publishedAt.Add(15 * time.Second)
 	adapter := newTestAdapter(s)
-	if !adapter.PRAlreadyReviewed(99, updatedAt) {
+	if !adapter.PRAlreadyReviewed(99, "org/r", 99, updatedAt) {
 		t.Errorf("slow review (3 min) must not re-loop when updated_at is within 2m grace of PublishedAt")
 	}
 }
@@ -261,8 +261,51 @@ func TestPRAlreadyReviewed_FallsBackToCreatedAtWhenPublishedAtZero(t *testing.T)
 
 	updatedAt := createdAt.Add(10 * time.Second)
 	adapter := newTestAdapter(s)
-	if !adapter.PRAlreadyReviewed(100, updatedAt) {
+	if !adapter.PRAlreadyReviewed(100, "org/r", 100, updatedAt) {
 		t.Errorf("legacy row (PublishedAt zero) must fall back to CreatedAt and still dedup")
+	}
+}
+
+// TestPRAlreadyReviewed_FallsBackToRepoNumberWhenGithubIDDiffers covers the
+// Search Issues API vs Pulls API id mismatch from theburrowhub/heimdallm#351.
+// The stored row came from the Pulls API after a successful review, while the
+// next Tier 2 poll checks the Search API id before deciding whether to publish
+// another review job. The stable repo/number identity must bridge that gap.
+func TestPRAlreadyReviewed_FallsBackToRepoNumberWhenGithubIDDiffers(t *testing.T) {
+	s := newMemStore(t)
+	const pullsAPIID int64 = 3578062677
+	const searchAPIID int64 = 4321703389
+
+	publishedAt := time.Now().UTC().Add(-30 * time.Second)
+	prRow := &store.PR{
+		GithubID:  pullsAPIID,
+		Repo:      "org/r",
+		Number:    337,
+		Title:     "t",
+		State:     "open",
+		UpdatedAt: publishedAt.Add(-time.Minute),
+	}
+	prID, err := s.UpsertPR(prRow)
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	if _, err := s.InsertReview(&store.Review{
+		PRID:        prID,
+		CLIUsed:     "claude",
+		Issues:      "[]",
+		Suggestions: "[]",
+		Severity:    "low",
+		CreatedAt:   publishedAt.Add(-2 * time.Minute),
+		PublishedAt: publishedAt,
+		HeadSHA:     "abc",
+	}); err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+
+	updatedAt := publishedAt.Add(15 * time.Second)
+	adapter := newTestAdapter(s)
+	if !adapter.PRAlreadyReviewed(searchAPIID, "org/r", 337, updatedAt) {
+		t.Errorf("Search API github_id miss must dedup via repo/number fallback")
 	}
 }
 
@@ -306,7 +349,7 @@ func TestRun_TwoInstancesSharingStoreDoNotDoubleReview(t *testing.T) {
 
 	// B is a fresh adapter instance on the same store.
 	adapterB := pipeline.NewTestAdapter(s)
-	if !adapterB.PRAlreadyReviewed(1234, updatedAt) {
+	if !adapterB.PRAlreadyReviewed(1234, "org/r", 1234, updatedAt) {
 		t.Errorf("Instance B must dedup against Instance A's PublishedAt in the shared store")
 	}
 }
@@ -333,7 +376,7 @@ func TestPRAlreadyReviewed_AllowsReviewAfterGraceWindow(t *testing.T) {
 
 	updatedAt := time.Now()
 	adapter := newTestAdapter(s)
-	if adapter.PRAlreadyReviewed(101, updatedAt) {
+	if adapter.PRAlreadyReviewed(101, "org/r", 101, updatedAt) {
 		t.Errorf("activity 5 min after publish must be treated as new change (grace only 2m)")
 	}
 }

--- a/daemon/internal/pipeline/testutil_test.go
+++ b/daemon/internal/pipeline/testutil_test.go
@@ -27,8 +27,11 @@ func NewTestAdapter(s *store.Store) *testAdapter {
 // cmd/heimdallm/main.go. Keep the two in sync — the external reloop tests
 // exercise this copy, but production traffic flows through the main.go
 // version. See theburrowhub/heimdallm#243.
-func (a *testAdapter) PRAlreadyReviewed(githubID int64, updatedAt time.Time) bool {
+func (a *testAdapter) PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time) bool {
 	existing, _ := a.store.GetPRByGithubID(githubID)
+	if existing == nil && repo != "" && number > 0 {
+		existing, _ = a.store.GetPRByRepoNumber(repo, number)
+	}
 	if existing == nil {
 		return false
 	}

--- a/daemon/internal/scheduler/types.go
+++ b/daemon/internal/scheduler/types.go
@@ -83,7 +83,7 @@ type Tier2PRPublisher interface {
 
 // Tier2Store checks if a PR has already been reviewed recently.
 type Tier2Store interface {
-	PRAlreadyReviewed(githubID int64, updatedAt time.Time) bool
+	PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time) bool
 }
 
 // ── Tier 3 / Watch types (formerly in tier3.go + queue.go) ──────────────

--- a/daemon/internal/store/prs.go
+++ b/daemon/internal/store/prs.go
@@ -68,6 +68,27 @@ func (s *Store) GetPRByGithubID(githubID int64) (*PR, error) {
 	return scanPR(row)
 }
 
+// GetPRByRepoNumber retrieves a PR by its stable repository-local identity.
+// GitHub's Search Issues API and Pulls API can return different global IDs for
+// the same PR, so scheduler-side dedup needs this fallback after github_id
+// misses. If duplicate rows exist from an older bug, prefer the row that
+// already has review history so we dedup against the real prior work.
+func (s *Store) GetPRByRepoNumber(repo string, number int) (*PR, error) {
+	row := s.db.QueryRow(`
+		SELECT p.id, p.github_id, p.repo, p.number, p.title, p.author, p.url,
+		       p.state, p.updated_at, p.fetched_at, p.dismissed
+		FROM prs p
+		WHERE p.repo = ? AND p.number = ?
+		ORDER BY (
+			SELECT COALESCE(MAX(r.created_at), '')
+			FROM reviews r
+			WHERE r.pr_id = p.id
+		) DESC, p.fetched_at DESC, p.id DESC
+		LIMIT 1
+	`, repo, number)
+	return scanPR(row)
+}
+
 // ListPRs returns all non-dismissed PRs ordered by updated_at descending.
 // An optional list of states (e.g. "open", "closed") filters the result;
 // when no states are provided all non-dismissed PRs are returned.

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -196,6 +196,9 @@ func Open(dsn string) (*Store, error) {
 	// JOIN drives from prs.repo with no index and table-scans on every
 	// poll-cycle breaker check.
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_prs_repo ON prs(repo)")
+	// Hot path for PR identity fallback when GitHub's Search Issues API and
+	// Pulls API disagree on github_id for the same repo/number (#351).
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_prs_repo_number ON prs(repo, number)")
 	// Mirrors of the above for the issue-side circuit breaker added in
 	// theburrowhub/heimdallm#292. Without these, CountIssueReviewsForIssue
 	// and CountIssueTriagesForRepo table-scan issue_reviews on every

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -48,6 +48,43 @@ func TestPR_UpsertAndGet(t *testing.T) {
 	}
 }
 
+func TestPR_GetByRepoNumberPrefersReviewedRow(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	reviewedID, err := s.UpsertPR(&store.PR{
+		GithubID: 101, Repo: "org/repo", Number: 42, Title: "reviewed",
+		Author: "alice", URL: "https://github.com/org/repo/pull/42",
+		State: "open", UpdatedAt: now.Add(-2 * time.Minute), FetchedAt: now.Add(-2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("upsert reviewed pr: %v", err)
+	}
+	if _, err := s.InsertReview(&store.Review{
+		PRID: reviewedID, CLIUsed: "claude", Summary: "ok",
+		Issues: "[]", Suggestions: "[]", Severity: "low",
+		CreatedAt: now.Add(-time.Minute), PublishedAt: now.Add(-time.Minute),
+		HeadSHA: "abc",
+	}); err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+	if _, err := s.UpsertPR(&store.PR{
+		GithubID: 202, Repo: "org/repo", Number: 42, Title: "unreviewed duplicate",
+		Author: "alice", URL: "https://github.com/org/repo/pull/42",
+		State: "open", UpdatedAt: now, FetchedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert duplicate pr: %v", err)
+	}
+
+	got, err := s.GetPRByRepoNumber("org/repo", 42)
+	if err != nil {
+		t.Fatalf("get by repo number: %v", err)
+	}
+	if got.ID != reviewedID {
+		t.Errorf("GetPRByRepoNumber picked row %d, want reviewed row %d", got.ID, reviewedID)
+	}
+}
+
 func TestReview_InsertAndList(t *testing.T) {
 	s := newTestStore(t)
 	pr := &store.PR{GithubID: 1, Repo: "org/r", Number: 1, Title: "t", Author: "a", URL: "u", State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now()}


### PR DESCRIPTION
## Summary

Fixes #351.

- Adds a store lookup by stable PR identity `(repo, number)`.
- Uses that lookup as a scheduler-side fallback when `github_id` lookup misses.
- Keeps the existing `github_id` fast path for normal Pulls API / Tier 3 flows.
- Adds regression coverage for the Search API vs Pulls API ID mismatch and duplicate-row preference.

## Root cause

Tier 2 checks `PRAlreadyReviewed` with the ID returned by GitHub Search Issues API, but stored PR rows are written from Pulls API data. Those IDs can differ for the same PR, causing the scheduler to publish review work that the downstream SHA guard later skips.

## Validation

- `git diff --check` passes.
- `make test-docker GO_TEST_ARGS="-run TestPRAlreadyReviewed -count=1 ./internal/pipeline"` could not run locally because Docker returned `500 Internal Server Error` on the Docker socket. I did not run host `go test`, per repo instructions.