### PR TITLE
[codex] feat: improve activity log UX

### DIFF
--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -1106,7 +1106,9 @@ func (srv *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 //	from=YYYY-MM-DD & to=YYYY-MM-DD  — inclusive range in daemon local TZ
 //	org=... (repeatable)             — org filter
 //	repo=... (repeatable)            — repo filter (full slug "org/name")
-//	action=review|triage|implement|promote|error (repeatable)
+//	item_type=pr|issue (repeatable)  — item type filter
+//	action=review|review_skipped|triage|implement|promote|error (repeatable)
+//	outcome=... (repeatable)         — exact outcome filter
 //	limit=N (default 500, max 5000)
 //
 // Default when neither date nor from/to is supplied: today in daemon local TZ.
@@ -1186,13 +1188,36 @@ func (srv *Server) handleActivity(w http.ResponseWriter, r *http.Request) {
 		limit = n
 	}
 
+	orgs, ok := activityFilterValues(w, q, "org", nil)
+	if !ok {
+		return
+	}
+	repos, ok := activityFilterValues(w, q, "repo", nil)
+	if !ok {
+		return
+	}
+	itemTypes, ok := activityFilterValues(w, q, "item_type", validActivityItemTypes)
+	if !ok {
+		return
+	}
+	actions, ok := activityFilterValues(w, q, "action", validActivityActions)
+	if !ok {
+		return
+	}
+	outcomes, ok := activityFilterValues(w, q, "outcome", nil)
+	if !ok {
+		return
+	}
+
 	entries, truncated, err := srv.store.ListActivity(store.ActivityQuery{
-		From:    start,
-		To:      end,
-		Orgs:    q["org"],
-		Repos:   q["repo"],
-		Actions: q["action"],
-		Limit:   limit,
+		From:      start,
+		To:        end,
+		Orgs:      orgs,
+		Repos:     repos,
+		ItemTypes: itemTypes,
+		Actions:   actions,
+		Outcomes:  outcomes,
+		Limit:     limit,
 	})
 	if err != nil {
 		slog.Error("activity: list failed", "err", err)
@@ -1239,6 +1264,46 @@ func (srv *Server) handleActivity(w http.ResponseWriter, r *http.Request) {
 		"count":     len(out),
 		"truncated": truncated,
 	})
+}
+
+const maxActivityFilterValues = 50
+const maxActivityFilterValueLen = 512
+
+var validActivityItemTypes = map[string]bool{
+	"pr":    true,
+	"issue": true,
+}
+
+var validActivityActions = map[string]bool{
+	"review":         true,
+	"review_skipped": true,
+	"triage":         true,
+	"implement":      true,
+	"promote":        true,
+	"error":          true,
+}
+
+func activityFilterValues(w http.ResponseWriter, q url.Values, name string, allowed map[string]bool) ([]string, bool) {
+	values := q[name]
+	if len(values) > maxActivityFilterValues {
+		httpJSONErr(w, http.StatusBadRequest, name+" has too many values")
+		return nil, false
+	}
+	for _, v := range values {
+		if v == "" {
+			httpJSONErr(w, http.StatusBadRequest, name+" cannot be empty")
+			return nil, false
+		}
+		if len(v) > maxActivityFilterValueLen {
+			httpJSONErr(w, http.StatusBadRequest, name+" value is too long")
+			return nil, false
+		}
+		if allowed != nil && !allowed[v] {
+			httpJSONErr(w, http.StatusBadRequest, name+" has an invalid value")
+			return nil, false
+		}
+	}
+	return values, true
 }
 
 // httpJSONErr writes a JSON {"error": msg} body with the given HTTP status.

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1020,6 +1020,91 @@ func TestHandleActivity_FilterByRepoAndAction(t *testing.T) {
 	}
 }
 
