### PR TITLE
fix: filter PR auto-discovery by discovery_orgs

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1900,6 +1900,15 @@ func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
 		known[r] = struct{}{}
 	}
 
+	// Build an org allowlist from DiscoveryOrgs. When set, repos whose org
+	// prefix is not in the list are silently skipped — prevents the PR
+	// review-requested search (which spans all of GitHub) from auto-adopting
+	// repos outside the operator's intended organisations.
+	allowedOrgs := make(map[string]struct{}, len(c.GitHub.DiscoveryOrgs))
+	for _, o := range c.GitHub.DiscoveryOrgs {
+		allowedOrgs[strings.ToLower(o)] = struct{}{}
+	}
+
 	enable := c.GitHub.AutoEnablePRForDiscovery()
 	added := []string{}
 	for _, pr := range prs {
@@ -1908,6 +1917,18 @@ func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
 		}
 		if _, alreadyKnown := known[pr.Repo]; alreadyKnown {
 			continue
+		}
+		// Filter by allowed orgs when configured.
+		if len(allowedOrgs) > 0 {
+			org := ""
+			if i := strings.IndexByte(pr.Repo, '/'); i > 0 {
+				org = pr.Repo[:i]
+			}
+			if _, ok := allowedOrgs[strings.ToLower(org)]; !ok {
+				slog.Debug("upsertDiscoveredRepos: skipping repo outside allowed orgs",
+					"repo", pr.Repo, "org", org, "allowed", c.GitHub.DiscoveryOrgs)
+				continue
+			}
 		}
 		if enable {
 			c.GitHub.Repositories = append(c.GitHub.Repositories, pr.Repo)
@@ -2130,10 +2151,27 @@ func (a *tier2Adapter) FetchPRsToReview() ([]scheduler.Tier2PR, error) {
 	// seenIDs tracks every PR GitHub ID encountered this cycle so we can prune
 	// the skip-dedup map to only live PRs after the loop.
 	seenIDs := make(map[int64]struct{}, len(prs))
+
+	// Build org allowlist for PR filtering — mirrors the upsert filter.
+	prAllowedOrgs := make(map[string]struct{}, len(cfg.GitHub.DiscoveryOrgs))
+	for _, o := range cfg.GitHub.DiscoveryOrgs {
+		prAllowedOrgs[strings.ToLower(o)] = struct{}{}
+	}
+
 	for _, pr := range prs {
 		if pr.Repo == "" {
 			slog.Warn("adapter: skipping PR with empty repo", "pr_number", pr.Number)
 			continue
+		}
+		// Skip PRs from orgs outside discovery_orgs when configured.
+		if len(prAllowedOrgs) > 0 {
+			org := ""
+			if i := strings.IndexByte(pr.Repo, '/'); i > 0 {
+				org = pr.Repo[:i]
+			}
+			if _, ok := prAllowedOrgs[strings.ToLower(org)]; !ok {
+				continue
+			}
 		}
 		seenIDs[pr.ID] = struct{}{}
 		reason := pipeline.Evaluate(pipeline.PRGate{

--- a/daemon/cmd/heimdallm/main_discover_test.go
+++ b/daemon/cmd/heimdallm/main_discover_test.go
@@ -93,3 +93,56 @@ func TestUpsertDiscoveredRepos_IgnoresPRsWithEmptyRepo(t *testing.T) {
 		t.Fatalf("PRs with empty Repo must be ignored, got %v", added)
 	}
 }
+
+func TestUpsertDiscoveredRepos_FiltersOutsideDiscoveryOrgs(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.DiscoveryOrgs = []string{"overmind-swarm"}
+
+	prs := []*gh.PullRequest{
+		{RepositoryURL: "https://api.github.com/repos/overmind-swarm/backend", Number: 1},
+		{RepositoryURL: "https://api.github.com/repos/freepik-company/fc-py-cogito", Number: 2},
+		{RepositoryURL: "https://api.github.com/repos/other-org/repo", Number: 3},
+	}
+	for _, pr := range prs {
+		pr.ResolveRepo()
+	}
+
+	added := upsertDiscoveredRepos(cfg, prs)
+	if len(added) != 1 || added[0] != "overmind-swarm/backend" {
+		t.Fatalf("expected only overmind-swarm/backend, got %v", added)
+	}
+}
+
+func TestUpsertDiscoveredRepos_NoOrgFilterWhenDiscoveryOrgsEmpty(t *testing.T) {
+	cfg := &config.Config{}
+	// DiscoveryOrgs empty → all orgs accepted (backward compat)
+
+	prs := []*gh.PullRequest{
+		{RepositoryURL: "https://api.github.com/repos/any-org/repo", Number: 1},
+	}
+	for _, pr := range prs {
+		pr.ResolveRepo()
+	}
+
+	added := upsertDiscoveredRepos(cfg, prs)
+	if len(added) != 1 || added[0] != "any-org/repo" {
+		t.Fatalf("without DiscoveryOrgs all repos should be accepted, got %v", added)
+	}
+}
+
+func TestUpsertDiscoveredRepos_OrgFilterCaseInsensitive(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.DiscoveryOrgs = []string{"Overmind-Swarm"}
+
+	prs := []*gh.PullRequest{
+		{RepositoryURL: "https://api.github.com/repos/overmind-swarm/repo", Number: 1},
+	}
+	for _, pr := range prs {
+		pr.ResolveRepo()
+	}
+
+	added := upsertDiscoveredRepos(cfg, prs)
+	if len(added) != 1 {
+		t.Fatalf("org filter should be case-insensitive, got %v", added)
+	}
+}


### PR DESCRIPTION
## Summary
- `FetchPRsToReview` searches all of GitHub for review-requested PRs (no `repo:` qualifier). `upsertDiscoveredRepos` was blindly adopting every repo it found, letting repos from orgs outside `discovery_orgs` (e.g. `freepik-company/fc-py-cogito`) get auto-adopted.
- This caused endless 403 errors every minute (issue fetch + promote) and wasted API rate limit.
- Now both `upsertDiscoveredRepos` and the PR pipeline loop check the repo's org prefix against `DiscoveryOrgs` (case-insensitive). When the list is empty, behaviour is unchanged (backward compat).

## Test plan
3 new tests in `main_discover_test.go`:
- `TestUpsertDiscoveredRepos_FiltersOutsideDiscoveryOrgs`
- `TestUpsertDiscoveredRepos_NoOrgFilterWhenDiscoveryOrgsEmpty`
- `TestUpsertDiscoveredRepos_OrgFilterCaseInsensitive`

Full suite passes: `make test-docker GO_DOCKER_IMAGE="golang:1.25-alpine"`