### PR TITLE
feat(cli): merge Logs tab into Activity tab

### DIFF
--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -544,10 +544,37 @@ func (d *Dashboard) scrollDetailUp() {
 	}
 }
 
+// isScrollOffsetTab reports whether the active tab uses the cursor as a
+// scroll offset (first visible line) rather than a selected-row index.
+// Read-only informational tabs (Stats, Config) have no selectable rows,
+// so j/k/arrows scroll the viewport directly instead of moving a highlight.
+func (d *Dashboard) isScrollOffsetTab() bool {
+	return d.activeTab == tabStats || d.activeTab == tabConfig
+}
+
 func (d *Dashboard) clampCursor() {
 	max := d.tabItemCount()
-	if max > 0 && d.cursor >= max {
-		d.cursor = max - 1
+	if d.isScrollOffsetTab() {
+		// cursor is a scroll offset: clamp so the last line is visible
+		// at the bottom of the viewport.
+		visible := d.contentHeight()
+		if d.activeTab == tabConfig {
+			visible -= 2 // header + separator
+		}
+		if visible < 1 {
+			visible = 1
+		}
+		upper := max - visible
+		if upper < 0 {
+			upper = 0
+		}
+		if d.cursor > upper {
+			d.cursor = upper
+		}
+	} else {
+		if max > 0 && d.cursor >= max {
+			d.cursor = max - 1
+		}
 	}
 	if d.cursor < 0 {
 		d.cursor = 0
@@ -814,11 +841,24 @@ func (d *Dashboard) renderConfig(height int) string {
 		return b.String()
 	}
 
-	maxVisible := height - 2
+	maxVisible := height - 2 // header + separator
 	if maxVisible < 1 {
 		maxVisible = 1
 	}
-	start, end := visibleRange(d.cursor, len(lines), maxVisible)
+
+	// cursor is a scroll offset (first visible line).
+	start := d.cursor
+	if start > len(lines)-maxVisible {
+		start = len(lines) - maxVisible
+	}
+	if start < 0 {
+		start = 0
+	}
+	end := start + maxVisible
+	if end > len(lines) {
+		end = len(lines)
+	}
+
 	for i := start; i < end; i++ {
 		b.WriteString(lines[i])
 		b.WriteString("\n")
@@ -845,7 +885,20 @@ func (d *Dashboard) renderStats(height int) string {
 	if maxVisible < 1 {
 		maxVisible = 1
 	}
-	start, end := visibleRange(d.cursor, len(lines), maxVisible)
+
+	// cursor is a scroll offset (first visible line).
+	start := d.cursor
+	if start > len(lines)-maxVisible {
+		start = len(lines) - maxVisible
+	}
+	if start < 0 {
+		start = 0
+	}
+	end := start + maxVisible
+	if end > len(lines) {
+		end = len(lines)
+	}
+
 	for i := start; i < end; i++ {
 		b.WriteString(lines[i])
 		b.WriteString("\n")

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -21,10 +21,9 @@ const (
 	tabIssues
 	tabConfig
 	tabStats
-	tabLogs
 )
 
-var tabNames = []string{"Activity", "PRs", "Issues", "Config", "Stats", "Logs"}
+var tabNames = []string{"Activity", "PRs", "Issues", "Config", "Stats"}
 
 type Dashboard struct {
 	client *api.Client
@@ -34,11 +33,10 @@ type Dashboard struct {
 	activeTab tab
 	cursor    int
 
-	prs      []api.PR
-	issues   []api.Issue
-	config   map[string]any
-	stats    *api.Stats
-	activity []activityLine
+	prs    []api.PR
+	issues []api.Issue
+	config map[string]any
+	stats  *api.Stats
 
 	logLines  []logLine
 	logFollow bool
@@ -62,13 +60,6 @@ type Dashboard struct {
 	showDetail   bool
 	detailScroll int
 	detailLines  []string
-}
-
-type activityLine struct {
-	Time     string
-	Event    string
-	Info     string
-	ItemType string // "pr" or "issue"
 }
 
 type tickMsg time.Time
@@ -198,7 +189,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.MouseButtonWheelUp:
 			if d.showDetail {
 				d.scrollDetailUp()
-			} else if d.activeTab == tabLogs {
+			} else if d.activeTab == tabActivity {
 				for i := 0; i < 3; i++ {
 					d.scrollLogsUp()
 				}
@@ -211,7 +202,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.MouseButtonWheelDown:
 			if d.showDetail {
 				d.scrollDetailDown()
-			} else if d.activeTab == tabLogs {
+			} else if d.activeTab == tabActivity {
 				for i := 0; i < 3; i++ {
 					d.scrollLogsDown()
 				}
@@ -249,15 +240,6 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d.config = msg.config
 			d.stats = msg.stats
 			if msg.activity != nil {
-				d.activity = make([]activityLine, 0, len(msg.activity.Entries))
-				for _, e := range msg.activity.Entries {
-					d.activity = append(d.activity, activityLine{
-						Time:     formatActivityTime(e.TS),
-						Event:    e.Action,
-						Info:     formatActivityInfo(e.Repo, e.ItemType, e.ItemNumber),
-						ItemType: e.ItemType,
-					})
-				}
 				if !d.logSeeded {
 					entries := msg.activity.Entries
 					d.logLines = make([]logLine, 0, len(entries))
@@ -271,17 +253,6 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return d, nil
 
 	case sseMsg:
-		itemType, info := formatSSEData(msg.Data)
-		line := activityLine{
-			Time:     time.Now().Format("15:04"),
-			Event:    msg.Type,
-			Info:     info,
-			ItemType: itemType,
-		}
-		d.activity = append([]activityLine{line}, d.activity...)
-		if len(d.activity) > 100 {
-			d.activity = d.activity[:100]
-		}
 		d.logLines = append(d.logLines, sseToLogLine(api.SSEEvent(msg)))
 		if len(d.logLines) > 1000 {
 			excess := len(d.logLines) - 1000
@@ -361,14 +332,14 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		d.activeTab = (d.activeTab - 1 + tab(len(tabNames))) % tab(len(tabNames))
 		d.cursor = 0
 	case "j", "down":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			d.scrollLogsDown()
 		} else {
 			d.cursor++
 			d.clampCursor()
 		}
 	case "k", "up":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			d.scrollLogsUp()
 		} else {
 			if d.cursor > 0 {
@@ -376,7 +347,7 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case "pgdown":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			for i := 0; i < d.contentHeight(); i++ {
 				d.scrollLogsDown()
 			}
@@ -385,7 +356,7 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			d.clampCursor()
 		}
 	case "pgup":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			for i := 0; i < d.contentHeight(); i++ {
 				d.scrollLogsUp()
 			}
@@ -396,14 +367,14 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case "home":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			d.logOffset = 0
 			d.logFollow = false
 		} else {
 			d.cursor = 0
 		}
 	case "end":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			d.logFollow = true
 		} else {
 			max := d.tabItemCount()
@@ -412,7 +383,7 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case "G":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			d.logFollow = true
 		} else {
 			max := d.tabItemCount()
@@ -448,9 +419,6 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		d.cursor = 0
 	case "5":
 		d.activeTab = tabStats
-		d.cursor = 0
-	case "6":
-		d.activeTab = tabLogs
 		d.cursor = 0
 	}
 	return d, nil
@@ -685,7 +653,7 @@ func (d *Dashboard) renderContent(height int) string {
 	}
 	switch d.activeTab {
 	case tabActivity:
-		return d.renderActivity(height)
+		return d.renderLogs(height)
 	case tabPRs:
 		return d.renderPRs(height)
 	case tabIssues:
@@ -694,47 +662,8 @@ func (d *Dashboard) renderContent(height int) string {
 		return d.renderConfig(height)
 	case tabStats:
 		return d.renderStats(height)
-	case tabLogs:
-		return d.renderLogs(height)
 	}
 	return ""
-}
-
-func (d *Dashboard) renderActivity(height int) string {
-	if len(d.activity) == 0 {
-		return lipgloss.NewStyle().Foreground(colorMuted).Render("  No activity yet. Events will appear here in real-time.")
-	}
-
-	var b strings.Builder
-	header := fmt.Sprintf("  %-7s %-7s %-25s %s", "TIME", "TYPE", "EVENT", "INFO")
-	b.WriteString(headerStyle.Render(header))
-	b.WriteString("\n")
-	b.WriteString("  " + strings.Repeat("─", 78))
-	b.WriteString("\n")
-
-	maxVisible := height - 2
-	if maxVisible < 1 {
-		maxVisible = 1
-	}
-	start, end := visibleRange(d.cursor, len(d.activity), maxVisible)
-
-	for i := start; i < end; i++ {
-		a := d.activity[i]
-		badge := activityBadge(a.ItemType)
-		info := itemTypeStyle(a.ItemType).Render(a.Info)
-		line := fmt.Sprintf("  %-7s %s %-25s %s", a.Time, badge, a.Event, info)
-		if i == d.cursor {
-			b.WriteString(selectedRowStyle.Render(line))
-		} else {
-			b.WriteString(line)
-		}
-		b.WriteString("\n")
-	}
-
-	if ind := scrollIndicator(start, end, len(d.activity)); ind != "" {
-		b.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Render(ind))
-	}
-	return b.String()
 }
 
 func (d *Dashboard) renderPRs(height int) string {
@@ -999,9 +928,12 @@ func (d *Dashboard) renderHelp() string {
 		return helpStyle.Render("[esc]close  [j/k]scroll  [pgup/pgdn]page  [q]uit")
 	}
 	if d.activeTab == tabPRs || d.activeTab == tabIssues {
-		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
+		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-5]jump")
 	}
-	return helpStyle.Render("[q]uit  [r]efresh  [s]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump  [G]follow")
+	if d.activeTab == tabActivity {
+		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-5]jump  [G]follow")
+	}
+	return helpStyle.Render("[q]uit  [r]efresh  [s]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-5]jump")
 }
 
 func (d *Dashboard) contentHeight() int {
@@ -1015,7 +947,7 @@ func (d *Dashboard) contentHeight() int {
 func (d *Dashboard) tabItemCount() int {
 	switch d.activeTab {
 	case tabActivity:
-		return len(d.activity)
+		return len(d.logLines)
 	case tabPRs:
 		return len(d.prs)
 	case tabIssues:
@@ -1100,14 +1032,6 @@ func formatConfigValue(v any) string {
 	}
 }
 
-func formatActivityTime(ts string) string {
-	t, err := time.Parse(time.RFC3339, ts)
-	if err != nil {
-		return ts
-	}
-	return t.Format("15:04")
-}
-
 func formatSSEData(data string) (itemType string, info string) {
 	var m map[string]any
 	if err := json.Unmarshal([]byte(data), &m); err != nil {
@@ -1140,42 +1064,6 @@ func formatSSEData(data string) (itemType string, info string) {
 		return itemType, strings.Join(parts, " ")
 	}
 	return itemType, data
-}
-
-func formatActivityInfo(repo, itemType string, itemNumber int) string {
-	if itemNumber == 0 {
-		return repo
-	}
-	switch itemType {
-	case "pr":
-		return fmt.Sprintf("%s PR #%d", repo, itemNumber)
-	case "issue":
-		return fmt.Sprintf("%s Issue #%d", repo, itemNumber)
-	default:
-		return fmt.Sprintf("%s #%d", repo, itemNumber)
-	}
-}
-
-func activityBadge(itemType string) string {
-	switch itemType {
-	case "pr":
-		return logBadgeStyleFn("PR").Render(fmt.Sprintf("[%-5s]", "PR"))
-	case "issue":
-		return logBadgeStyleFn("ISSUE").Render(fmt.Sprintf("[%-5s]", "ISSUE"))
-	default:
-		return fmt.Sprintf("%-7s", "")
-	}
-}
-
-func itemTypeStyle(itemType string) lipgloss.Style {
-	switch itemType {
-	case "pr":
-		return lipgloss.NewStyle().Foreground(colorPR)
-	case "issue":
-		return lipgloss.NewStyle().Foreground(colorIssue)
-	default:
-		return lipgloss.NewStyle()
-	}
 }
 
 func toInt(v any) int {

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -672,29 +672,40 @@ func (d *Dashboard) isScrollOffsetTab() bool {
 	return d.activeTab == tabStats || d.activeTab == tabConfig
 }
 
+// clampScrollOffset returns offset clamped to [0, max(0, total - visible)].
+// A viewport of `visible` lines starting at the returned offset still
+// shows the last line of `total`-length content. Shared by clampCursor
+// (when the active tab uses cursor as a scroll offset) and by renderConfig
+// / renderStats (which compute their viewport `start` the same way).
+func clampScrollOffset(offset, total, visible int) int {
+	if visible < 1 {
+		visible = 1
+	}
+	upper := total - visible
+	if upper < 0 {
+		upper = 0
+	}
+	if offset < 0 {
+		return 0
+	}
+	if offset > upper {
+		return upper
+	}
+	return offset
+}
+
 func (d *Dashboard) clampCursor() {
 	max := d.tabItemCount()
 	if d.isScrollOffsetTab() {
-		// cursor is a scroll offset: clamp so the last line is visible
-		// at the bottom of the viewport.
 		visible := d.contentHeight()
 		if d.activeTab == tabConfig {
-			visible -= 2 // header + separator
+			visible -= 2 // header + separator rendered by renderConfig
 		}
-		if visible < 1 {
-			visible = 1
-		}
-		upper := max - visible
-		if upper < 0 {
-			upper = 0
-		}
-		if d.cursor > upper {
-			d.cursor = upper
-		}
-	} else {
-		if max > 0 && d.cursor >= max {
-			d.cursor = max - 1
-		}
+		d.cursor = clampScrollOffset(d.cursor, max, visible)
+		return
+	}
+	if max > 0 && d.cursor >= max {
+		d.cursor = max - 1
 	}
 	if d.cursor < 0 {
 		d.cursor = 0
@@ -931,18 +942,7 @@ func (d *Dashboard) renderConfig(height int) string {
 	}
 
 	maxVisible := height - 2 // header + separator
-	if maxVisible < 1 {
-		maxVisible = 1
-	}
-
-	// cursor is a scroll offset (first visible line).
-	start := d.cursor
-	if start > len(lines)-maxVisible {
-		start = len(lines) - maxVisible
-	}
-	if start < 0 {
-		start = 0
-	}
+	start := clampScrollOffset(d.cursor, len(lines), maxVisible)
 	end := start + maxVisible
 	if end > len(lines) {
 		end = len(lines)
@@ -1050,18 +1050,7 @@ func (d *Dashboard) renderStats(height int) string {
 
 	var b strings.Builder
 	maxVisible := height
-	if maxVisible < 1 {
-		maxVisible = 1
-	}
-
-	// cursor is a scroll offset (first visible line).
-	start := d.cursor
-	if start > len(lines)-maxVisible {
-		start = len(lines) - maxVisible
-	}
-	if start < 0 {
-		start = 0
-	}
+	start := clampScrollOffset(d.cursor, len(lines), maxVisible)
 	end := start + maxVisible
 	if end > len(lines) {
 		end = len(lines)
@@ -1192,7 +1181,11 @@ func (d *Dashboard) contentHeight() int {
 func (d *Dashboard) tabItemCount() int {
 	switch d.activeTab {
 	case tabActivity:
-		return len(d.logLines)
+		// Activity scrolls via d.logOffset / d.logFollow, not d.cursor.
+		// clampCursor never reads this value for tabActivity, and the
+		// cursor-bound branches in handleKey skip tabActivity outright.
+		// Return 0 so any accidental future caller treats it as empty.
+		return 0
 	case tabPRs:
 		return len(d.prs)
 	case tabIssues:

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -21,11 +21,10 @@ const (
 	tabIssues
 	tabConfig
 	tabStats
-	tabLogs
 	tabServer
 )
 
-var tabNames = []string{"Activity", "PRs", "Issues", "Config", "Stats", "Logs", "Server"}
+var tabNames = []string{"Activity", "PRs", "Issues", "Config", "Stats", "Server"}
 
 type Dashboard struct {
 	client *api.Client
@@ -35,11 +34,10 @@ type Dashboard struct {
 	activeTab tab
 	cursor    int
 
-	prs      []api.PR
-	issues   []api.Issue
-	config   map[string]any
-	stats    *api.Stats
-	activity []activityLine
+	prs    []api.PR
+	issues []api.Issue
+	config map[string]any
+	stats  *api.Stats
 
 	logLines  []logLine
 	logFollow bool
@@ -68,13 +66,6 @@ type Dashboard struct {
 	showDetail   bool
 	detailScroll int
 	detailLines  []string
-}
-
-type activityLine struct {
-	Time     string
-	Event    string
-	Info     string
-	ItemType string // "pr" or "issue"
 }
 
 type tickMsg time.Time
@@ -262,7 +253,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.MouseButtonWheelUp:
 			if d.showDetail {
 				d.scrollDetailUp()
-			} else if d.activeTab == tabLogs {
+			} else if d.activeTab == tabActivity {
 				for i := 0; i < 3; i++ {
 					d.scrollLogsUp()
 				}
@@ -275,7 +266,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.MouseButtonWheelDown:
 			if d.showDetail {
 				d.scrollDetailDown()
-			} else if d.activeTab == tabLogs {
+			} else if d.activeTab == tabActivity {
 				for i := 0; i < 3; i++ {
 					d.scrollLogsDown()
 				}
@@ -323,15 +314,6 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d.config = msg.config
 			d.stats = msg.stats
 			if msg.activity != nil {
-				d.activity = make([]activityLine, 0, len(msg.activity.Entries))
-				for _, e := range msg.activity.Entries {
-					d.activity = append(d.activity, activityLine{
-						Time:     formatActivityTime(e.TS),
-						Event:    e.Action,
-						Info:     formatActivityInfo(e.Repo, e.ItemType, e.ItemNumber),
-						ItemType: e.ItemType,
-					})
-				}
 				if !d.logSeeded {
 					entries := msg.activity.Entries
 					d.logLines = make([]logLine, 0, len(entries))
@@ -357,19 +339,8 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d.err = nil
 		}
 		if event.Type == "heartbeat" {
-			// Heartbeats are liveness-only and intentionally skipped in Activity/Logs.
+			// Heartbeats are liveness-only and intentionally skipped in Activity.
 			return d, d.listenSSE(d.sseSessionID, d.sseCtx, d.sseEvents)
-		}
-		itemType, info := formatSSEData(event.Type, event.Data)
-		line := activityLine{
-			Time:     time.Now().Format("15:04"),
-			Event:    event.Type,
-			Info:     info,
-			ItemType: itemType,
-		}
-		d.activity = append([]activityLine{line}, d.activity...)
-		if len(d.activity) > 100 {
-			d.activity = d.activity[:100]
 		}
 		d.logLines = append(d.logLines, sseToLogLine(event))
 		if len(d.logLines) > 1000 {
@@ -489,14 +460,14 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		d.activeTab = (d.activeTab - 1 + tab(len(tabNames))) % tab(len(tabNames))
 		d.cursor = 0
 	case "j", "down":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			d.scrollLogsDown()
 		} else {
 			d.cursor++
 			d.clampCursor()
 		}
 	case "k", "up":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			d.scrollLogsUp()
 		} else {
 			if d.cursor > 0 {
@@ -504,7 +475,7 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case "pgdown":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			for i := 0; i < d.contentHeight(); i++ {
 				d.scrollLogsDown()
 			}
@@ -513,7 +484,7 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			d.clampCursor()
 		}
 	case "pgup":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			for i := 0; i < d.contentHeight(); i++ {
 				d.scrollLogsUp()
 			}
@@ -524,14 +495,14 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case "home":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			d.logOffset = 0
 			d.logFollow = false
 		} else {
 			d.cursor = 0
 		}
 	case "end":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			d.logFollow = true
 		} else {
 			max := d.tabItemCount()
@@ -540,7 +511,7 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case "G":
-		if d.activeTab == tabLogs {
+		if d.activeTab == tabActivity {
 			d.logFollow = true
 		} else {
 			max := d.tabItemCount()
@@ -582,9 +553,6 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		d.activeTab = tabStats
 		d.cursor = 0
 	case "6":
-		d.activeTab = tabLogs
-		d.cursor = 0
-	case "7":
 		d.activeTab = tabServer
 		d.cursor = 0
 	}
@@ -843,7 +811,7 @@ func (d *Dashboard) renderContent(height int) string {
 	}
 	switch d.activeTab {
 	case tabActivity:
-		return d.renderActivity(height)
+		return d.renderLogs(height)
 	case tabPRs:
 		return d.renderPRs(height)
 	case tabIssues:
@@ -852,49 +820,10 @@ func (d *Dashboard) renderContent(height int) string {
 		return d.renderConfig(height)
 	case tabStats:
 		return d.renderStats(height)
-	case tabLogs:
-		return d.renderLogs(height)
 	case tabServer:
 		return d.renderServer(height)
 	}
 	return ""
-}
-
-func (d *Dashboard) renderActivity(height int) string {
-	if len(d.activity) == 0 {
-		return lipgloss.NewStyle().Foreground(colorMuted).Render("  No activity yet. Events will appear here in real-time.")
-	}
-
-	var b strings.Builder
-	header := fmt.Sprintf("  %-7s %-7s %-25s %s", "TIME", "TYPE", "EVENT", "INFO")
-	b.WriteString(headerStyle.Render(header))
-	b.WriteString("\n")
-	b.WriteString("  " + strings.Repeat("─", 78))
-	b.WriteString("\n")
-
-	maxVisible := height - 2
-	if maxVisible < 1 {
-		maxVisible = 1
-	}
-	start, end := visibleRange(d.cursor, len(d.activity), maxVisible)
-
-	for i := start; i < end; i++ {
-		a := d.activity[i]
-		badge := activityBadge(a.ItemType)
-		info := itemTypeStyle(a.ItemType).Render(a.Info)
-		line := fmt.Sprintf("  %-7s %s %-25s %s", a.Time, badge, a.Event, info)
-		if i == d.cursor {
-			b.WriteString(selectedRowStyle.Render(line))
-		} else {
-			b.WriteString(line)
-		}
-		b.WriteString("\n")
-	}
-
-	if ind := scrollIndicator(start, end, len(d.activity)); ind != "" {
-		b.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Render(ind))
-	}
-	return b.String()
 }
 
 func (d *Dashboard) renderPRs(height int) string {
@@ -1241,12 +1170,15 @@ func (d *Dashboard) renderHelp() string {
 		return helpStyle.Render("[esc]close  [j/k]scroll  [pgup/pgdn]page  [q]uit")
 	}
 	if d.activeTab == tabIssues {
-		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [p]romote  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-7]jump")
+		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [p]romote  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
 	}
 	if d.activeTab == tabPRs {
-		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-7]jump")
+		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
 	}
-	return helpStyle.Render("[q]uit  [r]efresh  [s]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-7]jump  [G]follow")
+	if d.activeTab == tabActivity {
+		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump  [G]follow")
+	}
+	return helpStyle.Render("[q]uit  [r]efresh  [s]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
 }
 
 func (d *Dashboard) contentHeight() int {
@@ -1260,7 +1192,7 @@ func (d *Dashboard) contentHeight() int {
 func (d *Dashboard) tabItemCount() int {
 	switch d.activeTab {
 	case tabActivity:
-		return len(d.activity)
+		return len(d.logLines)
 	case tabPRs:
 		return len(d.prs)
 	case tabIssues:
@@ -1345,14 +1277,6 @@ func formatConfigValue(v any) string {
 	}
 }
 
-func formatActivityTime(ts string) string {
-	t, err := time.Parse(time.RFC3339, ts)
-	if err != nil {
-		return ts
-	}
-	return t.Format("15:04")
-}
-
 func formatSSEData(eventType, data string) (itemType string, info string) {
 	var m map[string]any
 	if err := json.Unmarshal([]byte(data), &m); err != nil {
@@ -1399,42 +1323,6 @@ func formatSSEData(eventType, data string) (itemType string, info string) {
 	return itemType, data
 }
 
-func formatActivityInfo(repo, itemType string, itemNumber int) string {
-	if itemNumber == 0 {
-		return repo
-	}
-	switch itemType {
-	case "pr":
-		return fmt.Sprintf("%s PR #%d", repo, itemNumber)
-	case "issue":
-		return fmt.Sprintf("%s Issue #%d", repo, itemNumber)
-	default:
-		return fmt.Sprintf("%s #%d", repo, itemNumber)
-	}
-}
-
-func activityBadge(itemType string) string {
-	switch itemType {
-	case "pr":
-		return logBadgeStyleFn("PR").Render(fmt.Sprintf("[%-5s]", "PR"))
-	case "issue":
-		return logBadgeStyleFn("ISSUE").Render(fmt.Sprintf("[%-5s]", "ISSUE"))
-	default:
-		return fmt.Sprintf("%-7s", "")
-	}
-}
-
-func itemTypeStyle(itemType string) lipgloss.Style {
-	switch itemType {
-	case "pr":
-		return lipgloss.NewStyle().Foreground(colorPR)
-	case "issue":
-		return lipgloss.NewStyle().Foreground(colorIssue)
-	default:
-		return lipgloss.NewStyle()
-	}
-}
-
 func canPromoteIssue(issue api.Issue) bool {
 	if issue.LatestReview == nil {
 		return false
@@ -1446,6 +1334,7 @@ func canPromoteIssue(issue api.Issue) bool {
 		return false
 	}
 }
+
 
 func toInt(v any) int {
 	switch n := v.(type) {

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -99,3 +99,61 @@ func TestDashboardDropsStaleReconnectAfterWatchdogReset(t *testing.T) {
 		t.Fatal("stale reconnect tick should be ignored")
 	}
 }
+
+func TestClampScrollOffset(t *testing.T) {
+	cases := []struct {
+		name                    string
+		offset, total, visible  int
+		want                    int
+	}{
+		{"viewport larger than content keeps offset at 0", 0, 5, 20, 0},
+		{"viewport larger than content clamps non-zero offset to 0", 7, 5, 20, 0},
+		{"viewport exactly fits content keeps offset at 0", 0, 10, 10, 0},
+		{"offset within bounds passes through", 3, 20, 10, 3},
+		{"offset at upper bound passes through", 10, 20, 10, 10},
+		{"offset past upper bound clamps to upper", 18, 20, 10, 10},
+		{"negative offset clamps to 0", -5, 20, 10, 0},
+		{"zero visible treated as 1 (last line reachable)", 5, 3, 0, 2},
+		{"negative visible treated as 1", 5, 3, -4, 2},
+		{"empty content always 0", 0, 0, 10, 0},
+		{"empty content with positive offset clamps to 0", 9, 0, 10, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := clampScrollOffset(tc.offset, tc.total, tc.visible)
+			if got != tc.want {
+				t.Fatalf("clampScrollOffset(%d, %d, %d) = %d, want %d",
+					tc.offset, tc.total, tc.visible, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsScrollOffsetTab(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	want := map[tab]bool{
+		tabActivity: false,
+		tabPRs:      false,
+		tabIssues:   false,
+		tabConfig:   true,
+		tabStats:    true,
+		tabServer:   false,
+	}
+	for tb, expected := range want {
+		d.activeTab = tb
+		if got := d.isScrollOffsetTab(); got != expected {
+			t.Fatalf("isScrollOffsetTab(tab=%d) = %v, want %v", tb, got, expected)
+		}
+	}
+}
+
+func TestTabItemCountActivityIsZero(t *testing.T) {
+	// Activity scrolls via logOffset, never via cursor. Returning the
+	// length of logLines would mislead callers — assert the contract.
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.activeTab = tabActivity
+	d.logLines = []logLine{{}, {}, {}}
+	if got := d.tabItemCount(); got != 0 {
+		t.Fatalf("tabItemCount(tabActivity) = %d, want 0 (cursor is unused for Activity)", got)
+	}
+}

--- a/cli/internal/tui/logs.go
+++ b/cli/internal/tui/logs.go
@@ -255,7 +255,7 @@ var (
 
 func (d *Dashboard) renderLogs(height int) string {
 	if len(d.logLines) == 0 {
-		return lipgloss.NewStyle().Foreground(colorMuted).Render("  No log entries yet. Events will appear here in real-time.")
+		return lipgloss.NewStyle().Foreground(colorMuted).Render("  No activity yet. Events will appear here in real-time.")
 	}
 
 	var b strings.Builder

--- a/cli/internal/tui/logs.go
+++ b/cli/internal/tui/logs.go
@@ -264,7 +264,7 @@ var (
 
 func (d *Dashboard) renderLogs(height int) string {
 	if len(d.logLines) == 0 {
-		return lipgloss.NewStyle().Foreground(colorMuted).Render("  No log entries yet. Events will appear here in real-time.")
+		return lipgloss.NewStyle().Foreground(colorMuted).Render("  No activity yet. Events will appear here in real-time.")
 	}
 
 	var b strings.Builder

--- a/cli/internal/tui/styles.go
+++ b/cli/internal/tui/styles.go
@@ -10,8 +10,6 @@ var (
 	colorDanger    = lipgloss.Color("#EF4444")
 	colorMuted     = lipgloss.Color("#6B7280")
 	colorBorder    = lipgloss.Color("#4B5563")
-	colorPR        = lipgloss.Color("#3B82F6")
-	colorIssue     = lipgloss.Color("#F59E0B")
 
 	titleStyle = lipgloss.NewStyle().
 			Bold(true).


### PR DESCRIPTION
## Summary
- Merges the redundant Logs tab into Activity — both consumed the same data (GET /activity + SSE /events) but Activity was a dumbed-down version
- Activity tab now uses the Logs rendering engine: chronological order, color-coded status icons (▶/✓/✗), follow-mode (`G`), 1000-entry history
- Removes ~115 lines of dead code: `tabLogs`, `activityLine` struct, `renderActivity`, and Activity-only helpers

Closes #337