### PR TITLE
fix: keep TOML repo lists above store state

### DIFF
--- a/daemon/internal/config/store.go
+++ b/daemon/internal/config/store.go
@@ -13,11 +13,11 @@ type StoreLister interface {
 	ListConfigs() (map[string]string, error)
 }
 
-// MergeStoreLayer is the full "apply the store layer on top of TOML+env"
-// operation: fetch rows, apply them atomically, re-validate. Callers that
-// need each step separately can still use ListConfigs + ApplyStore + Validate
-// directly; this helper exists so main.go's bootstrap and reload paths can
-// share one code path and so tests can drive the whole flow with a fake.
+// MergeStoreLayer fetches rows, applies them atomically, then re-validates.
+// Most store-backed keys are operator overrides from the legacy PUT /config
+// path and therefore still sit above TOML+env. Repository lists are different:
+// the poller also writes them as runtime discovery state, so ApplyStore merges
+// those rows below explicit TOML/env values.
 //
 // Returns the first error encountered. On error the receiver is untouched
 // (ApplyStore is atomic and Validate is a read-only check), so the caller is
@@ -38,7 +38,12 @@ func (c *Config) MergeStoreLayer(s StoreLister) error {
 
 // ApplyStore merges runtime-overridable config values written by the
 // PUT /config handler on top of whatever is already in the Config (TOML +
-// env vars). Precedence is TOML < env < store, so this step runs last.
+// env vars). Most keys use TOML < env < store precedence.
+//
+// Repository lists are the exception. Auto-discovery also writes
+// repositories/non_monitored rows, so those store rows are treated as
+// lower-priority runtime additions: store-only repos are kept, but explicit
+// TOML/env list entries win conflicts.
 //
 // The handler stores string values bare and everything else as JSON, so the
 // decoding here is symmetric to handlers.go:handlePutConfig.
@@ -61,6 +66,10 @@ func (c *Config) MergeStoreLayer(s StoreLister) error {
 // leak through to the receiver even when a later row fails.
 func (c *Config) ApplyStore(rows map[string]string) error {
 	shadow := *c
+	var storeRepos []string
+	var storeNonMonitored []string
+	var sawStoreRepos bool
+	var sawStoreNonMonitored bool
 	for key, raw := range rows {
 		switch key {
 		case "poll_interval":
@@ -76,13 +85,15 @@ func (c *Config) ApplyStore(rows map[string]string) error {
 			if err := json.Unmarshal([]byte(raw), &repos); err != nil {
 				return fmt.Errorf("config: apply store key %q: %w", key, err)
 			}
-			shadow.GitHub.Repositories = repos
+			storeRepos = repos
+			sawStoreRepos = true
 		case "non_monitored":
 			var nm []string
 			if err := json.Unmarshal([]byte(raw), &nm); err != nil {
 				return fmt.Errorf("config: apply store key %q: %w", key, err)
 			}
-			shadow.GitHub.NonMonitored = nm
+			storeNonMonitored = nm
+			sawStoreNonMonitored = true
 		case "repo_first_seen":
 			// Auxiliary data read directly from the store by the HTTP
 			// config handler (to render NEW badges) — not applied to the
@@ -126,6 +137,57 @@ func (c *Config) ApplyStore(rows map[string]string) error {
 			slog.Warn("config: unknown store key, skipping", "key", key)
 		}
 	}
+	if sawStoreRepos || sawStoreNonMonitored {
+		mergeStoreRepoLists(&shadow, storeRepos, storeNonMonitored)
+	}
 	*c = shadow
 	return nil
+}
+
+func mergeStoreRepoLists(c *Config, storeRepos, storeNonMonitored []string) {
+	repoSet := make(map[string]struct{}, len(c.GitHub.Repositories)+len(storeRepos))
+	for _, repo := range c.GitHub.Repositories {
+		repoSet[repo] = struct{}{}
+	}
+	nonMonitoredSet := make(map[string]struct{}, len(c.GitHub.NonMonitored)+len(storeNonMonitored))
+	for _, repo := range c.GitHub.NonMonitored {
+		nonMonitoredSet[repo] = struct{}{}
+	}
+
+	// Within the store layer, non_monitored keeps the old effective behavior:
+	// a repo in both store lists is not monitored. Explicit TOML/env
+	// repositories still win because repoSet is checked before appending.
+	storeNonMonitoredSet := make(map[string]struct{}, len(storeNonMonitored))
+	for _, repo := range storeNonMonitored {
+		storeNonMonitoredSet[repo] = struct{}{}
+		if _, monitored := repoSet[repo]; monitored {
+			continue
+		}
+		if _, exists := nonMonitoredSet[repo]; exists {
+			continue
+		}
+		c.GitHub.NonMonitored = append(c.GitHub.NonMonitored, repo)
+		nonMonitoredSet[repo] = struct{}{}
+	}
+
+	// If HEIMDALLM_REPOSITORIES is set, the deployment-provided monitored list
+	// is authoritative. Keep store non_monitored rows for UI/history, but do
+	// not append store-only monitored repositories.
+	if _, envReposSet := csvEnv("HEIMDALLM_REPOSITORIES"); envReposSet {
+		return
+	}
+
+	for _, repo := range storeRepos {
+		if _, monitored := repoSet[repo]; monitored {
+			continue
+		}
+		if _, disabled := nonMonitoredSet[repo]; disabled {
+			continue
+		}
+		if _, disabledInStore := storeNonMonitoredSet[repo]; disabledInStore {
+			continue
+		}
+		c.GitHub.Repositories = append(c.GitHub.Repositories, repo)
+		repoSet[repo] = struct{}{}
+	}
 }

--- a/daemon/internal/config/store_test.go
+++ b/daemon/internal/config/store_test.go
@@ -15,15 +15,16 @@ func (f *fakeStoreLister) ListConfigs() (map[string]string, error) {
 	return f.rows, f.err
 }
 
-// ApplyStore is the third layer of config precedence: TOML < env < store.
-// It receives the `configs` table rows (key → raw value string) that the
-// PUT /config handler writes, and merges them onto an already-loaded cfg.
+// ApplyStore receives the `configs` table rows (key → raw value string) that
+// the legacy PUT /config handler writes, and merges them onto an already-loaded
+// cfg. Most keys use TOML < env < store precedence; repository lists are lower
+// priority runtime-discovery state, so explicit TOML/env entries win conflicts.
 //
 // Values stored as bare strings (e.g. "5m" for poll_interval) are assigned
 // as-is; everything else was json.Marshal'd by the handler, so we unmarshal
 // here symmetrically.
 
-func TestApplyStore_MergesRepositoriesAndIssueTracking(t *testing.T) {
+func TestApplyStore_MergesStoreOnlyRepositoriesAndIssueTracking(t *testing.T) {
 	cfg := &Config{}
 	cfg.applyDefaults()
 	cfg.GitHub.Repositories = []string{"toml/one"}
@@ -37,9 +38,9 @@ func TestApplyStore_MergesRepositoriesAndIssueTracking(t *testing.T) {
 		t.Fatalf("ApplyStore: %v", err)
 	}
 
-	got := cfg.GitHub.Repositories
-	if len(got) != 2 || got[0] != "store/a" || got[1] != "store/b" {
-		t.Errorf("Repositories = %v, want [store/a store/b]", got)
+	wantRepos := []string{"toml/one", "store/a", "store/b"}
+	if fmt.Sprintf("%v", cfg.GitHub.Repositories) != fmt.Sprintf("%v", wantRepos) {
+		t.Errorf("Repositories = %v, want %v", cfg.GitHub.Repositories, wantRepos)
 	}
 	it := cfg.GitHub.IssueTracking
 	if !it.Enabled {
@@ -56,7 +57,7 @@ func TestApplyStore_MergesRepositoriesAndIssueTracking(t *testing.T) {
 	}
 }
 
-func TestApplyStore_MergesNonMonitored(t *testing.T) {
+func TestApplyStore_MergesStoreOnlyNonMonitored(t *testing.T) {
 	cfg := &Config{}
 	cfg.applyDefaults()
 	cfg.GitHub.NonMonitored = []string{"toml/skip"}
@@ -69,9 +70,81 @@ func TestApplyStore_MergesNonMonitored(t *testing.T) {
 		t.Fatalf("ApplyStore: %v", err)
 	}
 
-	got := cfg.GitHub.NonMonitored
-	if len(got) != 2 || got[0] != "store/a" || got[1] != "store/b" {
-		t.Errorf("NonMonitored = %v, want [store/a store/b]", got)
+	want := []string{"toml/skip", "store/a", "store/b"}
+	if fmt.Sprintf("%v", cfg.GitHub.NonMonitored) != fmt.Sprintf("%v", want) {
+		t.Errorf("NonMonitored = %v, want %v", cfg.GitHub.NonMonitored, want)
+	}
+}
+
+func TestApplyStore_RepoLists_TOMLRepositoriesWinStoreNonMonitored(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.GitHub.Repositories = []string{"toml/monitored"}
+
+	rows := map[string]string{
+		"non_monitored": `["toml/monitored","store/disabled"]`,
+	}
+
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+
+	wantRepos := []string{"toml/monitored"}
+	wantNonMonitored := []string{"store/disabled"}
+	if fmt.Sprintf("%v", cfg.GitHub.Repositories) != fmt.Sprintf("%v", wantRepos) {
+		t.Errorf("Repositories = %v, want %v", cfg.GitHub.Repositories, wantRepos)
+	}
+	if fmt.Sprintf("%v", cfg.GitHub.NonMonitored) != fmt.Sprintf("%v", wantNonMonitored) {
+		t.Errorf("NonMonitored = %v, want %v", cfg.GitHub.NonMonitored, wantNonMonitored)
+	}
+}
+
+func TestApplyStore_RepoLists_TOMLNonMonitoredWinsStoreRepositories(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.GitHub.NonMonitored = []string{"toml/disabled"}
+
+	rows := map[string]string{
+		"repositories": `["toml/disabled","store/monitored"]`,
+	}
+
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+
+	wantRepos := []string{"store/monitored"}
+	wantNonMonitored := []string{"toml/disabled"}
+	if fmt.Sprintf("%v", cfg.GitHub.Repositories) != fmt.Sprintf("%v", wantRepos) {
+		t.Errorf("Repositories = %v, want %v", cfg.GitHub.Repositories, wantRepos)
+	}
+	if fmt.Sprintf("%v", cfg.GitHub.NonMonitored) != fmt.Sprintf("%v", wantNonMonitored) {
+		t.Errorf("NonMonitored = %v, want %v", cfg.GitHub.NonMonitored, wantNonMonitored)
+	}
+}
+
+func TestApplyStore_RepoLists_EnvRepositoriesIgnoreStoreAdditions(t *testing.T) {
+	t.Setenv("HEIMDALLM_REPOSITORIES", "env/one,env/two")
+
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.applyEnvOverrides()
+
+	rows := map[string]string{
+		"repositories":  `["store/monitored"]`,
+		"non_monitored": `["env/one","store/disabled"]`,
+	}
+
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+
+	wantRepos := []string{"env/one", "env/two"}
+	wantNonMonitored := []string{"store/disabled"}
+	if fmt.Sprintf("%v", cfg.GitHub.Repositories) != fmt.Sprintf("%v", wantRepos) {
+		t.Errorf("Repositories = %v, want %v", cfg.GitHub.Repositories, wantRepos)
+	}
+	if fmt.Sprintf("%v", cfg.GitHub.NonMonitored) != fmt.Sprintf("%v", wantNonMonitored) {
+		t.Errorf("NonMonitored = %v, want %v", cfg.GitHub.NonMonitored, wantNonMonitored)
 	}
 }
 
@@ -233,8 +306,8 @@ func TestApplyStore_PartialFailure_LeavesCfgUnchanged(t *testing.T) {
 	cfg.AI.Primary = "claude"
 
 	rows := map[string]string{
-		"poll_interval": "30m",             // valid — would apply on its own
-		"repositories":  "not valid json",  // bad — should poison the whole batch
+		"poll_interval": "30m",            // valid — would apply on its own
+		"repositories":  "not valid json", // bad — should poison the whole batch
 	}
 
 	err := cfg.ApplyStore(rows)

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -392,7 +392,6 @@ func (srv *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 // data injection into the configs table (security issue #4).
 var validConfigKeys = map[string]struct{}{
 	"poll_interval":  {},
-	"repositories":   {},
 	"ai_primary":     {},
 	"ai_fallback":    {},
 	"review_mode":    {},
@@ -408,6 +407,9 @@ var validConfigKeys = map[string]struct{}{
 // arbitrary keys permitted.
 //
 // Why each key is here:
+//   - repositories  : repo-list changes belong in config.toml via PATCH
+//     /config. Persisting this key in SQLite lets runtime discovery override
+//     explicit TOML/env repo choices.
 //   - non_monitored : Flutter-UI managed list of disabled repos, not a
 //     web-UI concern.
 //   - repo_overrides: per-repo AI config lives in [ai.repos.<name>] or
@@ -418,6 +420,7 @@ var validConfigKeys = map[string]struct{}{
 //     flight would drop every in-flight connection). Its numeric-range
 //     pre-check still runs so clients get feedback on bad values.
 var readOnlyConfigKeys = map[string]struct{}{
+	"repositories":   {},
 	"non_monitored":  {},
 	"repo_overrides": {},
 	"agent_configs":  {},

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -755,11 +755,12 @@ func TestHandlerPutConfig_ReadOnlyKeys_Accepted(t *testing.T) {
 		name string
 		body string
 	}{
+		{"repositories", `{"repositories":["org/monitored"]}`},
 		{"non_monitored", `{"non_monitored":["org/archived"]}`},
 		{"repo_overrides", `{"repo_overrides":{"org/a":{"primary":"claude"}}}`},
 		{"agent_configs", `{"agent_configs":{"claude":{"model":"claude-opus-4-7"}}}`},
 		{"server_port", `{"server_port":7842}`},
-		{"all-at-once", `{"non_monitored":[],"repo_overrides":{},"agent_configs":{},"server_port":7842}`},
+		{"all-at-once", `{"repositories":[],"non_monitored":[],"repo_overrides":{},"agent_configs":{},"server_port":7842}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -778,7 +779,7 @@ func TestHandlerPutConfig_ReadOnlyKeys_NotPersisted(t *testing.T) {
 	// reload doesn't have to re-examine them and ApplyStore's
 	// "unknown/bootstrap-only" branches stay dormant.
 	srv, s := setupServer(t)
-	body := `{"non_monitored":["org/x"],"repo_overrides":{"org/a":{"primary":"claude"}},"agent_configs":{"claude":{"model":"x"}},"server_port":7842}`
+	body := `{"repositories":["org/y"],"non_monitored":["org/x"],"repo_overrides":{"org/a":{"primary":"claude"}},"agent_configs":{"claude":{"model":"x"}},"server_port":7842}`
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, putConfigRequest(body))
 	if w.Code != http.StatusOK {
@@ -789,7 +790,7 @@ func TestHandlerPutConfig_ReadOnlyKeys_NotPersisted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListConfigs: %v", err)
 	}
-	for _, banned := range []string{"non_monitored", "repo_overrides", "agent_configs", "server_port"} {
+	for _, banned := range []string{"repositories", "non_monitored", "repo_overrides", "agent_configs", "server_port"} {
 		if _, leaked := rows[banned]; leaked {
 			t.Errorf("read-only key %q was persisted (rows: %v)", banned, rows)
 		}
@@ -801,7 +802,7 @@ func TestHandlerPutConfig_WritableAndReadOnly_Mixed(t *testing.T) {
 	// round-tripped read-only ones. Only the editable fields land in the
 	// store — nothing else bleeds in.
 	srv, s := setupServer(t)
-	body := `{"poll_interval":"30m","agent_configs":{"claude":{"model":"x"}},"non_monitored":["org/x"]}`
+	body := `{"poll_interval":"30m","agent_configs":{"claude":{"model":"x"}},"repositories":["org/y"],"non_monitored":["org/x"]}`
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, putConfigRequest(body))
 	if w.Code != http.StatusOK {
@@ -817,6 +818,9 @@ func TestHandlerPutConfig_WritableAndReadOnly_Mixed(t *testing.T) {
 	}
 	if _, ok := rows["agent_configs"]; ok {
 		t.Errorf("agent_configs unexpectedly persisted")
+	}
+	if _, ok := rows["repositories"]; ok {
+		t.Errorf("repositories unexpectedly persisted")
 	}
 	if _, ok := rows["non_monitored"]; ok {
 		t.Errorf("non_monitored unexpectedly persisted")
@@ -1157,6 +1161,42 @@ func TestHandlePatchConfig(t *testing.T) {
 	}
 	if ai["fallback"] != "gemini" {
 		t.Errorf("fallback = %v, want gemini (should be preserved)", ai["fallback"])
+	}
+}
+
+func TestHandlePatchConfig_RepoListsWriteTOML(t *testing.T) {
+	tomlContent := "[ai]\nprimary = \"claude\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	body := `{"github":{"repositories":["org/monitored"],"non_monitored":["org/disabled"]}}`
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, err := config.ReadTOMLMap(tomlPath)
+	if err != nil {
+		t.Fatalf("read TOML after PATCH: %v", err)
+	}
+	gh, ok := m["github"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected [github] section in TOML, got %v", m)
+	}
+	repos, ok := gh["repositories"].([]any)
+	if !ok || len(repos) != 1 || repos[0] != "org/monitored" {
+		t.Fatalf("repositories = %v, want [org/monitored]", gh["repositories"])
+	}
+	nonMonitored, ok := gh["non_monitored"].([]any)
+	if !ok || len(nonMonitored) != 1 || nonMonitored[0] != "org/disabled" {
+		t.Fatalf("non_monitored = %v, want [org/disabled]", gh["non_monitored"])
 	}
 }
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -91,6 +91,10 @@ HEIMDALLM_REPOSITORIES=myorg/api,myorg/backend,myorg/frontend
 repositories = ["myorg/api", "myorg/backend", "myorg/frontend"]
 ```
 
+Explicit repo lists in `config.toml` or `HEIMDALLM_REPOSITORIES` win over
+runtime discovery state saved in SQLite. A repo explicitly listed as monitored
+will not be disabled by an older `non_monitored` store row.
+
 ### Topic-based discovery
 
 Instead of (or in addition to) a static list, tag GitHub repositories with a topic and let the daemon discover them automatically.


### PR DESCRIPTION
## Summary
- fix repository/non_monitored store merge semantics so explicit TOML/env repo choices win over SQLite runtime state
- keep store-only discovered repos as lower-priority additions for compatibility
- stop legacy PUT /config from persisting repositories into SQLite; PATCH /config continues to write repo lists to TOML
- document repo-list source-of-truth precedence

Fixes #284

## Verification
- make test-docker GO_DOCKER_IMAGE=golang:1.25-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced GO_TEST_ARGS="./internal/config/... ./internal/server/..."
- make test-docker GO_DOCKER_IMAGE=golang:1.25-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced

Note: this branch is based on main and uses the Go image override until #372 lands, because main's default make test-docker image is still Go 1.21.