+func TestHandleActivity_FilterByItemTypeAndOutcome(t *testing.T) {
+	srv, s := setupServer(t)
+	now := time.Now()
+	_, _ = s.InsertActivity(now, "acme", "acme/api", "pr", 1, "t", "review_skipped", "draft", nil)
+	_, _ = s.InsertActivity(now, "acme", "acme/api", "pr", 2, "t", "review_skipped", "not_open", nil)
+	_, _ = s.InsertActivity(now, "acme", "acme/api", "issue", 3, "t", "triage", "draft", nil)
+
+	req := httptest.NewRequest("GET", "/activity?item_type=pr&action=review_skipped&outcome=draft", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Entries []struct {
+			ItemType   string `json:"item_type"`
+			ItemNumber int    `json:"item_number"`
+			Action     string `json:"action"`
+			Outcome    string `json:"outcome"`
+		} `json:"entries"`
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Count != 1 {
+		t.Fatalf("count = %d, want 1", resp.Count)
+	}
+	if resp.Entries[0].ItemType != "pr" ||
+		resp.Entries[0].ItemNumber != 1 ||
+		resp.Entries[0].Action != "review_skipped" ||
+		resp.Entries[0].Outcome != "draft" {
+		t.Errorf("wrong entry: %+v", resp.Entries[0])
+	}
+}
+
+func TestHandleActivity_RejectsInvalidFilterValues(t *testing.T) {
+	cases := []struct {
+		name  string
+		query url.Values
+	}{
+		{
+			name:  "invalid item_type",
+			query: url.Values{"item_type": {"repo"}},
+		},
+		{
+			name:  "invalid action",
+			query: url.Values{"action": {"reviewSkipped"}},
+		},
+		{
+			name:  "empty repo",
+			query: url.Values{"repo": {""}},
+		},
+		{
+			name:  "too long outcome",
+			query: url.Values{"outcome": {strings.Repeat("x", 513)}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := setupServer(t)
+			req := httptest.NewRequest("GET", "/activity?"+tc.query.Encode(), nil)
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body = %s)", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleActivity_RejectsTooManyFilterValues(t *testing.T) {
+	srv, _ := setupServer(t)
+	q := url.Values{}
+	for i := 0; i < 51; i++ {
+		q.Add("repo", fmt.Sprintf("acme/api-%d", i))
+	}
+
+	req := httptest.NewRequest("GET", "/activity?"+q.Encode(), nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body = %s)", w.Code, w.Body.String())
+	}
+}
+
 func TestHandlerPutConfigValueValidation(t *testing.T) {
 	srv := setupServerWithToken(t, "secret-token")
 

--- a/daemon/internal/store/activity.go
+++ b/daemon/internal/store/activity.go
@@ -29,12 +29,14 @@ type Activity struct {
 // To is an EXCLUSIVE upper bound (ts < To). Pass the start of the day
 // AFTER your intended last day, not 23:59:59 on the last day.
 type ActivityQuery struct {
-	From    time.Time
-	To      time.Time
-	Orgs    []string
-	Repos   []string
-	Actions []string
-	Limit   int
+	From      time.Time
+	To        time.Time
+	Orgs      []string
+	Repos     []string
+	ItemTypes []string
+	Actions   []string
+	Outcomes  []string
+	Limit     int
 }
 
 const defaultActivityLimit = 500
@@ -100,10 +102,22 @@ func (s *Store) ListActivity(q ActivityQuery) ([]*Activity, bool, error) {
 			args = append(args, r)
 		}
 	}
+	if len(q.ItemTypes) > 0 {
+		where = append(where, "item_type IN ("+placeholders(len(q.ItemTypes))+")")
+		for _, typ := range q.ItemTypes {
+			args = append(args, typ)
+		}
+	}
 	if len(q.Actions) > 0 {
 		where = append(where, "action IN ("+placeholders(len(q.Actions))+")")
 		for _, a := range q.Actions {
 			args = append(args, a)
+		}
+	}
+	if len(q.Outcomes) > 0 {
+		where = append(where, "outcome IN ("+placeholders(len(q.Outcomes))+")")
+		for _, o := range q.Outcomes {
+			args = append(args, o)
 		}
 	}
 

--- a/daemon/internal/store/activity_test.go
+++ b/daemon/internal/store/activity_test.go
@@ -83,6 +83,36 @@ func TestListActivity_FilterByOrgAndAction(t *testing.T) {
 	}
 }
 
+func TestListActivity_FilterByItemTypeAndOutcome(t *testing.T) {
+	s := newActivityStore(t)
+	base := time.Now().UTC().Truncate(time.Second)
+
+	must := func(itemType, action, outcome string, number int) {
+		t.Helper()
+		if _, err := s.InsertActivity(base, "acme", "acme/api", itemType, number, "t", action, outcome, nil); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	must("pr", "review_skipped", "draft", 1)
+	must("pr", "review_skipped", "not_open", 2)
+	must("issue", "triage", "draft", 3)
+
+	entries, _, err := s.ListActivity(store.ActivityQuery{
+		ItemTypes: []string{"pr"},
+		Actions:   []string{"review_skipped"},
+		Outcomes:  []string{"draft"},
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if entries[0].ItemNumber != 1 {
+		t.Errorf("item_number = %d, want 1", entries[0].ItemNumber)
+	}
+}
+
 func TestListActivity_Truncation(t *testing.T) {
 	s := newActivityStore(t)
 	base := time.Now().UTC().Truncate(time.Second)

--- a/flutter_app/lib/core/models/activity.dart
+++ b/flutter_app/lib/core/models/activity.dart
@@ -1,8 +1,30 @@
 /// Known activity actions from the daemon's activity_log. `unknown` is a
 /// safety fallback so the UI never crashes on a forward-compat value.
-enum ActivityAction { review, triage, implement, promote, error, unknown }
+enum ActivityAction {
+  review,
+  reviewSkipped,
+  triage,
+  implement,
+  promote,
+  error,
+  unknown,
+}
 
-final Map<String, ActivityAction> _actionByName = ActivityAction.values.asNameMap();
+extension ActivityActionWireName on ActivityAction {
+  String get wireName => switch (this) {
+    ActivityAction.review => 'review',
+    ActivityAction.reviewSkipped => 'review_skipped',
+    ActivityAction.triage => 'triage',
+    ActivityAction.implement => 'implement',
+    ActivityAction.promote => 'promote',
+    ActivityAction.error => 'error',
+    ActivityAction.unknown => 'unknown',
+  };
+}
+
+final Map<String, ActivityAction> _actionByName = {
+  for (final action in ActivityAction.values) action.wireName: action,
+};
 
 ActivityAction _parseAction(String s) =>
     _actionByName[s] ?? ActivityAction.unknown;
@@ -57,7 +79,9 @@ class ActivityQuery {
   final DateTime? to;
   final Set<String> orgs;
   final Set<String> repos;
+  final Set<String> itemTypes;
   final Set<ActivityAction> actions;
+  final Set<String> outcomes;
   final int limit;
 
   const ActivityQuery({
@@ -66,12 +90,14 @@ class ActivityQuery {
     this.to,
     this.orgs = const {},
     this.repos = const {},
+    this.itemTypes = const {},
     this.actions = const {},
+    this.outcomes = const {},
     this.limit = 500,
   }) : assert(
-          (from == null) == (to == null),
-          'from and to must both be set or both null',
-        );
+         (from == null) == (to == null),
+         'from and to must both be set or both null',
+       );
 
   /// Returns a copy with the given fields overridden. `date`, `from`, `to`
   /// use a sentinel to distinguish "not passed" (keep current) from
@@ -82,17 +108,21 @@ class ActivityQuery {
     Object? to = _unset,
     Set<String>? orgs,
     Set<String>? repos,
+    Set<String>? itemTypes,
     Set<ActivityAction>? actions,
+    Set<String>? outcomes,
     int? limit,
   }) {
     return ActivityQuery(
-      date:    identical(date, _unset) ? this.date : date as DateTime?,
-      from:    identical(from, _unset) ? this.from : from as DateTime?,
-      to:      identical(to,   _unset) ? this.to   : to   as DateTime?,
-      orgs:    orgs    ?? this.orgs,
-      repos:   repos   ?? this.repos,
+      date: identical(date, _unset) ? this.date : date as DateTime?,
+      from: identical(from, _unset) ? this.from : from as DateTime?,
+      to: identical(to, _unset) ? this.to : to as DateTime?,
+      orgs: orgs ?? this.orgs,
+      repos: repos ?? this.repos,
+      itemTypes: itemTypes ?? this.itemTypes,
       actions: actions ?? this.actions,
-      limit:   limit   ?? this.limit,
+      outcomes: outcomes ?? this.outcomes,
+      limit: limit ?? this.limit,
     );
   }
 
@@ -108,9 +138,11 @@ class ActivityQuery {
     }
     if (orgs.isNotEmpty) params['org'] = orgs.toList();
     if (repos.isNotEmpty) params['repo'] = repos.toList();
+    if (itemTypes.isNotEmpty) params['item_type'] = itemTypes.toList();
     if (actions.isNotEmpty) {
-      params['action'] = actions.map((a) => a.name).toList();
+      params['action'] = actions.map((a) => a.wireName).toList();
     }
+    if (outcomes.isNotEmpty) params['outcome'] = outcomes.toList();
     params['limit'] = [limit.toString()];
     return params;
   }

--- a/flutter_app/lib/features/activity/activity_providers.dart
+++ b/flutter_app/lib/features/activity/activity_providers.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/activity.dart';
-import '../dashboard/dashboard_providers.dart' show apiClientProvider;
+import '../dashboard/dashboard_providers.dart'
+    show apiClientProvider, sseStreamProvider;
 
 /// Notifier managing the current query (date, range, filter sets).
 /// Widgets read & mutate this; the entries provider watches it.
@@ -23,7 +26,7 @@ class ActivityQueryNotifier extends StateNotifier<ActivityQuery> {
 
   void setRange(DateTime from, DateTime to) {
     final start = DateTime(from.year, from.month, from.day);
-    final end   = DateTime(to.year,   to.month,   to.day);
+    final end = DateTime(to.year, to.month, to.day);
     final (a, b) = start.isAfter(end) ? (end, start) : (start, end);
     state = state.copyWith(date: null, from: a, to: b);
   }
@@ -32,18 +35,53 @@ class ActivityQueryNotifier extends StateNotifier<ActivityQuery> {
       state = state.copyWith(orgs: _toggled(state.orgs, org));
   void toggleRepo(String repo) =>
       state = state.copyWith(repos: _toggled(state.repos, repo));
+  void toggleItemType(String itemType) =>
+      state = state.copyWith(itemTypes: _toggled(state.itemTypes, itemType));
   void toggleAction(ActivityAction a) =>
       state = state.copyWith(actions: _toggled(state.actions, a));
+  void toggleOutcome(String outcome) =>
+      state = state.copyWith(outcomes: _toggled(state.outcomes, outcome));
+
+  void setQuickFilter({
+    ActivityAction? action,
+    String? itemType,
+    String? outcome,
+    required bool enabled,
+  }) {
+    state = state.copyWith(
+      actions: action == null
+          ? null
+          : _setMembership(state.actions, action, enabled),
+      itemTypes: itemType == null
+          ? null
+          : _setMembership(state.itemTypes, itemType, enabled),
+      outcomes: outcome == null
+          ? null
+          : _setMembership(state.outcomes, outcome, enabled),
+    );
+  }
 
   void clearFilters() => state = state.copyWith(
-        orgs: const {},
-        repos: const {},
-        actions: const {},
-      );
+    orgs: const {},
+    repos: const {},
+    itemTypes: const {},
+    actions: const {},
+    outcomes: const {},
+  );
 
   static Set<T> _toggled<T>(Set<T> set, T v) {
     final next = Set<T>.from(set);
     if (!next.add(v)) next.remove(v);
+    return next;
+  }
+
+  static Set<T> _setMembership<T>(Set<T> set, T v, bool enabled) {
+    final next = Set<T>.from(set);
+    if (enabled) {
+      next.add(v);
+    } else {
+      next.remove(v);
+    }
     return next;
   }
 }
@@ -51,8 +89,45 @@ class ActivityQueryNotifier extends StateNotifier<ActivityQuery> {
 /// Current query state.
 final activityQueryProvider =
     StateNotifierProvider<ActivityQueryNotifier, ActivityQuery>(
-  (ref) => ActivityQueryNotifier(),
-);
+      (ref) => ActivityQueryNotifier(),
+    );
+
+final activityLiveUpdatesProvider = StateProvider<bool>((ref) => false);
+
+const _activityLiveRefreshDelay = Duration(milliseconds: 750);
+
+const _activityLogEventTypes = {
+  'review_completed',
+  'review_error',
+  'review_skipped',
+  'issue_review_completed',
+  'issue_implemented',
+  'issue_review_error',
+  'issue_promoted',
+};
+
+/// Installs the live-mode SSE listener for ActivityScreen.
+///
+/// This provider is intentionally side-effectful: the screen must watch it so
+/// live mode refreshes the persisted activity query when activity-log events
+/// arrive. Events that are not recorded in `activity_log` are ignored.
+final activityLiveRefreshProvider = Provider<void>((ref) {
+  if (!ref.watch(activityLiveUpdatesProvider)) return;
+
+  Timer? debounce;
+  ref.onDispose(() => debounce?.cancel());
+
+  ref.listen(sseStreamProvider, (previous, next) {
+    next.whenData((event) {
+      if (!_activityLogEventTypes.contains(event.type)) return;
+      debounce?.cancel();
+      debounce = Timer(_activityLiveRefreshDelay, () {
+        ref.invalidate(activityEntriesProvider);
+        ref.invalidate(activityOptionsProvider);
+      });
+    });
+  });
+});
 
 /// Entries for the current query. Watches the query so filter changes
 /// trigger a refetch automatically.
@@ -74,7 +149,7 @@ const int _activityOptionsLimit = 10000;
 final activityOptionsProvider = FutureProvider<ActivityPage>((ref) async {
   final date = ref.watch(activityQueryProvider.select((q) => q.date));
   final from = ref.watch(activityQueryProvider.select((q) => q.from));
-  final to   = ref.watch(activityQueryProvider.select((q) => q.to));
+  final to = ref.watch(activityQueryProvider.select((q) => q.to));
   final api = ref.watch(apiClientProvider);
   return api.fetchActivity(
     ActivityQuery(date: date, from: from, to: to, limit: _activityOptionsLimit),

--- a/flutter_app/lib/features/activity/activity_screen.dart
+++ b/flutter_app/lib/features/activity/activity_screen.dart
@@ -1,8 +1,10 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/models/activity.dart';
-import '../../shared/widgets/toast.dart';
 import 'activity_providers.dart';
 import 'widgets/activity_entry_tile.dart';
 import 'widgets/activity_filter_chips.dart';
@@ -18,15 +20,23 @@ class ActivityScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final q = ref.watch(activityQueryProvider);
+    ref.watch(activityLiveRefreshProvider);
     final async = ref.watch(activityEntriesProvider);
     final optionsAsync = ref.watch(activityOptionsProvider);
 
-    final orgs = optionsAsync.valueOrNull?.entries
-            .map((e) => e.org).toSet().toList()
-        ?? const <String>[];
-    final repos = optionsAsync.valueOrNull?.entries
-            .map((e) => e.repo).toSet().toList()
-        ?? const <String>[];
+    final orgs =
+        optionsAsync.valueOrNull?.entries.map((e) => e.org).toSet().toList() ??
+        const <String>[];
+    final repos =
+        optionsAsync.valueOrNull?.entries.map((e) => e.repo).toSet().toList() ??
+        const <String>[];
+    final outcomes =
+        optionsAsync.valueOrNull?.entries
+            .map((e) => e.outcome)
+            .where((o) => o.isNotEmpty)
+            .toSet()
+            .toList() ??
+        const <String>[];
 
     return Column(
       children: [
@@ -36,6 +46,7 @@ class ActivityScreen extends ConsumerWidget {
           child: ActivityFilterChips(
             availableOrgs: orgs,
             availableRepos: repos,
+            availableOutcomes: outcomes,
           ),
         ),
         const Divider(height: 1),
@@ -66,8 +77,10 @@ class _ErrorView extends StatelessWidget {
             children: [
               Icon(Icons.toggle_off_outlined, size: 48, color: Colors.grey),
               SizedBox(height: 12),
-              Text('Activity log is disabled',
-                  style: TextStyle(fontWeight: FontWeight.w600)),
+              Text(
+                'Activity log is disabled',
+                style: TextStyle(fontWeight: FontWeight.w600),
+              ),
               SizedBox(height: 4),
               Text(
                 'Enable activity_log in the daemon config to start recording activity.',
@@ -97,56 +110,75 @@ class _DatePickerBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final notifier   = ref.read(activityQueryProvider.notifier);
-    final today      = DateTime.now();
-    final yesterday  = today.subtract(const Duration(days: 1));
-    final isToday    = _isSameDay(query.date, today);
+    final notifier = ref.read(activityQueryProvider.notifier);
+    final live = ref.watch(activityLiveUpdatesProvider);
+    final today = DateTime.now();
+    final yesterday = today.subtract(const Duration(days: 1));
+    final isToday = _isSameDay(query.date, today);
     final isYesterday = _isSameDay(query.date, yesterday);
 
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: Row(children: [
-        ChoiceChip(
-          label: const Text('Today'),
-          selected: isToday,
-          onSelected: (_) => notifier.setDate(today),
-        ),
-        const SizedBox(width: 8),
-        ChoiceChip(
-          label: const Text('Yesterday'),
-          selected: isYesterday,
-          onSelected: (_) => notifier.setDate(yesterday),
-        ),
-        const SizedBox(width: 8),
-        ActionChip(
-          label: const Text('Pick day'),
-          onPressed: () async {
-            final picked = await showDatePicker(
-              context: context,
-              initialDate: query.date ?? today,
-              firstDate: today.subtract(const Duration(days: 365)),
-              lastDate: today,
-            );
-            if (picked != null) notifier.setDate(picked);
-          },
-        ),
-        const SizedBox(width: 8),
-        ActionChip(
-          label: const Text('Pick range'),
-          onPressed: () async {
-            final picked = await showDateRangePicker(
-              context: context,
-              firstDate: today.subtract(const Duration(days: 365)),
-              lastDate: today,
-              initialDateRange: (query.from != null && query.to != null)
-                  ? DateTimeRange(start: query.from!, end: query.to!)
-                  : null,
-            );
-            if (picked != null) notifier.setRange(picked.start, picked.end);
-          },
-        ),
-      ]),
+      child: Row(
+        children: [
+          ChoiceChip(
+            label: const Text('Today'),
+            selected: isToday,
+            onSelected: (_) => notifier.setDate(today),
+          ),
+          const SizedBox(width: 8),
+          ChoiceChip(
+            label: const Text('Yesterday'),
+            selected: isYesterday,
+            onSelected: (_) => notifier.setDate(yesterday),
+          ),
+          const SizedBox(width: 8),
+          ActionChip(
+            label: const Text('Pick day'),
+            onPressed: () async {
+              final picked = await showDatePicker(
+                context: context,
+                initialDate: query.date ?? today,
+                firstDate: today.subtract(const Duration(days: 365)),
+                lastDate: today,
+              );
+              if (picked != null) notifier.setDate(picked);
+            },
+          ),
+          const SizedBox(width: 8),
+          ActionChip(
+            label: const Text('Pick range'),
+            onPressed: () async {
+              final picked = await showDateRangePicker(
+                context: context,
+                firstDate: today.subtract(const Duration(days: 365)),
+                lastDate: today,
+                initialDateRange: (query.from != null && query.to != null)
+                    ? DateTimeRange(start: query.from!, end: query.to!)
+                    : null,
+              );
+              if (picked != null) notifier.setRange(picked.start, picked.end);
+            },
+          ),
+          const SizedBox(width: 8),
+          FilterChip(
+            label: const Text('Live'),
+            selected: live,
+            onSelected: (v) =>
+                ref.read(activityLiveUpdatesProvider.notifier).state = v,
+          ),
+          const SizedBox(width: 4),
+          IconButton(
+            tooltip: 'Refresh activity',
+            icon: const Icon(Icons.refresh),
+            onPressed: () {
+              ref.invalidate(activityEntriesProvider);
+              ref.invalidate(activityOptionsProvider);
+            },
+          ),
+        ],
+      ),
     );
   }
 }
@@ -238,9 +270,9 @@ class _Timeline extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
           child: Text(
             _formatDay(day),
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
+            style: Theme.of(
+              context,
+            ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
           ),
         );
       case _HourHeader(:final hour):
@@ -254,23 +286,170 @@ class _Timeline extends StatelessWidget {
       case _EntryItem(:final entry):
         return ActivityEntryTile(
           entry: entry,
-          onTap: () {
-            // Tap → detail navigation is deferred: the activity_log row knows
-            // repo + number but not the PR/issue store ID the /prs/:id and
-            // /issues/:id routes expect. Follow-up spec (AI report generation)
-            // will add a by-number lookup endpoint.
-            showToast(context, '${entry.repo} #${entry.itemNumber}',
-                duration: const Duration(seconds: 2));
-          },
+          onTap: () => _showActivityDetail(context, entry),
         );
     }
   }
 
   static String _formatDay(DateTime d) {
     const months = [
-      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
     ];
     return '${months[d.month - 1]} ${d.day}, ${d.year}';
+  }
+}
+
+void _showActivityDetail(BuildContext context, ActivityEntry entry) {
+  showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    constraints: const BoxConstraints(maxWidth: 760),
+    builder: (_) => _ActivityDetailSheet(entry: entry),
+  );
+}
+
+class _ActivityDetailSheet extends StatelessWidget {
+  final ActivityEntry entry;
+  const _ActivityDetailSheet({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final details = const JsonEncoder.withIndent('  ').convert(entry.details);
+    final githubUrl = _githubUrl(entry);
+
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(20, 18, 20, 24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                ActivityActionBadge(action: entry.action),
+                const SizedBox(width: 8),
+                ActivityItemTypeBadge(itemType: entry.itemType),
+                const Spacer(),
+                IconButton(
+                  tooltip: 'Close',
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+            const SizedBox(height: 14),
+            Text(
+              activityEntryTitle(entry),
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              activityOutcomeText(entry),
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(color: scheme.onSurfaceVariant),
+            ),
+            const SizedBox(height: 18),
+            _DetailRow(label: 'Repository', value: entry.repo),
+            _DetailRow(label: 'Number', value: '#${entry.itemNumber}'),
+            _DetailRow(label: 'Title', value: entry.itemTitle),
+            _DetailRow(label: 'Action', value: entry.action.wireName),
+            _DetailRow(label: 'Outcome', value: entry.outcome),
+            _DetailRow(label: 'Time', value: _formatTimestamp(entry.timestamp)),
+            const SizedBox(height: 14),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.open_in_new, size: 16),
+              label: const Text('Open in GitHub'),
+              onPressed: () async {
+                final opened = await launchUrl(githubUrl);
+                if (!context.mounted || opened) return;
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('Could not open $githubUrl')),
+                );
+              },
+            ),
+            if (entry.details.isNotEmpty) ...[
+              const SizedBox(height: 20),
+              Text(
+                'Details',
+                style: Theme.of(
+                  context,
+                ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: 8),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: scheme.surfaceContainerHighest.withValues(alpha: 0.55),
+                  borderRadius: BorderRadius.circular(6),
+                  border: Border.all(color: scheme.outlineVariant),
+                ),
+                child: SelectableText(
+                  details,
+                  style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  static Uri _githubUrl(ActivityEntry entry) {
+    final kind = entry.itemType == 'issue' ? 'issues' : 'pull';
+    return Uri.parse(
+      'https://github.com/${entry.repo}/$kind/${entry.itemNumber}',
+    );
+  }
+
+  static String _formatTimestamp(DateTime t) {
+    final date =
+        '${t.year.toString().padLeft(4, '0')}-${t.month.toString().padLeft(2, '0')}-${t.day.toString().padLeft(2, '0')}';
+    return '$date ${activityTimeLabel(t)}';
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  final String label;
+  final String value;
+  const _DetailRow({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    if (value.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 96,
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Expanded(child: SelectableText(value)),
+        ],
+      ),
+    );
   }
 }

--- a/flutter_app/lib/features/activity/widgets/activity_entry_tile.dart
+++ b/flutter_app/lib/features/activity/widgets/activity_entry_tile.dart
@@ -11,61 +11,288 @@ class ActivityEntryTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    final iconColor = entry.action == ActivityAction.error
-        ? scheme.error
-        : scheme.primary;
+    final divider = Theme.of(context).dividerColor.withValues(alpha: 0.45);
 
-    return ListTile(
-      leading: Icon(_iconFor(entry.action), color: iconColor),
-      title: Text(
-        '${entry.repo} · #${entry.itemNumber} · ${entry.itemTitle}',
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border(bottom: BorderSide(color: divider)),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              if (constraints.maxWidth >= 760) {
+                return _WideEntryRow(entry: entry);
+              }
+              return _CompactEntryRow(entry: entry);
+            },
+          ),
+        ),
       ),
-      subtitle: Text(_subtitle(entry)),
-      trailing: Text(
-        _hhmmss(entry.timestamp),
-        style: const TextStyle(fontFamily: 'monospace'),
-      ),
-      onTap: onTap,
     );
   }
+}
 
-  static IconData _iconFor(ActivityAction a) {
-    switch (a) {
-      case ActivityAction.review:    return Icons.rate_review;
-      case ActivityAction.triage:    return Icons.label;
-      case ActivityAction.implement: return Icons.build;
-      case ActivityAction.promote:   return Icons.swap_horiz;
-      case ActivityAction.error:     return Icons.error_outline;
-      case ActivityAction.unknown:   return Icons.help_outline;
-    }
+class _WideEntryRow extends StatelessWidget {
+  final ActivityEntry entry;
+  const _WideEntryRow({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 78,
+          child: Text(
+            activityTimeLabel(entry.timestamp),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              fontFamily: 'monospace',
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        SizedBox(width: 128, child: ActivityActionBadge(action: entry.action)),
+        const SizedBox(width: 8),
+        SizedBox(
+          width: 64,
+          child: ActivityItemTypeBadge(itemType: entry.itemType),
+        ),
+        const SizedBox(width: 12),
+        Expanded(child: _EntryText(entry: entry)),
+      ],
+    );
   }
+}
 
-  static String _subtitle(ActivityEntry e) {
-    switch (e.action) {
-      case ActivityAction.review:
-        final cli = e.details['cli_used'];
-        final suffix = (cli is String && cli.isNotEmpty) ? ' by $cli' : '';
-        return '${e.outcome} review$suffix';
-      case ActivityAction.triage:
-        final cat = e.details['category'];
-        final catStr = (cat is String && cat.isNotEmpty) ? ' ($cat)' : '';
-        return 'triaged${e.outcome.isEmpty ? '' : ': ${e.outcome}'}$catStr';
-      case ActivityAction.implement:
-        final n = e.details['pr_number'];
-        if (n is num && n > 0) return 'opened PR #${n.toInt()}';
-        return 'implement failed';
-      case ActivityAction.promote:
-        return 'promoted: ${e.outcome}';
-      case ActivityAction.error:
-        return e.outcome;
-      case ActivityAction.unknown:
-        return '';
-    }
+class _CompactEntryRow extends StatelessWidget {
+  final ActivityEntry entry;
+  const _CompactEntryRow({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            ActivityActionBadge(action: entry.action),
+            const SizedBox(width: 8),
+            ActivityItemTypeBadge(itemType: entry.itemType),
+            const Spacer(),
+            Text(
+              activityTimeLabel(entry.timestamp),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                fontFamily: 'monospace',
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        _EntryText(entry: entry),
+      ],
+    );
   }
+}
 
-  static String _hhmmss(DateTime t) =>
-      '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}:${t.second.toString().padLeft(2, '0')}';
+class _EntryText extends StatelessWidget {
+  final ActivityEntry entry;
+  const _EntryText({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    final titleStyle = Theme.of(
+      context,
+    ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600);
+    final subtitleStyle = Theme.of(context).textTheme.bodySmall?.copyWith(
+      color: Theme.of(context).colorScheme.onSurfaceVariant,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          activityEntryTitle(entry),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: titleStyle,
+        ),
+        const SizedBox(height: 2),
+        Text(
+          activityOutcomeText(entry),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: subtitleStyle,
+        ),
+      ],
+    );
+  }
+}
+
+class ActivityActionBadge extends StatelessWidget {
+  final ActivityAction action;
+  const ActivityActionBadge({super.key, required this.action});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = activityActionColor(Theme.of(context).colorScheme, action);
+    return Container(
+      height: 28,
+      constraints: const BoxConstraints(maxWidth: 120),
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: color.withValues(alpha: 0.28)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(activityIconFor(action), size: 15, color: color),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              activityActionLabel(action),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: color,
+                fontWeight: FontWeight.w700,
+                fontSize: 12,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ActivityItemTypeBadge extends StatelessWidget {
+  final String itemType;
+  const ActivityItemTypeBadge({super.key, required this.itemType});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final isIssue = itemType == 'issue';
+    final color = isIssue ? scheme.tertiary : scheme.primary;
+    final label = isIssue ? 'Issue' : 'PR';
+    return Container(
+      height: 28,
+      alignment: Alignment.center,
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: color.withValues(alpha: 0.22)),
+      ),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(
+          color: color,
+          fontWeight: FontWeight.w700,
+          fontSize: 12,
+        ),
+      ),
+    );
+  }
+}
+
+IconData activityIconFor(ActivityAction action) => switch (action) {
+  ActivityAction.review => Icons.rate_review,
+  ActivityAction.reviewSkipped => Icons.visibility_off_outlined,
+  ActivityAction.triage => Icons.label,
+  ActivityAction.implement => Icons.build,
+  ActivityAction.promote => Icons.swap_horiz,
+  ActivityAction.error => Icons.error_outline,
+  ActivityAction.unknown => Icons.help_outline,
+};
+
+String activityActionLabel(ActivityAction action) => switch (action) {
+  ActivityAction.review => 'Review',
+  ActivityAction.reviewSkipped => 'Skipped',
+  ActivityAction.triage => 'Triage',
+  ActivityAction.implement => 'Implement',
+  ActivityAction.promote => 'Promote',
+  ActivityAction.error => 'Error',
+  ActivityAction.unknown => 'Unknown',
+};
+
+Color activityActionColor(ColorScheme scheme, ActivityAction action) =>
+    switch (action) {
+      ActivityAction.error => scheme.error,
+      ActivityAction.reviewSkipped => scheme.outline,
+      ActivityAction.triage => scheme.tertiary,
+      ActivityAction.implement => scheme.secondary,
+      ActivityAction.promote => scheme.primary,
+      ActivityAction.review => scheme.primary,
+      ActivityAction.unknown => scheme.outline,
+    };
+
+String activityEntryTitle(ActivityEntry entry) {
+  final title = entry.itemTitle.trim();
+  final suffix = title.isEmpty ? '' : ' · $title';
+  return '${entry.repo} · #${entry.itemNumber}$suffix';
+}
+
+String activityOutcomeText(ActivityEntry entry) => switch (entry.action) {
+  ActivityAction.review => _reviewOutcome(entry),
+  ActivityAction.reviewSkipped => _skippedOutcome(entry),
+  ActivityAction.triage => _triageOutcome(entry),
+  ActivityAction.implement => _implementOutcome(entry),
+  ActivityAction.promote => 'Promoted: ${entry.outcome}',
+  ActivityAction.error => entry.outcome.isEmpty ? 'Error' : entry.outcome,
+  ActivityAction.unknown =>
+    entry.outcome.isEmpty
+        ? 'Unknown activity action'
+        : 'Unknown: ${entry.outcome}',
+};
+
+String activityTimeLabel(DateTime t) =>
+    '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}:${t.second.toString().padLeft(2, '0')}';
+
+String _reviewOutcome(ActivityEntry entry) {
+  final cli = entry.details['cli_used'];
+  final suffix = (cli is String && cli.isNotEmpty) ? ' by $cli' : '';
+  final severity = entry.outcome.isEmpty ? 'completed' : entry.outcome;
+  return '$severity review$suffix';
+}
+
+String _skippedOutcome(ActivityEntry entry) {
+  final reason = _detailString(entry, 'reason') ?? entry.outcome;
+  final label = _skipReasonLabel(reason);
+  return label.isEmpty ? 'Skipped review' : 'Skipped because $label';
+}
+
+String _triageOutcome(ActivityEntry entry) {
+  final cat = entry.details['category'];
+  final catStr = (cat is String && cat.isNotEmpty) ? ' ($cat)' : '';
+  return 'Triaged${entry.outcome.isEmpty ? '' : ': ${entry.outcome}'}$catStr';
+}
+
+String _implementOutcome(ActivityEntry entry) {
+  final n = entry.details['pr_number'];
+  if (n is num && n > 0) return 'Opened PR #${n.toInt()}';
+  return 'Implementation failed';
+}
+
+String _skipReasonLabel(String reason) => switch (reason) {
+  'draft' => 'PR is draft',
+  'not_open' => 'PR is not open',
+  'self_authored' => 'PR was authored by the bot',
+  'sha_unchanged' => 'HEAD SHA is unchanged',
+  'legacy_backfill' => 'legacy review was backfilled',
+  _ => reason.replaceAll('_', ' '),
+};
+
+String? _detailString(ActivityEntry entry, String key) {
+  final value = entry.details[key];
+  if (value is String && value.isNotEmpty) return value;
+  return null;
 }

--- a/flutter_app/lib/features/activity/widgets/activity_filter_chips.dart
+++ b/flutter_app/lib/features/activity/widgets/activity_filter_chips.dart
@@ -9,51 +9,131 @@ import '../activity_providers.dart';
 class ActivityFilterChips extends ConsumerWidget {
   final List<String> availableOrgs;
   final List<String> availableRepos;
+  final List<String> availableOutcomes;
 
   const ActivityFilterChips({
     super.key,
     required this.availableOrgs,
     required this.availableRepos,
+    this.availableOutcomes = const [],
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final q = ref.watch(activityQueryProvider);
-    final anyActive = q.orgs.isNotEmpty || q.repos.isNotEmpty || q.actions.isNotEmpty;
+    final anyActive =
+        q.orgs.isNotEmpty ||
+        q.repos.isNotEmpty ||
+        q.itemTypes.isNotEmpty ||
+        q.actions.isNotEmpty ||
+        q.outcomes.isNotEmpty;
 
     return Wrap(
       spacing: 8,
       runSpacing: 4,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
-        _chip(context,
-            label: 'Organization',
-            count: q.orgs.length,
+        _quickChip(
+          label: 'PRs',
+          selected: q.itemTypes.contains('pr'),
+          onSelected: (v) => ref
+              .read(activityQueryProvider.notifier)
+              .setQuickFilter(itemType: 'pr', enabled: v),
+        ),
+        _quickChip(
+          label: 'Issues',
+          selected: q.itemTypes.contains('issue'),
+          onSelected: (v) => ref
+              .read(activityQueryProvider.notifier)
+              .setQuickFilter(itemType: 'issue', enabled: v),
+        ),
+        _quickChip(
+          label: 'Skipped',
+          selected: q.actions.contains(ActivityAction.reviewSkipped),
+          onSelected: (v) => ref
+              .read(activityQueryProvider.notifier)
+              .setQuickFilter(action: ActivityAction.reviewSkipped, enabled: v),
+        ),
+        _quickChip(
+          label: 'Errors',
+          selected: q.actions.contains(ActivityAction.error),
+          onSelected: (v) => ref
+              .read(activityQueryProvider.notifier)
+              .setQuickFilter(action: ActivityAction.error, enabled: v),
+        ),
+        _quickChip(
+          label: 'Draft skips',
+          selected:
+              q.actions.contains(ActivityAction.reviewSkipped) &&
+              q.outcomes.contains('draft'),
+          onSelected: (v) => ref
+              .read(activityQueryProvider.notifier)
+              .setQuickFilter(
+                action: ActivityAction.reviewSkipped,
+                outcome: 'draft',
+                enabled: v,
+              ),
+        ),
+        _chip(
+          context,
+          label: 'Organization',
+          count: q.orgs.length,
+          onTap: () => _pickStrings(
+            context,
+            options: availableOrgs,
+            select: (q) => q.orgs,
+            toggle: (v) =>
+                ref.read(activityQueryProvider.notifier).toggleOrg(v),
+          ),
+        ),
+        _chip(
+          context,
+          label: 'Repository',
+          count: q.repos.length,
+          onTap: () => _pickStrings(
+            context,
+            options: availableRepos,
+            select: (q) => q.repos,
+            toggle: (v) =>
+                ref.read(activityQueryProvider.notifier).toggleRepo(v),
+          ),
+        ),
+        _chip(
+          context,
+          label: 'Type',
+          count: q.itemTypes.length,
+          onTap: () => _pickStrings(
+            context,
+            options: const ['pr', 'issue'],
+            select: (q) => q.itemTypes,
+            toggle: (v) =>
+                ref.read(activityQueryProvider.notifier).toggleItemType(v),
+            labelFor: _itemTypeLabel,
+          ),
+        ),
+        _chip(
+          context,
+          label: 'Action',
+          count: q.actions.length,
+          onTap: () => _pickActions(
+            context,
+            toggle: (a) =>
+                ref.read(activityQueryProvider.notifier).toggleAction(a),
+          ),
+        ),
+        if (availableOutcomes.isNotEmpty)
+          _chip(
+            context,
+            label: 'Outcome',
+            count: q.outcomes.length,
             onTap: () => _pickStrings(
-                  context,
-                  options: availableOrgs,
-                  select: (q) => q.orgs,
-                  toggle: (v) =>
-                      ref.read(activityQueryProvider.notifier).toggleOrg(v),
-                )),
-        _chip(context,
-            label: 'Repository',
-            count: q.repos.length,
-            onTap: () => _pickStrings(
-                  context,
-                  options: availableRepos,
-                  select: (q) => q.repos,
-                  toggle: (v) =>
-                      ref.read(activityQueryProvider.notifier).toggleRepo(v),
-                )),
-        _chip(context,
-            label: 'Action',
-            count: q.actions.length,
-            onTap: () => _pickActions(
-                  context,
-                  toggle: (a) =>
-                      ref.read(activityQueryProvider.notifier).toggleAction(a),
-                )),
+              context,
+              options: availableOutcomes,
+              select: (q) => q.outcomes,
+              toggle: (v) =>
+                  ref.read(activityQueryProvider.notifier).toggleOutcome(v),
+            ),
+          ),
         if (anyActive)
           TextButton(
             onPressed: ref.read(activityQueryProvider.notifier).clearFilters,
@@ -63,11 +143,27 @@ class ActivityFilterChips extends ConsumerWidget {
     );
   }
 
-  Widget _chip(BuildContext context,
-      {required String label, required int count, required VoidCallback onTap}) {
+  Widget _chip(
+    BuildContext context, {
+    required String label,
+    required int count,
+    required VoidCallback onTap,
+  }) {
     return ActionChip(
       label: Text(count == 0 ? label : '$label · $count'),
       onPressed: onTap,
+    );
+  }
+
+  Widget _quickChip({
+    required String label,
+    required bool selected,
+    required ValueChanged<bool> onSelected,
+  }) {
+    return FilterChip(
+      label: Text(label),
+      selected: selected,
+      onSelected: onSelected,
     );
   }
 
@@ -76,6 +172,7 @@ class ActivityFilterChips extends ConsumerWidget {
     required List<String> options,
     required Set<String> Function(ActivityQuery q) select,
     required void Function(String) toggle,
+    String Function(String)? labelFor,
   }) async {
     await showModalBottomSheet<void>(
       context: context,
@@ -84,11 +181,13 @@ class ActivityFilterChips extends ConsumerWidget {
           final selected = select(ref.watch(activityQueryProvider));
           return ListView(
             children: options
-                .map((o) => CheckboxListTile(
-                      value: selected.contains(o),
-                      title: Text(o),
-                      onChanged: (_) => toggle(o),
-                    ))
+                .map(
+                  (o) => CheckboxListTile(
+                    value: selected.contains(o),
+                    title: Text(labelFor?.call(o) ?? o),
+                    onChanged: (_) => toggle(o),
+                  ),
+                )
                 .toList(),
           );
         },
@@ -102,6 +201,7 @@ class ActivityFilterChips extends ConsumerWidget {
   }) async {
     const options = [
       ActivityAction.review,
+      ActivityAction.reviewSkipped,
       ActivityAction.triage,
       ActivityAction.implement,
       ActivityAction.promote,
@@ -114,15 +214,33 @@ class ActivityFilterChips extends ConsumerWidget {
           final selected = ref.watch(activityQueryProvider).actions;
           return ListView(
             children: options
-                .map((a) => CheckboxListTile(
-                      value: selected.contains(a),
-                      title: Text(a.name),
-                      onChanged: (_) => toggle(a),
-                    ))
+                .map(
+                  (a) => CheckboxListTile(
+                    value: selected.contains(a),
+                    title: Text(_actionLabel(a)),
+                    onChanged: (_) => toggle(a),
+                  ),
+                )
                 .toList(),
           );
         },
       ),
     );
   }
+
+  static String _itemTypeLabel(String itemType) => switch (itemType) {
+    'pr' => 'Pull requests',
+    'issue' => 'Issues',
+    _ => itemType,
+  };
+
+  static String _actionLabel(ActivityAction action) => switch (action) {
+    ActivityAction.review => 'Reviews',
+    ActivityAction.reviewSkipped => 'Skipped reviews',
+    ActivityAction.triage => 'Triage',
+    ActivityAction.implement => 'Implementation',
+    ActivityAction.promote => 'Promotion',
+    ActivityAction.error => 'Errors',
+    ActivityAction.unknown => 'Unknown',
+  };
 }

--- a/flutter_app/test/features/activity/activity_entry_tile_test.dart
+++ b/flutter_app/test/features/activity/activity_entry_tile_test.dart
@@ -8,59 +8,70 @@ ActivityEntry _mk({
   String outcome = '',
   Map<String, dynamic> details = const {},
   DateTime? ts,
-}) =>
-    ActivityEntry(
-      id: 1,
-      timestamp: ts ?? DateTime(2026, 4, 20, 9, 34, 12),
-      org: 'acme',
-      repo: 'acme/api',
-      itemType: 'pr',
-      itemNumber: 42,
-      itemTitle: 'Fix rate limiter race',
-      action: action,
-      outcome: outcome,
-      details: details,
-    );
+}) => ActivityEntry(
+  id: 1,
+  timestamp: ts ?? DateTime(2026, 4, 20, 9, 34, 12),
+  org: 'acme',
+  repo: 'acme/api',
+  itemType: 'pr',
+  itemNumber: 42,
+  itemTitle: 'Fix rate limiter race',
+  action: action,
+  outcome: outcome,
+  details: details,
+);
 
 void main() {
-  testWidgets('renders repo, number, title, time, outcome for review', (tester) async {
+  testWidgets('renders repo, number, title, time, outcome for review', (
+    tester,
+  ) async {
     final entry = _mk(
       action: ActivityAction.review,
       outcome: 'major',
       details: {'cli_used': 'claude'},
     );
 
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(body: ActivityEntryTile(entry: entry, onTap: () {})),
-    ));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ActivityEntryTile(entry: entry, onTap: () {}),
+        ),
+      ),
+    );
 
-    expect(find.textContaining('acme/api'),             findsOneWidget);
-    expect(find.textContaining('#42'),                   findsOneWidget);
+    expect(find.textContaining('acme/api'), findsOneWidget);
+    expect(find.textContaining('#42'), findsOneWidget);
     expect(find.textContaining('Fix rate limiter race'), findsOneWidget);
-    expect(find.textContaining('09:34:12'),              findsOneWidget);
+    expect(find.textContaining('09:34:12'), findsOneWidget);
     expect(find.textContaining('major review by claude'), findsOneWidget);
     expect(find.byIcon(Icons.rate_review), findsOneWidget);
   });
 
   testWidgets('error action shows error icon and outcome text', (tester) async {
     final entry = _mk(action: ActivityAction.error, outcome: 'cli_not_found');
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(body: ActivityEntryTile(entry: entry)),
-    ));
-    expect(find.byIcon(Icons.error_outline),     findsOneWidget);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ActivityEntryTile(entry: entry)),
+      ),
+    );
+    expect(find.byIcon(Icons.error_outline), findsOneWidget);
     expect(find.textContaining('cli_not_found'), findsOneWidget);
   });
 
