### PR TITLE
fix: make discovery interval follow poll interval

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -527,7 +527,10 @@ func main() {
 
 		// Tier 1: Discovery — publishes to NATS
 		cfgMu.Lock()
-		discoveryInterval := parseDiscoveryInterval(cfg.GitHub.DiscoveryInterval)
+		discoveryInterval := parseDiscoveryInterval(
+			cfg.GitHub.DiscoveryInterval,
+			cfg.GitHub.PollInterval,
+		)
 		cfgMu.Unlock()
 		wg.Add(1)
 		go func() {
@@ -1652,13 +1655,14 @@ func parsePollInterval(s string) time.Duration {
 	return d
 }
 
-// parseDiscoveryInterval falls back to 15m when the value is empty or invalid.
+// parseDiscoveryInterval falls back to pollInterval when the discovery-specific
+// value is empty or invalid.
 // Config.Validate rejects invalid durations before we reach here, so the
-// fallback only covers the unset-in-TOML-but-topic-defaulted case.
-func parseDiscoveryInterval(s string) time.Duration {
-	d, err := time.ParseDuration(s)
+// fallback normally covers the unset discovery_interval case.
+func parseDiscoveryInterval(discoveryInterval, pollInterval string) time.Duration {
+	d, err := time.ParseDuration(discoveryInterval)
 	if err != nil || d <= 0 {
-		return 15 * time.Minute
+		return parsePollInterval(pollInterval)
 	}
 	return d
 }

--- a/daemon/cmd/heimdallm/main_interval_test.go
+++ b/daemon/cmd/heimdallm/main_interval_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDiscoveryIntervalFallsBackToPollInterval(t *testing.T) {
+	got := parseDiscoveryInterval("", "1m")
+	if got != time.Minute {
+		t.Fatalf("parseDiscoveryInterval(empty, 1m) = %v, want 1m", got)
+	}
+}
+
+func TestParseDiscoveryIntervalPreservesExplicitInterval(t *testing.T) {
+	got := parseDiscoveryInterval("30m", "1m")
+	if got != 30*time.Minute {
+		t.Fatalf("parseDiscoveryInterval(30m, 1m) = %v, want 30m", got)
+	}
+}
+
+func TestParseDiscoveryIntervalUsesPollDefaultWhenBothInvalid(t *testing.T) {
+	got := parseDiscoveryInterval("", "nope")
+	if got != 5*time.Minute {
+		t.Fatalf("parseDiscoveryInterval(empty, invalid) = %v, want 5m", got)
+	}
+}

--- a/daemon/cmd/heimdallm/main_interval_test.go
+++ b/daemon/cmd/heimdallm/main_interval_test.go
@@ -19,9 +19,17 @@ func TestParseDiscoveryIntervalPreservesExplicitInterval(t *testing.T) {
 	}
 }
 
+func TestParseDiscoveryIntervalNegativeFallsBackToPollInterval(t *testing.T) {
+	got := parseDiscoveryInterval("-5m", "1m")
+	if got != time.Minute {
+		t.Fatalf("parseDiscoveryInterval(-5m, 1m) = %v, want 1m", got)
+	}
+}
+
 func TestParseDiscoveryIntervalUsesPollDefaultWhenBothInvalid(t *testing.T) {
+	want := parsePollInterval("nope")
 	got := parseDiscoveryInterval("", "nope")
-	if got != 5*time.Minute {
-		t.Fatalf("parseDiscoveryInterval(empty, invalid) = %v, want 5m", got)
+	if got != want {
+		t.Fatalf("parseDiscoveryInterval(empty, invalid) = %v, want %v", got, want)
 	}
 }

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -61,9 +61,8 @@ type GitHubConfig struct {
 	// Required when DiscoveryTopic is set (prevents scanning all of GitHub).
 	DiscoveryOrgs []string `toml:"discovery_orgs"`
 	// DiscoveryInterval controls how often the discovery query is refreshed.
-	// Independent from PollInterval because the Search API has a stricter
-	// rate limit (30 req/min authenticated). Defaults to "15m" when discovery
-	// is enabled. Accepts any Go time.ParseDuration value.
+	// When empty, discovery follows PollInterval; set this when discovery
+	// should run on its own cadence. Accepts any Go time.ParseDuration value.
 	DiscoveryInterval string `toml:"discovery_interval"`
 
 	// AutoEnablePROnDiscovery controls the initial prEnabled value for repos
@@ -623,9 +622,6 @@ func (c *Config) applyDefaults() {
 	}
 	if c.GitHub.PollInterval == "" {
 		c.GitHub.PollInterval = "5m"
-	}
-	if c.GitHub.DiscoveryTopic != "" && c.GitHub.DiscoveryInterval == "" {
-		c.GitHub.DiscoveryInterval = "15m"
 	}
 	if c.GitHub.IssueTracking.FilterMode == "" {
 		c.GitHub.IssueTracking.FilterMode = FilterModeExclusive

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -62,7 +62,8 @@ type GitHubConfig struct {
 	DiscoveryOrgs []string `toml:"discovery_orgs"`
 	// DiscoveryInterval controls how often the discovery query is refreshed.
 	// When empty, discovery follows PollInterval; set this when discovery
-	// should run on its own cadence. Accepts any Go time.ParseDuration value.
+	// should run on its own cadence, for example to preserve Search API budget
+	// across many discovery_orgs. Accepts any Go time.ParseDuration value.
 	DiscoveryInterval string `toml:"discovery_interval"`
 
 	// AutoEnablePROnDiscovery controls the initial prEnabled value for repos

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -196,13 +196,13 @@ func TestValidate_AllValidIntervals(t *testing.T) {
 
 // ── Topic-based discovery ────────────────────────────────────────────────────
 
-func TestApplyDefaults_DiscoveryIntervalWhenTopicSet(t *testing.T) {
+func TestApplyDefaults_DiscoveryIntervalUnsetWhenTopicSet(t *testing.T) {
 	cfg := &Config{}
 	cfg.GitHub.DiscoveryTopic = "heimdallm-review"
 	cfg.applyDefaults()
 
-	if cfg.GitHub.DiscoveryInterval != "15m" {
-		t.Errorf("DiscoveryInterval = %q, want default %q", cfg.GitHub.DiscoveryInterval, "15m")
+	if cfg.GitHub.DiscoveryInterval != "" {
+		t.Errorf("DiscoveryInterval = %q, want empty runtime fallback", cfg.GitHub.DiscoveryInterval)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #282.

- Make Tier 1 discovery use `poll_interval` when `discovery_interval` is not explicitly configured.
- Preserve explicit `discovery_interval` as an override for deployments that want a separate discovery cadence.
- Stop materializing a default `15m` discovery interval in config defaults so env/store `poll_interval` changes can drive the effective discovery cadence.
- Add parser coverage for fallback/default/explicit interval behavior and negative discovery intervals.

## Behavior Change

Deployments with `discovery_topic` but no explicit `discovery_interval` now refresh discovery at the effective `poll_interval` cadence instead of the previous implicit `15m` cadence. With default config this means `5m`; if `poll_interval` is set lower, discovery follows that lower cadence too. Set `discovery_interval` explicitly to keep discovery slower, for example when Search API budget is tight across many `discovery_orgs`.

## Validation

- `git diff --check` passed
- `make test-docker GO_TEST_ARGS="-run TestParseDiscoveryInterval ./cmd/heimdallm"` blocked locally by Docker socket 500 before the container started: `request returned 500 Internal Server Error for API route .../_ping`

Go tests were not run on host per repo policy; CI should exercise the Docker/Go suite.