### PR TITLE
feat: add organization config scope

### DIFF
--- a/cli/internal/cli/config.go
+++ b/cli/internal/cli/config.go
@@ -197,20 +197,44 @@ func cfgOrgLines(cfg map[string]any) []string {
 		sub = cfgSubList(sub, "PR labels", ov["pr_labels"])
 		sub = cfgSubKV(sub, "PR draft", ov["pr_draft"])
 		if it, ok := ov["issue_tracking"].(map[string]any); ok {
-			sub = cfgSubKV(sub, "Issue tracking enabled", it["enabled"])
-			sub = cfgSubKV(sub, "Issue filter mode", it["filter_mode"])
-			sub = cfgSubKV(sub, "Issue default action", it["default_action"])
-			sub = cfgSubList(sub, "Develop labels", it["develop_labels"])
-			sub = cfgSubList(sub, "Review only labels", it["review_only_labels"])
-			sub = cfgSubList(sub, "Skip labels", it["skip_labels"])
-			sub = cfgSubList(sub, "Blocked labels", it["blocked_labels"])
-			sub = cfgSubKV(sub, "Promote to label", it["promote_to_label"])
-			sub = cfgSubList(sub, "Issue organizations", it["organizations"])
-			sub = cfgSubList(sub, "Issue assignees", it["assignees"])
+			sub = cfgIssueTrackingSubLines(sub, it)
 		}
 		if len(sub) > 0 {
 			out = append(out, fmt.Sprintf("  %s", cfgKeyStyle.Render(org)))
 			out = append(out, sub...)
+		}
+	}
+	return out
+}
+
+type cfgIssueTrackingLine struct {
+	label string
+	key   string
+	list  bool
+}
+
+var cfgIssueTrackingLineSpecs = []cfgIssueTrackingLine{
+	{label: "Enabled", key: "enabled"},
+	{label: "Develop enabled", key: "develop_enabled"},
+	{label: "Filter mode", key: "filter_mode"},
+	{label: "Default action", key: "default_action"},
+	{label: "Organizations", key: "organizations", list: true},
+	{label: "Assignees", key: "assignees", list: true},
+	{label: "Develop labels", key: "develop_labels", list: true},
+	{label: "Review only labels", key: "review_only_labels", list: true},
+	{label: "Skip labels", key: "skip_labels", list: true},
+	{label: "Blocked labels", key: "blocked_labels", list: true},
+	{label: "Promote to label", key: "promote_to_label"},
+}
+
+func cfgIssueTrackingSubLines(out []string, m map[string]any) []string {
+	for _, spec := range cfgIssueTrackingLineSpecs {
+		if spec.list {
+			out = cfgSubList(out, spec.label, m[spec.key])
+		} else if _, ok := m[spec.key]; ok {
+			out = cfgSubKVPresent(out, spec.label, m[spec.key])
+		} else {
+			out = cfgSubKV(out, spec.label, m[spec.key])
 		}
 	}
 	return out
@@ -222,16 +246,13 @@ func cfgIssueTrackingLines(cfg map[string]any) []string {
 		return nil
 	}
 	var out []string
-	out = cfgKV(out, "Enabled", m["enabled"])
-	out = cfgKV(out, "Filter mode", m["filter_mode"])
-	out = cfgKV(out, "Default action", m["default_action"])
-	out = cfgStringList(out, "Organizations", m["organizations"])
-	out = cfgStringList(out, "Assignees", m["assignees"])
-	out = cfgStringList(out, "Develop labels", m["develop_labels"])
-	out = cfgStringList(out, "Review only labels", m["review_only_labels"])
-	out = cfgStringList(out, "Skip labels", m["skip_labels"])
-	out = cfgStringList(out, "Blocked labels", m["blocked_labels"])
-	out = cfgKV(out, "Promote to label", m["promote_to_label"])
+	for _, spec := range cfgIssueTrackingLineSpecs {
+		if spec.list {
+			out = cfgStringList(out, spec.label, m[spec.key])
+		} else {
+			out = cfgKV(out, spec.label, m[spec.key])
+		}
+	}
 	return out
 }
 
@@ -279,6 +300,17 @@ func cfgKV(lines []string, key string, val any) []string {
 
 func cfgSubKV(lines []string, key string, val any) []string {
 	if cfgEmpty(val) {
+		return lines
+	}
+	padded := fmt.Sprintf("%-20s", key+":")
+	return append(lines, fmt.Sprintf("    %s %s", cfgKeyStyle.Render(padded), cfgFmtVal(val)))
+}
+
+func cfgSubKVPresent(lines []string, key string, val any) []string {
+	if val == nil {
+		return lines
+	}
+	if s, ok := val.(string); ok && s == "" {
 		return lines
 	}
 	padded := fmt.Sprintf("%-20s", key+":")

--- a/cli/internal/cli/config.go
+++ b/cli/internal/cli/config.go
@@ -53,6 +53,7 @@ func printHumanConfig(cfg map[string]any) {
 		{"Server", cfgServerLines(cfg)},
 		{"Repositories", cfgRepoLines(cfg)},
 		{"AI", cfgAILines(cfg)},
+		{"Organizations", cfgOrgLines(cfg)},
 		{"Issue Tracking", cfgIssueTrackingLines(cfg)},
 		{"Discovery", cfgDiscoveryLines(cfg)},
 	}
@@ -161,6 +162,54 @@ func cfgAILines(cfg map[string]any) []string {
 		sub = cfgSubKV(sub, "Permission mode", ac["permission_mode"])
 		if len(sub) > 0 {
 			out = append(out, fmt.Sprintf("  %s", cfgKeyStyle.Render("Agent: "+name)))
+			out = append(out, sub...)
+		}
+	}
+	return out
+}
+
+func cfgOrgLines(cfg map[string]any) []string {
+	overrides, _ := cfg["org_overrides"].(map[string]any)
+	if len(overrides) == 0 {
+		return nil
+	}
+	var out []string
+	for _, org := range cfgSortedKeys(overrides) {
+		ov, ok := overrides[org].(map[string]any)
+		if !ok {
+			continue
+		}
+		var sub []string
+		sub = cfgSubKV(sub, "Primary", ov["primary"])
+		sub = cfgSubKV(sub, "Fallback", ov["fallback"])
+		sub = cfgSubKV(sub, "Review mode", ov["review_mode"])
+		sub = cfgSubKV(sub, "Prompt", ov["prompt"])
+		sub = cfgSubKV(sub, "Issue prompt", ov["issue_prompt"])
+		sub = cfgSubKV(sub, "Implement prompt", ov["implement_prompt"])
+		sub = cfgSubKV(sub, "Local dir", ov["local_dir"])
+		sub = cfgSubKV(sub, "Triage owner", ov["triage_owner"])
+		sub = cfgSubKV(sub, "Clone dir", ov["clone_dir"])
+		sub = cfgSubKV(sub, "Auto-promote triage", ov["auto_promote_triage"])
+		sub = cfgSubKV(sub, "Auto-promote refinement", ov["auto_promote_refinement"])
+		sub = cfgSubKV(sub, "Generate PR description", ov["generate_pr_description"])
+		sub = cfgSubList(sub, "PR reviewers", ov["pr_reviewers"])
+		sub = cfgSubKV(sub, "PR assignee", ov["pr_assignee"])
+		sub = cfgSubList(sub, "PR labels", ov["pr_labels"])
+		sub = cfgSubKV(sub, "PR draft", ov["pr_draft"])
+		if it, ok := ov["issue_tracking"].(map[string]any); ok {
+			sub = cfgSubKV(sub, "Issue tracking enabled", it["enabled"])
+			sub = cfgSubKV(sub, "Issue filter mode", it["filter_mode"])
+			sub = cfgSubKV(sub, "Issue default action", it["default_action"])
+			sub = cfgSubList(sub, "Develop labels", it["develop_labels"])
+			sub = cfgSubList(sub, "Review only labels", it["review_only_labels"])
+			sub = cfgSubList(sub, "Skip labels", it["skip_labels"])
+			sub = cfgSubList(sub, "Blocked labels", it["blocked_labels"])
+			sub = cfgSubKV(sub, "Promote to label", it["promote_to_label"])
+			sub = cfgSubList(sub, "Issue organizations", it["organizations"])
+			sub = cfgSubList(sub, "Issue assignees", it["assignees"])
+		}
+		if len(sub) > 0 {
+			out = append(out, fmt.Sprintf("  %s", cfgKeyStyle.Render(org)))
 			out = append(out, sub...)
 		}
 	}

--- a/cli/internal/cli/config_test.go
+++ b/cli/internal/cli/config_test.go
@@ -213,8 +213,9 @@ func TestCfgOrgLines(t *testing.T) {
 				"review_mode":  "multi",
 				"pr_reviewers": []any{"alice"},
 				"issue_tracking": map[string]any{
-					"enabled":        true,
-					"develop_labels": []any{"ready"},
+					"enabled":         true,
+					"develop_enabled": false,
+					"develop_labels":  []any{"ready"},
 				},
 			},
 		},
@@ -229,6 +230,9 @@ func TestCfgOrgLines(t *testing.T) {
 	}
 	if !strings.Contains(joined, "ready") {
 		t.Error("missing org issue tracking labels")
+	}
+	if !strings.Contains(joined, "Develop enabled") || !strings.Contains(joined, "false") {
+		t.Error("missing org issue tracking develop_enabled=false")
 	}
 }
 

--- a/cli/internal/cli/config_test.go
+++ b/cli/internal/cli/config_test.go
@@ -204,6 +204,34 @@ func TestCfgAILinesPRMetadata(t *testing.T) {
 	}
 }
 
+func TestCfgOrgLines(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	cfg := map[string]any{
+		"org_overrides": map[string]any{
+			"myorg": map[string]any{
+				"primary":      "gemini",
+				"review_mode":  "multi",
+				"pr_reviewers": []any{"alice"},
+				"issue_tracking": map[string]any{
+					"enabled":        true,
+					"develop_labels": []any{"ready"},
+				},
+			},
+		},
+	}
+	lines := cfgOrgLines(cfg)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "myorg") {
+		t.Error("missing org header")
+	}
+	if !strings.Contains(joined, "gemini") {
+		t.Error("missing org primary")
+	}
+	if !strings.Contains(joined, "ready") {
+		t.Error("missing org issue tracking labels")
+	}
+}
+
 func TestCfgIssueTrackingLinesDisabled(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	cfg := map[string]any{

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1075,30 +1075,13 @@ func main() {
 		nonMonList := append([]string(nil), c.GitHub.NonMonitored...)
 		localDirBaseList := append([]string(nil), c.GitHub.LocalDirBase...)
 		cfgMu.Unlock()
+		orgOverrides := make(map[string]map[string]any)
+		for org, ai := range c.AI.Orgs {
+			orgOverrides[org] = orgAIOverrideMap(ai)
+		}
 		repoOverrides := make(map[string]map[string]any)
 		for repo, ai := range c.AI.Repos {
-			ro := map[string]any{
-				"primary":     ai.Primary,
-				"fallback":    ai.Fallback,
-				"review_mode": ai.ReviewMode,
-				"local_dir":   ai.LocalDir,
-			}
-			if len(ai.PRReviewers) > 0 {
-				ro["pr_reviewers"] = ai.PRReviewers
-			}
-			if ai.PRAssignee != "" {
-				ro["pr_assignee"] = ai.PRAssignee
-			}
-			if len(ai.PRLabels) > 0 {
-				ro["pr_labels"] = ai.PRLabels
-			}
-			if ai.PRDraft != nil {
-				ro["pr_draft"] = *ai.PRDraft
-			}
-			if ai.IssueTracking != nil {
-				ro["issue_tracking"] = ai.IssueTracking
-			}
-			repoOverrides[repo] = ro
+			repoOverrides[repo] = repoAIOverrideMap(ai)
 		}
 		// Auto-detected local_dir for every repo the UI may render. Populated
 		// only when config.ResolveLocalDir() finds a matching directory under
@@ -1174,6 +1157,7 @@ func main() {
 			"retention_days":              c.Retention.MaxDays,
 			"issue_tracking":              c.GitHub.IssueTracking,
 			"repo_overrides":              repoOverrides,
+			"org_overrides":               orgOverrides,
 			"agent_configs":               agentConfigs,
 			"local_dirs_detected":         localDirsDetected,
 			"activity_log_enabled":        ptrBoolOrTrue(c.ActivityLog.Enabled),
@@ -1508,9 +1492,11 @@ func main() {
 			return fmt.Errorf("promote issue: get issue %d: %w", issueID, err)
 		}
 
-		// Read the issue tracking config to know which labels to add/remove.
+		// Read the repo-scoped issue tracking config to know which labels to
+		// add/remove. Org-level labels must behave the same as repo-level
+		// labels here, otherwise manual promotion would silently use globals.
 		cfgMu.Lock()
-		it := cfg.GitHub.IssueTracking
+		it := cfg.IssueTrackingForRepo(iss.Repo)
 		cfgMu.Unlock()
 
 		if len(it.DevelopLabels) == 0 {
@@ -2360,19 +2346,9 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 	a.cfgMu.Lock()
 	c := *a.cfg
 	repoIT := c.IssueTrackingForRepo(repo)
-	globalIT := c.GitHub.IssueTracking
-	anyITEnabled := globalIT.Enabled
-	if !anyITEnabled {
-		for _, r := range c.AI.Repos {
-			if r.IssueTracking != nil && r.IssueTracking.Enabled {
-				anyITEnabled = true
-				break
-			}
-		}
-	}
 	a.cfgMu.Unlock()
 
-	if !anyITEnabled || !repoIT.Enabled {
+	if !repoIT.Enabled {
 		return 0, nil
 	}
 
@@ -2449,19 +2425,32 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 
 // PromoteReady implements scheduler.Tier2Promoter.
 func (a *tier2Adapter) PromoteReady(ctx context.Context, repos []string) (int, error) {
+	type scopedPromoteConfig struct {
+		repo string
+		it   config.IssueTrackingConfig
+	}
+
 	a.cfgMu.Lock()
 	c := *a.cfg
-	globalIT := c.GitHub.IssueTracking
+	scoped := make([]scopedPromoteConfig, 0, len(repos))
+	for _, repo := range repos {
+		it := c.IssueTrackingForRepo(repo)
+		if it.Enabled && len(it.BlockedLabels) > 0 {
+			scoped = append(scoped, scopedPromoteConfig{repo: repo, it: it})
+		}
+	}
 	a.cfgMu.Unlock()
 
-	// Promotion only makes sense when blocked labels are configured.
-	// Intentionally NOT gated on globalIT.Enabled — per-repo IT configs
-	// can enable issue tracking independently while global is disabled.
-	// Gating on Enabled here would silently regress promotion for those users.
-	if len(globalIT.BlockedLabels) == 0 {
-		return 0, nil
+	total := 0
+	var firstErr error
+	for _, item := range scoped {
+		n, err := issuepipeline.PromoteReady(ctx, a.ghClient, item.it, []string{item.repo}, a.broker)
+		total += n
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
-	return issuepipeline.PromoteReady(ctx, a.ghClient, globalIT, repos, a.broker)
+	return total, firstErr
 }
 
 // PRAlreadyReviewed implements scheduler.Tier2Store.
@@ -2958,6 +2947,124 @@ func ptrIntOr(p *int, defaultV int) int {
 		return defaultV
 	}
 	return *p
+}
+
+func repoAIOverrideMap(ai config.RepoAI) map[string]any {
+	out := map[string]any{
+		"primary":     ai.Primary,
+		"fallback":    ai.Fallback,
+		"review_mode": ai.ReviewMode,
+		"local_dir":   ai.LocalDir,
+	}
+	addCommonAIOverrideFields(out, ai.Prompt, ai.IssuePrompt, ai.ImplementPrompt,
+		ai.TriageOwner, ai.CloneDir, ai.AutoPromoteTriage, ai.AutoPromoteRefinement,
+		ai.PRReviewers, ai.PRAssignee, ai.PRLabels, ai.PRDraft, ai.GeneratePRDescription)
+	if ai.IssueTracking != nil {
+		out["issue_tracking"] = issueTrackingOverrideMap(ai.IssueTracking)
+	}
+	return out
+}
+
+func orgAIOverrideMap(ai config.OrgAI) map[string]any {
+	out := map[string]any{}
+	if ai.Primary != "" {
+		out["primary"] = ai.Primary
+	}
+	if ai.Fallback != "" {
+		out["fallback"] = ai.Fallback
+	}
+	if ai.ReviewMode != "" {
+		out["review_mode"] = ai.ReviewMode
+	}
+	if ai.LocalDir != "" {
+		out["local_dir"] = ai.LocalDir
+	}
+	addCommonAIOverrideFields(out, ai.Prompt, ai.IssuePrompt, ai.ImplementPrompt,
+		ai.TriageOwner, ai.CloneDir, ai.AutoPromoteTriage, ai.AutoPromoteRefinement,
+		ai.PRReviewers, ai.PRAssignee, ai.PRLabels, ai.PRDraft, ai.GeneratePRDescription)
+	if ai.IssueTracking != nil {
+		out["issue_tracking"] = issueTrackingOverrideMap(ai.IssueTracking)
+	}
+	return out
+}
+
+func addCommonAIOverrideFields(out map[string]any, prompt, issuePrompt, implementPrompt, triageOwner, cloneDir string,
+	autoPromoteTriage, autoPromoteRefinement *bool, prReviewers []string, prAssignee string, prLabels []string,
+	prDraft, generatePRDescription *bool) {
+	if prompt != "" {
+		out["prompt"] = prompt
+	}
+	if issuePrompt != "" {
+		out["issue_prompt"] = issuePrompt
+	}
+	if implementPrompt != "" {
+		out["implement_prompt"] = implementPrompt
+	}
+	if triageOwner != "" {
+		out["triage_owner"] = triageOwner
+	}
+	if cloneDir != "" {
+		out["clone_dir"] = cloneDir
+	}
+	if autoPromoteTriage != nil {
+		out["auto_promote_triage"] = *autoPromoteTriage
+	}
+	if autoPromoteRefinement != nil {
+		out["auto_promote_refinement"] = *autoPromoteRefinement
+	}
+	if prReviewers != nil {
+		out["pr_reviewers"] = prReviewers
+	}
+	if prAssignee != "" {
+		out["pr_assignee"] = prAssignee
+	}
+	if prLabels != nil {
+		out["pr_labels"] = prLabels
+	}
+	if prDraft != nil {
+		out["pr_draft"] = *prDraft
+	}
+	if generatePRDescription != nil {
+		out["generate_pr_description"] = *generatePRDescription
+	}
+}
+
+func issueTrackingOverrideMap(ov *config.IssueTrackingOverride) map[string]any {
+	out := map[string]any{}
+	if ov.Enabled != nil {
+		out["enabled"] = *ov.Enabled
+	}
+	if ov.DevelopEnabled != nil {
+		out["develop_enabled"] = *ov.DevelopEnabled
+	}
+	if ov.FilterMode != "" {
+		out["filter_mode"] = ov.FilterMode
+	}
+	if ov.DefaultAction != "" {
+		out["default_action"] = ov.DefaultAction
+	}
+	if ov.DevelopLabels != nil {
+		out["develop_labels"] = ov.DevelopLabels
+	}
+	if ov.ReviewOnlyLabels != nil {
+		out["review_only_labels"] = ov.ReviewOnlyLabels
+	}
+	if ov.SkipLabels != nil {
+		out["skip_labels"] = ov.SkipLabels
+	}
+	if ov.BlockedLabels != nil {
+		out["blocked_labels"] = ov.BlockedLabels
+	}
+	if ov.PromoteToLabel != "" {
+		out["promote_to_label"] = ov.PromoteToLabel
+	}
+	if ov.Organizations != nil {
+		out["organizations"] = ov.Organizations
+	}
+	if ov.Assignees != nil {
+		out["assignees"] = ov.Assignees
+	}
+	return out
 }
 
 // enrollOpenItems enrolls up to 10 open PRs/issues not yet in watch_state.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2434,32 +2434,68 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 
 // PromoteReady implements scheduler.Tier2Promoter.
 func (a *tier2Adapter) PromoteReady(ctx context.Context, repos []string) (int, error) {
-	type scopedPromoteConfig struct {
-		repo string
-		it   config.IssueTrackingConfig
+	type promoteGroup struct {
+		it    config.IssueTrackingConfig
+		repos []string
 	}
 
 	a.cfgMu.Lock()
 	c := *a.cfg
-	scoped := make([]scopedPromoteConfig, 0, len(repos))
+	groupOrder := make([]string, 0, len(repos))
+	groups := make(map[string]*promoteGroup)
 	for _, repo := range repos {
 		it := c.IssueTrackingForRepo(repo)
 		if it.Enabled && len(it.BlockedLabels) > 0 {
-			scoped = append(scoped, scopedPromoteConfig{repo: repo, it: it})
+			key := promoteIssueTrackingKey(it)
+			group := groups[key]
+			if group == nil {
+				group = &promoteGroup{it: it}
+				groups[key] = group
+				groupOrder = append(groupOrder, key)
+			}
+			group.repos = append(group.repos, repo)
 		}
 	}
 	a.cfgMu.Unlock()
 
 	total := 0
-	var firstErr error
-	for _, item := range scoped {
-		n, err := issuepipeline.PromoteReady(ctx, a.ghClient, item.it, []string{item.repo}, a.broker)
+	var promoteErr error
+	for _, key := range groupOrder {
+		item := groups[key]
+		n, err := issuepipeline.PromoteReady(ctx, a.ghClient, item.it, item.repos, a.broker)
 		total += n
-		if err != nil && firstErr == nil {
-			firstErr = err
+		if err != nil {
+			promoteErr = errors.Join(promoteErr, fmt.Errorf("issues promote for %s: %w", strings.Join(item.repos, ","), err))
 		}
 	}
-	return total, firstErr
+	return total, promoteErr
+}
+
+func promoteIssueTrackingKey(it config.IssueTrackingConfig) string {
+	b, _ := json.Marshal(struct {
+		Enabled          bool              `json:"enabled"`
+		FilterMode       config.FilterMode `json:"filter_mode"`
+		Organizations    []string          `json:"organizations"`
+		Assignees        []string          `json:"assignees"`
+		DevelopLabels    []string          `json:"develop_labels"`
+		ReviewOnlyLabels []string          `json:"review_only_labels"`
+		SkipLabels       []string          `json:"skip_labels"`
+		BlockedLabels    []string          `json:"blocked_labels"`
+		PromoteToLabel   string            `json:"promote_to_label"`
+		DefaultAction    string            `json:"default_action"`
+	}{
+		Enabled:          it.Enabled,
+		FilterMode:       it.FilterMode,
+		Organizations:    it.Organizations,
+		Assignees:        it.Assignees,
+		DevelopLabels:    it.DevelopLabels,
+		ReviewOnlyLabels: it.ReviewOnlyLabels,
+		SkipLabels:       it.SkipLabels,
+		BlockedLabels:    it.BlockedLabels,
+		PromoteToLabel:   it.PromoteToLabel,
+		DefaultAction:    it.DefaultAction,
+	})
+	return string(b)
 }
 
 // PRAlreadyReviewed implements scheduler.Tier2Store.
@@ -2965,9 +3001,20 @@ func repoAIOverrideMap(ai config.RepoAI) map[string]any {
 		"review_mode": ai.ReviewMode,
 		"local_dir":   ai.LocalDir,
 	}
-	addCommonAIOverrideFields(out, ai.Prompt, ai.IssuePrompt, ai.ImplementPrompt,
-		ai.TriageOwner, ai.CloneDir, ai.AutoPromoteTriage, ai.AutoPromoteRefinement,
-		ai.PRReviewers, ai.PRAssignee, ai.PRLabels, ai.PRDraft, ai.GeneratePRDescription)
+	addCommonAIOverrideFields(out, aiOverrideFields{
+		Prompt:                ai.Prompt,
+		IssuePrompt:           ai.IssuePrompt,
+		ImplementPrompt:       ai.ImplementPrompt,
+		TriageOwner:           ai.TriageOwner,
+		CloneDir:              ai.CloneDir,
+		AutoPromoteTriage:     ai.AutoPromoteTriage,
+		AutoPromoteRefinement: ai.AutoPromoteRefinement,
+		PRReviewers:           ai.PRReviewers,
+		PRAssignee:            ai.PRAssignee,
+		PRLabels:              ai.PRLabels,
+		PRDraft:               ai.PRDraft,
+		GeneratePRDescription: ai.GeneratePRDescription,
+	})
 	if ai.IssueTracking != nil {
 		out["issue_tracking"] = issueTrackingOverrideMap(ai.IssueTracking)
 	}
@@ -2988,53 +3035,77 @@ func orgAIOverrideMap(ai config.OrgAI) map[string]any {
 	if ai.LocalDir != "" {
 		out["local_dir"] = ai.LocalDir
 	}
-	addCommonAIOverrideFields(out, ai.Prompt, ai.IssuePrompt, ai.ImplementPrompt,
-		ai.TriageOwner, ai.CloneDir, ai.AutoPromoteTriage, ai.AutoPromoteRefinement,
-		ai.PRReviewers, ai.PRAssignee, ai.PRLabels, ai.PRDraft, ai.GeneratePRDescription)
+	addCommonAIOverrideFields(out, aiOverrideFields{
+		Prompt:                ai.Prompt,
+		IssuePrompt:           ai.IssuePrompt,
+		ImplementPrompt:       ai.ImplementPrompt,
+		TriageOwner:           ai.TriageOwner,
+		CloneDir:              ai.CloneDir,
+		AutoPromoteTriage:     ai.AutoPromoteTriage,
+		AutoPromoteRefinement: ai.AutoPromoteRefinement,
+		PRReviewers:           ai.PRReviewers,
+		PRAssignee:            ai.PRAssignee,
+		PRLabels:              ai.PRLabels,
+		PRDraft:               ai.PRDraft,
+		GeneratePRDescription: ai.GeneratePRDescription,
+	})
 	if ai.IssueTracking != nil {
 		out["issue_tracking"] = issueTrackingOverrideMap(ai.IssueTracking)
 	}
 	return out
 }
 
-func addCommonAIOverrideFields(out map[string]any, prompt, issuePrompt, implementPrompt, triageOwner, cloneDir string,
-	autoPromoteTriage, autoPromoteRefinement *bool, prReviewers []string, prAssignee string, prLabels []string,
-	prDraft, generatePRDescription *bool) {
-	if prompt != "" {
-		out["prompt"] = prompt
+type aiOverrideFields struct {
+	Prompt                string
+	IssuePrompt           string
+	ImplementPrompt       string
+	TriageOwner           string
+	CloneDir              string
+	AutoPromoteTriage     *bool
+	AutoPromoteRefinement *bool
+	PRReviewers           []string
+	PRAssignee            string
+	PRLabels              []string
+	PRDraft               *bool
+	GeneratePRDescription *bool
+}
+
+func addCommonAIOverrideFields(out map[string]any, fields aiOverrideFields) {
+	if fields.Prompt != "" {
+		out["prompt"] = fields.Prompt
 	}
-	if issuePrompt != "" {
-		out["issue_prompt"] = issuePrompt
+	if fields.IssuePrompt != "" {
+		out["issue_prompt"] = fields.IssuePrompt
 	}
-	if implementPrompt != "" {
-		out["implement_prompt"] = implementPrompt
+	if fields.ImplementPrompt != "" {
+		out["implement_prompt"] = fields.ImplementPrompt
 	}
-	if triageOwner != "" {
-		out["triage_owner"] = triageOwner
+	if fields.TriageOwner != "" {
+		out["triage_owner"] = fields.TriageOwner
 	}
-	if cloneDir != "" {
-		out["clone_dir"] = cloneDir
+	if fields.CloneDir != "" {
+		out["clone_dir"] = fields.CloneDir
 	}
-	if autoPromoteTriage != nil {
-		out["auto_promote_triage"] = *autoPromoteTriage
+	if fields.AutoPromoteTriage != nil {
+		out["auto_promote_triage"] = *fields.AutoPromoteTriage
 	}
-	if autoPromoteRefinement != nil {
-		out["auto_promote_refinement"] = *autoPromoteRefinement
+	if fields.AutoPromoteRefinement != nil {
+		out["auto_promote_refinement"] = *fields.AutoPromoteRefinement
 	}
-	if prReviewers != nil {
-		out["pr_reviewers"] = prReviewers
+	if fields.PRReviewers != nil {
+		out["pr_reviewers"] = fields.PRReviewers
 	}
-	if prAssignee != "" {
-		out["pr_assignee"] = prAssignee
+	if fields.PRAssignee != "" {
+		out["pr_assignee"] = fields.PRAssignee
 	}
-	if prLabels != nil {
-		out["pr_labels"] = prLabels
+	if fields.PRLabels != nil {
+		out["pr_labels"] = fields.PRLabels
 	}
-	if prDraft != nil {
-		out["pr_draft"] = *prDraft
+	if fields.PRDraft != nil {
+		out["pr_draft"] = *fields.PRDraft
 	}
-	if generatePRDescription != nil {
-		out["generate_pr_description"] = *generatePRDescription
+	if fields.GeneratePRDescription != nil {
+		out["generate_pr_description"] = *fields.GeneratePRDescription
 	}
 }
 

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1164,6 +1164,15 @@ func main() {
 			"activity_log_retention_days": ptrIntOr(c.ActivityLog.RetentionDays, 90),
 			"issue_prompt":                c.AI.IssuePrompt,
 			"implement_prompt":            c.AI.ImplementPrompt,
+			"triage_owner":                c.AI.TriageOwner,
+			"clone_dir":                   c.AI.CloneDir,
+			"generate_pr_description":     c.AI.GeneratePRDescription,
+		}
+		if c.AI.AutoPromoteTriage != nil {
+			result["auto_promote_triage"] = *c.AI.AutoPromoteTriage
+		}
+		if c.AI.AutoPromoteRefinement != nil {
+			result["auto_promote_refinement"] = *c.AI.AutoPromoteRefinement
 		}
 		reviewers, labels, assignee, draft := c.ResolvedPRMetadata()
 		pm := map[string]any{}

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/heimdallm/daemon/internal/bus"
 	"github.com/heimdallm/daemon/internal/config"
+	gh "github.com/heimdallm/daemon/internal/github"
 	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
 	natsserver "github.com/nats-io/nats-server/v2/server"
@@ -202,6 +205,98 @@ func TestTier2AdapterPublishPendingDefersInFlightReviews(t *testing.T) {
 		_ = bus.Decode(msg.Data, &got)
 		t.Fatalf("unexpected extra publish message: %+v", got)
 	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestTier2AdapterPromoteReadyUsesOrgScopedIssueTracking(t *testing.T) {
+	var addedLabels [][]string
+	removedLabels := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/repo/issues":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"number": 10,
+					"title":  "blocked",
+					"state":  "open",
+					"body":   "## Depends on\n- #5\n",
+					"labels": []map[string]string{{"name": "blocked"}},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/repo/issues/10/sub_issues":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/repo/issues/5":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number": 5,
+				"title":  "dependency",
+				"state":  "closed",
+				"labels": []map[string]string{},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/org/repo/issues/10/labels":
+			var payload struct {
+				Labels []string `json:"labels"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Errorf("decode labels payload: %v", err)
+			}
+			addedLabels = append(addedLabels, payload.Labels)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"name": "org-ready"}})
+		case r.Method == http.MethodDelete && r.URL.Path == "/repos/org/repo/issues/10/labels/blocked":
+			removedLabels++
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]string{})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/org/repo/issues/10/comments":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"created_at": time.Now().UTC().Format(time.RFC3339),
+			})
+		default:
+			t.Errorf("unexpected GitHub request: %s %s", r.Method, r.URL.String())
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.GitHub.IssueTracking = config.IssueTrackingConfig{
+		Enabled:       false,
+		FilterMode:    config.FilterModeExclusive,
+		DefaultAction: string(config.IssueModeIgnore),
+		BlockedLabels: []string{"blocked"},
+		DevelopLabels: []string{"global-ready"},
+	}
+	cfg.AI.Orgs = map[string]config.OrgAI{
+		"org": {
+			IssueTracking: &config.IssueTrackingOverride{
+				Enabled:        &enabled,
+				PromoteToLabel: "org-ready",
+			},
+		},
+	}
+	cfgRef := cfg
+	var cfgMu sync.Mutex
+	a := &tier2Adapter{
+		ghClient: gh.NewClient("token", gh.WithBaseURL(srv.URL)),
+		cfgMu:    &cfgMu,
+		cfg:      &cfgRef,
+		broker:   sse.NewBroker(),
+	}
+
+	n, err := a.PromoteReady(t.Context(), []string{"org/repo"})
+	if err != nil {
+		t.Fatalf("PromoteReady: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("promotions = %d, want 1", n)
+	}
+	if len(addedLabels) != 1 || len(addedLabels[0]) != 1 || addedLabels[0][0] != "org-ready" {
+		t.Fatalf("added labels = %#v, want [[org-ready]]", addedLabels)
+	}
+	if removedLabels != 1 {
+		t.Fatalf("removed labels = %d, want 1", removedLabels)
 	}
 }
 

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -300,6 +300,121 @@ func TestTier2AdapterPromoteReadyUsesOrgScopedIssueTracking(t *testing.T) {
 	}
 }
 
+func TestTier2AdapterPromoteReadyBatchesReposWithSameIssueTracking(t *testing.T) {
+	sharedGets := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/a/issues":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"number": 10,
+					"title":  "blocked a",
+					"state":  "open",
+					"body":   "## Depends on\n- org/shared#5\n",
+					"labels": []map[string]string{{"name": "blocked"}},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/b/issues":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"number": 20,
+					"title":  "blocked b",
+					"state":  "open",
+					"body":   "## Depends on\n- org/shared#5\n",
+					"labels": []map[string]string{{"name": "blocked"}},
+				},
+			})
+		case r.Method == http.MethodGet && (r.URL.Path == "/repos/org/a/issues/10/sub_issues" || r.URL.Path == "/repos/org/b/issues/20/sub_issues"):
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/shared/issues/5":
+			sharedGets++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number": 5,
+				"title":  "shared dependency",
+				"state":  "closed",
+				"labels": []map[string]string{},
+			})
+		case r.Method == http.MethodDelete && (r.URL.Path == "/repos/org/a/issues/10/labels/blocked" || r.URL.Path == "/repos/org/b/issues/20/labels/blocked"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]string{})
+		case r.Method == http.MethodPost && (r.URL.Path == "/repos/org/a/issues/10/labels" || r.URL.Path == "/repos/org/b/issues/20/labels"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"name": "ready"}})
+		case r.Method == http.MethodPost && (r.URL.Path == "/repos/org/a/issues/10/comments" || r.URL.Path == "/repos/org/b/issues/20/comments"):
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"created_at": time.Now().UTC().Format(time.RFC3339),
+			})
+		default:
+			t.Errorf("unexpected GitHub request: %s %s", r.Method, r.URL.String())
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{}
+	cfg.GitHub.IssueTracking = config.IssueTrackingConfig{
+		Enabled:       true,
+		FilterMode:    config.FilterModeExclusive,
+		DefaultAction: string(config.IssueModeIgnore),
+		BlockedLabels: []string{"blocked"},
+		DevelopLabels: []string{"ready"},
+	}
+	cfgRef := cfg
+	var cfgMu sync.Mutex
+	a := &tier2Adapter{
+		ghClient: gh.NewClient("token", gh.WithBaseURL(srv.URL)),
+		cfgMu:    &cfgMu,
+		cfg:      &cfgRef,
+		broker:   sse.NewBroker(),
+	}
+
+	n, err := a.PromoteReady(t.Context(), []string{"org/a", "org/b"})
+	if err != nil {
+		t.Fatalf("PromoteReady: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("promotions = %d, want 2", n)
+	}
+	if sharedGets != 1 {
+		t.Fatalf("shared dependency fetches = %d, want 1", sharedGets)
+	}
+}
+
+func TestTier2AdapterPromoteReadyReportsAllGroupErrors(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.IssueTracking = config.IssueTrackingConfig{
+		Enabled:       true,
+		BlockedLabels: []string{"blocked"},
+	}
+	cfg.AI.Repos = map[string]config.RepoAI{
+		"org/b": {
+			IssueTracking: &config.IssueTrackingOverride{
+				Assignees: []string{"bob"},
+			},
+		},
+	}
+	cfgRef := cfg
+	var cfgMu sync.Mutex
+	a := &tier2Adapter{
+		cfgMu:  &cfgMu,
+		cfg:    &cfgRef,
+		broker: sse.NewBroker(),
+	}
+
+	n, err := a.PromoteReady(t.Context(), []string{"org/a", "org/b"})
+	if n != 0 {
+		t.Fatalf("promotions = %d, want 0", n)
+	}
+	if err == nil {
+		t.Fatal("PromoteReady error = nil, want config group errors")
+	}
+	if got := err.Error(); !strings.Contains(got, "org/a") || !strings.Contains(got, "org/b") {
+		t.Fatalf("joined error = %q, want both repo groups", got)
+	}
+}
+
 func TestPRAlreadyReviewedCircuitBreakerSuppressesRepeatedEnqueue(t *testing.T) {
 	s := newMemStore(t)
 	now := time.Now().UTC().Truncate(time.Second)

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -341,6 +341,8 @@ type RepoAI struct {
 	AutoPromoteRefinement *bool  `toml:"auto_promote_refinement,omitempty"`
 
 	// PR creation metadata (applied by auto_implement after CreatePR).
+	// Nil slices inherit from org/global; non-nil empty slices explicitly
+	// clear inherited values for this repo.
 	PRReviewers []string `toml:"pr_reviewers"`       // GitHub logins to request review from
 	PRAssignee  string   `toml:"pr_assignee"`        // GitHub login to assign the PR to
 	PRLabels    []string `toml:"pr_labels"`          // labels to add to the PR
@@ -397,6 +399,8 @@ type OrgAI struct {
 	AutoPromoteTriage     *bool  `toml:"auto_promote_triage,omitempty"`
 	AutoPromoteRefinement *bool  `toml:"auto_promote_refinement,omitempty"`
 
+	// Nil slices inherit from global; non-nil empty slices explicitly clear
+	// inherited values for every repo in this org.
 	PRReviewers []string `toml:"pr_reviewers"`
 	PRAssignee  string   `toml:"pr_assignee"`
 	PRLabels    []string `toml:"pr_labels"`
@@ -561,104 +565,114 @@ func (c *Config) AIForRepo(repo string) RepoAI {
 }
 
 func applyOrgAI(out *RepoAI, o OrgAI) {
-	if o.Primary != "" {
-		out.Primary = o.Primary
-	}
-	if o.Fallback != "" {
-		out.Fallback = o.Fallback
-	}
-	if o.ReviewMode != "" {
-		out.ReviewMode = o.ReviewMode
-	}
-	if o.Prompt != "" {
-		out.Prompt = o.Prompt
-	}
-	if o.IssuePrompt != "" {
-		out.IssuePrompt = o.IssuePrompt
-	}
-	if o.ImplementPrompt != "" {
-		out.ImplementPrompt = o.ImplementPrompt
-	}
-	if o.LocalDir != "" {
-		out.LocalDir = o.LocalDir
-	}
-	if o.TriageOwner != "" {
-		out.TriageOwner = o.TriageOwner
-	}
-	if o.CloneDir != "" {
-		out.CloneDir = o.CloneDir
-	}
-	if o.AutoPromoteTriage != nil {
-		out.AutoPromoteTriage = o.AutoPromoteTriage
-	}
-	if o.AutoPromoteRefinement != nil {
-		out.AutoPromoteRefinement = o.AutoPromoteRefinement
-	}
-	if o.PRReviewers != nil {
-		out.PRReviewers = o.PRReviewers
-	}
-	if o.PRLabels != nil {
-		out.PRLabels = o.PRLabels
-	}
-	if o.PRAssignee != "" {
-		out.PRAssignee = o.PRAssignee
-	}
-	if o.PRDraft != nil {
-		out.PRDraft = o.PRDraft
-	}
-	if o.GeneratePRDescription != nil {
-		out.GeneratePRDescription = o.GeneratePRDescription
-	}
+	applyScopedAI(out, scopedAIFields{
+		Primary:               o.Primary,
+		Fallback:              o.Fallback,
+		ReviewMode:            o.ReviewMode,
+		Prompt:                o.Prompt,
+		IssuePrompt:           o.IssuePrompt,
+		ImplementPrompt:       o.ImplementPrompt,
+		LocalDir:              o.LocalDir,
+		TriageOwner:           o.TriageOwner,
+		CloneDir:              o.CloneDir,
+		AutoPromoteTriage:     o.AutoPromoteTriage,
+		AutoPromoteRefinement: o.AutoPromoteRefinement,
+		PRReviewers:           o.PRReviewers,
+		PRLabels:              o.PRLabels,
+		PRAssignee:            o.PRAssignee,
+		PRDraft:               o.PRDraft,
+		GeneratePRDescription: o.GeneratePRDescription,
+	})
 }
 
 func applyRepoAI(out *RepoAI, r RepoAI) {
-	if r.Primary != "" {
-		out.Primary = r.Primary
+	applyScopedAI(out, scopedAIFields{
+		Primary:               r.Primary,
+		Fallback:              r.Fallback,
+		ReviewMode:            r.ReviewMode,
+		Prompt:                r.Prompt,
+		IssuePrompt:           r.IssuePrompt,
+		ImplementPrompt:       r.ImplementPrompt,
+		LocalDir:              r.LocalDir,
+		TriageOwner:           r.TriageOwner,
+		CloneDir:              r.CloneDir,
+		AutoPromoteTriage:     r.AutoPromoteTriage,
+		AutoPromoteRefinement: r.AutoPromoteRefinement,
+		PRReviewers:           r.PRReviewers,
+		PRLabels:              r.PRLabels,
+		PRAssignee:            r.PRAssignee,
+		PRDraft:               r.PRDraft,
+		GeneratePRDescription: r.GeneratePRDescription,
+	})
+}
+
+type scopedAIFields struct {
+	Primary               string
+	Fallback              string
+	ReviewMode            string
+	Prompt                string
+	IssuePrompt           string
+	ImplementPrompt       string
+	LocalDir              string
+	TriageOwner           string
+	CloneDir              string
+	AutoPromoteTriage     *bool
+	AutoPromoteRefinement *bool
+	PRReviewers           []string
+	PRLabels              []string
+	PRAssignee            string
+	PRDraft               *bool
+	GeneratePRDescription *bool
+}
+
+func applyScopedAI(out *RepoAI, fields scopedAIFields) {
+	if fields.Primary != "" {
+		out.Primary = fields.Primary
 	}
-	if r.Fallback != "" {
-		out.Fallback = r.Fallback
+	if fields.Fallback != "" {
+		out.Fallback = fields.Fallback
 	}
-	if r.ReviewMode != "" {
-		out.ReviewMode = r.ReviewMode
+	if fields.ReviewMode != "" {
+		out.ReviewMode = fields.ReviewMode
 	}
-	if r.Prompt != "" {
-		out.Prompt = r.Prompt
+	if fields.Prompt != "" {
+		out.Prompt = fields.Prompt
 	}
-	if r.IssuePrompt != "" {
-		out.IssuePrompt = r.IssuePrompt
+	if fields.IssuePrompt != "" {
+		out.IssuePrompt = fields.IssuePrompt
 	}
-	if r.ImplementPrompt != "" {
-		out.ImplementPrompt = r.ImplementPrompt
+	if fields.ImplementPrompt != "" {
+		out.ImplementPrompt = fields.ImplementPrompt
 	}
-	if r.LocalDir != "" {
-		out.LocalDir = r.LocalDir
+	if fields.LocalDir != "" {
+		out.LocalDir = fields.LocalDir
 	}
-	if r.TriageOwner != "" {
-		out.TriageOwner = r.TriageOwner
+	if fields.TriageOwner != "" {
+		out.TriageOwner = fields.TriageOwner
 	}
-	if r.CloneDir != "" {
-		out.CloneDir = r.CloneDir
+	if fields.CloneDir != "" {
+		out.CloneDir = fields.CloneDir
 	}
-	if r.AutoPromoteTriage != nil {
-		out.AutoPromoteTriage = r.AutoPromoteTriage
+	if fields.AutoPromoteTriage != nil {
+		out.AutoPromoteTriage = fields.AutoPromoteTriage
 	}
-	if r.AutoPromoteRefinement != nil {
-		out.AutoPromoteRefinement = r.AutoPromoteRefinement
+	if fields.AutoPromoteRefinement != nil {
+		out.AutoPromoteRefinement = fields.AutoPromoteRefinement
 	}
-	if r.PRReviewers != nil {
-		out.PRReviewers = r.PRReviewers
+	if fields.PRReviewers != nil {
+		out.PRReviewers = fields.PRReviewers
 	}
-	if r.PRLabels != nil {
-		out.PRLabels = r.PRLabels
+	if fields.PRLabels != nil {
+		out.PRLabels = fields.PRLabels
 	}
-	if r.PRAssignee != "" {
-		out.PRAssignee = r.PRAssignee
+	if fields.PRAssignee != "" {
+		out.PRAssignee = fields.PRAssignee
 	}
-	if r.PRDraft != nil {
-		out.PRDraft = r.PRDraft
+	if fields.PRDraft != nil {
+		out.PRDraft = fields.PRDraft
 	}
-	if r.GeneratePRDescription != nil {
-		out.GeneratePRDescription = r.GeneratePRDescription
+	if fields.GeneratePRDescription != nil {
+		out.GeneratePRDescription = fields.GeneratePRDescription
 	}
 }
 

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -288,7 +288,7 @@ type AIConfig struct {
 	ExecutionTimeout string                    `toml:"execution_timeout"` // e.g. "20m", "1h"
 	Agents           map[string]CLIAgentConfig `toml:"agents"`            // keyed by CLI name
 	Repos            map[string]RepoAI         `toml:"repos"`
-	Orgs             map[string]OrgAI          `toml:"orgs"`        // per-org PR metadata overrides
+	Orgs             map[string]OrgAI          `toml:"orgs"`        // per-org AI/issue/PR metadata overrides
 	PRMetadata       PRMetadataConfig          `toml:"pr_metadata"` // global PR creation defaults
 
 	// Top-level PR metadata fields — flat alternatives to [ai.pr_metadata].
@@ -304,6 +304,14 @@ type AIConfig struct {
 	// ImplementPrompt is the global default agent profile ID for auto-implement.
 	// Per-repo overrides in [ai.repos.<name>] take precedence.
 	ImplementPrompt string `toml:"implement_prompt"`
+
+	// Future issue pipeline fields. They are parsed and resolved through the
+	// same repo > org > global hierarchy so follow-up pipeline work can consume
+	// them without changing the config contract again.
+	TriageOwner           string `toml:"triage_owner"`
+	CloneDir              string `toml:"clone_dir"`
+	AutoPromoteTriage     *bool  `toml:"auto_promote_triage,omitempty"`
+	AutoPromoteRefinement *bool  `toml:"auto_promote_refinement,omitempty"`
 
 	// GeneratePRDescription enables LLM-generated PR titles and descriptions
 	// for auto_implement PRs. When true, after the implementation commit,
@@ -323,10 +331,14 @@ type RepoAI struct {
 	// ImplementPrompt is the ID of an agent profile whose ImplementPrompt /
 	// ImplementInstructions fields drive the auto_implement code-generation
 	// prompt for this repo. Overrides agent-level and global default.
-	ImplementPrompt string `toml:"implement_prompt"`
-	Fallback        string `toml:"fallback"`
-	ReviewMode      string `toml:"review_mode"` // "" = inherit global
-	LocalDir        string `toml:"local_dir"`   // local repo path for full-repo analysis
+	ImplementPrompt       string `toml:"implement_prompt"`
+	Fallback              string `toml:"fallback"`
+	ReviewMode            string `toml:"review_mode"` // "" = inherit global
+	LocalDir              string `toml:"local_dir"`   // local repo path for full-repo analysis
+	TriageOwner           string `toml:"triage_owner"`
+	CloneDir              string `toml:"clone_dir"`
+	AutoPromoteTriage     *bool  `toml:"auto_promote_triage,omitempty"`
+	AutoPromoteRefinement *bool  `toml:"auto_promote_refinement,omitempty"`
 
 	// PR creation metadata (applied by auto_implement after CreatePR).
 	PRReviewers []string `toml:"pr_reviewers"`       // GitHub logins to request review from
@@ -338,9 +350,8 @@ type RepoAI struct {
 	// for this repo. nil = inherit from global.
 	GeneratePRDescription *bool `toml:"generate_pr_description,omitempty"`
 
-	// Per-repo issue tracking override. When set, non-zero fields replace
-	// the global [github.issue_tracking] values for this repo only.
-	IssueTracking *IssueTrackingConfig `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
+	// Per-repo issue tracking override. Nil fields inherit from org/global.
+	IssueTracking *IssueTrackingOverride `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
 }
 
 // PRMetadataConfig holds global defaults for PR creation metadata,
@@ -352,14 +363,47 @@ type PRMetadataConfig struct {
 	Draft     *bool    `toml:"pr_draft,omitempty"`
 }
 
-// OrgAI holds per-organisation PR metadata overrides, applied to all repos
-// in the org unless overridden per-repo. Keyed by GitHub org slug under
-// [ai.orgs."org-name"].
+// IssueTrackingOverride holds repo/org scoped issue-tracking overrides.
+//
+// Pointer bools and nil slices mean "inherit". Non-nil slices, including
+// empty slices, are explicit overrides. That distinction matters for org scope:
+// an org must be able to intentionally clear a global label list for all repos.
+type IssueTrackingOverride struct {
+	Enabled          *bool      `toml:"enabled,omitempty" json:"enabled,omitempty"`
+	DevelopEnabled   *bool      `toml:"develop_enabled,omitempty" json:"develop_enabled,omitempty"`
+	FilterMode       FilterMode `toml:"filter_mode,omitempty" json:"filter_mode,omitempty"`
+	Organizations    []string   `toml:"organizations,omitempty" json:"organizations,omitempty"`
+	Assignees        []string   `toml:"assignees,omitempty" json:"assignees,omitempty"`
+	DevelopLabels    []string   `toml:"develop_labels,omitempty" json:"develop_labels,omitempty"`
+	ReviewOnlyLabels []string   `toml:"review_only_labels,omitempty" json:"review_only_labels,omitempty"`
+	SkipLabels       []string   `toml:"skip_labels,omitempty" json:"skip_labels,omitempty"`
+	BlockedLabels    []string   `toml:"blocked_labels,omitempty" json:"blocked_labels,omitempty"`
+	PromoteToLabel   string     `toml:"promote_to_label,omitempty" json:"promote_to_label,omitempty"`
+	DefaultAction    string     `toml:"default_action,omitempty" json:"default_action,omitempty"`
+}
+
+// OrgAI holds per-organisation overrides, applied to all repos in the org
+// unless overridden per-repo. Keyed by GitHub org slug under [ai.orgs."org-name"].
 type OrgAI struct {
+	Primary               string `toml:"primary"`
+	Prompt                string `toml:"prompt"`
+	IssuePrompt           string `toml:"issue_prompt"`
+	ImplementPrompt       string `toml:"implement_prompt"`
+	Fallback              string `toml:"fallback"`
+	ReviewMode            string `toml:"review_mode"`
+	LocalDir              string `toml:"local_dir"`
+	TriageOwner           string `toml:"triage_owner"`
+	CloneDir              string `toml:"clone_dir"`
+	AutoPromoteTriage     *bool  `toml:"auto_promote_triage,omitempty"`
+	AutoPromoteRefinement *bool  `toml:"auto_promote_refinement,omitempty"`
+
 	PRReviewers []string `toml:"pr_reviewers"`
 	PRAssignee  string   `toml:"pr_assignee"`
 	PRLabels    []string `toml:"pr_labels"`
 	PRDraft     *bool    `toml:"pr_draft,omitempty"`
+
+	GeneratePRDescription *bool                  `toml:"generate_pr_description,omitempty"`
+	IssueTracking         *IssueTrackingOverride `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
 }
 
 type RetentionConfig struct {
@@ -486,97 +530,170 @@ func (c *Config) ResolvedPRMetadata() (reviewers, labels []string, assignee stri
 // field resolves independently.
 func (c *Config) AIForRepo(repo string) RepoAI {
 	gReviewers, gLabels, gAssignee, gDraft := c.ResolvedPRMetadata()
-
-	// Org-level layer: start from global, overlay org-level fields.
-	orgReviewers, orgLabels, orgAssignee, orgDraft := gReviewers, gLabels, gAssignee, gDraft
+	gGenDesc := c.AI.GeneratePRDescription
+	out := RepoAI{
+		Primary:               c.AI.Primary,
+		Fallback:              c.AI.Fallback,
+		ReviewMode:            c.AI.ReviewMode,
+		IssuePrompt:           c.AI.IssuePrompt,
+		ImplementPrompt:       c.AI.ImplementPrompt,
+		PRReviewers:           gReviewers,
+		PRLabels:              gLabels,
+		PRAssignee:            gAssignee,
+		PRDraft:               gDraft,
+		GeneratePRDescription: &gGenDesc,
+		TriageOwner:           c.AI.TriageOwner,
+		CloneDir:              c.AI.CloneDir,
+		AutoPromoteTriage:     c.AI.AutoPromoteTriage,
+		AutoPromoteRefinement: c.AI.AutoPromoteRefinement,
+	}
 	if org := repoOrg(repo); org != "" && c.AI.Orgs != nil {
 		if o, ok := c.AI.Orgs[org]; ok {
-			if len(o.PRReviewers) > 0 {
-				orgReviewers = o.PRReviewers
-			}
-			if len(o.PRLabels) > 0 {
-				orgLabels = o.PRLabels
-			}
-			if o.PRAssignee != "" {
-				orgAssignee = o.PRAssignee
-			}
-			if o.PRDraft != nil {
-				orgDraft = o.PRDraft
-			}
+			applyOrgAI(&out, o)
 		}
 	}
-
 	if c.AI.Repos != nil {
 		if r, ok := c.AI.Repos[repo]; ok {
-			if r.Primary == "" {
-				r.Primary = c.AI.Primary
-			}
-			if r.Fallback == "" {
-				r.Fallback = c.AI.Fallback
-			}
-			if r.ReviewMode == "" {
-				r.ReviewMode = c.AI.ReviewMode
-			}
-			if len(r.PRReviewers) == 0 {
-				r.PRReviewers = orgReviewers
-			}
-			if len(r.PRLabels) == 0 {
-				r.PRLabels = orgLabels
-			}
-			if r.PRAssignee == "" {
-				r.PRAssignee = orgAssignee
-			}
-			if r.PRDraft == nil {
-				r.PRDraft = orgDraft
-			}
-			if r.GeneratePRDescription == nil {
-				v := c.AI.GeneratePRDescription
-				r.GeneratePRDescription = &v
-			}
-			return r
+			applyRepoAI(&out, r)
 		}
 	}
-	gGenDesc := c.AI.GeneratePRDescription
-	return RepoAI{
-		Primary: c.AI.Primary, Fallback: c.AI.Fallback, ReviewMode: c.AI.ReviewMode,
-		PRReviewers: orgReviewers, PRLabels: orgLabels, PRAssignee: orgAssignee, PRDraft: orgDraft,
-		GeneratePRDescription: &gGenDesc,
+	return out
+}
+
+func applyOrgAI(out *RepoAI, o OrgAI) {
+	if o.Primary != "" {
+		out.Primary = o.Primary
+	}
+	if o.Fallback != "" {
+		out.Fallback = o.Fallback
+	}
+	if o.ReviewMode != "" {
+		out.ReviewMode = o.ReviewMode
+	}
+	if o.Prompt != "" {
+		out.Prompt = o.Prompt
+	}
+	if o.IssuePrompt != "" {
+		out.IssuePrompt = o.IssuePrompt
+	}
+	if o.ImplementPrompt != "" {
+		out.ImplementPrompt = o.ImplementPrompt
+	}
+	if o.LocalDir != "" {
+		out.LocalDir = o.LocalDir
+	}
+	if o.TriageOwner != "" {
+		out.TriageOwner = o.TriageOwner
+	}
+	if o.CloneDir != "" {
+		out.CloneDir = o.CloneDir
+	}
+	if o.AutoPromoteTriage != nil {
+		out.AutoPromoteTriage = o.AutoPromoteTriage
+	}
+	if o.AutoPromoteRefinement != nil {
+		out.AutoPromoteRefinement = o.AutoPromoteRefinement
+	}
+	if o.PRReviewers != nil {
+		out.PRReviewers = o.PRReviewers
+	}
+	if o.PRLabels != nil {
+		out.PRLabels = o.PRLabels
+	}
+	if o.PRAssignee != "" {
+		out.PRAssignee = o.PRAssignee
+	}
+	if o.PRDraft != nil {
+		out.PRDraft = o.PRDraft
+	}
+	if o.GeneratePRDescription != nil {
+		out.GeneratePRDescription = o.GeneratePRDescription
+	}
+}
+
+func applyRepoAI(out *RepoAI, r RepoAI) {
+	if r.Primary != "" {
+		out.Primary = r.Primary
+	}
+	if r.Fallback != "" {
+		out.Fallback = r.Fallback
+	}
+	if r.ReviewMode != "" {
+		out.ReviewMode = r.ReviewMode
+	}
+	if r.Prompt != "" {
+		out.Prompt = r.Prompt
+	}
+	if r.IssuePrompt != "" {
+		out.IssuePrompt = r.IssuePrompt
+	}
+	if r.ImplementPrompt != "" {
+		out.ImplementPrompt = r.ImplementPrompt
+	}
+	if r.LocalDir != "" {
+		out.LocalDir = r.LocalDir
+	}
+	if r.TriageOwner != "" {
+		out.TriageOwner = r.TriageOwner
+	}
+	if r.CloneDir != "" {
+		out.CloneDir = r.CloneDir
+	}
+	if r.AutoPromoteTriage != nil {
+		out.AutoPromoteTriage = r.AutoPromoteTriage
+	}
+	if r.AutoPromoteRefinement != nil {
+		out.AutoPromoteRefinement = r.AutoPromoteRefinement
+	}
+	if r.PRReviewers != nil {
+		out.PRReviewers = r.PRReviewers
+	}
+	if r.PRLabels != nil {
+		out.PRLabels = r.PRLabels
+	}
+	if r.PRAssignee != "" {
+		out.PRAssignee = r.PRAssignee
+	}
+	if r.PRDraft != nil {
+		out.PRDraft = r.PRDraft
+	}
+	if r.GeneratePRDescription != nil {
+		out.GeneratePRDescription = r.GeneratePRDescription
 	}
 }
 
 // IssueTrackingForRepo returns the issue tracking config for a specific repo,
-// merging per-repo overrides (field-level) with the global config.
-// Non-zero per-repo fields win; zero/nil fields inherit from global.
+// merging repo > org > global overrides field-by-field.
 func (c *Config) IssueTrackingForRepo(repo string) IssueTrackingConfig {
-	global := c.GitHub.IssueTracking
-	if c.AI.Repos == nil {
-		return global
+	merged := c.GitHub.IssueTracking
+	if org := repoOrg(repo); org != "" && c.AI.Orgs != nil {
+		if o, ok := c.AI.Orgs[org]; ok {
+			applyIssueTrackingOverride(&merged, o.IssueTracking)
+		}
 	}
-	r, ok := c.AI.Repos[repo]
-	if !ok || r.IssueTracking == nil {
-		return global
+	if c.AI.Repos != nil {
+		if r, ok := c.AI.Repos[repo]; ok {
+			applyIssueTrackingOverride(&merged, r.IssueTracking)
+		}
 	}
-	ov := r.IssueTracking
-	merged := global
-	// Enabled resolution: the per-repo override enables IT if Enabled is
-	// explicitly true OR if labels are configured (implicit intent). This
-	// prevents the common mistake of configuring labels but forgetting the
-	// toggle.
-	//
-	// Limitation: a per-repo override cannot explicitly disable IT when the
-	// global is on, because Enabled=false is indistinguishable from "not set"
-	// (bool zero value). A *bool refactor would fix this if needed.
-	if ov.Enabled || len(ov.DevelopLabels) > 0 || len(ov.ReviewOnlyLabels) > 0 {
-		merged.Enabled = true
+	return merged
+}
+
+func applyIssueTrackingOverride(merged *IssueTrackingConfig, ov *IssueTrackingOverride) {
+	if ov == nil {
+		return
 	}
-	if len(ov.DevelopLabels) > 0 {
+	if ov.DevelopLabels != nil {
 		merged.DevelopLabels = ov.DevelopLabels
 	}
-	if len(ov.ReviewOnlyLabels) > 0 {
+	if ov.ReviewOnlyLabels != nil {
 		merged.ReviewOnlyLabels = ov.ReviewOnlyLabels
 	}
-	if len(ov.SkipLabels) > 0 {
+	if ov.SkipLabels != nil {
 		merged.SkipLabels = ov.SkipLabels
+	}
+	if ov.BlockedLabels != nil {
+		merged.BlockedLabels = ov.BlockedLabels
 	}
 	if ov.FilterMode != "" {
 		merged.FilterMode = ov.FilterMode
@@ -584,13 +701,21 @@ func (c *Config) IssueTrackingForRepo(repo string) IssueTrackingConfig {
 	if ov.DefaultAction != "" {
 		merged.DefaultAction = ov.DefaultAction
 	}
-	if len(ov.Organizations) > 0 {
+	if ov.PromoteToLabel != "" {
+		merged.PromoteToLabel = ov.PromoteToLabel
+	}
+	if ov.Organizations != nil {
 		merged.Organizations = ov.Organizations
 	}
-	if len(ov.Assignees) > 0 {
+	if ov.Assignees != nil {
 		merged.Assignees = ov.Assignees
 	}
-	return merged
+	if ov.Enabled == nil && (len(ov.DevelopLabels) > 0 || len(ov.ReviewOnlyLabels) > 0) {
+		merged.Enabled = true
+	}
+	if ov.Enabled != nil {
+		merged.Enabled = *ov.Enabled
+	}
 }
 
 // AutoEnablePRForDiscovery returns the effective boolean value.
@@ -846,7 +971,13 @@ func (c *Config) Validate() error {
 	if err := c.validateDiscovery(); err != nil {
 		return err
 	}
+	if err := c.validateOrgKeys(); err != nil {
+		return err
+	}
 	if err := c.validateIssueTracking(); err != nil {
+		return err
+	}
+	if err := c.validateScopedIssueTracking(); err != nil {
 		return err
 	}
 	if c.ActivityLog.RetentionDays != nil {
@@ -870,9 +1001,7 @@ func (c *Config) Validate() error {
 // take the extra fields as parameters too or future validations will pass
 // silently against zero values.
 func ValidateIssueTracking(it IssueTrackingConfig) error {
-	c := &Config{}
-	c.GitHub.IssueTracking = it
-	return c.validateIssueTracking()
+	return validateIssueTrackingConfig("github.issue_tracking", it)
 }
 
 // validateIssueTracking enforces the small set of invariants the pipeline
@@ -883,22 +1012,68 @@ func ValidateIssueTracking(it IssueTrackingConfig) error {
 // errors; they exist so an explicit typo like filter_mode = "excluive" fails
 // fast instead of defaulting silently.
 func (c *Config) validateIssueTracking() error {
-	it := c.GitHub.IssueTracking
+	return validateIssueTrackingConfig("github.issue_tracking", c.GitHub.IssueTracking)
+}
+
+func validateIssueTrackingConfig(path string, it IssueTrackingConfig) error {
 	if !it.Enabled {
 		return nil
 	}
 	switch it.FilterMode {
 	case FilterModeExclusive, FilterModeInclusive:
 	default:
-		return fmt.Errorf("config: github.issue_tracking.filter_mode %q is invalid (must be %q or %q)", it.FilterMode, FilterModeExclusive, FilterModeInclusive)
+		return fmt.Errorf("config: %s.filter_mode %q is invalid (must be %q or %q)", path, it.FilterMode, FilterModeExclusive, FilterModeInclusive)
 	}
 	switch IssueMode(it.DefaultAction) {
 	case IssueModeIgnore, IssueModeReviewOnly:
 	default:
-		return fmt.Errorf("config: github.issue_tracking.default_action %q is invalid (must be %q or %q)", it.DefaultAction, IssueModeIgnore, IssueModeReviewOnly)
+		return fmt.Errorf("config: %s.default_action %q is invalid (must be %q or %q)", path, it.DefaultAction, IssueModeIgnore, IssueModeReviewOnly)
 	}
 	if len(it.BlockedLabels) > 0 && it.ResolvePromoteToLabel() == "" {
-		return fmt.Errorf("config: github.issue_tracking.blocked_labels set but no promote target — set promote_to_label or populate develop_labels")
+		return fmt.Errorf("config: %s.blocked_labels set but no promote target — set promote_to_label or populate develop_labels", path)
+	}
+	return nil
+}
+
+func (c *Config) validateScopedIssueTracking() error {
+	for org, o := range c.AI.Orgs {
+		if o.IssueTracking == nil {
+			continue
+		}
+		it := c.GitHub.IssueTracking
+		applyIssueTrackingOverride(&it, o.IssueTracking)
+		if err := validateIssueTrackingConfig(fmt.Sprintf("ai.orgs.%q.issue_tracking", org), it); err != nil {
+			return err
+		}
+	}
+	for repo, r := range c.AI.Repos {
+		it := c.GitHub.IssueTracking
+		if org := repoOrg(repo); org != "" && c.AI.Orgs != nil {
+			if o, ok := c.AI.Orgs[org]; ok {
+				applyIssueTrackingOverride(&it, o.IssueTracking)
+			}
+		}
+		applyIssueTrackingOverride(&it, r.IssueTracking)
+		if err := validateIssueTrackingConfig(fmt.Sprintf("ai.repos.%q.issue_tracking", repo), it); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateOrgSlug validates a GitHub org/user slug used as an [ai.orgs] key.
+func ValidateOrgSlug(org string) error {
+	if !githubOrgPattern.MatchString(org) {
+		return fmt.Errorf("config: org %q is invalid (must match GitHub org/user slug: 1-39 alphanumerics plus internal hyphens)", org)
+	}
+	return nil
+}
+
+func (c *Config) validateOrgKeys() error {
+	for org := range c.AI.Orgs {
+		if err := ValidateOrgSlug(org); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -1644,6 +1644,41 @@ func TestIssueTrackingForRepo_LabelsImplyEnabled(t *testing.T) {
 	}
 }
 
+func TestIssueTrackingForRepo_OrgLabelsImplyEnabled(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{Enabled: false}
+	c.AI.Orgs = map[string]OrgAI{
+		"org": {
+			IssueTracking: &IssueTrackingOverride{
+				DevelopLabels:    []string{"heimdallm-auto-implement"},
+				ReviewOnlyLabels: []string{"heimdallm-auto-refine"},
+			},
+		},
+	}
+	got := c.IssueTrackingForRepo("org/labels-only")
+	if !got.Enabled {
+		t.Error("org with labels should be implicitly enabled")
+	}
+}
+
+func TestIssueTrackingForRepo_ExplicitFalseWinsOverOrgLabels(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{Enabled: true}
+	c.AI.Orgs = map[string]OrgAI{
+		"org": {
+			IssueTracking: &IssueTrackingOverride{
+				Enabled:          testBoolPtr(false),
+				DevelopLabels:    []string{"heimdallm-auto-implement"},
+				ReviewOnlyLabels: []string{"heimdallm-auto-refine"},
+			},
+		},
+	}
+	got := c.IssueTrackingForRepo("org/labels-only")
+	if got.Enabled {
+		t.Error("explicit org enabled=false should win over labels")
+	}
+}
+
 func TestIssueTrackingForRepo_NoLabelsNoOverride(t *testing.T) {
 	c := &Config{}
 	c.GitHub.IssueTracking = IssueTrackingConfig{Enabled: false}

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -1400,6 +1400,135 @@ pr_reviewers = ["data-lead"]
 	}
 }
 
+func TestAIForRepo_ThreeLevelAllScopedFields(t *testing.T) {
+	globalTriage := false
+	globalRefine := true
+	globalDraft := false
+	orgTriage := true
+	orgRefine := false
+	orgDraft := true
+	orgGenDesc := true
+	repoRefine := true
+	repoDraft := false
+	repoGenDesc := false
+
+	cfg := &Config{
+		AI: AIConfig{
+			Primary:               "global-primary",
+			Fallback:              "global-fallback",
+			ReviewMode:            "single",
+			IssuePrompt:           "global-issue",
+			ImplementPrompt:       "global-impl",
+			TriageOwner:           "global-owner",
+			CloneDir:              "global-clone",
+			AutoPromoteTriage:     &globalTriage,
+			AutoPromoteRefinement: &globalRefine,
+			GeneratePRDescription: false,
+			PRReviewers:           []string{"global-reviewer"},
+			PRLabels:              []string{"global-label"},
+			PRAssignee:            "global-assignee",
+			PRDraft:               &globalDraft,
+			Orgs: map[string]OrgAI{
+				"org": {
+					Primary:               "org-primary",
+					Fallback:              "org-fallback",
+					ReviewMode:            "multi",
+					Prompt:                "org-prompt",
+					IssuePrompt:           "org-issue",
+					ImplementPrompt:       "org-impl",
+					LocalDir:              "/org/local",
+					TriageOwner:           "org-owner",
+					CloneDir:              "org-clone",
+					AutoPromoteTriage:     &orgTriage,
+					AutoPromoteRefinement: &orgRefine,
+					PRReviewers:           []string{"org-reviewer"},
+					PRAssignee:            "org-assignee",
+					PRLabels:              []string{"org-label"},
+					PRDraft:               &orgDraft,
+					GeneratePRDescription: &orgGenDesc,
+				},
+			},
+			Repos: map[string]RepoAI{
+				"org/repo": {
+					Primary:               "repo-primary",
+					Prompt:                "repo-prompt",
+					ImplementPrompt:       "repo-impl",
+					LocalDir:              "/repo/local",
+					CloneDir:              "repo-clone",
+					AutoPromoteRefinement: &repoRefine,
+					PRLabels:              []string{"repo-label"},
+					PRDraft:               &repoDraft,
+					GeneratePRDescription: &repoGenDesc,
+				},
+			},
+		},
+	}
+
+	got := cfg.AIForRepo("org/repo")
+	if got.Primary != "repo-primary" || got.Fallback != "org-fallback" || got.ReviewMode != "multi" {
+		t.Fatalf("agent selection = (%q,%q,%q), want repo/org/org", got.Primary, got.Fallback, got.ReviewMode)
+	}
+	if got.Prompt != "repo-prompt" || got.IssuePrompt != "org-issue" || got.ImplementPrompt != "repo-impl" {
+		t.Fatalf("prompts = (%q,%q,%q), want repo/org/repo", got.Prompt, got.IssuePrompt, got.ImplementPrompt)
+	}
+	if got.LocalDir != "/repo/local" || got.TriageOwner != "org-owner" || got.CloneDir != "repo-clone" {
+		t.Fatalf("paths/owners = (%q,%q,%q), want repo/org/repo", got.LocalDir, got.TriageOwner, got.CloneDir)
+	}
+	if got.AutoPromoteTriage == nil || !*got.AutoPromoteTriage {
+		t.Fatal("AutoPromoteTriage should come from org")
+	}
+	if got.AutoPromoteRefinement == nil || !*got.AutoPromoteRefinement {
+		t.Fatal("AutoPromoteRefinement should come from repo")
+	}
+	if len(got.PRReviewers) != 1 || got.PRReviewers[0] != "org-reviewer" {
+		t.Fatalf("PRReviewers = %v, want org reviewer", got.PRReviewers)
+	}
+	if got.PRAssignee != "org-assignee" || len(got.PRLabels) != 1 || got.PRLabels[0] != "repo-label" {
+		t.Fatalf("PR metadata = assignee %q labels %v, want org/repo", got.PRAssignee, got.PRLabels)
+	}
+	if got.PRDraft == nil || *got.PRDraft {
+		t.Fatal("PRDraft should come from repo false")
+	}
+	if got.GeneratePRDescription == nil || *got.GeneratePRDescription {
+		t.Fatal("GeneratePRDescription should come from repo false")
+	}
+}
+
+func TestAIForRepo_EmptyPRMetadataOverridesClearInheritedValues(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	content := `
+[ai]
+primary = "claude"
+pr_reviewers = ["global-r1"]
+pr_labels = ["global-label"]
+
+[ai.orgs."org"]
+pr_reviewers = []
+pr_labels = ["org-label"]
+
+[ai.repos."org/repo"]
+pr_labels = []
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	r := cfg.AIForRepo("org/repo")
+	if len(r.PRReviewers) != 0 {
+		t.Fatalf("PRReviewers = %v, want explicit org clear", r.PRReviewers)
+	}
+	if len(r.PRLabels) != 0 {
+		t.Fatalf("PRLabels = %v, want explicit repo clear", r.PRLabels)
+	}
+}
+
 func TestRepoOrg(t *testing.T) {
 	cases := map[string]string{
 		"org/repo": "org",
@@ -1644,6 +1773,32 @@ func TestIssueTrackingForRepo_LabelsImplyEnabled(t *testing.T) {
 	}
 }
 
+func TestIssueTrackingForRepo_TOMLLabelsWithoutEnabledImplicitlyEnable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	content := `
+[ai]
+primary = "claude"
+
+[ai.repos."org/repo".issue_tracking]
+develop_labels = ["ready"]
+review_only_labels = ["triage"]
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.IssueTrackingForRepo("org/repo")
+	if !got.Enabled {
+		t.Error("TOML labels without enabled should preserve implicit-enable behavior")
+	}
+}
+
 func TestIssueTrackingForRepo_OrgLabelsImplyEnabled(t *testing.T) {
 	c := &Config{}
 	c.GitHub.IssueTracking = IssueTrackingConfig{Enabled: false}
@@ -1676,6 +1831,68 @@ func TestIssueTrackingForRepo_ExplicitFalseWinsOverOrgLabels(t *testing.T) {
 	got := c.IssueTrackingForRepo("org/labels-only")
 	if got.Enabled {
 		t.Error("explicit org enabled=false should win over labels")
+	}
+}
+
+func TestIssueTrackingForRepo_RepoExplicitFalseWithLabelsDisables(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{Enabled: true}
+	c.AI.Repos = map[string]RepoAI{
+		"org/repo": {
+			IssueTracking: &IssueTrackingOverride{
+				Enabled:          testBoolPtr(false),
+				DevelopLabels:    []string{"heimdallm-auto-implement"},
+				ReviewOnlyLabels: []string{"heimdallm-auto-refine"},
+			},
+		},
+	}
+	got := c.IssueTrackingForRepo("org/repo")
+	if got.Enabled {
+		t.Error("explicit repo enabled=false should win over labels")
+	}
+}
+
+func TestIssueTrackingForRepo_OrgImplicitEnableSurvivesRepoMetadataOverride(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{Enabled: false}
+	c.AI.Orgs = map[string]OrgAI{
+		"org": {
+			IssueTracking: &IssueTrackingOverride{
+				ReviewOnlyLabels: []string{"needs-triage"},
+			},
+		},
+	}
+	c.AI.Repos = map[string]RepoAI{
+		"org/repo": {
+			IssueTracking: &IssueTrackingOverride{
+				PromoteToLabel: "ready",
+			},
+		},
+	}
+	got := c.IssueTrackingForRepo("org/repo")
+	if !got.Enabled {
+		t.Error("repo override without enabled or labels should not undo org implicit enable")
+	}
+}
+
+func TestIssueTrackingForRepo_RepoLabelsReenableOrgDisabled(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{Enabled: true}
+	c.AI.Orgs = map[string]OrgAI{
+		"org": {
+			IssueTracking: &IssueTrackingOverride{Enabled: testBoolPtr(false)},
+		},
+	}
+	c.AI.Repos = map[string]RepoAI{
+		"org/repo": {
+			IssueTracking: &IssueTrackingOverride{
+				DevelopLabels: []string{"ready"},
+			},
+		},
+	}
+	got := c.IssueTrackingForRepo("org/repo")
+	if !got.Enabled {
+		t.Error("repo labels should re-enable tracking after org disabled it")
 	}
 }
 

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 )
 
+func testBoolPtr(v bool) *bool { return &v }
+
 // ── applyDefaults ────────────────────────────────────────────────────────────
 
 func TestApplyDefaults(t *testing.T) {
@@ -561,6 +563,48 @@ func TestValidate_IssueTrackingEnabledDefaultsPassValidation(t *testing.T) {
 	}
 }
 
+func TestValidate_InvalidOrgOverrideKey(t *testing.T) {
+	cfg := &Config{
+		AI: AIConfig{
+			Primary: "claude",
+			Orgs: map[string]OrgAI{
+				"bad org": {Primary: "gemini"},
+			},
+		},
+	}
+	cfg.applyDefaults()
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate with invalid org key = nil, want error")
+	}
+}
+
+func TestValidate_OrgIssueTrackingOverride(t *testing.T) {
+	cfg := &Config{
+		AI: AIConfig{
+			Primary: "claude",
+			Orgs: map[string]OrgAI{
+				"org": {
+					IssueTracking: &IssueTrackingOverride{
+						Enabled:       testBoolPtr(true),
+						FilterMode:    FilterMode("bad-mode"),
+						DefaultAction: string(IssueModeIgnore),
+					},
+				},
+			},
+		},
+	}
+	cfg.applyDefaults()
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate with invalid org issue_tracking = nil, want error")
+	}
+	if !strings.Contains(err.Error(), `ai.orgs."org".issue_tracking.filter_mode`) {
+		t.Fatalf("error should name org issue_tracking path, got: %v", err)
+	}
+}
+
 // ── Issue classification ─────────────────────────────────────────────────────
 
 func TestClassify_Precedence(t *testing.T) {
@@ -628,9 +672,9 @@ func TestClassify_BlockedPrecedence(t *testing.T) {
 
 func TestResolvePromoteToLabel(t *testing.T) {
 	cases := []struct {
-		name          string
-		cfg           IssueTrackingConfig
-		wantLabel     string
+		name      string
+		cfg       IssueTrackingConfig
+		wantLabel string
 	}{
 		{
 			name:      "explicit target wins",
@@ -1051,6 +1095,93 @@ func TestAIForRepo_OrgDraftOverride(t *testing.T) {
 	}
 }
 
+func TestAIForRepo_OrgOverridesAgentSelectionAndPrompts(t *testing.T) {
+	autoTriage := true
+	autoRefine := false
+	genDesc := true
+	cfg := &Config{
+		AI: AIConfig{
+			Primary:               "claude",
+			Fallback:              "gemini",
+			ReviewMode:            "single",
+			IssuePrompt:           "global-issue",
+			ImplementPrompt:       "global-impl",
+			TriageOwner:           "global-owner",
+			CloneDir:              "/tmp/global-clones",
+			GeneratePRDescription: false,
+			Orgs: map[string]OrgAI{
+				"myorg": {
+					Primary:               "codex",
+					Fallback:              "opencode",
+					ReviewMode:            "multi",
+					Prompt:                "org-pr",
+					IssuePrompt:           "org-issue",
+					ImplementPrompt:       "org-impl",
+					TriageOwner:           "org-owner",
+					CloneDir:              "/tmp/org-clones",
+					AutoPromoteTriage:     &autoTriage,
+					AutoPromoteRefinement: &autoRefine,
+					GeneratePRDescription: &genDesc,
+				},
+			},
+		},
+	}
+
+	r := cfg.AIForRepo("myorg/repo")
+	if r.Primary != "codex" || r.Fallback != "opencode" || r.ReviewMode != "multi" {
+		t.Fatalf("agent selection = (%q,%q,%q), want org values", r.Primary, r.Fallback, r.ReviewMode)
+	}
+	if r.Prompt != "org-pr" || r.IssuePrompt != "org-issue" || r.ImplementPrompt != "org-impl" {
+		t.Fatalf("prompts = (%q,%q,%q), want org prompts", r.Prompt, r.IssuePrompt, r.ImplementPrompt)
+	}
+	if r.TriageOwner != "org-owner" || r.CloneDir != "/tmp/org-clones" {
+		t.Fatalf("future fields = (%q,%q), want org values", r.TriageOwner, r.CloneDir)
+	}
+	if r.AutoPromoteTriage == nil || !*r.AutoPromoteTriage {
+		t.Fatal("AutoPromoteTriage should inherit org true")
+	}
+	if r.AutoPromoteRefinement == nil || *r.AutoPromoteRefinement {
+		t.Fatal("AutoPromoteRefinement should inherit org false")
+	}
+	if r.GeneratePRDescription == nil || !*r.GeneratePRDescription {
+		t.Fatal("GeneratePRDescription should inherit org true")
+	}
+}
+
+func TestAIForRepo_RepoOverridesOrgAgentSelectionAndPrompts(t *testing.T) {
+	orgAuto := true
+	repoAuto := false
+	cfg := &Config{
+		AI: AIConfig{
+			Primary: "claude",
+			Orgs: map[string]OrgAI{
+				"myorg": {
+					Primary:           "codex",
+					Prompt:            "org-pr",
+					IssuePrompt:       "org-issue",
+					AutoPromoteTriage: &orgAuto,
+				},
+			},
+			Repos: map[string]RepoAI{
+				"myorg/repo": {
+					Primary:           "gemini",
+					Prompt:            "repo-pr",
+					IssuePrompt:       "repo-issue",
+					AutoPromoteTriage: &repoAuto,
+				},
+			},
+		},
+	}
+
+	r := cfg.AIForRepo("myorg/repo")
+	if r.Primary != "gemini" || r.Prompt != "repo-pr" || r.IssuePrompt != "repo-issue" {
+		t.Fatalf("repo fields did not override org: %+v", r)
+	}
+	if r.AutoPromoteTriage == nil || *r.AutoPromoteTriage {
+		t.Fatal("repo AutoPromoteTriage=false should override org true")
+	}
+}
+
 func TestAIForRepo_IndependentFieldResolution(t *testing.T) {
 	cfg := &Config{
 		AI: AIConfig{
@@ -1271,11 +1402,11 @@ pr_reviewers = ["data-lead"]
 
 func TestRepoOrg(t *testing.T) {
 	cases := map[string]string{
-		"org/repo":   "org",
-		"a/b/c":      "a",
-		"noslash":     "",
-		"":            "",
-		"/leading":    "",
+		"org/repo": "org",
+		"a/b/c":    "a",
+		"noslash":  "",
+		"":         "",
+		"/leading": "",
 	}
 	for input, want := range cases {
 		if got := repoOrg(input); got != want {
@@ -1304,6 +1435,119 @@ func TestIssueTrackingForRepo_GlobalOnly(t *testing.T) {
 	}
 }
 
+func TestIssueTrackingForRepo_OrgOverride(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{
+		Enabled:          true,
+		FilterMode:       FilterModeExclusive,
+		DevelopLabels:    []string{"global-dev"},
+		ReviewOnlyLabels: []string{"global-review"},
+		SkipLabels:       []string{"global-skip"},
+		BlockedLabels:    []string{"global-blocked"},
+		PromoteToLabel:   "global-ready",
+		DefaultAction:    "ignore",
+	}
+	c.AI.Orgs = map[string]OrgAI{
+		"org": {
+			IssueTracking: &IssueTrackingOverride{
+				FilterMode:       FilterModeInclusive,
+				DevelopLabels:    []string{"org-dev"},
+				ReviewOnlyLabels: []string{"org-review"},
+				BlockedLabels:    []string{"org-blocked"},
+				PromoteToLabel:   "org-ready",
+			},
+		},
+	}
+
+	got := c.IssueTrackingForRepo("org/repo")
+	if !got.Enabled {
+		t.Fatal("enabled should inherit true from global")
+	}
+	if got.FilterMode != FilterModeInclusive {
+		t.Errorf("filter_mode = %q, want org override", got.FilterMode)
+	}
+	if len(got.DevelopLabels) != 1 || got.DevelopLabels[0] != "org-dev" {
+		t.Errorf("develop_labels = %v, want org override", got.DevelopLabels)
+	}
+	if len(got.SkipLabels) != 1 || got.SkipLabels[0] != "global-skip" {
+		t.Errorf("skip_labels = %v, want inherited global skip label", got.SkipLabels)
+	}
+	if len(got.BlockedLabels) != 1 || got.BlockedLabels[0] != "org-blocked" {
+		t.Errorf("blocked_labels = %v, want org override", got.BlockedLabels)
+	}
+	if got.PromoteToLabel != "org-ready" {
+		t.Errorf("promote_to_label = %q, want org-ready", got.PromoteToLabel)
+	}
+}
+
+func TestIssueTrackingForRepo_RepoOverridesOrg(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{
+		Enabled:       true,
+		FilterMode:    FilterModeExclusive,
+		DevelopLabels: []string{"global-dev"},
+		DefaultAction: "ignore",
+	}
+	c.AI.Orgs = map[string]OrgAI{
+		"org": {
+			IssueTracking: &IssueTrackingOverride{
+				DevelopLabels: []string{"org-dev"},
+				SkipLabels:    []string{"org-skip"},
+			},
+		},
+	}
+	c.AI.Repos = map[string]RepoAI{
+		"org/repo": {
+			IssueTracking: &IssueTrackingOverride{
+				DevelopLabels: []string{"repo-dev"},
+			},
+		},
+	}
+
+	got := c.IssueTrackingForRepo("org/repo")
+	if len(got.DevelopLabels) != 1 || got.DevelopLabels[0] != "repo-dev" {
+		t.Errorf("develop_labels = %v, want repo override", got.DevelopLabels)
+	}
+	if len(got.SkipLabels) != 1 || got.SkipLabels[0] != "org-skip" {
+		t.Errorf("skip_labels = %v, want inherited org override", got.SkipLabels)
+	}
+}
+
+func TestIssueTrackingForRepo_ExplicitFalseDisablesInheritedEnabled(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{Enabled: true, FilterMode: FilterModeExclusive, DefaultAction: "ignore"}
+	c.AI.Orgs = map[string]OrgAI{
+		"org": {
+			IssueTracking: &IssueTrackingOverride{Enabled: testBoolPtr(false)},
+		},
+	}
+
+	got := c.IssueTrackingForRepo("org/repo")
+	if got.Enabled {
+		t.Fatal("org enabled=false should disable global issue tracking for that org")
+	}
+}
+
+func TestIssueTrackingForRepo_EmptyListClearsInheritedLabels(t *testing.T) {
+	c := &Config{}
+	c.GitHub.IssueTracking = IssueTrackingConfig{
+		Enabled:       true,
+		FilterMode:    FilterModeExclusive,
+		DevelopLabels: []string{"global-dev"},
+		DefaultAction: "ignore",
+	}
+	c.AI.Orgs = map[string]OrgAI{
+		"org": {
+			IssueTracking: &IssueTrackingOverride{DevelopLabels: []string{}},
+		},
+	}
+
+	got := c.IssueTrackingForRepo("org/repo")
+	if got.DevelopLabels == nil || len(got.DevelopLabels) != 0 {
+		t.Fatalf("develop_labels = %#v, want explicit empty override", got.DevelopLabels)
+	}
+}
+
 func TestIssueTrackingForRepo_PerRepoOverride(t *testing.T) {
 	c := &Config{}
 	c.GitHub.IssueTracking = IssueTrackingConfig{
@@ -1316,8 +1560,8 @@ func TestIssueTrackingForRepo_PerRepoOverride(t *testing.T) {
 	c.AI.Primary = "claude"
 	c.AI.Repos = map[string]RepoAI{
 		"org/secure-repo": {
-			IssueTracking: &IssueTrackingConfig{
-				Enabled:       true, // per-repo Enabled overrides global unconditionally
+			IssueTracking: &IssueTrackingOverride{
+				Enabled:       testBoolPtr(true), // per-repo Enabled overrides global unconditionally
 				DevelopLabels: []string{"security-fix"},
 				SkipLabels:    []string{"wontfix", "stale"},
 			},
@@ -1361,8 +1605,8 @@ func TestIssueTrackingForRepo_PerRepoEnablesWhenGlobalOff(t *testing.T) {
 	}
 	c.AI.Repos = map[string]RepoAI{
 		"org/active-repo": {
-			IssueTracking: &IssueTrackingConfig{
-				Enabled:       true,
+			IssueTracking: &IssueTrackingOverride{
+				Enabled:       testBoolPtr(true),
 				DevelopLabels: []string{"feature"},
 			},
 		},
@@ -1387,7 +1631,7 @@ func TestIssueTrackingForRepo_LabelsImplyEnabled(t *testing.T) {
 	c.GitHub.IssueTracking = IssueTrackingConfig{Enabled: false}
 	c.AI.Repos = map[string]RepoAI{
 		"org/labels-only": {
-			IssueTracking: &IssueTrackingConfig{
+			IssueTracking: &IssueTrackingOverride{
 				// Enabled not set (false), but labels configured
 				DevelopLabels:    []string{"heimdallm-auto-implement"},
 				ReviewOnlyLabels: []string{"heimdallm-auto-refine"},
@@ -1405,7 +1649,7 @@ func TestIssueTrackingForRepo_NoLabelsNoOverride(t *testing.T) {
 	c.GitHub.IssueTracking = IssueTrackingConfig{Enabled: false}
 	c.AI.Repos = map[string]RepoAI{
 		"org/empty-override": {
-			IssueTracking: &IssueTrackingConfig{},
+			IssueTracking: &IssueTrackingOverride{},
 		},
 	}
 	got := c.IssueTrackingForRepo("org/empty-override")

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -269,6 +269,8 @@ func (srv *Server) buildRouter() chi.Router {
 	r.Patch("/config", srv.handlePatchConfig)
 	r.Patch("/config/repos/{repo}", srv.handlePatchRepoConfig)
 	r.Delete("/config/repos/{repo}/*", srv.handleDeleteRepoField)
+	r.Patch("/config/orgs/{org}", srv.handlePatchOrgConfig)
+	r.Delete("/config/orgs/{org}/*", srv.handleDeleteOrgField)
 	r.Post("/reload", srv.handleReload)
 	r.Post("/shutdown", srv.handleShutdown)
 	r.Get("/events", srv.handleSSE)
@@ -414,6 +416,8 @@ var validConfigKeys = map[string]struct{}{
 //     web-UI concern.
 //   - repo_overrides: per-repo AI config lives in [ai.repos.<name>] or
 //     the Flutter app; no write-path through this endpoint.
+//   - org_overrides : per-org AI config lives in [ai.orgs.<name>] and is
+//     patched through /config/orgs/{org}.
 //   - agent_configs : per-CLI agent tuning lives in [ai.agents.<name>]
 //     or /agents endpoints; no write-path here.
 //   - server_port   : bootstrap-only (changing the listening port mid-
@@ -423,6 +427,7 @@ var readOnlyConfigKeys = map[string]struct{}{
 	"repositories":   {},
 	"non_monitored":  {},
 	"repo_overrides": {},
+	"org_overrides":  {},
 	"agent_configs":  {},
 	"server_port":    {},
 }
@@ -644,6 +649,67 @@ func (srv *Server) handlePatchRepoConfig(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, result)
 }
 
+func (srv *Server) handlePatchOrgConfig(w http.ResponseWriter, r *http.Request) {
+	if srv.configPath == "" {
+		http.Error(w, `{"error":"PATCH not available — configPath not set"}`, http.StatusServiceUnavailable)
+		return
+	}
+	org, err := url.PathUnescape(chi.URLParam(r, "org"))
+	if err != nil || org == "" {
+		http.Error(w, `{"error":"invalid org parameter"}`, http.StatusBadRequest)
+		return
+	}
+	if err := config.ValidateOrgSlug(org); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var patch map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		return
+	}
+	if err := config.ContainsNull(patch); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "null values not allowed in PATCH — use DELETE to remove fields",
+		})
+		return
+	}
+	config.NormalizeNumbers(patch)
+
+	globalPatch := map[string]any{
+		"ai": map[string]any{
+			"orgs": map[string]any{
+				org: patch,
+			},
+		},
+	}
+
+	result, err := srv.patchTOML(func(m map[string]any) error {
+		merged := config.DeepMerge(m, globalPatch)
+		for k, v := range merged {
+			m[k] = v
+		}
+		for k := range m {
+			if _, ok := merged[k]; !ok {
+				delete(m, k)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		slog.Error("PATCH /config/orgs failed", "org", org, "err", err)
+		var ve *config.ValidationError
+		if errors.As(err, &ve) {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		} else {
+			http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
 func (srv *Server) handleDeleteRepoField(w http.ResponseWriter, r *http.Request) {
 	if srv.configPath == "" {
 		http.Error(w, `{"error":"DELETE not available — configPath not set"}`, http.StatusServiceUnavailable)
@@ -669,6 +735,44 @@ func (srv *Server) handleDeleteRepoField(w http.ResponseWriter, r *http.Request)
 	})
 	if err != nil {
 		slog.Error("DELETE /config/repos field failed", "repo", repo, "field", field, "err", err)
+		var ve *config.ValidationError
+		if errors.As(err, &ve) {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		} else {
+			http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (srv *Server) handleDeleteOrgField(w http.ResponseWriter, r *http.Request) {
+	if srv.configPath == "" {
+		http.Error(w, `{"error":"DELETE not available — configPath not set"}`, http.StatusServiceUnavailable)
+		return
+	}
+	org, err := url.PathUnescape(chi.URLParam(r, "org"))
+	if err != nil || org == "" {
+		http.Error(w, `{"error":"invalid org parameter"}`, http.StatusBadRequest)
+		return
+	}
+	if err := config.ValidateOrgSlug(org); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	field := chi.URLParam(r, "*")
+	if field == "" {
+		http.Error(w, `{"error":"field path required"}`, http.StatusBadRequest)
+		return
+	}
+	segments := append([]string{"ai", "orgs", org}, strings.Split(field, "/")...)
+
+	result, err := srv.patchTOML(func(m map[string]any) error {
+		config.DeleteNestedKey(m, segments)
+		return nil
+	})
+	if err != nil {
+		slog.Error("DELETE /config/orgs field failed", "org", org, "field", field, "err", err)
 		var ve *config.ValidationError
 		if errors.As(err, &ve) {
 			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -758,9 +758,10 @@ func TestHandlerPutConfig_ReadOnlyKeys_Accepted(t *testing.T) {
 		{"repositories", `{"repositories":["org/monitored"]}`},
 		{"non_monitored", `{"non_monitored":["org/archived"]}`},
 		{"repo_overrides", `{"repo_overrides":{"org/a":{"primary":"claude"}}}`},
+		{"org_overrides", `{"org_overrides":{"org":{"primary":"claude"}}}`},
 		{"agent_configs", `{"agent_configs":{"claude":{"model":"claude-opus-4-7"}}}`},
 		{"server_port", `{"server_port":7842}`},
-		{"all-at-once", `{"repositories":[],"non_monitored":[],"repo_overrides":{},"agent_configs":{},"server_port":7842}`},
+		{"all-at-once", `{"repositories":[],"non_monitored":[],"repo_overrides":{},"org_overrides":{},"agent_configs":{},"server_port":7842}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -779,7 +780,7 @@ func TestHandlerPutConfig_ReadOnlyKeys_NotPersisted(t *testing.T) {
 	// reload doesn't have to re-examine them and ApplyStore's
 	// "unknown/bootstrap-only" branches stay dormant.
 	srv, s := setupServer(t)
-	body := `{"repositories":["org/y"],"non_monitored":["org/x"],"repo_overrides":{"org/a":{"primary":"claude"}},"agent_configs":{"claude":{"model":"x"}},"server_port":7842}`
+	body := `{"repositories":["org/y"],"non_monitored":["org/x"],"repo_overrides":{"org/a":{"primary":"claude"}},"org_overrides":{"org":{"primary":"gemini"}},"agent_configs":{"claude":{"model":"x"}},"server_port":7842}`
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, putConfigRequest(body))
 	if w.Code != http.StatusOK {
@@ -790,7 +791,7 @@ func TestHandlerPutConfig_ReadOnlyKeys_NotPersisted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListConfigs: %v", err)
 	}
-	for _, banned := range []string{"repositories", "non_monitored", "repo_overrides", "agent_configs", "server_port"} {
+	for _, banned := range []string{"repositories", "non_monitored", "repo_overrides", "org_overrides", "agent_configs", "server_port"} {
 		if _, leaked := rows[banned]; leaked {
 			t.Errorf("read-only key %q was persisted (rows: %v)", banned, rows)
 		}
@@ -1391,6 +1392,73 @@ func TestHandlePatchRepoConfig_CreatesNewSection(t *testing.T) {
 	}
 }
 
+func TestHandlePatchOrgConfig(t *testing.T) {
+	tomlContent := "[ai]\nprimary = \"claude\"\n\n[ai.orgs.\"org\"]\nprimary = \"gemini\"\nfallback = \"openai\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	body := `{"primary":"codex","issue_tracking":{"enabled":true,"develop_labels":["ready"]}}`
+	req := httptest.NewRequest("PATCH", "/config/orgs/"+url.PathEscape("org"), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, err := config.ReadTOMLMap(tomlPath)
+	if err != nil {
+		t.Fatalf("read TOML after PATCH: %v", err)
+	}
+	ai, ok := m["ai"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected [ai] section, got %v", m)
+	}
+	orgs, ok := ai["orgs"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected [ai.orgs] section, got %v", ai)
+	}
+	org, ok := orgs["org"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected [ai.orgs.org] section, got %v", orgs)
+	}
+	if org["primary"] != "codex" {
+		t.Errorf("primary = %v, want codex", org["primary"])
+	}
+	if org["fallback"] != "openai" {
+		t.Errorf("fallback = %v, want openai (should be preserved)", org["fallback"])
+	}
+	it, ok := org["issue_tracking"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected issue_tracking section, got %v", org)
+	}
+	labels, ok := it["develop_labels"].([]any)
+	if !ok || len(labels) != 1 || labels[0] != "ready" {
+		t.Fatalf("develop_labels = %v, want [ready]", it["develop_labels"])
+	}
+}
+
+func TestHandlePatchOrgConfig_RejectsInvalidOrg(t *testing.T) {
+	tomlPath := writeTempTOML(t, "[ai]\nprimary = \"claude\"\n")
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	req := httptest.NewRequest("PATCH", "/config/orgs/"+url.PathEscape("bad org"), strings.NewReader(`{"primary":"codex"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
 func TestHandleDeleteRepoField_TopLevel(t *testing.T) {
 	tomlContent := "[ai]\nprimary = \"claude\"\n\n[ai.repos.\"org/repo1\"]\nprimary = \"gemini\"\npr_draft = true\n"
 	tomlPath := writeTempTOML(t, tomlContent)
@@ -1466,6 +1534,50 @@ func TestHandleDeleteRepoField_NestedPath(t *testing.T) {
 	issueTracking, ok := repo1["issue_tracking"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected issue_tracking section, got %v", repo1)
+	}
+	if _, found := issueTracking["develop_labels"]; found {
+		t.Errorf("develop_labels should have been deleted, still present: %v", issueTracking)
+	}
+	if issueTracking["filter_mode"] != "exclusive" {
+		t.Errorf("filter_mode = %v, want exclusive (should be preserved)", issueTracking["filter_mode"])
+	}
+}
+
+func TestHandleDeleteOrgField_NestedPath(t *testing.T) {
+	tomlContent := "[ai]\nprimary = \"claude\"\n\n[ai.orgs.\"org\".issue_tracking]\ndevelop_labels = [\"ready\"]\nfilter_mode = \"exclusive\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	req := httptest.NewRequest("DELETE", "/config/orgs/"+url.PathEscape("org")+"/issue_tracking/develop_labels", nil)
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, err := config.ReadTOMLMap(tomlPath)
+	if err != nil {
+		t.Fatalf("read TOML after DELETE: %v", err)
+	}
+	ai, ok := m["ai"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected [ai] section, got %v", m)
+	}
+	orgs, ok := ai["orgs"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected [ai.orgs] section, got %v", ai)
+	}
+	org, ok := orgs["org"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected [ai.orgs.org] section, got %v", orgs)
+	}
+	issueTracking, ok := org["issue_tracking"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected issue_tracking section, got %v", org)
 	}
 	if _, found := issueTracking["develop_labels"]; found {
 		t.Errorf("develop_labels should have been deleted, still present: %v", issueTracking)

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -47,6 +47,10 @@ primary = "claude"
 # fallback = "gemini"
 review_mode = "single"   # "single" or "multi"
 # execution_timeout = "20m"   # default: 5m; increase for complex auto_implement
+# triage_owner = "muriano"
+# clone_dir = "/repos/worktrees"
+# auto_promote_triage = true
+# auto_promote_refinement = false
 
 # When true, auto_implement PRs get an LLM-generated title and description
 # instead of the default template. A second (cheap) LLM call analyses the
@@ -99,6 +103,11 @@ review_mode = "single"   # "single" or "multi"
 # prompt = "org-pr-review-profile"
 # issue_prompt = "org-issue-triage-profile"
 # implement_prompt = "org-implementation-profile"
+# triage_owner = "muriano"
+# clone_dir = "/repos/freepik-worktrees"
+# auto_promote_triage = true
+# auto_promote_refinement = false
+# generate_pr_description = true
 # pr_reviewers = ["muriano", "ivanmunozruiz"]
 # pr_labels = ["auto-generated", "ai-platform"]
 # pr_assignee = "sergiotejon"

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -96,6 +96,8 @@ review_mode = "single"   # "single" or "multi"
 
 # Per-org overrides (optional)
 # Applied to all repos in the org unless overridden per-repo.
+# Omit fields to inherit. Empty arrays such as pr_reviewers = [] explicitly
+# clear inherited lists; enabled = false explicitly disables issue tracking.
 # [ai.orgs."freepik-company"]
 # primary = "gemini"
 # fallback = "claude"

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -90,15 +90,28 @@ review_mode = "single"   # "single" or "multi"
 # assignee = "sergiotejon"
 # draft = false
 
-# Per-org PR metadata overrides (optional)
+# Per-org overrides (optional)
 # Applied to all repos in the org unless overridden per-repo.
 # [ai.orgs."freepik-company"]
+# primary = "gemini"
+# fallback = "claude"
+# review_mode = "multi"
+# prompt = "org-pr-review-profile"
+# issue_prompt = "org-issue-triage-profile"
+# implement_prompt = "org-implementation-profile"
 # pr_reviewers = ["muriano", "ivanmunozruiz"]
 # pr_labels = ["auto-generated", "ai-platform"]
 # pr_assignee = "sergiotejon"
 # pr_draft = false
+#
+# [ai.orgs."freepik-company".issue_tracking]
+# enabled = true
+# develop_labels = ["heimdallm-develop"]
+# review_only_labels = ["heimdallm-triage"]
+# skip_labels = ["wontfix"]
 
 # [ai.orgs."theburrowhub"]
+# primary = "codex"
 # pr_reviewers = ["muriano", "ivanmunozruiz", "vbuenog"]
 # pr_labels = ["auto-generated"]
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -496,16 +496,32 @@ draft     = false
 
 ### Per-org overrides
 
-Applied to all repos in the org unless a per-repo override exists:
+Applied to all repos in the org unless a per-repo override exists. Resolution is
+field-by-field: `ai.repos."org/repo"` wins over `ai.orgs."org"`, which wins
+over global defaults.
 
 ```toml
 [ai.orgs."myorg"]
+primary      = "gemini"
+fallback     = "claude"
+review_mode  = "multi"
+prompt       = "org-pr-review-profile"
+issue_prompt = "org-issue-triage-profile"
+implement_prompt = "org-implementation-profile"
+
 pr_reviewers = ["alice", "bob", "carol"]
 pr_labels    = ["auto-generated", "ai-platform"]
 pr_assignee  = "myusername"
 pr_draft     = false
 
+[ai.orgs."myorg".issue_tracking]
+enabled            = true
+develop_labels     = ["heimdallm-develop"]
+review_only_labels = ["heimdallm-triage"]
+skip_labels        = ["wontfix"]
+
 [ai.orgs."other-org"]
+primary = "codex"
 pr_reviewers = ["dave"]
 pr_labels    = ["auto-generated"]
 ```
@@ -921,16 +937,30 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # pr_assignee  = "myusername"
 # pr_draft     = false
 
-# ── Per-org PR metadata overrides ────────────────────────────────────────────
+# ── Per-org overrides ────────────────────────────────────────────────────────
 # Applied to all repos in the org unless overridden per-repo.
+# Each field is optional and inherits from global defaults when absent.
 
 # [ai.orgs."myorg"]
+# primary = "gemini"
+# fallback = "claude"
+# review_mode = "multi"
+# prompt = "org-pr-review-profile"
+# issue_prompt = "org-issue-triage-profile"
+# implement_prompt = "org-implementation-profile"
 # pr_reviewers = ["alice", "bob"]
 # pr_labels    = ["auto-generated", "myorg-team"]
 # pr_assignee  = "myusername"
 # pr_draft     = false
+#
+# [ai.orgs."myorg".issue_tracking]
+# enabled = true
+# develop_labels = ["heimdallm-develop"]
+# review_only_labels = ["heimdallm-triage"]
+# skip_labels = ["wontfix"]
 
 # [ai.orgs."other-org"]
+# primary = "codex"
 # pr_reviewers = ["carol"]
 
 # ── Per-repo AI overrides ─────────────────────────────────────────────────────

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -535,6 +535,18 @@ pr_labels    = ["auto-generated"]
 resolution path as repo overrides, but prefer `local_dir_base` or per-repo
 `local_dir` unless every repo in the org should use the same checkout path.
 
+Scoped overrides distinguish "unset" from "set to empty/false":
+
+- Omit `enabled` under `ai.orgs.*.issue_tracking` or
+  `ai.repos.*.issue_tracking` to inherit. If labels are present and `enabled`
+  is omitted, Heimdallm still treats that scope as enabled, preserving the
+  historical labels-imply-enabled behaviour.
+- Set `enabled = false` to explicitly disable issue tracking at that scope,
+  even when labels are also present.
+- Omit list fields such as `pr_reviewers`, `pr_labels`, `develop_labels`, or
+  `review_only_labels` to inherit. Set them to `[]` to explicitly clear the
+  inherited list.
+
 ### Per-repo overrides
 
 ```toml

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -508,6 +508,11 @@ review_mode  = "multi"
 prompt       = "org-pr-review-profile"
 issue_prompt = "org-issue-triage-profile"
 implement_prompt = "org-implementation-profile"
+triage_owner = "alice"
+clone_dir = "/home/heimdallm/repos/myorg-worktrees"
+auto_promote_triage = true
+auto_promote_refinement = false
+generate_pr_description = true
 
 pr_reviewers = ["alice", "bob", "carol"]
 pr_labels    = ["auto-generated", "ai-platform"]
@@ -525,6 +530,10 @@ primary = "codex"
 pr_reviewers = ["dave"]
 pr_labels    = ["auto-generated"]
 ```
+
+`local_dir` is also accepted at org scope because org overrides share the same
+resolution path as repo overrides, but prefer `local_dir_base` or per-repo
+`local_dir` unless every repo in the org should use the same checkout path.
 
 ### Per-repo overrides
 
@@ -901,6 +910,12 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # Global execution timeout for AI CLI calls.
 # execution_timeout = "20m"   # default: 5m — env: HEIMDALLM_EXECUTION_TIMEOUT
 
+# Issue pipeline ownership and promotion defaults.
+# triage_owner = "alice"
+# clone_dir = "/home/heimdallm/repos/worktrees"
+# auto_promote_triage = true
+# auto_promote_refinement = false
+
 # Generate LLM-produced PR titles and descriptions for auto_implement PRs.
 # generate_pr_description = false
 
@@ -948,6 +963,11 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # prompt = "org-pr-review-profile"
 # issue_prompt = "org-issue-triage-profile"
 # implement_prompt = "org-implementation-profile"
+# triage_owner = "alice"
+# clone_dir = "/home/heimdallm/repos/myorg-worktrees"
+# auto_promote_triage = true
+# auto_promote_refinement = false
+# generate_pr_description = true
 # pr_reviewers = ["alice", "bob"]
 # pr_labels    = ["auto-generated", "myorg-team"]
 # pr_assignee  = "myusername"

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -11,8 +11,8 @@ class ApiClient {
   final PlatformServices _platform;
 
   ApiClient({http.Client? httpClient, required PlatformServices platform})
-      : _client = httpClient ?? http.Client(),
-        _platform = platform;
+    : _client = httpClient ?? http.Client(),
+      _platform = platform;
 
   Uri _uri(String path) => Uri.parse('${_platform.apiBaseUrl}$path');
 
@@ -53,11 +53,16 @@ class ApiClient {
       throw ApiException('GET /prs failed: ${resp.statusCode}');
     }
     final list = jsonDecode(resp.body) as List<dynamic>;
-    return list.map((e) => _parsePRWithReview(e as Map<String, dynamic>)).toList();
+    return list
+        .map((e) => _parsePRWithReview(e as Map<String, dynamic>))
+        .toList();
   }
 
   Future<Map<String, dynamic>> fetchPR(int id) async {
-    final resp = await _client.get(_uri('/prs/$id'), headers: await _authHeaders());
+    final resp = await _client.get(
+      _uri('/prs/$id'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 200) {
       throw ApiException('GET /prs/$id failed: ${resp.statusCode}');
     }
@@ -75,7 +80,9 @@ class ApiClient {
     // Build /activity via the shared _uri helper so both desktop
     // (http://127.0.0.1:7842/activity) and web (/api/activity — resolved
     // against the browser origin and proxied by Nginx) work unchanged.
-    final uri = _uri('/activity').replace(queryParameters: q.toQueryParameters());
+    final uri = _uri(
+      '/activity',
+    ).replace(queryParameters: q.toQueryParameters());
     final resp = await _client.get(uri, headers: headers);
     if (resp.statusCode == 503) {
       throw ActivityDisabledException();
@@ -88,26 +95,34 @@ class ApiClient {
   }
 
   Future<void> triggerReview(int prId) async {
-    final resp = await _client.post(_uri('/prs/$prId/review'),
-        headers: await _authHeaders());
+    final resp = await _client.post(
+      _uri('/prs/$prId/review'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 202) {
       throw ApiException('POST /prs/$prId/review failed: ${resp.statusCode}');
     }
   }
 
   Future<void> dismissPR(int prId) async {
-    final resp = await _client.post(_uri('/prs/$prId/dismiss'),
-        headers: await _authHeaders());
+    final resp = await _client.post(
+      _uri('/prs/$prId/dismiss'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 200) {
       throw ApiException('POST /prs/$prId/dismiss failed: ${resp.statusCode}');
     }
   }
 
   Future<void> undismissPR(int prId) async {
-    final resp = await _client.post(_uri('/prs/$prId/undismiss'),
-        headers: await _authHeaders());
+    final resp = await _client.post(
+      _uri('/prs/$prId/undismiss'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 200) {
-      throw ApiException('POST /prs/$prId/undismiss failed: ${resp.statusCode}');
+      throw ApiException(
+        'POST /prs/$prId/undismiss failed: ${resp.statusCode}',
+      );
     }
   }
 
@@ -121,16 +136,20 @@ class ApiClient {
   }
 
   Future<void> shutdownDaemon() async {
-    final resp = await _client.post(_uri('/shutdown'),
-        headers: await _authHeaders());
+    final resp = await _client.post(
+      _uri('/shutdown'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 202) {
       throw ApiException('POST /shutdown failed: ${resp.statusCode}');
     }
   }
 
   Future<Map<String, dynamic>> fetchConfig() async {
-    final resp = await _client.get(_uri('/config'),
-        headers: await _authHeaders());
+    final resp = await _client.get(
+      _uri('/config'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 200) {
       throw ApiException('GET /config failed: ${resp.statusCode}');
     }
@@ -140,29 +159,43 @@ class ApiClient {
   // ── Agents ──────────────────────────────────────────────────────────────
 
   Future<List<Map<String, dynamic>>> fetchAgents() async {
-    final resp = await _client.get(_uri('/agents'),
-        headers: await _authHeaders());
-    if (resp.statusCode != 200) throw ApiException('GET /agents failed: ${resp.statusCode}');
+    final resp = await _client.get(
+      _uri('/agents'),
+      headers: await _authHeaders(),
+    );
+    if (resp.statusCode != 200) {
+      throw ApiException('GET /agents failed: ${resp.statusCode}');
+    }
     return (jsonDecode(resp.body) as List<dynamic>)
         .cast<Map<String, dynamic>>();
   }
 
   Future<void> upsertAgent(Map<String, dynamic> agent) async {
-    final resp = await _client.post(_uri('/agents'),
-        headers: await _authHeaders(),
-        body: jsonEncode(agent));
-    if (resp.statusCode != 200) throw ApiException('POST /agents failed: ${resp.statusCode}');
+    final resp = await _client.post(
+      _uri('/agents'),
+      headers: await _authHeaders(),
+      body: jsonEncode(agent),
+    );
+    if (resp.statusCode != 200) {
+      throw ApiException('POST /agents failed: ${resp.statusCode}');
+    }
   }
 
   Future<void> deleteAgent(String id) async {
-    final resp = await _client.delete(_uri('/agents/$id'),
-        headers: await _authHeaders());
-    if (resp.statusCode != 200) throw ApiException('DELETE /agents/$id failed: ${resp.statusCode}');
+    final resp = await _client.delete(
+      _uri('/agents/$id'),
+      headers: await _authHeaders(),
+    );
+    if (resp.statusCode != 200) {
+      throw ApiException('DELETE /agents/$id failed: ${resp.statusCode}');
+    }
   }
 
   Future<String> fetchMe() async {
     final resp = await _client.get(_uri('/me'), headers: await _authHeaders());
-    if (resp.statusCode != 200) throw ApiException('GET /me failed: ${resp.statusCode}');
+    if (resp.statusCode != 200) {
+      throw ApiException('GET /me failed: ${resp.statusCode}');
+    }
     final body = jsonDecode(resp.body) as Map<String, dynamic>;
     return body['login'] as String? ?? '';
   }
@@ -174,9 +207,13 @@ class ApiClient {
     final params = <String, String>{};
     if (repos.isNotEmpty) params['repos'] = repos.join(',');
     if (orgs.isNotEmpty) params['orgs'] = orgs.join(',');
-    final uri = _uri('/stats').replace(queryParameters: params.isNotEmpty ? params : null);
+    final uri = _uri(
+      '/stats',
+    ).replace(queryParameters: params.isNotEmpty ? params : null);
     final resp = await _client.get(uri, headers: await _authHeaders());
-    if (resp.statusCode != 200) throw ApiException('GET /stats failed: ${resp.statusCode}');
+    if (resp.statusCode != 200) {
+      throw ApiException('GET /stats failed: ${resp.statusCode}');
+    }
     return jsonDecode(resp.body) as Map<String, dynamic>;
   }
 
@@ -203,7 +240,9 @@ class ApiClient {
       body: jsonEncode(patch),
     );
     if (resp.statusCode != 200) {
-      throw ApiException('PATCH /config failed: ${resp.statusCode} ${resp.body}');
+      throw ApiException(
+        'PATCH /config failed: ${resp.statusCode} ${resp.body}',
+      );
     }
     return jsonDecode(resp.body) as Map<String, dynamic>;
   }
@@ -212,7 +251,9 @@ class ApiClient {
   /// patch into [ai.repos."<repo>"] in the TOML file. Returns the full
   /// config after the merge.
   Future<Map<String, dynamic>> patchRepoConfig(
-      String repo, Map<String, dynamic> patch) async {
+    String repo,
+    Map<String, dynamic> patch,
+  ) async {
     final resp = await _client.patch(
       _uri('/config/repos/${Uri.encodeComponent(repo)}'),
       headers: await _authHeaders(),
@@ -220,7 +261,28 @@ class ApiClient {
     );
     if (resp.statusCode != 200) {
       throw ApiException(
-          'PATCH /config/repos failed: ${resp.statusCode} ${resp.body}');
+        'PATCH /config/repos failed: ${resp.statusCode} ${resp.body}',
+      );
+    }
+    return jsonDecode(resp.body) as Map<String, dynamic>;
+  }
+
+  /// Sends a partial per-organization override update. The daemon deep-merges
+  /// the patch into [ai.orgs."<org>"] in the TOML file. Returns the full
+  /// config after the merge.
+  Future<Map<String, dynamic>> patchOrgConfig(
+    String org,
+    Map<String, dynamic> patch,
+  ) async {
+    final resp = await _client.patch(
+      _uri('/config/orgs/${Uri.encodeComponent(org)}'),
+      headers: await _authHeaders(),
+      body: jsonEncode(patch),
+    );
+    if (resp.statusCode != 200) {
+      throw ApiException(
+        'PATCH /config/orgs failed: ${resp.statusCode} ${resp.body}',
+      );
     }
     return jsonDecode(resp.body) as Map<String, dynamic>;
   }
@@ -230,14 +292,35 @@ class ApiClient {
   /// fields (e.g. "issue_tracking/develop_labels"). Returns the full
   /// config after the deletion.
   Future<Map<String, dynamic>> deleteRepoField(
-      String repo, String fieldPath) async {
+    String repo,
+    String fieldPath,
+  ) async {
     final resp = await _client.delete(
       _uri('/config/repos/${Uri.encodeComponent(repo)}/$fieldPath'),
       headers: await _authHeaders(),
     );
     if (resp.statusCode != 200) {
       throw ApiException(
-          'DELETE /config/repos field failed: ${resp.statusCode} ${resp.body}');
+        'DELETE /config/repos field failed: ${resp.statusCode} ${resp.body}',
+      );
+    }
+    return jsonDecode(resp.body) as Map<String, dynamic>;
+  }
+
+  /// Resets a per-organization override field back to the global default by
+  /// removing it from the TOML file. [fieldPath] uses "/" for nested fields.
+  Future<Map<String, dynamic>> deleteOrgField(
+    String org,
+    String fieldPath,
+  ) async {
+    final resp = await _client.delete(
+      _uri('/config/orgs/${Uri.encodeComponent(org)}/$fieldPath'),
+      headers: await _authHeaders(),
+    );
+    if (resp.statusCode != 200) {
+      throw ApiException(
+        'DELETE /config/orgs field failed: ${resp.statusCode} ${resp.body}',
+      );
     }
     return jsonDecode(resp.body) as Map<String, dynamic>;
   }
@@ -246,23 +329,27 @@ class ApiClient {
 
   Future<List<String>> fetchRepoLabels(String repo) async {
     final resp = await _client.get(
-        _uri('/repos/${Uri.encodeComponent(repo)}/labels'),
-        headers: await _authHeaders());
+      _uri('/repos/${Uri.encodeComponent(repo)}/labels'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 200) return [];
     return (jsonDecode(resp.body) as List<dynamic>).cast<String>();
   }
 
   Future<List<String>> fetchRepoCollaborators(String repo) async {
     final resp = await _client.get(
-        _uri('/repos/${Uri.encodeComponent(repo)}/collaborators'),
-        headers: await _authHeaders());
+      _uri('/repos/${Uri.encodeComponent(repo)}/collaborators'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 200) return [];
     return (jsonDecode(resp.body) as List<dynamic>).cast<String>();
   }
 
   // ── Issues ────────────────────────────────────────────────────────────
 
-  Future<List<TrackedIssue>> fetchIssues({List<String> states = const []}) async {
+  Future<List<TrackedIssue>> fetchIssues({
+    List<String> states = const [],
+  }) async {
     var path = '/issues';
     if (states.isNotEmpty) {
       path += '?state=${states.join(',')}';
@@ -273,57 +360,83 @@ class ApiClient {
     }
     final list = jsonDecode(resp.body) as List<dynamic>;
     return list
-        .map((e) => TrackedIssue.fromJson(_parseIssueMap(e as Map<String, dynamic>)))
+        .map(
+          (e) =>
+              TrackedIssue.fromJson(_parseIssueMap(e as Map<String, dynamic>)),
+        )
         .toList();
   }
 
   Future<Map<String, dynamic>> fetchIssue(int id) async {
-    final resp = await _client.get(_uri('/issues/$id'), headers: await _authHeaders());
+    final resp = await _client.get(
+      _uri('/issues/$id'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 200) {
       throw ApiException('GET /issues/$id failed: ${resp.statusCode}');
     }
     final body = jsonDecode(resp.body) as Map<String, dynamic>;
     final issue = TrackedIssue.fromJson(
-        _parseIssueMap(body['issue'] as Map<String, dynamic>));
+      _parseIssueMap(body['issue'] as Map<String, dynamic>),
+    );
     final reviewsRaw = body['reviews'] as List<dynamic>? ?? [];
     final reviews = reviewsRaw
-        .map((r) => TrackedIssueReview.fromJson(
-            _parseIssueReviewMap(r as Map<String, dynamic>)))
+        .map(
+          (r) => TrackedIssueReview.fromJson(
+            _parseIssueReviewMap(r as Map<String, dynamic>),
+          ),
+        )
         .toList();
     return {'issue': issue, 'reviews': reviews};
   }
 
   Future<void> triggerIssueReview(int issueId) async {
-    final resp = await _client.post(_uri('/issues/$issueId/review'),
-        headers: await _authHeaders());
+    final resp = await _client.post(
+      _uri('/issues/$issueId/review'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 202) {
-      throw ApiException('POST /issues/$issueId/review failed: ${resp.statusCode}');
+      throw ApiException(
+        'POST /issues/$issueId/review failed: ${resp.statusCode}',
+      );
     }
   }
 
   /// Promotes a review_only-classified issue to auto_implement, triggering the
   /// full develop pipeline without requiring a GitHub label change.
   Future<void> promoteIssue(int issueId) async {
-    final resp = await _client.post(_uri('/issues/$issueId/promote'),
-        headers: await _authHeaders());
+    final resp = await _client.post(
+      _uri('/issues/$issueId/promote'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 202) {
-      throw ApiException('POST /issues/$issueId/promote failed: ${resp.statusCode}');
+      throw ApiException(
+        'POST /issues/$issueId/promote failed: ${resp.statusCode}',
+      );
     }
   }
 
   Future<void> dismissIssue(int issueId) async {
-    final resp = await _client.post(_uri('/issues/$issueId/dismiss'),
-        headers: await _authHeaders());
+    final resp = await _client.post(
+      _uri('/issues/$issueId/dismiss'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 200) {
-      throw ApiException('POST /issues/$issueId/dismiss failed: ${resp.statusCode}');
+      throw ApiException(
+        'POST /issues/$issueId/dismiss failed: ${resp.statusCode}',
+      );
     }
   }
 
   Future<void> undismissIssue(int issueId) async {
-    final resp = await _client.post(_uri('/issues/$issueId/undismiss'),
-        headers: await _authHeaders());
+    final resp = await _client.post(
+      _uri('/issues/$issueId/undismiss'),
+      headers: await _authHeaders(),
+    );
     if (resp.statusCode != 200) {
-      throw ApiException('POST /issues/$issueId/undismiss failed: ${resp.statusCode}');
+      throw ApiException(
+        'POST /issues/$issueId/undismiss failed: ${resp.statusCode}',
+      );
     }
   }
 
@@ -331,7 +444,8 @@ class ApiClient {
     if (json['latest_review'] != null) {
       json = Map.from(json);
       json['latest_review'] = _parseReviewMap(
-          json['latest_review'] as Map<String, dynamic>);
+        json['latest_review'] as Map<String, dynamic>,
+      );
     }
     return PR.fromJson(json);
   }
@@ -357,7 +471,8 @@ class ApiClient {
     final result = Map<String, dynamic>.from(json);
     if (result['latest_review'] != null) {
       result['latest_review'] = _parseIssueReviewMap(
-          result['latest_review'] as Map<String, dynamic>);
+        result['latest_review'] as Map<String, dynamic>,
+      );
     }
     return result;
   }

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -1,18 +1,20 @@
 /// Per-agent CLI execution settings.
 /// Stored under ai.agents.<name> in config.toml.
 class CLIAgentConfig {
-  final String model;         // --model value ('' = use CLI default)
-  final int maxTurns;         // claude: --max-turns (0 = not set)
-  final String approvalMode;  // codex: --approval-mode ('' = not set)
-  final String extraFlags;    // free-form additional CLI flags (space-separated)
-  final String? promptId;     // agent-level prompt override (null = use global default)
+  final String model; // --model value ('' = use CLI default)
+  final int maxTurns; // claude: --max-turns (0 = not set)
+  final String approvalMode; // codex: --approval-mode ('' = not set)
+  final String extraFlags; // free-form additional CLI flags (space-separated)
+  final String?
+  promptId; // agent-level prompt override (null = use global default)
 
   // Claude-specific flags
-  final String effort;              // '' | 'low' | 'medium' | 'high' | 'max'
-  final String permissionMode;      // '' | 'default' | 'auto' | 'bypassPermissions' | 'acceptEdits' | 'dontAsk'
-  final bool bare;                  // --bare
-  final bool dangerouslySkipPerms;  // --dangerously-skip-permissions
-  final bool noSessionPersistence;  // --no-session-persistence
+  final String effort; // '' | 'low' | 'medium' | 'high' | 'max'
+  final String
+  permissionMode; // '' | 'default' | 'auto' | 'bypassPermissions' | 'acceptEdits' | 'dontAsk'
+  final bool bare; // --bare
+  final bool dangerouslySkipPerms; // --dangerously-skip-permissions
+  final bool noSessionPersistence; // --no-session-persistence
 
   const CLIAgentConfig({
     this.model = '',
@@ -28,9 +30,15 @@ class CLIAgentConfig {
   });
 
   bool get hasConfig =>
-      model.isNotEmpty || maxTurns > 0 || approvalMode.isNotEmpty ||
-      extraFlags.isNotEmpty || promptId != null || effort.isNotEmpty ||
-      permissionMode.isNotEmpty || bare || dangerouslySkipPerms ||
+      model.isNotEmpty ||
+      maxTurns > 0 ||
+      approvalMode.isNotEmpty ||
+      extraFlags.isNotEmpty ||
+      promptId != null ||
+      effort.isNotEmpty ||
+      permissionMode.isNotEmpty ||
+      bare ||
+      dangerouslySkipPerms ||
       noSessionPersistence;
 
   CLIAgentConfig copyWith({
@@ -45,60 +53,69 @@ class CLIAgentConfig {
     bool? dangerouslySkipPerms,
     bool? noSessionPersistence,
   }) => CLIAgentConfig(
-    model:                model        ?? this.model,
-    maxTurns:             maxTurns     ?? this.maxTurns,
-    approvalMode:         approvalMode ?? this.approvalMode,
-    extraFlags:           extraFlags   ?? this.extraFlags,
-    promptId:             promptId == _sentinel ? this.promptId : promptId as String?,
-    effort:               effort              ?? this.effort,
-    permissionMode:       permissionMode      ?? this.permissionMode,
-    bare:                 bare                ?? this.bare,
+    model: model ?? this.model,
+    maxTurns: maxTurns ?? this.maxTurns,
+    approvalMode: approvalMode ?? this.approvalMode,
+    extraFlags: extraFlags ?? this.extraFlags,
+    promptId: promptId == _sentinel ? this.promptId : promptId as String?,
+    effort: effort ?? this.effort,
+    permissionMode: permissionMode ?? this.permissionMode,
+    bare: bare ?? this.bare,
     dangerouslySkipPerms: dangerouslySkipPerms ?? this.dangerouslySkipPerms,
     noSessionPersistence: noSessionPersistence ?? this.noSessionPersistence,
   );
 
   factory CLIAgentConfig.fromJson(Map<String, dynamic> json) => CLIAgentConfig(
-    model:                (json['model']                  as String?) ?? '',
-    maxTurns:             (json['max_turns']              as int?)    ?? 0,
-    approvalMode:         (json['approval_mode']          as String?) ?? '',
-    extraFlags:           (json['extra_flags']            as String?) ?? '',
-    promptId:             _nonEmpty(json['prompt']),
-    effort:               (json['effort']                 as String?) ?? '',
-    permissionMode:       (json['permission_mode']        as String?) ?? '',
-    bare:                 (json['bare']                   as bool?)   ?? false,
-    dangerouslySkipPerms: (json['dangerously_skip_perms'] as bool?)   ?? false,
-    noSessionPersistence: (json['no_session_persistence'] as bool?)   ?? false,
+    model: (json['model'] as String?) ?? '',
+    maxTurns: (json['max_turns'] as int?) ?? 0,
+    approvalMode: (json['approval_mode'] as String?) ?? '',
+    extraFlags: (json['extra_flags'] as String?) ?? '',
+    promptId: _nonEmpty(json['prompt']),
+    effort: (json['effort'] as String?) ?? '',
+    permissionMode: (json['permission_mode'] as String?) ?? '',
+    bare: (json['bare'] as bool?) ?? false,
+    dangerouslySkipPerms: (json['dangerously_skip_perms'] as bool?) ?? false,
+    noSessionPersistence: (json['no_session_persistence'] as bool?) ?? false,
   );
 
   static const modelOptions = <String, List<String>>{
-    'claude': ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+    'claude': [
+      'claude-opus-4-6',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5-20251001',
+    ],
     'gemini': ['gemini-2.5-pro', 'gemini-2.0-flash', 'gemini-1.5-pro'],
-    'codex':  ['o4-mini', 'o3', 'gpt-4o'],
+    'codex': ['o4-mini', 'o3', 'gpt-4o'],
   };
 
   static const approvalModeOptions = ['full-auto', 'auto-edit', 'suggest'];
-  static const effortOptions       = ['low', 'medium', 'high', 'max'];
+  static const effortOptions = ['low', 'medium', 'high', 'max'];
   static const permissionModeOptions = [
-    'default', 'auto', 'bypassPermissions', 'acceptEdits', 'dontAsk',
+    'default',
+    'auto',
+    'bypassPermissions',
+    'acceptEdits',
+    'dontAsk',
   ];
 }
 
 /// Per-repo AI override. null fields mean "use global default".
 class RepoConfig {
   // Per-feature activation (null = inherit global behavior)
-  final bool? prEnabled;      // PR auto-review
-  final bool? itEnabled;      // Issue tracking (triage)
-  final bool? devEnabled;     // Develop (auto-implement)
+  final bool? prEnabled; // PR auto-review
+  final bool? itEnabled; // Issue tracking (triage)
+  final bool? devEnabled; // Develop (auto-implement)
 
   // General
-  final String? localDir;     // local repo directory for full-repo analysis
-  final DateTime? firstSeenAt; // when the daemon first discovered this repo (null = unknown)
+  final String? localDir; // local repo directory for full-repo analysis
+  final DateTime?
+  firstSeenAt; // when the daemon first discovered this repo (null = unknown)
 
   // PR Review config
-  final String? aiPrimary;    // null = use global
-  final String? aiFallback;   // null = use global
-  final String? promptId;     // null = use globally active prompt
-  final String? reviewMode;   // null = use global ("single" | "multi")
+  final String? aiPrimary; // null = use global
+  final String? aiFallback; // null = use global
+  final String? promptId; // null = use globally active prompt
+  final String? reviewMode; // null = use global ("single" | "multi")
 
   // Issue tracking overrides (null = inherit global)
   final List<String>? reviewOnlyLabels;
@@ -147,22 +164,43 @@ class RepoConfig {
   /// True if any feature is actively enabled (per-repo or inherited).
   /// Used by the repo list to classify monitored vs not-monitored,
   /// and by the TOML writer to decide which repos go in `repositories`.
-  bool get isMonitored =>
-      (prEnabled ?? false) ||
-      (itEnabled ?? false) ||
-      (devEnabled ?? false) ||
-      (reviewOnlyLabels != null && reviewOnlyLabels!.isNotEmpty) ||
-      (developLabels != null && developLabels!.isNotEmpty);
+  bool get isMonitored {
+    final issueActive =
+        itEnabled == true ||
+        (itEnabled != false &&
+            reviewOnlyLabels != null &&
+            reviewOnlyLabels!.isNotEmpty);
+    final developActive =
+        devEnabled == true ||
+        (devEnabled != false &&
+            developLabels != null &&
+            developLabels!.isNotEmpty);
+    return (prEnabled ?? false) || issueActive || developActive;
+  }
 
   /// Legacy getter — repos with any override need to be written to TOML.
   bool get hasAiOverride =>
-      prEnabled != null || itEnabled != null || devEnabled != null ||
-      aiPrimary != null || aiFallback != null || promptId != null ||
-      reviewMode != null || (localDir != null && localDir!.isNotEmpty) ||
-      developLabels != null || reviewOnlyLabels != null || skipLabels != null ||
-      issueFilterMode != null || issueDefaultAction != null ||
-      issuePromptId != null || developPromptId != null ||
-      prReviewers != null || prAssignee != null || prLabels != null;
+      prEnabled != null ||
+      itEnabled != null ||
+      devEnabled != null ||
+      aiPrimary != null ||
+      aiFallback != null ||
+      promptId != null ||
+      reviewMode != null ||
+      (localDir != null && localDir!.isNotEmpty) ||
+      developLabels != null ||
+      reviewOnlyLabels != null ||
+      skipLabels != null ||
+      issueFilterMode != null ||
+      issueDefaultAction != null ||
+      issueOrganizations != null ||
+      issueAssignees != null ||
+      issuePromptId != null ||
+      developPromptId != null ||
+      prReviewers != null ||
+      prAssignee != null ||
+      prLabels != null ||
+      prDraft != null;
 
   /// LED status for each feature: 'off', 'global', 'repo'
   String prLedStatus(bool globalMonitored) {
@@ -170,6 +208,7 @@ class RepoConfig {
     if (prEnabled == false) return 'off';
     return globalMonitored ? 'global' : 'off';
   }
+
   String itLedStatus(bool globalITEnabled) {
     // Explicit toggle wins
     if (itEnabled == true) return 'repo';
@@ -178,61 +217,275 @@ class RepoConfig {
     if (reviewOnlyLabels != null && reviewOnlyLabels!.isNotEmpty) return 'repo';
     return globalITEnabled ? 'global' : 'off';
   }
+
   String devLedStatus(bool globalITEnabled, bool hasLocalDir) {
     if (devEnabled == true) return 'repo';
     if (devEnabled == false) return 'off';
     // Labels configured = implicitly active
-    if (developLabels != null && developLabels!.isNotEmpty && hasLocalDir) return 'repo';
+    if (developLabels != null && developLabels!.isNotEmpty && hasLocalDir) {
+      return 'repo';
+    }
     return (globalITEnabled && hasLocalDir) ? 'global' : 'off';
   }
 
   RepoConfig copyWith({
-    Object? prEnabled          = _sentinel,
-    Object? itEnabled          = _sentinel,
-    Object? devEnabled         = _sentinel,
-    Object? localDir           = _sentinel,
-    Object? aiPrimary          = _sentinel,
-    Object? aiFallback         = _sentinel,
-    Object? promptId           = _sentinel,
-    Object? reviewMode         = _sentinel,
-    Object? reviewOnlyLabels   = _sentinel,
-    Object? skipLabels         = _sentinel,
-    Object? issueFilterMode    = _sentinel,
+    Object? prEnabled = _sentinel,
+    Object? itEnabled = _sentinel,
+    Object? devEnabled = _sentinel,
+    Object? localDir = _sentinel,
+    Object? aiPrimary = _sentinel,
+    Object? aiFallback = _sentinel,
+    Object? promptId = _sentinel,
+    Object? reviewMode = _sentinel,
+    Object? reviewOnlyLabels = _sentinel,
+    Object? skipLabels = _sentinel,
+    Object? issueFilterMode = _sentinel,
     Object? issueDefaultAction = _sentinel,
     Object? issueOrganizations = _sentinel,
-    Object? issueAssignees     = _sentinel,
-    Object? issuePromptId      = _sentinel,
-    Object? developLabels      = _sentinel,
-    Object? developPromptId    = _sentinel,
-    Object? prReviewers        = _sentinel,
-    Object? prAssignee         = _sentinel,
-    Object? prLabels           = _sentinel,
-    Object? prDraft            = _sentinel,
-    Object? firstSeenAt        = _sentinel,
+    Object? issueAssignees = _sentinel,
+    Object? issuePromptId = _sentinel,
+    Object? developLabels = _sentinel,
+    Object? developPromptId = _sentinel,
+    Object? prReviewers = _sentinel,
+    Object? prAssignee = _sentinel,
+    Object? prLabels = _sentinel,
+    Object? prDraft = _sentinel,
+    Object? firstSeenAt = _sentinel,
   }) {
     return RepoConfig(
-      prEnabled:          prEnabled          == _sentinel ? this.prEnabled          : prEnabled          as bool?,
-      itEnabled:          itEnabled          == _sentinel ? this.itEnabled          : itEnabled          as bool?,
-      devEnabled:         devEnabled         == _sentinel ? this.devEnabled         : devEnabled         as bool?,
-      localDir:           localDir           == _sentinel ? this.localDir           : localDir           as String?,
-      aiPrimary:          aiPrimary          == _sentinel ? this.aiPrimary          : aiPrimary          as String?,
-      aiFallback:         aiFallback         == _sentinel ? this.aiFallback         : aiFallback         as String?,
-      promptId:           promptId           == _sentinel ? this.promptId           : promptId           as String?,
-      reviewMode:         reviewMode         == _sentinel ? this.reviewMode         : reviewMode         as String?,
-      reviewOnlyLabels:   reviewOnlyLabels   == _sentinel ? this.reviewOnlyLabels   : reviewOnlyLabels   as List<String>?,
-      skipLabels:         skipLabels         == _sentinel ? this.skipLabels         : skipLabels         as List<String>?,
-      issueFilterMode:    issueFilterMode    == _sentinel ? this.issueFilterMode    : issueFilterMode    as String?,
-      issueDefaultAction: issueDefaultAction == _sentinel ? this.issueDefaultAction : issueDefaultAction as String?,
-      issueOrganizations: issueOrganizations == _sentinel ? this.issueOrganizations : issueOrganizations as List<String>?,
-      issueAssignees:     issueAssignees     == _sentinel ? this.issueAssignees     : issueAssignees     as List<String>?,
-      issuePromptId:      issuePromptId      == _sentinel ? this.issuePromptId      : issuePromptId      as String?,
-      developLabels:      developLabels      == _sentinel ? this.developLabels      : developLabels      as List<String>?,
-      developPromptId:    developPromptId    == _sentinel ? this.developPromptId    : developPromptId    as String?,
-      prReviewers:        prReviewers        == _sentinel ? this.prReviewers        : prReviewers        as List<String>?,
-      prAssignee:         prAssignee         == _sentinel ? this.prAssignee         : prAssignee         as String?,
-      prLabels:           prLabels           == _sentinel ? this.prLabels           : prLabels           as List<String>?,
-      prDraft:            prDraft            == _sentinel ? this.prDraft            : prDraft            as bool?,
-      firstSeenAt:        firstSeenAt        == _sentinel ? this.firstSeenAt        : firstSeenAt        as DateTime?,
+      prEnabled: prEnabled == _sentinel ? this.prEnabled : prEnabled as bool?,
+      itEnabled: itEnabled == _sentinel ? this.itEnabled : itEnabled as bool?,
+      devEnabled: devEnabled == _sentinel
+          ? this.devEnabled
+          : devEnabled as bool?,
+      localDir: localDir == _sentinel ? this.localDir : localDir as String?,
+      aiPrimary: aiPrimary == _sentinel ? this.aiPrimary : aiPrimary as String?,
+      aiFallback: aiFallback == _sentinel
+          ? this.aiFallback
+          : aiFallback as String?,
+      promptId: promptId == _sentinel ? this.promptId : promptId as String?,
+      reviewMode: reviewMode == _sentinel
+          ? this.reviewMode
+          : reviewMode as String?,
+      reviewOnlyLabels: reviewOnlyLabels == _sentinel
+          ? this.reviewOnlyLabels
+          : reviewOnlyLabels as List<String>?,
+      skipLabels: skipLabels == _sentinel
+          ? this.skipLabels
+          : skipLabels as List<String>?,
+      issueFilterMode: issueFilterMode == _sentinel
+          ? this.issueFilterMode
+          : issueFilterMode as String?,
+      issueDefaultAction: issueDefaultAction == _sentinel
+          ? this.issueDefaultAction
+          : issueDefaultAction as String?,
+      issueOrganizations: issueOrganizations == _sentinel
+          ? this.issueOrganizations
+          : issueOrganizations as List<String>?,
+      issueAssignees: issueAssignees == _sentinel
+          ? this.issueAssignees
+          : issueAssignees as List<String>?,
+      issuePromptId: issuePromptId == _sentinel
+          ? this.issuePromptId
+          : issuePromptId as String?,
+      developLabels: developLabels == _sentinel
+          ? this.developLabels
+          : developLabels as List<String>?,
+      developPromptId: developPromptId == _sentinel
+          ? this.developPromptId
+          : developPromptId as String?,
+      prReviewers: prReviewers == _sentinel
+          ? this.prReviewers
+          : prReviewers as List<String>?,
+      prAssignee: prAssignee == _sentinel
+          ? this.prAssignee
+          : prAssignee as String?,
+      prLabels: prLabels == _sentinel
+          ? this.prLabels
+          : prLabels as List<String>?,
+      prDraft: prDraft == _sentinel ? this.prDraft : prDraft as bool?,
+      firstSeenAt: firstSeenAt == _sentinel
+          ? this.firstSeenAt
+          : firstSeenAt as DateTime?,
+    );
+  }
+}
+
+/// Per-organization override. null fields mean "inherit global".
+class OrgConfig {
+  final String? aiPrimary;
+  final String? aiFallback;
+  final String? promptId;
+  final String? reviewMode;
+  final String? localDir;
+  final String? issuePromptId;
+  final String? developPromptId;
+  final bool? itEnabled;
+  final bool? devEnabled;
+  final List<String>? reviewOnlyLabels;
+  final List<String>? developLabels;
+  final List<String>? skipLabels;
+  final String? issueFilterMode;
+  final String? issueDefaultAction;
+  final List<String>? issueOrganizations;
+  final List<String>? issueAssignees;
+  final List<String>? prReviewers;
+  final String? prAssignee;
+  final List<String>? prLabels;
+  final bool? prDraft;
+
+  const OrgConfig({
+    this.aiPrimary,
+    this.aiFallback,
+    this.promptId,
+    this.reviewMode,
+    this.localDir,
+    this.issuePromptId,
+    this.developPromptId,
+    this.itEnabled,
+    this.devEnabled,
+    this.reviewOnlyLabels,
+    this.developLabels,
+    this.skipLabels,
+    this.issueFilterMode,
+    this.issueDefaultAction,
+    this.issueOrganizations,
+    this.issueAssignees,
+    this.prReviewers,
+    this.prAssignee,
+    this.prLabels,
+    this.prDraft,
+  });
+
+  bool get hasOverride =>
+      aiPrimary != null ||
+      aiFallback != null ||
+      promptId != null ||
+      reviewMode != null ||
+      localDir != null ||
+      issuePromptId != null ||
+      developPromptId != null ||
+      itEnabled != null ||
+      devEnabled != null ||
+      reviewOnlyLabels != null ||
+      developLabels != null ||
+      skipLabels != null ||
+      issueFilterMode != null ||
+      issueDefaultAction != null ||
+      issueOrganizations != null ||
+      issueAssignees != null ||
+      prReviewers != null ||
+      prAssignee != null ||
+      prLabels != null ||
+      prDraft != null;
+
+  OrgConfig copyWith({
+    Object? aiPrimary = _sentinel,
+    Object? aiFallback = _sentinel,
+    Object? promptId = _sentinel,
+    Object? reviewMode = _sentinel,
+    Object? localDir = _sentinel,
+    Object? issuePromptId = _sentinel,
+    Object? developPromptId = _sentinel,
+    Object? itEnabled = _sentinel,
+    Object? devEnabled = _sentinel,
+    Object? reviewOnlyLabels = _sentinel,
+    Object? developLabels = _sentinel,
+    Object? skipLabels = _sentinel,
+    Object? issueFilterMode = _sentinel,
+    Object? issueDefaultAction = _sentinel,
+    Object? issueOrganizations = _sentinel,
+    Object? issueAssignees = _sentinel,
+    Object? prReviewers = _sentinel,
+    Object? prAssignee = _sentinel,
+    Object? prLabels = _sentinel,
+    Object? prDraft = _sentinel,
+  }) => OrgConfig(
+    aiPrimary: aiPrimary == _sentinel ? this.aiPrimary : aiPrimary as String?,
+    aiFallback: aiFallback == _sentinel
+        ? this.aiFallback
+        : aiFallback as String?,
+    promptId: promptId == _sentinel ? this.promptId : promptId as String?,
+    reviewMode: reviewMode == _sentinel
+        ? this.reviewMode
+        : reviewMode as String?,
+    localDir: localDir == _sentinel ? this.localDir : localDir as String?,
+    issuePromptId: issuePromptId == _sentinel
+        ? this.issuePromptId
+        : issuePromptId as String?,
+    developPromptId: developPromptId == _sentinel
+        ? this.developPromptId
+        : developPromptId as String?,
+    itEnabled: itEnabled == _sentinel ? this.itEnabled : itEnabled as bool?,
+    devEnabled: devEnabled == _sentinel ? this.devEnabled : devEnabled as bool?,
+    reviewOnlyLabels: reviewOnlyLabels == _sentinel
+        ? this.reviewOnlyLabels
+        : reviewOnlyLabels as List<String>?,
+    developLabels: developLabels == _sentinel
+        ? this.developLabels
+        : developLabels as List<String>?,
+    skipLabels: skipLabels == _sentinel
+        ? this.skipLabels
+        : skipLabels as List<String>?,
+    issueFilterMode: issueFilterMode == _sentinel
+        ? this.issueFilterMode
+        : issueFilterMode as String?,
+    issueDefaultAction: issueDefaultAction == _sentinel
+        ? this.issueDefaultAction
+        : issueDefaultAction as String?,
+    issueOrganizations: issueOrganizations == _sentinel
+        ? this.issueOrganizations
+        : issueOrganizations as List<String>?,
+    issueAssignees: issueAssignees == _sentinel
+        ? this.issueAssignees
+        : issueAssignees as List<String>?,
+    prReviewers: prReviewers == _sentinel
+        ? this.prReviewers
+        : prReviewers as List<String>?,
+    prAssignee: prAssignee == _sentinel
+        ? this.prAssignee
+        : prAssignee as String?,
+    prLabels: prLabels == _sentinel ? this.prLabels : prLabels as List<String>?,
+    prDraft: prDraft == _sentinel ? this.prDraft : prDraft as bool?,
+  );
+
+  factory OrgConfig.fromJson(Map<String, dynamic> json) {
+    final itRaw = json['issue_tracking'] as Map<String, dynamic>?;
+    return OrgConfig(
+      aiPrimary: _nonEmpty(json['primary']),
+      aiFallback: _nonEmpty(json['fallback']),
+      promptId: _nonEmpty(json['prompt']),
+      reviewMode: _nonEmpty(json['review_mode']),
+      localDir: _nonEmpty(json['local_dir']),
+      issuePromptId:
+          _nonEmpty(json['issue_prompt']) ??
+          (itRaw != null ? _nonEmpty(itRaw['issue_prompt']) : null),
+      developPromptId: _nonEmpty(json['implement_prompt']),
+      itEnabled: itRaw?['enabled'] as bool?,
+      devEnabled: itRaw?['develop_enabled'] as bool?,
+      reviewOnlyLabels: itRaw != null
+          ? _nullableStringListAllowEmpty(itRaw['review_only_labels'])
+          : null,
+      developLabels: itRaw != null
+          ? _nullableStringListAllowEmpty(itRaw['develop_labels'])
+          : null,
+      skipLabels: itRaw != null
+          ? _nullableStringListAllowEmpty(itRaw['skip_labels'])
+          : null,
+      issueFilterMode: itRaw != null ? _nonEmpty(itRaw['filter_mode']) : null,
+      issueDefaultAction: itRaw != null
+          ? _nonEmpty(itRaw['default_action'])
+          : null,
+      issueOrganizations: itRaw != null
+          ? _nullableStringListAllowEmpty(itRaw['organizations'])
+          : null,
+      issueAssignees: itRaw != null
+          ? _nullableStringListAllowEmpty(itRaw['assignees'])
+          : null,
+      prReviewers: _nullableStringListAllowEmpty(json['pr_reviewers']),
+      prAssignee: _nonEmpty(json['pr_assignee']),
+      prLabels: _nullableStringListAllowEmpty(json['pr_labels']),
+      prDraft: json['pr_draft'] as bool?,
     );
   }
 }
@@ -248,15 +501,27 @@ String? _nonEmpty(dynamic v) {
 
 /// Returns null when the list is absent or empty, otherwise a non-empty String list.
 List<String>? _nullableStringList(dynamic v) {
-  final list = (v as List<dynamic>?)?.cast<String>().where((s) => s.isNotEmpty).toList();
+  final list = (v as List<dynamic>?)
+      ?.cast<String>()
+      .where((s) => s.isNotEmpty)
+      .toList();
   return (list != null && list.isNotEmpty) ? list : null;
+}
+
+/// Returns null when absent, but preserves an explicit empty list override.
+List<String>? _nullableStringListAllowEmpty(dynamic v) {
+  if (v == null) return null;
+  return (v as List<dynamic>)
+      .cast<String>()
+      .where((s) => s.isNotEmpty)
+      .toList();
 }
 
 /// Issue tracking pipeline configuration.
 class IssueTrackingConfig {
   final bool enabled;
-  final String filterMode;      // "exclusive" | "inclusive"
-  final String defaultAction;   // "ignore" | "review_only"
+  final String filterMode; // "exclusive" | "inclusive"
+  final String defaultAction; // "ignore" | "review_only"
   final List<String> developLabels;
   final List<String> reviewOnlyLabels;
   final List<String> skipLabels;
@@ -284,25 +549,25 @@ class IssueTrackingConfig {
     List<String>? organizations,
     List<String>? assignees,
   }) => IssueTrackingConfig(
-    enabled:          enabled          ?? this.enabled,
-    filterMode:       filterMode       ?? this.filterMode,
-    defaultAction:    defaultAction    ?? this.defaultAction,
-    developLabels:    developLabels    ?? this.developLabels,
+    enabled: enabled ?? this.enabled,
+    filterMode: filterMode ?? this.filterMode,
+    defaultAction: defaultAction ?? this.defaultAction,
+    developLabels: developLabels ?? this.developLabels,
     reviewOnlyLabels: reviewOnlyLabels ?? this.reviewOnlyLabels,
-    skipLabels:       skipLabels       ?? this.skipLabels,
-    organizations:    organizations    ?? this.organizations,
-    assignees:        assignees        ?? this.assignees,
+    skipLabels: skipLabels ?? this.skipLabels,
+    organizations: organizations ?? this.organizations,
+    assignees: assignees ?? this.assignees,
   );
 
   Map<String, dynamic> toJson() => {
-    'enabled':            enabled,
-    'filter_mode':        filterMode,
-    'default_action':     defaultAction,
-    'develop_labels':     developLabels,
+    'enabled': enabled,
+    'filter_mode': filterMode,
+    'default_action': defaultAction,
+    'develop_labels': developLabels,
     'review_only_labels': reviewOnlyLabels,
-    'skip_labels':        skipLabels,
-    'organizations':      organizations,
-    'assignees':          assignees,
+    'skip_labels': skipLabels,
+    'organizations': organizations,
+    'assignees': assignees,
   };
 
   static const validFilterModes = ['exclusive', 'inclusive'];
@@ -312,15 +577,19 @@ class IssueTrackingConfig {
     final rawFilterMode = (json['filter_mode'] as String?) ?? 'exclusive';
     final rawDefaultAction = (json['default_action'] as String?) ?? 'ignore';
     return IssueTrackingConfig(
-        enabled:          (json['enabled']       as bool?)   ?? false,
-        filterMode:       validFilterModes.contains(rawFilterMode) ? rawFilterMode : 'exclusive',
-        defaultAction:    validDefaultActions.contains(rawDefaultAction) ? rawDefaultAction : 'ignore',
-        developLabels:    _stringList(json['develop_labels']),
-        reviewOnlyLabels: _stringList(json['review_only_labels']),
-        skipLabels:       _stringList(json['skip_labels']),
-        organizations:    _stringList(json['organizations']),
-        assignees:        _stringList(json['assignees']),
-      );
+      enabled: (json['enabled'] as bool?) ?? false,
+      filterMode: validFilterModes.contains(rawFilterMode)
+          ? rawFilterMode
+          : 'exclusive',
+      defaultAction: validDefaultActions.contains(rawDefaultAction)
+          ? rawDefaultAction
+          : 'ignore',
+      developLabels: _stringList(json['develop_labels']),
+      reviewOnlyLabels: _stringList(json['review_only_labels']),
+      skipLabels: _stringList(json['skip_labels']),
+      organizations: _stringList(json['organizations']),
+      assignees: _stringList(json['assignees']),
+    );
   }
 
   static List<String> _stringList(dynamic v) =>
@@ -335,7 +604,8 @@ class AppConfig {
   final String reviewMode; // "single" | "multi"
   final int retentionDays;
   final Map<String, CLIAgentConfig> agentConfigs; // keyed by CLI name
-  final Map<String, RepoConfig> repoConfigs;      // keyed by "org/repo"
+  final Map<String, RepoConfig> repoConfigs; // keyed by "org/repo"
+  final Map<String, OrgConfig> orgConfigs; // keyed by "org"
   final IssueTrackingConfig issueTracking;
   final List<String> globalPRReviewers;
   final List<String> globalPRLabels;
@@ -343,9 +613,11 @@ class AppConfig {
   final bool globalPRDraft;
   final String globalIssuePrompt;
   final String globalImplementPrompt;
+
   /// Host paths the daemon scans (in order) when a repo has no explicit
   /// `local_dir` set — first match at `{base}/{short-repo-name}` wins.
   final List<String> localDirBase;
+
   /// Auto-detected `local_dir` per repo, populated by the daemon when the
   /// repo is visible at `/home/heimdallm/repos/<short-name>` in the
   /// container (i.e. the operator set HEIMDALLM_LOCAL_DIR_BASE). The
@@ -364,6 +636,7 @@ class AppConfig {
     this.retentionDays = 90,
     this.agentConfigs = const {},
     this.repoConfigs = const {},
+    this.orgConfigs = const {},
     this.issueTracking = const IssueTrackingConfig(),
     this.globalPRReviewers = const [],
     this.globalPRLabels = const [],
@@ -377,11 +650,12 @@ class AppConfig {
 
   /// Computed list of monitored repos — this is what the daemon uses.
   /// A repo is monitored if any of its 3 features (PR, IT, Dev) is active.
-  List<String> get repositories => (repoConfigs.entries
-      .where((e) => e.value.isMonitored)
-      .map((e) => e.key)
-      .toList()
-    ..sort());
+  List<String> get repositories =>
+      (repoConfigs.entries
+          .where((e) => e.value.isMonitored)
+          .map((e) => e.key)
+          .toList()
+        ..sort());
 
   AppConfig copyWith({
     int? serverPort,
@@ -392,6 +666,7 @@ class AppConfig {
     int? retentionDays,
     Map<String, CLIAgentConfig>? agentConfigs,
     Map<String, RepoConfig>? repoConfigs,
+    Map<String, OrgConfig>? orgConfigs,
     IssueTrackingConfig? issueTracking,
     List<String>? globalPRReviewers,
     List<String>? globalPRLabels,
@@ -403,45 +678,49 @@ class AppConfig {
     Map<String, String>? localDirsDetected,
   }) {
     return AppConfig(
-      serverPort:        serverPort        ?? this.serverPort,
-      pollInterval:      pollInterval      ?? this.pollInterval,
-      aiPrimary:         aiPrimary         ?? this.aiPrimary,
-      aiFallback:        aiFallback        ?? this.aiFallback,
-      reviewMode:        reviewMode        ?? this.reviewMode,
-      retentionDays:     retentionDays     ?? this.retentionDays,
-      agentConfigs:      agentConfigs      ?? this.agentConfigs,
-      repoConfigs:       repoConfigs       ?? this.repoConfigs,
-      issueTracking:     issueTracking     ?? this.issueTracking,
+      serverPort: serverPort ?? this.serverPort,
+      pollInterval: pollInterval ?? this.pollInterval,
+      aiPrimary: aiPrimary ?? this.aiPrimary,
+      aiFallback: aiFallback ?? this.aiFallback,
+      reviewMode: reviewMode ?? this.reviewMode,
+      retentionDays: retentionDays ?? this.retentionDays,
+      agentConfigs: agentConfigs ?? this.agentConfigs,
+      repoConfigs: repoConfigs ?? this.repoConfigs,
+      orgConfigs: orgConfigs ?? this.orgConfigs,
+      issueTracking: issueTracking ?? this.issueTracking,
       globalPRReviewers: globalPRReviewers ?? this.globalPRReviewers,
-      globalPRLabels:    globalPRLabels    ?? this.globalPRLabels,
-      globalPRAssignee:       globalPRAssignee       ?? this.globalPRAssignee,
-      globalPRDraft:          globalPRDraft          ?? this.globalPRDraft,
-      globalIssuePrompt:     globalIssuePrompt     ?? this.globalIssuePrompt,
-      globalImplementPrompt: globalImplementPrompt ?? this.globalImplementPrompt,
-      localDirBase:           localDirBase           ?? this.localDirBase,
-      localDirsDetected:     localDirsDetected     ?? this.localDirsDetected,
+      globalPRLabels: globalPRLabels ?? this.globalPRLabels,
+      globalPRAssignee: globalPRAssignee ?? this.globalPRAssignee,
+      globalPRDraft: globalPRDraft ?? this.globalPRDraft,
+      globalIssuePrompt: globalIssuePrompt ?? this.globalIssuePrompt,
+      globalImplementPrompt:
+          globalImplementPrompt ?? this.globalImplementPrompt,
+      localDirBase: localDirBase ?? this.localDirBase,
+      localDirsDetected: localDirsDetected ?? this.localDirsDetected,
     );
   }
 
   Map<String, dynamic> toJson() => {
-    'server_port':    serverPort,
-    'poll_interval':  pollInterval,
-    'repositories':   repositories,
-    'ai_primary':     aiPrimary,
-    'ai_fallback':    aiFallback,
-    'review_mode':    reviewMode,
+    'server_port': serverPort,
+    'poll_interval': pollInterval,
+    'repositories': repositories,
+    'ai_primary': aiPrimary,
+    'ai_fallback': aiFallback,
+    'review_mode': reviewMode,
     'retention_days': retentionDays,
     'issue_tracking': issueTracking.toJson(),
   };
 
   factory AppConfig.fromJson(Map<String, dynamic> json) {
-    final repos = (json['repositories'] as List<dynamic>?)?.cast<String>() ?? [];
+    final repos =
+        (json['repositories'] as List<dynamic>?)?.cast<String>() ?? [];
     final configs = <String, RepoConfig>{
       // Repos in the monitored list have PR review enabled
       for (final r in repos) r: const RepoConfig(prEnabled: true),
     };
     // Restore non-monitored repos
-    final nonMonitored = (json['non_monitored'] as List<dynamic>?)?.cast<String>() ?? [];
+    final nonMonitored =
+        (json['non_monitored'] as List<dynamic>?)?.cast<String>() ?? [];
     for (final r in nonMonitored) {
       configs.putIfAbsent(r, () => const RepoConfig());
     }
@@ -453,37 +732,71 @@ class AppConfig {
         final existing = configs[entry.key];
         final itRaw = ov['issue_tracking'] as Map<String, dynamic>?;
         // Derive enabled flags from reality: explicit enabled OR labels configured
-        final hasReviewLabels = _nullableStringList(itRaw?['review_only_labels']) != null;
-        final hasDevLabels = _nullableStringList(itRaw?['develop_labels']) != null;
-        final itExplicit = itRaw?['enabled'] as bool? ?? false;
-        final devExplicit = itRaw?['develop_enabled'] as bool? ?? false;
+        final hasReviewLabels =
+            _nullableStringList(itRaw?['review_only_labels']) != null;
+        final hasDevLabels =
+            _nullableStringList(itRaw?['develop_labels']) != null;
+        final itExplicit = itRaw != null && itRaw.containsKey('enabled')
+            ? itRaw['enabled'] as bool?
+            : null;
+        final devExplicit =
+            itRaw != null && itRaw.containsKey('develop_enabled')
+            ? itRaw['develop_enabled'] as bool?
+            : null;
         final fsRaw = ov['first_seen_at'];
         final firstSeen = fsRaw is int
             ? DateTime.fromMillisecondsSinceEpoch(fsRaw * 1000)
             : null;
         configs[entry.key] = RepoConfig(
-          prEnabled:          existing?.prEnabled,
-          itEnabled:          (itExplicit || hasReviewLabels) ? true : null,
-          devEnabled:         (devExplicit || hasDevLabels) ? true : null,
-          localDir:           _nonEmpty(ov['local_dir']),
-          aiPrimary:          _nonEmpty(ov['primary']),
-          aiFallback:         _nonEmpty(ov['fallback']),
-          reviewMode:         _nonEmpty(ov['review_mode']),
-          promptId:           _nonEmpty(ov['prompt']),
-          reviewOnlyLabels:   itRaw != null ? _nullableStringList(itRaw['review_only_labels']) : null,
-          skipLabels:         itRaw != null ? _nullableStringList(itRaw['skip_labels']) : null,
-          issueFilterMode:    itRaw != null ? _nonEmpty(itRaw['filter_mode']) : null,
-          issueDefaultAction: itRaw != null ? _nonEmpty(itRaw['default_action']) : null,
-          issueOrganizations: itRaw != null ? _nullableStringList(itRaw['organizations']) : null,
-          issueAssignees:     itRaw != null ? _nullableStringList(itRaw['assignees']) : null,
-          issuePromptId:      itRaw != null ? _nonEmpty(itRaw['issue_prompt']) : null,
-          developLabels:      itRaw != null ? _nullableStringList(itRaw['develop_labels']) : null,
-          developPromptId:    itRaw != null ? _nonEmpty(itRaw['develop_prompt']) : null,
-          prReviewers:        _nullableStringList(ov['pr_reviewers']),
-          prAssignee:         _nonEmpty(ov['pr_assignee']),
-          prLabels:           _nullableStringList(ov['pr_labels']),
-          prDraft:            ov['pr_draft'] as bool?,
-          firstSeenAt:        firstSeen,
+          prEnabled: existing?.prEnabled,
+          itEnabled: itExplicit ?? (hasReviewLabels ? true : null),
+          devEnabled: devExplicit ?? (hasDevLabels ? true : null),
+          localDir: _nonEmpty(ov['local_dir']),
+          aiPrimary: _nonEmpty(ov['primary']),
+          aiFallback: _nonEmpty(ov['fallback']),
+          reviewMode: _nonEmpty(ov['review_mode']),
+          promptId: _nonEmpty(ov['prompt']),
+          reviewOnlyLabels: itRaw != null
+              ? _nullableStringListAllowEmpty(itRaw['review_only_labels'])
+              : null,
+          skipLabels: itRaw != null
+              ? _nullableStringListAllowEmpty(itRaw['skip_labels'])
+              : null,
+          issueFilterMode: itRaw != null
+              ? _nonEmpty(itRaw['filter_mode'])
+              : null,
+          issueDefaultAction: itRaw != null
+              ? _nonEmpty(itRaw['default_action'])
+              : null,
+          issueOrganizations: itRaw != null
+              ? _nullableStringListAllowEmpty(itRaw['organizations'])
+              : null,
+          issueAssignees: itRaw != null
+              ? _nullableStringListAllowEmpty(itRaw['assignees'])
+              : null,
+          issuePromptId:
+              _nonEmpty(ov['issue_prompt']) ??
+              (itRaw != null ? _nonEmpty(itRaw['issue_prompt']) : null),
+          developLabels: itRaw != null
+              ? _nullableStringListAllowEmpty(itRaw['develop_labels'])
+              : null,
+          developPromptId:
+              _nonEmpty(ov['implement_prompt']) ??
+              (itRaw != null ? _nonEmpty(itRaw['develop_prompt']) : null),
+          prReviewers: _nullableStringListAllowEmpty(ov['pr_reviewers']),
+          prAssignee: _nonEmpty(ov['pr_assignee']),
+          prLabels: _nullableStringListAllowEmpty(ov['pr_labels']),
+          prDraft: ov['pr_draft'] as bool?,
+          firstSeenAt: firstSeen,
+        );
+      }
+    }
+    final orgOverrides = json['org_overrides'] as Map<String, dynamic>?;
+    final orgConfigs = <String, OrgConfig>{};
+    if (orgOverrides != null) {
+      for (final entry in orgOverrides.entries) {
+        orgConfigs[entry.key] = OrgConfig.fromJson(
+          entry.value as Map<String, dynamic>,
         );
       }
     }
@@ -492,8 +805,9 @@ class AppConfig {
     final agentConfigs = <String, CLIAgentConfig>{};
     if (agentsRaw != null) {
       for (final entry in agentsRaw.entries) {
-        agentConfigs[entry.key] =
-            CLIAgentConfig.fromJson(entry.value as Map<String, dynamic>);
+        agentConfigs[entry.key] = CLIAgentConfig.fromJson(
+          entry.value as Map<String, dynamic>,
+        );
       }
     }
     final itRaw = json['issue_tracking'] as Map<String, dynamic>?;
@@ -512,22 +826,33 @@ class AppConfig {
     }
 
     return AppConfig(
-      serverPort:        (json['server_port']   as int?)    ?? 7842,
-      pollInterval:      (json['poll_interval'] as String?) ?? '5m',
-      aiPrimary:         (json['ai_primary']    as String?) ?? 'claude',
-      aiFallback:        (json['ai_fallback']   as String?) ?? '',
-      reviewMode:        (json['review_mode']   as String?) ?? 'single',
-      retentionDays:     (json['retention_days'] as int?)   ?? 90,
-      agentConfigs:      agentConfigs,
-      repoConfigs:       configs,
-      issueTracking:     issueTracking,
-      globalPRReviewers: _parseStringList((json['pr_metadata'] as Map<String, dynamic>?)?['reviewers']),
-      globalPRLabels:    _parseStringList((json['pr_metadata'] as Map<String, dynamic>?)?['labels']),
-      globalPRAssignee:       (json['pr_metadata'] as Map<String, dynamic>?)?['pr_assignee'] as String? ?? '',
-      globalPRDraft:          (json['pr_metadata'] as Map<String, dynamic>?)?['pr_draft'] as bool? ?? false,
-      globalIssuePrompt:     (json['issue_prompt'] as String?) ?? '',
+      serverPort: (json['server_port'] as int?) ?? 7842,
+      pollInterval: (json['poll_interval'] as String?) ?? '5m',
+      aiPrimary: (json['ai_primary'] as String?) ?? 'claude',
+      aiFallback: (json['ai_fallback'] as String?) ?? '',
+      reviewMode: (json['review_mode'] as String?) ?? 'single',
+      retentionDays: (json['retention_days'] as int?) ?? 90,
+      agentConfigs: agentConfigs,
+      repoConfigs: configs,
+      orgConfigs: orgConfigs,
+      issueTracking: issueTracking,
+      globalPRReviewers: _parseStringList(
+        (json['pr_metadata'] as Map<String, dynamic>?)?['reviewers'],
+      ),
+      globalPRLabels: _parseStringList(
+        (json['pr_metadata'] as Map<String, dynamic>?)?['labels'],
+      ),
+      globalPRAssignee:
+          (json['pr_metadata'] as Map<String, dynamic>?)?['pr_assignee']
+              as String? ??
+          '',
+      globalPRDraft:
+          (json['pr_metadata'] as Map<String, dynamic>?)?['pr_draft']
+              as bool? ??
+          false,
+      globalIssuePrompt: (json['issue_prompt'] as String?) ?? '',
       globalImplementPrompt: (json['implement_prompt'] as String?) ?? '',
-      localDirBase:           _parseStringList(json['local_dir_base']),
+      localDirBase: _parseStringList(json['local_dir_base']),
       localDirsDetected: localDirsDetected,
     );
   }

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -747,6 +747,44 @@ class AppConfig {
           .toList()
         ..sort());
 
+  List<String> get knownOrganizations {
+    final orgs = <String>{...orgConfigs.keys, ...issueTracking.organizations};
+    for (final repo in repoConfigs.keys) {
+      final slash = repo.indexOf('/');
+      if (slash > 0) orgs.add(repo.substring(0, slash));
+    }
+    for (final org in orgConfigs.values) {
+      final issueOrgs = org.issueOrganizations;
+      if (issueOrgs != null) orgs.addAll(issueOrgs);
+    }
+    for (final repo in repoConfigs.values) {
+      final issueOrgs = repo.issueOrganizations;
+      if (issueOrgs != null) orgs.addAll(issueOrgs);
+    }
+    return orgs.where((o) => o.trim().isNotEmpty).toList()..sort();
+  }
+
+  List<String> get knownGitHubUsers {
+    final users = <String>{
+      ...globalPRReviewers,
+      ...issueTracking.assignees,
+      if (globalPRAssignee.trim().isNotEmpty) globalPRAssignee,
+    };
+    for (final org in orgConfigs.values) {
+      users.addAll(org.prReviewers ?? const <String>[]);
+      users.addAll(org.issueAssignees ?? const <String>[]);
+      final assignee = org.prAssignee;
+      if (assignee != null && assignee.trim().isNotEmpty) users.add(assignee);
+    }
+    for (final repo in repoConfigs.values) {
+      users.addAll(repo.prReviewers ?? const <String>[]);
+      users.addAll(repo.issueAssignees ?? const <String>[]);
+      final assignee = repo.prAssignee;
+      if (assignee != null && assignee.trim().isNotEmpty) users.add(assignee);
+    }
+    return users.where((u) => u.trim().isNotEmpty).toList()..sort();
+  }
+
   AppConfig copyWith({
     int? serverPort,
     String? pollInterval,

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -108,6 +108,11 @@ class RepoConfig {
 
   // General
   final String? localDir; // local repo directory for full-repo analysis
+  final String? triageOwner;
+  final String? cloneDir;
+  final bool? autoPromoteTriage;
+  final bool? autoPromoteRefinement;
+  final bool? generatePRDescription;
   final DateTime?
   firstSeenAt; // when the daemon first discovered this repo (null = unknown)
 
@@ -141,6 +146,11 @@ class RepoConfig {
     this.itEnabled,
     this.devEnabled,
     this.localDir,
+    this.triageOwner,
+    this.cloneDir,
+    this.autoPromoteTriage,
+    this.autoPromoteRefinement,
+    this.generatePRDescription,
     this.aiPrimary,
     this.aiFallback,
     this.promptId,
@@ -188,6 +198,11 @@ class RepoConfig {
       promptId != null ||
       reviewMode != null ||
       (localDir != null && localDir!.isNotEmpty) ||
+      triageOwner != null ||
+      cloneDir != null ||
+      autoPromoteTriage != null ||
+      autoPromoteRefinement != null ||
+      generatePRDescription != null ||
       developLabels != null ||
       reviewOnlyLabels != null ||
       skipLabels != null ||
@@ -233,6 +248,11 @@ class RepoConfig {
     Object? itEnabled = _sentinel,
     Object? devEnabled = _sentinel,
     Object? localDir = _sentinel,
+    Object? triageOwner = _sentinel,
+    Object? cloneDir = _sentinel,
+    Object? autoPromoteTriage = _sentinel,
+    Object? autoPromoteRefinement = _sentinel,
+    Object? generatePRDescription = _sentinel,
     Object? aiPrimary = _sentinel,
     Object? aiFallback = _sentinel,
     Object? promptId = _sentinel,
@@ -259,6 +279,19 @@ class RepoConfig {
           ? this.devEnabled
           : devEnabled as bool?,
       localDir: localDir == _sentinel ? this.localDir : localDir as String?,
+      triageOwner: triageOwner == _sentinel
+          ? this.triageOwner
+          : triageOwner as String?,
+      cloneDir: cloneDir == _sentinel ? this.cloneDir : cloneDir as String?,
+      autoPromoteTriage: autoPromoteTriage == _sentinel
+          ? this.autoPromoteTriage
+          : autoPromoteTriage as bool?,
+      autoPromoteRefinement: autoPromoteRefinement == _sentinel
+          ? this.autoPromoteRefinement
+          : autoPromoteRefinement as bool?,
+      generatePRDescription: generatePRDescription == _sentinel
+          ? this.generatePRDescription
+          : generatePRDescription as bool?,
       aiPrimary: aiPrimary == _sentinel ? this.aiPrimary : aiPrimary as String?,
       aiFallback: aiFallback == _sentinel
           ? this.aiFallback
@@ -318,6 +351,11 @@ class OrgConfig {
   final String? promptId;
   final String? reviewMode;
   final String? localDir;
+  final String? triageOwner;
+  final String? cloneDir;
+  final bool? autoPromoteTriage;
+  final bool? autoPromoteRefinement;
+  final bool? generatePRDescription;
   final String? issuePromptId;
   final String? developPromptId;
   final bool? itEnabled;
@@ -340,6 +378,11 @@ class OrgConfig {
     this.promptId,
     this.reviewMode,
     this.localDir,
+    this.triageOwner,
+    this.cloneDir,
+    this.autoPromoteTriage,
+    this.autoPromoteRefinement,
+    this.generatePRDescription,
     this.issuePromptId,
     this.developPromptId,
     this.itEnabled,
@@ -363,6 +406,11 @@ class OrgConfig {
       promptId != null ||
       reviewMode != null ||
       localDir != null ||
+      triageOwner != null ||
+      cloneDir != null ||
+      autoPromoteTriage != null ||
+      autoPromoteRefinement != null ||
+      generatePRDescription != null ||
       issuePromptId != null ||
       developPromptId != null ||
       itEnabled != null ||
@@ -385,6 +433,11 @@ class OrgConfig {
     Object? promptId = _sentinel,
     Object? reviewMode = _sentinel,
     Object? localDir = _sentinel,
+    Object? triageOwner = _sentinel,
+    Object? cloneDir = _sentinel,
+    Object? autoPromoteTriage = _sentinel,
+    Object? autoPromoteRefinement = _sentinel,
+    Object? generatePRDescription = _sentinel,
     Object? issuePromptId = _sentinel,
     Object? developPromptId = _sentinel,
     Object? itEnabled = _sentinel,
@@ -410,6 +463,19 @@ class OrgConfig {
         ? this.reviewMode
         : reviewMode as String?,
     localDir: localDir == _sentinel ? this.localDir : localDir as String?,
+    triageOwner: triageOwner == _sentinel
+        ? this.triageOwner
+        : triageOwner as String?,
+    cloneDir: cloneDir == _sentinel ? this.cloneDir : cloneDir as String?,
+    autoPromoteTriage: autoPromoteTriage == _sentinel
+        ? this.autoPromoteTriage
+        : autoPromoteTriage as bool?,
+    autoPromoteRefinement: autoPromoteRefinement == _sentinel
+        ? this.autoPromoteRefinement
+        : autoPromoteRefinement as bool?,
+    generatePRDescription: generatePRDescription == _sentinel
+        ? this.generatePRDescription
+        : generatePRDescription as bool?,
     issuePromptId: issuePromptId == _sentinel
         ? this.issuePromptId
         : issuePromptId as String?,
@@ -451,18 +517,32 @@ class OrgConfig {
 
   factory OrgConfig.fromJson(Map<String, dynamic> json) {
     final itRaw = json['issue_tracking'] as Map<String, dynamic>?;
+    final hasReviewLabels =
+        _nullableStringList(itRaw?['review_only_labels']) != null;
+    final hasDevLabels = _nullableStringList(itRaw?['develop_labels']) != null;
+    final itExplicit = itRaw != null && itRaw.containsKey('enabled')
+        ? itRaw['enabled'] as bool?
+        : null;
+    final devExplicit = itRaw != null && itRaw.containsKey('develop_enabled')
+        ? itRaw['develop_enabled'] as bool?
+        : null;
     return OrgConfig(
       aiPrimary: _nonEmpty(json['primary']),
       aiFallback: _nonEmpty(json['fallback']),
       promptId: _nonEmpty(json['prompt']),
       reviewMode: _nonEmpty(json['review_mode']),
       localDir: _nonEmpty(json['local_dir']),
+      triageOwner: _nonEmpty(json['triage_owner']),
+      cloneDir: _nonEmpty(json['clone_dir']),
+      autoPromoteTriage: json['auto_promote_triage'] as bool?,
+      autoPromoteRefinement: json['auto_promote_refinement'] as bool?,
+      generatePRDescription: json['generate_pr_description'] as bool?,
       issuePromptId:
           _nonEmpty(json['issue_prompt']) ??
           (itRaw != null ? _nonEmpty(itRaw['issue_prompt']) : null),
       developPromptId: _nonEmpty(json['implement_prompt']),
-      itEnabled: itRaw?['enabled'] as bool?,
-      devEnabled: itRaw?['develop_enabled'] as bool?,
+      itEnabled: itExplicit ?? (hasReviewLabels ? true : null),
+      devEnabled: devExplicit ?? (hasDevLabels ? true : null),
       reviewOnlyLabels: itRaw != null
           ? _nullableStringListAllowEmpty(itRaw['review_only_labels'])
           : null,
@@ -613,6 +693,11 @@ class AppConfig {
   final bool globalPRDraft;
   final String globalIssuePrompt;
   final String globalImplementPrompt;
+  final String globalTriageOwner;
+  final String globalCloneDir;
+  final bool? globalAutoPromoteTriage;
+  final bool? globalAutoPromoteRefinement;
+  final bool globalGeneratePRDescription;
 
   /// Host paths the daemon scans (in order) when a repo has no explicit
   /// `local_dir` set — first match at `{base}/{short-repo-name}` wins.
@@ -644,6 +729,11 @@ class AppConfig {
     this.globalPRDraft = false,
     this.globalIssuePrompt = '',
     this.globalImplementPrompt = '',
+    this.globalTriageOwner = '',
+    this.globalCloneDir = '',
+    this.globalAutoPromoteTriage,
+    this.globalAutoPromoteRefinement,
+    this.globalGeneratePRDescription = false,
     this.localDirBase = const [],
     this.localDirsDetected = const {},
   });
@@ -674,6 +764,11 @@ class AppConfig {
     bool? globalPRDraft,
     String? globalIssuePrompt,
     String? globalImplementPrompt,
+    String? globalTriageOwner,
+    String? globalCloneDir,
+    Object? globalAutoPromoteTriage = _sentinel,
+    Object? globalAutoPromoteRefinement = _sentinel,
+    bool? globalGeneratePRDescription,
     List<String>? localDirBase,
     Map<String, String>? localDirsDetected,
   }) {
@@ -695,6 +790,16 @@ class AppConfig {
       globalIssuePrompt: globalIssuePrompt ?? this.globalIssuePrompt,
       globalImplementPrompt:
           globalImplementPrompt ?? this.globalImplementPrompt,
+      globalTriageOwner: globalTriageOwner ?? this.globalTriageOwner,
+      globalCloneDir: globalCloneDir ?? this.globalCloneDir,
+      globalAutoPromoteTriage: globalAutoPromoteTriage == _sentinel
+          ? this.globalAutoPromoteTriage
+          : globalAutoPromoteTriage as bool?,
+      globalAutoPromoteRefinement: globalAutoPromoteRefinement == _sentinel
+          ? this.globalAutoPromoteRefinement
+          : globalAutoPromoteRefinement as bool?,
+      globalGeneratePRDescription:
+          globalGeneratePRDescription ?? this.globalGeneratePRDescription,
       localDirBase: localDirBase ?? this.localDirBase,
       localDirsDetected: localDirsDetected ?? this.localDirsDetected,
     );
@@ -709,6 +814,11 @@ class AppConfig {
     'review_mode': reviewMode,
     'retention_days': retentionDays,
     'issue_tracking': issueTracking.toJson(),
+    'triage_owner': globalTriageOwner,
+    'clone_dir': globalCloneDir,
+    'auto_promote_triage': globalAutoPromoteTriage,
+    'auto_promote_refinement': globalAutoPromoteRefinement,
+    'generate_pr_description': globalGeneratePRDescription,
   };
 
   factory AppConfig.fromJson(Map<String, dynamic> json) {
@@ -752,6 +862,11 @@ class AppConfig {
           itEnabled: itExplicit ?? (hasReviewLabels ? true : null),
           devEnabled: devExplicit ?? (hasDevLabels ? true : null),
           localDir: _nonEmpty(ov['local_dir']),
+          triageOwner: _nonEmpty(ov['triage_owner']),
+          cloneDir: _nonEmpty(ov['clone_dir']),
+          autoPromoteTriage: ov['auto_promote_triage'] as bool?,
+          autoPromoteRefinement: ov['auto_promote_refinement'] as bool?,
+          generatePRDescription: ov['generate_pr_description'] as bool?,
           aiPrimary: _nonEmpty(ov['primary']),
           aiFallback: _nonEmpty(ov['fallback']),
           reviewMode: _nonEmpty(ov['review_mode']),
@@ -852,6 +967,12 @@ class AppConfig {
           false,
       globalIssuePrompt: (json['issue_prompt'] as String?) ?? '',
       globalImplementPrompt: (json['implement_prompt'] as String?) ?? '',
+      globalTriageOwner: (json['triage_owner'] as String?) ?? '',
+      globalCloneDir: (json['clone_dir'] as String?) ?? '',
+      globalAutoPromoteTriage: json['auto_promote_triage'] as bool?,
+      globalAutoPromoteRefinement: json['auto_promote_refinement'] as bool?,
+      globalGeneratePRDescription:
+          (json['generate_pr_description'] as bool?) ?? false,
       localDirBase: _parseStringList(json['local_dir_base']),
       localDirsDetected: localDirsDetected,
     );

--- a/flutter_app/lib/core/setup/first_run_setup.dart
+++ b/flutter_app/lib/core/setup/first_run_setup.dart
@@ -280,6 +280,25 @@ class FirstRunSetup {
         'implement_prompt = "${_tomlEscapeString(config.globalImplementPrompt)}"',
       );
     }
+    if (config.globalTriageOwner.isNotEmpty) {
+      buf.writeln(
+        'triage_owner = "${_tomlEscapeString(config.globalTriageOwner)}"',
+      );
+    }
+    if (config.globalCloneDir.isNotEmpty) {
+      buf.writeln('clone_dir = "${_tomlEscapeString(config.globalCloneDir)}"');
+    }
+    if (config.globalAutoPromoteTriage != null) {
+      buf.writeln('auto_promote_triage = ${config.globalAutoPromoteTriage}');
+    }
+    if (config.globalAutoPromoteRefinement != null) {
+      buf.writeln(
+        'auto_promote_refinement = ${config.globalAutoPromoteRefinement}',
+      );
+    }
+    if (config.globalGeneratePRDescription) {
+      buf.writeln('generate_pr_description = true');
+    }
     buf.writeln();
 
     // Global PR metadata defaults
@@ -380,6 +399,21 @@ class FirstRunSetup {
         if (oc.localDir != null && oc.localDir!.isNotEmpty) {
           buf.writeln('local_dir = "${_tomlEscapeString(oc.localDir!)}"');
         }
+        if (oc.triageOwner != null && oc.triageOwner!.isNotEmpty) {
+          buf.writeln('triage_owner = "${_tomlEscapeString(oc.triageOwner!)}"');
+        }
+        if (oc.cloneDir != null && oc.cloneDir!.isNotEmpty) {
+          buf.writeln('clone_dir = "${_tomlEscapeString(oc.cloneDir!)}"');
+        }
+        if (oc.autoPromoteTriage != null) {
+          buf.writeln('auto_promote_triage = ${oc.autoPromoteTriage}');
+        }
+        if (oc.autoPromoteRefinement != null) {
+          buf.writeln('auto_promote_refinement = ${oc.autoPromoteRefinement}');
+        }
+        if (oc.generatePRDescription != null) {
+          buf.writeln('generate_pr_description = ${oc.generatePRDescription}');
+        }
         if (oc.prReviewers != null) {
           buf.writeln('pr_reviewers = ${_tomlStringArray(oc.prReviewers!)}');
         }
@@ -474,6 +508,21 @@ class FirstRunSetup {
         }
         if (rc.localDir != null && rc.localDir!.isNotEmpty) {
           buf.writeln('local_dir = "${_tomlEscapeString(rc.localDir!)}"');
+        }
+        if (rc.triageOwner != null && rc.triageOwner!.isNotEmpty) {
+          buf.writeln('triage_owner = "${_tomlEscapeString(rc.triageOwner!)}"');
+        }
+        if (rc.cloneDir != null && rc.cloneDir!.isNotEmpty) {
+          buf.writeln('clone_dir = "${_tomlEscapeString(rc.cloneDir!)}"');
+        }
+        if (rc.autoPromoteTriage != null) {
+          buf.writeln('auto_promote_triage = ${rc.autoPromoteTriage}');
+        }
+        if (rc.autoPromoteRefinement != null) {
+          buf.writeln('auto_promote_refinement = ${rc.autoPromoteRefinement}');
+        }
+        if (rc.generatePRDescription != null) {
+          buf.writeln('generate_pr_description = ${rc.generatePRDescription}');
         }
         // PR metadata (must be written BEFORE any sub-table headers)
         if (rc.prReviewers != null) {

--- a/flutter_app/lib/core/setup/first_run_setup.dart
+++ b/flutter_app/lib/core/setup/first_run_setup.dart
@@ -57,13 +57,20 @@ class FirstRunSetup {
 
   static Future<void> _storeTokenMacOS(String token) async {
     await Process.run('security', [
-      'delete-generic-password', '-s', _keychainService, '-a', _keychainAccount,
+      'delete-generic-password',
+      '-s',
+      _keychainService,
+      '-a',
+      _keychainAccount,
     ]);
     final result = await Process.run('security', [
       'add-generic-password',
-      '-s', _keychainService,
-      '-a', _keychainAccount,
-      '-w', token,
+      '-s',
+      _keychainService,
+      '-a',
+      _keychainAccount,
+      '-w',
+      token,
     ]);
     if (result.exitCode != 0) {
       throw Exception('Failed to store token in Keychain: ${result.stderr}');
@@ -72,7 +79,12 @@ class FirstRunSetup {
 
   static Future<String?> _getTokenMacOS() async {
     final result = await Process.run('security', [
-      'find-generic-password', '-s', _keychainService, '-a', _keychainAccount, '-w',
+      'find-generic-password',
+      '-s',
+      _keychainService,
+      '-a',
+      _keychainAccount,
+      '-w',
     ]);
     if (result.exitCode == 0) {
       final token = (result.stdout as String).trim();
@@ -89,8 +101,10 @@ class FirstRunSetup {
       final proc = await Process.start('secret-tool', [
         'store',
         '--label=Heimdallm GitHub Token',
-        'service', _keychainService,
-        'account', _keychainAccount,
+        'service',
+        _keychainService,
+        'account',
+        _keychainAccount,
       ]);
       // secret-tool reads the secret from stdin
       proc.stdin.write(token);
@@ -108,8 +122,10 @@ class FirstRunSetup {
     try {
       final result = await Process.run('secret-tool', [
         'lookup',
-        'service', _keychainService,
-        'account', _keychainAccount,
+        'service',
+        _keychainService,
+        'account',
+        _keychainAccount,
       ]);
       if (result.exitCode == 0) {
         final token = (result.stdout as String).trim();
@@ -172,6 +188,9 @@ class FirstRunSetup {
       .replaceAll('\n', r'\n')
       .replaceAll('\r', r'\r');
 
+  static String _tomlStringArray(List<String> values) =>
+      '[${values.map((v) => '"${_tomlEscapeString(v)}"').join(', ')}]';
+
   static String _buildToml(AppConfig config) {
     final buf = StringBuffer();
 
@@ -181,15 +200,21 @@ class FirstRunSetup {
 
     buf.writeln('[github]');
     buf.writeln('poll_interval = "${_tomlEscapeString(config.pollInterval)}"');
-    final repos = config.repositories.map((r) => '"${_tomlEscapeString(r)}"').join(', ');
+    final repos = config.repositories
+        .map((r) => '"${_tomlEscapeString(r)}"')
+        .join(', ');
     buf.writeln('repositories = [$repos]');
     // Persist non-monitored repos so the UI can display and re-enable them after restart.
-    final nonMonitored = config.repoConfigs.entries
-        .where((e) => !e.value.isMonitored)
-        .map((e) => e.key)
-        .toList()..sort();
+    final nonMonitored =
+        config.repoConfigs.entries
+            .where((e) => !e.value.isMonitored)
+            .map((e) => e.key)
+            .toList()
+          ..sort();
     if (nonMonitored.isNotEmpty) {
-      final nonMon = nonMonitored.map((r) => '"${_tomlEscapeString(r)}"').join(', ');
+      final nonMon = nonMonitored
+          .map((r) => '"${_tomlEscapeString(r)}"')
+          .join(', ');
       buf.writeln('non_monitored = [$nonMon]');
     }
     // Persist local_dir_base so a Flutter-side save doesn't silently drop
@@ -213,19 +238,29 @@ class FirstRunSetup {
     buf.writeln('filter_mode = "${_tomlEscapeString(it.filterMode)}"');
     buf.writeln('default_action = "${_tomlEscapeString(it.defaultAction)}"');
     if (it.developLabels.isNotEmpty) {
-      buf.writeln('develop_labels = [${it.developLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+      buf.writeln(
+        'develop_labels = [${it.developLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]',
+      );
     }
     if (it.reviewOnlyLabels.isNotEmpty) {
-      buf.writeln('review_only_labels = [${it.reviewOnlyLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+      buf.writeln(
+        'review_only_labels = [${it.reviewOnlyLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]',
+      );
     }
     if (it.skipLabels.isNotEmpty) {
-      buf.writeln('skip_labels = [${it.skipLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+      buf.writeln(
+        'skip_labels = [${it.skipLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]',
+      );
     }
     if (it.organizations.isNotEmpty) {
-      buf.writeln('organizations = [${it.organizations.map((o) => '"${_tomlEscapeString(o)}"').join(', ')}]');
+      buf.writeln(
+        'organizations = [${it.organizations.map((o) => '"${_tomlEscapeString(o)}"').join(', ')}]',
+      );
     }
     if (it.assignees.isNotEmpty) {
-      buf.writeln('assignees = [${it.assignees.map((a) => '"${_tomlEscapeString(a)}"').join(', ')}]');
+      buf.writeln(
+        'assignees = [${it.assignees.map((a) => '"${_tomlEscapeString(a)}"').join(', ')}]',
+      );
     }
     buf.writeln();
 
@@ -236,25 +271,37 @@ class FirstRunSetup {
     }
     buf.writeln('review_mode = "${_tomlEscapeString(config.reviewMode)}"');
     if (config.globalIssuePrompt.isNotEmpty) {
-      buf.writeln('issue_prompt = "${_tomlEscapeString(config.globalIssuePrompt)}"');
+      buf.writeln(
+        'issue_prompt = "${_tomlEscapeString(config.globalIssuePrompt)}"',
+      );
     }
     if (config.globalImplementPrompt.isNotEmpty) {
-      buf.writeln('implement_prompt = "${_tomlEscapeString(config.globalImplementPrompt)}"');
+      buf.writeln(
+        'implement_prompt = "${_tomlEscapeString(config.globalImplementPrompt)}"',
+      );
     }
     buf.writeln();
 
     // Global PR metadata defaults
-    if (config.globalPRReviewers.isNotEmpty || config.globalPRLabels.isNotEmpty ||
-        config.globalPRAssignee.isNotEmpty || config.globalPRDraft) {
+    if (config.globalPRReviewers.isNotEmpty ||
+        config.globalPRLabels.isNotEmpty ||
+        config.globalPRAssignee.isNotEmpty ||
+        config.globalPRDraft) {
       buf.writeln('[ai.pr_metadata]');
       if (config.globalPRReviewers.isNotEmpty) {
-        buf.writeln('reviewers = [${config.globalPRReviewers.map((r) => '"${_tomlEscapeString(r)}"').join(', ')}]');
+        buf.writeln(
+          'reviewers = [${config.globalPRReviewers.map((r) => '"${_tomlEscapeString(r)}"').join(', ')}]',
+        );
       }
       if (config.globalPRLabels.isNotEmpty) {
-        buf.writeln('labels = [${config.globalPRLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+        buf.writeln(
+          'labels = [${config.globalPRLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]',
+        );
       }
       if (config.globalPRAssignee.isNotEmpty) {
-        buf.writeln('pr_assignee = "${_tomlEscapeString(config.globalPRAssignee)}"');
+        buf.writeln(
+          'pr_assignee = "${_tomlEscapeString(config.globalPRAssignee)}"',
+        );
       }
       if (config.globalPRDraft) {
         buf.writeln('pr_draft = true');
@@ -268,16 +315,131 @@ class FirstRunSetup {
       final ac = entry.value;
       if (ac.hasConfig) {
         buf.writeln('[ai.agents.$name]');
-        if (ac.model.isNotEmpty) buf.writeln('model = "${_tomlEscapeString(ac.model)}"');
+        if (ac.model.isNotEmpty) {
+          buf.writeln('model = "${_tomlEscapeString(ac.model)}"');
+        }
         if (ac.maxTurns > 0) buf.writeln('max_turns = ${ac.maxTurns}');
-        if (ac.approvalMode.isNotEmpty) buf.writeln('approval_mode = "${_tomlEscapeString(ac.approvalMode)}"');
-        if (ac.extraFlags.isNotEmpty) buf.writeln('extra_flags = "${_tomlEscapeString(ac.extraFlags)}"');
-        if (ac.promptId != null) buf.writeln('prompt = "${_tomlEscapeString(ac.promptId!)}"');
-        if (ac.effort.isNotEmpty) buf.writeln('effort = "${_tomlEscapeString(ac.effort)}"');
-        if (ac.permissionMode.isNotEmpty) buf.writeln('permission_mode = "${_tomlEscapeString(ac.permissionMode)}"');
+        if (ac.approvalMode.isNotEmpty) {
+          buf.writeln(
+            'approval_mode = "${_tomlEscapeString(ac.approvalMode)}"',
+          );
+        }
+        if (ac.extraFlags.isNotEmpty) {
+          buf.writeln('extra_flags = "${_tomlEscapeString(ac.extraFlags)}"');
+        }
+        if (ac.promptId != null) {
+          buf.writeln('prompt = "${_tomlEscapeString(ac.promptId!)}"');
+        }
+        if (ac.effort.isNotEmpty) {
+          buf.writeln('effort = "${_tomlEscapeString(ac.effort)}"');
+        }
+        if (ac.permissionMode.isNotEmpty) {
+          buf.writeln(
+            'permission_mode = "${_tomlEscapeString(ac.permissionMode)}"',
+          );
+        }
         if (ac.bare) buf.writeln('bare = true');
-        if (ac.dangerouslySkipPerms) buf.writeln('dangerously_skip_perms = true');
-        if (ac.noSessionPersistence) buf.writeln('no_session_persistence = true');
+        if (ac.dangerouslySkipPerms) {
+          buf.writeln('dangerously_skip_perms = true');
+        }
+        if (ac.noSessionPersistence) {
+          buf.writeln('no_session_persistence = true');
+        }
+        buf.writeln();
+      }
+    }
+
+    // Per-org overrides.
+    for (final entry in config.orgConfigs.entries) {
+      final org = entry.key;
+      final oc = entry.value;
+      if (oc.hasOverride) {
+        buf.writeln('[ai.orgs."${_tomlEscapeString(org)}"]');
+        if (oc.aiPrimary != null) {
+          buf.writeln('primary = "${_tomlEscapeString(oc.aiPrimary!)}"');
+        }
+        if (oc.aiFallback != null) {
+          buf.writeln('fallback = "${_tomlEscapeString(oc.aiFallback!)}"');
+        }
+        if (oc.promptId != null) {
+          buf.writeln('prompt = "${_tomlEscapeString(oc.promptId!)}"');
+        }
+        if (oc.issuePromptId != null) {
+          buf.writeln(
+            'issue_prompt = "${_tomlEscapeString(oc.issuePromptId!)}"',
+          );
+        }
+        if (oc.developPromptId != null) {
+          buf.writeln(
+            'implement_prompt = "${_tomlEscapeString(oc.developPromptId!)}"',
+          );
+        }
+        if (oc.reviewMode != null) {
+          buf.writeln('review_mode = "${_tomlEscapeString(oc.reviewMode!)}"');
+        }
+        if (oc.localDir != null && oc.localDir!.isNotEmpty) {
+          buf.writeln('local_dir = "${_tomlEscapeString(oc.localDir!)}"');
+        }
+        if (oc.prReviewers != null) {
+          buf.writeln('pr_reviewers = ${_tomlStringArray(oc.prReviewers!)}');
+        }
+        if (oc.prAssignee != null && oc.prAssignee!.isNotEmpty) {
+          buf.writeln('pr_assignee = "${_tomlEscapeString(oc.prAssignee!)}"');
+        }
+        if (oc.prLabels != null) {
+          buf.writeln('pr_labels = ${_tomlStringArray(oc.prLabels!)}');
+        }
+        if (oc.prDraft != null) {
+          buf.writeln('pr_draft = ${oc.prDraft}');
+        }
+        final hasIT =
+            oc.developLabels != null ||
+            oc.reviewOnlyLabels != null ||
+            oc.skipLabels != null ||
+            oc.issueFilterMode != null ||
+            oc.issueDefaultAction != null ||
+            oc.issueOrganizations != null ||
+            oc.issueAssignees != null ||
+            oc.itEnabled != null ||
+            oc.devEnabled != null;
+        if (hasIT) {
+          buf.writeln('[ai.orgs."${_tomlEscapeString(org)}".issue_tracking]');
+          if (oc.itEnabled != null) buf.writeln('enabled = ${oc.itEnabled}');
+          if (oc.devEnabled != null) {
+            buf.writeln('develop_enabled = ${oc.devEnabled}');
+          }
+          if (oc.developLabels != null) {
+            buf.writeln(
+              'develop_labels = ${_tomlStringArray(oc.developLabels!)}',
+            );
+          }
+          if (oc.reviewOnlyLabels != null) {
+            buf.writeln(
+              'review_only_labels = ${_tomlStringArray(oc.reviewOnlyLabels!)}',
+            );
+          }
+          if (oc.skipLabels != null) {
+            buf.writeln('skip_labels = ${_tomlStringArray(oc.skipLabels!)}');
+          }
+          if (oc.issueFilterMode != null) {
+            buf.writeln(
+              'filter_mode = "${_tomlEscapeString(oc.issueFilterMode!)}"',
+            );
+          }
+          if (oc.issueDefaultAction != null) {
+            buf.writeln(
+              'default_action = "${_tomlEscapeString(oc.issueDefaultAction!)}"',
+            );
+          }
+          if (oc.issueOrganizations != null) {
+            buf.writeln(
+              'organizations = ${_tomlStringArray(oc.issueOrganizations!)}',
+            );
+          }
+          if (oc.issueAssignees != null) {
+            buf.writeln('assignees = ${_tomlStringArray(oc.issueAssignees!)}');
+          }
+        }
         buf.writeln();
       }
     }
@@ -288,53 +450,91 @@ class FirstRunSetup {
       final rc = entry.value;
       if (rc.hasAiOverride) {
         buf.writeln('[ai.repos."${_tomlEscapeString(repo)}"]');
-        if (rc.aiPrimary != null) buf.writeln('primary = "${_tomlEscapeString(rc.aiPrimary!)}"');
-        if (rc.aiFallback != null) buf.writeln('fallback = "${_tomlEscapeString(rc.aiFallback!)}"');
-        if (rc.promptId != null) buf.writeln('prompt = "${_tomlEscapeString(rc.promptId!)}"');
-        if (rc.reviewMode != null) buf.writeln('review_mode = "${_tomlEscapeString(rc.reviewMode!)}"');
+        if (rc.aiPrimary != null) {
+          buf.writeln('primary = "${_tomlEscapeString(rc.aiPrimary!)}"');
+        }
+        if (rc.aiFallback != null) {
+          buf.writeln('fallback = "${_tomlEscapeString(rc.aiFallback!)}"');
+        }
+        if (rc.promptId != null) {
+          buf.writeln('prompt = "${_tomlEscapeString(rc.promptId!)}"');
+        }
+        if (rc.issuePromptId != null) {
+          buf.writeln(
+            'issue_prompt = "${_tomlEscapeString(rc.issuePromptId!)}"',
+          );
+        }
+        if (rc.developPromptId != null) {
+          buf.writeln(
+            'implement_prompt = "${_tomlEscapeString(rc.developPromptId!)}"',
+          );
+        }
+        if (rc.reviewMode != null) {
+          buf.writeln('review_mode = "${_tomlEscapeString(rc.reviewMode!)}"');
+        }
         if (rc.localDir != null && rc.localDir!.isNotEmpty) {
           buf.writeln('local_dir = "${_tomlEscapeString(rc.localDir!)}"');
         }
         // PR metadata (must be written BEFORE any sub-table headers)
-        if (rc.prReviewers != null && rc.prReviewers!.isNotEmpty) {
-          buf.writeln('pr_reviewers = [${rc.prReviewers!.map((r) => '"${_tomlEscapeString(r)}"').join(', ')}]');
+        if (rc.prReviewers != null) {
+          buf.writeln('pr_reviewers = ${_tomlStringArray(rc.prReviewers!)}');
         }
         if (rc.prAssignee != null && rc.prAssignee!.isNotEmpty) {
           buf.writeln('pr_assignee = "${_tomlEscapeString(rc.prAssignee!)}"');
         }
-        if (rc.prLabels != null && rc.prLabels!.isNotEmpty) {
-          buf.writeln('pr_labels = [${rc.prLabels!.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+        if (rc.prLabels != null) {
+          buf.writeln('pr_labels = ${_tomlStringArray(rc.prLabels!)}');
         }
-        if (rc.prDraft == true) {
-          buf.writeln('pr_draft = true');
+        if (rc.prDraft != null) {
+          buf.writeln('pr_draft = ${rc.prDraft}');
         }
         // Issue tracking overrides (sub-table — must come after all repo-level keys)
-        final hasIT = rc.developLabels != null || rc.reviewOnlyLabels != null ||
-            rc.skipLabels != null || rc.issueFilterMode != null ||
-            rc.issueDefaultAction != null || rc.issueOrganizations != null ||
+        final hasIT =
+            rc.developLabels != null ||
+            rc.reviewOnlyLabels != null ||
+            rc.skipLabels != null ||
+            rc.issueFilterMode != null ||
+            rc.issueDefaultAction != null ||
+            rc.itEnabled != null ||
+            rc.devEnabled != null ||
+            rc.issueOrganizations != null ||
             rc.issueAssignees != null;
         if (hasIT) {
           buf.writeln('[ai.repos."${_tomlEscapeString(repo)}".issue_tracking]');
-          if (rc.developLabels != null && rc.developLabels!.isNotEmpty) {
-            buf.writeln('develop_labels = [${rc.developLabels!.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+          if (rc.itEnabled != null) buf.writeln('enabled = ${rc.itEnabled}');
+          if (rc.devEnabled != null) {
+            buf.writeln('develop_enabled = ${rc.devEnabled}');
           }
-          if (rc.reviewOnlyLabels != null && rc.reviewOnlyLabels!.isNotEmpty) {
-            buf.writeln('review_only_labels = [${rc.reviewOnlyLabels!.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+          if (rc.developLabels != null) {
+            buf.writeln(
+              'develop_labels = ${_tomlStringArray(rc.developLabels!)}',
+            );
           }
-          if (rc.skipLabels != null && rc.skipLabels!.isNotEmpty) {
-            buf.writeln('skip_labels = [${rc.skipLabels!.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]');
+          if (rc.reviewOnlyLabels != null) {
+            buf.writeln(
+              'review_only_labels = ${_tomlStringArray(rc.reviewOnlyLabels!)}',
+            );
+          }
+          if (rc.skipLabels != null) {
+            buf.writeln('skip_labels = ${_tomlStringArray(rc.skipLabels!)}');
           }
           if (rc.issueFilterMode != null) {
-            buf.writeln('filter_mode = "${_tomlEscapeString(rc.issueFilterMode!)}"');
+            buf.writeln(
+              'filter_mode = "${_tomlEscapeString(rc.issueFilterMode!)}"',
+            );
           }
           if (rc.issueDefaultAction != null) {
-            buf.writeln('default_action = "${_tomlEscapeString(rc.issueDefaultAction!)}"');
+            buf.writeln(
+              'default_action = "${_tomlEscapeString(rc.issueDefaultAction!)}"',
+            );
           }
-          if (rc.issueOrganizations != null && rc.issueOrganizations!.isNotEmpty) {
-            buf.writeln('organizations = [${rc.issueOrganizations!.map((o) => '"${_tomlEscapeString(o)}"').join(', ')}]');
+          if (rc.issueOrganizations != null) {
+            buf.writeln(
+              'organizations = ${_tomlStringArray(rc.issueOrganizations!)}',
+            );
           }
-          if (rc.issueAssignees != null && rc.issueAssignees!.isNotEmpty) {
-            buf.writeln('assignees = [${rc.issueAssignees!.map((a) => '"${_tomlEscapeString(a)}"').join(', ')}]');
+          if (rc.issueAssignees != null) {
+            buf.writeln('assignees = ${_tomlStringArray(rc.issueAssignees!)}');
           }
         }
         buf.writeln();

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -86,8 +86,9 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
   }
 }
 
-final configNotifierProvider =
-    AsyncNotifierProvider<ConfigNotifier, AppConfig>(ConfigNotifier.new);
+final configNotifierProvider = AsyncNotifierProvider<ConfigNotifier, AppConfig>(
+  ConfigNotifier.new,
+);
 
 /// Computes a nested diff between two AppConfig instances, returning only
 /// the fields that changed in the structure expected by PATCH /config
@@ -99,9 +100,15 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
   final retentionDiff = <String, dynamic>{};
 
   // AI section
-  if (old.aiPrimary != updated.aiPrimary) aiDiff['primary'] = updated.aiPrimary;
-  if (old.aiFallback != updated.aiFallback) aiDiff['fallback'] = updated.aiFallback;
-  if (old.reviewMode != updated.reviewMode) aiDiff['review_mode'] = updated.reviewMode;
+  if (old.aiPrimary != updated.aiPrimary) {
+    aiDiff['primary'] = updated.aiPrimary;
+  }
+  if (old.aiFallback != updated.aiFallback) {
+    aiDiff['fallback'] = updated.aiFallback;
+  }
+  if (old.reviewMode != updated.reviewMode) {
+    aiDiff['review_mode'] = updated.reviewMode;
+  }
 
   // PR metadata
   final prMeta = <String, dynamic>{};
@@ -125,8 +132,27 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
   if (old.globalImplementPrompt != updated.globalImplementPrompt) {
     aiDiff['implement_prompt'] = updated.globalImplementPrompt;
   }
+  if (old.globalTriageOwner != updated.globalTriageOwner) {
+    aiDiff['triage_owner'] = updated.globalTriageOwner;
+  }
+  if (old.globalCloneDir != updated.globalCloneDir) {
+    aiDiff['clone_dir'] = updated.globalCloneDir;
+  }
+  if (old.globalAutoPromoteTriage != updated.globalAutoPromoteTriage &&
+      updated.globalAutoPromoteTriage != null) {
+    aiDiff['auto_promote_triage'] = updated.globalAutoPromoteTriage;
+  }
+  if (old.globalAutoPromoteRefinement != updated.globalAutoPromoteRefinement &&
+      updated.globalAutoPromoteRefinement != null) {
+    aiDiff['auto_promote_refinement'] = updated.globalAutoPromoteRefinement;
+  }
+  if (old.globalGeneratePRDescription != updated.globalGeneratePRDescription) {
+    aiDiff['generate_pr_description'] = updated.globalGeneratePRDescription;
+  }
 
-  if (aiDiff.isNotEmpty) diff['ai'] = aiDiff;
+  if (aiDiff.isNotEmpty) {
+    diff['ai'] = aiDiff;
+  }
 
   // GitHub section
   if (old.pollInterval != updated.pollInterval) {
@@ -135,40 +161,75 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
   if (_listsDiffer(old.repositories, updated.repositories)) {
     githubDiff['repositories'] = updated.repositories;
   }
-  final oldNonMon = old.repoConfigs.entries
-      .where((e) => !e.value.isMonitored).map((e) => e.key).toList()..sort();
-  final newNonMon = updated.repoConfigs.entries
-      .where((e) => !e.value.isMonitored).map((e) => e.key).toList()..sort();
+  final oldNonMon =
+      old.repoConfigs.entries
+          .where((e) => !e.value.isMonitored)
+          .map((e) => e.key)
+          .toList()
+        ..sort();
+  final newNonMon =
+      updated.repoConfigs.entries
+          .where((e) => !e.value.isMonitored)
+          .map((e) => e.key)
+          .toList()
+        ..sort();
   if (_listsDiffer(oldNonMon, newNonMon)) {
     githubDiff['non_monitored'] = newNonMon;
   }
 
   // Issue tracking (global)
-  final itDiff = _computeIssueTrackingDiff(old.issueTracking, updated.issueTracking);
-  if (itDiff.isNotEmpty) githubDiff['issue_tracking'] = itDiff;
+  final itDiff = _computeIssueTrackingDiff(
+    old.issueTracking,
+    updated.issueTracking,
+  );
+  if (itDiff.isNotEmpty) {
+    githubDiff['issue_tracking'] = itDiff;
+  }
 
-  if (githubDiff.isNotEmpty) diff['github'] = githubDiff;
+  if (githubDiff.isNotEmpty) {
+    diff['github'] = githubDiff;
+  }
 
   // Retention
   if (old.retentionDays != updated.retentionDays) {
     retentionDiff['max_days'] = updated.retentionDays;
   }
-  if (retentionDiff.isNotEmpty) diff['retention'] = retentionDiff;
+  if (retentionDiff.isNotEmpty) {
+    diff['retention'] = retentionDiff;
+  }
 
   return diff;
 }
 
 Map<String, dynamic> _computeIssueTrackingDiff(
-    IssueTrackingConfig old, IssueTrackingConfig updated) {
+  IssueTrackingConfig old,
+  IssueTrackingConfig updated,
+) {
   final diff = <String, dynamic>{};
-  if (old.enabled != updated.enabled) diff['enabled'] = updated.enabled;
-  if (old.filterMode != updated.filterMode) diff['filter_mode'] = updated.filterMode;
-  if (old.defaultAction != updated.defaultAction) diff['default_action'] = updated.defaultAction;
-  if (_listsDiffer(old.developLabels, updated.developLabels)) diff['develop_labels'] = updated.developLabels;
-  if (_listsDiffer(old.reviewOnlyLabels, updated.reviewOnlyLabels)) diff['review_only_labels'] = updated.reviewOnlyLabels;
-  if (_listsDiffer(old.skipLabels, updated.skipLabels)) diff['skip_labels'] = updated.skipLabels;
-  if (_listsDiffer(old.organizations, updated.organizations)) diff['organizations'] = updated.organizations;
-  if (_listsDiffer(old.assignees, updated.assignees)) diff['assignees'] = updated.assignees;
+  if (old.enabled != updated.enabled) {
+    diff['enabled'] = updated.enabled;
+  }
+  if (old.filterMode != updated.filterMode) {
+    diff['filter_mode'] = updated.filterMode;
+  }
+  if (old.defaultAction != updated.defaultAction) {
+    diff['default_action'] = updated.defaultAction;
+  }
+  if (_listsDiffer(old.developLabels, updated.developLabels)) {
+    diff['develop_labels'] = updated.developLabels;
+  }
+  if (_listsDiffer(old.reviewOnlyLabels, updated.reviewOnlyLabels)) {
+    diff['review_only_labels'] = updated.reviewOnlyLabels;
+  }
+  if (_listsDiffer(old.skipLabels, updated.skipLabels)) {
+    diff['skip_labels'] = updated.skipLabels;
+  }
+  if (_listsDiffer(old.organizations, updated.organizations)) {
+    diff['organizations'] = updated.organizations;
+  }
+  if (_listsDiffer(old.assignees, updated.assignees)) {
+    diff['assignees'] = updated.assignees;
+  }
   return diff;
 }
 

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -63,8 +63,9 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     }
 
     // 2. Fall back to stored token / env var
-    final stored = await platform.getStoredGitHubToken()
-        ?? platform.readEnv('GITHUB_TOKEN');
+    final stored =
+        await platform.getStoredGitHubToken() ??
+        platform.readEnv('GITHUB_TOKEN');
     if (!mounted || stored == null || stored.isEmpty) return;
     setState(() => _tokenController.text = stored);
   }
@@ -76,8 +77,12 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     _retentionDays = config.retentionDays;
     _repoConfigs = Map.from(config.repoConfigs);
     _issueTracking = config.issueTracking;
-    _issuePromptId = config.globalIssuePrompt.isEmpty ? null : config.globalIssuePrompt;
-    _developPromptId = config.globalImplementPrompt.isEmpty ? null : config.globalImplementPrompt;
+    _issuePromptId = config.globalIssuePrompt.isEmpty
+        ? null
+        : config.globalIssuePrompt;
+    _developPromptId = config.globalImplementPrompt.isEmpty
+        ? null
+        : config.globalImplementPrompt;
   }
 
   /// Auto-discovers repos from the user's PRs. Runs silently on init.
@@ -85,14 +90,22 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     final token = _tokenController.text.trim();
     if (token.isEmpty) return;
     if (!mounted) return;
-    setState(() { _discovering = true; _discoverError = null; });
+    setState(() {
+      _discovering = true;
+      _discoverError = null;
+    });
     try {
-      final discovered = await ref.read(platformServicesProvider).discoverReposFromPRs(token);
+      final discovered = await ref
+          .read(platformServicesProvider)
+          .discoverReposFromPRs(token);
       if (!mounted) return;
       setState(() {
         for (final repo in discovered) {
           // Keep existing toggle state; default new ones to monitored
-          _repoConfigs.putIfAbsent(repo, () => const RepoConfig(prEnabled: true));
+          _repoConfigs.putIfAbsent(
+            repo,
+            () => const RepoConfig(prEnabled: true),
+          );
         }
         _discovering = false;
       });
@@ -114,8 +127,9 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       appBar: AppBar(
         title: const Text('Settings'),
         leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
-            onPressed: () => context.canPop() ? context.pop() : context.go('/')),
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.canPop() ? context.pop() : context.go('/'),
+        ),
       ),
       body: configAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
@@ -123,8 +137,10 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text('Could not load config: $e',
-                  style: TextStyle(color: Colors.red.shade400, fontSize: 13)),
+              Text(
+                'Could not load config: $e',
+                style: TextStyle(color: Colors.red.shade400, fontSize: 13),
+              ),
               const SizedBox(height: 12),
               ElevatedButton(
                 onPressed: () => ref.invalidate(configNotifierProvider),
@@ -141,7 +157,11 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     );
   }
 
-  Widget _buildForm(BuildContext context, AppConfig config, bool daemonRunning) {
+  Widget _buildForm(
+    BuildContext context,
+    AppConfig config,
+    bool daemonRunning,
+  ) {
     return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
       child: ConstrainedBox(
@@ -157,7 +177,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             const SizedBox(height: 20),
             _retentionSection(),
             const SizedBox(height: 20),
-            _issueTrackingSection(),
+            _issueTrackingSection(config),
             const SizedBox(height: 20),
             _developSection(config),
             const SizedBox(height: 28),
@@ -191,7 +211,9 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
               helperText: 'Required scopes: repo, read:org',
               border: const OutlineInputBorder(),
               suffixIcon: IconButton(
-                icon: Icon(_obscureToken ? Icons.visibility : Icons.visibility_off),
+                icon: Icon(
+                  _obscureToken ? Icons.visibility : Icons.visibility_off,
+                ),
                 onPressed: () => setState(() => _obscureToken = !_obscureToken),
               ),
             ),
@@ -221,7 +243,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             if (_discovering) ...[
               const SizedBox(width: 10),
               const SizedBox(
-                width: 14, height: 14,
+                width: 14,
+                height: 14,
                 child: CircularProgressIndicator(strokeWidth: 2),
               ),
             ],
@@ -248,9 +271,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
 
   Widget _repoList() {
     final sorted = _repoConfigs.keys.toList()..sort();
-    return Column(
-      children: sorted.map((repo) => _repoTile(repo)).toList(),
-    );
+    return Column(children: sorted.map((repo) => _repoTile(repo)).toList());
   }
 
   Widget _repoTile(String repo) {
@@ -264,20 +285,27 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             _repoConfigs[repo] = rc.copyWith(prEnabled: v);
           }),
         ),
-        title: Text(repo,
-            style: TextStyle(
-              color: rc.isMonitored ? null : Colors.grey,
-              fontWeight: rc.isMonitored ? FontWeight.w600 : FontWeight.normal,
-            )),
+        title: Text(
+          repo,
+          style: TextStyle(
+            color: rc.isMonitored ? null : Colors.grey,
+            fontWeight: rc.isMonitored ? FontWeight.w600 : FontWeight.normal,
+          ),
+        ),
         subtitle: rc.hasAiOverride
-            ? Text('AI: ${rc.aiPrimary ?? "global"}', style: const TextStyle(fontSize: 12))
+            ? Text(
+                'AI: ${rc.aiPrimary ?? "global"}',
+                style: const TextStyle(fontSize: 12),
+              )
             : null,
         childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
         children: [
           const Divider(height: 1),
           const SizedBox(height: 10),
-          const Text('AI overrides for this repo',
-              style: TextStyle(fontSize: 12, color: Colors.grey)),
+          const Text(
+            'AI overrides for this repo',
+            style: TextStyle(fontSize: 12, color: Colors.grey),
+          ),
           const SizedBox(height: 8),
           Row(
             children: [
@@ -321,8 +349,13 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         isDense: true,
       ),
       items: [
-        const DropdownMenuItem<String?>(value: null, child: Text('Global (no override)')),
-        ..._aiOptions.map((v) => DropdownMenuItem<String?>(value: v, child: Text(v))),
+        const DropdownMenuItem<String?>(
+          value: null,
+          child: Text('Global (no override)'),
+        ),
+        ..._aiOptions.map(
+          (v) => DropdownMenuItem<String?>(value: v, child: Text(v)),
+        ),
       ],
       onChanged: onChanged,
     );
@@ -343,9 +376,12 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             helperText: 'How often to check GitHub for new review requests',
             border: OutlineInputBorder(),
           ),
-          items: ['1m', '5m', '30m', '1h']
-              .map((v) => DropdownMenuItem(value: v, child: Text(v)))
-              .toList(),
+          items: [
+            '1m',
+            '5m',
+            '30m',
+            '1h',
+          ].map((v) => DropdownMenuItem(value: v, child: Text(v))).toList(),
           onChanged: (v) => setState(() => _pollInterval = v!),
         ),
       ],
@@ -366,7 +402,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             border: OutlineInputBorder(),
           ),
           keyboardType: TextInputType.number,
-          onChanged: (v) => setState(() => _retentionDays = int.tryParse(v) ?? 90),
+          onChanged: (v) =>
+              setState(() => _retentionDays = int.tryParse(v) ?? 90),
         ),
       ],
     );
@@ -374,13 +411,14 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
 
   // ── Issue tracking ──────────────────────────────────────────────────────
 
-  Widget _issueTrackingSection() {
+  Widget _issueTrackingSection(AppConfig config) {
     return _settingsCard('Issue Tracking', [
       SwitchListTile(
-        title: const Text('Triage issues',
-            style: TextStyle(fontSize: 13)),
-        subtitle: const Text('AI reviews and triages GitHub issues',
-            style: TextStyle(fontSize: 11)),
+        title: const Text('Triage issues', style: TextStyle(fontSize: 13)),
+        subtitle: const Text(
+          'AI reviews and triages GitHub issues',
+          style: TextStyle(fontSize: 11),
+        ),
         dense: true,
         contentPadding: EdgeInsets.zero,
         value: _issueTracking.enabled,
@@ -454,7 +492,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           label: 'Organizations',
           helper: 'Limit to issues from these orgs (empty = all monitored)',
           selectedValues: _issueTracking.organizations,
-          availableOptions: const [],
+          availableOptions: _knownOrganizationOptions(config),
           onChanged: (v) => setState(() {
             _issueTracking = _issueTracking.copyWith(organizations: v ?? []);
           }),
@@ -464,7 +502,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           label: 'Assignees',
           helper: 'Only process issues assigned to these users (empty = any)',
           selectedValues: _issueTracking.assignees,
-          availableOptions: const [],
+          availableOptions: config.knownGitHubUsers,
           onChanged: (v) => setState(() {
             _issueTracking = _issueTracking.copyWith(assignees: v ?? []);
           }),
@@ -478,6 +516,15 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         ),
       ],
     ]);
+  }
+
+  List<String> _knownOrganizationOptions(AppConfig config) {
+    final orgs = <String>{...config.knownOrganizations};
+    for (final repo in _repoConfigs.keys) {
+      final slash = repo.indexOf('/');
+      if (slash > 0) orgs.add(repo.substring(0, slash));
+    }
+    return orgs.where((o) => o.trim().isNotEmpty).toList()..sort();
   }
 
   List<String> _globalPRReviewers = [];
@@ -500,10 +547,14 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     final hasLabels = _issueTracking.developLabels.isNotEmpty;
     return _settingsCard('Develop', [
       SwitchListTile(
-        title: const Text('Auto-implement issues',
-            style: TextStyle(fontSize: 13)),
-        subtitle: const Text('Issues with develop labels get a branch + PR',
-            style: TextStyle(fontSize: 11)),
+        title: const Text(
+          'Auto-implement issues',
+          style: TextStyle(fontSize: 13),
+        ),
+        subtitle: const Text(
+          'Issues with develop labels get a branch + PR',
+          style: TextStyle(fontSize: 11),
+        ),
         dense: true,
         contentPadding: EdgeInsets.zero,
         value: hasLabels,
@@ -511,7 +562,9 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           if (v) {
             // Give it a default label so the section stays enabled
             if (_issueTracking.developLabels.isEmpty) {
-              _issueTracking = _issueTracking.copyWith(developLabels: ['develop']);
+              _issueTracking = _issueTracking.copyWith(
+                developLabels: ['develop'],
+              );
             }
           } else {
             _issueTracking = _issueTracking.copyWith(developLabels: []);
@@ -562,14 +615,21 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         const SizedBox(height: 10),
         Container(
           decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+            color: Theme.of(
+              context,
+            ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
             borderRadius: BorderRadius.circular(6),
           ),
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
           child: SwitchListTile(
-            title: const Text('Create as draft', style: TextStyle(fontSize: 11)),
-            subtitle: Text('PRs are created as drafts by default',
-                style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+            title: const Text(
+              'Create as draft',
+              style: TextStyle(fontSize: 11),
+            ),
+            subtitle: Text(
+              'PRs are created as drafts by default',
+              style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+            ),
             dense: true,
             contentPadding: EdgeInsets.zero,
             value: _globalPRDraft,
@@ -594,10 +654,14 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     required ValueChanged<String?> onChanged,
   }) {
     final agents = ref.watch(agentsProvider).valueOrNull ?? [];
-    final effective = (value != null && agents.any((a) => a.id == value)) ? value : null;
+    final effective = (value != null && agents.any((a) => a.id == value))
+        ? value
+        : null;
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        color: Theme.of(
+          context,
+        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(6),
       ),
       padding: const EdgeInsets.all(10),
@@ -606,9 +670,15 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         children: [
           Row(
             children: [
-              Text(label, style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
+              Text(
+                label,
+                style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+              ),
               const Spacer(),
-              Text('global', style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+              Text(
+                'global',
+                style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+              ),
             ],
           ),
           const SizedBox(height: 6),
@@ -626,18 +696,24 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
                 value: null,
                 child: Text('default', style: TextStyle(fontSize: 12)),
               ),
-              ...agents.map((a) => DropdownMenuItem<String?>(
-                    value: a.id,
-                    child: Text(a.name.isNotEmpty ? a.name : a.id,
-                        style: const TextStyle(fontSize: 12)),
-                  )),
+              ...agents.map(
+                (a) => DropdownMenuItem<String?>(
+                  value: a.id,
+                  child: Text(
+                    a.name.isNotEmpty ? a.name : a.id,
+                    style: const TextStyle(fontSize: 12),
+                  ),
+                ),
+              ),
             ],
             onChanged: onChanged,
           ),
           Padding(
             padding: const EdgeInsets.only(top: 4),
-            child: Text(helper,
-                style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+            child: Text(
+              helper,
+              style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+            ),
           ),
         ],
       ),
@@ -654,8 +730,13 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(title, style: const TextStyle(
-                  fontWeight: FontWeight.w600, fontSize: 15)),
+              Text(
+                title,
+                style: const TextStyle(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 15,
+                ),
+              ),
               const SizedBox(height: 12),
               ...children,
             ],
@@ -682,14 +763,18 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             try {
               final token = _tokenController.text.trim();
               if (token.isNotEmpty && !_tokenFromGh) {
-                await ref.read(platformServicesProvider).storeGitHubToken(token);
+                await ref
+                    .read(platformServicesProvider)
+                    .storeGitHubToken(token);
                 // Invalidate the cached token so the ApiClient re-reads it on the next request.
                 ref.read(apiClientProvider).clearTokenCache();
               }
               await ref.read(configNotifierProvider.notifier).save(updated);
               if (context.mounted) showToast(context, 'Settings saved');
             } catch (e) {
-              if (context.mounted) showToast(context, 'Error: $e', isError: true);
+              if (context.mounted) {
+                showToast(context, 'Error: $e', isError: true);
+              }
             }
           },
           child: const Text('Save'),
@@ -701,32 +786,48 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       width: double.infinity,
       child: FilledButton.icon(
         icon: isLoading
-            ? const SizedBox(width: 16, height: 16,
-                child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+            ? const SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: Colors.white,
+                ),
+              )
             : const Icon(Icons.rocket_launch),
         label: Text(isLoading ? 'Starting…' : 'Save and start Heimdallm'),
-        onPressed: isLoading ? null : () async {
-          final updated = _buildConfig(base);
-          final token = _tokenController.text.trim();
-          if (!_tokenFromGh && token.isEmpty) {
-            showToast(context, 'GitHub token is required', isError: true);
-            return;
-          }
-          await ref.read(configNotifierProvider.notifier).saveAndStartDaemon(
-            token: _tokenFromGh ? (_tokenController.text.trim()) : token,
-            config: updated,
-            daemonBinaryPath: ref.read(platformServicesProvider).defaultDaemonBinaryPath() ?? '',
-          );
-          if (context.mounted) {
-            final state = ref.read(configNotifierProvider);
-            if (state.hasError) {
-              showToast(context, '${state.error}', isError: true);
-            } else {
-              ref.invalidate(daemonHealthProvider);
-              context.canPop() ? context.pop() : context.go('/');
-            }
-          }
-        },
+        onPressed: isLoading
+            ? null
+            : () async {
+                final updated = _buildConfig(base);
+                final token = _tokenController.text.trim();
+                if (!_tokenFromGh && token.isEmpty) {
+                  showToast(context, 'GitHub token is required', isError: true);
+                  return;
+                }
+                await ref
+                    .read(configNotifierProvider.notifier)
+                    .saveAndStartDaemon(
+                      token: _tokenFromGh
+                          ? (_tokenController.text.trim())
+                          : token,
+                      config: updated,
+                      daemonBinaryPath:
+                          ref
+                              .read(platformServicesProvider)
+                              .defaultDaemonBinaryPath() ??
+                          '',
+                    );
+                if (context.mounted) {
+                  final state = ref.read(configNotifierProvider);
+                  if (state.hasError) {
+                    showToast(context, '${state.error}', isError: true);
+                  } else {
+                    ref.invalidate(daemonHealthProvider);
+                    context.canPop() ? context.pop() : context.go('/');
+                  }
+                }
+              },
       ),
     );
   }
@@ -757,13 +858,17 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         border: Border.all(color: Colors.orange.shade700),
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Row(children: [
-        Icon(Icons.info_outline, color: Colors.orange.shade700),
-        const SizedBox(width: 8),
-        const Expanded(
-          child: Text('Heimdallm is not running. Configure and tap "Save and start".'),
-        ),
-      ]),
+      child: Row(
+        children: [
+          Icon(Icons.info_outline, color: Colors.orange.shade700),
+          const SizedBox(width: 8),
+          const Expanded(
+            child: Text(
+              'Heimdallm is not running. Configure and tap "Save and start".',
+            ),
+          ),
+        ],
+      ),
     ),
   );
 
@@ -775,19 +880,27 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       border: Border.all(color: color.withValues(alpha: 0.4)),
       borderRadius: BorderRadius.circular(6),
     ),
-    child: Row(children: [
-      Icon(icon, size: 16, color: color),
-      const SizedBox(width: 6),
-      Expanded(child: Text(text, style: TextStyle(fontSize: 13, color: color))),
-    ]),
+    child: Row(
+      children: [
+        Icon(icon, size: 16, color: color),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(text, style: TextStyle(fontSize: 13, color: color)),
+        ),
+      ],
+    ),
   );
 
   Widget _sectionHeader(String title) => Padding(
     padding: const EdgeInsets.only(bottom: 10),
-    child: Text(title, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 15)),
+    child: Text(
+      title,
+      style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+    ),
   );
 
   Widget _sectionHeaderInline(String title) => Text(
-    title, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+    title,
+    style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
   );
 }

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -318,6 +318,36 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                     onReset: () => _resetField('issue_tracking/default_action'),
                   ),
                   const SizedBox(height: 10),
+                  AutocompleteChipField(
+                    label: 'Organizations',
+                    helper: 'GitHub org names to filter issues',
+                    selectedValues:
+                        _config.issueOrganizations ??
+                        appConfig.issueTracking.organizations,
+                    availableOptions: appConfig.knownOrganizations,
+                    isOverridden: _config.issueOrganizations != null,
+                    globalHint: _joinList(
+                      appConfig.issueTracking.organizations,
+                    ),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issueOrganizations: v)),
+                    onReset: () => _resetField('issue_tracking/organizations'),
+                  ),
+                  const SizedBox(height: 10),
+                  AutocompleteChipField(
+                    label: 'Assignees',
+                    helper: 'Only process issues assigned to these users',
+                    selectedValues:
+                        _config.issueAssignees ??
+                        appConfig.issueTracking.assignees,
+                    availableOptions: appConfig.knownGitHubUsers,
+                    isOverridden: _config.issueAssignees != null,
+                    globalHint: _joinList(appConfig.issueTracking.assignees),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issueAssignees: v)),
+                    onReset: () => _resetField('issue_tracking/assignees'),
+                  ),
+                  const SizedBox(height: 10),
                   OverrideDropdown(
                     label: 'Prompt',
                     globalValue: appConfig.globalIssuePrompt.isEmpty

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -97,6 +97,24 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
     if (old.localDir != updated.localDir) {
       diff['local_dir'] = updated.localDir ?? '';
     }
+    if (old.triageOwner != updated.triageOwner) {
+      diff['triage_owner'] = updated.triageOwner ?? '';
+    }
+    if (old.cloneDir != updated.cloneDir) {
+      diff['clone_dir'] = updated.cloneDir ?? '';
+    }
+    if (old.autoPromoteTriage != updated.autoPromoteTriage &&
+        updated.autoPromoteTriage != null) {
+      diff['auto_promote_triage'] = updated.autoPromoteTriage!;
+    }
+    if (old.autoPromoteRefinement != updated.autoPromoteRefinement &&
+        updated.autoPromoteRefinement != null) {
+      diff['auto_promote_refinement'] = updated.autoPromoteRefinement!;
+    }
+    if (old.generatePRDescription != updated.generatePRDescription &&
+        updated.generatePRDescription != null) {
+      diff['generate_pr_description'] = updated.generatePRDescription!;
+    }
     if (old.issuePromptId != updated.issuePromptId) {
       diff['issue_prompt'] = updated.issuePromptId ?? '';
     }
@@ -312,6 +330,66 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                     onReset: () => _resetField('issue_prompt'),
                   ),
                 ], accent: FeaturePalette.issueTracking),
+                _sectionCard('Pipeline', [
+                  OverrideTextField(
+                    label: 'Triage owner',
+                    globalValue: appConfig.globalTriageOwner,
+                    overrideValue: _config.triageOwner,
+                    onChanged: (v) => _update(_config.copyWith(triageOwner: v)),
+                    onReset: () => _resetField('triage_owner'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideTextField(
+                    label: 'Clone directory',
+                    globalValue: appConfig.globalCloneDir,
+                    overrideValue: _config.cloneDir,
+                    onChanged: (v) => _update(_config.copyWith(cloneDir: v)),
+                    onReset: () => _resetField('clone_dir'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Auto-promote triage',
+                    globalValue: (appConfig.globalAutoPromoteTriage ?? false)
+                        .toString(),
+                    overrideValue: _config.autoPromoteTriage?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        autoPromoteTriage: v != null ? v == 'true' : null,
+                      ),
+                    ),
+                    onReset: () => _resetField('auto_promote_triage'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Auto-promote refinement',
+                    globalValue:
+                        (appConfig.globalAutoPromoteRefinement ?? false)
+                            .toString(),
+                    overrideValue: _config.autoPromoteRefinement?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        autoPromoteRefinement: v != null ? v == 'true' : null,
+                      ),
+                    ),
+                    onReset: () => _resetField('auto_promote_refinement'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Generate PR description',
+                    globalValue: appConfig.globalGeneratePRDescription
+                        .toString(),
+                    overrideValue: _config.generatePRDescription?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        generatePRDescription: v != null ? v == 'true' : null,
+                      ),
+                    ),
+                    onReset: () => _resetField('generate_pr_description'),
+                  ),
+                ]),
                 _sectionCard('Develop', [
                   Row(
                     children: [

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -1,0 +1,434 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/models/agent.dart';
+import '../../core/models/config_model.dart';
+import '../../shared/widgets/autocomplete_chip_field.dart';
+import '../../shared/widgets/override_field.dart';
+import '../../shared/widgets/toast.dart';
+import '../agents/agents_screen.dart' show agentsProvider;
+import '../config/config_providers.dart';
+import '../dashboard/dashboard_providers.dart';
+import '../repositories/widgets/feature_palette.dart';
+import '../repositories/widgets/feature_switch.dart';
+
+class OrgDetailScreen extends ConsumerStatefulWidget {
+  final String orgName;
+  const OrgDetailScreen({super.key, required this.orgName});
+
+  @override
+  ConsumerState<OrgDetailScreen> createState() => _OrgDetailScreenState();
+}
+
+class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
+  OrgConfig _config = const OrgConfig();
+  bool _initialized = false;
+  Timer? _debounce;
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  void _initFrom(AppConfig config) {
+    if (_initialized) return;
+    _initialized = true;
+    _config = config.orgConfigs[widget.orgName] ?? const OrgConfig();
+  }
+
+  void _update(OrgConfig updated) {
+    final previous = _config;
+    setState(() => _config = updated);
+    _debounce?.cancel();
+    _debounce = Timer(
+      const Duration(milliseconds: 800),
+      () => _autoSave(previous),
+    );
+  }
+
+  Future<void> _autoSave(OrgConfig previous) async {
+    final diff = _computeOrgDiff(previous, _config);
+    if (diff.isEmpty) return;
+    try {
+      final freshJson = await ref
+          .read(apiClientProvider)
+          .patchOrgConfig(widget.orgName, diff);
+      ref.read(configNotifierProvider.notifier).updateFromServer(freshJson);
+      if (mounted) showToast(context, 'Saved');
+    } catch (e) {
+      if (mounted) showToast(context, 'Error: $e', isError: true);
+    }
+  }
+
+  Future<void> _resetField(String fieldPath) async {
+    try {
+      final freshJson = await ref
+          .read(apiClientProvider)
+          .deleteOrgField(widget.orgName, fieldPath);
+      ref.read(configNotifierProvider.notifier).updateFromServer(freshJson);
+      final freshConfig = AppConfig.fromJson(freshJson);
+      setState(() {
+        _config = freshConfig.orgConfigs[widget.orgName] ?? const OrgConfig();
+      });
+      if (mounted) showToast(context, 'Reset to global');
+    } catch (e) {
+      if (mounted) showToast(context, 'Error: $e', isError: true);
+    }
+  }
+
+  Map<String, dynamic> _computeOrgDiff(OrgConfig old, OrgConfig updated) {
+    final diff = <String, dynamic>{};
+    if (old.aiPrimary != updated.aiPrimary) {
+      diff['primary'] = updated.aiPrimary ?? '';
+    }
+    if (old.aiFallback != updated.aiFallback) {
+      diff['fallback'] = updated.aiFallback ?? '';
+    }
+    if (old.reviewMode != updated.reviewMode) {
+      diff['review_mode'] = updated.reviewMode ?? '';
+    }
+    if (old.promptId != updated.promptId) {
+      diff['prompt'] = updated.promptId ?? '';
+    }
+    if (old.localDir != updated.localDir) {
+      diff['local_dir'] = updated.localDir ?? '';
+    }
+    if (old.issuePromptId != updated.issuePromptId) {
+      diff['issue_prompt'] = updated.issuePromptId ?? '';
+    }
+    if (old.developPromptId != updated.developPromptId) {
+      diff['implement_prompt'] = updated.developPromptId ?? '';
+    }
+    if (old.prAssignee != updated.prAssignee) {
+      diff['pr_assignee'] = updated.prAssignee ?? '';
+    }
+    if (old.prDraft != updated.prDraft && updated.prDraft != null) {
+      diff['pr_draft'] = updated.prDraft!;
+    }
+    if (!_listsEqual(old.prReviewers, updated.prReviewers)) {
+      diff['pr_reviewers'] = updated.prReviewers ?? <String>[];
+    }
+    if (!_listsEqual(old.prLabels, updated.prLabels)) {
+      diff['pr_labels'] = updated.prLabels ?? <String>[];
+    }
+
+    final itDiff = <String, dynamic>{};
+    if (old.itEnabled != updated.itEnabled && updated.itEnabled != null) {
+      itDiff['enabled'] = updated.itEnabled!;
+    }
+    if (old.devEnabled != updated.devEnabled && updated.devEnabled != null) {
+      itDiff['develop_enabled'] = updated.devEnabled!;
+    }
+    if (old.issueFilterMode != updated.issueFilterMode) {
+      itDiff['filter_mode'] = updated.issueFilterMode ?? '';
+    }
+    if (old.issueDefaultAction != updated.issueDefaultAction) {
+      itDiff['default_action'] = updated.issueDefaultAction ?? '';
+    }
+    if (!_listsEqual(old.reviewOnlyLabels, updated.reviewOnlyLabels)) {
+      itDiff['review_only_labels'] = updated.reviewOnlyLabels ?? <String>[];
+    }
+    if (!_listsEqual(old.developLabels, updated.developLabels)) {
+      itDiff['develop_labels'] = updated.developLabels ?? <String>[];
+    }
+    if (!_listsEqual(old.skipLabels, updated.skipLabels)) {
+      itDiff['skip_labels'] = updated.skipLabels ?? <String>[];
+    }
+    if (!_listsEqual(old.issueOrganizations, updated.issueOrganizations)) {
+      itDiff['organizations'] = updated.issueOrganizations ?? <String>[];
+    }
+    if (!_listsEqual(old.issueAssignees, updated.issueAssignees)) {
+      itDiff['assignees'] = updated.issueAssignees ?? <String>[];
+    }
+    if (itDiff.isNotEmpty) diff['issue_tracking'] = itDiff;
+    return diff;
+  }
+
+  bool _listsEqual(List<String>? a, List<String>? b) {
+    if (a == null && b == null) return true;
+    if (a == null || b == null) return false;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+
+  String _joinList(List<String>? list) => list?.join(', ') ?? '';
+
+  @override
+  Widget build(BuildContext context) {
+    final configAsync = ref.watch(configNotifierProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.orgName),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.canPop() ? context.pop() : context.go('/'),
+        ),
+      ),
+      body: configAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => const Center(child: Text('Could not load config')),
+        data: (appConfig) {
+          _initFrom(appConfig);
+          final prompts =
+              ref.watch(agentsProvider).valueOrNull ?? <ReviewPrompt>[];
+          final promptOptions = prompts.map((p) => p.id).toList();
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                _sectionCard('General', [
+                  OverrideTextField(
+                    label: 'Local directory',
+                    globalValue: '',
+                    overrideValue: _config.localDir,
+                    onChanged: (v) => _update(_config.copyWith(localDir: v)),
+                    onReset: () => _resetField('local_dir'),
+                  ),
+                ]),
+                _sectionCard('PR Review', [
+                  OverrideDropdown(
+                    label: 'Primary',
+                    globalValue: appConfig.aiPrimary,
+                    overrideValue: _config.aiPrimary,
+                    options: const ['claude', 'gemini', 'codex'],
+                    onChanged: (v) => _update(_config.copyWith(aiPrimary: v)),
+                    onReset: () => _resetField('primary'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Fallback',
+                    globalValue: appConfig.aiFallback.isEmpty
+                        ? 'none'
+                        : appConfig.aiFallback,
+                    overrideValue: _config.aiFallback,
+                    options: const ['claude', 'gemini', 'codex'],
+                    onChanged: (v) => _update(_config.copyWith(aiFallback: v)),
+                    onReset: () => _resetField('fallback'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Review mode',
+                    globalValue: appConfig.reviewMode,
+                    overrideValue: _config.reviewMode,
+                    options: const ['single', 'multi'],
+                    onChanged: (v) => _update(_config.copyWith(reviewMode: v)),
+                    onReset: () => _resetField('review_mode'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Prompt',
+                    globalValue: 'default',
+                    overrideValue: _config.promptId,
+                    options: promptOptions,
+                    onChanged: (v) => _update(_config.copyWith(promptId: v)),
+                    onReset: () => _resetField('prompt'),
+                  ),
+                ], accent: FeaturePalette.prReview),
+                _sectionCard('Issue Tracking', [
+                  Row(
+                    children: [
+                      const Expanded(
+                        child: Text(
+                          'Triage issues',
+                          style: TextStyle(fontSize: 13),
+                        ),
+                      ),
+                      FeatureSwitch(
+                        feature: Feature.issueTracking,
+                        value:
+                            _config.itEnabled ??
+                            appConfig.issueTracking.enabled,
+                        onChanged: (v) =>
+                            _update(_config.copyWith(itEnabled: v)),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  AutocompleteChipField(
+                    label: 'Review-only labels',
+                    selectedValues:
+                        _config.reviewOnlyLabels ??
+                        appConfig.issueTracking.reviewOnlyLabels,
+                    availableOptions: const <String>[],
+                    isOverridden: _config.reviewOnlyLabels != null,
+                    globalHint: _joinList(
+                      appConfig.issueTracking.reviewOnlyLabels,
+                    ),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(reviewOnlyLabels: v)),
+                    onReset: () =>
+                        _resetField('issue_tracking/review_only_labels'),
+                  ),
+                  const SizedBox(height: 10),
+                  AutocompleteChipField(
+                    label: 'Skip labels',
+                    selectedValues:
+                        _config.skipLabels ??
+                        appConfig.issueTracking.skipLabels,
+                    availableOptions: const <String>[],
+                    isOverridden: _config.skipLabels != null,
+                    globalHint: _joinList(appConfig.issueTracking.skipLabels),
+                    onChanged: (v) => _update(_config.copyWith(skipLabels: v)),
+                    onReset: () => _resetField('issue_tracking/skip_labels'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Filter mode',
+                    globalValue: appConfig.issueTracking.filterMode,
+                    overrideValue: _config.issueFilterMode,
+                    options: const ['exclusive', 'inclusive'],
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issueFilterMode: v)),
+                    onReset: () => _resetField('issue_tracking/filter_mode'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Default action',
+                    globalValue: appConfig.issueTracking.defaultAction,
+                    overrideValue: _config.issueDefaultAction,
+                    options: const ['ignore', 'review_only'],
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issueDefaultAction: v)),
+                    onReset: () => _resetField('issue_tracking/default_action'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Prompt',
+                    globalValue: appConfig.globalIssuePrompt.isEmpty
+                        ? 'default'
+                        : appConfig.globalIssuePrompt,
+                    overrideValue: _config.issuePromptId,
+                    options: promptOptions,
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issuePromptId: v)),
+                    onReset: () => _resetField('issue_prompt'),
+                  ),
+                ], accent: FeaturePalette.issueTracking),
+                _sectionCard('Develop', [
+                  Row(
+                    children: [
+                      const Expanded(
+                        child: Text(
+                          'Auto-implement issues',
+                          style: TextStyle(fontSize: 13),
+                        ),
+                      ),
+                      FeatureSwitch(
+                        feature: Feature.develop,
+                        value: _config.devEnabled ?? false,
+                        onChanged: (v) =>
+                            _update(_config.copyWith(devEnabled: v)),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  AutocompleteChipField(
+                    label: 'Develop labels',
+                    selectedValues:
+                        _config.developLabels ??
+                        appConfig.issueTracking.developLabels,
+                    availableOptions: const <String>[],
+                    isOverridden: _config.developLabels != null,
+                    globalHint: _joinList(
+                      appConfig.issueTracking.developLabels,
+                    ),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(developLabels: v)),
+                    onReset: () => _resetField('issue_tracking/develop_labels'),
+                  ),
+                  const SizedBox(height: 10),
+                  AutocompleteChipField(
+                    label: 'PR Reviewers',
+                    selectedValues:
+                        _config.prReviewers ?? appConfig.globalPRReviewers,
+                    availableOptions: const <String>[],
+                    isOverridden: _config.prReviewers != null,
+                    globalHint: _joinList(appConfig.globalPRReviewers),
+                    onChanged: (v) => _update(_config.copyWith(prReviewers: v)),
+                    onReset: () => _resetField('pr_reviewers'),
+                  ),
+                  const SizedBox(height: 10),
+                  AutocompleteChipField(
+                    label: 'PR Labels',
+                    selectedValues:
+                        _config.prLabels ?? appConfig.globalPRLabels,
+                    availableOptions: const <String>[],
+                    isOverridden: _config.prLabels != null,
+                    globalHint: _joinList(appConfig.globalPRLabels),
+                    onChanged: (v) => _update(_config.copyWith(prLabels: v)),
+                    onReset: () => _resetField('pr_labels'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideTextField(
+                    label: 'PR Assignee',
+                    globalValue: appConfig.globalPRAssignee,
+                    overrideValue: _config.prAssignee,
+                    onChanged: (v) => _update(_config.copyWith(prAssignee: v)),
+                    onReset: () => _resetField('pr_assignee'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Draft',
+                    globalValue: appConfig.globalPRDraft.toString(),
+                    overrideValue: _config.prDraft?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(
+                      _config.copyWith(prDraft: v != null ? v == 'true' : null),
+                    ),
+                    onReset: () => _resetField('pr_draft'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Prompt',
+                    globalValue: appConfig.globalImplementPrompt.isEmpty
+                        ? 'default'
+                        : appConfig.globalImplementPrompt,
+                    overrideValue: _config.developPromptId,
+                    options: promptOptions,
+                    onChanged: (v) =>
+                        _update(_config.copyWith(developPromptId: v)),
+                    onReset: () => _resetField('implement_prompt'),
+                  ),
+                ], accent: FeaturePalette.develop),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _sectionCard(String title, List<Widget> children, {Color? accent}) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(10),
+        side: accent != null
+            ? BorderSide(color: accent, width: 2)
+            : BorderSide.none,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            ...children,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -68,7 +68,10 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
     final previous = _config;
     setState(() => _config = updated);
     _debounce?.cancel();
-    _debounce = Timer(const Duration(milliseconds: 800), () => _autoSave(previous));
+    _debounce = Timer(
+      const Duration(milliseconds: 800),
+      () => _autoSave(previous),
+    );
   }
 
   Future<void> _autoSave(RepoConfig previous) async {
@@ -84,16 +87,22 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
       if (monitoringChanged) {
         final current = ref.read(configNotifierProvider).valueOrNull;
         if (current != null) {
-          final updatedRepos = Map<String, RepoConfig>.from(current.repoConfigs);
+          final updatedRepos = Map<String, RepoConfig>.from(
+            current.repoConfigs,
+          );
           updatedRepos[widget.repoName] = _config;
-          final monitored = updatedRepos.entries
-              .where((e) => e.value.isMonitored)
-              .map((e) => e.key)
-              .toList()..sort();
-          final nonMonitored = updatedRepos.entries
-              .where((e) => !e.value.isMonitored)
-              .map((e) => e.key)
-              .toList()..sort();
+          final monitored =
+              updatedRepos.entries
+                  .where((e) => e.value.isMonitored)
+                  .map((e) => e.key)
+                  .toList()
+                ..sort();
+          final nonMonitored =
+              updatedRepos.entries
+                  .where((e) => !e.value.isMonitored)
+                  .map((e) => e.key)
+                  .toList()
+                ..sort();
           lastResponse = await api.patchConfig({
             'github': {
               'repositories': monitored,
@@ -104,7 +113,9 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
       }
 
       if (lastResponse != null) {
-        ref.read(configNotifierProvider.notifier).updateFromServer(lastResponse);
+        ref
+            .read(configNotifierProvider.notifier)
+            .updateFromServer(lastResponse);
       }
       _previousConfig = _config;
       if (mounted) showToast(context, 'Saved');
@@ -120,7 +131,8 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
       ref.read(configNotifierProvider.notifier).updateFromServer(freshJson);
       final freshConfig = AppConfig.fromJson(freshJson);
       setState(() {
-        _config = freshConfig.repoConfigs[widget.repoName] ?? const RepoConfig();
+        _config =
+            freshConfig.repoConfigs[widget.repoName] ?? const RepoConfig();
         _previousConfig = _config;
       });
       if (mounted) showToast(context, 'Reset to global');
@@ -131,14 +143,33 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
 
   Map<String, dynamic> _computeRepoDiff(RepoConfig old, RepoConfig updated) {
     final diff = <String, dynamic>{};
-    if (old.aiPrimary != updated.aiPrimary) diff['primary'] = updated.aiPrimary ?? '';
-    if (old.aiFallback != updated.aiFallback) diff['fallback'] = updated.aiFallback ?? '';
-    if (old.reviewMode != updated.reviewMode) diff['review_mode'] = updated.reviewMode ?? '';
-    if (old.promptId != updated.promptId) diff['prompt'] = updated.promptId ?? '';
-    if (old.localDir != updated.localDir) diff['local_dir'] = updated.localDir ?? '';
-    if (old.prAssignee != updated.prAssignee) diff['pr_assignee'] = updated.prAssignee ?? '';
-    if (old.prDraft != updated.prDraft && updated.prDraft != null) diff['pr_draft'] = updated.prDraft!;
-    if (old.developPromptId != updated.developPromptId) diff['implement_prompt'] = updated.developPromptId ?? '';
+    if (old.aiPrimary != updated.aiPrimary) {
+      diff['primary'] = updated.aiPrimary ?? '';
+    }
+    if (old.aiFallback != updated.aiFallback) {
+      diff['fallback'] = updated.aiFallback ?? '';
+    }
+    if (old.reviewMode != updated.reviewMode) {
+      diff['review_mode'] = updated.reviewMode ?? '';
+    }
+    if (old.promptId != updated.promptId) {
+      diff['prompt'] = updated.promptId ?? '';
+    }
+    if (old.localDir != updated.localDir) {
+      diff['local_dir'] = updated.localDir ?? '';
+    }
+    if (old.prAssignee != updated.prAssignee) {
+      diff['pr_assignee'] = updated.prAssignee ?? '';
+    }
+    if (old.prDraft != updated.prDraft && updated.prDraft != null) {
+      diff['pr_draft'] = updated.prDraft!;
+    }
+    if (old.developPromptId != updated.developPromptId) {
+      diff['implement_prompt'] = updated.developPromptId ?? '';
+    }
+    if (old.issuePromptId != updated.issuePromptId) {
+      diff['issue_prompt'] = updated.issuePromptId ?? '';
+    }
 
     if (!_listsEqual(old.prReviewers, updated.prReviewers)) {
       diff['pr_reviewers'] = updated.prReviewers ?? <String>[];
@@ -159,9 +190,6 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
     }
     if (old.issueDefaultAction != updated.issueDefaultAction) {
       itDiff['default_action'] = updated.issueDefaultAction ?? '';
-    }
-    if (old.issuePromptId != updated.issuePromptId) {
-      itDiff['issue_prompt'] = updated.issuePromptId ?? '';
     }
     if (!_listsEqual(old.reviewOnlyLabels, updated.reviewOnlyLabels)) {
       itDiff['review_only_labels'] = updated.reviewOnlyLabels ?? <String>[];
@@ -250,18 +278,22 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
         title: Text(widget.repoName),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () =>
-              context.canPop() ? context.pop() : context.go('/'),
+          onPressed: () => context.canPop() ? context.pop() : context.go('/'),
         ),
       ),
       body: configAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (_, __) =>
-            const Center(child: Text('Could not load config')),
+        error: (_, __) => const Center(child: Text('Could not load config')),
         data: (appConfig) {
           _initFrom(appConfig);
           final prompts =
               ref.watch(agentsProvider).valueOrNull ?? <ReviewPrompt>[];
+          final orgName = widget.repoName.contains('/')
+              ? widget.repoName.split('/').first
+              : widget.repoName;
+          final orgConfig = appConfig.orgConfigs[orgName];
+          String source(bool hasOrgValue) =>
+              hasOrgValue ? 'org: $orgName' : 'global';
 
           return SingleChildScrollView(
             padding: const EdgeInsets.all(16),
@@ -269,114 +301,148 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
               children: [
                 // ── Section 1: General ─────────────────────────────────
                 _sectionCard('General', [
-                  const Text('Local directory',
-                      style: TextStyle(fontSize: 12, color: Colors.grey)),
+                  const Text(
+                    'Local directory',
+                    style: TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
                   const SizedBox(height: 4),
                   Text(
                     'When set, the AI agent runs inside this directory and can read all project files.',
-                    style: TextStyle(
-                        fontSize: 11, color: Colors.grey.shade600),
+                    style: TextStyle(fontSize: 11, color: Colors.grey.shade600),
                   ),
                   const SizedBox(height: 8),
                   _LocalDirField(
-                    value: _config.localDir ?? '',
+                    value: _config.localDir ?? orgConfig?.localDir ?? '',
+                    sourceLabel: _config.localDir != null
+                        ? 'repo override'
+                        : source(orgConfig?.localDir != null),
                     detectedDir: appConfig.localDirsDetected[widget.repoName],
-                    onChanged: (dir) => _update(_config.copyWith(
-                        localDir: dir.isEmpty ? null : dir)),
+                    onChanged: (dir) => _update(
+                      _config.copyWith(localDir: dir.isEmpty ? null : dir),
+                    ),
                   ),
                 ]),
 
                 // ── Section 2: PR Review ───────────────────────────────
                 _sectionCard('PR Review', [
-                  Row(children: [
-                    const Expanded(
-                      child: Text('Auto-review PRs',
-                          style: TextStyle(fontSize: 13)),
-                    ),
-                    FeatureSwitch(
-                      feature: Feature.prReview,
-                      value: _config.prEnabled ?? false,
-                      onChanged: (v) =>
-                          _update(_config.copyWith(prEnabled: v)),
-                    ),
-                  ]),
+                  Row(
+                    children: [
+                      const Expanded(
+                        child: Text(
+                          'Auto-review PRs',
+                          style: TextStyle(fontSize: 13),
+                        ),
+                      ),
+                      FeatureSwitch(
+                        feature: Feature.prReview,
+                        value: _config.prEnabled ?? false,
+                        onChanged: (v) =>
+                            _update(_config.copyWith(prEnabled: v)),
+                      ),
+                    ],
+                  ),
                   const SizedBox(height: 6),
                   OverrideDropdown(
                     label: 'Primary',
-                    globalValue: appConfig.aiPrimary,
+                    globalValue: orgConfig?.aiPrimary ?? appConfig.aiPrimary,
+                    inheritedLabel: source(orgConfig?.aiPrimary != null),
                     overrideValue: _config.aiPrimary,
                     options: const ['claude', 'gemini', 'codex'],
-                    onChanged: (v) =>
-                        _update(_config.copyWith(aiPrimary: v)),
+                    onChanged: (v) => _update(_config.copyWith(aiPrimary: v)),
                     onReset: () => _resetField('primary'),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
                     label: 'Fallback',
-                    globalValue: appConfig.aiFallback.isEmpty
+                    globalValue:
+                        (orgConfig?.aiFallback ?? appConfig.aiFallback).isEmpty
                         ? 'none'
-                        : appConfig.aiFallback,
+                        : (orgConfig?.aiFallback ?? appConfig.aiFallback),
+                    inheritedLabel: source(orgConfig?.aiFallback != null),
                     overrideValue: _config.aiFallback,
                     options: const ['claude', 'gemini', 'codex'],
-                    onChanged: (v) =>
-                        _update(_config.copyWith(aiFallback: v)),
+                    onChanged: (v) => _update(_config.copyWith(aiFallback: v)),
                     onReset: () => _resetField('fallback'),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
                     label: 'Review mode',
-                    globalValue: appConfig.reviewMode,
+                    globalValue: orgConfig?.reviewMode ?? appConfig.reviewMode,
+                    inheritedLabel: source(orgConfig?.reviewMode != null),
                     overrideValue: _config.reviewMode,
                     options: const ['single', 'multi'],
-                    onChanged: (v) =>
-                        _update(_config.copyWith(reviewMode: v)),
+                    onChanged: (v) => _update(_config.copyWith(reviewMode: v)),
                     onReset: () => _resetField('review_mode'),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
                     label: 'Prompt',
-                    globalValue: 'default',
+                    globalValue: orgConfig?.promptId ?? 'default',
+                    inheritedLabel: source(orgConfig?.promptId != null),
                     overrideValue: _config.promptId,
                     options: prompts.map((p) => p.id).toList(),
-                    onChanged: (v) =>
-                        _update(_config.copyWith(promptId: v)),
+                    onChanged: (v) => _update(_config.copyWith(promptId: v)),
                     onReset: () => _resetField('prompt'),
                   ),
                 ], accent: FeaturePalette.prReview),
 
                 // ── Section 3: Issue Tracking ──────────────────────────
                 _sectionCard('Issue Tracking', [
-                  Row(children: [
-                    const Expanded(
-                      child: Text('Triage issues',
-                          style: TextStyle(fontSize: 13)),
-                    ),
-                    FeatureSwitch(
-                      feature: Feature.issueTracking,
-                      value: _config.itEnabled ?? false,
-                      onChanged: (v) =>
-                          _update(_config.copyWith(itEnabled: v)),
-                    ),
-                  ]),
+                  Row(
+                    children: [
+                      const Expanded(
+                        child: Text(
+                          'Triage issues',
+                          style: TextStyle(fontSize: 13),
+                        ),
+                      ),
+                      FeatureSwitch(
+                        feature: Feature.issueTracking,
+                        value:
+                            _config.itEnabled ??
+                            orgConfig?.itEnabled ??
+                            appConfig.issueTracking.enabled,
+                        onChanged: (v) =>
+                            _update(_config.copyWith(itEnabled: v)),
+                      ),
+                    ],
+                  ),
                   const SizedBox(height: 6),
                   AutocompleteChipField(
                     label: 'Review-only labels',
-                    helper: 'Issues with these labels get a review comment only',
-                    selectedValues: _config.reviewOnlyLabels ?? appConfig.issueTracking.reviewOnlyLabels,
+                    helper:
+                        'Issues with these labels get a review comment only',
+                    selectedValues:
+                        _config.reviewOnlyLabels ??
+                        orgConfig?.reviewOnlyLabels ??
+                        appConfig.issueTracking.reviewOnlyLabels,
                     availableOptions: _repoLabels,
                     isOverridden: _config.reviewOnlyLabels != null,
-                    globalHint: _joinList(appConfig.issueTracking.reviewOnlyLabels),
-                    onChanged: (v) => _update(_config.copyWith(reviewOnlyLabels: v)),
-                    onReset: () => _resetField('issue_tracking/review_only_labels'),
+                    inheritedLabel: source(orgConfig?.reviewOnlyLabels != null),
+                    globalHint: _joinList(
+                      orgConfig?.reviewOnlyLabels ??
+                          appConfig.issueTracking.reviewOnlyLabels,
+                    ),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(reviewOnlyLabels: v)),
+                    onReset: () =>
+                        _resetField('issue_tracking/review_only_labels'),
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(
                     label: 'Skip labels',
                     helper: 'Issues with these labels are ignored',
-                    selectedValues: _config.skipLabels ?? appConfig.issueTracking.skipLabels,
+                    selectedValues:
+                        _config.skipLabels ??
+                        orgConfig?.skipLabels ??
+                        appConfig.issueTracking.skipLabels,
                     availableOptions: _repoLabels,
                     isOverridden: _config.skipLabels != null,
-                    globalHint: _joinList(appConfig.issueTracking.skipLabels),
+                    inheritedLabel: source(orgConfig?.skipLabels != null),
+                    globalHint: _joinList(
+                      orgConfig?.skipLabels ??
+                          appConfig.issueTracking.skipLabels,
+                    ),
                     onChanged: (v) => _update(_config.copyWith(skipLabels: v)),
                     onReset: () => _resetField('issue_tracking/skip_labels'),
                   ),
@@ -384,88 +450,138 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                   OverrideDropdown(
                     label: 'Filter mode',
                     globalValue:
+                        orgConfig?.issueFilterMode ??
                         appConfig.issueTracking.filterMode,
+                    inheritedLabel: source(orgConfig?.issueFilterMode != null),
                     overrideValue: _config.issueFilterMode,
                     options: const ['exclusive', 'inclusive'],
-                    onChanged: (v) => _update(
-                        _config.copyWith(issueFilterMode: v)),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issueFilterMode: v)),
                     onReset: () => _resetField('issue_tracking/filter_mode'),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
                     label: 'Default action',
                     globalValue:
+                        orgConfig?.issueDefaultAction ??
                         appConfig.issueTracking.defaultAction,
+                    inheritedLabel: source(
+                      orgConfig?.issueDefaultAction != null,
+                    ),
                     overrideValue: _config.issueDefaultAction,
                     options: const ['ignore', 'review_only'],
-                    onChanged: (v) => _update(
-                        _config.copyWith(issueDefaultAction: v)),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issueDefaultAction: v)),
                     onReset: () => _resetField('issue_tracking/default_action'),
                   ),
                   const SizedBox(height: 10),
                   OverrideTextField(
                     label: 'Organizations',
                     helper: 'GitHub org names to filter issues',
-                    globalValue: _joinList(appConfig.issueTracking.organizations),
+                    globalValue: _joinList(
+                      orgConfig?.issueOrganizations ??
+                          appConfig.issueTracking.organizations,
+                    ),
+                    inheritedLabel: source(
+                      orgConfig?.issueOrganizations != null,
+                    ),
                     overrideValue: _config.issueOrganizations?.join(', '),
-                    onChanged: (v) => _update(_config.copyWith(
-                        issueOrganizations: v != null ? _parseList(v) : null)),
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        issueOrganizations: v != null ? _parseList(v) : null,
+                      ),
+                    ),
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(
                     label: 'Assignees',
                     helper: 'Only process issues assigned to these users',
-                    selectedValues: _config.issueAssignees ?? appConfig.issueTracking.assignees,
+                    selectedValues:
+                        _config.issueAssignees ??
+                        orgConfig?.issueAssignees ??
+                        appConfig.issueTracking.assignees,
                     availableOptions: _repoCollaborators,
                     isOverridden: _config.issueAssignees != null,
-                    globalHint: _joinList(appConfig.issueTracking.assignees),
-                    onChanged: (v) => _update(_config.copyWith(issueAssignees: v)),
+                    inheritedLabel: source(orgConfig?.issueAssignees != null),
+                    globalHint: _joinList(
+                      orgConfig?.issueAssignees ??
+                          appConfig.issueTracking.assignees,
+                    ),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issueAssignees: v)),
                     onReset: () => _resetField('issue_tracking/assignees'),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
                     label: 'Prompt',
-                    globalValue: 'default',
+                    globalValue:
+                        orgConfig?.issuePromptId ??
+                        (appConfig.globalIssuePrompt.isEmpty
+                            ? 'default'
+                            : appConfig.globalIssuePrompt),
+                    inheritedLabel: source(orgConfig?.issuePromptId != null),
                     overrideValue: _config.issuePromptId,
                     options: prompts.map((p) => p.id).toList(),
                     onChanged: (v) =>
                         _update(_config.copyWith(issuePromptId: v)),
-                    onReset: () => _resetField('issue_tracking/issue_prompt'),
+                    onReset: () => _resetField('issue_prompt'),
                   ),
                 ], accent: FeaturePalette.issueTracking),
 
                 // ── Section 4: Develop ─────────────────────────────────
                 _sectionCard('Develop', [
-                  Row(children: [
-                    const Expanded(
-                      child: Text('Auto-implement issues',
-                          style: TextStyle(fontSize: 13)),
-                    ),
-                    FeatureSwitch(
-                      feature: Feature.develop,
-                      value: _config.devEnabled ?? false,
-                      onChanged: (v) =>
-                          _update(_config.copyWith(devEnabled: v)),
-                    ),
-                  ]),
+                  Row(
+                    children: [
+                      const Expanded(
+                        child: Text(
+                          'Auto-implement issues',
+                          style: TextStyle(fontSize: 13),
+                        ),
+                      ),
+                      FeatureSwitch(
+                        feature: Feature.develop,
+                        value:
+                            _config.devEnabled ??
+                            orgConfig?.devEnabled ??
+                            false,
+                        onChanged: (v) =>
+                            _update(_config.copyWith(devEnabled: v)),
+                      ),
+                    ],
+                  ),
                   const SizedBox(height: 6),
                   AutocompleteChipField(
                     label: 'Develop labels',
                     helper: 'Issues with these labels get a branch + PR',
-                    selectedValues: _config.developLabels ?? appConfig.issueTracking.developLabels,
+                    selectedValues:
+                        _config.developLabels ??
+                        orgConfig?.developLabels ??
+                        appConfig.issueTracking.developLabels,
                     availableOptions: _repoLabels,
                     isOverridden: _config.developLabels != null,
-                    globalHint: _joinList(appConfig.issueTracking.developLabels),
-                    onChanged: (v) => _update(_config.copyWith(developLabels: v)),
+                    inheritedLabel: source(orgConfig?.developLabels != null),
+                    globalHint: _joinList(
+                      orgConfig?.developLabels ??
+                          appConfig.issueTracking.developLabels,
+                    ),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(developLabels: v)),
                     onReset: () => _resetField('issue_tracking/develop_labels'),
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(
                     label: 'PR Reviewers',
                     helper: 'GitHub usernames to request review',
-                    selectedValues: _config.prReviewers ?? [],
+                    selectedValues:
+                        _config.prReviewers ??
+                        orgConfig?.prReviewers ??
+                        appConfig.globalPRReviewers,
                     availableOptions: _repoCollaborators,
                     isOverridden: _config.prReviewers != null,
+                    inheritedLabel: source(orgConfig?.prReviewers != null),
+                    globalHint: _joinList(
+                      orgConfig?.prReviewers ?? appConfig.globalPRReviewers,
+                    ),
                     onChanged: (v) => _update(_config.copyWith(prReviewers: v)),
                     onReset: () => _resetField('pr_reviewers'),
                   ),
@@ -473,37 +589,64 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                   AutocompleteChipField(
                     label: 'PR Assignee',
                     helper: 'GitHub username to assign to PRs',
-                    selectedValues: _config.prAssignee != null ? [_config.prAssignee!] : [],
+                    selectedValues: _config.prAssignee != null
+                        ? [_config.prAssignee!]
+                        : (orgConfig?.prAssignee != null
+                              ? [orgConfig!.prAssignee!]
+                              : (appConfig.globalPRAssignee.isNotEmpty
+                                    ? [appConfig.globalPRAssignee]
+                                    : [])),
                     availableOptions: _repoCollaborators,
                     isOverridden: _config.prAssignee != null,
-                    onChanged: (v) => _update(_config.copyWith(
-                        prAssignee: v != null && v.isNotEmpty ? v.first : null)),
+                    inheritedLabel: source(orgConfig?.prAssignee != null),
+                    globalHint:
+                        orgConfig?.prAssignee ?? appConfig.globalPRAssignee,
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        prAssignee: v != null && v.isNotEmpty ? v.first : null,
+                      ),
+                    ),
                     onReset: () => _resetField('pr_assignee'),
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(
                     label: 'PR Labels',
                     helper: 'Labels to add to PRs',
-                    selectedValues: _config.prLabels ?? [],
+                    selectedValues:
+                        _config.prLabels ??
+                        orgConfig?.prLabels ??
+                        appConfig.globalPRLabels,
                     availableOptions: _repoLabels,
                     isOverridden: _config.prLabels != null,
+                    inheritedLabel: source(orgConfig?.prLabels != null),
+                    globalHint: _joinList(
+                      orgConfig?.prLabels ?? appConfig.globalPRLabels,
+                    ),
                     onChanged: (v) => _update(_config.copyWith(prLabels: v)),
                     onReset: () => _resetField('pr_labels'),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
                     label: 'Draft',
-                    globalValue: 'false',
+                    globalValue: (orgConfig?.prDraft ?? appConfig.globalPRDraft)
+                        .toString(),
+                    inheritedLabel: source(orgConfig?.prDraft != null),
                     overrideValue: _config.prDraft?.toString(),
                     options: const ['true', 'false'],
-                    onChanged: (v) => _update(_config.copyWith(
-                        prDraft: v != null ? v == 'true' : null)),
+                    onChanged: (v) => _update(
+                      _config.copyWith(prDraft: v != null ? v == 'true' : null),
+                    ),
                     onReset: () => _resetField('pr_draft'),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
                     label: 'Prompt',
-                    globalValue: 'default',
+                    globalValue:
+                        orgConfig?.developPromptId ??
+                        (appConfig.globalImplementPrompt.isEmpty
+                            ? 'default'
+                            : appConfig.globalImplementPrompt),
+                    inheritedLabel: source(orgConfig?.developPromptId != null),
                     overrideValue: _config.developPromptId,
                     options: prompts.map((p) => p.id).toList(),
                     onChanged: (v) =>
@@ -524,7 +667,9 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
 
 class _LocalDirField extends StatefulWidget {
   final String value;
+  final String sourceLabel;
   final ValueChanged<String> onChanged;
+
   /// Non-null when the daemon detected a `/home/heimdallm/repos/<name>` path
   /// for this repo (HEIMDALLM_LOCAL_DIR_BASE is mounted and the repo is
   /// visible there). Shown
@@ -533,6 +678,7 @@ class _LocalDirField extends StatefulWidget {
   final String? detectedDir;
   const _LocalDirField({
     required this.value,
+    required this.sourceLabel,
     required this.onChanged,
     this.detectedDir,
   });
@@ -548,6 +694,14 @@ class _LocalDirFieldState extends State<_LocalDirField> {
   void initState() {
     super.initState();
     _ctrl = TextEditingController(text: widget.value);
+  }
+
+  @override
+  void didUpdateWidget(_LocalDirField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.value != oldWidget.value && _ctrl.text != widget.value) {
+      _ctrl.text = widget.value;
+    }
   }
 
   @override
@@ -575,76 +729,92 @@ class _LocalDirFieldState extends State<_LocalDirField> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(children: [
-          Expanded(
-            child: TextFormField(
-              controller: _ctrl,
-              decoration: InputDecoration(
-                hintText: hintText,
-                hintStyle: detected != null && detected.isNotEmpty
-                    ? TextStyle(
-                        color: Colors.blue.shade400,
-                        fontStyle: FontStyle.italic,
-                      )
-                    : null,
-                border: const OutlineInputBorder(),
-                isDense: true,
+        Padding(
+          padding: const EdgeInsets.only(bottom: 6),
+          child: Text(
+            widget.sourceLabel,
+            style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+          ),
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: TextFormField(
+                controller: _ctrl,
+                decoration: InputDecoration(
+                  hintText: hintText,
+                  hintStyle: detected != null && detected.isNotEmpty
+                      ? TextStyle(
+                          color: Colors.blue.shade400,
+                          fontStyle: FontStyle.italic,
+                        )
+                      : null,
+                  border: const OutlineInputBorder(),
+                  isDense: true,
+                ),
+                onChanged: widget.onChanged,
               ),
-              onChanged: widget.onChanged,
             ),
-          ),
-      // Browse button is desktop-only — browsers can't expose native
-      // filesystem paths to the daemon. On web the operator types a
-      // path that exists inside the daemon container (e.g.
-      // /home/heimdallm/repos/foo if they've bind-mounted their host
-      // repos root via HEIMDALLM_LOCAL_DIR_BASE).
-      if (!kIsWeb) ...[
-        const SizedBox(width: 8),
-        OutlinedButton.icon(
-          icon: const Icon(Icons.folder_open, size: 16),
-          label: const Text('Browse'),
-          onPressed: _pick,
-          style: OutlinedButton.styleFrom(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-          ),
+            // Browse button is desktop-only — browsers can't expose native
+            // filesystem paths to the daemon. On web the operator types a
+            // path that exists inside the daemon container (e.g.
+            // /home/heimdallm/repos/foo if they've bind-mounted their host
+            // repos root via HEIMDALLM_LOCAL_DIR_BASE).
+            if (!kIsWeb) ...[
+              const SizedBox(width: 8),
+              OutlinedButton.icon(
+                icon: const Icon(Icons.folder_open, size: 16),
+                label: const Text('Browse'),
+                onPressed: _pick,
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 12,
+                  ),
+                ),
+              ),
+            ] else ...[
+              const SizedBox(width: 8),
+              Tooltip(
+                message:
+                    'The daemon runs in a container, so paths here refer to '
+                    'directories inside that container — typically a bind-mount '
+                    'like /home/heimdallm/repos/<name>. Enter the path manually.',
+                child: Icon(
+                  Icons.info_outline,
+                  size: 16,
+                  color: Colors.grey.shade500,
+                ),
+              ),
+            ],
+            if (_ctrl.text.isNotEmpty) ...[
+              const SizedBox(width: 4),
+              IconButton(
+                icon: const Icon(Icons.clear, size: 16),
+                tooltip: 'Clear',
+                onPressed: () {
+                  setState(() => _ctrl.clear());
+                  widget.onChanged('');
+                },
+              ),
+            ],
+          ],
         ),
-      ] else ...[
-        const SizedBox(width: 8),
-        Tooltip(
-          message: 'The daemon runs in a container, so paths here refer to '
-              'directories inside that container — typically a bind-mount '
-              'like /home/heimdallm/repos/<name>. Enter the path manually.',
-          child: Icon(Icons.info_outline,
-              size: 16, color: Colors.grey.shade500),
-        ),
-      ],
-      if (_ctrl.text.isNotEmpty) ...[
-        const SizedBox(width: 4),
-        IconButton(
-          icon: const Icon(Icons.clear, size: 16),
-          tooltip: 'Clear',
-          onPressed: () {
-            setState(() => _ctrl.clear());
-            widget.onChanged('');
-          },
-        ),
-      ],
-        ]),
         if (detected != null && detected.isNotEmpty && _ctrl.text.isEmpty) ...[
           const SizedBox(height: 6),
-          Row(children: [
-            Icon(Icons.auto_awesome, size: 12, color: Colors.blue.shade400),
-            const SizedBox(width: 4),
-            Expanded(
-              child: Text(
-                'Leave empty to use the auto-detected path above. '
-                'Type a different path to override.',
-                style: TextStyle(
-                    fontSize: 11, color: Colors.blue.shade400),
+          Row(
+            children: [
+              Icon(Icons.auto_awesome, size: 12, color: Colors.blue.shade400),
+              const SizedBox(width: 4),
+              Expanded(
+                child: Text(
+                  'Leave empty to use the auto-detected path above. '
+                  'Type a different path to override.',
+                  style: TextStyle(fontSize: 11, color: Colors.blue.shade400),
+                ),
               ),
-            ),
-          ]),
+            ],
+          ),
         ],
       ],
     );

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -225,15 +225,9 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
 
   String _joinList(List<String>? list) => list?.join(', ') ?? '';
 
-  List<String>? _parseList(String? value) {
-    if (value == null) return null;
-    final parsed = value
-        .split(',')
-        .map((s) => s.trim())
-        .where((s) => s.isNotEmpty)
-        .toList();
-    return parsed.isEmpty ? null : parsed;
-  }
+  List<String> _mergeOptions(List<String> first, List<String> second) =>
+      ({...first, ...second}.where((v) => v.trim().isNotEmpty).toList()
+        ..sort());
 
   // ── Section card ─────────────────────────────────────────────────────────────
 
@@ -475,22 +469,25 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                     onReset: () => _resetField('issue_tracking/default_action'),
                   ),
                   const SizedBox(height: 10),
-                  OverrideTextField(
+                  AutocompleteChipField(
                     label: 'Organizations',
                     helper: 'GitHub org names to filter issues',
-                    globalValue: _joinList(
-                      orgConfig?.issueOrganizations ??
-                          appConfig.issueTracking.organizations,
-                    ),
+                    selectedValues:
+                        _config.issueOrganizations ??
+                        orgConfig?.issueOrganizations ??
+                        appConfig.issueTracking.organizations,
+                    availableOptions: appConfig.knownOrganizations,
+                    isOverridden: _config.issueOrganizations != null,
                     inheritedLabel: source(
                       orgConfig?.issueOrganizations != null,
                     ),
-                    overrideValue: _config.issueOrganizations?.join(', '),
-                    onChanged: (v) => _update(
-                      _config.copyWith(
-                        issueOrganizations: v != null ? _parseList(v) : null,
-                      ),
+                    globalHint: _joinList(
+                      orgConfig?.issueOrganizations ??
+                          appConfig.issueTracking.organizations,
                     ),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issueOrganizations: v)),
+                    onReset: () => _resetField('issue_tracking/organizations'),
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(
@@ -500,7 +497,10 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                         _config.issueAssignees ??
                         orgConfig?.issueAssignees ??
                         appConfig.issueTracking.assignees,
-                    availableOptions: _repoCollaborators,
+                    availableOptions: _mergeOptions(
+                      _repoCollaborators,
+                      appConfig.knownGitHubUsers,
+                    ),
                     isOverridden: _config.issueAssignees != null,
                     inheritedLabel: source(orgConfig?.issueAssignees != null),
                     globalHint: _joinList(

--- a/flutter_app/lib/features/repositories/repos_screen.dart
+++ b/flutter_app/lib/features/repositories/repos_screen.dart
@@ -89,13 +89,12 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
       return result ?? false;
     }
 
-    bool hasDir(RepoConfig c) =>
-        c.localDir != null && c.localDir!.isNotEmpty;
+    bool hasDir(RepoConfig c) => c.localDir != null && c.localDir!.isNotEmpty;
 
     return {
-      Feature.prReview:      agg((c) => c.prEnabled ?? false),
+      Feature.prReview: agg((c) => c.prEnabled ?? false),
       Feature.issueTracking: agg((c) => c.itEnabled ?? false),
-      Feature.develop:       agg((c) => (c.devEnabled ?? false) && hasDir(c)),
+      Feature.develop: agg((c) => (c.devEnabled ?? false) && hasDir(c)),
     };
   }
 
@@ -114,9 +113,9 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
           continue;
         }
         _repoConfigs[r] = switch (f) {
-          Feature.prReview      => c.copyWith(prEnabled: enable),
+          Feature.prReview => c.copyWith(prEnabled: enable),
           Feature.issueTracking => c.copyWith(itEnabled: enable),
-          Feature.develop       => c.copyWith(devEnabled: enable),
+          Feature.develop => c.copyWith(devEnabled: enable),
         };
       }
     });
@@ -167,8 +166,9 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
       if (!mounted) return;
       setState(() => _syncStatus = _SyncStatus.saved);
       _savedResetTimer?.cancel();
-      _savedResetTimer = Timer(const Duration(seconds: 2),
-          () { if (mounted) setState(() => _syncStatus = _SyncStatus.idle); });
+      _savedResetTimer = Timer(const Duration(seconds: 2), () {
+        if (mounted) setState(() => _syncStatus = _SyncStatus.idle);
+      });
     } catch (e) {
       if (mounted) {
         setState(() => _syncStatus = _SyncStatus.idle);
@@ -197,11 +197,12 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
           });
         // Derive all orgs for the org filter dropdown. Only shown when more
         // than one org has at least one repo.
-        final allOrgs = _repoConfigs.keys
-            .map((r) => r.contains('/') ? r.split('/').first : r)
-            .toSet()
-            .toList()
-          ..sort();
+        final allOrgs =
+            _repoConfigs.keys
+                .map((r) => r.contains('/') ? r.split('/').first : r)
+                .toSet()
+                .toList()
+              ..sort();
 
         final filtered = allRepos.where((r) {
           if (_search.isNotEmpty &&
@@ -263,34 +264,46 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
                       const SizedBox(width: 4),
                       GestureDetector(
                         onTap: () => setState(() => _orgFilter = {}),
-                        child: const Icon(Icons.clear, size: 16, color: Colors.grey),
+                        child: const Icon(
+                          Icons.clear,
+                          size: 16,
+                          color: Colors.grey,
+                        ),
                       ),
                     ],
                     const SizedBox(width: 8),
                   ],
-                  Row(children: [
-                    _ViewToggleButton(
-                      icon: Icons.view_list,
-                      active: _viewMode == 'list',
-                      onTap: () => _setViewMode('list'),
-                      buttonKey: const Key('repos_view_toggle_list'),
-                    ),
-                    _ViewToggleButton(
-                      icon: Icons.grid_view,
-                      active: _viewMode == 'grid',
-                      onTap: () => _setViewMode('grid'),
-                      buttonKey: const Key('repos_view_toggle_grid'),
-                    ),
-                  ]),
+                  Row(
+                    children: [
+                      _ViewToggleButton(
+                        icon: Icons.view_list,
+                        active: _viewMode == 'list',
+                        onTap: () => _setViewMode('list'),
+                        buttonKey: const Key('repos_view_toggle_list'),
+                      ),
+                      _ViewToggleButton(
+                        icon: Icons.grid_view,
+                        active: _viewMode == 'grid',
+                        onTap: () => _setViewMode('grid'),
+                        buttonKey: const Key('repos_view_toggle_grid'),
+                      ),
+                    ],
+                  ),
                   const SizedBox(width: 12),
                   // Auto-save status indicator
                   SizedBox(
-                    width: 22, height: 22,
+                    width: 22,
+                    height: 22,
                     child: switch (_syncStatus) {
-                      _SyncStatus.saving => const CircularProgressIndicator(strokeWidth: 2),
-                      _SyncStatus.saved  => Icon(Icons.cloud_done_outlined,
-                          size: 20, color: Colors.green.shade500),
-                      _SyncStatus.idle   => const SizedBox.shrink(),
+                      _SyncStatus.saving => const CircularProgressIndicator(
+                        strokeWidth: 2,
+                      ),
+                      _SyncStatus.saved => Icon(
+                        Icons.cloud_done_outlined,
+                        size: 20,
+                        color: Colors.green.shade500,
+                      ),
+                      _SyncStatus.idle => const SizedBox.shrink(),
                     },
                   ),
                 ],
@@ -308,25 +321,25 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
               child: filtered.isEmpty
                   ? Center(child: Text(_emptyStateText()))
                   : _viewMode == 'grid'
-                      ? _ReposGrid(
-                          repos: filtered,
-                          configs: _repoConfigs,
-                          appConfig: config,
-                          selected: _selected,
-                          onSelectionToggle: _toggleSelection,
-                          showNewFor: _shouldShowNew,
-                          onDismissNew: _dismissNew,
-                        )
-                      : _RepoListWithSections(
-                          repos: filtered,
-                          configs: _repoConfigs,
-                          appConfig: config,
-                          onChanged: _onChange,
-                          selected: _selected,
-                          onSelectionToggle: _toggleSelection,
-                          showNewFor: _shouldShowNew,
-                          onDismissNew: _dismissNew,
-                        ),
+                  ? _ReposGrid(
+                      repos: filtered,
+                      configs: _repoConfigs,
+                      appConfig: config,
+                      selected: _selected,
+                      onSelectionToggle: _toggleSelection,
+                      showNewFor: _shouldShowNew,
+                      onDismissNew: _dismissNew,
+                    )
+                  : _RepoListWithSections(
+                      repos: filtered,
+                      configs: _repoConfigs,
+                      appConfig: config,
+                      onChanged: _onChange,
+                      selected: _selected,
+                      onSelectionToggle: _toggleSelection,
+                      showNewFor: _shouldShowNew,
+                      onDismissNew: _dismissNew,
+                    ),
             ),
           ],
         );
@@ -385,15 +398,18 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
     }
     // Return sorted by org name
     return Map.fromEntries(
-        groups.entries.toList()..sort((a, b) => a.key.compareTo(b.key)));
+      groups.entries.toList()..sort((a, b) => a.key.compareTo(b.key)),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    final monitored =
-        widget.repos.where((r) => widget.configs[r]!.isMonitored).toList();
-    final disabled =
-        widget.repos.where((r) => !widget.configs[r]!.isMonitored).toList();
+    final monitored = widget.repos
+        .where((r) => widget.configs[r]!.isMonitored)
+        .toList();
+    final disabled = widget.repos
+        .where((r) => !widget.configs[r]!.isMonitored)
+        .toList();
 
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 4),
@@ -427,10 +443,7 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
     );
   }
 
-  List<Widget> _buildOrgGroups(
-    String section,
-    List<String> repos,
-  ) {
+  List<Widget> _buildOrgGroups(String section, List<String> repos) {
     final groups = _groupByOrg(repos);
     final items = <Widget>[];
     for (final entry in groups.entries) {
@@ -439,21 +452,31 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
       final key = '$section:$org';
       final expanded = _isExpanded(key);
 
-      items.add(_orgHeader(org, orgRepos.length, expanded, () => _toggle(key)));
+      items.add(
+        _orgHeader(
+          org,
+          orgRepos.length,
+          expanded,
+          () => _toggle(key),
+          () => context.push('/orgs/${Uri.encodeComponent(org)}'),
+        ),
+      );
       if (expanded) {
         for (final r in orgRepos) {
-          items.add(RepoListTile(
-            repo: r,
-            config: widget.configs[r]!,
-            appConfig: widget.appConfig,
-            selected: widget.selected.contains(r),
-            showNew: widget.showNewFor(r, widget.configs[r]!),
-            onSelectionToggle: () => widget.onSelectionToggle(r),
-            onTap: () {
-              widget.onDismissNew(r);
-              context.push('/repos/${Uri.encodeComponent(r)}');
-            },
-          ));
+          items.add(
+            RepoListTile(
+              repo: r,
+              config: widget.configs[r]!,
+              appConfig: widget.appConfig,
+              selected: widget.selected.contains(r),
+              showNew: widget.showNewFor(r, widget.configs[r]!),
+              onSelectionToggle: () => widget.onSelectionToggle(r),
+              onTap: () {
+                widget.onDismissNew(r);
+                context.push('/repos/${Uri.encodeComponent(r)}');
+              },
+            ),
+          );
         }
       }
     }
@@ -461,49 +484,80 @@ class _RepoListWithSectionsState extends ConsumerState<_RepoListWithSections> {
   }
 
   Widget _sectionHeader(
-      BuildContext ctx, String label, int count, Color color) {
+    BuildContext ctx,
+    String label,
+    int count,
+    Color color,
+  ) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 14, 16, 4),
-      child: Row(children: [
-        Container(
+      child: Row(
+        children: [
+          Container(
             width: 8,
             height: 8,
-            decoration: BoxDecoration(color: color, shape: BoxShape.circle)),
-        const SizedBox(width: 6),
-        Text(label,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            label,
             style: TextStyle(
-                fontSize: 12,
-                color: Colors.grey.shade400,
-                fontWeight: FontWeight.w600)),
-        const SizedBox(width: 6),
-        Text('$count',
-            style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
-      ]),
+              fontSize: 12,
+              color: Colors.grey.shade400,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            '$count',
+            style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+          ),
+        ],
+      ),
     );
   }
 
   Widget _orgHeader(
-      String org, int count, bool expanded, VoidCallback onTap) {
+    String org,
+    int count,
+    bool expanded,
+    VoidCallback onTap,
+    VoidCallback onConfig,
+  ) {
     return InkWell(
       onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.fromLTRB(24, 6, 16, 2),
-        child: Row(children: [
-          Icon(
-            expanded ? Icons.expand_less : Icons.expand_more,
-            size: 16,
-            color: Colors.grey.shade500,
-          ),
-          const SizedBox(width: 4),
-          Text(org,
+        child: Row(
+          children: [
+            Icon(
+              expanded ? Icons.expand_less : Icons.expand_more,
+              size: 16,
+              color: Colors.grey.shade500,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              org,
               style: TextStyle(
-                  fontSize: 12,
-                  color: Colors.grey.shade400,
-                  fontWeight: FontWeight.w500)),
-          const SizedBox(width: 6),
-          Text('$count',
-              style: TextStyle(fontSize: 11, color: Colors.grey.shade600)),
-        ]),
+                fontSize: 12,
+                color: Colors.grey.shade400,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              '$count',
+              style: TextStyle(fontSize: 11, color: Colors.grey.shade600),
+            ),
+            const Spacer(),
+            IconButton(
+              icon: const Icon(Icons.settings_outlined, size: 16),
+              tooltip: 'Organization settings',
+              visualDensity: VisualDensity.compact,
+              onPressed: onConfig,
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -528,9 +582,12 @@ class _ViewToggleButton extends StatelessWidget {
       onTap: onTap,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-        color: active ? primary.withValues(alpha:0.22) : null,
-        child: Icon(icon,
-            size: 18, color: active ? primary : Colors.grey.shade500),
+        color: active ? primary.withValues(alpha: 0.22) : null,
+        child: Icon(
+          icon,
+          size: 18,
+          color: active ? primary : Colors.grey.shade500,
+        ),
       ),
     );
   }
@@ -566,15 +623,27 @@ class _ReposGrid extends StatelessWidget {
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(16, 14, 16, 4),
-              child: Row(children: [
-                Container(
-                  width: 8, height: 8,
-                  decoration: const BoxDecoration(color: Color(0xFF3FB950), shape: BoxShape.circle),
-                ),
-                const SizedBox(width: 6),
-                Text('MONITORED · ${monitored.length}',
-                    style: TextStyle(fontSize: 11.5, color: Colors.grey.shade400, fontWeight: FontWeight.w600)),
-              ]),
+              child: Row(
+                children: [
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: const BoxDecoration(
+                      color: Color(0xFF3FB950),
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    'MONITORED · ${monitored.length}',
+                    style: TextStyle(
+                      fontSize: 11.5,
+                      color: Colors.grey.shade400,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
           SliverPadding(
@@ -586,24 +655,21 @@ class _ReposGrid extends StatelessWidget {
                 crossAxisSpacing: 10,
                 childAspectRatio: 1.0,
               ),
-              delegate: SliverChildBuilderDelegate(
-                (ctx, i) {
-                  final r = monitored[i];
-                  return RepoGridTile(
-                    repo: r,
-                    config: configs[r]!,
-                    appConfig: appConfig,
-                    selected: selected.contains(r),
-                    showNew: showNewFor(r, configs[r]!),
-                    onSelectionToggle: () => onSelectionToggle(r),
-                    onTap: () {
-                      onDismissNew(r);
-                      ctx.push('/repos/${Uri.encodeComponent(r)}');
-                    },
-                  );
-                },
-                childCount: monitored.length,
-              ),
+              delegate: SliverChildBuilderDelegate((ctx, i) {
+                final r = monitored[i];
+                return RepoGridTile(
+                  repo: r,
+                  config: configs[r]!,
+                  appConfig: appConfig,
+                  selected: selected.contains(r),
+                  showNew: showNewFor(r, configs[r]!),
+                  onSelectionToggle: () => onSelectionToggle(r),
+                  onTap: () {
+                    onDismissNew(r);
+                    ctx.push('/repos/${Uri.encodeComponent(r)}');
+                  },
+                );
+              }, childCount: monitored.length),
             ),
           ),
         ],
@@ -611,15 +677,27 @@ class _ReposGrid extends StatelessWidget {
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-              child: Row(children: [
-                Container(
-                  width: 8, height: 8,
-                  decoration: BoxDecoration(color: Colors.grey.shade600, shape: BoxShape.circle),
-                ),
-                const SizedBox(width: 6),
-                Text('NOT MONITORED · ${disabled.length}',
-                    style: TextStyle(fontSize: 11.5, color: Colors.grey.shade400, fontWeight: FontWeight.w600)),
-              ]),
+              child: Row(
+                children: [
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: Colors.grey.shade600,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    'NOT MONITORED · ${disabled.length}',
+                    style: TextStyle(
+                      fontSize: 11.5,
+                      color: Colors.grey.shade400,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
           SliverPadding(
@@ -631,24 +709,21 @@ class _ReposGrid extends StatelessWidget {
                 crossAxisSpacing: 10,
                 childAspectRatio: 1.0,
               ),
-              delegate: SliverChildBuilderDelegate(
-                (ctx, i) {
-                  final r = disabled[i];
-                  return RepoGridTile(
-                    repo: r,
-                    config: configs[r]!,
-                    appConfig: appConfig,
-                    selected: selected.contains(r),
-                    showNew: showNewFor(r, configs[r]!),
-                    onSelectionToggle: () => onSelectionToggle(r),
-                    onTap: () {
-                      onDismissNew(r);
-                      ctx.push('/repos/${Uri.encodeComponent(r)}');
-                    },
-                  );
-                },
-                childCount: disabled.length,
-              ),
+              delegate: SliverChildBuilderDelegate((ctx, i) {
+                final r = disabled[i];
+                return RepoGridTile(
+                  repo: r,
+                  config: configs[r]!,
+                  appConfig: appConfig,
+                  selected: selected.contains(r),
+                  showNew: showNewFor(r, configs[r]!),
+                  onSelectionToggle: () => onSelectionToggle(r),
+                  onTap: () {
+                    onDismissNew(r);
+                    ctx.push('/repos/${Uri.encodeComponent(r)}');
+                  },
+                );
+              }, childCount: disabled.length),
             ),
           ),
         ],
@@ -656,7 +731,6 @@ class _ReposGrid extends StatelessWidget {
     );
   }
 }
-
 
 /// Multi-select org filter chip. Opens a checkbox dialog when tapped.
 /// Matches the Activity screen's org filter UX (issue #112 / PR #133).
@@ -688,14 +762,18 @@ class _OrgFilterChip extends StatelessWidget {
         if (result != null) onChanged(result);
       },
       child: Chip(
-        avatar: Icon(Icons.business, size: 14, color: isActive ? primary : Colors.grey),
+        avatar: Icon(
+          Icons.business,
+          size: 14,
+          color: isActive ? primary : Colors.grey,
+        ),
         label: Text(
           isActive ? 'Org (${selected.length})' : 'Org',
           style: TextStyle(fontSize: 12, color: isActive ? primary : null),
         ),
         visualDensity: VisualDensity.compact,
         side: isActive
-            ? BorderSide(color: primary.withValues(alpha:0.5))
+            ? BorderSide(color: primary.withValues(alpha: 0.5))
             : const BorderSide(color: Colors.transparent),
       ),
     );

--- a/flutter_app/lib/features/repositories/widgets/led_source.dart
+++ b/flutter_app/lib/features/repositories/widgets/led_source.dart
@@ -6,6 +6,7 @@
 // in one place.
 import '../../../core/models/config_model.dart';
 import 'feature_palette.dart';
+import 'local_dir_resolution.dart';
 
 /// Whether the feature LED should render in its "on" colour for the given
 /// repo. Returns true when the daemon will act on the feature for this
@@ -18,14 +19,18 @@ bool featureIsOn({
   required AppConfig appConfig,
 }) {
   final inGlobalList = appConfig.repositories.contains(repo);
-  final globalIt = appConfig.issueTracking.enabled;
-  final hasDir = config.localDir != null && config.localDir!.isNotEmpty;
-  final status = switch (feature) {
-    Feature.prReview      => config.prLedStatus(inGlobalList),
-    Feature.issueTracking => config.itLedStatus(globalIt),
-    Feature.develop       => config.devLedStatus(globalIt, hasDir),
+  final org = _orgForRepo(repo);
+  final orgConfig = org != null ? appConfig.orgConfigs[org] : null;
+  final hasDir = LocalDirResolution.resolve(
+    repo: repo,
+    config: config,
+    appConfig: appConfig,
+  ).hasDir;
+  return switch (feature) {
+    Feature.prReview => config.prLedStatus(inGlobalList) != 'off',
+    Feature.issueTracking => _issueTrackingOn(config, orgConfig, appConfig),
+    Feature.develop => hasDir && _developOn(config, orgConfig, appConfig),
   };
-  return status != 'off';
 }
 
 /// "Source: …" line shown at the bottom of the LED tooltip. Answers the
@@ -37,33 +42,105 @@ String featureSourceLine({
   required AppConfig appConfig,
 }) {
   final inGlobalList = appConfig.repositories.contains(repo);
-  final globalIt = appConfig.issueTracking.enabled;
-  final hasDir = config.localDir != null && config.localDir!.isNotEmpty;
+  final org = _orgForRepo(repo);
+  final orgConfig = org != null ? appConfig.orgConfigs[org] : null;
+  final hasDir = LocalDirResolution.resolve(
+    repo: repo,
+    config: config,
+    appConfig: appConfig,
+  ).hasDir;
   switch (feature) {
     case Feature.prReview:
-      if (config.prEnabled == true) return 'Source: repo-level (prEnabled = true)';
-      if (config.prEnabled == false) return 'Source: disabled per-repo (prEnabled = false)';
+      if (config.prEnabled == true) {
+        return 'Source: repo-level (prEnabled = true)';
+      }
+      if (config.prEnabled == false) {
+        return 'Source: disabled per-repo (prEnabled = false)';
+      }
       return inGlobalList
           ? 'Source: inherited from global monitored list'
           : 'Source: not in monitored list';
     case Feature.issueTracking:
-      if (config.itEnabled == true) return 'Source: repo-level (itEnabled = true)';
-      if (config.itEnabled == false) return 'Source: disabled per-repo (itEnabled = false)';
+      if (config.itEnabled == true) {
+        return 'Source: repo-level (itEnabled = true)';
+      }
+      if (config.itEnabled == false) {
+        return 'Source: disabled per-repo (itEnabled = false)';
+      }
       if ((config.reviewOnlyLabels ?? const []).isNotEmpty) {
         return 'Source: implied by per-repo labels';
       }
-      return globalIt
+      if (orgConfig?.itEnabled == true) {
+        return 'Source: inherited from org issue tracking';
+      }
+      if (orgConfig?.itEnabled == false) return 'Source: disabled at org level';
+      if ((orgConfig?.reviewOnlyLabels ?? const []).isNotEmpty ||
+          (orgConfig?.developLabels ?? const []).isNotEmpty) {
+        return 'Source: implied by org labels';
+      }
+      return appConfig.issueTracking.enabled
           ? 'Source: inherited from global issue tracking'
           : 'Source: globally disabled';
     case Feature.develop:
-      if (config.devEnabled == true && hasDir) return 'Source: repo-level (devEnabled = true)';
-      if (config.devEnabled == false) return 'Source: disabled per-repo (devEnabled = false)';
-      if (!hasDir) return 'Reason: no local directory configured (Develop requires one)';
+      if (config.devEnabled == true && hasDir) {
+        return 'Source: repo-level (devEnabled = true)';
+      }
+      if (config.devEnabled == false) {
+        return 'Source: disabled per-repo (devEnabled = false)';
+      }
+      if (!hasDir) {
+        return 'Reason: no local directory configured (Develop requires one)';
+      }
       if ((config.developLabels ?? const []).isNotEmpty) {
         return 'Source: implied by per-repo develop labels';
       }
-      return globalIt
+      if (orgConfig?.devEnabled == true) {
+        return 'Source: inherited from org develop setting';
+      }
+      if (orgConfig?.devEnabled == false) {
+        return 'Source: disabled at org level';
+      }
+      if ((orgConfig?.developLabels ?? const []).isNotEmpty) {
+        return 'Source: implied by org develop labels';
+      }
+      return appConfig.issueTracking.enabled
           ? 'Source: inherited from global issue tracking'
           : 'Source: globally disabled';
   }
+}
+
+String? _orgForRepo(String repo) {
+  if (!repo.contains('/')) return null;
+  final org = repo.split('/').first;
+  return org.isEmpty ? null : org;
+}
+
+bool _issueTrackingOn(
+  RepoConfig config,
+  OrgConfig? orgConfig,
+  AppConfig appConfig,
+) {
+  if (config.itEnabled == true) return true;
+  if (config.itEnabled == false) return false;
+  if ((config.reviewOnlyLabels ?? const []).isNotEmpty ||
+      (config.developLabels ?? const []).isNotEmpty) {
+    return true;
+  }
+  if (orgConfig?.itEnabled == true) return true;
+  if (orgConfig?.itEnabled == false) return false;
+  if ((orgConfig?.reviewOnlyLabels ?? const []).isNotEmpty ||
+      (orgConfig?.developLabels ?? const []).isNotEmpty) {
+    return true;
+  }
+  return appConfig.issueTracking.enabled;
+}
+
+bool _developOn(RepoConfig config, OrgConfig? orgConfig, AppConfig appConfig) {
+  if (config.devEnabled == true) return true;
+  if (config.devEnabled == false) return false;
+  if ((config.developLabels ?? const []).isNotEmpty) return true;
+  if (orgConfig?.devEnabled == true) return true;
+  if (orgConfig?.devEnabled == false) return false;
+  if ((orgConfig?.developLabels ?? const []).isNotEmpty) return true;
+  return appConfig.issueTracking.enabled;
 }

--- a/flutter_app/lib/features/repositories/widgets/local_dir_resolution.dart
+++ b/flutter_app/lib/features/repositories/widgets/local_dir_resolution.dart
@@ -42,8 +42,12 @@ class LocalDirResolution {
     required RepoConfig config,
     required AppConfig appConfig,
   }) {
-    final configured =
-        (config.localDir ?? '').isNotEmpty ? config.localDir : null;
+    final org = repo.contains('/') ? repo.split('/').first : null;
+    final orgConfig = org != null ? appConfig.orgConfigs[org] : null;
+    final orgLocalDir = orgConfig?.localDir;
+    final configured = (config.localDir ?? '').isNotEmpty
+        ? config.localDir
+        : ((orgLocalDir ?? '').isNotEmpty ? orgLocalDir : null);
     return LocalDirResolution(
       configured: configured,
       detected: appConfig.localDirsDetected[repo],
@@ -75,7 +79,9 @@ class LocalDirBadge extends StatelessWidget {
     // local (not spread through callers) makes the narrowing explicit
     // for linters that don't promote through getters.
     final color = resolution.hasDir
-        ? (resolution.isAutoDetected ? Colors.blue.shade400 : Colors.green.shade500)
+        ? (resolution.isAutoDetected
+              ? Colors.blue.shade400
+              : Colors.green.shade500)
         : Colors.grey.shade600;
     final String label;
     if (!resolution.hasDir) {
@@ -84,20 +90,22 @@ class LocalDirBadge extends StatelessWidget {
       final dirName = resolution.effective!.split('/').last;
       label = resolution.isAutoDetected ? 'Auto: $dirName' : dirName;
     }
-    return Row(children: [
-      Icon(
-        resolution.hasDir ? Icons.folder : Icons.folder_off_outlined,
-        size: iconSize,
-        color: color,
-      ),
-      const SizedBox(width: 4),
-      Flexible(
-        child: Text(
-          label,
-          style: TextStyle(fontSize: fontSize, color: color),
-          overflow: TextOverflow.ellipsis,
+    return Row(
+      children: [
+        Icon(
+          resolution.hasDir ? Icons.folder : Icons.folder_off_outlined,
+          size: iconSize,
+          color: color,
         ),
-      ),
-    ]);
+        const SizedBox(width: 4),
+        Flexible(
+          child: Text(
+            label,
+            style: TextStyle(fontSize: fontSize, color: color),
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/flutter_app/lib/shared/router.dart
+++ b/flutter_app/lib/shared/router.dart
@@ -4,15 +4,13 @@ import '../features/issues/issue_detail_screen.dart';
 import '../features/pr_detail/pr_detail_screen.dart';
 import '../features/config/config_screen.dart';
 import '../features/logs/logs_screen.dart';
+import '../features/organizations/org_detail_screen.dart';
 import '../features/repositories/repo_detail_screen.dart';
 
 GoRouter createRouter({String initialLocation = '/'}) => GoRouter(
   initialLocation: initialLocation,
   routes: [
-    GoRoute(
-      path: '/',
-      builder: (context, state) => const DashboardScreen(),
-    ),
+    GoRoute(path: '/', builder: (context, state) => const DashboardScreen()),
     GoRoute(
       path: '/prs/:id',
       builder: (context, state) {
@@ -35,13 +33,14 @@ GoRouter createRouter({String initialLocation = '/'}) => GoRouter(
       },
     ),
     GoRoute(
-      path: '/config',
-      builder: (context, state) => const ConfigScreen(),
+      path: '/orgs/:name',
+      builder: (context, state) {
+        final name = Uri.decodeComponent(state.pathParameters['name']!);
+        return OrgDetailScreen(orgName: name);
+      },
     ),
-    GoRoute(
-      path: '/logs',
-      builder: (context, state) => const LogsScreen(),
-    ),
+    GoRoute(path: '/config', builder: (context, state) => const ConfigScreen()),
+    GoRoute(path: '/logs', builder: (context, state) => const LogsScreen()),
   ],
 );
 

--- a/flutter_app/lib/shared/widgets/autocomplete_chip_field.dart
+++ b/flutter_app/lib/shared/widgets/autocomplete_chip_field.dart
@@ -174,7 +174,9 @@ class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
           // Text input + suggestions
           Focus(
             onFocusChange: (focused) {
-              if (!focused) {
+              if (focused) {
+                setState(() => _showSuggestions = true);
+              } else {
                 // Delay hiding so tap on suggestion registers first
                 Future.delayed(const Duration(milliseconds: 200), () {
                   if (mounted) setState(() => _showSuggestions = false);
@@ -200,6 +202,7 @@ class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
                     ),
                   ),
                   onChanged: (_) => setState(() => _showSuggestions = true),
+                  onTap: () => setState(() => _showSuggestions = true),
                   onFieldSubmitted: _handleSubmit,
                 ),
                 if (_showSuggestions && _filteredSuggestions.isNotEmpty)

--- a/flutter_app/lib/shared/widgets/autocomplete_chip_field.dart
+++ b/flutter_app/lib/shared/widgets/autocomplete_chip_field.dart
@@ -9,6 +9,7 @@ class AutocompleteChipField extends StatefulWidget {
   final List<String> selectedValues;
   final List<String> availableOptions;
   final String? globalHint;
+  final String inheritedLabel;
   final bool isOverridden;
   final ValueChanged<List<String>?> onChanged;
   final VoidCallback? onReset;
@@ -20,6 +21,7 @@ class AutocompleteChipField extends StatefulWidget {
     required this.selectedValues,
     required this.availableOptions,
     this.globalHint,
+    this.inheritedLabel = 'global',
     this.isOverridden = false,
     required this.onChanged,
     this.onReset,
@@ -46,7 +48,7 @@ class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
 
   void _addValue(String value) {
     final updated = [...widget.selectedValues, value];
-    widget.onChanged(updated.isEmpty ? null : updated);
+    widget.onChanged(updated);
     _ctrl.clear();
     setState(() => _showSuggestions = false);
     _focusNode.requestFocus();
@@ -54,7 +56,7 @@ class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
 
   void _removeValue(String value) {
     final updated = widget.selectedValues.where((v) => v != value).toList();
-    widget.onChanged(updated.isEmpty ? null : updated);
+    widget.onChanged(updated);
   }
 
   void _handleSubmit(String text) {
@@ -75,12 +77,16 @@ class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        color: Theme.of(
+          context,
+        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(6),
         border: Border(
           left: BorderSide(
             width: 3,
-            color: widget.isOverridden ? Colors.green.shade600 : Colors.transparent,
+            color: widget.isOverridden
+                ? Colors.green.shade600
+                : Colors.transparent,
           ),
         ),
       ),
@@ -91,37 +97,57 @@ class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
           // Header with label + override badge
           Row(
             children: [
-              Text(widget.label,
-                  style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
+              Text(
+                widget.label,
+                style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+              ),
               const Spacer(),
               if (widget.isOverridden) ...[
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 1,
+                  ),
                   decoration: BoxDecoration(
                     color: Colors.green.shade900.withValues(alpha: 0.4),
                     borderRadius: BorderRadius.circular(3),
                   ),
-                  child: Text('overridden',
-                      style: TextStyle(fontSize: 10, color: Colors.green.shade400)),
+                  child: Text(
+                    'overridden',
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: Colors.green.shade400,
+                    ),
+                  ),
                 ),
                 if (widget.onReset != null) ...[
                   const SizedBox(width: 6),
                   GestureDetector(
                     onTap: widget.onReset,
                     child: Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 6,
+                        vertical: 1,
+                      ),
                       decoration: BoxDecoration(
                         border: Border.all(color: Colors.grey.shade700),
                         borderRadius: BorderRadius.circular(3),
                       ),
-                      child: Text('\u00d7 reset',
-                          style: TextStyle(fontSize: 10, color: Colors.grey.shade500)),
+                      child: Text(
+                        '\u00d7 reset',
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: Colors.grey.shade500,
+                        ),
+                      ),
                     ),
                   ),
                 ],
               ] else
-                Text('global',
-                    style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+                Text(
+                  widget.inheritedLabel,
+                  style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+                ),
             ],
           ),
           const SizedBox(height: 6),
@@ -132,13 +158,17 @@ class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
               child: Wrap(
                 spacing: 4,
                 runSpacing: 4,
-                children: widget.selectedValues.map((v) => Chip(
-                  label: Text(v, style: const TextStyle(fontSize: 11)),
-                  deleteIcon: const Icon(Icons.close, size: 14),
-                  onDeleted: () => _removeValue(v),
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  visualDensity: VisualDensity.compact,
-                )).toList(),
+                children: widget.selectedValues
+                    .map(
+                      (v) => Chip(
+                        label: Text(v, style: const TextStyle(fontSize: 11)),
+                        deleteIcon: const Icon(Icons.close, size: 14),
+                        onDeleted: () => _removeValue(v),
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        visualDensity: VisualDensity.compact,
+                      ),
+                    )
+                    .toList(),
               ),
             ),
           // Text input + suggestions
@@ -164,7 +194,10 @@ class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
                     hintText: 'Type to add...',
                     helperText: widget.helper,
                     helperMaxLines: 2,
-                    contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 8,
+                    ),
                   ),
                   onChanged: (_) => setState(() => _showSuggestions = true),
                   onFieldSubmitted: _handleSubmit,
@@ -174,20 +207,32 @@ class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
                     margin: const EdgeInsets.only(top: 2),
                     constraints: const BoxConstraints(maxHeight: 160),
                     decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.surfaceContainerHighest,
                       borderRadius: BorderRadius.circular(4),
                       border: Border.all(color: Colors.grey.shade700),
                     ),
                     child: ListView(
                       shrinkWrap: true,
                       padding: EdgeInsets.zero,
-                      children: _filteredSuggestions.map((s) => InkWell(
-                        onTap: () => _addValue(s),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                          child: Text(s, style: const TextStyle(fontSize: 12)),
-                        ),
-                      )).toList(),
+                      children: _filteredSuggestions
+                          .map(
+                            (s) => InkWell(
+                              onTap: () => _addValue(s),
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 10,
+                                  vertical: 6,
+                                ),
+                                child: Text(
+                                  s,
+                                  style: const TextStyle(fontSize: 12),
+                                ),
+                              ),
+                            ),
+                          )
+                          .toList(),
                     ),
                   ),
               ],
@@ -196,8 +241,10 @@ class _AutocompleteChipFieldState extends State<AutocompleteChipField> {
           if (widget.isOverridden && widget.globalHint != null)
             Padding(
               padding: const EdgeInsets.only(top: 4),
-              child: Text('Global: ${widget.globalHint}',
-                  style: TextStyle(fontSize: 10, color: Colors.grey.shade700)),
+              child: Text(
+                '${widget.inheritedLabel}: ${widget.globalHint}',
+                style: TextStyle(fontSize: 10, color: Colors.grey.shade700),
+              ),
             ),
         ],
       ),

--- a/flutter_app/lib/shared/widgets/override_field.dart
+++ b/flutter_app/lib/shared/widgets/override_field.dart
@@ -10,6 +10,7 @@ class OverrideTextField extends StatefulWidget {
   final String label;
   final String? helper;
   final String globalValue;
+  final String inheritedLabel;
   final String? overrideValue;
   final ValueChanged<String?> onChanged;
   final VoidCallback? onReset;
@@ -19,6 +20,7 @@ class OverrideTextField extends StatefulWidget {
     required this.label,
     this.helper,
     required this.globalValue,
+    this.inheritedLabel = 'global',
     required this.overrideValue,
     required this.onChanged,
     this.onReset,
@@ -35,7 +37,9 @@ class _OverrideTextFieldState extends State<OverrideTextField> {
   @override
   void initState() {
     super.initState();
-    _ctrl = TextEditingController(text: widget.overrideValue ?? widget.globalValue);
+    _ctrl = TextEditingController(
+      text: widget.overrideValue ?? widget.globalValue,
+    );
   }
 
   @override
@@ -85,7 +89,9 @@ class _OverrideTextFieldState extends State<OverrideTextField> {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        color: Theme.of(
+          context,
+        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(6),
         border: Border(
           left: BorderSide(
@@ -100,35 +106,55 @@ class _OverrideTextFieldState extends State<OverrideTextField> {
         children: [
           Row(
             children: [
-              Text(widget.label,
-                  style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
+              Text(
+                widget.label,
+                style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+              ),
               const Spacer(),
               if (_isOverridden) ...[
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 1,
+                  ),
                   decoration: BoxDecoration(
                     color: Colors.green.shade900.withValues(alpha: 0.4),
                     borderRadius: BorderRadius.circular(3),
                   ),
-                  child: Text('overridden',
-                      style: TextStyle(fontSize: 10, color: Colors.green.shade400)),
+                  child: Text(
+                    'overridden',
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: Colors.green.shade400,
+                    ),
+                  ),
                 ),
                 const SizedBox(width: 6),
                 GestureDetector(
                   onTap: _reset,
                   child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 6,
+                      vertical: 1,
+                    ),
                     decoration: BoxDecoration(
                       border: Border.all(color: Colors.grey.shade700),
                       borderRadius: BorderRadius.circular(3),
                     ),
-                    child: Text('\u00d7 reset',
-                        style: TextStyle(fontSize: 10, color: Colors.grey.shade500)),
+                    child: Text(
+                      '\u00d7 reset',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Colors.grey.shade500,
+                      ),
+                    ),
                   ),
                 ),
               ] else
-                Text('global',
-                    style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+                Text(
+                  widget.inheritedLabel,
+                  style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+                ),
             ],
           ),
           const SizedBox(height: 6),
@@ -143,15 +169,20 @@ class _OverrideTextFieldState extends State<OverrideTextField> {
               border: const OutlineInputBorder(),
               helperText: widget.helper,
               helperMaxLines: 2,
-              contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 8,
+                vertical: 8,
+              ),
             ),
             onChanged: _handleChange,
           ),
           if (_isOverridden)
             Padding(
               padding: const EdgeInsets.only(top: 4),
-              child: Text('Global: ${widget.globalValue}',
-                  style: TextStyle(fontSize: 10, color: Colors.grey.shade700)),
+              child: Text(
+                '${widget.inheritedLabel}: ${widget.globalValue}',
+                style: TextStyle(fontSize: 10, color: Colors.grey.shade700),
+              ),
             ),
         ],
       ),
@@ -163,6 +194,7 @@ class _OverrideTextFieldState extends State<OverrideTextField> {
 class OverrideDropdown extends StatelessWidget {
   final String label;
   final String globalValue;
+  final String inheritedLabel;
   final String? overrideValue;
   final List<String> options;
   final ValueChanged<String?> onChanged;
@@ -172,6 +204,7 @@ class OverrideDropdown extends StatelessWidget {
     super.key,
     required this.label,
     required this.globalValue,
+    this.inheritedLabel = 'global',
     required this.overrideValue,
     required this.options,
     required this.onChanged,
@@ -184,7 +217,9 @@ class OverrideDropdown extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        color: Theme.of(
+          context,
+        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(6),
         border: Border(
           left: BorderSide(
@@ -199,18 +234,28 @@ class OverrideDropdown extends StatelessWidget {
         children: [
           Row(
             children: [
-              Text(label,
-                  style: TextStyle(fontSize: 11, color: Colors.grey.shade500)),
+              Text(
+                label,
+                style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+              ),
               const Spacer(),
               if (_isOverridden) ...[
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 1,
+                  ),
                   decoration: BoxDecoration(
                     color: Colors.green.shade900.withValues(alpha: 0.4),
                     borderRadius: BorderRadius.circular(3),
                   ),
-                  child: Text('overridden',
-                      style: TextStyle(fontSize: 10, color: Colors.green.shade400)),
+                  child: Text(
+                    'overridden',
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: Colors.green.shade400,
+                    ),
+                  ),
                 ),
                 const SizedBox(width: 6),
                 GestureDetector(
@@ -222,18 +267,28 @@ class OverrideDropdown extends StatelessWidget {
                     }
                   },
                   child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 6,
+                      vertical: 1,
+                    ),
                     decoration: BoxDecoration(
                       border: Border.all(color: Colors.grey.shade700),
                       borderRadius: BorderRadius.circular(3),
                     ),
-                    child: Text('\u00d7 reset',
-                        style: TextStyle(fontSize: 10, color: Colors.grey.shade500)),
+                    child: Text(
+                      '\u00d7 reset',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Colors.grey.shade500,
+                      ),
+                    ),
                   ),
                 ),
               ] else
-                Text('global',
-                    style: TextStyle(fontSize: 10, color: Colors.grey.shade600)),
+                Text(
+                  inheritedLabel,
+                  style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+                ),
             ],
           ),
           const SizedBox(height: 6),
@@ -247,13 +302,17 @@ class OverrideDropdown extends StatelessWidget {
             items: [
               DropdownMenuItem<String?>(
                 value: null,
-                child: Text('Global ($globalValue)',
-                    style: TextStyle(color: Colors.grey.shade600, fontSize: 12)),
+                child: Text(
+                  '${_capitalize(inheritedLabel)} ($globalValue)',
+                  style: TextStyle(color: Colors.grey.shade600, fontSize: 12),
+                ),
               ),
-              ...options.map((v) => DropdownMenuItem<String?>(
-                    value: v,
-                    child: Text(v, style: const TextStyle(fontSize: 12)),
-                  )),
+              ...options.map(
+                (v) => DropdownMenuItem<String?>(
+                  value: v,
+                  child: Text(v, style: const TextStyle(fontSize: 12)),
+                ),
+              ),
             ],
             onChanged: onChanged,
           ),
@@ -261,4 +320,9 @@ class OverrideDropdown extends StatelessWidget {
       ),
     );
   }
+}
+
+String _capitalize(String s) {
+  if (s.isEmpty) return s;
+  return s[0].toUpperCase() + s.substring(1);
 }

--- a/flutter_app/test/core/api_client_test.dart
+++ b/flutter_app/test/core/api_client_test.dart
@@ -16,15 +16,23 @@ void main() {
       final mockClient = MockClient((request) async {
         captured = request;
         if (request.url.path == '/prs') {
-          return http.Response(jsonEncode([
-            {
-              'id': 1, 'github_id': 101, 'repo': 'org/repo', 'number': 42,
-              'title': 'Fix bug', 'author': 'alice',
-              'url': 'https://github.com/org/repo/pull/42',
-              'state': 'open', 'updated_at': '2026-03-31T10:00:00Z',
-              'latest_review': null,
-            }
-          ]), 200);
+          return http.Response(
+            jsonEncode([
+              {
+                'id': 1,
+                'github_id': 101,
+                'repo': 'org/repo',
+                'number': 42,
+                'title': 'Fix bug',
+                'author': 'alice',
+                'url': 'https://github.com/org/repo/pull/42',
+                'state': 'open',
+                'updated_at': '2026-03-31T10:00:00Z',
+                'latest_review': null,
+              },
+            ]),
+            200,
+          );
         }
         return http.Response('not found', 404);
       });
@@ -53,26 +61,80 @@ void main() {
 
     test('checkHealth returns true when daemon up', () async {
       final platform = FakePlatformServices(token: 'abc-123');
-      final mockClient = MockClient((_) async =>
-          http.Response(jsonEncode({'status': 'ok'}), 200));
+      final mockClient = MockClient(
+        (_) async => http.Response(jsonEncode({'status': 'ok'}), 200),
+      );
       final client = ApiClient(httpClient: mockClient, platform: platform);
       expect(await client.checkHealth(), isTrue);
     });
 
     test('checkHealth returns false when daemon down', () async {
       final platform = FakePlatformServices(token: 'abc-123');
-      final mockClient = MockClient((_) async => throw Exception('Connection refused'));
+      final mockClient = MockClient(
+        (_) async => throw Exception('Connection refused'),
+      );
       final client = ApiClient(httpClient: mockClient, platform: platform);
       expect(await client.checkHealth(), isFalse);
+    });
+
+    test('patchOrgConfig uses encoded org route and PATCH body', () async {
+      final platform = FakePlatformServices(
+        apiBaseUrl: 'http://127.0.0.1:7842',
+        token: 'abc-123',
+      );
+      http.Request? captured;
+      final mockClient = MockClient((request) async {
+        captured = request;
+        return http.Response(jsonEncode({'org_overrides': {}}), 200);
+      });
+      final client = ApiClient(httpClient: mockClient, platform: platform);
+
+      await client.patchOrgConfig('acme-org', {
+        'primary': 'gemini',
+        'issue_tracking': {
+          'review_only_labels': ['needs-review'],
+        },
+      });
+
+      expect(captured!.method, 'PATCH');
+      expect(
+        captured!.url.toString(),
+        'http://127.0.0.1:7842/config/orgs/acme-org',
+      );
+      expect(captured!.headers['X-Heimdallm-Token'], 'abc-123');
+      expect(jsonDecode(captured!.body), {
+        'primary': 'gemini',
+        'issue_tracking': {
+          'review_only_labels': ['needs-review'],
+        },
+      });
+    });
+
+    test('deleteOrgField uses nested field route', () async {
+      final platform = FakePlatformServices(
+        apiBaseUrl: 'http://127.0.0.1:7842',
+        token: 'abc-123',
+      );
+      http.BaseRequest? captured;
+      final mockClient = MockClient((request) async {
+        captured = request;
+        return http.Response(jsonEncode({'org_overrides': {}}), 200);
+      });
+      final client = ApiClient(httpClient: mockClient, platform: platform);
+
+      await client.deleteOrgField('acme-org', 'issue_tracking/develop_labels');
+
+      expect(captured!.method, 'DELETE');
+      expect(
+        captured!.url.toString(),
+        'http://127.0.0.1:7842/config/orgs/acme-org/issue_tracking/develop_labels',
+      );
     });
   });
 
   group('ApiClient (web shape — relative URL, no token)', () {
     test('fetchPRs sends relative URL + no X-Heimdallm-Token header', () async {
-      final platform = FakePlatformServices(
-        apiBaseUrl: '/api',
-        token: null,
-      );
+      final platform = FakePlatformServices(apiBaseUrl: '/api', token: null);
       http.BaseRequest? captured;
       final mockClient = MockClient((request) async {
         captured = request;
@@ -82,8 +144,11 @@ void main() {
       await client.fetchPRs();
       // Dart's Uri.parse resolves a relative string against a default base;
       // we assert the path + absence of the auth header.
-      expect(captured!.url.path.endsWith('/api/prs'), isTrue,
-          reason: 'expected path ending in /api/prs, got ${captured!.url}');
+      expect(
+        captured!.url.path.endsWith('/api/prs'),
+        isTrue,
+        reason: 'expected path ending in /api/prs, got ${captured!.url}',
+      );
       expect(captured!.headers.containsKey('X-Heimdallm-Token'), isFalse);
     });
 

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -85,14 +85,23 @@ void main() {
       'ai_primary': 'claude',
       'ai_fallback': '',
       'review_mode': 'single',
+      'triage_owner': 'global-owner',
+      'clone_dir': '/work/global',
+      'auto_promote_triage': true,
+      'auto_promote_refinement': false,
+      'generate_pr_description': true,
       'issue_tracking': {'enabled': false},
       'org_overrides': {
         'acme': {
           'primary': 'gemini',
           'issue_prompt': 'org-issue',
+          'triage_owner': 'alice',
+          'clone_dir': '/work/acme',
+          'auto_promote_triage': false,
+          'auto_promote_refinement': true,
+          'generate_pr_description': false,
           'pr_reviewers': ['alice'],
           'issue_tracking': {
-            'enabled': true,
             'develop_labels': ['ready'],
           },
         },
@@ -103,9 +112,20 @@ void main() {
     final org = cfg.orgConfigs['acme']!;
     expect(org.aiPrimary, 'gemini');
     expect(org.issuePromptId, 'org-issue');
+    expect(org.triageOwner, 'alice');
+    expect(org.cloneDir, '/work/acme');
+    expect(org.autoPromoteTriage, isFalse);
+    expect(org.autoPromoteRefinement, isTrue);
+    expect(org.generatePRDescription, isFalse);
     expect(org.prReviewers, ['alice']);
-    expect(org.itEnabled, isTrue);
+    expect(org.itEnabled, isNull);
+    expect(org.devEnabled, isTrue);
     expect(org.developLabels, ['ready']);
+    expect(cfg.globalTriageOwner, 'global-owner');
+    expect(cfg.globalCloneDir, '/work/global');
+    expect(cfg.globalAutoPromoteTriage, isTrue);
+    expect(cfg.globalAutoPromoteRefinement, isFalse);
+    expect(cfg.globalGeneratePRDescription, isTrue);
   });
 
   test('AppConfig preserves scoped false and empty-list overrides', () {
@@ -125,6 +145,11 @@ void main() {
       'repo_overrides': {
         'acme/api': {
           'implement_prompt': 'repo-impl',
+          'triage_owner': 'repo-owner',
+          'clone_dir': '/work/repo',
+          'auto_promote_triage': false,
+          'auto_promote_refinement': true,
+          'generate_pr_description': true,
           'issue_tracking': {
             'enabled': false,
             'review_only_labels': <String>[],
@@ -143,11 +168,41 @@ void main() {
     expect(repo.itEnabled, isFalse);
     expect(repo.reviewOnlyLabels, isEmpty);
     expect(repo.developPromptId, 'repo-impl');
+    expect(repo.triageOwner, 'repo-owner');
+    expect(repo.cloneDir, '/work/repo');
+    expect(repo.autoPromoteTriage, isFalse);
+    expect(repo.autoPromoteRefinement, isTrue);
+    expect(repo.generatePRDescription, isTrue);
     expect(repo.isMonitored, isFalse);
 
     final org = cfg.orgConfigs['acme']!;
     expect(org.itEnabled, isFalse);
     expect(org.developLabels, isEmpty);
+  });
+
+  test('OrgConfig derives enabled switches from label overrides', () {
+    final cfg = AppConfig.fromJson({
+      'repositories': <String>[],
+      'server_port': 1,
+      'poll_interval': '60s',
+      'retention_days': 30,
+      'ai_primary': 'claude',
+      'ai_fallback': '',
+      'review_mode': 'single',
+      'issue_tracking': {'enabled': false},
+      'org_overrides': {
+        'acme': {
+          'issue_tracking': {
+            'review_only_labels': ['needs-triage'],
+            'develop_labels': ['ready'],
+          },
+        },
+      },
+    });
+
+    final org = cfg.orgConfigs['acme']!;
+    expect(org.itEnabled, isTrue);
+    expect(org.devEnabled, isTrue);
   });
 
   testWidgets('saveAndStartDaemon calls platform.spawnDaemon', (tester) async {

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -36,14 +36,14 @@ void main() {
         overrides: [
           apiClientProvider.overrideWithValue(mockApi),
           configNotifierProvider.overrideWith(ConfigNotifier.new),
-          platformServicesProvider.overrideWithValue(
-            FakePlatformServices(),
-          ),
+          platformServicesProvider.overrideWithValue(FakePlatformServices()),
         ],
         child: MaterialApp.router(
-          routerConfig: GoRouter(routes: [
-            GoRoute(path: '/', builder: (_, __) => const ConfigScreen()),
-          ]),
+          routerConfig: GoRouter(
+            routes: [
+              GoRoute(path: '/', builder: (_, __) => const ConfigScreen()),
+            ],
+          ),
         ),
       ),
     );
@@ -60,8 +60,12 @@ void main() {
       'repo_overrides': {
         'a/b': {'first_seen_at': 1234567890},
       },
-      'server_port': 1, 'poll_interval': '60s', 'retention_days': 30,
-      'ai_primary': 'claude', 'ai_fallback': '', 'review_mode': 'single',
+      'server_port': 1,
+      'poll_interval': '60s',
+      'retention_days': 30,
+      'ai_primary': 'claude',
+      'ai_fallback': '',
+      'review_mode': 'single',
       'issue_tracking': {'enabled': false},
     };
     final cfg = AppConfig.fromJson(json);
@@ -71,14 +75,89 @@ void main() {
     );
   });
 
+  test('AppConfig parses organization overrides', () {
+    final json = {
+      'repositories': <String>[],
+      'non_monitored': ['acme/api'],
+      'server_port': 1,
+      'poll_interval': '60s',
+      'retention_days': 30,
+      'ai_primary': 'claude',
+      'ai_fallback': '',
+      'review_mode': 'single',
+      'issue_tracking': {'enabled': false},
+      'org_overrides': {
+        'acme': {
+          'primary': 'gemini',
+          'issue_prompt': 'org-issue',
+          'pr_reviewers': ['alice'],
+          'issue_tracking': {
+            'enabled': true,
+            'develop_labels': ['ready'],
+          },
+        },
+      },
+    };
+
+    final cfg = AppConfig.fromJson(json);
+    final org = cfg.orgConfigs['acme']!;
+    expect(org.aiPrimary, 'gemini');
+    expect(org.issuePromptId, 'org-issue');
+    expect(org.prReviewers, ['alice']);
+    expect(org.itEnabled, isTrue);
+    expect(org.developLabels, ['ready']);
+  });
+
+  test('AppConfig preserves scoped false and empty-list overrides', () {
+    final json = {
+      'repositories': <String>[],
+      'non_monitored': ['acme/api'],
+      'server_port': 1,
+      'poll_interval': '60s',
+      'retention_days': 30,
+      'ai_primary': 'claude',
+      'ai_fallback': '',
+      'review_mode': 'single',
+      'issue_tracking': {
+        'enabled': true,
+        'review_only_labels': ['global-review'],
+      },
+      'repo_overrides': {
+        'acme/api': {
+          'implement_prompt': 'repo-impl',
+          'issue_tracking': {
+            'enabled': false,
+            'review_only_labels': <String>[],
+          },
+        },
+      },
+      'org_overrides': {
+        'acme': {
+          'issue_tracking': {'enabled': false, 'develop_labels': <String>[]},
+        },
+      },
+    };
+
+    final cfg = AppConfig.fromJson(json);
+    final repo = cfg.repoConfigs['acme/api']!;
+    expect(repo.itEnabled, isFalse);
+    expect(repo.reviewOnlyLabels, isEmpty);
+    expect(repo.developPromptId, 'repo-impl');
+    expect(repo.isMonitored, isFalse);
+
+    final org = cfg.orgConfigs['acme']!;
+    expect(org.itEnabled, isFalse);
+    expect(org.developLabels, isEmpty);
+  });
+
   testWidgets('saveAndStartDaemon calls platform.spawnDaemon', (tester) async {
     final platform = FakePlatformServices(
       daemonBinaryPath: '/fake/bin/heimdalld',
       githubToken: 'fake-token',
     );
-    final container = ProviderContainer(overrides: [
-      platformServicesProvider.overrideWithValue(platform),
-    ]);
+    final container = ProviderContainer(
+      overrides: [platformServicesProvider.overrideWithValue(platform)],
+    );
     addTearDown(container.dispose);
 
     // Call saveAndStartDaemon via the notifier. We don't verify daemon health
@@ -88,11 +167,13 @@ void main() {
 
     // Run in real-async mode so Future.delayed works without fake-async leaks.
     await tester.runAsync(() async {
-      unawaited(notifier.saveAndStartDaemon(
-        token: 'fake-gh-token',
-        config: const AppConfig(),
-        daemonBinaryPath: '/fake/bin/heimdalld',
-      ));
+      unawaited(
+        notifier.saveAndStartDaemon(
+          token: 'fake-gh-token',
+          config: const AppConfig(),
+          daemonBinaryPath: '/fake/bin/heimdalld',
+        ),
+      );
       // Allow the microtasks that lead to the first spawnDaemon to run.
       await Future.delayed(const Duration(milliseconds: 50));
     });
@@ -100,32 +181,37 @@ void main() {
     expect(platform.spawnedDaemons, contains('/fake/bin/heimdalld'));
   });
 
-  testWidgets('saveAndStartDaemon routes daemon spawn through PlatformServices', (tester) async {
-    final platform = FakePlatformServices(
-      daemonBinaryPath: '/fake/bin/heimdalld',
-      githubToken: 'fake-token',
-    );
-    final container = ProviderContainer(overrides: [
-      platformServicesProvider.overrideWithValue(platform),
-    ]);
-    addTearDown(container.dispose);
-
-    // Call saveAndStartDaemon via the notifier. We don't verify daemon health
-    // (the fake's ApiClient isn't wired), but we do verify the spawn reached
-    // the platform layer at least once before the health-check loop timed out.
-    final notifier = container.read(configNotifierProvider.notifier);
-    // Kick off the call but ignore its completion — we only care about the
-    // side-effect of calling spawnDaemon.
-    await tester.runAsync(() async {
-      unawaited(notifier.saveAndStartDaemon(
-        token: 'fake-gh-token',
-        config: const AppConfig(),
+  testWidgets(
+    'saveAndStartDaemon routes daemon spawn through PlatformServices',
+    (tester) async {
+      final platform = FakePlatformServices(
         daemonBinaryPath: '/fake/bin/heimdalld',
-      ));
-      // Allow the microtasks that lead to the first spawnDaemon to run.
-      await Future.delayed(const Duration(milliseconds: 50));
-    });
+        githubToken: 'fake-token',
+      );
+      final container = ProviderContainer(
+        overrides: [platformServicesProvider.overrideWithValue(platform)],
+      );
+      addTearDown(container.dispose);
 
-    expect(platform.spawnedDaemons, contains('/fake/bin/heimdalld'));
-  });
+      // Call saveAndStartDaemon via the notifier. We don't verify daemon health
+      // (the fake's ApiClient isn't wired), but we do verify the spawn reached
+      // the platform layer at least once before the health-check loop timed out.
+      final notifier = container.read(configNotifierProvider.notifier);
+      // Kick off the call but ignore its completion — we only care about the
+      // side-effect of calling spawnDaemon.
+      await tester.runAsync(() async {
+        unawaited(
+          notifier.saveAndStartDaemon(
+            token: 'fake-gh-token',
+            config: const AppConfig(),
+            daemonBinaryPath: '/fake/bin/heimdalld',
+          ),
+        );
+        // Allow the microtasks that lead to the first spawnDaemon to run.
+        await Future.delayed(const Duration(milliseconds: 50));
+      });
+
+      expect(platform.spawnedDaemons, contains('/fake/bin/heimdalld'));
+    },
+  );
 }

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -205,6 +205,52 @@ void main() {
     expect(org.devEnabled, isTrue);
   });
 
+  test('AppConfig exposes known autocomplete options', () {
+    const cfg = AppConfig(
+      repoConfigs: {
+        'acme/api': RepoConfig(
+          issueOrganizations: ['security'],
+          issueAssignees: ['repo-assignee'],
+          prReviewers: ['repo-reviewer'],
+          prAssignee: 'repo-owner',
+        ),
+      },
+      orgConfigs: {
+        'platform': OrgConfig(
+          issueOrganizations: ['external'],
+          issueAssignees: ['org-assignee'],
+          prReviewers: ['org-reviewer'],
+          prAssignee: 'org-owner',
+        ),
+      },
+      issueTracking: IssueTrackingConfig(
+        organizations: ['global-org'],
+        assignees: ['global-assignee'],
+      ),
+      globalPRReviewers: ['global-reviewer'],
+      globalPRAssignee: 'global-owner',
+    );
+
+    expect(cfg.knownOrganizations, [
+      'acme',
+      'external',
+      'global-org',
+      'platform',
+      'security',
+    ]);
+    expect(cfg.knownGitHubUsers, [
+      'global-assignee',
+      'global-owner',
+      'global-reviewer',
+      'org-assignee',
+      'org-owner',
+      'org-reviewer',
+      'repo-assignee',
+      'repo-owner',
+      'repo-reviewer',
+    ]);
+  });
+
   testWidgets('saveAndStartDaemon calls platform.spawnDaemon', (tester) async {
     final platform = FakePlatformServices(
       daemonBinaryPath: '/fake/bin/heimdalld',

--- a/flutter_app/test/features/organizations/org_detail_screen_test.dart
+++ b/flutter_app/test/features/organizations/org_detail_screen_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/api/api_client.dart';
+import 'package:heimdallm/core/models/agent.dart';
+import 'package:heimdallm/features/agents/agents_screen.dart';
+import 'package:heimdallm/features/config/config_providers.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
+import 'package:heimdallm/features/organizations/org_detail_screen.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  testWidgets('OrgDetailScreen exposes pipeline org overrides', (tester) async {
+    final mockApi = MockApiClient();
+    when(() => mockApi.fetchConfig()).thenAnswer(
+      (_) async => {
+        'repositories': <String>[],
+        'server_port': 1,
+        'poll_interval': '60s',
+        'retention_days': 30,
+        'ai_primary': 'claude',
+        'ai_fallback': '',
+        'review_mode': 'single',
+        'issue_tracking': {'enabled': false},
+        'triage_owner': 'global-owner',
+        'clone_dir': '/work/global',
+        'auto_promote_triage': false,
+        'auto_promote_refinement': false,
+        'generate_pr_description': false,
+        'org_overrides': {
+          'acme': {
+            'triage_owner': 'alice',
+            'clone_dir': '/work/acme',
+            'auto_promote_triage': true,
+            'auto_promote_refinement': true,
+            'generate_pr_description': true,
+          },
+        },
+      },
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiClientProvider.overrideWithValue(mockApi),
+          configNotifierProvider.overrideWith(ConfigNotifier.new),
+          agentsProvider.overrideWith((_) async => <ReviewPrompt>[]),
+        ],
+        child: const MaterialApp(home: OrgDetailScreen(orgName: 'acme')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pipeline'), findsOneWidget);
+    expect(find.text('Triage owner'), findsOneWidget);
+    expect(find.text('Clone directory'), findsOneWidget);
+    expect(find.text('Auto-promote triage'), findsOneWidget);
+    expect(find.text('Auto-promote refinement'), findsOneWidget);
+    expect(find.text('Generate PR description'), findsOneWidget);
+  });
+}

--- a/flutter_app/test/features/organizations/org_detail_screen_test.dart
+++ b/flutter_app/test/features/organizations/org_detail_screen_test.dart
@@ -36,6 +36,10 @@ void main() {
             'auto_promote_triage': true,
             'auto_promote_refinement': true,
             'generate_pr_description': true,
+            'issue_tracking': {
+              'organizations': ['acme'],
+              'assignees': ['alice'],
+            },
           },
         },
       },
@@ -59,5 +63,7 @@ void main() {
     expect(find.text('Auto-promote triage'), findsOneWidget);
     expect(find.text('Auto-promote refinement'), findsOneWidget);
     expect(find.text('Generate PR description'), findsOneWidget);
+    expect(find.text('Organizations'), findsOneWidget);
+    expect(find.text('Assignees'), findsOneWidget);
   });
 }

--- a/flutter_app/test/shared/autocomplete_chip_field_test.dart
+++ b/flutter_app/test/shared/autocomplete_chip_field_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/shared/widgets/autocomplete_chip_field.dart';
+
+void main() {
+  testWidgets('shows available options when focused with empty query', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AutocompleteChipField(
+            label: 'Organizations',
+            selectedValues: const [],
+            availableOptions: const ['acme', 'platform'],
+            onChanged: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('acme'), findsNothing);
+    expect(find.text('platform'), findsNothing);
+
+    await tester.tap(find.byType(TextFormField));
+    await tester.pump();
+
+    expect(find.text('acme'), findsOneWidget);
+    expect(find.text('platform'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Closes #396.

Adds organization-level configuration overrides between global and repository scope, including backend resolution, API endpoints, Flutter UI support, CLI output, docs, and tests.

## Changes

- Add `OrgAI`, `IssueTrackingOverride`, and org override validation/resolution for repo effective config.
- Add config API support for listing, patching, and deleting organization overrides.
- Add Flutter org config models, routes, org detail screen, inherited source labels, and explicit empty-list preservation.
- Update promotion/review flows to use repo-effective issue tracking configuration.
- Extend CLI config output and example/docs for org-level overrides.

## Validation

- `make test-docker`
- `cd flutter_app && flutter test`
- `cd flutter_app && flutter analyze`
- `make build-web`
- CLI module in Docker: `go test ./...`

Notes: Flutter tests passed with existing hit-test warnings in agent tests. `make build-web` passed with Flutter's existing CupertinoIcons tree-shaking warning.