-  testWidgets('implement with pr_number > 0 shows opened PR text', (tester) async {
+  testWidgets('implement with pr_number > 0 shows opened PR text', (
+    tester,
+  ) async {
     final entry = _mk(
       action: ActivityAction.implement,
       details: {'pr_number': 99},
     );
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(body: ActivityEntryTile(entry: entry)),
-    ));
-    expect(find.byIcon(Icons.build),              findsOneWidget);
-    expect(find.textContaining('opened PR #99'),  findsOneWidget);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ActivityEntryTile(entry: entry)),
+      ),
+    );
+    expect(find.byIcon(Icons.build), findsOneWidget);
+    expect(find.textContaining('Opened PR #99'), findsOneWidget);
   });
 
   testWidgets('implement with pr_number 0 shows failed text', (tester) async {
@@ -68,10 +79,12 @@ void main() {
       action: ActivityAction.implement,
       details: {'pr_number': 0},
     );
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(body: ActivityEntryTile(entry: entry)),
-    ));
-    expect(find.textContaining('implement failed'), findsOneWidget);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ActivityEntryTile(entry: entry)),
+      ),
+    );
+    expect(find.textContaining('Implementation failed'), findsOneWidget);
   });
 
   testWidgets('promote shows from → to outcome', (tester) async {
@@ -79,11 +92,13 @@ void main() {
       action: ActivityAction.promote,
       outcome: 'blocked → develop',
     );
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(body: ActivityEntryTile(entry: entry)),
-    ));
-    expect(find.byIcon(Icons.swap_horiz),                      findsOneWidget);
-    expect(find.textContaining('promoted: blocked → develop'), findsOneWidget);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ActivityEntryTile(entry: entry)),
+      ),
+    );
+    expect(find.byIcon(Icons.swap_horiz), findsOneWidget);
+    expect(find.textContaining('Promoted: blocked → develop'), findsOneWidget);
   });
 
   testWidgets('triage shows category', (tester) async {
@@ -92,11 +107,31 @@ void main() {
       outcome: 'major',
       details: {'category': 'develop'},
     );
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(body: ActivityEntryTile(entry: entry)),
-    ));
-    expect(find.byIcon(Icons.label),              findsOneWidget);
-    expect(find.textContaining('major'),          findsOneWidget);
-    expect(find.textContaining('(develop)'),      findsOneWidget);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ActivityEntryTile(entry: entry)),
+      ),
+    );
+    expect(find.byIcon(Icons.label), findsOneWidget);
+    expect(find.textContaining('major'), findsOneWidget);
+    expect(find.textContaining('(develop)'), findsOneWidget);
+  });
+
+  testWidgets('review_skipped shows skipped badge and draft reason', (
+    tester,
+  ) async {
+    final entry = _mk(
+      action: ActivityAction.reviewSkipped,
+      outcome: 'draft',
+      details: {'reason': 'draft'},
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ActivityEntryTile(entry: entry)),
+      ),
+    );
+    expect(find.byIcon(Icons.visibility_off_outlined), findsOneWidget);
+    expect(find.text('Skipped'), findsOneWidget);
+    expect(find.textContaining('Skipped because PR is draft'), findsOneWidget);
   });
 }

