### PR TITLE
fix: avoid duplicate review publish retries

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -38,7 +38,9 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
-// Let the initial pipeline publish finish before retry workers consider the row.
+// reviewPublishRetryMinAge only gates retry paths. The pipeline still submits
+// immediately after InsertReview; after this window, PublishPending will
+// re-enqueue rows that remain unpublished.
 const reviewPublishRetryMinAge = 2 * time.Minute
 
 func main() {
@@ -684,9 +686,9 @@ func main() {
 			return nil // idempotent — ack
 		}
 		if !reviewReadyForPublishRetry(rev, time.Now().UTC()) {
-			slog.Info("publish-worker: review still in initial publish window, skipping",
+			slog.Debug("publish-worker: review still in initial publish window, skipping",
 				"review_id", msg.ReviewID, "created_at", rev.CreatedAt)
-			return nil // PublishPending will re-enqueue if it remains unpublished.
+			return nil // Ack early messages; PublishPending re-enqueues aged unpublished rows.
 		}
 
 		pr, err := s.GetPR(rev.PRID)
@@ -2256,9 +2258,6 @@ func (a *tier2Adapter) PublishPending() {
 }
 
 func (a *tier2Adapter) publishPending(now time.Time) {
-	if a.publishPub == nil {
-		return
-	}
 	reviews, err := a.store.ListUnpublishedReviews()
 	if err != nil || len(reviews) == 0 {
 		return

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -38,6 +38,9 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
+// Let the initial pipeline publish finish before retry workers consider the row.
+const reviewPublishRetryMinAge = 2 * time.Minute
+
 func main() {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
@@ -679,6 +682,11 @@ func main() {
 			slog.Info("publish-worker: already published, skipping",
 				"review_id", msg.ReviewID, "github_review_id", rev.GitHubReviewID)
 			return nil // idempotent — ack
+		}
+		if !reviewReadyForPublishRetry(rev, time.Now().UTC()) {
+			slog.Info("publish-worker: review still in initial publish window, skipping",
+				"review_id", msg.ReviewID, "created_at", rev.CreatedAt)
+			return nil // PublishPending will re-enqueue if it remains unpublished.
 		}
 
 		pr, err := s.GetPR(rev.PRID)
@@ -2244,15 +2252,35 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 
 // PublishPending implements scheduler.Tier2PRProcessor.
 func (a *tier2Adapter) PublishPending() {
+	a.publishPending(time.Now().UTC())
+}
+
+func (a *tier2Adapter) publishPending(now time.Time) {
+	if a.publishPub == nil {
+		return
+	}
 	reviews, err := a.store.ListUnpublishedReviews()
 	if err != nil || len(reviews) == 0 {
 		return
 	}
 	for _, rev := range reviews {
+		if !reviewReadyForPublishRetry(rev, now) {
+			continue
+		}
 		if err := a.publishPub.PublishPRPublish(context.Background(), rev.ID); err != nil {
 			slog.Warn("publish-pending: enqueue failed", "review_id", rev.ID, "err", err)
 		}
 	}
+}
+
+func reviewReadyForPublishRetry(rev *store.Review, now time.Time) bool {
+	if rev == nil || rev.GitHubReviewID != 0 {
+		return false
+	}
+	if rev.CreatedAt.IsZero() {
+		return true
+	}
+	return !now.Before(rev.CreatedAt.Add(reviewPublishRetryMinAge))
 }
 
 // ProcessRepo implements scheduler.Tier2IssueProcessor.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -38,11 +38,6 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
-// reviewPublishRetryMinAge only gates retry paths. The pipeline still submits
-// immediately after InsertReview; after this window, PublishPending will
-// re-enqueue rows that remain unpublished.
-const reviewPublishRetryMinAge = 2 * time.Minute
-
 func main() {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
@@ -685,11 +680,6 @@ func main() {
 				"review_id", msg.ReviewID, "github_review_id", rev.GitHubReviewID)
 			return nil // idempotent — ack
 		}
-		if !reviewReadyForPublishRetry(rev, time.Now().UTC()) {
-			slog.Debug("publish-worker: review still in initial publish window, skipping",
-				"review_id", msg.ReviewID, "created_at", rev.CreatedAt)
-			return nil // Ack early messages; PublishPending re-enqueues aged unpublished rows.
-		}
 
 		pr, err := s.GetPR(rev.PRID)
 		if err != nil {
@@ -703,6 +693,15 @@ func main() {
 				"review_id", msg.ReviewID)
 			_ = s.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
 			return nil // permanent — ack
+		}
+		inFlight, err := s.ReviewInFlight(pr.GithubID, rev.HeadSHA)
+		if err != nil {
+			return fmt.Errorf("check in-flight review: %w", err)
+		}
+		if inFlight {
+			slog.Debug("publish-worker: initial publish still in flight, skipping retry",
+				"review_id", msg.ReviewID, "github_id", pr.GithubID, "head_sha", rev.HeadSHA)
+			return nil // PublishPending re-enqueues if the row remains unpublished after release.
 		}
 
 		// Rebuild ReviewResult from stored JSON
@@ -2254,16 +2253,21 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 
 // PublishPending implements scheduler.Tier2PRProcessor.
 func (a *tier2Adapter) PublishPending() {
-	a.publishPending(time.Now().UTC())
+	a.publishPending()
 }
 
-func (a *tier2Adapter) publishPending(now time.Time) {
+func (a *tier2Adapter) publishPending() {
 	reviews, err := a.store.ListUnpublishedReviews()
 	if err != nil || len(reviews) == 0 {
 		return
 	}
 	for _, rev := range reviews {
-		if !reviewReadyForPublishRetry(rev, now) {
+		ready, err := a.reviewReadyForPublishRetry(rev)
+		if err != nil {
+			slog.Warn("publish-pending: in-flight check failed", "review_id", rev.ID, "err", err)
+			continue
+		}
+		if !ready {
 			continue
 		}
 		if err := a.publishPub.PublishPRPublish(context.Background(), rev.ID); err != nil {
@@ -2272,14 +2276,19 @@ func (a *tier2Adapter) publishPending(now time.Time) {
 	}
 }
 
-func reviewReadyForPublishRetry(rev *store.Review, now time.Time) bool {
+func (a *tier2Adapter) reviewReadyForPublishRetry(rev *store.Review) (bool, error) {
 	if rev == nil || rev.GitHubReviewID != 0 {
-		return false
+		return false, nil
 	}
-	if rev.CreatedAt.IsZero() {
-		return true
+	pr, err := a.store.GetPR(rev.PRID)
+	if err != nil {
+		return false, err
 	}
-	return !now.Before(rev.CreatedAt.Add(reviewPublishRetryMinAge))
+	inFlight, err := a.store.ReviewInFlight(pr.GithubID, rev.HeadSHA)
+	if err != nil {
+		return false, err
+	}
+	return !inFlight, nil
 }
 
 // ProcessRepo implements scheduler.Tier2IssueProcessor.

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -115,7 +115,7 @@ func TestTier2AdapterPublishPendingDefersFreshReviews(t *testing.T) {
 	s := newMemStore(t)
 	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
 	oldReviewID := seedPRWithReview(t, s, 101, now.Add(-reviewPublishRetryMinAge-time.Second))
-	freshReviewID := seedPRWithReview(t, s, 102, now.Add(-reviewPublishRetryMinAge+time.Second))
+	seedPRWithReview(t, s, 102, now.Add(-reviewPublishRetryMinAge+time.Second))
 
 	conn := newInProcessNATS(t)
 	ch := make(chan *nats.Msg, 2)
@@ -150,13 +150,12 @@ func TestTier2AdapterPublishPendingDefersFreshReviews(t *testing.T) {
 		t.Fatal("old pending review was not enqueued")
 	}
 
+	// publishPending publishes synchronously; the short wait catches stray
+	// buffered messages without making this negative assertion expensive.
 	select {
 	case msg := <-ch:
 		var got bus.PRPublishMsg
 		_ = bus.Decode(msg.Data, &got)
-		if got.ReviewID == freshReviewID {
-			t.Fatalf("fresh review %d was enqueued during initial publish window", freshReviewID)
-		}
 		t.Fatalf("unexpected extra publish message: %+v", got)
 	case <-time.After(150 * time.Millisecond):
 	}

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -94,28 +94,68 @@ func seedPRWithReview(t *testing.T, s *store.Store, githubID int64, createdAt ti
 	return revID
 }
 
-func TestReviewReadyForPublishRetry(t *testing.T) {
+func TestTier2AdapterReviewReadyForPublishRetry(t *testing.T) {
+	s := newMemStore(t)
 	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	readyID := seedPRWithReview(t, s, 101, now)
+	inFlightID := seedPRWithReview(t, s, 102, now)
+	if claimed, err := s.ClaimInFlightReview(102, "abc123"); err != nil {
+		t.Fatalf("claim in-flight review: %v", err)
+	} else if !claimed {
+		t.Fatal("expected in-flight claim to succeed")
+	}
+	a := &tier2Adapter{store: s}
 
-	if reviewReadyForPublishRetry(&store.Review{GitHubReviewID: 123, CreatedAt: now.Add(-time.Hour)}, now) {
+	readyRev, err := s.GetReview(readyID)
+	if err != nil {
+		t.Fatalf("get ready review: %v", err)
+	}
+	ready, err := a.reviewReadyForPublishRetry(readyRev)
+	if err != nil {
+		t.Fatalf("reviewReadyForPublishRetry ready: %v", err)
+	}
+	if !ready {
+		t.Fatal("unpublished review with no in-flight claim should be ready")
+	}
+
+	inFlightRev, err := s.GetReview(inFlightID)
+	if err != nil {
+		t.Fatalf("get in-flight review: %v", err)
+	}
+	ready, err = a.reviewReadyForPublishRetry(inFlightRev)
+	if err != nil {
+		t.Fatalf("reviewReadyForPublishRetry in-flight: %v", err)
+	}
+	if ready {
+		t.Fatal("in-flight review should not be ready for retry")
+	}
+
+	if err := s.MarkReviewPublished(readyID, 123, "APPROVED", now); err != nil {
+		t.Fatalf("mark published: %v", err)
+	}
+	publishedRev, err := s.GetReview(readyID)
+	if err != nil {
+		t.Fatalf("get published review: %v", err)
+	}
+	ready, err = a.reviewReadyForPublishRetry(publishedRev)
+	if err != nil {
+		t.Fatalf("reviewReadyForPublishRetry published: %v", err)
+	}
+	if ready {
 		t.Fatal("published review should not be ready for retry")
-	}
-	if reviewReadyForPublishRetry(&store.Review{CreatedAt: now.Add(-reviewPublishRetryMinAge + time.Second)}, now) {
-		t.Fatal("fresh unpublished review should stay in the initial publish window")
-	}
-	if !reviewReadyForPublishRetry(&store.Review{CreatedAt: now.Add(-reviewPublishRetryMinAge)}, now) {
-		t.Fatal("unpublished review at the retry boundary should be ready")
-	}
-	if !reviewReadyForPublishRetry(&store.Review{}, now) {
-		t.Fatal("legacy review with missing created_at should be retryable")
 	}
 }
 
-func TestTier2AdapterPublishPendingDefersFreshReviews(t *testing.T) {
+func TestTier2AdapterPublishPendingDefersInFlightReviews(t *testing.T) {
 	s := newMemStore(t)
 	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
-	oldReviewID := seedPRWithReview(t, s, 101, now.Add(-reviewPublishRetryMinAge-time.Second))
-	seedPRWithReview(t, s, 102, now.Add(-reviewPublishRetryMinAge+time.Second))
+	readyReviewID := seedPRWithReview(t, s, 101, now)
+	seedPRWithReview(t, s, 102, now)
+	if claimed, err := s.ClaimInFlightReview(102, "abc123"); err != nil {
+		t.Fatalf("claim in-flight review: %v", err)
+	} else if !claimed {
+		t.Fatal("expected in-flight claim to succeed")
+	}
 
 	conn := newInProcessNATS(t)
 	ch := make(chan *nats.Msg, 2)
@@ -132,7 +172,7 @@ func TestTier2AdapterPublishPendingDefersFreshReviews(t *testing.T) {
 		store:      s,
 		publishPub: bus.NewPRPublishPublisher(conn),
 	}
-	a.publishPending(now)
+	a.publishPending()
 	if err := conn.Flush(); err != nil {
 		t.Fatalf("flush publish: %v", err)
 	}
@@ -143,11 +183,11 @@ func TestTier2AdapterPublishPendingDefersFreshReviews(t *testing.T) {
 		if err := bus.Decode(msg.Data, &got); err != nil {
 			t.Fatalf("decode publish msg: %v", err)
 		}
-		if got.ReviewID != oldReviewID {
-			t.Fatalf("published review ID = %d, want old review %d", got.ReviewID, oldReviewID)
+		if got.ReviewID != readyReviewID {
+			t.Fatalf("published review ID = %d, want ready review %d", got.ReviewID, readyReviewID)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("old pending review was not enqueued")
+		t.Fatal("ready pending review was not enqueued")
 	}
 
 	// publishPending publishes synchronously; the short wait catches stray

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -5,8 +5,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/heimdallm/daemon/internal/bus"
 	"github.com/heimdallm/daemon/internal/store"
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
 )
 
 // newMemStore returns an in-memory SQLite store with a short cleanup hook.
@@ -27,6 +31,134 @@ func seedAgent(t *testing.T, s *store.Store, a store.Agent) {
 	t.Helper()
 	if err := s.UpsertAgent(&a); err != nil {
 		t.Fatalf("upsert agent %q: %v", a.ID, err)
+	}
+}
+
+func newInProcessNATS(t *testing.T) *nats.Conn {
+	t.Helper()
+	srv, err := natsserver.NewServer(&natsserver.Options{
+		ServerName: t.Name(),
+		DontListen: true,
+		NoLog:      true,
+		NoSigs:     true,
+	})
+	if err != nil {
+		t.Fatalf("new nats server: %v", err)
+	}
+	srv.Start()
+	if !srv.ReadyForConnections(5 * time.Second) {
+		t.Fatal("nats server not ready")
+	}
+	conn, err := nats.Connect("", nats.InProcessServer(srv), nats.Name(t.Name()))
+	if err != nil {
+		t.Fatalf("connect nats: %v", err)
+	}
+	t.Cleanup(func() {
+		conn.Close()
+		srv.Shutdown()
+		srv.WaitForShutdown()
+	})
+	return conn
+}
+
+func seedPRWithReview(t *testing.T, s *store.Store, githubID int64, createdAt time.Time) int64 {
+	t.Helper()
+	prID, err := s.UpsertPR(&store.PR{
+		GithubID:  githubID,
+		Repo:      "org/repo",
+		Number:    int(githubID),
+		Title:     "test pr",
+		Author:    "alice",
+		URL:       "https://github.test/org/repo/pull/1",
+		State:     "open",
+		UpdatedAt: createdAt,
+		FetchedAt: createdAt,
+	})
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	revID, err := s.InsertReview(&store.Review{
+		PRID:           prID,
+		CLIUsed:        "codex",
+		Summary:        "summary",
+		Issues:         "[]",
+		Suggestions:    "[]",
+		Severity:       "low",
+		CreatedAt:      createdAt,
+		GitHubReviewID: 0,
+		HeadSHA:        "abc123",
+	})
+	if err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+	return revID
+}
+
+func TestReviewReadyForPublishRetry(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	if reviewReadyForPublishRetry(&store.Review{GitHubReviewID: 123, CreatedAt: now.Add(-time.Hour)}, now) {
+		t.Fatal("published review should not be ready for retry")
+	}
+	if reviewReadyForPublishRetry(&store.Review{CreatedAt: now.Add(-reviewPublishRetryMinAge + time.Second)}, now) {
+		t.Fatal("fresh unpublished review should stay in the initial publish window")
+	}
+	if !reviewReadyForPublishRetry(&store.Review{CreatedAt: now.Add(-reviewPublishRetryMinAge)}, now) {
+		t.Fatal("unpublished review at the retry boundary should be ready")
+	}
+	if !reviewReadyForPublishRetry(&store.Review{}, now) {
+		t.Fatal("legacy review with missing created_at should be retryable")
+	}
+}
+
+func TestTier2AdapterPublishPendingDefersFreshReviews(t *testing.T) {
+	s := newMemStore(t)
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	oldReviewID := seedPRWithReview(t, s, 101, now.Add(-reviewPublishRetryMinAge-time.Second))
+	freshReviewID := seedPRWithReview(t, s, 102, now.Add(-reviewPublishRetryMinAge+time.Second))
+
+	conn := newInProcessNATS(t)
+	ch := make(chan *nats.Msg, 2)
+	sub, err := conn.ChanSubscribe(bus.SubjPRPublish, ch)
+	if err != nil {
+		t.Fatalf("subscribe publish subject: %v", err)
+	}
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	if err := conn.Flush(); err != nil {
+		t.Fatalf("flush subscribe: %v", err)
+	}
+
+	a := &tier2Adapter{
+		store:      s,
+		publishPub: bus.NewPRPublishPublisher(conn),
+	}
+	a.publishPending(now)
+	if err := conn.Flush(); err != nil {
+		t.Fatalf("flush publish: %v", err)
+	}
+
+	select {
+	case msg := <-ch:
+		var got bus.PRPublishMsg
+		if err := bus.Decode(msg.Data, &got); err != nil {
+			t.Fatalf("decode publish msg: %v", err)
+		}
+		if got.ReviewID != oldReviewID {
+			t.Fatalf("published review ID = %d, want old review %d", got.ReviewID, oldReviewID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("old pending review was not enqueued")
+	}
+
+	select {
+	case msg := <-ch:
+		var got bus.PRPublishMsg
+		_ = bus.Decode(msg.Data, &got)
+		if got.ReviewID == freshReviewID {
+			t.Fatalf("fresh review %d was enqueued during initial publish window", freshReviewID)
+		}
+		t.Fatalf("unexpected extra publish message: %+v", got)
+	case <-time.After(150 * time.Millisecond):
 	}
 }
 
@@ -86,10 +218,10 @@ func TestResolveImplementPrompt_AgentFallbackWhenNoRepoMatch(t *testing.T) {
 func TestResolveImplementPrompt_DefaultFallbackWhenAgentMissing(t *testing.T) {
 	s := newMemStore(t)
 	seedAgent(t, s, store.Agent{
-		ID:                    "default-agent",
-		Name:                  "default",
-		IsDefaultDev:          true,
-		ImplementPrompt:       "DEFAULT TEMPLATE",
+		ID:              "default-agent",
+		Name:            "default",
+		IsDefaultDev:    true,
+		ImplementPrompt: "DEFAULT TEMPLATE",
 	})
 
 	// Neither the repo nor the agent ID exists → use global default's ImplementPrompt.

--- a/daemon/internal/store/inflight.go
+++ b/daemon/internal/store/inflight.go
@@ -30,6 +30,24 @@ func (s *Store) ClaimInFlightReview(prID int64, headSHA string) (bool, error) {
 	return n == 1, nil
 }
 
+// ReviewInFlight reports whether (prID, headSHA) is currently claimed. The PR
+// ID must use the same namespace as ClaimInFlightReview; the daemon passes the
+// GitHub PR ID for poll-driven reviews.
+func (s *Store) ReviewInFlight(prID int64, headSHA string) (bool, error) {
+	if headSHA == "" {
+		return false, nil
+	}
+	var n int
+	err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM reviews_in_flight WHERE pr_id = ? AND head_sha = ?",
+		prID, headSHA,
+	).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("store: review inflight: %w", err)
+	}
+	return n > 0, nil
+}
+
 // ReleaseInFlightReview removes the (prID, headSHA) row so the pair can be
 // re-claimed. Always call in a defer from the caller that successfully
 // claimed; no-op if the row doesn't exist.

--- a/daemon/internal/store/inflight_test.go
+++ b/daemon/internal/store/inflight_test.go
@@ -7,12 +7,33 @@ import (
 
 func TestInFlight_ClaimAndRelease(t *testing.T) {
 	s := newTestStore(t)
+	inFlight, err := s.ReviewInFlight(42, "abc123")
+	if err != nil {
+		t.Fatalf("initial in-flight check: %v", err)
+	}
+	if inFlight {
+		t.Fatal("review should not be in-flight before claim")
+	}
 	claimed, err := s.ClaimInFlightReview(42, "abc123")
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
 	if !claimed {
 		t.Errorf("first claim should succeed")
+	}
+	inFlight, err = s.ReviewInFlight(42, "abc123")
+	if err != nil {
+		t.Fatalf("in-flight check after claim: %v", err)
+	}
+	if !inFlight {
+		t.Fatal("review should be in-flight after claim")
+	}
+	inFlight, err = s.ReviewInFlight(42, "")
+	if err != nil {
+		t.Fatalf("empty sha in-flight check: %v", err)
+	}
+	if inFlight {
+		t.Fatal("empty head SHA should not match an in-flight review")
 	}
 	// Second claim on the same (pr_id, head_sha) must fail.
 	claimed, err = s.ClaimInFlightReview(42, "abc123")
@@ -33,6 +54,13 @@ func TestInFlight_ClaimAndRelease(t *testing.T) {
 	// Release the first claim; should allow a re-claim.
 	if err := s.ReleaseInFlightReview(42, "abc123"); err != nil {
 		t.Fatalf("release: %v", err)
+	}
+	inFlight, err = s.ReviewInFlight(42, "abc123")
+	if err != nil {
+		t.Fatalf("in-flight check after release: %v", err)
+	}
+	if inFlight {
+		t.Fatal("review should not be in-flight after release")
 	}
 	claimed, err = s.ClaimInFlightReview(42, "abc123")
 	if err != nil {


### PR DESCRIPTION
## Summary

- Defer publish retry enqueues for freshly-created unpublished reviews so `PublishPending` cannot race the pipeline's initial GitHub publish.
- Make the publish worker skip too-fresh review rows; if the row is still unpublished later, `PublishPending` will enqueue it again.
- Add cmd-layer coverage for the retry-age guard and pending publish filtering.

## Root Cause

PR `freepik-company/ai-platform-iqs-v3#437` was reviewed twice on the same head SHA by the same account one second apart. Local logs show a single local review row (`review_id=310`) was saved, then the pipeline published it directly while the publish retry path also picked up the same `github_review_id=0` row before `MarkReviewPublished` landed.

This is not two local daemons; it is a race between initial publish and retry publish.

## Validation

- `docker run --rm --user "$(id -u):$(id -g)" -v "$(pwd):/src:ro" -w /src/daemon -e HOME=/tmp/home -e GOCACHE=/tmp/go-build -e GOMODCACHE=/tmp/gomod golang:1.25-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced sh -c 'go vet ./... && go test -count=1 ./cmd/heimdallm'`

Note: `make test-docker GO_TEST_ARGS="-run 'TestReviewReadyForPublishRetry|TestTier2AdapterPublishPendingDefersFreshReviews' ./cmd/heimdallm"` currently fails before tests because the persistent `/tmp/heimdallm-gocache/gomod` mount does not resolve base modules (`github.com/BurntSushi/toml`, `modernc.org/sqlite`, `github.com/go-chi/chi/v5`). The same pinned image passes with an in-container module cache.