### PR TITLE
fix: refresh topic discovery before publishing repos

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -560,9 +560,6 @@ func main() {
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-					if err := limiter.Acquire(ctx, scheduler.TierDiscovery); err != nil {
-						return
-					}
 					sendDiscoveryRepos(ctx, discoverySvc, limiter, repoPublisher, tier1ConfigFn)
 				}
 			}
@@ -585,7 +582,11 @@ func main() {
 			tier2ConfigFn := func() []string {
 				cfgMu.Lock()
 				defer cfgMu.Unlock()
-				return discovery.MergeRepos(cfg.GitHub.Repositories, discoverySvc.Discovered(), cfg.GitHub.NonMonitored)
+				var discovered []string
+				if cfg.GitHub.DiscoveryTopic != "" {
+					discovered = discoverySvc.Discovered()
+				}
+				return discovery.MergeRepos(cfg.GitHub.Repositories, discovered, cfg.GitHub.NonMonitored)
 			}
 			runTier2(ctx, adapter, limiter, prReviewPublisher, tier2ConfigFn, reposChan, pollInterval, coldStart)
 		}()
@@ -1699,36 +1700,21 @@ func sendDiscoveryRepos(
 	configFn func() scheduler.Tier1Config,
 ) {
 	cfg := configFn()
-	discovered := disc.Discovered()
-
-	// Merge static + discovered, exclude non-monitored
-	nonMon := make(map[string]struct{}, len(cfg.NonMonitored))
-	for _, r := range cfg.NonMonitored {
-		nonMon[r] = struct{}{}
-	}
-	seen := make(map[string]struct{})
-	var repos []string
-	for _, r := range cfg.StaticRepos {
-		if _, skip := nonMon[r]; skip {
-			continue
+	var discovered []string
+	if cfg.DiscoveryTopic != "" {
+		if limiter != nil {
+			if err := limiter.Acquire(ctx, scheduler.TierDiscovery); err != nil {
+				slog.Warn("tier1: acquire discovery rate-limit token failed", "err", err)
+				return
+			}
 		}
-		if _, dup := seen[r]; dup {
-			continue
+		if err := disc.Refresh(cfg.DiscoveryTopic, cfg.DiscoveryOrgs); err != nil {
+			slog.Warn("tier1: discovery refresh failed, using cached discovered repos", "err", err)
 		}
-		seen[r] = struct{}{}
-		repos = append(repos, r)
-	}
-	for _, r := range discovered {
-		if _, skip := nonMon[r]; skip {
-			continue
-		}
-		if _, dup := seen[r]; dup {
-			continue
-		}
-		seen[r] = struct{}{}
-		repos = append(repos, r)
+		discovered = disc.Discovered()
 	}
 
+	repos := discovery.MergeRepos(cfg.StaticRepos, discovered, cfg.NonMonitored)
 	slog.Info("tier1: discovery complete", "repos", len(repos))
 	if err := pub.PublishRepos(ctx, repos); err != nil {
 		slog.Error("tier1: publish repos failed", "err", err)

--- a/daemon/cmd/heimdallm/main_discovery_tier1_test.go
+++ b/daemon/cmd/heimdallm/main_discovery_tier1_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/scheduler"
+)
+
+type fakeTier1Discovery struct {
+	refreshCalls int
+	refreshTopic string
+	refreshOrgs  []string
+	refreshRepos []string
+	refreshErr   error
+	repos        []string
+}
+
+func (f *fakeTier1Discovery) Discovered() []string {
+	if len(f.repos) == 0 {
+		return nil
+	}
+	out := make([]string, len(f.repos))
+	copy(out, f.repos)
+	return out
+}
+
+func (f *fakeTier1Discovery) Refresh(topic string, orgs []string) error {
+	f.refreshCalls++
+	f.refreshTopic = topic
+	f.refreshOrgs = append([]string(nil), orgs...)
+	if f.refreshErr == nil {
+		f.repos = append([]string(nil), f.refreshRepos...)
+	}
+	return f.refreshErr
+}
+
+type fakeTier1Publisher struct {
+	calls int
+	repos []string
+}
+
+func (f *fakeTier1Publisher) PublishRepos(_ context.Context, repos []string) error {
+	f.calls++
+	f.repos = append([]string(nil), repos...)
+	return nil
+}
+
+func TestSendDiscoveryReposRefreshesTopicBeforePublish(t *testing.T) {
+	disc := &fakeTier1Discovery{
+		refreshRepos: []string{"org/discovered", "org/static", "org/ignored"},
+	}
+	pub := &fakeTier1Publisher{}
+
+	sendDiscoveryRepos(
+		context.Background(),
+		disc,
+		scheduler.NewRateLimiter(1),
+		pub,
+		func() scheduler.Tier1Config {
+			return scheduler.Tier1Config{
+				StaticRepos:    []string{"org/static"},
+				NonMonitored:   []string{"org/ignored"},
+				DiscoveryTopic: "heimdallm-review",
+				DiscoveryOrgs:  []string{"org"},
+			}
+		},
+	)
+
+	if disc.refreshCalls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", disc.refreshCalls)
+	}
+	if disc.refreshTopic != "heimdallm-review" {
+		t.Errorf("refresh topic = %q, want heimdallm-review", disc.refreshTopic)
+	}
+	if !reflect.DeepEqual(disc.refreshOrgs, []string{"org"}) {
+		t.Errorf("refresh orgs = %v, want [org]", disc.refreshOrgs)
+	}
+	want := []string{"org/static", "org/discovered"}
+	if !reflect.DeepEqual(pub.repos, want) {
+		t.Errorf("published repos = %v, want %v", pub.repos, want)
+	}
+}
+
+func TestSendDiscoveryReposSkipsRefreshWhenTopicDisabled(t *testing.T) {
+	disc := &fakeTier1Discovery{
+		repos:        []string{"org/cached"},
+		refreshRepos: []string{"org/discovered"},
+	}
+	pub := &fakeTier1Publisher{}
+
+	sendDiscoveryRepos(
+		context.Background(),
+		disc,
+		scheduler.NewRateLimiter(1),
+		pub,
+		func() scheduler.Tier1Config {
+			return scheduler.Tier1Config{
+				StaticRepos: []string{"org/static"},
+			}
+		},
+	)
+
+	if disc.refreshCalls != 0 {
+		t.Fatalf("refresh calls = %d, want 0", disc.refreshCalls)
+	}
+	want := []string{"org/static"}
+	if !reflect.DeepEqual(pub.repos, want) {
+		t.Errorf("published repos = %v, want %v", pub.repos, want)
+	}
+}
+
+func TestSendDiscoveryReposPublishesCachedReposWhenRefreshFails(t *testing.T) {
+	disc := &fakeTier1Discovery{
+		repos:      []string{"org/cached"},
+		refreshErr: errors.New("rate limited"),
+	}
+	pub := &fakeTier1Publisher{}
+
+	sendDiscoveryRepos(
+		context.Background(),
+		disc,
+		scheduler.NewRateLimiter(1),
+		pub,
+		func() scheduler.Tier1Config {
+			return scheduler.Tier1Config{
+				StaticRepos:    []string{"org/static"},
+				DiscoveryTopic: "heimdallm-review",
+				DiscoveryOrgs:  []string{"org"},
+			}
+		},
+	)
+
+	if disc.refreshCalls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", disc.refreshCalls)
+	}
+	want := []string{"org/static", "org/cached"}
+	if !reflect.DeepEqual(pub.repos, want) {
+		t.Errorf("published repos = %v, want %v", pub.repos, want)
+	}
+}

--- a/daemon/internal/scheduler/types.go
+++ b/daemon/internal/scheduler/types.go
@@ -10,6 +10,7 @@ import (
 // Tier1Discovery is the interface the discovery tier needs.
 type Tier1Discovery interface {
 	Discovered() []string
+	Refresh(topic string, orgs []string) error
 }
 
 // Tier1Publisher publishes the discovered repo list.


### PR DESCRIPTION
## Summary
- refresh topic-based repository discovery before Tier 1 publishes repo lists
- keep using the previous discovery cache when a refresh fails
- stop including cached discovered repos when discovery_topic is disabled
- add regression coverage for refresh, disabled discovery, and refresh-failure fallback

## Verification
- make test-docker GO_DOCKER_IMAGE=golang:1.25-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced GO_TEST_ARGS="-run TestSendDiscoveryRepos ./cmd/heimdallm"
- make test-docker GO_DOCKER_IMAGE=golang:1.25-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced

Note: this branch is based on main and uses the Go image override until #372 lands, because main's default make test-docker image is still Go 1.21.