### PR TITLE
feat: auto-clone repo context for agents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
         release-local package-macos install-service verify-linux run-linux \
         install-linux uninstall-linux \
         setup up up-build up-daemon up-build-daemon down logs logs-daemon \
-        ps restart clean _check-docker _check-env _check-linux _post-up-hints
+        ps restart clean clean-clones _check-docker _check-env _check-linux _post-up-hints
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 
@@ -104,6 +104,14 @@ dev-stop:
 	   kill "$$UI_PID" 2>/dev/null && echo "↓  UI parada (PID $$UI_PID)" || true; \
 	   rm -f "$$UI_PID_FILE"; \
 	 fi
+
+clean-clones:
+	@: "$${HEIMDALLM_API_TOKEN:?set HEIMDALLM_API_TOKEN to the daemon API token}"
+	@HEIMDALLM_SERVER_URL="$${HEIMDALLM_SERVER_URL:-http://localhost:7842}"; \
+	  curl -fsS -X DELETE \
+	    -H "X-Heimdallm-Token: $$HEIMDALLM_API_TOKEN" \
+	    "$$HEIMDALLM_SERVER_URL/config/clones"; \
+	  echo
 
 # ── Local release (macOS only: sign + notarize + DMG + GitHub release) ───────
 #

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -280,16 +281,47 @@ func main() {
 	srv := server.New(s, broker, p, apiToken)
 	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)
-	srv.SetCleanCloneFn(func(repo string) error {
-		cfgMu.Lock()
-		aiCfg := cfg.AIForRepo(repo)
-		cfgMu.Unlock()
-		return repoCtx.Purge(context.Background(), repo, aiCfg.CloneDir)
-	})
 	shutdownReq := make(chan struct{}, 1)
 
 	// discoverySvc holds the discovered repo cache.
 	discoverySvc := discovery.NewService(ghClient)
+
+	srv.SetCleanCloneFn(func(ctx context.Context, repo string) error {
+		cfgMu.Lock()
+		aiCfg := cfg.AIForRepo(repo)
+		cfgMu.Unlock()
+		return repoCtx.Purge(ctx, repo, aiCfg.CloneDir)
+	})
+	srv.SetCleanClonesFn(func(ctx context.Context) (int, error) {
+		cfgMu.Lock()
+		cfgSnap := cfg
+		cfgMu.Unlock()
+		return purgeAllManagedClones(ctx, repoCtx, cfgSnap)
+	})
+
+	runCloneRetention := func(reason string) {
+		cfgMu.Lock()
+		cfgSnap := cfg
+		var discovered []string
+		if cfg.GitHub.DiscoveryTopic != "" {
+			discovered = discoverySvc.Discovered()
+		}
+		cfgMu.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		removed, err := purgeStaleManagedClones(ctx, repoCtx, cfgSnap, discovered)
+		if err != nil {
+			slog.Warn("clone retention purge failed", "reason", reason, "err", err)
+			return
+		}
+		if removed > 0 {
+			slog.Info("clone retention purge removed managed clones", "reason", reason, "removed", removed)
+		}
+	}
+	runCloneRetention("startup")
+	clonePurge := scheduler.New(24*time.Hour, func() { runCloneRetention("periodic") })
+	clonePurge.Start()
+	defer clonePurge.Stop()
 
 	// loginMu guards cachedLogin against concurrent reads/writes from the
 	// poll cycle and HTTP goroutines.