--- a/flutter_app/test/features/activity/activity_filter_chips_test.dart
+++ b/flutter_app/test/features/activity/activity_filter_chips_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/models/activity.dart';
 import 'package:heimdallm/features/activity/activity_providers.dart';
 import 'package:heimdallm/features/activity/widgets/activity_filter_chips.dart';
 
@@ -18,8 +19,9 @@ Widget _host({List<String> orgs = const ['acme', 'initech']}) {
 }
 
 void main() {
-  testWidgets('org checkbox updates visually when tapped in bottom sheet',
-      (tester) async {
+  testWidgets('org checkbox updates visually when tapped in bottom sheet', (
+    tester,
+  ) async {
     await tester.pumpWidget(_host());
     await tester.pumpAndSettle();
 
@@ -43,8 +45,9 @@ void main() {
     expect(tester.widget<CheckboxListTile>(acmeTile).value, isFalse);
   });
 
-  testWidgets('action checkbox updates visually when tapped in bottom sheet',
-      (tester) async {
+  testWidgets('action checkbox updates visually when tapped in bottom sheet', (
+    tester,
+  ) async {
     await tester.pumpWidget(_host());
     await tester.pumpAndSettle();
 
@@ -52,7 +55,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final reviewTile = find.ancestor(
-      of: find.text('review'),
+      of: find.text('Reviews'),
       matching: find.byType(CheckboxListTile),
     );
     expect(tester.widget<CheckboxListTile>(reviewTile).value, isFalse);
@@ -61,6 +64,38 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(tester.widget<CheckboxListTile>(reviewTile).value, isTrue);
+  });
+
+  testWidgets('quick chips update type, action, and outcome filters', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: ActivityFilterChips(
+              availableOrgs: [],
+              availableRepos: [],
+              availableOutcomes: ['draft'],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('PRs'));
+    await tester.tap(find.text('Draft skips'));
+    await tester.pumpAndSettle();
+
+    final q = container.read(activityQueryProvider);
+    expect(q.itemTypes, {'pr'});
+    expect(q.actions, {ActivityAction.reviewSkipped});
+    expect(q.outcomes, {'draft'});
   });
 
   testWidgets('chip label shows selection count', (tester) async {
@@ -86,32 +121,34 @@ void main() {
     expect(find.text('Organization · 1'), findsOneWidget);
   });
 
-  testWidgets('Clear filters button appears when any filter is active and resets',
-      (tester) async {
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
-    container.read(activityQueryProvider.notifier).toggleOrg('acme');
+  testWidgets(
+    'Clear filters button appears when any filter is active and resets',
+    (tester) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(activityQueryProvider.notifier).toggleOrg('acme');
 
-    await tester.pumpWidget(
-      UncontrolledProviderScope(
-        container: container,
-        child: const MaterialApp(
-          home: Scaffold(
-            body: ActivityFilterChips(
-              availableOrgs: ['acme'],
-              availableRepos: [],
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(
+              body: ActivityFilterChips(
+                availableOrgs: ['acme'],
+                availableRepos: [],
+              ),
             ),
           ),
         ),
-      ),
-    );
-    await tester.pumpAndSettle();
+      );
+      await tester.pumpAndSettle();
 
-    expect(find.text('Clear filters'), findsOneWidget);
-    await tester.tap(find.text('Clear filters'));
-    await tester.pumpAndSettle();
+      expect(find.text('Clear filters'), findsOneWidget);
+      await tester.tap(find.text('Clear filters'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Clear filters'), findsNothing);
-    expect(container.read(activityQueryProvider).orgs, isEmpty);
-  });
+      expect(find.text('Clear filters'), findsNothing);
+      expect(container.read(activityQueryProvider).orgs, isEmpty);
+    },
+  );
 }

--- a/flutter_app/test/features/activity/activity_models_test.dart
+++ b/flutter_app/test/features/activity/activity_models_test.dart
@@ -41,6 +41,23 @@ void main() {
       expect(e.action, ActivityAction.unknown);
     });
 
+    test('parses review_skipped action', () {
+      final e = ActivityEntry.fromJson({
+        'id': 1,
+        'ts': '2026-04-20T09:34:12+02:00',
+        'org': 'a',
+        'repo': 'a/b',
+        'item_type': 'pr',
+        'item_number': 1,
+        'item_title': 't',
+        'action': 'review_skipped',
+        'outcome': 'draft',
+        'details': {'reason': 'draft'},
+      });
+      expect(e.action, ActivityAction.reviewSkipped);
+      expect(e.outcome, 'draft');
+    });
+
     test('missing outcome defaults to empty string', () {
       final e = ActivityEntry.fromJson({
         'id': 1,
@@ -83,7 +100,7 @@ void main() {
             'action': 'review',
             'outcome': 'minor',
             'details': {},
-          }
+          },
         ],
         'count': 500,
         'truncated': true,
@@ -118,23 +135,23 @@ void main() {
       const q = ActivityQuery(
         orgs: {'a', 'b'},
         repos: {'a/x'},
-        actions: {ActivityAction.review, ActivityAction.triage},
+        itemTypes: {'pr'},
+        actions: {ActivityAction.reviewSkipped, ActivityAction.triage},
+        outcomes: {'draft'},
       );
       final p = q.toQueryParameters();
       expect(p['org']!.toSet(), {'a', 'b'});
       expect(p['repo'], ['a/x']);
-      expect(p['action']!.toSet(), {'review', 'triage'});
+      expect(p['item_type'], ['pr']);
+      expect(p['action']!.toSet(), {'review_skipped', 'triage'});
+      expect(p['outcome'], ['draft']);
     });
 
     test('always includes limit', () {
-      expect(
-        const ActivityQuery().toQueryParameters()['limit'],
-        ['500'],
-      );
-      expect(
-        const ActivityQuery(limit: 250).toQueryParameters()['limit'],
-        ['250'],
-      );
+      expect(const ActivityQuery().toQueryParameters()['limit'], ['500']);
+      expect(const ActivityQuery(limit: 250).toQueryParameters()['limit'], [
+        '250',
+      ]);
     });
   });
 

--- a/flutter_app/test/features/activity/activity_providers_test.dart
+++ b/flutter_app/test/features/activity/activity_providers_test.dart
@@ -11,11 +11,11 @@ void main() {
 
       final q = c.read(activityQueryProvider);
       final today = DateTime.now();
-      expect(q.date?.year,  today.year);
+      expect(q.date?.year, today.year);
       expect(q.date?.month, today.month);
-      expect(q.date?.day,   today.day);
+      expect(q.date?.day, today.day);
       expect(q.from, isNull);
-      expect(q.to,   isNull);
+      expect(q.to, isNull);
     });
 
     test('setDate clears range and keeps filters', () {
@@ -27,10 +27,10 @@ void main() {
       n.setDate(DateTime(2026, 4, 18));
 
       final q = c.read(activityQueryProvider);
-      expect(q.date,  DateTime(2026, 4, 18));
-      expect(q.from,  isNull);
-      expect(q.to,    isNull);
-      expect(q.orgs,  {'acme'});
+      expect(q.date, DateTime(2026, 4, 18));
+      expect(q.from, isNull);
+      expect(q.to, isNull);
+      expect(q.orgs, {'acme'});
     });
 
     test('setRange clears date and keeps filters', () {
@@ -42,9 +42,9 @@ void main() {
       n.setRange(DateTime(2026, 4, 18), DateTime(2026, 4, 20));
 
       final q = c.read(activityQueryProvider);
-      expect(q.date,  isNull);
-      expect(q.from,  DateTime(2026, 4, 18));
-      expect(q.to,    DateTime(2026, 4, 20));
+      expect(q.date, isNull);
+      expect(q.from, DateTime(2026, 4, 18));
+      expect(q.to, DateTime(2026, 4, 20));
       expect(q.repos, {'acme/api'});
     });
 
@@ -62,11 +62,53 @@ void main() {
 
       n.toggleAction(ActivityAction.review);
       n.toggleAction(ActivityAction.triage);
-      expect(c.read(activityQueryProvider).actions,
-          {ActivityAction.review, ActivityAction.triage});
+      expect(c.read(activityQueryProvider).actions, {
+        ActivityAction.review,
+        ActivityAction.triage,
+      });
 
       n.toggleAction(ActivityAction.review);
       expect(c.read(activityQueryProvider).actions, {ActivityAction.triage});
+
+      n.toggleItemType('pr');
+      n.toggleOutcome('draft');
+      expect(c.read(activityQueryProvider).itemTypes, {'pr'});
+      expect(c.read(activityQueryProvider).outcomes, {'draft'});
+
+      n.toggleItemType('pr');
+      n.toggleOutcome('draft');
+      expect(c.read(activityQueryProvider).itemTypes, isEmpty);
+      expect(c.read(activityQueryProvider).outcomes, isEmpty);
+    });
+
+    test('setQuickFilter updates requested filter dimensions', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final n = c.read(activityQueryProvider.notifier);
+
+      n.setQuickFilter(
+        action: ActivityAction.reviewSkipped,
+        itemType: 'pr',
+        outcome: 'draft',
+        enabled: true,
+      );
+
+      var q = c.read(activityQueryProvider);
+      expect(q.actions, {ActivityAction.reviewSkipped});
+      expect(q.itemTypes, {'pr'});
+      expect(q.outcomes, {'draft'});
+
+      n.setQuickFilter(
+        action: ActivityAction.reviewSkipped,
+        itemType: 'pr',
+        outcome: 'draft',
+        enabled: false,
+      );
+
+      q = c.read(activityQueryProvider);
+      expect(q.actions, isEmpty);
+      expect(q.itemTypes, isEmpty);
+      expect(q.outcomes, isEmpty);
     });
 
     test('setRange swaps from/to when inverted', () {
@@ -78,7 +120,7 @@ void main() {
 
       final q = c.read(activityQueryProvider);
       expect(q.from, DateTime(2026, 4, 18));
-      expect(q.to,   DateTime(2026, 4, 20));
+      expect(q.to, DateTime(2026, 4, 20));
     });
 
     test('clearFilters resets only filter sets', () {
@@ -89,14 +131,18 @@ void main() {
       n.setDate(DateTime(2026, 4, 18));
       n.toggleOrg('a');
       n.toggleRepo('a/b');
+      n.toggleItemType('pr');
       n.toggleAction(ActivityAction.review);
+      n.toggleOutcome('draft');
       n.clearFilters();
 
       final q = c.read(activityQueryProvider);
-      expect(q.date,    DateTime(2026, 4, 18));   // date preserved
-      expect(q.orgs,    isEmpty);
-      expect(q.repos,   isEmpty);
+      expect(q.date, DateTime(2026, 4, 18)); // date preserved
+      expect(q.orgs, isEmpty);
+      expect(q.repos, isEmpty);
+      expect(q.itemTypes, isEmpty);
       expect(q.actions, isEmpty);
+      expect(q.outcomes, isEmpty);
     });
   });
 }


### PR DESCRIPTION
Closes #376

## Summary

- Add first-class `review_skipped` handling in the Flutter Activity log, including a dedicated icon, badge, and human-readable skip reasons such as draft PRs.
- Redesign activity rows with time, action, PR/Issue badge, outcome text, responsive compact/wide layouts, and a detail sheet with formatted metadata plus GitHub links.
- Add quick filters for PRs, Issues, skipped reviews, errors, and draft skips, backed by new `/activity` `item_type` and `outcome` query filters.
- Add live refresh mode for the persisted activity log using debounced SSE-triggered refetches.

## Validation

- `cd flutter_app && flutter analyze`
- `cd flutter_app && flutter test`
- `cd flutter_app && flutter test test/features/activity`
- `make build-web`
- `git diff --check`

## Notes

- Go package validation via `make test-docker GO_TEST_ARGS="-run 'Test(ListActivity|HandleActivity)' ./internal/store ./internal/server"` could not start because Docker returned HTTP 500 on the local socket `_ping`. No host `go test` was run, per repo policy.