### PR TITLE
fix: restore docker go test gate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,22 @@
-# Docker context exclusions for Dockerfile.linux-verify
+# Docker context exclusions for repo-root builds
 .git
+.codex
+
+# Local secrets and runtime config
+.env
+.env.*
+!.env.example
+docker/.env
+docker/.env.*
+!docker/.env.example
+docker/config
+*.pem
+*.key
+*.crt
+*.p12
+*.pfx
+
+# Build outputs
 flutter_app/build
 daemon/bin
 dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Hardening details are inlined in the Makefile target. Summary:
 
 | Concern | Guarantee |
 |---|---|
-| Image | Official `golang:1.21-alpine`, **pinned by SHA256 digest** (not a mutable tag) |
+| Image | Official `golang:1.25-alpine`, **pinned by SHA256 digest** (not a mutable tag) |
 | Host filesystem access | Single mount: repo at `/src`, **read-only** (`:ro`) |
 | Build cache | Redirected to `/tmp/heimdallm-gocache/` — does not touch `~/.cache` or `~/go` |
 | Privileges | Runs as invoking user (`--user $(id -u):$(id -g)`) — no root in the container |

--- a/Dockerfile.linux-verify
+++ b/Dockerfile.linux-verify
@@ -1,6 +1,6 @@
 # Dockerfile.linux-verify
 #
-# Replicates the CI environment (ubuntu-22.04, Go 1.21, Flutter 3.x stable)
+# Replicates the CI environment (ubuntu-22.04, Go 1.25, Flutter 3.x stable)
 # and runs the full verification pipeline:
 #
 #   daemon tests → flutter pub get → flutter test →
@@ -23,8 +23,8 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
       git curl unzip xz-utils wget ca-certificates make \
     && rm -rf /var/lib/apt/lists/*
 
-# ── Go 1.21 (matches daemon/go.mod) ──────────────────────────────────────────
-RUN wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz -O /tmp/go.tar.gz \
+# ── Go 1.25 (matches daemon/go.mod) ──────────────────────────────────────────
+RUN wget -q https://go.dev/dl/go1.25.7.linux-amd64.tar.gz -O /tmp/go.tar.gz \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test:
 #   make test-docker
 #   make test-docker GO_TEST_ARGS="-run TestFoo ./internal/config/..."
 
-GO_DOCKER_IMAGE ?= golang:1.21-alpine@sha256:2414035b086e3c42b99654c8b26e6f5b1b1598080d65fd03c7f499552ff4dc94
+GO_DOCKER_IMAGE ?= golang:1.25-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced
 GO_TEST_ARGS    ?= -timeout 60s -count=1 ./...
 
 test-docker:

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ In **Docker mode** the daemon runs standalone with the web UI container as an op
 
 ### Prerequisites
 
-- Go 1.21+
+- Go 1.25+
 - Flutter 3.x (stable)
 - `gh` CLI authenticated
 - macOS 13+ with Xcode **or** Linux with GTK 3 dev libraries


### PR DESCRIPTION
## Summary
- update the pinned Go Docker test image to Go 1.25 to match daemon/go.mod
- update the Linux verifier Go toolchain and related docs
- harden .dockerignore so local secrets/runtime config stay out of Docker build contexts

## Verification
- make test-docker GO_TEST_ARGS="-run TestDoesNotExist ./..."
- make test-docker