### PR TITLE
fix: allow starting daemon from offline dashboard

### DIFF
--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -31,6 +31,9 @@ final sseStreamProvider = StreamProvider<SseEvent>((ref) {
 /// can't slip by silently (regression guard for the 2026-04-22 runaway).
 final circuitBreakerProvider = StateProvider<String?>((ref) => null);
 
+/// Tracks whether the desktop app is trying to spawn the daemon.
+final daemonStartingProvider = StateProvider<bool>((ref) => false);
+
 /// Tracks PRs currently being reviewed, keyed by "repo:prNumber". Used to
 /// show spinners in the tile list and detail view.
 ///

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -113,7 +113,8 @@ class DashboardScreen extends ConsumerWidget {
   }
 }
 
-final daemonStartingProvider = StateProvider<bool>((ref) => false);
+const _daemonStartHealthMaxAttempts = 80;
+const _daemonStartHealthInterval = Duration(milliseconds: 100);
 
 Future<void> _confirmShutdown(BuildContext context, WidgetRef ref) async {
   final confirmed = await showDialog<bool>(
@@ -162,14 +163,13 @@ Future<void> _startDaemon(BuildContext context, WidgetRef ref) async {
     await platform.spawnDaemon(binaryPath);
     final api = ref.read(apiClientProvider);
     var healthy = false;
-    for (var i = 0; i < 80; i++) {
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      if (!context.mounted) return;
+    for (var i = 0; i < _daemonStartHealthMaxAttempts; i++) {
+      await Future<void>.delayed(_daemonStartHealthInterval);
       healthy = await api.checkHealth();
       if (healthy) break;
     }
-    if (!context.mounted) return;
     _invalidateDashboardData(ref);
+    if (!context.mounted) return;
     if (healthy) {
       showToast(context, 'Server started');
     } else {
@@ -182,9 +182,7 @@ Future<void> _startDaemon(BuildContext context, WidgetRef ref) async {
   } catch (e) {
     if (context.mounted) showToast(context, 'Error: $e', isError: true);
   } finally {
-    if (context.mounted) {
-      ref.read(daemonStartingProvider.notifier).state = false;
-    }
+    ref.read(daemonStartingProvider.notifier).state = false;
   }
 }
 

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/models/pr.dart';
 import '../../core/models/tracked_issue.dart';
+import '../../core/platform/platform_services_provider.dart';
 import '../../shared/widgets/severity_badge.dart';
 import '../../shared/widgets/state_badge.dart';
 import '../../shared/widgets/toast.dart';
@@ -28,6 +29,7 @@ class DashboardScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final cbMessage = ref.watch(circuitBreakerProvider);
     final daemonRunning = ref.watch(daemonHealthProvider).valueOrNull ?? false;
+    final daemonStarting = ref.watch(daemonStartingProvider);
     return DefaultTabController(
       length: 6,
       child: Scaffold(
@@ -35,11 +37,23 @@ class DashboardScreen extends ConsumerWidget {
           title: const Text('Heimdallm'),
           actions: [
             IconButton(
-              icon: const Icon(Icons.power_settings_new),
-              tooltip: daemonRunning ? 'Stop Server' : 'Server offline',
-              onPressed: daemonRunning
+              icon: daemonStarting
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Icon(
+                      daemonRunning
+                          ? Icons.power_settings_new
+                          : Icons.play_arrow,
+                    ),
+              tooltip: daemonRunning ? 'Stop Server' : 'Start Server',
+              onPressed: daemonStarting
+                  ? null
+                  : daemonRunning
                   ? () => _confirmShutdown(context, ref)
-                  : null,
+                  : () => _startDaemon(context, ref),
             ),
             IconButton(
               icon: const Icon(Icons.article_outlined),
@@ -99,6 +113,8 @@ class DashboardScreen extends ConsumerWidget {
   }
 }
 
+final daemonStartingProvider = StateProvider<bool>((ref) => false);
+
 Future<void> _confirmShutdown(BuildContext context, WidgetRef ref) async {
   final confirmed = await showDialog<bool>(
     context: context,
@@ -131,6 +147,47 @@ Future<void> _confirmShutdown(BuildContext context, WidgetRef ref) async {
   }
 }
 
+Future<void> _startDaemon(BuildContext context, WidgetRef ref) async {
+  if (ref.read(daemonStartingProvider)) return;
+
+  final platform = ref.read(platformServicesProvider);
+  final binaryPath = platform.defaultDaemonBinaryPath();
+  if (binaryPath == null || binaryPath.isEmpty) {
+    showToast(context, 'Daemon binary not found', isError: true);
+    return;
+  }
+
+  ref.read(daemonStartingProvider.notifier).state = true;
+  try {
+    await platform.spawnDaemon(binaryPath);
+    final api = ref.read(apiClientProvider);
+    var healthy = false;
+    for (var i = 0; i < 80; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      if (!context.mounted) return;
+      healthy = await api.checkHealth();
+      if (healthy) break;
+    }
+    if (!context.mounted) return;
+    _invalidateDashboardData(ref);
+    if (healthy) {
+      showToast(context, 'Server started');
+    } else {
+      showToast(
+        context,
+        'Heimdallm could not start. Check the app installation.',
+        isError: true,
+      );
+    }
+  } catch (e) {
+    if (context.mounted) showToast(context, 'Error: $e', isError: true);
+  } finally {
+    if (context.mounted) {
+      ref.read(daemonStartingProvider.notifier).state = false;
+    }
+  }
+}
+
 Future<void> _refreshWhenDaemonStops(
   BuildContext context,
   WidgetRef ref,
@@ -155,6 +212,12 @@ Future<void> _refreshWhenDaemonStops(
   }
 
   if (!context.mounted) return;
+  _invalidateDashboardData(ref);
+}
+
+void _invalidateDashboardData(WidgetRef ref) {
+  ref.invalidate(sseStreamProvider);
+  ref.invalidate(daemonHealthProvider);
   ref.invalidate(prsProvider);
   ref.invalidate(issuesProvider);
   ref.invalidate(statsProvider);
@@ -457,6 +520,7 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
   }
 
   Widget _errorView(BuildContext context, Object e) {
+    final daemonStarting = ref.watch(daemonStartingProvider);
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -469,12 +533,14 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
           ),
           const SizedBox(height: 4),
           const Text(
-            'Go to Settings to configure and start it.',
+            'Start it here or open Settings to adjust configuration.',
             style: TextStyle(color: Colors.grey),
           ),
           const SizedBox(height: 16),
-          Row(
-            mainAxisSize: MainAxisSize.min,
+          Wrap(
+            alignment: WrapAlignment.center,
+            spacing: 8,
+            runSpacing: 8,
             children: [
               TextButton(
                 onPressed: () {
@@ -483,7 +549,22 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
                 },
                 child: const Text('Retry'),
               ),
-              const SizedBox(width: 8),
+              FilledButton.icon(
+                icon: daemonStarting
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      )
+                    : const Icon(Icons.play_arrow, size: 16),
+                label: Text(daemonStarting ? 'Starting...' : 'Start Server'),
+                onPressed: daemonStarting
+                    ? null
+                    : () => _startDaemon(context, ref),
+              ),
               FilledButton.icon(
                 icon: const Icon(Icons.settings, size: 16),
                 label: const Text('Settings'),

--- a/flutter_app/test/features/dashboard_test.dart
+++ b/flutter_app/test/features/dashboard_test.dart
@@ -3,10 +3,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:heimdallm/core/api/api_client.dart';
 import 'package:heimdallm/core/models/pr.dart';
 import 'package:heimdallm/core/models/review.dart';
+import 'package:heimdallm/core/platform/platform_services_provider.dart';
+import 'package:heimdallm/features/config/config_providers.dart';
 import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
 import 'package:heimdallm/features/dashboard/dashboard_screen.dart';
+import 'package:heimdallm/features/issues/issues_providers.dart';
+import '../core/platform/fake_platform_services.dart';
+
+class MockApiClient extends Mock implements ApiClient {}
 
 PR _pr({
   int id = 1,
@@ -123,5 +131,42 @@ void main() {
     );
     await tester.pump();
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('offline dashboard can start daemon', (tester) async {
+    final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
+    final api = MockApiClient();
+    when(() => api.checkHealth()).thenAnswer((_) async => true);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiClientProvider.overrideWithValue(api),
+          platformServicesProvider.overrideWithValue(platform),
+          daemonHealthProvider.overrideWith((ref) => Future.value(false)),
+          prsProvider.overrideWith((ref) => Future.error(Exception('offline'))),
+          issuesProvider.overrideWith(
+            (ref) => Future.error(Exception('offline')),
+          ),
+          sseStreamProvider.overrideWith((ref) => const Stream.empty()),
+        ],
+        child: MaterialApp.router(
+          routerConfig: GoRouter(
+            routes: [
+              GoRoute(path: '/', builder: (_, __) => const DashboardScreen()),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Start Server'), findsOneWidget);
+    await tester.tap(find.text('Start Server'));
+    await tester.pump(const Duration(milliseconds: 150));
+    await tester.pumpAndSettle();
+
+    expect(platform.spawnedDaemons, equals(['/tmp/heimdallm']));
+    verify(() => api.checkHealth()).called(1);
   });
 }

--- a/flutter_app/test/features/dashboard_test.dart
+++ b/flutter_app/test/features/dashboard_test.dart
@@ -16,49 +16,98 @@ import '../core/platform/fake_platform_services.dart';
 
 class MockApiClient extends Mock implements ApiClient {}
 
+class ThrowingPlatformServices extends FakePlatformServices {
+  ThrowingPlatformServices({
+    required this.spawnError,
+    required super.daemonBinaryPath,
+  });
+
+  final Object spawnError;
+
+  @override
+  Future<void> spawnDaemon(String binaryPath) async {
+    spawnedDaemons.add(binaryPath);
+    throw spawnError;
+  }
+}
+
 PR _pr({
   int id = 1,
   String repo = 'org/repo',
   int number = 42,
   Review? latestReview,
-}) =>
-    PR(
-      id: id,
-      githubId: 1000 + id,
-      repo: repo,
-      number: number,
-      title: 't',
-      author: 'a',
-      url: 'u',
-      state: 'open',
-      updatedAt: DateTime.utc(2026, 1, 1),
-      latestReview: latestReview,
-    );
+}) => PR(
+  id: id,
+  githubId: 1000 + id,
+  repo: repo,
+  number: number,
+  title: 't',
+  author: 'a',
+  url: 'u',
+  state: 'open',
+  updatedAt: DateTime.utc(2026, 1, 1),
+  latestReview: latestReview,
+);
 
 Review _review(int id) => Review(
-      id: id,
-      prId: 1,
-      cliUsed: 'claude',
-      summary: '',
-      issues: const [],
-      suggestions: const [],
-      severity: 'low',
-      createdAt: DateTime.utc(2026, 1, 1),
-    );
+  id: id,
+  prId: 1,
+  cliUsed: 'claude',
+  summary: '',
+  issues: const [],
+  suggestions: const [],
+  severity: 'low',
+  createdAt: DateTime.utc(2026, 1, 1),
+);
+
+Future<void> _pumpOfflineDashboard(
+  WidgetTester tester, {
+  required MockApiClient api,
+  required FakePlatformServices platform,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        apiClientProvider.overrideWithValue(api),
+        platformServicesProvider.overrideWithValue(platform),
+        daemonHealthProvider.overrideWith((ref) => Future.value(false)),
+        prsProvider.overrideWith((ref) => Future.error(Exception('offline'))),
+        issuesProvider.overrideWith(
+          (ref) => Future.error(Exception('offline')),
+        ),
+        sseStreamProvider.overrideWith((ref) => const Stream.empty()),
+      ],
+      child: MaterialApp.router(
+        routerConfig: GoRouter(
+          routes: [
+            GoRoute(path: '/', builder: (_, __) => const DashboardScreen()),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
 
 void main() {
   group('reconcileReviewing', () {
-    test('drops entry when first review lands (baseline=0, latestReview present)', () {
-      final pr = _pr(repo: 'org/repo', number: 1, latestReview: _review(42));
-      final out = reconcileReviewing({'org/repo:1': 0}, [pr]);
-      expect(out, isEmpty);
-    });
+    test(
+      'drops entry when first review lands (baseline=0, latestReview present)',
+      () {
+        final pr = _pr(repo: 'org/repo', number: 1, latestReview: _review(42));
+        final out = reconcileReviewing({'org/repo:1': 0}, [pr]);
+        expect(out, isEmpty);
+      },
+    );
 
-    test('keeps entry when review still pending (baseline=0, no latestReview yet)', () {
-      final pr = _pr(repo: 'org/repo', number: 1);
-      final out = reconcileReviewing({'org/repo:1': 0}, [pr]);
-      expect(out, equals({'org/repo:1': 0}));
-    });
+    test(
+      'keeps entry when review still pending (baseline=0, no latestReview yet)',
+      () {
+        final pr = _pr(repo: 'org/repo', number: 1);
+        final out = reconcileReviewing({'org/repo:1': 0}, [pr]);
+        expect(out, equals({'org/repo:1': 0}));
+      },
+    );
 
     test('keeps entry during re-review (baseline matches current id)', () {
       final pr = _pr(repo: 'org/repo', number: 1, latestReview: _review(42));
@@ -66,11 +115,14 @@ void main() {
       expect(out, equals({'org/repo:1': 42}));
     });
 
-    test('drops entry when re-review completes (baseline older than current id)', () {
-      final pr = _pr(repo: 'org/repo', number: 1, latestReview: _review(43));
-      final out = reconcileReviewing({'org/repo:1': 42}, [pr]);
-      expect(out, isEmpty);
-    });
+    test(
+      'drops entry when re-review completes (baseline older than current id)',
+      () {
+        final pr = _pr(repo: 'org/repo', number: 1, latestReview: _review(43));
+        final out = reconcileReviewing({'org/repo:1': 42}, [pr]);
+        expect(out, isEmpty);
+      },
+    );
 
     test('preserves entry for PR not in current list', () {
       final out = reconcileReviewing({'org/other:9': 5}, const []);
@@ -79,7 +131,12 @@ void main() {
 
     test('reconciles a mixed set (drops stale, keeps in-progress)', () {
       final stale = _pr(repo: 'org/a', number: 1, latestReview: _review(100));
-      final fresh = _pr(id: 2, repo: 'org/b', number: 2, latestReview: _review(200));
+      final fresh = _pr(
+        id: 2,
+        repo: 'org/b',
+        number: 2,
+        latestReview: _review(200),
+      );
       final out = reconcileReviewing(
         {'org/a:1': 0, 'org/b:2': 200},
         [stale, fresh],
@@ -90,64 +147,21 @@ void main() {
 
   testWidgets('DashboardScreen shows PR title', (tester) async {
     final pr = PR(
-      id: 1, githubId: 101, repo: 'org/repo', number: 42,
-      title: 'Fix critical bug', author: 'alice', url: 'https://github.com',
-      state: 'open', updatedAt: DateTime.now(),
+      id: 1,
+      githubId: 101,
+      repo: 'org/repo',
+      number: 42,
+      title: 'Fix critical bug',
+      author: 'alice',
+      url: 'https://github.com',
+      state: 'open',
+      updatedAt: DateTime.now(),
     );
 
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
           prsProvider.overrideWith((ref) => Future.value([pr])),
-          sseStreamProvider.overrideWith((ref) => const Stream.empty()),
-        ],
-        child: MaterialApp.router(
-          routerConfig: GoRouter(
-            routes: [GoRoute(path: '/', builder: (_, __) => const DashboardScreen())],
-          ),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.textContaining('Fix critical bug'), findsOneWidget);
-    expect(find.textContaining('org/repo'), findsOneWidget);
-  });
-
-  testWidgets('DashboardScreen shows loading indicator while fetching', (tester) async {
-    final completer = Completer<List<PR>>();
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          prsProvider.overrideWith((ref) => completer.future),
-          sseStreamProvider.overrideWith((ref) => const Stream.empty()),
-        ],
-        child: MaterialApp.router(
-          routerConfig: GoRouter(
-            routes: [GoRoute(path: '/', builder: (_, __) => const DashboardScreen())],
-          ),
-        ),
-      ),
-    );
-    await tester.pump();
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
-  });
-
-  testWidgets('offline dashboard can start daemon', (tester) async {
-    final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
-    final api = MockApiClient();
-    when(() => api.checkHealth()).thenAnswer((_) async => true);
-
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          apiClientProvider.overrideWithValue(api),
-          platformServicesProvider.overrideWithValue(platform),
-          daemonHealthProvider.overrideWith((ref) => Future.value(false)),
-          prsProvider.overrideWith((ref) => Future.error(Exception('offline'))),
-          issuesProvider.overrideWith(
-            (ref) => Future.error(Exception('offline')),
-          ),
           sseStreamProvider.overrideWith((ref) => const Stream.empty()),
         ],
         child: MaterialApp.router(
@@ -161,12 +175,142 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    expect(find.textContaining('Fix critical bug'), findsOneWidget);
+    expect(find.textContaining('org/repo'), findsOneWidget);
+  });
+
+  testWidgets('DashboardScreen shows loading indicator while fetching', (
+    tester,
+  ) async {
+    final completer = Completer<List<PR>>();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          prsProvider.overrideWith((ref) => completer.future),
+          sseStreamProvider.overrideWith((ref) => const Stream.empty()),
+        ],
+        child: MaterialApp.router(
+          routerConfig: GoRouter(
+            routes: [
+              GoRoute(path: '/', builder: (_, __) => const DashboardScreen()),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('offline dashboard can start daemon', (tester) async {
+    final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
+    final api = MockApiClient();
+    var healthChecks = 0;
+    when(() => api.checkHealth()).thenAnswer((_) async {
+      healthChecks++;
+      return healthChecks == 3;
+    });
+
+    await _pumpOfflineDashboard(tester, api: api, platform: platform);
+
     expect(find.text('Start Server'), findsOneWidget);
     await tester.tap(find.text('Start Server'));
-    await tester.pump(const Duration(milliseconds: 150));
-    await tester.pumpAndSettle();
+    await tester.pump();
+    expect(find.text('Starting...'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump();
 
     expect(platform.spawnedDaemons, equals(['/tmp/heimdallm']));
-    verify(() => api.checkHealth()).called(1);
+    verify(() => api.checkHealth()).called(3);
+    expect(find.text('Server started'), findsOneWidget);
+    expect(find.text('Starting...'), findsNothing);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(DashboardScreen)),
+      listen: false,
+    );
+    expect(container.read(daemonStartingProvider), isFalse);
+  });
+
+  testWidgets('offline dashboard reports missing daemon binary', (
+    tester,
+  ) async {
+    final platform = FakePlatformServices();
+    final api = MockApiClient();
+
+    await _pumpOfflineDashboard(tester, api: api, platform: platform);
+
+    await tester.tap(find.text('Start Server'));
+    await tester.pump();
+
+    expect(platform.spawnedDaemons, isEmpty);
+    verifyNever(() => api.checkHealth());
+    expect(find.text('Daemon binary not found'), findsOneWidget);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(DashboardScreen)),
+      listen: false,
+    );
+    expect(container.read(daemonStartingProvider), isFalse);
+  });
+
+  testWidgets('offline dashboard resets start state when spawn fails', (
+    tester,
+  ) async {
+    final platform = ThrowingPlatformServices(
+      daemonBinaryPath: '/tmp/heimdallm',
+      spawnError: Exception('boom'),
+    );
+    final api = MockApiClient();
+
+    await _pumpOfflineDashboard(tester, api: api, platform: platform);
+
+    await tester.tap(find.text('Start Server'));
+    await tester.pump();
+
+    expect(platform.spawnedDaemons, equals(['/tmp/heimdallm']));
+    verifyNever(() => api.checkHealth());
+    expect(find.text('Error: Exception: boom'), findsOneWidget);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(DashboardScreen)),
+      listen: false,
+    );
+    expect(container.read(daemonStartingProvider), isFalse);
+  });
+
+  testWidgets('offline dashboard reports daemon start timeout', (tester) async {
+    final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
+    final api = MockApiClient();
+    when(() => api.checkHealth()).thenAnswer((_) async => false);
+
+    await _pumpOfflineDashboard(tester, api: api, platform: platform);
+
+    await tester.tap(find.text('Start Server'));
+    await tester.pump();
+    expect(find.text('Starting...'), findsOneWidget);
+
+    for (var i = 0; i < 80; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump();
+    }
+
+    expect(platform.spawnedDaemons, equals(['/tmp/heimdallm']));
+    verify(() => api.checkHealth()).called(80);
+    expect(
+      find.text('Heimdallm could not start. Check the app installation.'),
+      findsOneWidget,
+    );
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(DashboardScreen)),
+      listen: false,
+    );
+    expect(container.read(daemonStartingProvider), isFalse);
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to #367.

- Change the dashboard power action to become a Start Server action when the daemon is offline.
- Add a Start Server button to the offline empty/error state so users are not forced through Settings after stopping the daemon.
- Reuse `PlatformServices.defaultDaemonBinaryPath()` and `spawnDaemon()` and poll health before refreshing dashboard providers.
- Add widget coverage for starting the daemon from the offline dashboard state.

## Validation

- `flutter test test/features/dashboard_test.dart` ✅
- `flutter analyze` ✅
- `flutter test` ✅
- `make build-web` ✅

## Notes

`flutter_app/pubspec.lock` still has an unrelated local diff and is intentionally excluded.