### PR TITLE
fix: use time.Now() in circuit breaker tests to stay within 24h window

### DIFF
--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -207,7 +207,7 @@ func TestTier2AdapterPublishPendingDefersInFlightReviews(t *testing.T) {
 
 func TestPRAlreadyReviewedCircuitBreakerSuppressesRepeatedEnqueue(t *testing.T) {
 	s := newMemStore(t)
-	now := time.Date(2026, 4, 28, 14, 30, 0, 0, time.UTC)
+	now := time.Now().UTC().Truncate(time.Second)
 	prID, err := s.UpsertPR(&store.PR{
 		GithubID:  1001,
 		Repo:      "org/repo",
@@ -318,7 +318,7 @@ func TestBreakerTripDedupPrunesByTTL(t *testing.T) {
 
 func TestPRAlreadyReviewedCircuitBreakerAllowsNewHeadSHA(t *testing.T) {
 	s := newMemStore(t)
-	now := time.Date(2026, 4, 28, 14, 30, 0, 0, time.UTC)
+	now := time.Now().UTC().Truncate(time.Second)
 	prID, err := s.UpsertPR(&store.PR{
 		GithubID:  1002,
 		Repo:      "org/repo",


### PR DESCRIPTION
## Summary
- `TestPRAlreadyReviewedCircuitBreakerSuppressesRepeatedEnqueue` and `TestPRAlreadyReviewedCircuitBreakerAllowsNewHeadSHA` used a hardcoded date (`2026-04-28`) for review timestamps. Once real time moved past 2026-04-29, the reviews fell outside the 24h window that `CheckCircuitBreaker` queries with `time.Now().Add(-24h)`, causing the count to return 0 and the breaker to never trip.
- Fix: replace the hardcoded `time.Date(...)` with `time.Now().UTC().Truncate(time.Second)`.

Closes #383

## Test plan
```bash
make test-docker GO_DOCKER_IMAGE="golang:1.25-alpine"
```
Full suite passes (all 15 packages).