### PR TITLE
feat: add daemon shutdown controls

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -264,6 +264,12 @@ func (c *Client) TriggerIssueReview(id int64) error {
 	return err
 }
 
+// Shutdown asks the daemon to stop gracefully.
+func (c *Client) Shutdown() error {
+	_, err := c.do("POST", "/shutdown")
+	return err
+}
+
 // DismissIssue hides an issue from the pipeline, stopping retries until undismissed.
 func (c *Client) DismissIssue(id int64) error {
 	_, err := c.do("POST", fmt.Sprintf("/issues/%d/dismiss", id))

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -946,9 +946,9 @@ func (d *Dashboard) renderHelp() string {
 		return helpStyle.Render("[esc]close  [j/k]scroll  [pgup/pgdn]page  [q]uit")
 	}
 	if d.activeTab == tabPRs || d.activeTab == tabIssues {
-		return helpStyle.Render("[q]uit  [r]efresh  [S]top  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
+		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
 	}
-	return helpStyle.Render("[q]uit  [r]efresh  [S]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump  [G]follow")
+	return helpStyle.Render("[q]uit  [r]efresh  [s]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump  [G]follow")
 }
 
 func (d *Dashboard) contentHeight() int {

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -45,12 +45,15 @@ type Dashboard struct {
 	logOffset int
 	logSeeded bool
 
-	err        error
-	connected  bool
-	refreshing bool
-	startTime  time.Time
-	lastUpdate time.Time
-	version    string
+	err              error
+	connected        bool
+	refreshing       bool
+	confirmShutdown  bool
+	shutdownInFlight bool
+	shutdownMessage  string
+	startTime        time.Time
+	lastUpdate       time.Time
+	version          string
 
 	sseEvents chan api.SSEEvent
 	sseCtx    context.Context
@@ -80,6 +83,7 @@ type dataMsg struct {
 type sseMsg api.SSEEvent
 type sseDisconnectMsg struct{ err error }
 type sseReconnectMsg struct{}
+type shutdownMsg struct{ err error }
 
 func NewDashboard(host, token, version string) *Dashboard {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -169,6 +173,12 @@ func (d *Dashboard) listenSSE() tea.Cmd {
 		case <-d.sseCtx.Done():
 			return nil
 		}
+	}
+}
+
+func (d *Dashboard) shutdownDaemon() tea.Cmd {
+	return func() tea.Msg {
+		return shutdownMsg{err: d.client.Shutdown()}
 	}
 }
 
@@ -293,6 +303,23 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sseReconnectMsg:
 		return d, d.connectSSE
+
+	case shutdownMsg:
+		d.shutdownInFlight = false
+		d.confirmShutdown = false
+		if msg.err != nil {
+			d.err = msg.err
+			d.connected = false
+			d.shutdownMessage = fmt.Sprintf("Shutdown failed: %v", msg.err)
+			return d, nil
+		}
+		d.connected = false
+		d.err = fmt.Errorf("daemon shutdown requested")
+		d.shutdownMessage = "Shutdown requested"
+		if d.sseCancel != nil {
+			d.sseCancel()
+		}
+		return d, nil
 	}
 
 	return d, nil
@@ -301,6 +328,25 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if d.showDetail {
 		return d.handleDetailKey(msg)
+	}
+	if d.confirmShutdown {
+		switch msg.String() {
+		case "y", "Y":
+			d.shutdownInFlight = true
+			d.shutdownMessage = "Requesting shutdown..."
+			return d, d.shutdownDaemon()
+		case "n", "N", "esc":
+			d.confirmShutdown = false
+			d.shutdownMessage = ""
+			return d, nil
+		case "q", "ctrl+c":
+			if d.sseCancel != nil {
+				d.sseCancel()
+			}
+			return d, tea.Quit
+		default:
+			return d, nil
+		}
 	}
 	switch msg.String() {
 	case "q", "ctrl+c":
@@ -383,6 +429,11 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		d.refreshing = true
 		return d, d.fetchData
+	case "s", "S":
+		if !d.shutdownInFlight {
+			d.confirmShutdown = true
+			d.shutdownMessage = "Stop daemon? y/n"
+		}
 	case "1":
 		d.activeTab = tabActivity
 		d.cursor = 0
@@ -536,6 +587,9 @@ func (d *Dashboard) View() string {
 }
 
 func (d *Dashboard) renderStatus() string {
+	if d.shutdownInFlight {
+		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).Render("● stopping...")
+	}
 	if d.refreshing {
 		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).Render("● refreshing...")
 	}
@@ -588,6 +642,11 @@ func (d *Dashboard) renderStatusBar() string {
 	}
 	if d.version != "" {
 		parts = append(parts, "v"+d.version)
+	}
+	if d.confirmShutdown {
+		parts = append(parts, "Confirm stop: y/n")
+	} else if d.shutdownMessage != "" {
+		parts = append(parts, truncateRunes(d.shutdownMessage, 80))
 	}
 
 	return headerStyle.Render(strings.Join(parts, "  │  "))
@@ -877,13 +936,19 @@ func (d *Dashboard) buildStatsLines() []string {
 }
 
 func (d *Dashboard) renderHelp() string {
+	if d.confirmShutdown {
+		return helpStyle.Render("Stop daemon and disconnect clients?  [y]es  [n/esc]cancel")
+	}
+	if d.shutdownInFlight {
+		return helpStyle.Render("Stopping daemon...")
+	}
 	if d.showDetail {
 		return helpStyle.Render("[esc]close  [j/k]scroll  [pgup/pgdn]page  [q]uit")
 	}
 	if d.activeTab == tabPRs || d.activeTab == tabIssues {
-		return helpStyle.Render("[q]uit  [r]efresh  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
+		return helpStyle.Render("[q]uit  [r]efresh  [S]top  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
 	}
-	return helpStyle.Render("[q]uit  [r]efresh  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump  [G]follow")
+	return helpStyle.Render("[q]uit  [r]efresh  [S]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump  [G]follow")
 }
 
 func (d *Dashboard) contentHeight() int {

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -273,6 +274,7 @@ func main() {
 	srv := server.New(s, broker, p, apiToken)
 	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)
+	shutdownReq := make(chan struct{}, 1)
 
 	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
@@ -1206,6 +1208,13 @@ func main() {
 		return login, err
 	})
 
+	srv.SetShutdownFn(func() {
+		select {
+		case shutdownReq <- struct{}{}:
+		default:
+		}
+	})
+
 	// Wire the reload callback: re-read config from disk, restart the
 	// pipeline so changes to discovery_topic / orgs / intervals take effect
 	// without a daemon restart. Reuses the `loadConfig` closure captured at
@@ -1521,18 +1530,24 @@ func main() {
 
 	go func() {
 		slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
-		if err := srv.Start(cfg.Server.Port, cfg.Server.BindAddr); err != nil {
+		if err := srv.Start(cfg.Server.Port, cfg.Server.BindAddr); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("server stopped", "err", err)
 		}
 	}()
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-	<-sig
-	slog.Info("shutting down")
+	select {
+	case received := <-sig:
+		slog.Info("shutting down", "signal", received.String())
+	case <-shutdownReq:
+		slog.Info("shutting down via API")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	srv.Shutdown(ctx)
+	if err := srv.Shutdown(ctx); err != nil {
+		slog.Warn("server shutdown failed", "err", err)
+	}
 	broker.Stop()
 }
 

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -30,13 +30,14 @@ import (
 
 // Server holds the HTTP router, SSE broker, store, and optional pipeline.
 type Server struct {
-	store           *store.Store
-	broker          *sse.Broker
-	natsConn        *nats.Conn // when set, handleSSE reads from NATS instead of broker
-	pipeline        *pipeline.Pipeline
-	router          chi.Router
-	httpServer      *http.Server
-	reloadFn        func() error
+	store                *store.Store
+	broker               *sse.Broker
+	natsConn             *nats.Conn // when set, handleSSE reads from NATS instead of broker
+	pipeline             *pipeline.Pipeline
+	router               chi.Router
+	httpServer           *http.Server
+	reloadFn             func() error
+	shutdownFn           func()
 	triggerReviewFn      func(prID int64) error
 	triggerIssueReviewFn func(issueID int64) error
 	triggerPromoteFn     func(issueID int64) error
@@ -106,7 +107,7 @@ var sensitiveGETPaths = []string{
 	"/agents",
 	"/events",
 	"/logs/stream",
-	"/me",    // exposes GitHub username
+	"/me",     // exposes GitHub username
 	"/prs",    // exposes PR titles, repos, authors
 	"/stats",  // exposes review activity metadata
 	"/issues", // covers /issues and /issues/{id}
@@ -148,6 +149,9 @@ func (srv *Server) authMiddleware(next http.Handler) http.Handler {
 
 // SetReloadFn wires the config-reload callback called by POST /reload.
 func (srv *Server) SetReloadFn(fn func() error) { srv.reloadFn = fn }
+
+// SetShutdownFn wires the daemon shutdown callback called by POST /shutdown.
+func (srv *Server) SetShutdownFn(fn func()) { srv.shutdownFn = fn }
 
 // SetTriggerReviewFn wires the review-trigger callback called by POST /prs/{id}/review.
 func (srv *Server) SetTriggerReviewFn(fn func(prID int64) error) { srv.triggerReviewFn = fn }
@@ -266,6 +270,7 @@ func (srv *Server) buildRouter() chi.Router {
 	r.Patch("/config/repos/{repo}", srv.handlePatchRepoConfig)
 	r.Delete("/config/repos/{repo}/*", srv.handleDeleteRepoField)
 	r.Post("/reload", srv.handleReload)
+	r.Post("/shutdown", srv.handleShutdown)
 	r.Get("/events", srv.handleSSE)
 	r.Get("/logs/stream", srv.handleLogsStream)
 	return r
@@ -686,6 +691,15 @@ func (srv *Server) handleReload(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "reloaded"})
 }
 
+func (srv *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
+	if srv.shutdownFn == nil {
+		http.Error(w, `{"error":"shutdown not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]string{"status": "shutdown queued"})
+	go srv.shutdownFn()
+}
+
 func (srv *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -885,7 +899,7 @@ func toIssueResponse(iss *store.Issue, rev *store.IssueReview) issueResponse {
 func toIssueReviewResponse(r *store.IssueReview) *issueReviewResponse {
 	return &issueReviewResponse{
 		ID: r.ID, IssueID: r.IssueID, CLIUsed: r.CLIUsed,
-		Summary: r.Summary,
+		Summary:     r.Summary,
 		Triage:      json.RawMessage(r.Triage),
 		Suggestions: json.RawMessage(r.Suggestions),
 		ActionTaken: r.ActionTaken, PRCreated: r.PRCreated,

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -696,7 +696,11 @@ func (srv *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"shutdown not available"}`, http.StatusServiceUnavailable)
 		return
 	}
+	slog.Info("shutdown requested via API")
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "shutdown queued"})
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
 	go srv.shutdownFn()
 }
 

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -148,6 +148,71 @@ func TestHandlerPutConfig(t *testing.T) {
 	}
 }
 
+func TestHandlerShutdown(t *testing.T) {
+	srv, _ := setupServer(t)
+	shutdown := make(chan struct{}, 1)
+	srv.SetShutdownFn(func() {
+		shutdown <- struct{}{}
+	})
+
+	req := httptest.NewRequest("POST", "/shutdown", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("shutdown: status %d, body: %s", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["status"] != "shutdown queued" {
+		t.Fatalf("status = %q, want shutdown queued", body["status"])
+	}
+	select {
+	case <-shutdown:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown callback was not called")
+	}
+}
+
+func TestHandlerShutdownNotConfigured(t *testing.T) {
+	srv, _ := setupServer(t)
+	req := httptest.NewRequest("POST", "/shutdown", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestHandlerShutdownRequiresAuthWhenTokenSet(t *testing.T) {
+	srv := setupServerWithToken(t, "secret-token")
+	shutdown := make(chan struct{}, 1)
+	srv.SetShutdownFn(func() {
+		shutdown <- struct{}{}
+	})
+
+	req := httptest.NewRequest("POST", "/shutdown", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("POST /shutdown without token: status = %d, want 401", w.Code)
+	}
+
+	req = httptest.NewRequest("POST", "/shutdown", nil)
+	req.Header.Set("X-Heimdallm-Token", "secret-token")
+	w = httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("POST /shutdown with token: status = %d, want 202", w.Code)
+	}
+	select {
+	case <-shutdown:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown callback was not called")
+	}
+}
+
 func itoa(n int64) string {
 	return fmt.Sprintf("%d", n)
 }
@@ -928,9 +993,9 @@ func TestHandleActivity_RequiresAuth(t *testing.T) {
 func TestHandleActivity_FilterByRepoAndAction(t *testing.T) {
 	srv, s := setupServer(t)
 	now := time.Now()
-	_, _ = s.InsertActivity(now, "acme",   "acme/api", "pr",    1, "t", "review", "minor", nil)
-	_, _ = s.InsertActivity(now, "acme",   "acme/api", "issue", 2, "t", "triage", "major", nil)
-	_, _ = s.InsertActivity(now, "globex", "globex/w", "pr",    3, "t", "review", "minor", nil)
+	_, _ = s.InsertActivity(now, "acme", "acme/api", "pr", 1, "t", "review", "minor", nil)
+	_, _ = s.InsertActivity(now, "acme", "acme/api", "issue", 2, "t", "triage", "major", nil)
+	_, _ = s.InsertActivity(now, "globex", "globex/w", "pr", 3, "t", "review", "minor", nil)
 
 	req := httptest.NewRequest("GET", "/activity?repo=acme/api&action=review", nil)
 	w := httptest.NewRecorder()

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -120,6 +120,14 @@ class ApiClient {
     }
   }
 
+  Future<void> shutdownDaemon() async {
+    final resp = await _client.post(_uri('/shutdown'),
+        headers: await _authHeaders());
+    if (resp.statusCode != 202) {
+      throw ApiException('POST /shutdown failed: ${resp.statusCode}');
+    }
+  }
+
   Future<Map<String, dynamic>> fetchConfig() async {
     final resp = await _client.get(_uri('/config'),
         headers: await _authHeaders());

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -125,18 +125,41 @@ Future<void> _confirmShutdown(BuildContext context, WidgetRef ref) async {
     showToast(context, 'Shutdown requested');
     ref.invalidate(sseStreamProvider);
     ref.invalidate(daemonHealthProvider);
-    Future<void>.delayed(const Duration(milliseconds: 500), () {
-      if (!context.mounted) return;
-      ref.invalidate(daemonHealthProvider);
-      ref.invalidate(prsProvider);
-      ref.invalidate(issuesProvider);
-      ref.invalidate(statsProvider);
-      ref.invalidate(activityEntriesProvider);
-      ref.invalidate(activityOptionsProvider);
-    });
+    await _refreshWhenDaemonStops(context, ref);
   } catch (e) {
     if (context.mounted) showToast(context, 'Error: $e', isError: true);
   }
+}
+
+Future<void> _refreshWhenDaemonStops(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  final api = ref.read(apiClientProvider);
+  const delays = [
+    Duration(milliseconds: 200),
+    Duration(milliseconds: 300),
+    Duration(milliseconds: 500),
+    Duration(milliseconds: 800),
+    Duration(milliseconds: 1200),
+    Duration(seconds: 2),
+  ];
+
+  for (final delay in delays) {
+    await Future<void>.delayed(delay);
+    if (!context.mounted) return;
+    final healthy = await api.checkHealth();
+    if (!context.mounted) return;
+    ref.invalidate(daemonHealthProvider);
+    if (!healthy) break;
+  }
+
+  if (!context.mounted) return;
+  ref.invalidate(prsProvider);
+  ref.invalidate(issuesProvider);
+  ref.invalidate(statsProvider);
+  ref.invalidate(activityEntriesProvider);
+  ref.invalidate(activityOptionsProvider);
 }
 
 // ── Reviews tab ──────────────────────────────────────────────────────────────

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -13,6 +13,7 @@ import '../activity/activity_providers.dart';
 import '../agents/agents_screen.dart';
 import '../circuit_breaker/circuit_breaker_banner.dart';
 import '../cli_agents/cli_agents_screen.dart';
+import '../config/config_providers.dart';
 import '../issues/issues_providers.dart';
 import '../repositories/repos_screen.dart';
 import '../stats/stats_screen.dart';
@@ -26,12 +27,20 @@ class DashboardScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final cbMessage = ref.watch(circuitBreakerProvider);
+    final daemonRunning = ref.watch(daemonHealthProvider).valueOrNull ?? false;
     return DefaultTabController(
       length: 6,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Heimdallm'),
           actions: [
+            IconButton(
+              icon: const Icon(Icons.power_settings_new),
+              tooltip: daemonRunning ? 'Stop Server' : 'Server offline',
+              onPressed: daemonRunning
+                  ? () => _confirmShutdown(context, ref)
+                  : null,
+            ),
             IconButton(
               icon: const Icon(Icons.article_outlined),
               tooltip: 'Daemon logs',
@@ -87,6 +96,46 @@ class DashboardScreen extends ConsumerWidget {
         ),
       ),
     );
+  }
+}
+
+Future<void> _confirmShutdown(BuildContext context, WidgetRef ref) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Stop Server?'),
+      content: const Text('Active reviews may be interrupted.'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Stop Server'),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true || !context.mounted) return;
+
+  try {
+    await ref.read(apiClientProvider).shutdownDaemon();
+    if (!context.mounted) return;
+    showToast(context, 'Shutdown requested');
+    ref.invalidate(sseStreamProvider);
+    ref.invalidate(daemonHealthProvider);
+    Future<void>.delayed(const Duration(milliseconds: 500), () {
+      if (!context.mounted) return;
+      ref.invalidate(daemonHealthProvider);
+      ref.invalidate(prsProvider);
+      ref.invalidate(issuesProvider);
+      ref.invalidate(statsProvider);
+      ref.invalidate(activityEntriesProvider);
+      ref.invalidate(activityOptionsProvider);
+    });
+  } catch (e) {
+    if (context.mounted) showToast(context, 'Error: $e', isError: true);
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #361.

- Add authenticated `POST /shutdown` to the daemon and wire it through the existing graceful shutdown path in `main`.
- Add Flutter GUI Stop Server action with confirmation and connection/status refresh after the request.
- Add TUI shutdown flow behind `S` + `y` confirmation, plus a CLI API client method.
- Cover the daemon shutdown handler contract, unconfigured behavior, and auth requirement.

## Validation

- `flutter analyze` ✅
- `flutter test` ✅
- `make build-web` ✅
- `make test-docker GO_TEST_ARGS='-run TestHandlerShutdown -count=1 ./internal/server'` could not start Docker locally: Docker socket returned `500 Internal Server Error` on `/_ping`.

## Notes

`flutter_app/pubspec.lock` had an unrelated local diff and was intentionally left out of this PR.