### PR TITLE
fix: stop circuit breaker requeue loop

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -491,6 +491,7 @@ func main() {
 		publishPub:           publishPub,
 		watchStore:           watchStore,
 		lastSkippedUpdatedAt: make(map[int64]time.Time),
+		lastBreakerTrips:     make(map[breakerTripKey]breakerTripDedup),
 	}
 
 	repoPublisher := bus.NewRepoPublisher(conn)
@@ -1827,7 +1828,7 @@ func runTier2(
 				if _, ok := monitoredSet[pr.Repo]; !ok {
 					continue
 				}
-				if adapter.PRAlreadyReviewed(pr.ID, pr.Repo, pr.Number, pr.UpdatedAt) {
+				if adapter.PRAlreadyReviewed(pr.ID, pr.Repo, pr.Number, pr.UpdatedAt, pr.HeadSHA) {
 					continue
 				}
 				if err := prPublisher.PublishPRReview(ctx, pr.Repo, pr.Number, pr.ID, pr.HeadSHA); err != nil {
@@ -1937,12 +1938,24 @@ type tier2Adapter struct {
 	publishPub *bus.PRPublishPublisher
 	watchStore *bus.WatchStore
 
-	// skipMu protects lastSkippedUpdatedAt, which deduplicates review_skipped
-	// SSE events across consecutive poll cycles for the same (PR ID, updated_at)
-	// pair. Entries are pruned at the end of each FetchPRsToReview cycle so the
-	// map stays bounded to the current set of review-requested PRs.
+	// skipMu protects the lightweight SSE dedup caches below.
 	skipMu               sync.Mutex
 	lastSkippedUpdatedAt map[int64]time.Time
+	lastBreakerTrips     map[breakerTripKey]breakerTripDedup
+}
+
+const breakerTripDedupTTL = 24 * time.Hour
+
+type breakerTripKey struct {
+	Repo    string
+	Number  int
+	HeadSHA string
+	Reason  string
+}
+
+type breakerTripDedup struct {
+	UpdatedAt time.Time
+	EmittedAt time.Time
 }
 
 // discoveryStore is the subset of *store.Store that processDiscoveredRepos
@@ -2204,6 +2217,7 @@ func (a *tier2Adapter) FetchPRsToReview() ([]scheduler.Tier2PR, error) {
 		}
 	}
 	a.skipMu.Unlock()
+	a.pruneBreakerTripDedup(time.Now())
 
 	return out, nil
 }
@@ -2401,7 +2415,7 @@ func (a *tier2Adapter) PromoteReady(ctx context.Context, repos []string) (int, e
 }
 
 // PRAlreadyReviewed implements scheduler.Tier2Store.
-func (a *tier2Adapter) PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time) bool {
+func (a *tier2Adapter) PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time, headSHA string) bool {
 	existing, _ := a.store.GetPRByGithubID(githubID)
 	if existing == nil && repo != "" && number > 0 {
 		existing, _ = a.store.GetPRByRepoNumber(repo, number)
@@ -2418,18 +2432,116 @@ func (a *tier2Adapter) PRAlreadyReviewed(githubID int64, repo string, number int
 		return true
 	}
 	rev, err := a.store.LatestReviewForPR(existing.ID)
-	if err != nil || rev == nil {
+	if err == nil && rev != nil {
+		// Prefer PublishedAt (stamped when SubmitReview returned); fall back to
+		// CreatedAt for legacy rows. CreatedAt is stamped BEFORE the Claude call,
+		// so a 30s grace on CreatedAt was useless for reviews taking >30s — the
+		// 2026-04-22 cost-runaway regression. See theburrowhub/heimdallm#243.
+		anchor := rev.PublishedAt
+		if anchor.IsZero() {
+			anchor = rev.CreatedAt
+		}
+		if pipeline.ReviewFreshEnough(anchor, updatedAt, pipeline.GraceDefault) {
+			return true
+		}
+	}
+	// The circuit breaker is the emergency brake for cross-bot review loops. If
+	// it is already tripped, treat the PR as handled for this poll cycle; otherwise
+	// GitHub's persistent review-requested result keeps re-enqueueing it and the
+	// operator gets a breaker banner every minute.
+	if a.circuitBreakerBlocksPR(existing, updatedAt, headSHA) {
+		return true
+	}
+	return false
+}
+
+func (a *tier2Adapter) circuitBreakerBlocksPR(pr *store.PR, updatedAt time.Time, headSHA string) bool {
+	if a == nil || a.store == nil || pr == nil {
 		return false
 	}
-	// Prefer PublishedAt (stamped when SubmitReview returned); fall back to
-	// CreatedAt for legacy rows. CreatedAt is stamped BEFORE the Claude call,
-	// so a 30s grace on CreatedAt was useless for reviews taking >30s — the
-	// 2026-04-22 cost-runaway regression. See theburrowhub/heimdallm#243.
-	anchor := rev.PublishedAt
-	if anchor.IsZero() {
-		anchor = rev.CreatedAt
+	if a.cfgMu == nil || a.cfg == nil || *a.cfg == nil {
+		return false
 	}
-	return pipeline.ReviewFreshEnough(anchor, updatedAt, pipeline.GraceDefault)
+	a.cfgMu.Lock()
+	c := *a.cfg
+	limits := store.CircuitBreakerLimits{
+		PerPR24h:  c.CircuitBreaker.PerPR24h,
+		PerRepoHr: c.CircuitBreaker.PerRepoHr,
+	}
+	a.cfgMu.Unlock()
+	if limits.PerPR24h == 0 && limits.PerRepoHr == 0 {
+		return false
+	}
+	tripped, reason, err := a.store.CheckCircuitBreaker(pr.ID, pr.Repo, headSHA, limits)
+	if err != nil {
+		slog.Warn("pr dedup: circuit breaker check failed, proceeding", "repo", pr.Repo, "pr", pr.Number, "err", err)
+		return false
+	}
+	if !tripped {
+		a.clearCircuitBreakerDedup(pr.Repo, pr.Number)
+		return false
+	}
+	a.publishCircuitBreakerTrippedOnce(pr, updatedAt, headSHA, reason)
+	return true
+}
+
+func (a *tier2Adapter) clearCircuitBreakerDedup(repo string, number int) {
+	if a == nil {
+		return
+	}
+	a.skipMu.Lock()
+	for key := range a.lastBreakerTrips {
+		if key.Repo == repo && key.Number == number {
+			delete(a.lastBreakerTrips, key)
+		}
+	}
+	a.skipMu.Unlock()
+}
+
+func (a *tier2Adapter) publishCircuitBreakerTrippedOnce(pr *store.PR, updatedAt time.Time, headSHA, reason string) {
+	if a == nil || a.broker == nil || pr == nil {
+		return
+	}
+	key := breakerTripKey{Repo: pr.Repo, Number: pr.Number, HeadSHA: headSHA, Reason: reason}
+	a.skipMu.Lock()
+	if a.lastBreakerTrips == nil {
+		a.lastBreakerTrips = make(map[breakerTripKey]breakerTripDedup)
+	}
+	prev, seen := a.lastBreakerTrips[key]
+	// Treat non-monotonic updated_at as already emitted for this exact
+	// breaker key. GitHub updated_at should be monotonic, but suppressing a
+	// duplicate banner is safer than paging the operator for clock skew.
+	alreadyEmitted := seen && !updatedAt.After(prev.UpdatedAt)
+	if !alreadyEmitted {
+		a.lastBreakerTrips[key] = breakerTripDedup{UpdatedAt: updatedAt, EmittedAt: time.Now()}
+	}
+	a.skipMu.Unlock()
+	if alreadyEmitted {
+		return
+	}
+	a.broker.Publish(sse.Event{
+		Type: sse.EventCircuitBreakerTripped,
+		Data: sseData(map[string]any{
+			"pr_number": pr.Number,
+			"repo":      pr.Repo,
+			"reason":    reason,
+		}),
+	})
+	slog.Info("pr dedup: circuit breaker tripped, suppressing review enqueue",
+		"repo", pr.Repo, "pr", pr.Number, "reason", reason)
+}
+
+func (a *tier2Adapter) pruneBreakerTripDedup(now time.Time) {
+	if a == nil {
+		return
+	}
+	a.skipMu.Lock()
+	defer a.skipMu.Unlock()
+	for key, trip := range a.lastBreakerTrips {
+		if trip.EmittedAt.IsZero() || now.Sub(trip.EmittedAt) > breakerTripDedupTTL {
+			delete(a.lastBreakerTrips, key)
+		}
+	}
 }
 
 // CheckItem implements scheduler.Tier3ItemChecker.
@@ -2559,7 +2671,7 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 		// LastSeen has already been overwritten by ResetBackoff on earlier
 		// ticks and is no longer a faithful representation of the PR's
 		// current updated_at.
-		if a.PRAlreadyReviewed(item.GithubID, item.Repo, item.Number, snap.UpdatedAt) {
+		if a.PRAlreadyReviewed(item.GithubID, item.Repo, item.Number, snap.UpdatedAt, snap.HeadSHA) {
 			slog.Debug("tier3: PR already reviewed, skipping", "pr", item.Number, "repo", item.Repo)
 			return nil
 		}

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
 	natsserver "github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
@@ -198,6 +202,169 @@ func TestTier2AdapterPublishPendingDefersInFlightReviews(t *testing.T) {
 		_ = bus.Decode(msg.Data, &got)
 		t.Fatalf("unexpected extra publish message: %+v", got)
 	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestPRAlreadyReviewedCircuitBreakerSuppressesRepeatedEnqueue(t *testing.T) {
+	s := newMemStore(t)
+	now := time.Date(2026, 4, 28, 14, 30, 0, 0, time.UTC)
+	prID, err := s.UpsertPR(&store.PR{
+		GithubID:  1001,
+		Repo:      "org/repo",
+		Number:    7,
+		Title:     "cost loop",
+		Author:    "alice",
+		URL:       "https://github.test/org/repo/pull/7",
+		State:     "open",
+		UpdatedAt: now,
+		FetchedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := s.InsertReview(&store.Review{
+			PRID:              prID,
+			CLIUsed:           "codex",
+			Summary:           "summary",
+			Issues:            "[]",
+			Suggestions:       "[]",
+			Severity:          "low",
+			CreatedAt:         now.Add(-time.Duration(i) * time.Minute),
+			PublishedAt:       now.Add(-time.Duration(i) * time.Minute),
+			GitHubReviewID:    int64(9000 + i),
+			GitHubReviewState: "APPROVED",
+			HeadSHA:           "abc123",
+		}); err != nil {
+			t.Fatalf("insert review %d: %v", i, err)
+		}
+	}
+
+	broker := sse.NewBroker()
+	broker.Start()
+	defer broker.Stop()
+	events := broker.Subscribe()
+	defer broker.Unsubscribe(events)
+
+	cfg := &config.Config{}
+	cfg.CircuitBreaker.PerPR24h = 3
+	cfg.CircuitBreaker.PerRepoHr = 999
+	var cfgMu sync.Mutex
+	a := &tier2Adapter{
+		store:            s,
+		broker:           broker,
+		cfgMu:            &cfgMu,
+		cfg:              &cfg,
+		lastBreakerTrips: make(map[breakerTripKey]breakerTripDedup),
+	}
+
+	updatedAt := now.Add(10 * time.Minute)
+	if !a.PRAlreadyReviewed(1001, "org/repo", 7, updatedAt, "abc123") {
+		t.Fatal("circuit breaker trip should suppress enqueue")
+	}
+	if !a.PRAlreadyReviewed(1001, "org/repo", 7, updatedAt, "abc123") {
+		t.Fatal("same circuit breaker trip should keep suppressing enqueue")
+	}
+
+	count := 0
+	var reason string
+drain:
+	for {
+		select {
+		case ev := <-events:
+			if ev.Type != sse.EventCircuitBreakerTripped {
+				continue
+			}
+			count++
+			var payload struct {
+				Reason string `json:"reason"`
+			}
+			if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+				t.Fatalf("decode circuit breaker event: %v", err)
+			}
+			reason = payload.Reason
+		case <-time.After(100 * time.Millisecond):
+			break drain
+		}
+	}
+	if count != 1 {
+		t.Fatalf("circuit breaker events = %d, want 1", count)
+	}
+	if reason != "per-PR HEAD cap reached: 3 reviews on this commit in last 24h (cap 3)" {
+		t.Fatalf("reason = %q", reason)
+	}
+}
+
+func TestBreakerTripDedupPrunesByTTL(t *testing.T) {
+	now := time.Date(2026, 4, 28, 15, 0, 0, 0, time.UTC)
+	freshKey := breakerTripKey{Repo: "org/repo", Number: 7, HeadSHA: "abc", Reason: "cap"}
+	oldKey := breakerTripKey{Repo: "org/repo", Number: 8, HeadSHA: "def", Reason: "cap"}
+	a := &tier2Adapter{
+		lastBreakerTrips: map[breakerTripKey]breakerTripDedup{
+			freshKey: {UpdatedAt: now, EmittedAt: now.Add(-breakerTripDedupTTL + time.Second)},
+			oldKey:   {UpdatedAt: now, EmittedAt: now.Add(-breakerTripDedupTTL - time.Second)},
+		},
+	}
+
+	a.pruneBreakerTripDedup(now)
+
+	if _, ok := a.lastBreakerTrips[freshKey]; !ok {
+		t.Fatal("fresh breaker dedup entry should survive pruning")
+	}
+	if _, ok := a.lastBreakerTrips[oldKey]; ok {
+		t.Fatal("old breaker dedup entry should be pruned")
+	}
+}
+
+func TestPRAlreadyReviewedCircuitBreakerAllowsNewHeadSHA(t *testing.T) {
+	s := newMemStore(t)
+	now := time.Date(2026, 4, 28, 14, 30, 0, 0, time.UTC)
+	prID, err := s.UpsertPR(&store.PR{
+		GithubID:  1002,
+		Repo:      "org/repo",
+		Number:    8,
+		Title:     "follow-up changes",
+		Author:    "alice",
+		URL:       "https://github.test/org/repo/pull/8",
+		State:     "open",
+		UpdatedAt: now,
+		FetchedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := s.InsertReview(&store.Review{
+			PRID:              prID,
+			CLIUsed:           "codex",
+			Summary:           "summary",
+			Issues:            "[]",
+			Suggestions:       "[]",
+			Severity:          "low",
+			CreatedAt:         now.Add(-time.Duration(i) * time.Minute),
+			PublishedAt:       now.Add(-time.Duration(i) * time.Minute),
+			GitHubReviewID:    int64(9100 + i),
+			GitHubReviewState: "APPROVED",
+			HeadSHA:           "old-sha",
+		}); err != nil {
+			t.Fatalf("insert review %d: %v", i, err)
+		}
+	}
+
+	cfg := &config.Config{}
+	cfg.CircuitBreaker.PerPR24h = 3
+	cfg.CircuitBreaker.PerRepoHr = 999
+	var cfgMu sync.Mutex
+	a := &tier2Adapter{
+		store:  s,
+		cfgMu:  &cfgMu,
+		cfg:    &cfg,
+		broker: sse.NewBroker(),
+	}
+
+	updatedAt := now.Add(10 * time.Minute)
+	if a.PRAlreadyReviewed(1002, "org/repo", 8, updatedAt, "new-sha") {
+		t.Fatal("new head SHA should not be suppressed by the per-PR circuit breaker")
 	}
 }
 

--- a/daemon/internal/config/circuit_breaker.go
+++ b/daemon/internal/config/circuit_breaker.go
@@ -13,8 +13,10 @@ package config
 // are independent: a busy repo running both PR review and issue triage
 // can consume PerRepoHr PR reviews AND PerIssueRepoHr triages per hour.
 type CircuitBreakerConfig struct {
-	// PerPR24h caps PR reviews on the same PR over any 24-hour window.
-	// Default 3; set to 0 to apply the default.
+	// PerPR24h caps PR reviews on the same PR HEAD SHA over any 24-hour
+	// window. A new commit gets its own allowance; an unresolved HEAD SHA
+	// falls back to the whole-PR cap. Default 3; set to 0 to apply the
+	// default.
 	PerPR24h int `toml:"per_pr_24h"`
 	// PerRepoHr caps PR reviews on the same repo over any 1-hour window.
 	// Default 20; set to 0 to apply the default.

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -15,14 +15,14 @@ import (
 )
 
 // ErrCircuitBreakerTripped is returned by Run when a review was skipped
-// because the per-PR or per-repo cap was exceeded. Callers detect it via
+// because the per-PR HEAD or per-repo cap was exceeded. Callers detect it via
 // errors.As on a *CircuitBreakerError value to extract the human-readable
 // reason for telemetry/UI, or via errors.Is(err, ErrCircuitBreakerTripped)
 // when the reason is not needed.
 var ErrCircuitBreakerTripped = errors.New("pipeline: circuit breaker tripped")
 
 // CircuitBreakerError wraps ErrCircuitBreakerTripped with the specific
-// reason the breaker returned ("per-PR cap reached: ...", etc). Use
+// reason the breaker returned ("per-PR HEAD cap reached: ...", etc). Use
 // errors.As on this type to read Reason without parsing the error string.
 type CircuitBreakerError struct {
 	Reason string
@@ -480,12 +480,12 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	}
 	slog.Info("pipeline: using CLI", "cli", cli)
 
-	// 4b. Circuit breaker: hard cap on review count per PR / per repo. Runs
-	// AFTER all dedup layers so it only fires when the dedup failed but the
-	// caller is about to spend Claude credits anyway. See
+	// 4b. Circuit breaker: hard cap on review count per PR HEAD / per repo.
+	// Runs AFTER all dedup layers so it only fires when the dedup failed but
+	// the caller is about to spend Claude credits anyway. See
 	// theburrowhub/heimdallm#243.
 	if p.breaker != nil {
-		tripped, reason, err := p.store.CheckCircuitBreaker(prID, pr.Repo, *p.breaker)
+		tripped, reason, err := p.store.CheckCircuitBreaker(prID, pr.Repo, pr.Head.SHA, *p.breaker)
 		if err != nil {
 			slog.Warn("pipeline: circuit breaker check failed, proceeding", "err", err)
 		} else if tripped {

--- a/daemon/internal/pipeline/pipeline_breaker_test.go
+++ b/daemon/internal/pipeline/pipeline_breaker_test.go
@@ -53,15 +53,10 @@ func (f *fakeExecBreaker) Execute(_, _ string, _ executor.ExecOptions) (*executo
 	return &executor.ReviewResult{Summary: "ok", Severity: "low"}, nil
 }
 
-// TestRun_CircuitBreakerTripStopsExecute verifies that when the per-PR cap
-// is reached, pipeline.Run refuses to call SubmitReview / Execute. This is
-// the unconditional ceiling that caps worst-case cost when every other
+// TestRun_CircuitBreakerTripStopsExecute verifies that when the per-PR HEAD
+// cap is reached, pipeline.Run refuses to call SubmitReview / Execute. This
+// is the unconditional ceiling that caps worst-case cost when every other
 // dedup defense fails (see issue #243).
-//
-// The test drives 3 reviews through the pipeline itself (rather than
-// pre-seeding the reviews table) so that the prID the pipeline sees on each
-// Run matches the pr_id value stored in the reviews rows — the circuit
-// breaker counts by prID, and any mismatch would silently fail the test.
 func TestRun_CircuitBreakerTripStopsExecute(t *testing.T) {
 	s, err := store.Open(":memory:")
 	if err != nil {
@@ -75,38 +70,57 @@ func TestRun_CircuitBreakerTripStopsExecute(t *testing.T) {
 	pub := &fakePublisher{}
 	p := pipeline.New(s, fgh, fexec, notify)
 	p.SetPublisher(pub)
-	// Cap at 3 per PR so the 4th review is the one that must trip.
+	p.SetBotLogin("heimdallm-bot")
+	// Cap at 3 per PR HEAD so the next explicit re-request on the same commit
+	// is the one that must trip.
 	p.SetCircuitBreakerLimits(&store.CircuitBreakerLimits{PerPR24h: 3, PerRepoHr: 999})
 
-	// Drive 3 successful reviews via the pipeline — each with a distinct
-	// HEAD SHA so the HEAD-SHA dedup does not short-circuit. This populates
-	// the reviews table with 3 rows all pointing at the correct pr_id.
-	for i, sha := range []string{"sha1", "sha2", "sha3"} {
-		fgh.submitted = false
-		pr := &gh.PullRequest{
-			ID: 42, Number: 42, Title: "t", Repo: "org/r",
-			User: gh.User{Login: "alice"}, State: "open",
-			UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/r/pull/42",
-			Head: gh.Branch{SHA: sha},
-		}
-		if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"}); err != nil {
-			t.Fatalf("seed run %d: %v", i, err)
-		}
+	now := time.Now().UTC()
+	prID, err := s.UpsertPR(&store.PR{
+		GithubID:  42,
+		Repo:      "org/r",
+		Number:    42,
+		Title:     "t",
+		Author:    "alice",
+		URL:       "https://github.com/org/r/pull/42",
+		State:     "open",
+		UpdatedAt: now,
+		FetchedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
 	}
-	// Sanity: executor should have been called 3 times so far.
-	if fexec.calls != 3 {
-		t.Fatalf("seed: executor calls = %d, want 3", fexec.calls)
+	for i := 0; i < 3; i++ {
+		createdAt := now.Add(time.Duration(-3+i) * time.Minute)
+		if _, err := s.InsertReview(&store.Review{
+			PRID:              prID,
+			CLIUsed:           "claude",
+			Issues:            "[]",
+			Suggestions:       "[]",
+			Severity:          "low",
+			CreatedAt:         createdAt,
+			PublishedAt:       createdAt,
+			GitHubReviewID:    int64(9000 + i),
+			GitHubReviewState: "APPROVED",
+			HeadSHA:           "sha1",
+		}); err != nil {
+			t.Fatalf("insert review %d: %v", i, err)
+		}
 	}
 
-	// 4th run on a new HEAD SHA — the HEAD-SHA dedup passes (new commit),
-	// so the breaker is the only defense left. It MUST trip.
-	fgh.submitted = false
+	// SHA dedup would normally skip same-commit reviews. Simulate an explicit
+	// GitHub re-request after the latest local review so the pipeline bypasses
+	// SHA dedup and the circuit breaker remains the last defense.
+	p.SetTimelineFetcher(&fakeTimeline{events: []gh.TimelineEvent{
+		{Event: "review_requested", Actor: "alice", CreatedAt: now.Add(time.Minute)},
+	}})
+
 	before := fexec.calls
 	pr := &gh.PullRequest{
 		ID: 42, Number: 42, Title: "t", Repo: "org/r",
 		User: gh.User{Login: "alice"}, State: "open",
-		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/r/pull/42",
-		Head: gh.Branch{SHA: "sha4"},
+		UpdatedAt: now.Add(time.Minute), HTMLURL: "https://github.com/org/r/pull/42",
+		Head: gh.Branch{SHA: "sha1"},
 	}
 	_, err = p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
 	// Verify both the typed-error contract and the sentinel: callers in main.go
@@ -136,8 +150,8 @@ func TestRun_CircuitBreakerTripStopsExecute(t *testing.T) {
 	// phantom spinner and the operator with a phantom desktop notification
 	// every time the cap clamped down.
 	startedNotifies := countNotify(notify.events, "PR Review Started")
-	if startedNotifies != 3 {
-		t.Errorf("notify(\"PR Review Started\"): got %d, want 3 (one per real review, none on breaker trip)", startedNotifies)
+	if startedNotifies != 0 {
+		t.Errorf("notify(\"PR Review Started\"): got %d, want 0 on breaker trip", startedNotifies)
 	}
 	startedSSEs := 0
 	for _, ev := range pub.types() {
@@ -145,7 +159,7 @@ func TestRun_CircuitBreakerTripStopsExecute(t *testing.T) {
 			startedSSEs++
 		}
 	}
-	if startedSSEs != 3 {
-		t.Errorf("EventReviewStarted: got %d, want 3 (one per real review, none on breaker trip)", startedSSEs)
+	if startedSSEs != 0 {
+		t.Errorf("EventReviewStarted: got %d, want 0 on breaker trip", startedSSEs)
 	}
 }

--- a/daemon/internal/pipeline/pipeline_reloop_test.go
+++ b/daemon/internal/pipeline/pipeline_reloop_test.go
@@ -199,7 +199,7 @@ func TestRun_LegacyRowWithEmptyHeadSHAIsBackfilledAndSkipped(t *testing.T) {
 // PRAlreadyReviewed for the test. Mirrors the real adapter in main.go but
 // without the Flutter/scheduler/config deps we don't need here.
 func newTestAdapter(s *store.Store) interface {
-	PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time) bool
+	PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time, headSHA string) bool
 } {
 	return pipeline.NewTestAdapter(s)
 }
@@ -233,7 +233,7 @@ func TestPRAlreadyReviewed_SlowReviewDoesNotReloop(t *testing.T) {
 	// the 2-minute grace. Should be treated as "already reviewed".
 	updatedAt := publishedAt.Add(15 * time.Second)
 	adapter := newTestAdapter(s)
-	if !adapter.PRAlreadyReviewed(99, "org/r", 99, updatedAt) {
+	if !adapter.PRAlreadyReviewed(99, "org/r", 99, updatedAt, "abc") {
 		t.Errorf("slow review (3 min) must not re-loop when updated_at is within 2m grace of PublishedAt")
 	}
 }
@@ -261,7 +261,7 @@ func TestPRAlreadyReviewed_FallsBackToCreatedAtWhenPublishedAtZero(t *testing.T)
 
 	updatedAt := createdAt.Add(10 * time.Second)
 	adapter := newTestAdapter(s)
-	if !adapter.PRAlreadyReviewed(100, "org/r", 100, updatedAt) {
+	if !adapter.PRAlreadyReviewed(100, "org/r", 100, updatedAt, "abc") {
 		t.Errorf("legacy row (PublishedAt zero) must fall back to CreatedAt and still dedup")
 	}
 }
@@ -304,7 +304,7 @@ func TestPRAlreadyReviewed_FallsBackToRepoNumberWhenGithubIDDiffers(t *testing.T
 
 	updatedAt := publishedAt.Add(15 * time.Second)
 	adapter := newTestAdapter(s)
-	if !adapter.PRAlreadyReviewed(searchAPIID, "org/r", 337, updatedAt) {
+	if !adapter.PRAlreadyReviewed(searchAPIID, "org/r", 337, updatedAt, "abc") {
 		t.Errorf("Search API github_id miss must dedup via repo/number fallback")
 	}
 }
@@ -349,7 +349,7 @@ func TestRun_TwoInstancesSharingStoreDoNotDoubleReview(t *testing.T) {
 
 	// B is a fresh adapter instance on the same store.
 	adapterB := pipeline.NewTestAdapter(s)
-	if !adapterB.PRAlreadyReviewed(1234, "org/r", 1234, updatedAt) {
+	if !adapterB.PRAlreadyReviewed(1234, "org/r", 1234, updatedAt, "abc") {
 		t.Errorf("Instance B must dedup against Instance A's PublishedAt in the shared store")
 	}
 }
@@ -376,7 +376,7 @@ func TestPRAlreadyReviewed_AllowsReviewAfterGraceWindow(t *testing.T) {
 
 	updatedAt := time.Now()
 	adapter := newTestAdapter(s)
-	if adapter.PRAlreadyReviewed(101, "org/r", 101, updatedAt) {
+	if adapter.PRAlreadyReviewed(101, "org/r", 101, updatedAt, "abc") {
 		t.Errorf("activity 5 min after publish must be treated as new change (grace only 2m)")
 	}
 }

--- a/daemon/internal/pipeline/testutil_test.go
+++ b/daemon/internal/pipeline/testutil_test.go
@@ -23,11 +23,11 @@ func NewTestAdapter(s *store.Store) *testAdapter {
 	return &testAdapter{store: s}
 }
 
-// PRAlreadyReviewed mirrors tier2Adapter.PRAlreadyReviewed in
-// cmd/heimdallm/main.go. Keep the two in sync — the external reloop tests
-// exercise this copy, but production traffic flows through the main.go
-// version. See theburrowhub/heimdallm#243.
-func (a *testAdapter) PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time) bool {
+// PRAlreadyReviewed mirrors the persisted freshness part of
+// tier2Adapter.PRAlreadyReviewed in cmd/heimdallm/main.go. It intentionally
+// omits cmd-layer circuit-breaker/SSE behavior, which depends on daemon config
+// and broker plumbing outside this package. See theburrowhub/heimdallm#243.
+func (a *testAdapter) PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time, _ string) bool {
 	existing, _ := a.store.GetPRByGithubID(githubID)
 	if existing == nil && repo != "" && number > 0 {
 		existing, _ = a.store.GetPRByRepoNumber(repo, number)

--- a/daemon/internal/scheduler/types.go
+++ b/daemon/internal/scheduler/types.go
@@ -84,7 +84,7 @@ type Tier2PRPublisher interface {
 
 // Tier2Store checks if a PR has already been reviewed recently.
 type Tier2Store interface {
-	PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time) bool
+	PRAlreadyReviewed(githubID int64, repo string, number int, updatedAt time.Time, headSHA string) bool
 }
 
 // ── Tier 3 / Watch types (formerly in tier3.go + queue.go) ──────────────

--- a/daemon/internal/store/circuitbreaker.go
+++ b/daemon/internal/store/circuitbreaker.go
@@ -7,9 +7,10 @@ import (
 
 // CountReviewsForPR returns the number of reviews for the given PR whose
 // created_at is at or after `since`. Used by the circuit breaker to cap
-// runaway re-review loops. Only reviews already persisted to SQLite count —
-// an in-flight review that has not called InsertReview yet is gated
-// separately via the inflight table (Task 5).
+// runaway re-review loops when the caller cannot scope the check to a HEAD
+// SHA. Only reviews already persisted to SQLite count — an in-flight review
+// that has not called InsertReview yet is gated separately via the inflight
+// table (Task 5).
 func (s *Store) CountReviewsForPR(prID int64, since time.Time) (int, error) {
 	var n int
 	err := s.db.QueryRow(
@@ -18,6 +19,22 @@ func (s *Store) CountReviewsForPR(prID int64, since time.Time) (int, error) {
 	).Scan(&n)
 	if err != nil {
 		return 0, fmt.Errorf("store: count reviews for pr: %w", err)
+	}
+	return n, nil
+}
+
+// CountReviewsForPRHeadSHA returns the number of reviews for the given PR and
+// HEAD SHA whose created_at is at or after `since`. This is the PR-side
+// breaker's primary axis: cap repeated reviews of the same commit while
+// allowing a developer's follow-up commit to be reviewed normally.
+func (s *Store) CountReviewsForPRHeadSHA(prID int64, headSHA string, since time.Time) (int, error) {
+	var n int
+	err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM reviews WHERE pr_id = ? AND head_sha = ? AND created_at >= ?",
+		prID, headSHA, since.UTC().Format(sqliteTimeFormat),
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("store: count reviews for pr head sha: %w", err)
 	}
 	return n, nil
 }
@@ -42,7 +59,7 @@ func (s *Store) CountReviewsForRepo(repo string, since time.Time) (int, error) {
 // CircuitBreakerLimits is the configured set of caps. Enforced by
 // CheckCircuitBreaker; zero values mean "unlimited" for that axis.
 type CircuitBreakerLimits struct {
-	PerPR24h  int // max reviews per PR in any 24h window
+	PerPR24h  int // max reviews per PR HEAD SHA in any 24h window
 	PerRepoHr int // max reviews per repo in any 1h window
 }
 
@@ -50,13 +67,24 @@ type CircuitBreakerLimits struct {
 // the caller MUST NOT proceed to spend Claude credits for this PR. reason is
 // a human-readable explanation suitable for logs and UI surfaces; it is
 // empty when tripped is false.
-func (s *Store) CheckCircuitBreaker(prID int64, repo string, cfg CircuitBreakerLimits) (bool, string, error) {
+func (s *Store) CheckCircuitBreaker(prID int64, repo, headSHA string, cfg CircuitBreakerLimits) (bool, string, error) {
 	if cfg.PerPR24h > 0 {
-		n, err := s.CountReviewsForPR(prID, time.Now().Add(-24*time.Hour))
+		var (
+			n   int
+			err error
+		)
+		if headSHA != "" {
+			n, err = s.CountReviewsForPRHeadSHA(prID, headSHA, time.Now().Add(-24*time.Hour))
+		} else {
+			n, err = s.CountReviewsForPR(prID, time.Now().Add(-24*time.Hour))
+		}
 		if err != nil {
 			return false, "", err
 		}
 		if n >= cfg.PerPR24h {
+			if headSHA != "" {
+				return true, fmt.Sprintf("per-PR HEAD cap reached: %d reviews on this commit in last 24h (cap %d)", n, cfg.PerPR24h), nil
+			}
 			return true, fmt.Sprintf("per-PR cap reached: %d reviews in last 24h (cap %d)", n, cfg.PerPR24h), nil
 		}
 	}

--- a/daemon/internal/store/circuitbreaker_test.go
+++ b/daemon/internal/store/circuitbreaker_test.go
@@ -37,6 +37,34 @@ func TestCountReviewsForPR_CountsWithinWindow(t *testing.T) {
 	}
 }
 
+func TestCountReviewsForPRHeadSHA_CountsOnlyMatchingHead(t *testing.T) {
+	s := newTestStore(t)
+	prID, err := s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/r", Number: 1,
+		Title: "t", State: "open", UpdatedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recent := time.Now().Add(-2 * time.Hour)
+	for _, headSHA := range []string{"abc", "abc", "def"} {
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+			Severity: "low", CreatedAt: recent, HeadSHA: headSHA,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	since := time.Now().Add(-24 * time.Hour)
+	n, err := s.CountReviewsForPRHeadSHA(prID, "abc", since)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("want 2 reviews for head abc, got %d", n)
+	}
+}
+
 func TestCountReviewsForRepo_CountsDistinctPRs(t *testing.T) {
 	s := newTestStore(t)
 	for i := int64(1); i <= 3; i++ {
@@ -68,6 +96,7 @@ func TestCircuitBreaker_TripsOnPerPRCap(t *testing.T) {
 		if _, err := s.InsertReview(&store.Review{
 			PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
 			Severity: "low", CreatedAt: time.Now().Add(time.Duration(-i) * time.Minute),
+			HeadSHA: "abc",
 		}); err != nil {
 			t.Fatal(err)
 		}
@@ -77,7 +106,7 @@ func TestCircuitBreaker_TripsOnPerPRCap(t *testing.T) {
 		PerPR24h:  3,
 		PerRepoHr: 20,
 	}
-	tripped, reason, err := s.CheckCircuitBreaker(prID, "org/r", cfg)
+	tripped, reason, err := s.CheckCircuitBreaker(prID, "org/r", "abc", cfg)
 	if err != nil {
 		t.Fatalf("check: %v", err)
 	}
@@ -86,6 +115,31 @@ func TestCircuitBreaker_TripsOnPerPRCap(t *testing.T) {
 	}
 	if reason == "" {
 		t.Errorf("tripped must include a human-readable reason")
+	}
+}
+
+func TestCircuitBreaker_AllowsDifferentHeadSHAUnderPerPRCap(t *testing.T) {
+	s := newTestStore(t)
+	prID, _ := s.UpsertPR(&store.PR{GithubID: 4, Repo: "org/r", Number: 4,
+		Title: "t", State: "open", UpdatedAt: time.Now()})
+	// Three reviews on the previous commit must not consume the allowance for
+	// a developer's follow-up commit.
+	for i := 0; i < 3; i++ {
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
+			Severity: "low", CreatedAt: time.Now().Add(time.Duration(-i) * time.Minute),
+			HeadSHA: "old",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := store.CircuitBreakerLimits{PerPR24h: 3, PerRepoHr: 20}
+	tripped, reason, err := s.CheckCircuitBreaker(prID, "org/r", "new", cfg)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if tripped {
+		t.Errorf("new head SHA should be allowed despite previous-head cap (reason=%q)", reason)
 	}
 }
 
@@ -98,12 +152,13 @@ func TestCircuitBreaker_AllowsUnderCap(t *testing.T) {
 		if _, err := s.InsertReview(&store.Review{
 			PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
 			Severity: "low", CreatedAt: time.Now().Add(time.Duration(-i) * time.Minute),
+			HeadSHA: "abc",
 		}); err != nil {
 			t.Fatal(err)
 		}
 	}
 	cfg := store.CircuitBreakerLimits{PerPR24h: 3, PerRepoHr: 20}
-	tripped, _, err := s.CheckCircuitBreaker(prID, "org/r", cfg)
+	tripped, _, err := s.CheckCircuitBreaker(prID, "org/r", "abc", cfg)
 	if err != nil {
 		t.Fatalf("check: %v", err)
 	}
@@ -125,12 +180,13 @@ func TestCircuitBreaker_ZeroCapMeansUnlimited(t *testing.T) {
 		if _, err := s.InsertReview(&store.Review{
 			PRID: prID, CLIUsed: "claude", Issues: "[]", Suggestions: "[]",
 			Severity: "low", CreatedAt: time.Now().Add(time.Duration(-i) * time.Minute),
+			HeadSHA: "abc",
 		}); err != nil {
 			t.Fatal(err)
 		}
 	}
 	cfg := store.CircuitBreakerLimits{PerPR24h: 0, PerRepoHr: 0}
-	tripped, _, err := s.CheckCircuitBreaker(prID, "org/r", cfg)
+	tripped, _, err := s.CheckCircuitBreaker(prID, "org/r", "abc", cfg)
 	if err != nil {
 		t.Fatalf("check: %v", err)
 	}

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -191,6 +191,7 @@ func Open(dsn string) (*Store, error) {
 	// Covering index for the circuit-breaker counters (see issue #243).
 	// CREATE INDEX IF NOT EXISTS is idempotent; safe on every startup.
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_reviews_pr_created ON reviews(pr_id, created_at)")
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_reviews_pr_head_created ON reviews(pr_id, head_sha, created_at)")
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_reviews_created ON reviews(created_at)")
 	// Hot path for CountReviewsForRepo (see issue #243). Without this the
 	// JOIN drives from prs.repo with no index and table-scans on every


### PR DESCRIPTION
## What changed

- Suppress review enqueue when the PR circuit breaker is already tripped, so a review-requested PR does not emit the same breaker banner every poll cycle.
- Deduplicate the breaker SSE event per PR/update/reason/head SHA.
- Change the PR-side breaker from whole-PR counting to PR + HEAD SHA counting. A repeated re-request on the same commit can still trip the safety cap, but a developer's follow-up commit gets a fresh allowance.
- Keep the per-repo hourly cap unchanged.

## Why

The observed loop on `freepik-company/ai-platform-iqs-v3#443` was caused by Tier 2 repeatedly enqueueing the same PR after the breaker had already rejected it. The breaker error was correct as a safety mechanism, but the poller treated the PR as reviewable again on the next tick, producing repeated banners and notifications.

The previous `per_pr_24h` semantics were also too blunt: after three reviews in 24h, a legitimate fix commit could be blocked. The cap now protects the failure mode we care about: repeated reviews of the same HEAD.

## Validation

- `docker run --rm --user "$(id -u):$(id -g)" -v "$(pwd):/src:ro" -w /src/daemon -e HOME=/tmp/home -e GOCACHE=/tmp/go-build -e GOMODCACHE=/tmp/gomod golang:1.25-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced sh -c 'go vet ./... && go test -count=1 ./...'`

Note: `make test-docker GO_TEST_ARGS="-count=1 ./cmd/heimdallm ./internal/store ./internal/pipeline"` still fails before tests with missing module resolution from the mounted `/tmp/heimdallm-gocache` `GOMODCACHE`; the same pinned image passes with an in-container `GOMODCACHE`.