@@ -3266,6 +3298,80 @@ func issueTrackingOverrideMap(ov *config.IssueTrackingOverride) map[string]any {
 	}
 	if ov.Assignees != nil {
 		out["assignees"] = ov.Assignees
+	}
+	return out
+}
+
+func purgeAllManagedClones(ctx context.Context, manager *repoctx.Manager, cfg *config.Config) (int, error) {
+	if manager == nil {
+		return 0, fmt.Errorf("repoctx: nil manager")
+	}
+	var total int
+	var errs []error
+	for _, cloneDir := range managedCloneDirs(cfg) {
+		report, err := manager.PurgeAll(ctx, cloneDir)
+		total += report.Removed
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return total, errors.Join(errs...)
+}
+
+func purgeStaleManagedClones(ctx context.Context, manager *repoctx.Manager, cfg *config.Config, discovered []string) (int, error) {
+	if manager == nil {
+		return 0, fmt.Errorf("repoctx: nil manager")
+	}
+	if cfg == nil || cfg.Retention.MaxDays <= 0 {
+		return 0, nil
+	}
+	monitored := monitoredRepoSet(cfg, discovered)
+	var total int
+	var errs []error
+	for _, cloneDir := range managedCloneDirs(cfg) {
+		report, err := manager.PurgeStale(ctx, cloneDir, monitored, cfg.Retention.MaxDays)
+		total += report.Removed
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return total, errors.Join(errs...)
+}
+
+func managedCloneDirs(cfg *config.Config) []string {
+	seen := map[string]struct{}{}
+	add := func(path string) {
+		seen[strings.TrimSpace(path)] = struct{}{}
+	}
+	add("")
+	if cfg != nil {
+		add(cfg.AI.CloneDir)
+		for _, org := range cfg.AI.Orgs {
+			add(org.CloneDir)
+		}
+		for _, repo := range cfg.AI.Repos {
+			add(repo.CloneDir)
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for path := range seen {
+		out = append(out, path)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func monitoredRepoSet(cfg *config.Config, discovered []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	if cfg == nil {
+		return out
+	}
+	repos := discovery.MergeRepos(cfg.GitHub.Repositories, discovered, cfg.GitHub.NonMonitored)
+	for _, repo := range repos {
+		repo = strings.TrimSpace(repo)
+		if repo != "" {
+			out[repo] = struct{}{}
+		}
 	}
 	return out
 }

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/heimdallm/daemon/internal/keychain"
 	"github.com/heimdallm/daemon/internal/notify"
 	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/repoctx"
 	"github.com/heimdallm/daemon/internal/scheduler"
 	"github.com/heimdallm/daemon/internal/server"
 	"github.com/heimdallm/daemon/internal/sse"
@@ -210,6 +211,7 @@ func main() {
 	notifier := notify.New()
 	ghClient := gh.NewClient(token)
 	exec := executor.New()
+	repoCtx := repoctx.NewManager()
 
 	// Load or create the per-daemon API token.  All mutating HTTP endpoints
 	// require this token in X-Heimdallm-Token (security issue #3).
@@ -271,14 +273,20 @@ func main() {
 	}
 	issueFetcher := issuepipeline.NewFetcher(ghClient, ghClient, s, issuePipe)
 	issueFetcher.SetBotLogin(resolvedBotLogin) // break re-triage loop (#362)
-	srv := server.New(s, broker, p, apiToken)
-	srv.SetNATSConn(eventBus.Conn())
-	srv.SetConfigPath(cfgPath)
-	shutdownReq := make(chan struct{}, 1)
-
 	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
 	var reloadMu sync.Mutex // serialises config reloads to prevent duplicate pipelines
+
+	srv := server.New(s, broker, p, apiToken)
+	srv.SetNATSConn(eventBus.Conn())
+	srv.SetConfigPath(cfgPath)
+	srv.SetCleanCloneFn(func(repo string) error {
+		cfgMu.Lock()
+		aiCfg := cfg.AIForRepo(repo)
+		cfgMu.Unlock()
+		return repoCtx.Purge(context.Background(), repo, aiCfg.CloneDir)
+	})
+	shutdownReq := make(chan struct{}, 1)
 
 	// discoverySvc holds the discovered repo cache.
 	discoverySvc := discovery.NewService(ghClient)
@@ -481,6 +489,7 @@ func main() {
 		pipeline:             p,
 		issuePipe:            issuePipe,
 		fetcher:              issueFetcher,
+		repoCtx:              repoCtx,
 		store:                s,
 		broker:               broker,
 		cfgMu:                &cfgMu,
@@ -636,7 +645,14 @@ func main() {
 		aiCfg := c.AIForRepo(pr.Repo)
 		localDirBase := c.GitHub.LocalDirBase
 		cfgMu.Unlock()
-		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo, localDirBase)
+		repoHandle, err := acquireRepoContext(ctx, repoCtx, pr.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		if err != nil {
+			logRepoContextFallback("review-worker", pr.Repo, err)
+			aiCfg.LocalDir = ""
+		}
+		if repoHandle != nil {
+			defer repoHandle.Release()
+		}
 
 		rev := runReview(pr, aiCfg)
 
@@ -783,7 +799,14 @@ func main() {
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
-		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, msg.Repo, localDirBase)
+		repoHandle, err := acquireRepoContext(ctx, repoCtx, msg.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		if err != nil {
+			logRepoContextFallback("triage-worker", msg.Repo, err)
+			aiCfg.LocalDir = ""
+		}
+		if repoHandle != nil {
+			defer repoHandle.Release()
+		}
 
 		extraFlags := agentCfg.ExtraFlags
 		if extraFlags != "" {
@@ -869,7 +892,21 @@ func main() {
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
-		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, msg.Repo, localDirBase)
+		repoHandle, err := acquireRepoContext(ctx, repoCtx, msg.Repo, &aiCfg, localDirBase, token, repoctx.ModeWrite)
+		if err != nil {
+			slog.Error("implement-worker: prepare repo context failed",
+				"repo", msg.Repo, "number", msg.Number, "err", err)
+			broker.Publish(sse.Event{
+				Type: sse.EventIssueReviewError,
+				Data: sseData(map[string]any{
+					"repo": msg.Repo, "number": msg.Number, "error": err.Error(),
+				}),
+			})
+			return
+		}
+		if repoHandle != nil {
+			defer repoHandle.Release()
+		}
 
 		extraFlags := agentCfg.ExtraFlags
 		if extraFlags != "" {
@@ -899,15 +936,16 @@ func main() {
 				NoSessionPersistence: agentCfg.NoSessionPersistence,
 				Timeout:              resolveExecutionTimeout(globalTimeout, agentCfg.ExecutionTimeout),
 			},
-			IssuePromptOverride:     issuePrompt,
-			IssueInstructions:       issueInstructions,
-			ImplementPromptOverride: implPrompt,
-			ImplementInstructions:   implInstructions,
-			PRReviewers:             aiCfg.PRReviewers,
-			PRAssignee:              aiCfg.PRAssignee,
-			PRLabels:                aiCfg.PRLabels,
-			PRDraft:                 aiCfg.PRDraft != nil && *aiCfg.PRDraft,
-			GeneratePRDescription:   aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+			IssuePromptOverride:      issuePrompt,
+			IssueInstructions:        issueInstructions,
+			ImplementPromptOverride:  implPrompt,
+			ImplementInstructions:    implInstructions,
+			PRReviewers:              aiCfg.PRReviewers,
+			PRAssignee:               aiCfg.PRAssignee,
+			PRLabels:                 aiCfg.PRLabels,
+			PRDraft:                  aiCfg.PRDraft != nil && *aiCfg.PRDraft,
+			GeneratePRDescription:    aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+			RequireWorkDirForDevelop: true,
 		}
 
 		if _, err := issuePipe.Run(ctx, ghIssue, opts); err != nil {
@@ -1302,9 +1340,14 @@ func main() {
 		aiCfg := cfg.AIForRepo(pr.Repo)
 		localDirBase := cfg.GitHub.LocalDirBase
 		cfgMu.Unlock()
-		// /home/heimdallm/repos/<short-name> fallback when local_dir is unset (stat-based,
-		// keep outside the mutex).
-		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo, localDirBase)
+		repoHandle, err := acquireRepoContext(context.Background(), repoCtx, pr.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		if err != nil {
+			logRepoContextFallback("trigger review", pr.Repo, err)
+			aiCfg.LocalDir = ""
+		}
+		if repoHandle != nil {
+			defer repoHandle.Release()
+		}
 
 		// Construct github.PullRequest from stored data
 		ghPR := &gh.PullRequest{
@@ -1411,9 +1454,14 @@ func main() {
 		localDirBase := cfg.GitHub.LocalDirBase
 		globalTimeout := cfg.AI.ExecutionTimeout
 		cfgMu.Unlock()
-		// /home/heimdallm/repos/<short-name> fallback when local_dir is unset (stat-based,
-		// keep outside the mutex).
-		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, iss.Repo, localDirBase)
+		repoHandle, err := acquireRepoContext(context.Background(), repoCtx, iss.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		if err != nil {
+			logRepoContextFallback("trigger issue review", iss.Repo, err)
+			aiCfg.LocalDir = ""
+		}
+		if repoHandle != nil {
+			defer repoHandle.Release()
+		}
 
 		// Reconstruct github.Issue from store data for the pipeline
 		ghIssue := &gh.Issue{
@@ -1944,6 +1992,7 @@ type tier2Adapter struct {
 	pipeline   *pipeline.Pipeline
 	issuePipe  *issuepipeline.Pipeline
 	fetcher    *issuepipeline.Fetcher
+	repoCtx    *repoctx.Manager
 	store      *store.Store
 	broker     *sse.Broker
 	cfgMu      *sync.Mutex
@@ -2274,10 +2323,14 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 	aiCfg := c.AIForRepo(pr.Repo)
 	localDirBase := c.GitHub.LocalDirBase
 	a.cfgMu.Unlock()
-	// /home/heimdallm/repos/<short-name> fallback when local_dir is unset (stat-based,
-	// keep outside the mutex). Lets HEIMDALLM_LOCAL_DIR_BASE give every
-	// monitored repo full-repo context without a per-repo override.
-	aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, pr.Repo, localDirBase)
+	repoHandle, err := acquireRepoContext(ctx, a.repoCtx, pr.Repo, &aiCfg, localDirBase, a.ghToken, repoctx.ModeRead)
+	if err != nil {
+		logRepoContextFallback("tier2 PR", pr.Repo, err)
+		aiCfg.LocalDir = ""
+	}
+	if repoHandle != nil {
+		defer repoHandle.Release()
+	}
 
 	ghPR := &gh.PullRequest{
 		ID:        pr.ID,
@@ -2385,9 +2438,33 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		a.cfgMu.Unlock()
-		// /home/heimdallm/repos/<short-name> fallback when local_dir is unset (stat-based,
-		// keep outside the mutex).
-		aiCfg.LocalDir = config.ResolveLocalDir(aiCfg.LocalDir, issue.Repo, localDirBase)
+		mode := repoctx.ModeRead
+		requireWorkDir := false
+		if issue.Mode == config.IssueModeDevelop {
+			mode = repoctx.ModeWrite
+			requireWorkDir = true
+		}
+		var releaseRepoContext func()
+		repoHandle, err := acquireRepoContext(ctx, a.repoCtx, issue.Repo, &aiCfg, localDirBase, a.ghToken, mode)
+		if err != nil {
+			if issue.Mode == config.IssueModeDevelop {
+				slog.Error("issue poll: prepare repo context failed",
+					"repo", issue.Repo, "number", issue.Number, "err", err)
+				if a.broker != nil {
+					a.broker.Publish(sse.Event{
+						Type: sse.EventIssueReviewError,
+						Data: sseData(map[string]any{
+							"repo": issue.Repo, "number": issue.Number, "error": err.Error(),
+						}),
+					})
+				}
+			} else {
+				logRepoContextFallback("issue poll", issue.Repo, err)
+			}
+			aiCfg.LocalDir = ""
+		} else if repoHandle != nil {
+			releaseRepoContext = repoHandle.Release
+		}
 
 		extraFlags := agentCfg.ExtraFlags
 		if extraFlags != "" {
@@ -2417,15 +2494,17 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 				NoSessionPersistence: agentCfg.NoSessionPersistence,
 				Timeout:              resolveExecutionTimeout(globalTimeout, agentCfg.ExecutionTimeout),
 			},
-			IssuePromptOverride:     issuePrompt,
-			IssueInstructions:       issueInstructions,
-			ImplementPromptOverride: implPrompt,
-			ImplementInstructions:   implInstructions,
-			PRReviewers:             aiCfg.PRReviewers,
-			PRAssignee:              aiCfg.PRAssignee,
-			PRLabels:                aiCfg.PRLabels,
-			PRDraft:                 aiCfg.PRDraft != nil && *aiCfg.PRDraft,
-			GeneratePRDescription:   aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+			IssuePromptOverride:      issuePrompt,
+			IssueInstructions:        issueInstructions,
+			ImplementPromptOverride:  implPrompt,
+			ImplementInstructions:    implInstructions,
+			PRReviewers:              aiCfg.PRReviewers,
+			PRAssignee:               aiCfg.PRAssignee,
+			PRLabels:                 aiCfg.PRLabels,
+			PRDraft:                  aiCfg.PRDraft != nil && *aiCfg.PRDraft,
+			GeneratePRDescription:    aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+			RequireWorkDirForDevelop: requireWorkDir,
+			ReleaseRepoContext:       releaseRepoContext,
 		}
 	}
 
@@ -2974,6 +3053,38 @@ func sseData(v map[string]any) string {
 		return "{}"
 	}
 	return string(b)
+}
+
+func acquireRepoContext(
+	ctx context.Context,
+	manager *repoctx.Manager,
+	repo string,
+	aiCfg *config.RepoAI,
+	localDirBase []string,
+	token string,
+	mode repoctx.Mode,
+) (*repoctx.Handle, error) {
+	if manager == nil {
+		manager = repoctx.NewManager()
+	}
+	h, err := manager.Acquire(ctx, repoctx.Request{
+		Repo:               repo,
+		ConfiguredLocalDir: aiCfg.LocalDir,
+		LocalDirBases:      localDirBase,
+		CloneDir:           aiCfg.CloneDir,
+		Token:              token,
+		Mode:               mode,
+	})
+	if err != nil {
+		return nil, err
+	}
+	aiCfg.LocalDir = h.Path()
+	return h, nil
+}
+
+func logRepoContextFallback(scope, repo string, err error) {
+	slog.Warn(scope+": repo context unavailable; continuing without local checkout",
+		"repo", repo, "err", err)
 }
 
 // ptrBoolOrTrue returns the dereferenced value of p, or true if p is nil.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2427,7 +2427,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 		}
 	}
 
-	optsFor := func(issue *gh.Issue) issuepipeline.RunOptions {
+	optsFor := func(issue *gh.Issue) (issuepipeline.RunOptions, bool) {
 		a.cfgMu.Lock()
 		c := *a.cfg
 		aiCfg := c.AIForRepo(issue.Repo)
@@ -2445,7 +2445,13 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 			requireWorkDir = true
 		}
 		var releaseRepoContext func()
+		releaseOnReturn := true
 		repoHandle, err := acquireRepoContext(ctx, a.repoCtx, issue.Repo, &aiCfg, localDirBase, a.ghToken, mode)
+		defer func() {
+			if releaseOnReturn && repoHandle != nil {
+				repoHandle.Release()
+			}
+		}()
 		if err != nil {
 			if issue.Mode == config.IssueModeDevelop {
 				slog.Error("issue poll: prepare repo context failed",
@@ -2458,6 +2464,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 						}),
 					})
 				}
+				return issuepipeline.RunOptions{}, false
 			} else {
 				logRepoContextFallback("issue poll", issue.Repo, err)
 			}
@@ -2477,7 +2484,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 		issuePrompt, issueInstructions := resolveIssuePrompt(a.store, aiCfg.IssuePrompt, agentCfg.PromptID)
 		implPrompt, implInstructions := resolveImplementPrompt(a.store, aiCfg.ImplementPrompt, agentCfg.PromptID)
 
-		return issuepipeline.RunOptions{
+		opts := issuepipeline.RunOptions{
 			GitHubToken: a.ghToken,
 			Primary:     aiCfg.Primary,
 			Fallback:    aiCfg.Fallback,
@@ -2506,6 +2513,8 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 			RequireWorkDirForDevelop: requireWorkDir,
 			ReleaseRepoContext:       releaseRepoContext,
 		}
+		releaseOnReturn = false
+		return opts, true
 	}
 
 	return a.fetcher.ProcessRepo(ctx, repo, repoIT, authUser, optsFor)
@@ -3065,7 +3074,7 @@ func acquireRepoContext(
 	mode repoctx.Mode,
 ) (*repoctx.Handle, error) {
 	if manager == nil {
-		manager = repoctx.NewManager()
+		return nil, fmt.Errorf("repoctx: nil manager")
 	}
 	h, err := manager.Acquire(ctx, repoctx.Request{
 		Repo:               repo,
@@ -3078,6 +3087,9 @@ func acquireRepoContext(
 	if err != nil {
 		return nil, err
 	}
+	// aiCfg.LocalDir is valid only while the returned handle is held. Callers
+	// must release the handle after the pipeline/executor has finished with the
+	// path.
 	aiCfg.LocalDir = h.Path()
 	return h, nil
 }

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -44,6 +44,88 @@ func TestAcquireRepoContextNilManagerIsError(t *testing.T) {
 	}
 }
 
+func TestManagedCloneDirsIncludesDefaultAndScopedOverrides(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.AI.CloneDir = "/global"
+	cfg.AI.Orgs = map[string]config.OrgAI{
+		"org": {CloneDir: "/org"},
+	}
+	cfg.AI.Repos = map[string]config.RepoAI{
+		"org/repo":  {CloneDir: "/repo"},
+		"org/other": {CloneDir: "/org"},
+	}
+
+	got := managedCloneDirs(cfg)
+	want := []string{"", "/global", "/org", "/repo"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("managedCloneDirs = %v, want %v", got, want)
+	}
+}
+
+func TestMonitoredRepoSetMergesDiscoveredAndExcludesNonMonitored(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.Repositories = []string{"org/static"}
+	cfg.GitHub.NonMonitored = []string{"org/disabled"}
+
+	got := monitoredRepoSet(cfg, []string{"org/discovered", "org/disabled"})
+	for _, repo := range []string{"org/static", "org/discovered"} {
+		if _, ok := got[repo]; !ok {
+			t.Fatalf("monitoredRepoSet missing %s: %v", repo, got)
+		}
+	}
+	if _, ok := got["org/disabled"]; ok {
+		t.Fatalf("monitoredRepoSet includes non-monitored repo: %v", got)
+	}
+}
+
+func TestPurgeStaleManagedClonesUsesRetentionAndConfiguredDirs(t *testing.T) {
+	base := t.TempDir()
+	oldRepo := filepath.Join(base, "org", "old")
+	keepRepo := filepath.Join(base, "org", "keep")
+	for repo, dir := range map[string]string{
+		"org/old":  oldRepo,
+		"org/keep": keepRepo,
+	} {
+		if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeManagedMarkerForTest(t, dir, repo)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	for _, dir := range []string{oldRepo, keepRepo} {
+		if err := os.Chtimes(filepath.Join(dir, repoctx.MarkerFile), old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{}
+	cfg.AI.CloneDir = base
+	cfg.GitHub.Repositories = []string{"org/keep"}
+	cfg.Retention.MaxDays = 1
+
+	removed, err := purgeStaleManagedClones(context.Background(), repoctx.NewManager(), cfg, nil)
+	if err != nil {
+		t.Fatalf("purgeStaleManagedClones: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	if _, err := os.Stat(oldRepo); !os.IsNotExist(err) {
+		t.Fatalf("old unmonitored clone still exists or stat failed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(keepRepo); err != nil {
+		t.Fatalf("monitored clone should remain: %v", err)
+	}
+}
+
+func writeManagedMarkerForTest(t *testing.T, dir, repo string) {
+	t.Helper()
+	data := []byte(`{"version":1,"repo":"` + repo + `","managed_by":"heimdallm"}` + "\n")
+	if err := os.WriteFile(filepath.Join(dir, repoctx.MarkerFile), data, 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+}
+
 func seedAgent(t *testing.T, s *store.Store, a store.Agent) {
 	t.Helper()
 	if err := s.UpsertAgent(&a); err != nil {

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"github.com/heimdallm/daemon/internal/bus"
 	"github.com/heimdallm/daemon/internal/config"
 	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/repoctx"
 	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
 	natsserver "github.com/nats-io/nats-server/v2/server"
@@ -32,6 +34,14 @@ func newMemStore(t *testing.T) *store.Store {
 	}
 	t.Cleanup(func() { _ = s.Close() })
 	return s
+}
+
+func TestAcquireRepoContextNilManagerIsError(t *testing.T) {
+	aiCfg := config.RepoAI{}
+	_, err := acquireRepoContext(context.Background(), nil, "org/repo", &aiCfg, nil, "secret", repoctx.ModeRead)
+	if err == nil || !strings.Contains(err.Error(), "nil manager") {
+		t.Fatalf("err = %v, want nil manager error", err)
+	}
 }
 
 func seedAgent(t *testing.T, s *store.Store, a store.Agent) {

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -316,6 +316,16 @@ func ValidateWorkDir(dir string) error {
 		return nil
 	}
 
+	// Allow the OS temp directory too. On Linux this is usually /tmp, but on
+	// macOS os.TempDir() commonly resolves under /private/var/folders/...; the
+	// repo-context manager uses that location for managed auto-clones by
+	// default.
+	if tempAbs, err := resolvedAbs(os.TempDir()); err == nil {
+		if abs == tempAbs || strings.HasPrefix(abs, tempAbs+"/") {
+			return nil
+		}
+	}
+
 	// Allow paths under the user's home directory only.
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -330,6 +340,14 @@ func ValidateWorkDir(dir string) error {
 	}
 
 	return nil
+}
+
+func resolvedAbs(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(resolved)
 }
 
 // Execute runs the AI CLI with the given prompt and options, returning the

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -319,9 +319,10 @@ func ValidateWorkDir(dir string) error {
 	// Allow the OS temp directory too. On Linux this is usually /tmp, but on
 	// macOS os.TempDir() commonly resolves under /private/var/folders/...; the
 	// repo-context manager uses that location for managed auto-clones by
-	// default.
+	// default. If the temp dir cannot be resolved, skip this extra allowance;
+	// the explicit /tmp case above still covers normal Linux containers.
 	if tempAbs, err := resolvedAbs(os.TempDir()); err == nil {
-		if abs == tempAbs || strings.HasPrefix(abs, tempAbs+"/") {
+		if pathWithin(tempAbs, abs) {
 			return nil
 		}
 	}
@@ -348,6 +349,14 @@ func resolvedAbs(path string) (string, error) {
 		return "", err
 	}
 	return filepath.Abs(resolved)
+}
+
+func pathWithin(base, target string) bool {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 // Execute runs the AI CLI with the given prompt and options, returning the

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -15,6 +15,7 @@ import (
 )
 
 const executionTimeout = 5 * time.Minute
+const cliHelpTimeout = 2 * time.Second
 
 // ReviewResult is the parsed JSON response from the AI CLI.
 type ReviewResult struct {
@@ -389,7 +390,15 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 		cliPath = cli // best effort; execution will fail with a useful error
 	}
 
-	args := buildArgs(cli, opts)
+	var workDirFlags []string
+	if opts.WorkDir != "" {
+		if err := ValidateWorkDir(opts.WorkDir); err != nil {
+			return nil, err
+		}
+		workDirFlags = detectWorkDirFlags(cli, cliPath, opts.WorkDir)
+	}
+
+	args := buildArgs(cli, opts, workDirFlags)
 	cmd := exec.CommandContext(ctx, cliPath, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 
@@ -401,9 +410,6 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 		cmd.Env = enrichedEnv
 	}
 	if opts.WorkDir != "" {
-		if err := ValidateWorkDir(opts.WorkDir); err != nil {
-			return nil, err
-		}
 		cmd.Dir = opts.WorkDir
 	}
 
@@ -424,7 +430,7 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 }
 
 // buildArgs constructs the CLI argument list based on the CLI name and options.
-func buildArgs(cli string, opts ExecOptions) []string {
+func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
 	var args []string
 
 	switch cli {
@@ -448,7 +454,11 @@ func buildArgs(cli string, opts ExecOptions) []string {
 		}
 	default:
 		// claude, gemini: stdin mode
-		args = append(args, "-p", "-")
+		if cli == "claude" && len(workDirFlags) > 0 {
+			args = append(args, "-p")
+		} else {
+			args = append(args, "-p", "-")
+		}
 		if opts.Model != "" {
 			args = append(args, "--model", opts.Model)
 		}
@@ -478,9 +488,14 @@ func buildArgs(cli string, opts ExecOptions) []string {
 		}
 	}
 
+	args = append(args, workDirFlags...)
+
 	// Append free-form extra flags (split on whitespace)
 	if opts.ExtraFlags != "" {
 		args = append(args, strings.Fields(opts.ExtraFlags)...)
+	}
+	if cli == "claude" && len(workDirFlags) > 0 {
+		args = append(args, "-")
 	}
 
 	return args
@@ -489,7 +504,66 @@ func buildArgs(cli string, opts ExecOptions) []string {
 var (
 	loginPathOnce sync.Once
 	loginPathEnv  []string // os.Environ() + enriched PATH from login shell
+	cliHelpCache  sync.Map // map[string]string, keyed by resolved CLI path
 )
+
+func detectWorkDirFlags(cli, cliPath, workDir string) []string {
+	if workDir == "" || cliPath == "" {
+		return nil
+	}
+	switch cli {
+	case "claude":
+		if cliHelpSupports(cliPath, "--add-dir") {
+			return []string{"--add-dir", workDir}
+		}
+		if cliHelpSupports(cliPath, "--directory") {
+			return []string{"--directory", workDir}
+		}
+	case "gemini":
+		if cliHelpSupports(cliPath, "--include-directories") {
+			return []string{"--include-directories", workDir}
+		}
+		if cliHelpSupports(cliPath, "--include-directory") {
+			return []string{"--include-directory", workDir}
+		}
+		if cliHelpSupports(cliPath, "--cwd") {
+			return []string{"--cwd", workDir}
+		}
+	case "codex":
+		if cliHelpSupports(cliPath, "--cd") {
+			return []string{"--cd", workDir}
+		}
+		if cliHelpSupports(cliPath, "--cwd") {
+			return []string{"--cwd", workDir}
+		}
+	}
+	return nil
+}
+
+func cliHelpSupports(cliPath, flag string) bool {
+	help, ok := cliHelp(cliPath)
+	return ok && strings.Contains(help, flag)
+}
+
+func cliHelp(cliPath string) (string, bool) {
+	if cached, ok := cliHelpCache.Load(cliPath); ok {
+		return cached.(string), true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), cliHelpTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, cliPath, "--help")
+	if env := enrichEnvWithLoginPath(); env != nil {
+		cmd.Env = env
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Debug("executor: CLI help unavailable; using cwd-only repo context", "cli", cliPath, "err", err)
+		return "", false
+	}
+	help := string(out)
+	cliHelpCache.Store(cliPath, help)
+	return help, true
+}
 
 // enrichEnvWithLoginPath returns the process environment augmented with the PATH
 // from a login shell. Cached after the first call — cheap after startup.

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -87,6 +87,11 @@ func TestValidateWorkDir(t *testing.T) {
 	if _, statErr := os.Stat(safeDir); statErr != nil {
 		safeDir = home
 	}
+	osTempDir, err := os.MkdirTemp("", "heimdallm-workdir-*")
+	if err != nil {
+		t.Fatalf("create os temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(osTempDir) })
 
 	tests := []struct {
 		name    string
@@ -101,6 +106,11 @@ func TestValidateWorkDir(t *testing.T) {
 		{
 			name:    "home subdir — allowed",
 			dir:     safeDir,
+			wantErr: false,
+		},
+		{
+			name:    "os temp dir — allowed",
+			dir:     osTempDir,
 			wantErr: false,
 		},
 		{

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -117,9 +117,7 @@ func TestExecuteRawAddsDetectedWorkDirFlags(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read captured cwd: %v", err)
 			}
-			if got := strings.TrimSpace(string(cwdBytes)); got != workDir {
-				t.Fatalf("cwd = %q, want %q", got, workDir)
-			}
+			requireSameDir(t, strings.TrimSpace(string(cwdBytes)), workDir)
 		})
 	}
 }
@@ -151,9 +149,7 @@ func TestExecuteRawFallsBackToCWDWhenWorkDirFlagUnsupported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read captured cwd: %v", err)
 	}
-	if got := strings.TrimSpace(string(cwdBytes)); got != workDir {
-		t.Fatalf("cwd = %q, want %q", got, workDir)
-	}
+	requireSameDir(t, strings.TrimSpace(string(cwdBytes)), workDir)
 }
 
 func containsInOrder(args []string, first, second string) bool {
@@ -178,6 +174,22 @@ func fakeCLIScript(help, captureArgs, captureCWD string) string {
 
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+func requireSameDir(t *testing.T, got, want string) {
+	t.Helper()
+	got = cleanResolvedPath(got)
+	want = cleanResolvedPath(want)
+	if got != want {
+		t.Fatalf("cwd = %q, want %q", got, want)
+	}
+}
+
+func cleanResolvedPath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	return filepath.Clean(path)
 }
 
 func TestValidateWorkDir(t *testing.T) {

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/heimdallm/daemon/internal/executor"
@@ -73,6 +74,110 @@ func TestExecute(t *testing.T) {
 	if result.Severity == "" {
 		t.Error("expected non-empty severity")
 	}
+}
+
+func TestExecuteRawAddsDetectedWorkDirFlags(t *testing.T) {
+	tests := []struct {
+		cli      string
+		help     string
+		wantFlag string
+	}{
+		{cli: "claude", help: "Usage: claude\n  --add-dir <directories...>\n", wantFlag: "--add-dir"},
+		{cli: "gemini", help: "Usage: gemini\n  --include-directories <dirs>\n", wantFlag: "--include-directories"},
+		{cli: "codex", help: "Usage: codex\n  -C, --cd <DIR>\n", wantFlag: "--cd"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.cli, func(t *testing.T) {
+			binDir := t.TempDir()
+			captureArgs := filepath.Join(t.TempDir(), "args.txt")
+			captureCWD := filepath.Join(t.TempDir(), "cwd.txt")
+			script := fakeCLIScript(tc.help, captureArgs, captureCWD)
+			path := filepath.Join(binDir, tc.cli)
+			if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+				t.Fatalf("write fake CLI: %v", err)
+			}
+			t.Setenv("PATH", binDir)
+
+			workDir := t.TempDir()
+			e := executor.New()
+			if _, err := e.ExecuteRaw(tc.cli, "prompt", executor.ExecOptions{WorkDir: workDir}); err != nil {
+				t.Fatalf("ExecuteRaw: %v", err)
+			}
+
+			argsBytes, err := os.ReadFile(captureArgs)
+			if err != nil {
+				t.Fatalf("read captured args: %v", err)
+			}
+			args := strings.Fields(string(argsBytes))
+			if !containsInOrder(args, tc.wantFlag, workDir) {
+				t.Fatalf("args = %v, want %s %s", args, tc.wantFlag, workDir)
+			}
+			cwdBytes, err := os.ReadFile(captureCWD)
+			if err != nil {
+				t.Fatalf("read captured cwd: %v", err)
+			}
+			if got := strings.TrimSpace(string(cwdBytes)); got != workDir {
+				t.Fatalf("cwd = %q, want %q", got, workDir)
+			}
+		})
+	}
+}
+
+func TestExecuteRawFallsBackToCWDWhenWorkDirFlagUnsupported(t *testing.T) {
+	binDir := t.TempDir()
+	captureArgs := filepath.Join(t.TempDir(), "args.txt")
+	captureCWD := filepath.Join(t.TempDir(), "cwd.txt")
+	script := fakeCLIScript("Usage: claude\n", captureArgs, captureCWD)
+	path := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	workDir := t.TempDir()
+	e := executor.New()
+	if _, err := e.ExecuteRaw("claude", "prompt", executor.ExecOptions{WorkDir: workDir}); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	argsBytes, err := os.ReadFile(captureArgs)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if strings.Contains(string(argsBytes), workDir) {
+		t.Fatalf("args = %q, workdir should only be passed via cwd when no supported flag is advertised", string(argsBytes))
+	}
+	cwdBytes, err := os.ReadFile(captureCWD)
+	if err != nil {
+		t.Fatalf("read captured cwd: %v", err)
+	}
+	if got := strings.TrimSpace(string(cwdBytes)); got != workDir {
+		t.Fatalf("cwd = %q, want %q", got, workDir)
+	}
+}
+
+func containsInOrder(args []string, first, second string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == first && args[i+1] == second {
+			return true
+		}
+	}
+	return false
+}
+
+func fakeCLIScript(help, captureArgs, captureCWD string) string {
+	return "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  printf '%s\\n' " + shellQuote(help) + "\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"printf '%s\\n' \"$*\" > " + shellQuote(captureArgs) + "\n" +
+		"printf '%s\\n' \"$PWD\" > " + shellQuote(captureCWD) + "\n" +
+		"printf '{\"ok\":true}\\n'\n"
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
 func TestValidateWorkDir(t *testing.T) {

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -79,8 +79,10 @@ type IssuePublisher interface {
 
 // OptionsFn lets the caller map each classified issue to its RunOptions.
 // In production main.go resolves per-repo AI config here; tests can return a
-// constant.
-type OptionsFn func(issue *github.Issue) RunOptions
+// constant. ok=false skips this issue after classification; use it when the
+// caller cannot prepare required execution context and has already surfaced
+// the failure.
+type OptionsFn func(issue *github.Issue) (opts RunOptions, ok bool)
 
 // Fetcher orchestrates: fetch issues for a repo, skip those already processed
 // without new activity, dispatch the rest to the pipeline.
@@ -177,7 +179,11 @@ func (f *Fetcher) ProcessRepo(ctx context.Context, repo string, cfg config.Issue
 				continue
 			}
 		} else {
-			if _, runErr := f.pipeline.Run(ctx, issue, optsFor(issue)); runErr != nil {
+			opts, ok := optsFor(issue)
+			if !ok {
+				continue
+			}
+			if _, runErr := f.pipeline.Run(ctx, issue, opts); runErr != nil {
 				slog.Error("issues fetcher: pipeline run failed",
 					"repo", repo, "number", issue.Number, "err", runErr)
 				continue

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -102,7 +102,7 @@ func (f *fakePipeline) Run(ctx context.Context, issue *github.Issue, opts issues
 	return &store.IssueReview{IssueID: int64(issue.Number), ActionTaken: string(config.IssueModeReviewOnly)}, nil
 }
 
-func noOpts(_ *github.Issue) issues.RunOptions { return issues.RunOptions{} }
+func noOpts(_ *github.Issue) (issues.RunOptions, bool) { return issues.RunOptions{}, true }
 
 func fixture(number int, updated time.Time) *github.Issue {
 	return &github.Issue{
@@ -163,6 +163,26 @@ func TestFetcher_DispatchesUnprocessedIssues(t *testing.T) {
 	}
 	if processed != 2 || len(p.calls) != 2 {
 		t.Errorf("expected 2 dispatches, got processed=%d calls=%v", processed, p.calls)
+	}
+}
+
+func TestFetcher_SkipsWhenOptionsFnReturnsFalse(t *testing.T) {
+	client := &fakeClient{issues: []*github.Issue{fixture(1, time.Now()), fixture(2, time.Now())}}
+	p := &fakePipeline{}
+	f := issues.NewFetcher(client, nil, &fakeDedup{byGithubID: map[int64]dedupEntry{}}, p)
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice",
+		func(issue *github.Issue) (issues.RunOptions, bool) {
+			if issue.Number == 1 {
+				return issues.RunOptions{}, false
+			}
+			return issues.RunOptions{}, true
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 1 || len(p.calls) != 1 || p.calls[0] != 2 {
+		t.Errorf("expected only issue 2 dispatched, got processed=%d calls=%v", processed, p.calls)
 	}
 }
 

--- a/daemon/internal/issues/integration_test.go
+++ b/daemon/internal/issues/integration_test.go
@@ -62,7 +62,9 @@ func TestIntegration_FetcherDrivesPipelineEndToEnd(t *testing.T) {
 		"org/repo",
 		config.IssueTrackingConfig{Enabled: true},
 		"reporter",
-		func(_ *github.Issue) issues.RunOptions { return issues.RunOptions{Primary: "claude"} },
+		func(_ *github.Issue) (issues.RunOptions, bool) {
+			return issues.RunOptions{Primary: "claude"}, true
+		},
 	)
 	if err != nil {
 		t.Fatalf("ProcessRepo: %v", err)
@@ -101,7 +103,9 @@ func TestIntegration_FetcherDrivesPipelineEndToEnd(t *testing.T) {
 		"org/repo",
 		config.IssueTrackingConfig{Enabled: true},
 		"reporter",
-		func(_ *github.Issue) issues.RunOptions { return issues.RunOptions{Primary: "claude"} },
+		func(_ *github.Issue) (issues.RunOptions, bool) {
+			return issues.RunOptions{Primary: "claude"}, true
+		},
 	)
 	if err != nil {
 		t.Fatalf("second ProcessRepo: %v", err)
@@ -344,8 +348,8 @@ func TestIntegration_IssueCircuitBreakerTripsAfterCap(t *testing.T) {
 // countingNotifier records how many times Notify was called so tests can
 // assert breaker-trip notifications are not repeated on the same snapshot.
 type countingNotifier struct {
-	mu  sync.Mutex
-	n   int
+	mu sync.Mutex
+	n  int
 }
 
 func (c *countingNotifier) Notify(_, _ string) {

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -196,6 +196,16 @@ type RunOptions struct {
 	// produce a rich PR title and description from the implementation diff.
 	// When false (default), the pipeline uses the template strings.
 	GeneratePRDescription bool
+
+	// RequireWorkDirForDevelop turns the historical develop→review_only
+	// fallback into a hard error. Production auto-clone callers set this so
+	// an auto_implement run never silently proceeds without a writable checkout.
+	RequireWorkDirForDevelop bool
+
+	// ReleaseRepoContext releases a checkout handle acquired by the caller.
+	// It is intentionally a one-shot cleanup hook rather than another source
+	// of path truth; ExecOpts.WorkDir remains authoritative.
+	ReleaseRepoContext func()
 }
 
 // Pipeline runs a single issue triage or implementation end-to-end.
@@ -275,6 +285,9 @@ func New(s issueStore, gh issueGitHub, exec CLIExecutor, git GitOps, broker Publ
 // passes a context so long-running network operations (git fetch / push,
 // CLI invocation) can be cancelled on daemon shutdown.
 func (p *Pipeline) Run(ctx context.Context, issue *github.Issue, opts RunOptions) (*store.IssueReview, error) {
+	if opts.ReleaseRepoContext != nil {
+		defer opts.ReleaseRepoContext()
+	}
 	if issue == nil {
 		return nil, fmt.Errorf("issues pipeline: nil issue")
 	}
@@ -298,10 +311,10 @@ func (p *Pipeline) Run(ctx context.Context, issue *github.Issue, opts RunOptions
 	// distinct — do not "unify" them without revisiting the
 	// claim-before-upsert ordering that gives Run an early exit.
 	var (
-		claimed       bool
-		breakerHeld   bool // when true, defer must NOT release the claim
-		claimKey      string
-		claimIssueID  = issue.ID
+		claimed      bool
+		breakerHeld  bool // when true, defer must NOT release the claim
+		claimKey     string
+		claimIssueID = issue.ID
 	)
 	if !issue.UpdatedAt.IsZero() && claimIssueID != 0 {
 		claimKey = issue.UpdatedAt.UTC().Format(time.RFC3339)
@@ -345,6 +358,9 @@ func (p *Pipeline) Run(ctx context.Context, issue *github.Issue, opts RunOptions
 	workDir := strings.TrimSpace(opts.ExecOpts.WorkDir)
 	effective := issue.Mode
 	if effective == config.IssueModeDevelop && workDir == "" {
+		if opts.RequireWorkDirForDevelop {
+			return nil, fmt.Errorf("issues pipeline: develop mode requires local repo context")
+		}
 		slog.Warn("issues pipeline: develop mode requires local_dir, downgrading to review_only",
 			"repo", issue.Repo, "issue", issue.Number)
 		effective = config.IssueModeReviewOnly

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -559,6 +559,24 @@ func TestPipeline_DevelopFallsBackToReviewOnlyWithoutLocalDir(t *testing.T) {
 	}
 }
 
+func TestPipeline_DevelopRequiresWorkDirWhenConfigured(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(validResult)}
+	p := issues.New(s, gh, exec, nil, &fakeBroker{}, nil)
+
+	_, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), issues.RunOptions{
+		Primary:                  "claude",
+		RequireWorkDirForDevelop: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires local repo context") {
+		t.Fatalf("err = %v, want local repo context error", err)
+	}
+	if len(gh.postCalls) != 0 {
+		t.Fatalf("pipeline should not degrade to review_only, got %d comments", len(gh.postCalls))
+	}
+}
+
 // ── auto_implement ───────────────────────────────────────────────────────────
 
 func autoImplementRunOptions() issues.RunOptions {
@@ -1406,9 +1424,9 @@ func TestPipeline_AutoImplementAbortsWhenIssueClosedDuringImplementation(t *test
 
 func TestPipeline_AutoImplementProceedsWhenStateCheckFails(t *testing.T) {
 	gh := &fakeGH{
-		defaultBranch: "main",
+		defaultBranch:  "main",
 		createPRNumber: 55,
-		getIssueErr:   errors.New("API timeout"),
+		getIssueErr:    errors.New("API timeout"),
 	}
 	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("done")}
 	git := &fakeGit{hasChanges: true}

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -1,0 +1,495 @@
+package repoctx
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+)
+
+const (
+	// MarkerFile identifies clones that Heimdallm is allowed to mutate.
+	MarkerFile = ".heimdallm-managed"
+
+	gitTimeout        = 3 * time.Minute
+	maxGitStderrBytes = 16 * 1024
+)
+
+var repoNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// Mode describes how the caller will use the resolved checkout.
+type Mode int
+
+const (
+	// ModeRead gives the AI CLI repository context. Existing local_dir and
+	// local_dir_base checkouts are accepted because the manager never mutates
+	// them.
+	ModeRead Mode = iota
+	// ModeWrite is for auto_implement. Only an explicit local_dir or a
+	// Heimdallm-managed clone is returned, because local_dir_base mounts are
+	// treated as read-only shared context.
+	ModeWrite
+)
+
+// Request is the repo-context acquisition contract.
+type Request struct {
+	Repo               string
+	ConfiguredLocalDir string
+	LocalDirBases      []string
+	CloneDir           string
+	Token              string
+	Mode               Mode
+}
+
+// Handle owns a repo-context lock until Release is called.
+type Handle struct {
+	path    string
+	managed bool
+	once    sync.Once
+	release func()
+}
+
+// Path returns the working directory to pass to the executor.
+func (h *Handle) Path() string {
+	if h == nil {
+		return ""
+	}
+	return h.path
+}
+
+// Managed reports whether Heimdallm created and may mutate this checkout.
+func (h *Handle) Managed() bool {
+	if h == nil {
+		return false
+	}
+	return h.managed
+}
+
+// Release frees the per-repo lock. It is safe to call more than once.
+func (h *Handle) Release() {
+	if h == nil {
+		return
+	}
+	h.once.Do(func() {
+		if h.release != nil {
+			h.release()
+		}
+	})
+}
+
+type repoLock struct {
+	ch   chan struct{}
+	refs int
+}
+
+type gitRunner interface {
+	Run(ctx context.Context, dir string, env []string, args ...string) error
+}
+
+// Manager resolves and prepares repository working directories for AI runs.
+type Manager struct {
+	mu      sync.Mutex
+	locks   map[string]*repoLock
+	git     gitRunner
+	tempDir func() string
+}
+
+// NewManager returns a Manager backed by the local git binary.
+func NewManager() *Manager {
+	return &Manager{
+		locks:   make(map[string]*repoLock),
+		git:     execGit{},
+		tempDir: os.TempDir,
+	}
+}
+
+// DefaultCloneDir is the base used when clone_dir is not configured.
+func DefaultCloneDir() string {
+	return filepath.Join(os.TempDir(), "heimdallm")
+}
+
+// Acquire returns a locked handle to the best available repo context.
+func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if m == nil {
+		m = NewManager()
+	}
+	owner, name, err := splitRepo(req.Repo)
+	if err != nil {
+		return nil, err
+	}
+	unlock, err := m.acquireRepoLock(ctx, req.Repo)
+	if err != nil {
+		return nil, err
+	}
+	released := false
+	release := func() {
+		if !released {
+			released = true
+			unlock()
+		}
+	}
+	defer func() {
+		if !released && err != nil {
+			release()
+		}
+	}()
+
+	if local := resolveLocal(req); local != "" {
+		return &Handle{path: local, managed: false, release: release}, nil
+	}
+
+	path, err := m.ensureManagedClone(ctx, owner, name, req)
+	if err != nil {
+		return nil, err
+	}
+	return &Handle{path: path, managed: true, release: release}, nil
+}
+
+// EnsureFullHistory upgrades a managed shallow clone in-place. It assumes the
+// caller still owns the handle lock returned by Acquire.
+func (m *Manager) EnsureFullHistory(ctx context.Context, h *Handle, token string) error {
+	if h == nil || h.Path() == "" || !h.Managed() {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if token == "" {
+		return fmt.Errorf("repoctx: full-history fetch requires a non-empty token")
+	}
+	shallow := filepath.Join(h.Path(), ".git", "shallow")
+	if _, err := os.Stat(shallow); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("repoctx: inspect shallow marker: %w", err)
+	}
+	env, cleanup, err := buildAskPassEnv(token)
+	if err != nil {
+		return fmt.Errorf("repoctx: setup askpass: %w", err)
+	}
+	defer cleanup()
+	if err := m.runner().Run(ctx, h.Path(), env, "fetch", "--unshallow", "--prune", "origin"); err != nil {
+		return fmt.Errorf("repoctx: unshallow %s: %w", h.Path(), err)
+	}
+	return nil
+}
+
+// Purge removes one managed clone. It refuses to delete directories without a
+// valid ownership marker.
+func (m *Manager) Purge(ctx context.Context, repo, cloneDir string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if m == nil {
+		m = NewManager()
+	}
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return err
+	}
+	unlock, err := m.acquireRepoLock(ctx, repo)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	target, err := m.cloneTarget(cloneDir, owner, name)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(target); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("repoctx: stat clone target %q: %w", target, err)
+	}
+	if err := validateMarker(target, repo); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(target); err != nil {
+		return fmt.Errorf("repoctx: purge %q: %w", target, err)
+	}
+	return nil
+}
+
+func resolveLocal(req Request) string {
+	configured := strings.TrimSpace(req.ConfiguredLocalDir)
+	if configured != "" {
+		return configured
+	}
+	if req.Mode == ModeWrite {
+		return ""
+	}
+	return config.ResolveLocalDir("", req.Repo, req.LocalDirBases)
+}
+
+func (m *Manager) ensureManagedClone(ctx context.Context, owner, name string, req Request) (string, error) {
+	if strings.TrimSpace(req.Token) == "" {
+		return "", fmt.Errorf("repoctx: clone %s requires a non-empty token", req.Repo)
+	}
+	target, err := m.cloneTarget(req.CloneDir, owner, name)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(target)
+	switch {
+	case err == nil:
+		if !info.IsDir() {
+			return "", fmt.Errorf("repoctx: clone target %q exists but is not a directory", target)
+		}
+		if err := validateMarker(target, req.Repo); err != nil {
+			return "", err
+		}
+		if err := requireGitDir(target); err != nil {
+			return "", err
+		}
+		if err := m.updateManagedClone(ctx, target, req.Repo, req.Token); err != nil {
+			return "", err
+		}
+		return target, nil
+	case errors.Is(err, os.ErrNotExist):
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return "", fmt.Errorf("repoctx: create clone parent: %w", err)
+		}
+		if err := m.clone(ctx, target, req.Repo, req.Token); err != nil {
+			_ = os.RemoveAll(target)
+			return "", err
+		}
+		if err := writeMarker(target, req.Repo); err != nil {
+			_ = os.RemoveAll(target)
+			return "", err
+		}
+		return target, nil
+	default:
+		return "", fmt.Errorf("repoctx: stat clone target %q: %w", target, err)
+	}
+}
+
+func (m *Manager) clone(ctx context.Context, target, repo, token string) error {
+	env, cleanup, err := buildAskPassEnv(token)
+	if err != nil {
+		return fmt.Errorf("repoctx: setup askpass: %w", err)
+	}
+	defer cleanup()
+	url := fmt.Sprintf("https://x-access-token@github.com/%s.git", repo)
+	if err := m.runner().Run(ctx, "", env, "clone", "--depth=1", url, target); err != nil {
+		return fmt.Errorf("repoctx: clone %s: %w", repo, err)
+	}
+	if err := requireGitDir(target); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) updateManagedClone(ctx context.Context, target, repo, token string) error {
+	env, cleanup, err := buildAskPassEnv(token)
+	if err != nil {
+		return fmt.Errorf("repoctx: setup askpass: %w", err)
+	}
+	defer cleanup()
+	url := fmt.Sprintf("https://x-access-token@github.com/%s.git", repo)
+	if err := m.runner().Run(ctx, target, nil, "remote", "set-url", "origin", url); err != nil {
+		return fmt.Errorf("repoctx: set remote url: %w", err)
+	}
+	if err := m.runner().Run(ctx, target, env, "fetch", "--depth=1", "--prune", "origin", "HEAD"); err != nil {
+		return fmt.Errorf("repoctx: fetch %s: %w", repo, err)
+	}
+	if err := m.runner().Run(ctx, target, nil, "reset", "--hard", "FETCH_HEAD"); err != nil {
+		return fmt.Errorf("repoctx: reset %s: %w", repo, err)
+	}
+	if err := m.runner().Run(ctx, target, nil, "clean", "-fd", "-e", MarkerFile); err != nil {
+		return fmt.Errorf("repoctx: clean %s: %w", repo, err)
+	}
+	return nil
+}
+
+func (m *Manager) cloneTarget(cloneDir, owner, name string) (string, error) {
+	base := strings.TrimSpace(cloneDir)
+	if base == "" {
+		if m != nil && m.tempDir != nil {
+			base = filepath.Join(m.tempDir(), "heimdallm")
+		} else {
+			base = DefaultCloneDir()
+		}
+	}
+	baseAbs, err := filepath.Abs(base)
+	if err != nil {
+		return "", fmt.Errorf("repoctx: resolve clone_dir %q: %w", base, err)
+	}
+	target := filepath.Join(baseAbs, owner, name)
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return "", fmt.Errorf("repoctx: resolve clone target %q: %w", target, err)
+	}
+	if !pathWithin(baseAbs, targetAbs) {
+		return "", fmt.Errorf("repoctx: clone target %q escapes clone_dir %q", targetAbs, baseAbs)
+	}
+	return targetAbs, nil
+}
+
+func (m *Manager) runner() gitRunner {
+	if m == nil || m.git == nil {
+		return execGit{}
+	}
+	return m.git
+}
+
+func (m *Manager) acquireRepoLock(ctx context.Context, repo string) (func(), error) {
+	m.mu.Lock()
+	if m.locks == nil {
+		m.locks = make(map[string]*repoLock)
+	}
+	l := m.locks[repo]
+	if l == nil {
+		l = &repoLock{ch: make(chan struct{}, 1)}
+		m.locks[repo] = l
+	}
+	l.refs++
+	m.mu.Unlock()
+
+	select {
+	case l.ch <- struct{}{}:
+	case <-ctx.Done():
+		m.releaseRepoRef(repo, l)
+		return nil, ctx.Err()
+	}
+
+	return func() {
+		<-l.ch
+		m.releaseRepoRef(repo, l)
+	}, nil
+}
+
+func (m *Manager) releaseRepoRef(repo string, l *repoLock) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	l.refs--
+	if l.refs == 0 && m.locks[repo] == l {
+		delete(m.locks, repo)
+	}
+}
+
+func splitRepo(repo string) (string, string, error) {
+	parts := strings.Split(strings.TrimSpace(repo), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("repoctx: repo %q must be in owner/name form", repo)
+	}
+	if err := config.ValidateOrgSlug(parts[0]); err != nil {
+		return "", "", err
+	}
+	name := parts[1]
+	if name == "." || name == ".." || !repoNamePattern.MatchString(name) {
+		return "", "", fmt.Errorf("repoctx: repo name %q is invalid", name)
+	}
+	return parts[0], name, nil
+}
+
+func pathWithin(base, target string) bool {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+type marker struct {
+	Version   int    `json:"version"`
+	Repo      string `json:"repo"`
+	ManagedBy string `json:"managed_by"`
+}
+
+func writeMarker(dir, repo string) error {
+	data, err := json.Marshal(marker{Version: 1, Repo: repo, ManagedBy: "heimdallm"})
+	if err != nil {
+		return fmt.Errorf("repoctx: marshal marker: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, MarkerFile), append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("repoctx: write marker: %w", err)
+	}
+	return nil
+}
+
+func validateMarker(dir, repo string) error {
+	data, err := os.ReadFile(filepath.Join(dir, MarkerFile))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("repoctx: clone target %q exists but is not managed by Heimdallm", dir)
+		}
+		return fmt.Errorf("repoctx: read marker: %w", err)
+	}
+	var m marker
+	if err := json.Unmarshal(data, &m); err != nil {
+		return fmt.Errorf("repoctx: invalid marker in %q: %w", dir, err)
+	}
+	if m.Version != 1 || m.ManagedBy != "heimdallm" || m.Repo != repo {
+		return fmt.Errorf("repoctx: marker in %q does not match repo %s", dir, repo)
+	}
+	return nil
+}
+
+func requireGitDir(dir string) error {
+	if info, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+		return fmt.Errorf("repoctx: clone target %q has no .git directory: %w", dir, err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("repoctx: clone target %q has non-directory .git", dir)
+	}
+	return nil
+}
+
+func buildAskPassEnv(token string) ([]string, func(), error) {
+	dir, err := os.MkdirTemp("", "heimdallm-askpass-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create askpass dir: %w", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		os.RemoveAll(dir)
+		return nil, nil, fmt.Errorf("chmod askpass dir: %w", err)
+	}
+	helperPath := filepath.Join(dir, "askpass.sh")
+	script := "#!/bin/sh\nprintf '%s' \"$HEIMDALLM_GIT_TOKEN\"\n"
+	if err := os.WriteFile(helperPath, []byte(script), 0o700); err != nil {
+		os.RemoveAll(dir)
+		return nil, nil, fmt.Errorf("write askpass script: %w", err)
+	}
+	env := append(os.Environ(),
+		"GIT_ASKPASS="+helperPath,
+		"GIT_TERMINAL_PROMPT=0",
+		"HEIMDALLM_GIT_TOKEN="+token,
+	)
+	cleanup := func() { os.RemoveAll(dir) }
+	return env, cleanup, nil
+}
+
+type execGit struct{}
+
+func (execGit) Run(ctx context.Context, dir string, env []string, args ...string) error {
+	runCtx, cancel := context.WithTimeout(ctx, gitTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, "git", args...)
+	cmd.Dir = dir
+	if env != nil {
+		cmd.Env = env
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		errText := stderr.String()
+		if len(errText) > maxGitStderrBytes {
+			errText = errText[:maxGitStderrBytes] + "\n... (stderr truncated)"
+		}
+		return fmt.Errorf("%w (stderr: %s)", err, strings.TrimSpace(errText))
+	}
+	return nil
+}

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -96,6 +96,19 @@ type gitRunner interface {
 	Run(ctx context.Context, dir string, env []string, args ...string) error
 }
 
+// PurgeReport summarizes managed clone cleanup without exposing local paths to
+// HTTP callers.
+type PurgeReport struct {
+	Scanned int
+	Removed int
+}
+
+type managedClone struct {
+	repo          string
+	path          string
+	markerModTime time.Time
+}
+
 // Manager resolves and prepares repository working directories for AI runs.
 // It intentionally uses one exclusive lock per repo for both ModeRead and
 // ModeWrite in v1: managed clones are shared checkouts, and a concurrent
@@ -161,7 +174,7 @@ func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
 	h := &Handle{path: path, managed: true, release: release}
 	if req.Mode == ModeWrite {
 		if err = m.EnsureFullHistory(ctx, h, req.Token); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w; retry after fixing Git access or purge the managed clone via DELETE /config/clones/{repo}", err)
 		}
 	}
 	return h, nil
@@ -195,6 +208,9 @@ func (m *Manager) EnsureFullHistory(ctx context.Context, h *Handle, token string
 	defer cleanup()
 	if err := m.runner().Run(ctx, h.Path(), env, "fetch", "--unshallow", "--prune", "origin"); err != nil {
 		return fmt.Errorf("repoctx: unshallow %s: %w", h.Path(), err)
+	}
+	if err := touchMarker(h.Path()); err != nil {
+		return err
 	}
 	return nil
 }
@@ -236,6 +252,69 @@ func (m *Manager) Purge(ctx context.Context, repo, cloneDir string) error {
 	return nil
 }
 
+// PurgeAll removes every valid Heimdallm-managed clone under cloneDir. It
+// ignores unmanaged directories and invalid markers so operator-owned paths are
+// never removed by a broad cleanup.
+func (m *Manager) PurgeAll(ctx context.Context, cloneDir string) (PurgeReport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if m == nil {
+		return PurgeReport{}, fmt.Errorf("repoctx: nil manager")
+	}
+	clones, err := m.managedClones(cloneDir)
+	if err != nil {
+		return PurgeReport{}, err
+	}
+	var report PurgeReport
+	var errs []error
+	for _, clone := range clones {
+		report.Scanned++
+		if err := m.purgeTarget(ctx, clone.repo, clone.path); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		report.Removed++
+	}
+	return report, errors.Join(errs...)
+}
+
+// PurgeStale removes managed clones for repos that are no longer monitored and
+// have not been prepared within maxDays. maxDays <= 0 disables cleanup.
+func (m *Manager) PurgeStale(ctx context.Context, cloneDir string, monitored map[string]struct{}, maxDays int) (PurgeReport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if m == nil {
+		return PurgeReport{}, fmt.Errorf("repoctx: nil manager")
+	}
+	if maxDays <= 0 {
+		return PurgeReport{}, nil
+	}
+	clones, err := m.managedClones(cloneDir)
+	if err != nil {
+		return PurgeReport{}, err
+	}
+	cutoff := time.Now().AddDate(0, 0, -maxDays)
+	var report PurgeReport
+	var errs []error
+	for _, clone := range clones {
+		report.Scanned++
+		if _, ok := monitored[clone.repo]; ok {
+			continue
+		}
+		if clone.markerModTime.After(cutoff) {
+			continue
+		}
+		if err := m.purgeTarget(ctx, clone.repo, clone.path); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		report.Removed++
+	}
+	return report, errors.Join(errs...)
+}
+
 func resolveLocal(req Request) string {
 	configured := strings.TrimSpace(req.ConfiguredLocalDir)
 	if configured != "" {
@@ -268,6 +347,9 @@ func (m *Manager) ensureManagedClone(ctx context.Context, owner, name string, re
 			return "", err
 		}
 		if err := m.updateManagedClone(ctx, target, req.Repo, req.Token); err != nil {
+			return "", err
+		}
+		if err := writeMarker(target, req.Repo); err != nil {
 			return "", err
 		}
 		return target, nil
@@ -329,7 +411,7 @@ func (m *Manager) updateManagedClone(ctx context.Context, target, repo, token st
 	return nil
 }
 
-func (m *Manager) cloneTarget(cloneDir, owner, name string) (string, error) {
+func (m *Manager) cloneBase(cloneDir string) (string, error) {
 	base := strings.TrimSpace(cloneDir)
 	if base == "" {
 		if m != nil && m.tempDir != nil {
@@ -342,6 +424,14 @@ func (m *Manager) cloneTarget(cloneDir, owner, name string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("repoctx: resolve clone_dir %q: %w", base, err)
 	}
+	return baseAbs, nil
+}
+
+func (m *Manager) cloneTarget(cloneDir, owner, name string) (string, error) {
+	baseAbs, err := m.cloneBase(cloneDir)
+	if err != nil {
+		return "", err
+	}
 	target := filepath.Join(baseAbs, owner, name)
 	targetAbs, err := filepath.Abs(target)
 	if err != nil {
@@ -351,6 +441,81 @@ func (m *Manager) cloneTarget(cloneDir, owner, name string) (string, error) {
 		return "", fmt.Errorf("repoctx: clone target %q escapes clone_dir %q", targetAbs, baseAbs)
 	}
 	return targetAbs, nil
+}
+
+func (m *Manager) managedClones(cloneDir string) ([]managedClone, error) {
+	baseAbs, err := m.cloneBase(cloneDir)
+	if err != nil {
+		return nil, err
+	}
+	orgEntries, err := os.ReadDir(baseAbs)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("repoctx: list clone_dir %q: %w", baseAbs, err)
+	}
+
+	var clones []managedClone
+	for _, orgEntry := range orgEntries {
+		if !orgEntry.IsDir() {
+			continue
+		}
+		orgPath := filepath.Join(baseAbs, orgEntry.Name())
+		repoEntries, err := os.ReadDir(orgPath)
+		if err != nil {
+			return nil, fmt.Errorf("repoctx: list clone org %q: %w", orgPath, err)
+		}
+		for _, repoEntry := range repoEntries {
+			if !repoEntry.IsDir() {
+				continue
+			}
+			target := filepath.Join(orgPath, repoEntry.Name())
+			targetAbs, err := filepath.Abs(target)
+			if err != nil || !pathWithin(baseAbs, targetAbs) {
+				continue
+			}
+			marker, info, err := readMarkerInfo(targetAbs)
+			if err != nil || marker.Version != 1 || marker.ManagedBy != "heimdallm" {
+				continue
+			}
+			owner, name, err := splitRepo(marker.Repo)
+			if err != nil {
+				continue
+			}
+			expected, err := m.cloneTarget(cloneDir, owner, name)
+			if err != nil || expected != targetAbs {
+				continue
+			}
+			clones = append(clones, managedClone{
+				repo:          marker.Repo,
+				path:          targetAbs,
+				markerModTime: info.ModTime(),
+			})
+		}
+	}
+	return clones, nil
+}
+
+func (m *Manager) purgeTarget(ctx context.Context, repo, target string) error {
+	unlock, err := m.acquireRepoLock(ctx, repo)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	if _, err := os.Stat(target); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("repoctx: stat clone target %q: %w", target, err)
+	}
+	if err := validateMarker(target, repo); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(target); err != nil {
+		return fmt.Errorf("repoctx: purge %q: %w", target, err)
+	}
+	return nil
 }
 
 func (m *Manager) runner() gitRunner {
@@ -436,21 +601,45 @@ func writeMarker(dir, repo string) error {
 }
 
 func validateMarker(dir, repo string) error {
-	data, err := os.ReadFile(filepath.Join(dir, MarkerFile))
+	marker, _, err := readMarkerInfo(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("repoctx: clone target %q exists but is not managed by Heimdallm", dir)
 		}
-		return fmt.Errorf("repoctx: read marker: %w", err)
+		return err
 	}
-	var m marker
-	if err := json.Unmarshal(data, &m); err != nil {
-		return fmt.Errorf("repoctx: invalid marker in %q: %w", dir, err)
-	}
-	if m.Version != 1 || m.ManagedBy != "heimdallm" || m.Repo != repo {
+	if marker.Version != 1 || marker.ManagedBy != "heimdallm" || marker.Repo != repo {
 		return fmt.Errorf("repoctx: marker in %q does not match repo %s", dir, repo)
 	}
 	return nil
+}
+
+func readMarkerInfo(dir string) (marker, os.FileInfo, error) {
+	path := filepath.Join(dir, MarkerFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return marker{}, nil, err
+	}
+	var m marker
+	if err := json.Unmarshal(data, &m); err != nil {
+		return marker{}, nil, fmt.Errorf("repoctx: invalid marker in %q: %w", dir, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return marker{}, nil, fmt.Errorf("repoctx: stat marker in %q: %w", dir, err)
+	}
+	return m, info, nil
+}
+
+func touchMarker(dir string) error {
+	marker, _, err := readMarkerInfo(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return writeMarker(dir, marker.Repo)
 }
 
 func requireGitDir(dir string) error {

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -97,6 +97,9 @@ type gitRunner interface {
 }
 
 // Manager resolves and prepares repository working directories for AI runs.
+// It intentionally uses one exclusive lock per repo for both ModeRead and
+// ModeWrite in v1: managed clones are shared checkouts, and a concurrent
+// fetch/reset/clean can invalidate files while an AI CLI is reading them.
 type Manager struct {
 	mu      sync.Mutex
 	locks   map[string]*repoLock
@@ -124,7 +127,7 @@ func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
 		ctx = context.Background()
 	}
 	if m == nil {
-		m = NewManager()
+		return nil, fmt.Errorf("repoctx: nil manager")
 	}
 	owner, name, err := splitRepo(req.Repo)
 	if err != nil {
@@ -155,12 +158,21 @@ func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Handle{path: path, managed: true, release: release}, nil
+	h := &Handle{path: path, managed: true, release: release}
+	if req.Mode == ModeWrite {
+		if err = m.EnsureFullHistory(ctx, h, req.Token); err != nil {
+			return nil, err
+		}
+	}
+	return h, nil
 }
 
 // EnsureFullHistory upgrades a managed shallow clone in-place. It assumes the
 // caller still owns the handle lock returned by Acquire.
 func (m *Manager) EnsureFullHistory(ctx context.Context, h *Handle, token string) error {
+	if m == nil {
+		return fmt.Errorf("repoctx: nil manager")
+	}
 	if h == nil || h.Path() == "" || !h.Managed() {
 		return nil
 	}
@@ -194,7 +206,7 @@ func (m *Manager) Purge(ctx context.Context, repo, cloneDir string) error {
 		ctx = context.Background()
 	}
 	if m == nil {
-		m = NewManager()
+		return fmt.Errorf("repoctx: nil manager")
 	}
 	owner, name, err := splitRepo(repo)
 	if err != nil {
@@ -300,6 +312,8 @@ func (m *Manager) updateManagedClone(ctx context.Context, target, repo, token st
 	}
 	defer cleanup()
 	url := fmt.Sprintf("https://x-access-token@github.com/%s.git", repo)
+	// set-url writes an opaque username-only URL and does not need
+	// credentials; keep the askpass env scoped to network operations.
 	if err := m.runner().Run(ctx, target, nil, "remote", "set-url", "origin", url); err != nil {
 		return fmt.Errorf("repoctx: set remote url: %w", err)
 	}
@@ -415,7 +429,7 @@ func writeMarker(dir, repo string) error {
 	if err != nil {
 		return fmt.Errorf("repoctx: marshal marker: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, MarkerFile), append(data, '\n'), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, MarkerFile), append(data, '\n'), 0o600); err != nil {
 		return fmt.Errorf("repoctx: write marker: %w", err)
 	}
 	return nil
@@ -479,6 +493,7 @@ func (execGit) Run(ctx context.Context, dir string, env []string, args ...string
 	defer cancel()
 	cmd := exec.CommandContext(runCtx, "git", args...)
 	cmd.Dir = dir
+	cmd.Env = os.Environ()
 	if env != nil {
 		cmd.Env = env
 	}

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -1,0 +1,336 @@
+package repoctx
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type gitCall struct {
+	Dir  string
+	Args []string
+	Env  []string
+}
+
+type fakeGit struct {
+	mu      sync.Mutex
+	calls   []gitCall
+	runErr  error
+	onRun   func(call gitCall) error
+	blockCh chan struct{}
+}
+
+func (f *fakeGit) Run(ctx context.Context, dir string, env []string, args ...string) error {
+	call := gitCall{Dir: dir, Args: append([]string(nil), args...), Env: append([]string(nil), env...)}
+	f.mu.Lock()
+	f.calls = append(f.calls, call)
+	f.mu.Unlock()
+
+	if f.blockCh != nil {
+		select {
+		case <-f.blockCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if f.onRun != nil {
+		if err := f.onRun(call); err != nil {
+			return err
+		}
+	}
+	if len(args) > 0 && args[0] == "clone" {
+		target := args[len(args)-1]
+		if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+			return err
+		}
+	}
+	return f.runErr
+}
+
+func (f *fakeGit) snapshot() []gitCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]gitCall(nil), f.calls...)
+}
+
+func newTestManager(t *testing.T) (*Manager, *fakeGit, string) {
+	t.Helper()
+	base := t.TempDir()
+	git := &fakeGit{}
+	m := NewManager()
+	m.git = git
+	m.tempDir = func() string { return base }
+	return m, git, base
+}
+
+func TestAcquireUsesExplicitLocalDirWithoutGit(t *testing.T) {
+	m, git, _ := newTestManager(t)
+
+	h, err := m.Acquire(context.Background(), Request{
+		Repo:               "org/repo",
+		ConfiguredLocalDir: "/tmp/user-worktree",
+		Token:              "secret",
+		Mode:               ModeWrite,
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer h.Release()
+
+	if h.Path() != "/tmp/user-worktree" || h.Managed() {
+		t.Fatalf("handle = (%q, managed=%v), want explicit unmanaged", h.Path(), h.Managed())
+	}
+	if calls := git.snapshot(); len(calls) != 0 {
+		t.Fatalf("git calls = %v, want none", calls)
+	}
+}
+
+func TestAcquireUsesLocalDirBaseOnlyForReadMode(t *testing.T) {
+	m, git, cloneBase := newTestManager(t)
+	localBase := t.TempDir()
+	localRepo := filepath.Join(localBase, "repo")
+	if err := os.MkdirAll(localRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	readHandle, err := m.Acquire(context.Background(), Request{
+		Repo:          "org/repo",
+		LocalDirBases: []string{localBase},
+		Token:         "secret",
+		Mode:          ModeRead,
+	})
+	if err != nil {
+		t.Fatalf("read Acquire: %v", err)
+	}
+	if readHandle.Path() != localRepo || readHandle.Managed() {
+		t.Fatalf("read handle = (%q, managed=%v), want local_dir_base unmanaged", readHandle.Path(), readHandle.Managed())
+	}
+	readHandle.Release()
+
+	writeHandle, err := m.Acquire(context.Background(), Request{
+		Repo:          "org/repo",
+		LocalDirBases: []string{localBase},
+		Token:         "secret",
+		Mode:          ModeWrite,
+	})
+	if err != nil {
+		t.Fatalf("write Acquire: %v", err)
+	}
+	defer writeHandle.Release()
+
+	wantManaged := filepath.Join(cloneBase, "heimdallm", "org", "repo")
+	if writeHandle.Path() != wantManaged || !writeHandle.Managed() {
+		t.Fatalf("write handle = (%q, managed=%v), want managed clone %q", writeHandle.Path(), writeHandle.Managed(), wantManaged)
+	}
+	if calls := git.snapshot(); len(calls) != 1 || calls[0].Args[0] != "clone" {
+		t.Fatalf("git calls = %v, want one clone", calls)
+	}
+}
+
+func TestAcquireClonesShallowWithOwnershipMarker(t *testing.T) {
+	m, git, base := newTestManager(t)
+
+	h, err := m.Acquire(context.Background(), Request{
+		Repo:  "org/repo",
+		Token: "top-secret-token",
+		Mode:  ModeRead,
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer h.Release()
+
+	wantPath := filepath.Join(base, "heimdallm", "org", "repo")
+	if h.Path() != wantPath || !h.Managed() {
+		t.Fatalf("handle = (%q, managed=%v), want %q managed", h.Path(), h.Managed(), wantPath)
+	}
+	if err := validateMarker(wantPath, "org/repo"); err != nil {
+		t.Fatalf("marker not valid: %v", err)
+	}
+	calls := git.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("git calls = %v, want one clone", calls)
+	}
+	if !reflect.DeepEqual(calls[0].Args[:2], []string{"clone", "--depth=1"}) {
+		t.Fatalf("clone args = %v, want shallow clone", calls[0].Args)
+	}
+	for _, arg := range calls[0].Args {
+		if strings.Contains(arg, "top-secret-token") {
+			t.Fatalf("token leaked in git args: %v", calls[0].Args)
+		}
+	}
+}
+
+func TestAcquireCloneFailureRemovesPartialManagedTarget(t *testing.T) {
+	m, git, base := newTestManager(t)
+	git.onRun = func(call gitCall) error {
+		if len(call.Args) > 0 && call.Args[0] == "clone" {
+			target := call.Args[len(call.Args)-1]
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+			return errors.New("network down")
+		}
+		return nil
+	}
+
+	_, err := m.Acquire(context.Background(), Request{
+		Repo:  "org/repo",
+		Token: "secret",
+		Mode:  ModeRead,
+	})
+	if err == nil || !strings.Contains(err.Error(), "network down") {
+		t.Fatalf("Acquire err = %v, want clone failure", err)
+	}
+	target := filepath.Join(base, "heimdallm", "org", "repo")
+	if _, statErr := os.Stat(target); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("partial clone target still exists or stat failed unexpectedly: %v", statErr)
+	}
+}
+
+func TestAcquireRefusesExistingUnmanagedTarget(t *testing.T) {
+	m, _, base := newTestManager(t)
+	target := filepath.Join(base, "heimdallm", "org", "repo")
+	if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := m.Acquire(context.Background(), Request{Repo: "org/repo", Token: "secret"})
+	if err == nil || !strings.Contains(err.Error(), "not managed") {
+		t.Fatalf("Acquire err = %v, want unmanaged-target error", err)
+	}
+	if _, statErr := os.Stat(target); statErr != nil {
+		t.Fatalf("unmanaged target was removed: %v", statErr)
+	}
+}
+
+func TestAcquireUpdatesExistingManagedClone(t *testing.T) {
+	m, git, base := newTestManager(t)
+	target := filepath.Join(base, "heimdallm", "org", "repo")
+	if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMarker(target, "org/repo"); err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := m.Acquire(context.Background(), Request{Repo: "org/repo", Token: "secret"})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	h.Release()
+
+	calls := git.snapshot()
+	got := make([]string, 0, len(calls))
+	for _, c := range calls {
+		got = append(got, strings.Join(c.Args, " "))
+	}
+	want := []string{
+		"remote set-url origin https://x-access-token@github.com/org/repo.git",
+		"fetch --depth=1 --prune origin HEAD",
+		"reset --hard FETCH_HEAD",
+		"clean -fd -e .heimdallm-managed",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("git calls = %v, want %v", got, want)
+	}
+	if err := validateMarker(target, "org/repo"); err != nil {
+		t.Fatalf("marker should survive update: %v", err)
+	}
+}
+
+func TestAcquireSerializesByRepoUntilRelease(t *testing.T) {
+	m, _, _ := newTestManager(t)
+	h, err := m.Acquire(context.Background(), Request{
+		Repo:               "org/repo",
+		ConfiguredLocalDir: "/tmp/worktree",
+	})
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+
+	acquired := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h2, err := m.Acquire(context.Background(), Request{
+			Repo:               "org/repo",
+			ConfiguredLocalDir: "/tmp/worktree",
+		})
+		if err != nil {
+			t.Errorf("second Acquire: %v", err)
+			return
+		}
+		close(acquired)
+		h2.Release()
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second Acquire completed before first handle was released")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	h.Release()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("second Acquire did not complete after release")
+	}
+	<-done
+}
+
+func TestPurgeOnlyRemovesManagedClone(t *testing.T) {
+	m, _, base := newTestManager(t)
+	managed := filepath.Join(base, "heimdallm", "org", "repo")
+	if err := os.MkdirAll(filepath.Join(managed, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMarker(managed, "org/repo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Purge(context.Background(), "org/repo", ""); err != nil {
+		t.Fatalf("Purge managed: %v", err)
+	}
+	if _, err := os.Stat(managed); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("managed clone still exists or stat failed unexpectedly: %v", err)
+	}
+
+	unmanaged := filepath.Join(base, "heimdallm", "org", "other")
+	if err := os.MkdirAll(filepath.Join(unmanaged, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := m.Purge(context.Background(), "org/other", "")
+	if err == nil || !strings.Contains(err.Error(), "not managed") {
+		t.Fatalf("Purge unmanaged err = %v, want not-managed error", err)
+	}
+	if _, statErr := os.Stat(unmanaged); statErr != nil {
+		t.Fatalf("unmanaged clone was removed: %v", statErr)
+	}
+}
+
+func TestEnsureFullHistoryUnshallowsManagedClone(t *testing.T) {
+	m, git, base := newTestManager(t)
+	target := filepath.Join(base, "heimdallm", "org", "repo")
+	if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, ".git", "shallow"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := &Handle{path: target, managed: true}
+
+	if err := m.EnsureFullHistory(context.Background(), h, "secret"); err != nil {
+		t.Fatalf("EnsureFullHistory: %v", err)
+	}
+	calls := git.snapshot()
+	if len(calls) != 1 || strings.Join(calls[0].Args, " ") != "fetch --unshallow --prune origin" {
+		t.Fatalf("git calls = %v, want unshallow fetch", calls)
+	}
+}

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -49,6 +49,9 @@ func (f *fakeGit) Run(ctx context.Context, dir string, env []string, args ...str
 		if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
 			return err
 		}
+		if err := os.WriteFile(filepath.Join(target, ".git", "shallow"), []byte("x"), 0o644); err != nil {
+			return err
+		}
 	}
 	return f.runErr
 }
@@ -91,6 +94,14 @@ func TestAcquireUsesExplicitLocalDirWithoutGit(t *testing.T) {
 	}
 }
 
+func TestAcquireNilManagerIsError(t *testing.T) {
+	var m *Manager
+	_, err := m.Acquire(context.Background(), Request{Repo: "org/repo", Token: "secret"})
+	if err == nil || !strings.Contains(err.Error(), "nil manager") {
+		t.Fatalf("Acquire err = %v, want nil manager error", err)
+	}
+}
+
 func TestAcquireUsesLocalDirBaseOnlyForReadMode(t *testing.T) {
 	m, git, cloneBase := newTestManager(t)
 	localBase := t.TempDir()
@@ -128,8 +139,9 @@ func TestAcquireUsesLocalDirBaseOnlyForReadMode(t *testing.T) {
 	if writeHandle.Path() != wantManaged || !writeHandle.Managed() {
 		t.Fatalf("write handle = (%q, managed=%v), want managed clone %q", writeHandle.Path(), writeHandle.Managed(), wantManaged)
 	}
-	if calls := git.snapshot(); len(calls) != 1 || calls[0].Args[0] != "clone" {
-		t.Fatalf("git calls = %v, want one clone", calls)
+	calls := git.snapshot()
+	if len(calls) != 2 || calls[0].Args[0] != "clone" || strings.Join(calls[1].Args, " ") != "fetch --unshallow --prune origin" {
+		t.Fatalf("git calls = %v, want clone then unshallow", calls)
 	}
 }
 
@@ -153,6 +165,11 @@ func TestAcquireClonesShallowWithOwnershipMarker(t *testing.T) {
 	if err := validateMarker(wantPath, "org/repo"); err != nil {
 		t.Fatalf("marker not valid: %v", err)
 	}
+	if info, err := os.Stat(filepath.Join(wantPath, MarkerFile)); err != nil {
+		t.Fatalf("stat marker: %v", err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Fatalf("marker mode = %o, want 600", info.Mode().Perm())
+	}
 	calls := git.snapshot()
 	if len(calls) != 1 {
 		t.Fatalf("git calls = %v, want one clone", calls)
@@ -164,6 +181,39 @@ func TestAcquireClonesShallowWithOwnershipMarker(t *testing.T) {
 		if strings.Contains(arg, "top-secret-token") {
 			t.Fatalf("token leaked in git args: %v", calls[0].Args)
 		}
+	}
+}
+
+func TestAcquireModeWriteEnsuresFullHistory(t *testing.T) {
+	m, git, base := newTestManager(t)
+	target := filepath.Join(base, "heimdallm", "org", "repo")
+	if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, ".git", "shallow"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMarker(target, "org/repo"); err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := m.Acquire(context.Background(), Request{
+		Repo:  "org/repo",
+		Token: "secret",
+		Mode:  ModeWrite,
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	h.Release()
+
+	calls := git.snapshot()
+	got := make([]string, 0, len(calls))
+	for _, c := range calls {
+		got = append(got, strings.Join(c.Args, " "))
+	}
+	if got[len(got)-1] != "fetch --unshallow --prune origin" {
+		t.Fatalf("last git call = %q, want unshallow; all calls = %v", got[len(got)-1], got)
 	}
 }
 
@@ -207,6 +257,19 @@ func TestAcquireRefusesExistingUnmanagedTarget(t *testing.T) {
 	}
 	if _, statErr := os.Stat(target); statErr != nil {
 		t.Fatalf("unmanaged target was removed: %v", statErr)
+	}
+}
+
+func TestAcquireInvalidRepoDoesNotCreateLock(t *testing.T) {
+	m, _, _ := newTestManager(t)
+	_, err := m.Acquire(context.Background(), Request{Repo: "bad org/repo", Token: "secret"})
+	if err == nil {
+		t.Fatal("expected invalid repo error")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.locks) != 0 {
+		t.Fatalf("locks = %d, want 0 after pre-lock validation failure", len(m.locks))
 	}
 }
 
@@ -312,6 +375,14 @@ func TestPurgeOnlyRemovesManagedClone(t *testing.T) {
 	}
 	if _, statErr := os.Stat(unmanaged); statErr != nil {
 		t.Fatalf("unmanaged clone was removed: %v", statErr)
+	}
+}
+
+func TestPurgeNilManagerIsError(t *testing.T) {
+	var m *Manager
+	err := m.Purge(context.Background(), "org/repo", "")
+	if err == nil || !strings.Contains(err.Error(), "nil manager") {
+		t.Fatalf("Purge err = %v, want nil manager error", err)
 	}
 }
 

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -378,6 +378,117 @@ func TestPurgeOnlyRemovesManagedClone(t *testing.T) {
 	}
 }
 
+func TestPurgeAllRemovesOnlyManagedClones(t *testing.T) {
+	m, _, base := newTestManager(t)
+	managed := filepath.Join(base, "heimdallm", "org", "repo")
+	alsoManaged := filepath.Join(base, "heimdallm", "other", "repo")
+	unmanaged := filepath.Join(base, "heimdallm", "org", "unmanaged")
+	mismatchedMarker := filepath.Join(base, "heimdallm", "org", "mismatch")
+	for _, dir := range []string{managed, alsoManaged, unmanaged, mismatchedMarker} {
+		if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writeMarker(managed, "org/repo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMarker(alsoManaged, "other/repo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMarker(mismatchedMarker, "other/repo"); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := m.PurgeAll(context.Background(), "")
+	if err != nil {
+		t.Fatalf("PurgeAll: %v", err)
+	}
+	if report.Removed != 2 {
+		t.Fatalf("PurgeAll removed = %d, want 2", report.Removed)
+	}
+	for _, dir := range []string{managed, alsoManaged} {
+		if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("managed clone %q still exists or stat failed unexpectedly: %v", dir, err)
+		}
+	}
+	if _, err := os.Stat(unmanaged); err != nil {
+		t.Fatalf("unmanaged clone should remain: %v", err)
+	}
+	if _, err := os.Stat(mismatchedMarker); err != nil {
+		t.Fatalf("mismatched marker clone should remain: %v", err)
+	}
+}
+
+func TestPurgeStaleRemovesOnlyOldUnmonitoredManagedClones(t *testing.T) {
+	m, _, base := newTestManager(t)
+	oldUnmonitored := filepath.Join(base, "heimdallm", "org", "old")
+	oldMonitored := filepath.Join(base, "heimdallm", "org", "keep")
+	recentUnmonitored := filepath.Join(base, "heimdallm", "org", "recent")
+	unmanaged := filepath.Join(base, "heimdallm", "org", "unmanaged")
+	for _, dir := range []string{oldUnmonitored, oldMonitored, recentUnmonitored, unmanaged} {
+		if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for repo, dir := range map[string]string{
+		"org/old":    oldUnmonitored,
+		"org/keep":   oldMonitored,
+		"org/recent": recentUnmonitored,
+	} {
+		if err := writeMarker(dir, repo); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	for _, dir := range []string{oldUnmonitored, oldMonitored} {
+		if err := os.Chtimes(filepath.Join(dir, MarkerFile), old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	report, err := m.PurgeStale(context.Background(), "", map[string]struct{}{"org/keep": {}}, 1)
+	if err != nil {
+		t.Fatalf("PurgeStale: %v", err)
+	}
+	if report.Removed != 1 {
+		t.Fatalf("PurgeStale removed = %d, want 1", report.Removed)
+	}
+	if _, err := os.Stat(oldUnmonitored); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old unmonitored clone still exists or stat failed unexpectedly: %v", err)
+	}
+	for _, dir := range []string{oldMonitored, recentUnmonitored, unmanaged} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("clone %q should remain: %v", dir, err)
+		}
+	}
+}
+
+func TestPurgeStaleDisabledWhenMaxDaysZero(t *testing.T) {
+	m, _, base := newTestManager(t)
+	managed := filepath.Join(base, "heimdallm", "org", "repo")
+	if err := os.MkdirAll(filepath.Join(managed, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMarker(managed, "org/repo"); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(filepath.Join(managed, MarkerFile), old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := m.PurgeStale(context.Background(), "", nil, 0)
+	if err != nil {
+		t.Fatalf("PurgeStale disabled: %v", err)
+	}
+	if report.Removed != 0 {
+		t.Fatalf("PurgeStale disabled removed = %d, want 0", report.Removed)
+	}
+	if _, err := os.Stat(managed); err != nil {
+		t.Fatalf("managed clone should remain: %v", err)
+	}
+}
+
 func TestPurgeNilManagerIsError(t *testing.T) {
 	var m *Manager
 	err := m.Purge(context.Background(), "org/repo", "")

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -801,7 +801,7 @@ func (srv *Server) handleDeleteManagedClone(w http.ResponseWriter, r *http.Reque
 	}
 	if err := srv.cleanCloneFn(repo); err != nil {
 		slog.Error("DELETE /config/clones failed", "repo", repo, "err", err)
-		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		http.Error(w, `{"error":"clone cleanup failed"}`, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted", "repo": repo})

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -41,6 +41,7 @@ type Server struct {
 	triggerReviewFn      func(prID int64) error
 	triggerIssueReviewFn func(issueID int64) error
 	triggerPromoteFn     func(issueID int64) error
+	cleanCloneFn         func(repo string) error
 	meFn                 func() (string, error)
 	// configFn returns the current running config as a JSON-serializable map.
 	configFn func() map[string]any
@@ -168,6 +169,9 @@ func (srv *Server) SetTriggerPromoteFn(fn func(issueID int64) error) {
 	srv.triggerPromoteFn = fn
 }
 
+// SetCleanCloneFn wires the manual managed-clone cleanup callback.
+func (srv *Server) SetCleanCloneFn(fn func(repo string) error) { srv.cleanCloneFn = fn }
+
 // SetMeFn wires the authenticated-user callback called by GET /me.
 func (srv *Server) SetMeFn(fn func() (string, error)) { srv.meFn = fn }
 
@@ -271,6 +275,7 @@ func (srv *Server) buildRouter() chi.Router {
 	r.Delete("/config/repos/{repo}/*", srv.handleDeleteRepoField)
 	r.Patch("/config/orgs/{org}", srv.handlePatchOrgConfig)
 	r.Delete("/config/orgs/{org}/*", srv.handleDeleteOrgField)
+	r.Delete("/config/clones/{repo}", srv.handleDeleteManagedClone)
 	r.Post("/reload", srv.handleReload)
 	r.Post("/shutdown", srv.handleShutdown)
 	r.Get("/events", srv.handleSSE)
@@ -782,6 +787,24 @@ func (srv *Server) handleDeleteOrgField(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	writeJSON(w, http.StatusOK, result)
+}
+
+func (srv *Server) handleDeleteManagedClone(w http.ResponseWriter, r *http.Request) {
+	if srv.cleanCloneFn == nil {
+		http.Error(w, `{"error":"clone cleanup not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+	repo, err := url.PathUnescape(chi.URLParam(r, "repo"))
+	if err != nil || repo == "" {
+		http.Error(w, `{"error":"invalid repo parameter"}`, http.StatusBadRequest)
+		return
+	}
+	if err := srv.cleanCloneFn(repo); err != nil {
+		slog.Error("DELETE /config/clones failed", "repo", repo, "err", err)
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted", "repo": repo})
 }
 
 func (srv *Server) handleReload(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -41,7 +41,8 @@ type Server struct {
 	triggerReviewFn      func(prID int64) error
 	triggerIssueReviewFn func(issueID int64) error
 	triggerPromoteFn     func(issueID int64) error
-	cleanCloneFn         func(repo string) error
+	cleanCloneFn         func(ctx context.Context, repo string) error
+	cleanClonesFn        func(ctx context.Context) (int, error)
 	meFn                 func() (string, error)
 	// configFn returns the current running config as a JSON-serializable map.
 	configFn func() map[string]any
@@ -67,6 +68,7 @@ type Options struct {
 }
 
 const defaultMaxConcurrentReviews = 5
+const cloneCleanupTimeout = 30 * time.Second
 
 // New creates a new Server. p may be nil if the pipeline is not yet configured.
 // apiToken must be the value returned by LoadOrCreateAPIToken — it is required
@@ -169,8 +171,15 @@ func (srv *Server) SetTriggerPromoteFn(fn func(issueID int64) error) {
 	srv.triggerPromoteFn = fn
 }
 
-// SetCleanCloneFn wires the manual managed-clone cleanup callback.
-func (srv *Server) SetCleanCloneFn(fn func(repo string) error) { srv.cleanCloneFn = fn }
+// SetCleanCloneFn wires the manual single-repo managed-clone cleanup callback.
+func (srv *Server) SetCleanCloneFn(fn func(ctx context.Context, repo string) error) {
+	srv.cleanCloneFn = fn
+}
+
+// SetCleanClonesFn wires the manual all-managed-clones cleanup callback.
+func (srv *Server) SetCleanClonesFn(fn func(ctx context.Context) (int, error)) {
+	srv.cleanClonesFn = fn
+}
 
 // SetMeFn wires the authenticated-user callback called by GET /me.
 func (srv *Server) SetMeFn(fn func() (string, error)) { srv.meFn = fn }
@@ -275,6 +284,7 @@ func (srv *Server) buildRouter() chi.Router {
 	r.Delete("/config/repos/{repo}/*", srv.handleDeleteRepoField)
 	r.Patch("/config/orgs/{org}", srv.handlePatchOrgConfig)
 	r.Delete("/config/orgs/{org}/*", srv.handleDeleteOrgField)
+	r.Delete("/config/clones", srv.handleDeleteManagedClones)
 	r.Delete("/config/clones/{repo}", srv.handleDeleteManagedClone)
 	r.Post("/reload", srv.handleReload)
 	r.Post("/shutdown", srv.handleShutdown)
@@ -799,12 +809,38 @@ func (srv *Server) handleDeleteManagedClone(w http.ResponseWriter, r *http.Reque
 		http.Error(w, `{"error":"invalid repo parameter"}`, http.StatusBadRequest)
 		return
 	}
-	if err := srv.cleanCloneFn(repo); err != nil {
+	ctx, cancel := context.WithTimeout(r.Context(), cloneCleanupTimeout)
+	defer cancel()
+	if err := srv.cleanCloneFn(ctx, repo); err != nil {
 		slog.Error("DELETE /config/clones failed", "repo", repo, "err", err)
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			http.Error(w, `{"error":"clone cleanup timed out"}`, http.StatusGatewayTimeout)
+			return
+		}
 		http.Error(w, `{"error":"clone cleanup failed"}`, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted", "repo": repo})
+}
+
+func (srv *Server) handleDeleteManagedClones(w http.ResponseWriter, r *http.Request) {
+	if srv.cleanClonesFn == nil {
+		http.Error(w, `{"error":"clone cleanup not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), cloneCleanupTimeout)
+	defer cancel()
+	removed, err := srv.cleanClonesFn(ctx)
+	if err != nil {
+		slog.Error("DELETE /config/clones failed", "err", err)
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			http.Error(w, `{"error":"clone cleanup timed out"}`, http.StatusGatewayTimeout)
+			return
+		}
+		http.Error(w, `{"error":"clone cleanup failed"}`, http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "deleted", "removed": removed})
 }
 
 func (srv *Server) handleReload(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1605,6 +1605,48 @@ func TestHandleDeleteRepoField_Idempotent(t *testing.T) {
 	}
 }
 
+func TestHandleDeleteManagedCloneRequiresAuthAndCallsCallback(t *testing.T) {
+	srv := setupServerWithToken(t, "test-token")
+	var gotRepo string
+	srv.SetCleanCloneFn(func(repo string) error {
+		gotRepo = repo
+		return nil
+	})
+	path := "/config/clones/" + url.PathEscape("org/repo")
+
+	req := httptest.NewRequest("DELETE", path, nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("DELETE without token status = %d, want 401", w.Code)
+	}
+
+	req = httptest.NewRequest("DELETE", path, nil)
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w = httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("DELETE with token status = %d, body: %s", w.Code, w.Body.String())
+	}
+	if gotRepo != "org/repo" {
+		t.Fatalf("callback repo = %q, want org/repo", gotRepo)
+	}
+}
+
+func TestHandleDeleteManagedCloneSurfacesCallbackError(t *testing.T) {
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetCleanCloneFn(func(repo string) error {
+		return fmt.Errorf("not managed")
+	})
+	req := httptest.NewRequest("DELETE", "/config/clones/"+url.PathEscape("org/repo"), nil)
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
 func TestHandleListPRs_StateFilter(t *testing.T) {
 	s, err := store.Open(":memory:")
 	if err != nil {

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1636,7 +1636,7 @@ func TestHandleDeleteManagedCloneRequiresAuthAndCallsCallback(t *testing.T) {
 func TestHandleDeleteManagedCloneSurfacesCallbackError(t *testing.T) {
 	srv := setupServerWithToken(t, "test-token")
 	srv.SetCleanCloneFn(func(repo string) error {
-		return fmt.Errorf("not managed")
+		return fmt.Errorf("repoctx: clone target %q exists but is not managed", "/tmp/heimdallm/org/repo")
 	})
 	req := httptest.NewRequest("DELETE", "/config/clones/"+url.PathEscape("org/repo"), nil)
 	req.Header.Set("X-Heimdallm-Token", "test-token")
@@ -1644,6 +1644,9 @@ func TestHandleDeleteManagedCloneSurfacesCallbackError(t *testing.T) {
 	srv.Router().ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "/tmp/heimdallm") {
+		t.Fatalf("response leaked clone path: %s", w.Body.String())
 	}
 }
 

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1608,7 +1608,7 @@ func TestHandleDeleteRepoField_Idempotent(t *testing.T) {
 func TestHandleDeleteManagedCloneRequiresAuthAndCallsCallback(t *testing.T) {
 	srv := setupServerWithToken(t, "test-token")
 	var gotRepo string
-	srv.SetCleanCloneFn(func(repo string) error {
+	srv.SetCleanCloneFn(func(ctx context.Context, repo string) error {
 		gotRepo = repo
 		return nil
 	})
@@ -1635,7 +1635,7 @@ func TestHandleDeleteManagedCloneRequiresAuthAndCallsCallback(t *testing.T) {
 
 func TestHandleDeleteManagedCloneSurfacesCallbackError(t *testing.T) {
 	srv := setupServerWithToken(t, "test-token")
-	srv.SetCleanCloneFn(func(repo string) error {
+	srv.SetCleanCloneFn(func(ctx context.Context, repo string) error {
 		return fmt.Errorf("repoctx: clone target %q exists but is not managed", "/tmp/heimdallm/org/repo")
 	})
 	req := httptest.NewRequest("DELETE", "/config/clones/"+url.PathEscape("org/repo"), nil)
@@ -1647,6 +1647,36 @@ func TestHandleDeleteManagedCloneSurfacesCallbackError(t *testing.T) {
 	}
 	if strings.Contains(w.Body.String(), "/tmp/heimdallm") {
 		t.Fatalf("response leaked clone path: %s", w.Body.String())
+	}
+}
+
+func TestHandleDeleteManagedClonesRequiresAuthAndCallsCallback(t *testing.T) {
+	srv := setupServerWithToken(t, "test-token")
+	called := false
+	srv.SetCleanClonesFn(func(ctx context.Context) (int, error) {
+		called = true
+		return 3, nil
+	})
+
+	req := httptest.NewRequest("DELETE", "/config/clones", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("DELETE without token status = %d, want 401", w.Code)
+	}
+
+	req = httptest.NewRequest("DELETE", "/config/clones", nil)
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w = httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("DELETE with token status = %d, body: %s", w.Code, w.Body.String())
+	}
+	if !called {
+		t.Fatal("expected cleanup callback to be called")
+	}
+	if !strings.Contains(w.Body.String(), `"removed":3`) {
+		t.Fatalf("body = %s, want removed count", w.Body.String())
 	}
 }
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -739,7 +739,10 @@ HEIMDALLM_RETENTION_DAYS=90
 max_days = 90
 ```
 
-The purge runs on each poll cycle. Records older than `max_days` are deleted. Set to `0` to disable purging.
+Review/activity records older than `max_days` are deleted. Managed auto-clones
+for repos that are no longer monitored are also purged after `max_days`, but
+only when their `.heimdallm-managed` marker is present. Set to `0` to disable
+purging.
 
 ### Log rotation
 
@@ -936,8 +939,14 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # os.TempDir()/heimdallm/<org>/<repo>. Existing directories are mutated only
 # when they contain Heimdallm's .heimdallm-managed marker; local_dir and
 # local_dir_base checkouts are treated as operator-owned.
-# Manual cleanup is available through the authenticated API:
+# AI CLIs always run with this directory as their process cwd. When the
+# installed CLI advertises a supported repo-context flag in --help, Heimdallm
+# also passes that flag (for example Claude --add-dir, Gemini
+# --include-directories, Codex --cd); otherwise it safely falls back to cwd.
+# Managed clone cleanup is marker-protected and authenticated:
+# DELETE /config/clones                         # all managed clones in configured clone dirs
 # DELETE /config/clones/<url-escaped org/repo>
+# make clean-clones                            # calls DELETE /config/clones
 
 # ── Per-CLI settings (optional) ──────────────────────────────────────────────
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -931,6 +931,14 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # Generate LLM-produced PR titles and descriptions for auto_implement PRs.
 # generate_pr_description = false
 
+# When local_dir is unset, Heimdallm prepares a managed shallow clone for agent
+# context under clone_dir. If clone_dir is also unset, the default is
+# os.TempDir()/heimdallm/<org>/<repo>. Existing directories are mutated only
+# when they contain Heimdallm's .heimdallm-managed marker; local_dir and
+# local_dir_base checkouts are treated as operator-owned.
+# Manual cleanup is available through the authenticated API:
+# DELETE /config/clones/<url-escaped org/repo>
+
 # ── Per-CLI settings (optional) ──────────────────────────────────────────────
 
 # [ai.agents.claude]


### PR DESCRIPTION
## Summary

- Add a repo-context manager that resolves `local_dir`, reuses read-only `local_dir_base` context, and auto-clones missing repos into managed shallow checkouts under `clone_dir` or `os.TempDir()/heimdallm/<org>/<repo>`.
- Protect managed checkouts with per-repo `Acquire`/`Release` locks and a `.heimdallm-managed` ownership marker before any `fetch/reset/clean` or cleanup.
- Wire repo context into PR review, issue triage, and auto-implement execution paths while keeping `GET /config` display-only resolution pure.
- Add authenticated manual clone cleanup via `DELETE /config/clones/{repo}` and document the behavior.

## Behavior

- PR review and issue triage degrade to diff-only / no local context if clone preparation fails.
- `auto_implement` fails visibly if a writable checkout cannot be prepared.
- `local_dir` remains operator-owned and can be used for write flows; `local_dir_base` remains read-only shared context.

Closes #394.

## Validation

- `make test-docker`