### PR TITLE
fix: populate activity filter options

### DIFF
--- a/flutter_app/lib/features/activity/activity_providers.dart
+++ b/flutter_app/lib/features/activity/activity_providers.dart
@@ -144,7 +144,8 @@ final activityEntriesProvider = FutureProvider<ActivityPage>((ref) async {
 /// Oversized so the distinct org/repo lists reflect the full window even when
 /// the main entries view is truncated. A dedicated facets endpoint would be
 /// the proper long-term fix.
-const int _activityOptionsLimit = 10000;
+// Must stay in sync with the daemon's /activity limit cap.
+const int _activityOptionsLimit = 5000;
 
 final activityOptionsProvider = FutureProvider<ActivityPage>((ref) async {
   final date = ref.watch(activityQueryProvider.select((q) => q.date));

--- a/flutter_app/lib/features/activity/activity_screen.dart
+++ b/flutter_app/lib/features/activity/activity_screen.dart
@@ -24,19 +24,15 @@ class ActivityScreen extends ConsumerWidget {
     final async = ref.watch(activityEntriesProvider);
     final optionsAsync = ref.watch(activityOptionsProvider);
 
-    final orgs =
-        optionsAsync.valueOrNull?.entries.map((e) => e.org).toSet().toList() ??
-        const <String>[];
-    final repos =
-        optionsAsync.valueOrNull?.entries.map((e) => e.repo).toSet().toList() ??
-        const <String>[];
-    final outcomes =
-        optionsAsync.valueOrNull?.entries
-            .map((e) => e.outcome)
-            .where((o) => o.isNotEmpty)
-            .toSet()
-            .toList() ??
-        const <String>[];
+    final optionEntries =
+        optionsAsync.valueOrNull?.entries ??
+        async.valueOrNull?.entries ??
+        const <ActivityEntry>[];
+    final usingFallbackOptions =
+        optionsAsync.valueOrNull == null && async.valueOrNull != null;
+    final orgs = _sortedDistinct(optionEntries.map((e) => e.org));
+    final repos = _sortedDistinct(optionEntries.map((e) => e.repo));
+    final outcomes = _sortedDistinct(optionEntries.map((e) => e.outcome));
 
     return Column(
       children: [
@@ -47,6 +43,7 @@ class ActivityScreen extends ConsumerWidget {
             availableOrgs: orgs,
             availableRepos: repos,
             availableOutcomes: outcomes,
+            optionsLimited: usingFallbackOptions,
           ),
         ),
         const Divider(height: 1),
@@ -60,6 +57,12 @@ class ActivityScreen extends ConsumerWidget {
       ],
     );
   }
+}
+
+List<String> _sortedDistinct(Iterable<String> values) {
+  final list = values.where((v) => v.isNotEmpty).toSet().toList();
+  list.sort();
+  return list;
 }
 
 class _ErrorView extends StatelessWidget {

--- a/flutter_app/lib/features/activity/widgets/activity_filter_chips.dart
+++ b/flutter_app/lib/features/activity/widgets/activity_filter_chips.dart
@@ -10,12 +10,14 @@ class ActivityFilterChips extends ConsumerWidget {
   final List<String> availableOrgs;
   final List<String> availableRepos;
   final List<String> availableOutcomes;
+  final bool optionsLimited;
 
   const ActivityFilterChips({
     super.key,
     required this.availableOrgs,
     required this.availableRepos,
     this.availableOutcomes = const [],
+    this.optionsLimited = false,
   });
 
   @override
@@ -81,6 +83,7 @@ class ActivityFilterChips extends ConsumerWidget {
           onTap: () => _pickStrings(
             context,
             options: availableOrgs,
+            optionsLimited: optionsLimited,
             select: (q) => q.orgs,
             toggle: (v) =>
                 ref.read(activityQueryProvider.notifier).toggleOrg(v),
@@ -93,6 +96,7 @@ class ActivityFilterChips extends ConsumerWidget {
           onTap: () => _pickStrings(
             context,
             options: availableRepos,
+            optionsLimited: optionsLimited,
             select: (q) => q.repos,
             toggle: (v) =>
                 ref.read(activityQueryProvider.notifier).toggleRepo(v),
@@ -129,6 +133,7 @@ class ActivityFilterChips extends ConsumerWidget {
             onTap: () => _pickStrings(
               context,
               options: availableOutcomes,
+              optionsLimited: optionsLimited,
               select: (q) => q.outcomes,
               toggle: (v) =>
                   ref.read(activityQueryProvider.notifier).toggleOutcome(v),
@@ -170,6 +175,7 @@ class ActivityFilterChips extends ConsumerWidget {
   Future<void> _pickStrings(
     BuildContext context, {
     required List<String> options,
+    bool optionsLimited = false,
     required Set<String> Function(ActivityQuery q) select,
     required void Function(String) toggle,
     String Function(String)? labelFor,
@@ -179,16 +185,34 @@ class ActivityFilterChips extends ConsumerWidget {
       builder: (_) => Consumer(
         builder: (ctx, ref, _) {
           final selected = select(ref.watch(activityQueryProvider));
+          if (options.isEmpty) {
+            return const SafeArea(
+              child: SizedBox(
+                height: 160,
+                child: Center(child: Text('No options available')),
+              ),
+            );
+          }
           return ListView(
-            children: options
-                .map(
-                  (o) => CheckboxListTile(
-                    value: selected.contains(o),
-                    title: Text(labelFor?.call(o) ?? o),
-                    onChanged: (_) => toggle(o),
+            children: [
+              if (optionsLimited)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+                  child: Text(
+                    'Options limited to visible activity',
+                    style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+                    ),
                   ),
-                )
-                .toList(),
+                ),
+              ...options.map(
+                (o) => CheckboxListTile(
+                  value: selected.contains(o),
+                  title: Text(labelFor?.call(o) ?? o),
+                  onChanged: (_) => toggle(o),
+                ),
+              ),
+            ],
           );
         },
       ),

--- a/flutter_app/test/features/activity/activity_filter_chips_test.dart
+++ b/flutter_app/test/features/activity/activity_filter_chips_test.dart
@@ -66,6 +66,18 @@ void main() {
     expect(tester.widget<CheckboxListTile>(reviewTile).value, isTrue);
   });
 
+  testWidgets('string picker shows an empty state instead of a blank sheet', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(orgs: const []));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Organization'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No options available'), findsOneWidget);
+  });
+
   testWidgets('quick chips update type, action, and outcome filters', (
     tester,
   ) async {

--- a/flutter_app/test/features/activity/activity_providers_test.dart
+++ b/flutter_app/test/features/activity/activity_providers_test.dart
@@ -1,9 +1,18 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:heimdallm/core/api/api_client.dart';
 import 'package:heimdallm/core/models/activity.dart';
 import 'package:heimdallm/features/activity/activity_providers.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockApiClient extends Mock implements ApiClient {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(const ActivityQuery());
+  });
+
   group('ActivityQueryNotifier', () {
     test('default query is today', () {
       final c = ProviderContainer();
@@ -143,6 +152,25 @@ void main() {
       expect(q.itemTypes, isEmpty);
       expect(q.actions, isEmpty);
       expect(q.outcomes, isEmpty);
+    });
+  });
+
+  group('activityOptionsProvider', () {
+    test('uses a daemon-compatible limit for option discovery', () async {
+      final api = MockApiClient();
+      ActivityQuery? captured;
+      when(() => api.fetchActivity(any())).thenAnswer((invocation) async {
+        captured = invocation.positionalArguments.single as ActivityQuery;
+        return const ActivityPage(entries: [], truncated: false, count: 0);
+      });
+      final c = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(api)],
+      );
+      addTearDown(c.dispose);
+
+      await c.read(activityOptionsProvider.future);
+
+      expect(captured?.limit, 5000);
     });
   });
 }

--- a/flutter_app/test/features/activity/activity_screen_test.dart
+++ b/flutter_app/test/features/activity/activity_screen_test.dart
@@ -5,19 +5,25 @@ import 'package:heimdallm/core/models/activity.dart';
 import 'package:heimdallm/features/activity/activity_providers.dart';
 import 'package:heimdallm/features/activity/activity_screen.dart';
 
-ActivityEntry _mk(int n, DateTime ts, {ActivityAction a = ActivityAction.review}) =>
-    ActivityEntry(
-      id: n,
-      timestamp: ts,
-      org: 'acme',
-      repo: 'acme/api',
-      itemType: 'pr',
-      itemNumber: n,
-      itemTitle: 'Title $n',
-      action: a,
-      outcome: 'minor',
-      details: const {},
-    );
+ActivityEntry _mk(
+  int n,
+  DateTime ts, {
+  ActivityAction a = ActivityAction.review,
+  String org = 'acme',
+  String repo = 'acme/api',
+  String outcome = 'minor',
+}) => ActivityEntry(
+  id: n,
+  timestamp: ts,
+  org: org,
+  repo: repo,
+  itemType: 'pr',
+  itemNumber: n,
+  itemTitle: 'Title $n',
+  action: a,
+  outcome: outcome,
+  details: const {},
+);
 
 ProviderScope _scope({required AsyncValue<ActivityPage> value}) {
   Future<ActivityPage> resolve() async {
@@ -38,56 +44,74 @@ ProviderScope _scope({required AsyncValue<ActivityPage> value}) {
 
 void main() {
   testWidgets('empty state when no entries', (tester) async {
-    await tester.pumpWidget(_scope(
-      value: const AsyncData(ActivityPage(entries: [], truncated: false, count: 0)),
-    ));
+    await tester.pumpWidget(
+      _scope(
+        value: const AsyncData(
+          ActivityPage(entries: [], truncated: false, count: 0),
+        ),
+      ),
+    );
     await tester.pumpAndSettle();
     expect(find.textContaining('No activity'), findsOneWidget);
   });
 
   testWidgets('groups entries by hour', (tester) async {
     final base = DateTime(2026, 4, 20, 9);
-    await tester.pumpWidget(_scope(
-      value: AsyncData(ActivityPage(
-        entries: [
-          _mk(1, base.add(const Duration(minutes: 5))),
-          _mk(2, base.add(const Duration(minutes: 30))),
-          _mk(3, base.add(const Duration(hours: 1, minutes: 10))),
-        ],
-        truncated: false,
-        count: 3,
-      )),
-    ));
+    await tester.pumpWidget(
+      _scope(
+        value: AsyncData(
+          ActivityPage(
+            entries: [
+              _mk(1, base.add(const Duration(minutes: 5))),
+              _mk(2, base.add(const Duration(minutes: 30))),
+              _mk(3, base.add(const Duration(hours: 1, minutes: 10))),
+            ],
+            truncated: false,
+            count: 3,
+          ),
+        ),
+      ),
+    );
     await tester.pumpAndSettle();
     expect(find.text('09:00'), findsOneWidget);
     expect(find.text('10:00'), findsOneWidget);
   });
 
   testWidgets('shows truncation banner when truncated', (tester) async {
-    await tester.pumpWidget(_scope(
-      value: AsyncData(ActivityPage(
-        entries: [_mk(1, DateTime.now())],
-        truncated: true,
-        count: 1,
-      )),
-    ));
+    await tester.pumpWidget(
+      _scope(
+        value: AsyncData(
+          ActivityPage(
+            entries: [_mk(1, DateTime.now())],
+            truncated: true,
+            count: 1,
+          ),
+        ),
+      ),
+    );
     await tester.pumpAndSettle();
     expect(find.textContaining('Showing'), findsOneWidget);
     expect(find.textContaining('Narrow filters'), findsOneWidget);
   });
 
-  testWidgets('emits a date header per day in multi-day ranges', (tester) async {
-    await tester.pumpWidget(_scope(
-      value: AsyncData(ActivityPage(
-        entries: [
-          _mk(1, DateTime(2026, 4, 18, 9, 5)),
-          _mk(2, DateTime(2026, 4, 19, 9, 30)),
-          _mk(3, DateTime(2026, 4, 19, 10, 0)),
-        ],
-        truncated: false,
-        count: 3,
-      )),
-    ));
+  testWidgets('emits a date header per day in multi-day ranges', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _scope(
+        value: AsyncData(
+          ActivityPage(
+            entries: [
+              _mk(1, DateTime(2026, 4, 18, 9, 5)),
+              _mk(2, DateTime(2026, 4, 19, 9, 30)),
+              _mk(3, DateTime(2026, 4, 19, 10, 0)),
+            ],
+            truncated: false,
+            count: 3,
+          ),
+        ),
+      ),
+    );
     await tester.pumpAndSettle();
     expect(find.text('Apr 18, 2026'), findsOneWidget);
     expect(find.text('Apr 19, 2026'), findsOneWidget);
@@ -96,22 +120,83 @@ void main() {
     expect(find.text('10:00'), findsOneWidget);
   });
 
-  testWidgets('ActivityDisabledException renders friendly empty state',
-      (tester) async {
-    await tester.pumpWidget(ProviderScope(
-      overrides: [
-        activityEntriesProvider.overrideWith(
-          (ref) => Future<ActivityPage>.error(ActivityDisabledException()),
-        ),
-        activityOptionsProvider.overrideWith(
-          (ref) => Future<ActivityPage>.error(ActivityDisabledException()),
-        ),
-      ],
-      child: const MaterialApp(home: Scaffold(body: ActivityScreen())),
-    ));
+  testWidgets('ActivityDisabledException renders friendly empty state', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activityEntriesProvider.overrideWith(
+            (ref) => Future<ActivityPage>.error(ActivityDisabledException()),
+          ),
+          activityOptionsProvider.overrideWith(
+            (ref) => Future<ActivityPage>.error(ActivityDisabledException()),
+          ),
+        ],
+        child: const MaterialApp(home: Scaffold(body: ActivityScreen())),
+      ),
+    );
     await tester.pumpAndSettle();
     expect(find.text('Activity log is disabled'), findsOneWidget);
     expect(find.textContaining('Enable activity_log'), findsOneWidget);
     expect(find.textContaining('Error:'), findsNothing);
+  });
+
+  testWidgets('filter options fall back to visible entries when options fail', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activityEntriesProvider.overrideWith(
+            (ref) async => ActivityPage(
+              entries: [_mk(1, DateTime(2026, 4, 20, 9))],
+              truncated: false,
+              count: 1,
+            ),
+          ),
+          activityOptionsProvider.overrideWith(
+            (ref) => Future<ActivityPage>.error(Exception('bad limit')),
+          ),
+        ],
+        child: const MaterialApp(home: Scaffold(body: ActivityScreen())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Organization'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('acme'), findsOneWidget);
+    expect(find.text('Options limited to visible activity'), findsOneWidget);
+  });
+
+  testWidgets('filter options are sorted for stable picker order', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _scope(
+        value: AsyncData(
+          ActivityPage(
+            entries: [
+              _mk(1, DateTime(2026, 4, 20, 9), org: 'zeta'),
+              _mk(2, DateTime(2026, 4, 20, 10), org: 'acme'),
+            ],
+            truncated: false,
+            count: 2,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Organization'));
+    await tester.pumpAndSettle();
+
+    final tiles = tester
+        .widgetList<CheckboxListTile>(find.byType(CheckboxListTile))
+        .toList();
+    expect((tiles[0].title as Text).data, 'acme');
+    expect((tiles[1].title as Text).data, 'zeta');
   });
 }


### PR DESCRIPTION
## Summary

- Align Activity log option discovery with the daemon `/activity` max limit (`5000`) so org/repo filters load instead of silently failing.
- Fall back to the visible activity entries when the options request fails, preventing empty org/repo pickers when the timeline has data.
- Add an explicit empty state inside string filter sheets instead of rendering a blank modal.

## Why

The Organization/Repository filter chips opened an empty bottom sheet because `activityOptionsProvider` requested `/activity?limit=10000`, while the daemon rejects limits above `5000` with HTTP 400. The main timeline still loaded with its default limit, so the failure was only visible when opening the filter sheet.

## Validation

- `flutter test test/features/activity`
- `flutter analyze`
- `make build-web`

Note: local `flutter_app/pubspec.lock` and `flutter_app/flutter_01.png` changes are intentionally not included.