### PR TITLE
fix: prevent duplicate SSE notification streams

### DIFF
--- a/flutter_app/lib/core/api/sse_client.dart
+++ b/flutter_app/lib/core/api/sse_client.dart
@@ -9,19 +9,29 @@ class SseEvent {
   const SseEvent({required this.type, required this.data});
 }
 
+/// SSE client that maintains at most one active HTTP stream and one pending
+/// reconnect timer per instance.
 class SseClient {
   final String path;
   final http.Client _httpClient;
   final PlatformServices _platform;
+  final Duration _errorReconnectDelay;
+  final Duration _doneReconnectDelay;
   StreamController<SseEvent>? _controller;
   StreamSubscription<String>? _subscription;
+  Timer? _reconnectTimer;
+  bool _connecting = false;
 
   SseClient({
     required PlatformServices platform,
     this.path = '/events',
     http.Client? httpClient,
-  })  : _platform = platform,
-        _httpClient = httpClient ?? http.Client();
+    Duration errorReconnectDelay = const Duration(seconds: 5),
+    Duration doneReconnectDelay = const Duration(seconds: 3),
+  }) : _platform = platform,
+       _httpClient = httpClient ?? http.Client(),
+       _errorReconnectDelay = errorReconnectDelay,
+       _doneReconnectDelay = doneReconnectDelay;
 
   /// Parses SSE wire format into events. Static for testability.
   static List<SseEvent> parseEvents(String raw) {
@@ -47,6 +57,10 @@ class SseClient {
 
   /// Returns a stream of SSE events from the daemon.
   Stream<SseEvent> connect() {
+    final existing = _controller;
+    if (existing != null && !existing.isClosed) {
+      return existing.stream;
+    }
     _controller = StreamController<SseEvent>.broadcast(
       onCancel: () => disconnect(),
     );
@@ -57,6 +71,16 @@ class SseClient {
   static const _maxBufferSize = 1024 * 1024; // 1 MB
 
   void _startListening() async {
+    final controller = _controller;
+    if (controller == null ||
+        controller.isClosed ||
+        _connecting ||
+        _subscription != null) {
+      return;
+    }
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    _connecting = true;
     try {
       final request = http.Request(
         'GET',
@@ -69,53 +93,75 @@ class SseClient {
         request.headers['X-Heimdallm-Token'] = token;
       }
       final response = await _httpClient.send(request);
+      _connecting = false;
+      if (_controller == null || _controller!.isClosed) {
+        unawaited(response.stream.drain<void>().catchError((_) {}));
+        return;
+      }
 
       String buffer = '';
-      _subscription = response.stream.transform(utf8.decoder).listen(
-        (chunk) {
-          buffer += chunk;
-          // Guard against unbounded buffer growth from a malformed/malicious stream.
-          if (buffer.length > _maxBufferSize) {
-            buffer = '';
-            _subscription?.cancel();
-            _subscription = null;
-            _startListening();
-            return;
-          }
-          while (buffer.contains('\n\n')) {
-            final idx = buffer.indexOf('\n\n');
-            final block = buffer.substring(0, idx + 2);
-            buffer = buffer.substring(idx + 2);
-            for (final event in parseEvents(block)) {
-              _controller?.add(event);
-            }
-          }
-        },
-        onError: (e) {
-          // Reconnect after a delay instead of propagating the error permanently.
-          Future.delayed(const Duration(seconds: 5), () {
-            if (_controller != null && !_controller!.isClosed) {
-              _startListening();
-            }
-          });
-        },
-        onDone: () {
-          // Server closed the connection (e.g. idle timeout) — reconnect.
-          Future.delayed(const Duration(seconds: 3), () {
-            if (_controller != null && !_controller!.isClosed) {
-              _startListening();
-            }
-          });
-        },
-      );
+      _subscription = response.stream
+          .transform(utf8.decoder)
+          .listen(
+            (chunk) {
+              buffer += chunk;
+              // Guard against unbounded buffer growth from a malformed/malicious stream.
+              if (buffer.length > _maxBufferSize) {
+                buffer = '';
+                _cancelSubscription();
+                _scheduleReconnect(_errorReconnectDelay);
+                return;
+              }
+              while (buffer.contains('\n\n')) {
+                final idx = buffer.indexOf('\n\n');
+                final block = buffer.substring(0, idx + 2);
+                buffer = buffer.substring(idx + 2);
+                for (final event in parseEvents(block)) {
+                  _controller?.add(event);
+                }
+              }
+            },
+            onError: (e) {
+              _cancelSubscription();
+              // Reconnect after a delay instead of propagating the error permanently.
+              _scheduleReconnect(_errorReconnectDelay);
+            },
+            onDone: () {
+              _subscription = null;
+              // Server closed the connection (e.g. idle timeout) — reconnect.
+              _scheduleReconnect(_doneReconnectDelay);
+            },
+          );
     } catch (e) {
+      _connecting = false;
       _controller?.addError(e);
+      _scheduleReconnect(_errorReconnectDelay);
     }
   }
 
-  void disconnect() {
-    _subscription?.cancel();
+  void _cancelSubscription() {
+    final subscription = _subscription;
     _subscription = null;
+    if (subscription != null) {
+      unawaited(subscription.cancel());
+    }
+  }
+
+  void _scheduleReconnect(Duration delay) {
+    final controller = _controller;
+    if (controller == null || controller.isClosed) return;
+    if (_reconnectTimer?.isActive ?? false) return;
+    _reconnectTimer = Timer(delay, () {
+      _reconnectTimer = null;
+      _startListening();
+    });
+  }
+
+  void disconnect() {
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    _connecting = false;
+    _cancelSubscription();
     _controller?.close();
     _controller = null;
   }

--- a/flutter_app/test/core/sse_client_test.dart
+++ b/flutter_app/test/core/sse_client_test.dart
@@ -42,8 +42,11 @@ void main() {
       final mockClient = MockClient.streaming((request, _) async {
         captured = request;
         final bytes = Stream<List<int>>.value(utf8.encode(': hello\n\n'));
-        return http.StreamedResponse(bytes, 200,
-            headers: {'content-type': 'text/event-stream'});
+        return http.StreamedResponse(
+          bytes,
+          200,
+          headers: {'content-type': 'text/event-stream'},
+        );
       });
       final client = SseClient(
         httpClient: mockClient,
@@ -62,16 +65,16 @@ void main() {
     });
 
     test('web uses relative /api/<path> and omits the auth header', () async {
-      final platform = FakePlatformServices(
-        apiBaseUrl: '/api',
-        token: null,
-      );
+      final platform = FakePlatformServices(apiBaseUrl: '/api', token: null);
       http.BaseRequest? captured;
       final mockClient = MockClient.streaming((request, _) async {
         captured = request;
         final bytes = Stream<List<int>>.value(utf8.encode(': hi\n\n'));
-        return http.StreamedResponse(bytes, 200,
-            headers: {'content-type': 'text/event-stream'});
+        return http.StreamedResponse(
+          bytes,
+          200,
+          headers: {'content-type': 'text/event-stream'},
+        );
       });
       final client = SseClient(
         httpClient: mockClient,
@@ -82,11 +85,211 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
       expect(captured, isNotNull);
-      expect(captured!.url.path.endsWith('/api/logs/stream'), isTrue,
-          reason: 'expected path ending in /api/logs/stream, got ${captured!.url}');
+      expect(
+        captured!.url.path.endsWith('/api/logs/stream'),
+        isTrue,
+        reason:
+            'expected path ending in /api/logs/stream, got ${captured!.url}',
+      );
       expect(captured!.headers.containsKey('X-Heimdallm-Token'), isFalse);
 
       await sub.cancel();
+    });
+
+    test(
+      'connect reuses the active stream instead of opening duplicates',
+      () async {
+        final platform = FakePlatformServices(
+          apiBaseUrl: 'http://127.0.0.1:7842',
+        );
+        var requests = 0;
+        final controller = StreamController<List<int>>();
+        final mockClient = MockClient.streaming((request, _) async {
+          requests++;
+          return http.StreamedResponse(
+            controller.stream,
+            200,
+            headers: {'content-type': 'text/event-stream'},
+          );
+        });
+        final client = SseClient(
+          httpClient: mockClient,
+          platform: platform,
+          path: '/events',
+        );
+
+        final sub1 = client.connect().listen((_) {});
+        final sub2 = client.connect().listen((_) {});
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(requests, 1);
+
+        await sub1.cancel();
+        await sub2.cancel();
+        await controller.close();
+      },
+    );
+
+    test(
+      'stream error followed by close schedules only one reconnect',
+      () async {
+        final platform = FakePlatformServices(
+          apiBaseUrl: 'http://127.0.0.1:7842',
+        );
+        var requests = 0;
+        final controllers = <StreamController<List<int>>>[];
+        final mockClient = MockClient.streaming((request, _) async {
+          requests++;
+          final controller = StreamController<List<int>>();
+          controllers.add(controller);
+          return http.StreamedResponse(
+            controller.stream,
+            200,
+            headers: {'content-type': 'text/event-stream'},
+          );
+        });
+        final client = SseClient(
+          httpClient: mockClient,
+          platform: platform,
+          path: '/events',
+          errorReconnectDelay: const Duration(milliseconds: 10),
+          doneReconnectDelay: const Duration(milliseconds: 10),
+        );
+
+        final sub = client.connect().listen((_) {});
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(requests, 1);
+
+        controllers.first.addError(Exception('socket closed'));
+        await controllers.first.close();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(requests, 2);
+
+        await sub.cancel();
+        for (final controller in controllers.skip(1)) {
+          if (!controller.isClosed) {
+            await controller.close();
+          }
+        }
+      },
+    );
+
+    test('send failure schedules a reconnect', () async {
+      final platform = FakePlatformServices(
+        apiBaseUrl: 'http://127.0.0.1:7842',
+      );
+      var requests = 0;
+      final controllers = <StreamController<List<int>>>[];
+      final mockClient = MockClient.streaming((request, _) async {
+        requests++;
+        if (requests == 1) {
+          throw Exception('connection refused');
+        }
+        final controller = StreamController<List<int>>();
+        controllers.add(controller);
+        return http.StreamedResponse(
+          controller.stream,
+          200,
+          headers: {'content-type': 'text/event-stream'},
+        );
+      });
+      final client = SseClient(
+        httpClient: mockClient,
+        platform: platform,
+        path: '/events',
+        errorReconnectDelay: const Duration(milliseconds: 10),
+      );
+
+      final sub = client.connect().listen((_) {}, onError: (_) {});
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(requests, 2);
+
+      await sub.cancel();
+      for (final controller in controllers) {
+        await controller.close();
+      }
+    });
+
+    test('drains the response if disconnected while connecting', () async {
+      final platform = FakePlatformServices(
+        apiBaseUrl: 'http://127.0.0.1:7842',
+      );
+      final responseCompleter = Completer<http.StreamedResponse>();
+      final requestStarted = Completer<void>();
+      var drained = false;
+      final responseBody = StreamController<List<int>>(
+        onListen: () => drained = true,
+      );
+      final mockClient = MockClient.streaming((request, _) async {
+        requestStarted.complete();
+        return responseCompleter.future;
+      });
+      final client = SseClient(
+        httpClient: mockClient,
+        platform: platform,
+        path: '/events',
+      );
+
+      final sub = client.connect().listen((_) {});
+      await requestStarted.future;
+      await sub.cancel();
+
+      responseCompleter.complete(
+        http.StreamedResponse(
+          responseBody.stream,
+          200,
+          headers: {'content-type': 'text/event-stream'},
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(drained, isTrue);
+
+      await responseBody.close();
+    });
+
+    test('buffer overflow reconnects after the error delay', () async {
+      final platform = FakePlatformServices(
+        apiBaseUrl: 'http://127.0.0.1:7842',
+      );
+      var requests = 0;
+      final controllers = <StreamController<List<int>>>[];
+      final mockClient = MockClient.streaming((request, _) async {
+        requests++;
+        final controller = StreamController<List<int>>();
+        controllers.add(controller);
+        return http.StreamedResponse(
+          controller.stream,
+          200,
+          headers: {'content-type': 'text/event-stream'},
+        );
+      });
+      final client = SseClient(
+        httpClient: mockClient,
+        platform: platform,
+        path: '/events',
+        errorReconnectDelay: const Duration(milliseconds: 30),
+      );
+
+      final sub = client.connect().listen((_) {});
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(requests, 1);
+
+      controllers.first.add(List<int>.filled(1024 * 1024 + 1, 65));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(requests, 1);
+
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      expect(requests, 2);
+
+      await sub.cancel();
+      for (final controller in controllers) {
+        if (!controller.isClosed) {
+          await controller.close();
+        }
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #377.

- Makes `SseClient.connect()` idempotent while a stream is already active.
- Tracks the active connection and pending reconnect timer so an error followed by `onDone` cannot open parallel `/events` streams.
- Adds regression coverage for duplicate `connect()` calls and the error-then-close reconnect path.

## Why

The OS notification spam can happen when the Flutter SSE client accumulates multiple active `/events` connections. Each connection receives the same server fan-out event and pushes it into the same client stream, so a single review event can trigger repeated notifications.

## Validation

- `flutter test test/core/sse_client_test.dart`
- `flutter analyze`
- `make build-web`

Note: `flutter_app/pubspec.lock` had a pre-existing local change and is intentionally not included in this PR.