### PR TITLE
feat: add lightweight issue triage heuristics

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1467,6 +1467,13 @@ func main() {
 
 	// Wire the issue-review trigger callback: re-run issue pipeline on a stored issue.
 	srv.SetTriggerIssueReviewFn(func(issueID int64) error {
+		// The HTTP handler queues this work in a goroutine and returns 202, so
+		// r.Context() would be cancelled as soon as the response is written.
+		// Use an explicit operation timeout instead of an unbounded background
+		// context so repo-context git operations remain cancellable.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
+
 		publishIssueErr := func(msg string) {
 			broker.Publish(sse.Event{
 				Type: sse.EventIssueReviewError,
@@ -1489,14 +1496,14 @@ func main() {
 		localDirBase := cfg.GitHub.LocalDirBase
 		globalTimeout := cfg.AI.ExecutionTimeout
 		cfgMu.Unlock()
-		repoHandle, err := acquireRepoContext(context.Background(), repoCtx, iss.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		repoHandle, err := acquireRepoContext(ctx, repoCtx, iss.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
 		if err != nil {
 			logRepoContextFallback("trigger issue review", iss.Repo, err)
 			aiCfg.LocalDir = ""
 		}
 		if repoHandle != nil {
 			defer repoHandle.Release()
-			ensureRepoContextFullHistory(context.Background(), repoCtx, repoHandle, token, "trigger issue review", iss.Repo)
+			ensureRepoContextFullHistory(ctx, repoCtx, repoHandle, token, "trigger issue review", iss.Repo)
 		}
 
 		// Reconstruct github.Issue from store data for the pipeline
@@ -1560,7 +1567,7 @@ func main() {
 		slog.Info("trigger issue review: running pipeline",
 			"store_issue_id", issueID, "repo", iss.Repo, "number", iss.Number)
 
-		_, err = issuePipe.Run(context.Background(), ghIssue, opts)
+		_, err = issuePipe.Run(ctx, ghIssue, opts)
 		if err != nil {
 			broker.Publish(sse.Event{Type: sse.EventIssueReviewError, Data: sseData(map[string]any{
 				"issue_id": issueID, "repo": iss.Repo, "error": err.Error(),

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -838,6 +838,7 @@ func main() {
 		}
 		if repoHandle != nil {
 			defer repoHandle.Release()
+			ensureRepoContextFullHistory(ctx, repoCtx, repoHandle, token, "triage-worker", msg.Repo)
 		}
 
 		extraFlags := agentCfg.ExtraFlags
@@ -870,6 +871,7 @@ func main() {
 			},
 			IssuePromptOverride:     issuePrompt,
 			IssueInstructions:       issueInstructions,
+			TriageOwner:             aiCfg.TriageOwner,
 			ImplementPromptOverride: implPrompt,
 			ImplementInstructions:   implInstructions,
 			PRReviewers:             aiCfg.PRReviewers,
@@ -970,6 +972,7 @@ func main() {
 			},
 			IssuePromptOverride:      issuePrompt,
 			IssueInstructions:        issueInstructions,
+			TriageOwner:              aiCfg.TriageOwner,
 			ImplementPromptOverride:  implPrompt,
 			ImplementInstructions:    implInstructions,
 			PRReviewers:              aiCfg.PRReviewers,
@@ -1493,6 +1496,7 @@ func main() {
 		}
 		if repoHandle != nil {
 			defer repoHandle.Release()
+			ensureRepoContextFullHistory(context.Background(), repoCtx, repoHandle, token, "trigger issue review", iss.Repo)
 		}
 
 		// Reconstruct github.Issue from store data for the pipeline
@@ -1543,6 +1547,7 @@ func main() {
 			},
 			IssuePromptOverride:     issuePrompt,
 			IssueInstructions:       issueInstructions,
+			TriageOwner:             aiCfg.TriageOwner,
 			ImplementPromptOverride: implPrompt,
 			ImplementInstructions:   implInstructions,
 			PRReviewers:             aiCfg.PRReviewers,
@@ -2502,6 +2507,9 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 			}
 			aiCfg.LocalDir = ""
 		} else if repoHandle != nil {
+			if issue.Mode == config.IssueModeReviewOnly {
+				ensureRepoContextFullHistory(ctx, a.repoCtx, repoHandle, a.ghToken, "issue poll", issue.Repo)
+			}
 			releaseRepoContext = repoHandle.Release
 		}
 
@@ -2535,6 +2543,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 			},
 			IssuePromptOverride:      issuePrompt,
 			IssueInstructions:        issueInstructions,
+			TriageOwner:              aiCfg.TriageOwner,
 			ImplementPromptOverride:  implPrompt,
 			ImplementInstructions:    implInstructions,
 			PRReviewers:              aiCfg.PRReviewers,
@@ -3124,6 +3133,16 @@ func acquireRepoContext(
 	// path.
 	aiCfg.LocalDir = h.Path()
 	return h, nil
+}
+
+func ensureRepoContextFullHistory(ctx context.Context, manager *repoctx.Manager, h *repoctx.Handle, token, scope, repo string) {
+	if manager == nil || h == nil {
+		return
+	}
+	if err := manager.EnsureFullHistory(ctx, h, token); err != nil {
+		slog.Warn(scope+": full git history unavailable; triage owner verification may fall back",
+			"repo", repo, "err", err)
+	}
 }
 
 func logRepoContextFallback(scope, repo string, err error) {

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -27,6 +28,8 @@ const maxDiffBodyBytes = 10 * 1024 * 1024 // 10 MB for diffs
 // maxErrBodyLen limits the number of bytes included in error messages to avoid
 // leaking sensitive GitHub diagnostic information (e.g. token details).
 const maxErrBodyLen = 200
+
+var labelColorRE = regexp.MustCompile(`^[0-9A-Fa-f]{6}$`)
 
 // safeTruncate shortens s to at most max bytes, snapping on a rune boundary
 // so we never emit a split multi-byte UTF-8 character in an error message.
@@ -863,15 +866,20 @@ func (c *Client) FetchLabels(repo string) ([]string, error) {
 	return names, nil
 }
 
-// CreateLabel creates a repository label. A 422 is tolerated because GitHub
-// returns it when a racing process created the label after FetchLabels.
+// CreateLabel creates a repository label. A 422 is tolerated only when GitHub
+// reports an already-existing label, which can happen if another process wins
+// the race after FetchLabels.
 func (c *Client) CreateLabel(repo, name, color, description string) error {
 	if repo == "" || name == "" {
 		return nil
 	}
+	color = strings.TrimPrefix(color, "#")
+	if !labelColorRE.MatchString(color) {
+		return fmt.Errorf("github: invalid label color %q", color)
+	}
 	payload, err := json.Marshal(map[string]string{
 		"name":        name,
-		"color":       strings.TrimPrefix(color, "#"),
+		"color":       color,
 		"description": description,
 	})
 	if err != nil {
@@ -886,13 +894,18 @@ func (c *Client) CreateLabel(repo, name, color, description string) error {
 	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	resp.Body.Close()
-	if resp.StatusCode == http.StatusUnprocessableEntity {
-		return nil
-	}
 	if resp.StatusCode != http.StatusCreated {
+		if resp.StatusCode == http.StatusUnprocessableEntity && labelAlreadyExistsBody(body) {
+			return nil
+		}
 		return fmt.Errorf("github: create label %q in %s: status %d: %s", name, repo, resp.StatusCode, safeTruncate(string(body), maxErrBodyLen))
 	}
 	return nil
+}
+
+func labelAlreadyExistsBody(body []byte) bool {
+	s := strings.ToLower(string(body))
+	return strings.Contains(s, "already_exists") || strings.Contains(s, "already exists")
 }
 
 // AddIssueLabel adds a label to an issue. No-op if the label is already present.

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -664,8 +664,8 @@ func (c *Client) FetchIssueCommentsOnly(repo string, number int) ([]Comment, err
 // timeline (commits, labels, comments, assignments…) are filtered out
 // at fetch time so callers don't have to reason about them.
 type TimelineEvent struct {
-	Event     string    // "review_requested" or "review_dismissed"
-	Actor     string    // login of the user who triggered the event
+	Event     string // "review_requested" or "review_dismissed"
+	Actor     string // login of the user who triggered the event
 	CreatedAt time.Time
 }
 
@@ -861,6 +861,38 @@ func (c *Client) FetchLabels(repo string) ([]string, error) {
 		names[i] = l.Name
 	}
 	return names, nil
+}
+
+// CreateLabel creates a repository label. A 422 is tolerated because GitHub
+// returns it when a racing process created the label after FetchLabels.
+func (c *Client) CreateLabel(repo, name, color, description string) error {
+	if repo == "" || name == "" {
+		return nil
+	}
+	payload, err := json.Marshal(map[string]string{
+		"name":        name,
+		"color":       strings.TrimPrefix(color, "#"),
+		"description": description,
+	})
+	if err != nil {
+		return fmt.Errorf("github: marshal label: %w", err)
+	}
+	resp, err := c.doWithBody("POST",
+		fmt.Sprintf("/repos/%s/labels", repo),
+		"application/vnd.github+json", "application/json",
+		strings.NewReader(string(payload)))
+	if err != nil {
+		return fmt.Errorf("github: create label: %w", err)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		return nil
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("github: create label %q in %s: status %d: %s", name, repo, resp.StatusCode, safeTruncate(string(body), maxErrBodyLen))
+	}
+	return nil
 }
 
 // AddIssueLabel adds a label to an issue. No-op if the label is already present.

--- a/daemon/internal/github/repos_test.go
+++ b/daemon/internal/github/repos_test.go
@@ -276,6 +276,63 @@ func TestAddLabels_Error(t *testing.T) {
 	}
 }
 
+// ── CreateLabel ──────────────────────────────────────────────────────────────
+
+func TestCreateLabel(t *testing.T) {
+	var captured map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/repos/org/repo/labels" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"name":"priority: high"}`))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	if err := c.CreateLabel("org/repo", "priority: high", "#D93F0B", "desc"); err != nil {
+		t.Fatalf("CreateLabel: %v", err)
+	}
+	if captured["color"] != "D93F0B" {
+		t.Errorf("color = %q, want D93F0B", captured["color"])
+	}
+}
+
+func TestCreateLabel_InvalidColor(t *testing.T) {
+	c := gh.NewClient("fake-token")
+	if err := c.CreateLabel("org/repo", "priority: high", "not-hex", "desc"); err == nil {
+		t.Fatal("expected invalid color error")
+	}
+}
+
+func TestCreateLabel_AlreadyExists422IsNoop(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"errors":[{"code":"already_exists","field":"name"}]}`))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	if err := c.CreateLabel("org/repo", "priority: high", "D93F0B", "desc"); err != nil {
+		t.Fatalf("already_exists should be nil, got: %v", err)
+	}
+}
+
+func TestCreateLabel_InvalidPayload422Surfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"errors":[{"code":"invalid","field":"name"}]}`))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	if err := c.CreateLabel("org/repo", "priority: high", "D93F0B", "desc"); err == nil {
+		t.Fatal("expected invalid 422 to surface")
+	}
+}
+
 // ── RemoveLabels ──────────────────────────────────────────────────────────────
 
 func TestRemoveLabels(t *testing.T) {

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -135,9 +135,19 @@ type Notifier interface {
 
 // Triage is the structured triage block returned by the LLM.
 type Triage struct {
-	Severity          string `json:"severity"`
-	Category          string `json:"category"`
-	SuggestedAssignee string `json:"suggested_assignee"`
+	Severity             string   `json:"severity"`
+	Category             string   `json:"category"`
+	AffectedArea         string   `json:"affected_area,omitempty"`
+	AffectedPaths        []string `json:"affected_paths,omitempty"`
+	PriorityLabel        string   `json:"priority_label,omitempty"`
+	SuggestedAssignee    string   `json:"suggested_assignee"`
+	AssignedAssignee     string   `json:"assigned_assignee,omitempty"`
+	AssigneeReason       string   `json:"assignee_reason,omitempty"`
+	AssigneeConfidence   string   `json:"assignee_confidence,omitempty"`
+	AssigneeEvidence     []string `json:"assignee_evidence,omitempty"`
+	AssignmentSource     string   `json:"assignment_source,omitempty"`
+	TentativeAssignee    string   `json:"tentative_assignee,omitempty"`
+	AssignmentDiagnostic string   `json:"assignment_diagnostic,omitempty"`
 }
 
 // IssueReviewResult is the parsed LLM output for a triage run. Mirrors the
@@ -179,6 +189,7 @@ type RunOptions struct {
 	// Priority: IssuePromptOverride (full template) > IssueInstructions (injected into default) > built-in default.
 	IssuePromptOverride string // full custom template from repo-level agent
 	IssueInstructions   string // plain text injected into default template
+	TriageOwner         string // fallback issue assignee resolved repo > org > global
 
 	// Auto_implement prompt customization (same resolution shape as the
 	// triage pair above, but consulted only on the runAutoImplement path).
@@ -488,6 +499,7 @@ func (p *Pipeline) runReviewOnly(ctx context.Context, issue *github.Issue, issue
 		Comments:      humanComments,
 		HasLocalDir:   workDir != "",
 		TriageContext: triageCtx,
+		TriageOwner:   opts.TriageOwner,
 	}
 	prompt := BuildPromptWithProfile(promptCtx, opts.IssuePromptOverride, opts.IssueInstructions)
 
@@ -506,6 +518,7 @@ func (p *Pipeline) runReviewOnly(ctx context.Context, issue *github.Issue, issue
 		p.publishError(issueID, issue, err)
 		return nil, fmt.Errorf("issues pipeline: parse result: %w", err)
 	}
+	enrichTriageResult(ctx, result, workDir, opts.TriageOwner, defaultGitHistoryRunner{})
 
 	// Build + post the Markdown comment. PostComment failure is not fatal —
 	// the review is still persisted locally with a zero pr_created so
@@ -516,6 +529,7 @@ func (p *Pipeline) runReviewOnly(ctx context.Context, issue *github.Issue, issue
 		slog.Warn("issues pipeline: PostComment failed, review will be stored locally only",
 			"repo", issue.Repo, "number", issue.Number, "err", postErr)
 	}
+	applyIssueTriageMetadata(p.gh, issue.Repo, issue.Number, result)
 
 	triageJSON, err := json.Marshal(result.Triage)
 	if err != nil {
@@ -914,6 +928,12 @@ func parseIssueResult(data []byte) (*IssueReviewResult, error) {
 	if r.Severity == "" {
 		r.Severity = "low"
 	}
+	r.Severity = normalizeSeverity(r.Severity)
+	if r.Triage.Severity == "" {
+		r.Triage.Severity = r.Severity
+	} else {
+		r.Triage.Severity = normalizeSeverity(r.Triage.Severity)
+	}
 	return &r, nil
 }
 
@@ -950,6 +970,56 @@ func applyPRMetadata(gh PRMetadataApplier, repo string, prNumber int, opts RunOp
 				"repo", repo, "pr", prNumber, "err", err)
 		}
 	}
+}
+
+// IssueLabelCatalog is optionally implemented by GitHub clients that can
+// inspect/create repository labels. Tests and custom clients can omit it; the
+// pipeline still attempts AddLabels and treats failures as non-fatal.
+type IssueLabelCatalog interface {
+	FetchLabels(repo string) ([]string, error)
+	CreateLabel(repo, name, color, description string) error
+}
+
+func applyIssueTriageMetadata(gh issueGitHub, repo string, number int, r *IssueReviewResult) {
+	if r == nil {
+		return
+	}
+	if label := strings.TrimSpace(r.Triage.PriorityLabel); label != "" {
+		label = ensureIssueLabel(gh, repo, label, r.Severity)
+		if err := gh.AddLabels(repo, number, []string{label}); err != nil {
+			slog.Warn("issues pipeline: add priority label failed",
+				"repo", repo, "issue", number, "label", label, "err", err)
+		}
+	}
+	if assignee := strings.TrimSpace(r.Triage.AssignedAssignee); assignee != "" {
+		if err := gh.SetAssignees(repo, number, []string{assignee}); err != nil {
+			slog.Warn("issues pipeline: set issue assignee failed",
+				"repo", repo, "issue", number, "assignee", assignee, "err", err)
+		}
+	}
+}
+
+func ensureIssueLabel(gh issueGitHub, repo, label, severity string) string {
+	catalog, ok := gh.(IssueLabelCatalog)
+	if !ok {
+		return label
+	}
+	labels, err := catalog.FetchLabels(repo)
+	if err != nil {
+		slog.Warn("issues pipeline: fetch labels failed; trying priority label directly",
+			"repo", repo, "label", label, "err", err)
+		return label
+	}
+	for _, existing := range labels {
+		if strings.EqualFold(existing, label) {
+			return existing
+		}
+	}
+	if err := catalog.CreateLabel(repo, label, priorityLabelColor(severity), "Heimdallm triage priority"); err != nil {
+		slog.Warn("issues pipeline: create priority label failed; trying to apply anyway",
+			"repo", repo, "label", label, "err", err)
+	}
+	return label
 }
 
 // extractSeverity pulls the severity string from a triage JSON blob.
@@ -1026,11 +1096,37 @@ func BuildMarkdownComment(r *IssueReviewResult) string {
 	if r.Triage.Severity != "" {
 		sb.WriteString(fmt.Sprintf("- **Suggested severity:** %s\n", r.Triage.Severity))
 	}
+	if r.Triage.PriorityLabel != "" {
+		sb.WriteString(fmt.Sprintf("- **Priority label:** %s\n", r.Triage.PriorityLabel))
+	}
+	if r.Triage.AffectedArea != "" {
+		sb.WriteString(fmt.Sprintf("- **Likely affected area:** %s\n", r.Triage.AffectedArea))
+	}
+	if len(r.Triage.AffectedPaths) > 0 {
+		sb.WriteString(fmt.Sprintf("- **Affected paths:** %s\n", strings.Join(r.Triage.AffectedPaths, ", ")))
+	}
+	if r.Triage.AssignedAssignee != "" {
+		sb.WriteString(fmt.Sprintf("- **Assigned owner:** @%s\n", strings.TrimLeft(r.Triage.AssignedAssignee, "@")))
+	} else if r.Triage.TentativeAssignee != "" {
+		sb.WriteString(fmt.Sprintf("- **Tentative owner:** @%s\n", strings.TrimLeft(r.Triage.TentativeAssignee, "@")))
+	}
 	if r.Triage.SuggestedAssignee != "" {
 		// Strip any leading '@' the LLM may have included so the template
 		// does not render a double '@@alice' that pings nobody.
 		assignee := strings.TrimLeft(r.Triage.SuggestedAssignee, "@")
 		sb.WriteString(fmt.Sprintf("- **Suggested assignee:** @%s\n", assignee))
+	}
+	if r.Triage.AssigneeReason != "" {
+		sb.WriteString(fmt.Sprintf("- **Owner rationale:** %s\n", r.Triage.AssigneeReason))
+	}
+	if r.Triage.AssigneeConfidence != "" {
+		sb.WriteString(fmt.Sprintf("- **Owner confidence:** %s\n", r.Triage.AssigneeConfidence))
+	}
+	if len(r.Triage.AssigneeEvidence) > 0 {
+		sb.WriteString("- **Owner evidence:**\n")
+		for _, ev := range r.Triage.AssigneeEvidence {
+			sb.WriteString(fmt.Sprintf("  - %s\n", ev))
+		}
 	}
 	sb.WriteString("\n")
 

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -928,12 +928,6 @@ func parseIssueResult(data []byte) (*IssueReviewResult, error) {
 	if r.Severity == "" {
 		r.Severity = "low"
 	}
-	r.Severity = normalizeSeverity(r.Severity)
-	if r.Triage.Severity == "" {
-		r.Triage.Severity = r.Severity
-	} else {
-		r.Triage.Severity = normalizeSeverity(r.Triage.Severity)
-	}
 	return &r, nil
 }
 
@@ -1002,6 +996,8 @@ func applyIssueTriageMetadata(gh issueGitHub, repo string, number int, r *IssueR
 func ensureIssueLabel(gh issueGitHub, repo, label, severity string) string {
 	catalog, ok := gh.(IssueLabelCatalog)
 	if !ok {
+		slog.Warn("issues pipeline: label catalog unavailable; trying priority label directly",
+			"repo", repo, "label", label)
 		return label
 	}
 	labels, err := catalog.FetchLabels(repo)

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -145,13 +145,24 @@ type fakeGH struct {
 	createPRErr      error
 
 	// PR metadata tracking
-	reviewersCalls [][]string
-	labelsCalls    [][]string
-	assigneesCalls [][]string
+	reviewersCalls  [][]string
+	labelsCalls     [][]string
+	assigneesCalls  [][]string
+	addLabelsErr    error
+	setAssigneesErr error
+
+	labelCatalog   []string
+	fetchLabelsErr error
+	createLabelErr error
+	createdLabels  []labelCall
 
 	// GetIssue stub for pre-push state check (#238).
 	getIssueState string // returned state; defaults to "open"
 	getIssueErr   error
+}
+
+type labelCall struct {
+	Repo, Name, Color, Description string
 }
 
 type postCall struct {
@@ -226,10 +237,24 @@ func (f *fakeGH) SetPRReviewers(repo string, prNumber int, reviewers []string) e
 }
 func (f *fakeGH) AddLabels(repo string, number int, labels []string) error {
 	f.labelsCalls = append(f.labelsCalls, labels)
-	return nil
+	return f.addLabelsErr
 }
 func (f *fakeGH) SetAssignees(repo string, number int, assignees []string) error {
 	f.assigneesCalls = append(f.assigneesCalls, assignees)
+	return f.setAssigneesErr
+}
+func (f *fakeGH) FetchLabels(repo string) ([]string, error) {
+	if f.fetchLabelsErr != nil {
+		return nil, f.fetchLabelsErr
+	}
+	return append([]string(nil), f.labelCatalog...), nil
+}
+func (f *fakeGH) CreateLabel(repo, name, color, description string) error {
+	f.createdLabels = append(f.createdLabels, labelCall{Repo: repo, Name: name, Color: color, Description: description})
+	if f.createLabelErr != nil {
+		return f.createLabelErr
+	}
+	f.labelCatalog = append(f.labelCatalog, name)
 	return nil
 }
 
@@ -1067,6 +1092,121 @@ func TestPipeline_StripsLeadingAtInSuggestedAssignee(t *testing.T) {
 	}
 	if !strings.Contains(body, "@alice") {
 		t.Errorf("body missing single @alice mention: %q", body)
+	}
+}
+
+func TestPipeline_ReviewOnlyAppliesPriorityLabelAndTriageOwnerFallback(t *testing.T) {
+	raw := `
+	{
+	  "summary": "new payment export",
+	  "triage": {
+	    "severity": "high",
+	    "category": "feature",
+	    "affected_area": "billing exports",
+	    "affected_paths": ["daemon/internal/billing/export.go"],
+	    "suggested_assignee": "",
+	    "assignee_reason": "no clear contributor without repo context",
+	    "assignee_confidence": "high"
+	  },
+	  "suggestions": ["identify export format"],
+	  "severity": "high"
+	}`
+	s := &fakeStore{}
+	gh := &fakeGH{labelCatalog: []string{"priority: high"}}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(raw)}
+	p := issues.New(s, gh, exec, nil, nil, nil)
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude", TriageOwner: "@maintainer"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(gh.labelsCalls) != 1 || !stringsEqual(gh.labelsCalls[0], []string{"priority: high"}) {
+		t.Fatalf("priority labels = %v, want [[priority: high]]", gh.labelsCalls)
+	}
+	if len(gh.createdLabels) != 0 {
+		t.Fatalf("existing priority label should not be recreated: %+v", gh.createdLabels)
+	}
+	if len(gh.assigneesCalls) != 1 || !stringsEqual(gh.assigneesCalls[0], []string{"maintainer"}) {
+		t.Fatalf("assignees = %v, want [[maintainer]]", gh.assigneesCalls)
+	}
+	if len(s.reviews) != 1 {
+		t.Fatalf("reviews = %d, want 1", len(s.reviews))
+	}
+	var triage issues.Triage
+	if err := json.Unmarshal([]byte(s.reviews[0].Triage), &triage); err != nil {
+		t.Fatalf("triage JSON: %v", err)
+	}
+	if triage.AssignedAssignee != "maintainer" || triage.AssignmentSource != "triage_owner" {
+		t.Errorf("assigned/source = %q/%q, want maintainer/triage_owner", triage.AssignedAssignee, triage.AssignmentSource)
+	}
+	if triage.PriorityLabel != "priority: high" {
+		t.Errorf("priority label = %q, want priority: high", triage.PriorityLabel)
+	}
+	if body := gh.postCalls[0].Body; !strings.Contains(body, "Assigned owner:** @maintainer") {
+		t.Errorf("comment missing assigned owner: %s", body)
+	}
+}
+
+func TestPipeline_ReviewOnlyCreatesMissingPriorityLabelBestEffort(t *testing.T) {
+	raw := `
+	{
+	  "summary": "outage",
+	  "triage": {"severity":"critical","category":"bug","assignee_confidence":"low"},
+	  "suggestions": [],
+	  "severity": "critical"
+	}`
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(raw)}
+	p := issues.New(s, gh, exec, nil, nil, nil)
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(gh.createdLabels) != 1 || gh.createdLabels[0].Name != "priority: critical" {
+		t.Fatalf("created labels = %+v, want priority: critical", gh.createdLabels)
+	}
+	if len(gh.labelsCalls) != 1 || !stringsEqual(gh.labelsCalls[0], []string{"priority: critical"}) {
+		t.Fatalf("labels = %v, want [[priority: critical]]", gh.labelsCalls)
+	}
+}
+
+func TestPipeline_MetadataFailuresDoNotAbortTriage(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{
+		addLabelsErr:    errors.New("missing label"),
+		setAssigneesErr: errors.New("not assignable"),
+	}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(validResult)}
+	p := issues.New(s, gh, exec, nil, nil, nil)
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude", TriageOwner: "maintainer"}); err != nil {
+		t.Fatalf("metadata failures must not abort triage, got: %v", err)
+	}
+	if len(s.reviews) != 1 {
+		t.Fatalf("review should still be persisted, got %d", len(s.reviews))
+	}
+}
+
+func TestPipeline_BackCompatOldIssueResultWithoutTriageBlock(t *testing.T) {
+	raw := `{"summary":"legacy result","suggestions":["look"],"severity":"medium"}`
+	s := &fakeStore{}
+	gh := &fakeGH{labelCatalog: []string{"priority: medium"}}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(raw)}
+	p := issues.New(s, gh, exec, nil, nil, nil)
+
+	rev, err := p.Run(context.Background(), newIssue(config.IssueModeReviewOnly), issues.RunOptions{Primary: "claude"})
+	if err != nil {
+		t.Fatalf("legacy result should still parse: %v", err)
+	}
+	var triage issues.Triage
+	if err := json.Unmarshal([]byte(rev.Triage), &triage); err != nil {
+		t.Fatalf("triage JSON: %v", err)
+	}
+	if triage.Severity != "medium" || triage.PriorityLabel != "priority: medium" {
+		t.Errorf("triage severity/priority = %q/%q, want medium/priority: medium", triage.Severity, triage.PriorityLabel)
+	}
+	if len(gh.assigneesCalls) != 0 {
+		t.Errorf("legacy result without confidence should not assign, got %v", gh.assigneesCalls)
 	}
 }
 

--- a/daemon/internal/issues/prompt.go
+++ b/daemon/internal/issues/prompt.go
@@ -33,15 +33,17 @@ type PromptContext struct {
 	Comments      []github.Comment
 	HasLocalDir   bool   // when true, the LLM can read the repo for deeper context
 	TriageContext string // structured re-triage context; empty on first triage
+	TriageOwner   string // fallback GitHub login when ownership is unclear
 }
 
 // BuildPromptWithProfile formats the LLM prompt for a review_only triage run,
 // applying customizations from Agent profiles when set:
 //   - customTemplate non-empty: replaces the entire default template with
 //     placeholder substitution ({repo}, {number}, {title}, {author}, {labels},
-//     {body}, {comments}, {assignees}). NOTE: the custom template is responsible
-//     for including the JSON output schema — the pipeline parses the LLM response
-//     as IssueReviewResult. Same contract as PR review custom prompts.
+//     {body}, {comments}, {assignees}, {triage_owner}). NOTE: the custom
+//     template is responsible for including the JSON output schema — the
+//     pipeline parses the LLM response as IssueReviewResult. Same contract as
+//     PR review custom prompts.
 //   - customInstructions non-empty: injects the text into the default template
 //     between the issue context and the JSON schema (safer — schema is preserved).
 //
@@ -90,6 +92,7 @@ func applyPlaceholders(tmpl string, ctx PromptContext) string {
 		"{comments}", comments,
 		"{assignees}", assignees,
 		"{triage_context}", ctx.TriageContext,
+		"{triage_owner}", ctx.TriageOwner,
 	)
 	result := r.Replace(tmpl)
 
@@ -127,7 +130,11 @@ func buildDefaultPrompt(ctx PromptContext, customInstructions string) string {
 		sb.WriteString("Labels: " + strings.Join(ctx.Labels, ", ") + "\n")
 	}
 	if ctx.HasLocalDir {
-		sb.WriteString("You have read access to the repository checked out at the working directory — consult the code when it helps the triage.\n")
+		sb.WriteString("You have read access to the repository checked out at the working directory. Keep triage lightweight, but inspect likely files and git history when it helps identify ownership.\n")
+		sb.WriteString("For bugs, prefer the person who recently touched or introduced the likely affected area. For feature requests, prefer the person with the most relevant changes in that area. Use git log/blame/shortlog evidence when available.\n")
+	}
+	if owner := strings.TrimSpace(ctx.TriageOwner); owner != "" {
+		sb.WriteString(fmt.Sprintf("Fallback triage owner: @%s. Use this only when the affected owner cannot be determined from repository evidence.\n", strings.TrimLeft(owner, "@")))
 	}
 	sb.WriteString("\n")
 
@@ -164,7 +171,13 @@ func buildDefaultPrompt(ctx PromptContext, customInstructions string) string {
 	sb.WriteString(`  "triage": {` + "\n")
 	sb.WriteString(`    "severity": "low|medium|high|critical",` + "\n")
 	sb.WriteString(`    "category": "one of: bug, feature, question, docs, infra, other",` + "\n")
-	sb.WriteString(`    "suggested_assignee": "github-login or empty string"` + "\n")
+	sb.WriteString(`    "affected_area": "short likely root-cause area, or empty string",` + "\n")
+	sb.WriteString(`    "affected_paths": ["relative/path.go"],` + "\n")
+	sb.WriteString(`    "priority_label": "priority: low|priority: medium|priority: high|priority: critical",` + "\n")
+	sb.WriteString(`    "suggested_assignee": "github-login or empty string",` + "\n")
+	sb.WriteString(`    "assignee_reason": "why this owner has the most relevant context, or why fallback was used",` + "\n")
+	sb.WriteString(`    "assignee_confidence": "low|medium|high",` + "\n")
+	sb.WriteString(`    "assignee_evidence": ["git log/blame/shortlog evidence or fallback reason"]` + "\n")
 	sb.WriteString("  },\n")
 	sb.WriteString(`  "suggestions": ["concrete next step", "another one"],` + "\n")
 	sb.WriteString(`  "severity": "low|medium|high|critical"` + "\n")

--- a/daemon/internal/issues/prompt_test.go
+++ b/daemon/internal/issues/prompt_test.go
@@ -43,6 +43,38 @@ func TestBuildImplementPrompt_DefaultTemplateContainsSafetyRules(t *testing.T) {
 	}
 }
 
+func TestBuildPrompt_DefaultTemplateContainsLightweightTriageHeuristics(t *testing.T) {
+	ctx := baseCtx()
+	ctx.HasLocalDir = true
+	ctx.TriageOwner = "@maintainer"
+
+	got := issues.BuildPrompt(ctx)
+	for _, want := range []string{
+		"Keep triage lightweight",
+		"git log/blame/shortlog",
+		"Fallback triage owner: @maintainer",
+		`"affected_area"`,
+		`"affected_paths"`,
+		`"priority_label"`,
+		`"assignee_confidence"`,
+		`"assignee_evidence"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("default triage prompt missing %q", want)
+		}
+	}
+}
+
+func TestBuildPromptWithProfile_TriageOwnerPlaceholder(t *testing.T) {
+	ctx := baseCtx()
+	ctx.TriageOwner = "maintainer"
+
+	got := issues.BuildPromptWithProfile(ctx, "owner={triage_owner}", "")
+	if got != "owner=maintainer" {
+		t.Errorf("triage_owner placeholder = %q, want owner=maintainer", got)
+	}
+}
+
 func TestBuildImplementPrompt_ExistingSignatureUnchanged(t *testing.T) {
 	// Guard against accidentally dropping the zero-arg entry point — the
 	// runAutoImplement fallback still calls it when no agent profile is

--- a/daemon/internal/issues/triage_assignment.go
+++ b/daemon/internal/issues/triage_assignment.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 )
 
-const maxAffectedPaths = 20
+const (
+	maxAffectedPaths       = 20
+	maxContributorLogCount = 500
+)
 
 var (
 	githubLoginRE                = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
@@ -50,7 +53,7 @@ func enrichTriageResult(ctx context.Context, r *IssueReviewResult, workDir, tria
 	r.Triage.Category = strings.ToLower(strings.TrimSpace(r.Triage.Category))
 	r.Triage.PriorityLabel = normalizePriorityLabel(r.Triage.PriorityLabel, r.Severity)
 	r.Triage.SuggestedAssignee = normalizeGitHubLogin(r.Triage.SuggestedAssignee)
-	r.Triage.TentativeAssignee = r.Triage.SuggestedAssignee
+	r.Triage.TentativeAssignee = normalizeGitHubLogin(firstNonEmpty(r.Triage.TentativeAssignee, r.Triage.SuggestedAssignee))
 	r.Triage.AssigneeConfidence = normalizeAssigneeConfidence(r.Triage.AssigneeConfidence)
 	r.Triage.AffectedPaths = sanitizeAffectedPaths(r.Triage.AffectedPaths)
 
@@ -127,7 +130,7 @@ func contributorsForPaths(ctx context.Context, runner gitHistoryRunner, workDir 
 		return nil, errShallowHistory
 	}
 
-	args := []string{"log", "--format=%ae%x00%an", "--all", "--"}
+	args := []string{"log", fmt.Sprintf("--max-count=%d", maxContributorLogCount), "--no-merges", "--format=%ae%x00%an", "--"}
 	args = append(args, affectedPaths...)
 	out, err := runner.Output(ctx, workDir, args...)
 	if err != nil {
@@ -172,15 +175,7 @@ func contributorLoginsFromEmail(email string) []string {
 	if m := githubNoreplyRE.FindStringSubmatch(email); len(m) == 2 {
 		return []string{m[1]}
 	}
-	local, _, ok := strings.Cut(email, "@")
-	if !ok {
-		return nil
-	}
-	local = strings.TrimSpace(local)
-	if normalizeGitHubLogin(local) == "" || strings.EqualFold(local, "noreply") {
-		return nil
-	}
-	return []string{local}
+	return nil
 }
 
 func contributorEvidence(contributors []contributorHit) []string {
@@ -203,11 +198,11 @@ func sanitizeAffectedPaths(paths []string) []string {
 	out := make([]string, 0, len(paths))
 	for _, p := range paths {
 		p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
-		if p == "" || strings.HasPrefix(p, "/") {
+		if p == "" || strings.HasPrefix(p, "/") || strings.HasPrefix(p, "-") {
 			continue
 		}
 		clean := path.Clean(p)
-		if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || clean == ".git" || strings.HasPrefix(clean, ".git/") {
+		if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || strings.HasPrefix(clean, "-") || clean == ".git" || strings.HasPrefix(clean, ".git/") {
 			continue
 		}
 		if _, ok := seen[clean]; ok {

--- a/daemon/internal/issues/triage_assignment.go
+++ b/daemon/internal/issues/triage_assignment.go
@@ -1,0 +1,283 @@
+package issues
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const maxAffectedPaths = 20
+
+var (
+	githubLoginRE                = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
+	githubNoreplyRE              = regexp.MustCompile(`(?i)^(?:\d+\+)?([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)@users\.noreply\.github\.com$`)
+	errShallowHistory            = errors.New("git history is shallow")
+	validSeverities              = map[string]struct{}{"low": {}, "medium": {}, "high": {}, "critical": {}}
+	validConfidences             = map[string]struct{}{"low": {}, "medium": {}, "high": {}}
+	priorityLabelColorBySeverity = map[string]string{
+		"critical": "B60205",
+		"high":     "D93F0B",
+		"medium":   "FBCA04",
+		"low":      "0E8A16",
+	}
+)
+
+type gitHistoryRunner interface {
+	Output(ctx context.Context, dir string, args ...string) ([]byte, error)
+}
+
+type defaultGitHistoryRunner struct{}
+
+func (defaultGitHistoryRunner) Output(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	return captureGit(ctx, dir, nil, args...)
+}
+
+type contributorHit struct {
+	login string
+	count int
+}
+
+func enrichTriageResult(ctx context.Context, r *IssueReviewResult, workDir, triageOwner string, runner gitHistoryRunner) {
+	if r == nil {
+		return
+	}
+	r.Severity = normalizeSeverity(r.Severity)
+	r.Triage.Severity = normalizeSeverity(firstNonEmpty(r.Triage.Severity, r.Severity))
+	r.Triage.Category = strings.ToLower(strings.TrimSpace(r.Triage.Category))
+	r.Triage.PriorityLabel = normalizePriorityLabel(r.Triage.PriorityLabel, r.Severity)
+	r.Triage.SuggestedAssignee = normalizeGitHubLogin(r.Triage.SuggestedAssignee)
+	r.Triage.TentativeAssignee = r.Triage.SuggestedAssignee
+	r.Triage.AssigneeConfidence = normalizeAssigneeConfidence(r.Triage.AssigneeConfidence)
+	r.Triage.AffectedPaths = sanitizeAffectedPaths(r.Triage.AffectedPaths)
+
+	assignee, source, diagnostic, evidence := resolveTriageAssignee(ctx, workDir, triageOwner, r.Triage, runner)
+	r.Triage.AssignedAssignee = assignee
+	r.Triage.AssignmentSource = source
+	r.Triage.AssignmentDiagnostic = diagnostic
+	if len(evidence) > 0 {
+		r.Triage.AssigneeEvidence = evidence
+	}
+}
+
+func resolveTriageAssignee(ctx context.Context, workDir, triageOwner string, triage Triage, runner gitHistoryRunner) (assignee, source, diagnostic string, evidence []string) {
+	fallback := normalizeGitHubLogin(triageOwner)
+	suggested := normalizeGitHubLogin(triage.SuggestedAssignee)
+	confidence := normalizeAssigneeConfidence(triage.AssigneeConfidence)
+
+	fallbackResult := func(reason string) (string, string, string, []string) {
+		if fallback == "" {
+			return "", "none", reason, nil
+		}
+		return fallback, "triage_owner", reason, []string{fmt.Sprintf("@%s configured as triage_owner fallback", fallback)}
+	}
+
+	if suggested == "" && fallback == "" {
+		return "", "none", "no suggested_assignee or triage_owner available", nil
+	}
+	if !confidenceAllowsAssignment(confidence) {
+		return fallbackResult("assignee confidence is low or missing")
+	}
+	if strings.TrimSpace(workDir) == "" {
+		return fallbackResult("repo workdir unavailable; cannot verify assignee against git history")
+	}
+	if len(triage.AffectedPaths) == 0 {
+		return fallbackResult("no affected_paths provided for git-history verification")
+	}
+	if runner == nil {
+		runner = defaultGitHistoryRunner{}
+	}
+
+	contributors, err := contributorsForPaths(ctx, runner, workDir, triage.AffectedPaths)
+	if err != nil {
+		return fallbackResult(fmt.Sprintf("git-history verification unavailable: %v", err))
+	}
+	if len(contributors) == 0 {
+		return fallbackResult("no GitHub-login-like contributors found in affected path history")
+	}
+
+	if suggested != "" {
+		for _, c := range contributors {
+			if strings.EqualFold(c.login, suggested) {
+				return c.login, "suggested_assignee_verified", "suggested_assignee appears in affected path history", contributorEvidence(contributors)
+			}
+		}
+	}
+
+	top := contributors[0]
+	reason := "assigned top contributor from affected path history"
+	if suggested != "" {
+		reason = fmt.Sprintf("model suggested @%s, but that login was not found in affected path history; assigned top contributor instead", suggested)
+	}
+	return top.login, "history_top_contributor", reason, contributorEvidence(contributors)
+}
+
+func contributorsForPaths(ctx context.Context, runner gitHistoryRunner, workDir string, affectedPaths []string) ([]contributorHit, error) {
+	if runner == nil {
+		runner = defaultGitHistoryRunner{}
+	}
+	shallow, err := runner.Output(ctx, workDir, "rev-parse", "--is-shallow-repository")
+	if err != nil {
+		return nil, fmt.Errorf("inspect repository depth: %w", err)
+	}
+	if strings.EqualFold(strings.TrimSpace(string(shallow)), "true") {
+		return nil, errShallowHistory
+	}
+
+	args := []string{"log", "--format=%ae%x00%an", "--all", "--"}
+	args = append(args, affectedPaths...)
+	out, err := runner.Output(ctx, workDir, args...)
+	if err != nil {
+		return nil, fmt.Errorf("git log affected paths: %w", err)
+	}
+
+	counts := map[string]int{}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\x00", 2)
+		email := strings.TrimSpace(parts[0])
+		seenInCommit := map[string]struct{}{}
+		for _, login := range contributorLoginsFromEmail(email) {
+			if _, seen := seenInCommit[strings.ToLower(login)]; seen {
+				continue
+			}
+			seenInCommit[strings.ToLower(login)] = struct{}{}
+			counts[login]++
+		}
+	}
+	hits := make([]contributorHit, 0, len(counts))
+	for login, count := range counts {
+		hits = append(hits, contributorHit{login: login, count: count})
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].count == hits[j].count {
+			return hits[i].login < hits[j].login
+		}
+		return hits[i].count > hits[j].count
+	})
+	return hits, nil
+}
+
+func contributorLoginsFromEmail(email string) []string {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return nil
+	}
+	if m := githubNoreplyRE.FindStringSubmatch(email); len(m) == 2 {
+		return []string{m[1]}
+	}
+	local, _, ok := strings.Cut(email, "@")
+	if !ok {
+		return nil
+	}
+	local = strings.TrimSpace(local)
+	if normalizeGitHubLogin(local) == "" || strings.EqualFold(local, "noreply") {
+		return nil
+	}
+	return []string{local}
+}
+
+func contributorEvidence(contributors []contributorHit) []string {
+	if len(contributors) == 0 {
+		return nil
+	}
+	n := len(contributors)
+	if n > 3 {
+		n = 3
+	}
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, fmt.Sprintf("@%s: %d commits touching affected paths", contributors[i].login, contributors[i].count))
+	}
+	return out
+}
+
+func sanitizeAffectedPaths(paths []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
+		if p == "" || strings.HasPrefix(p, "/") {
+			continue
+		}
+		clean := path.Clean(p)
+		if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || clean == ".git" || strings.HasPrefix(clean, ".git/") {
+			continue
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		out = append(out, clean)
+		if len(out) >= maxAffectedPaths {
+			break
+		}
+	}
+	return out
+}
+
+func normalizeGitHubLogin(login string) string {
+	login = strings.TrimSpace(strings.TrimLeft(login, "@"))
+	if login == "" || !githubLoginRE.MatchString(login) {
+		return ""
+	}
+	return login
+}
+
+func normalizeAssigneeConfidence(confidence string) string {
+	confidence = strings.ToLower(strings.TrimSpace(confidence))
+	if _, ok := validConfidences[confidence]; !ok {
+		return ""
+	}
+	return confidence
+}
+
+func confidenceAllowsAssignment(confidence string) bool {
+	return confidence == "medium" || confidence == "high"
+}
+
+func normalizeSeverity(severity string) string {
+	severity = strings.ToLower(strings.TrimSpace(severity))
+	if _, ok := validSeverities[severity]; !ok {
+		return "low"
+	}
+	return severity
+}
+
+func normalizePriorityLabel(label, severity string) string {
+	severity = normalizeSeverity(severity)
+	label = strings.ToLower(strings.TrimSpace(label))
+	switch label {
+	case "critical", "high", "medium", "low":
+		return "priority: " + label
+	case "priority: critical", "priority: high", "priority: medium", "priority: low":
+		return label
+	case "":
+		return "priority: " + severity
+	default:
+		return "priority: " + severity
+	}
+}
+
+func priorityLabelColor(severity string) string {
+	severity = normalizeSeverity(severity)
+	if color, ok := priorityLabelColorBySeverity[severity]; ok {
+		return color
+	}
+	return priorityLabelColorBySeverity["low"]
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/daemon/internal/issues/triage_assignment_test.go
+++ b/daemon/internal/issues/triage_assignment_test.go
@@ -1,0 +1,131 @@
+package issues
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type fakeHistoryRunner struct {
+	outByCmd map[string]string
+	errByCmd map[string]error
+	calls    [][]string
+}
+
+func (f *fakeHistoryRunner) Output(_ context.Context, _ string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, append([]string(nil), args...))
+	key := strings.Join(args, "\x00")
+	if err := f.errByCmd[key]; err != nil {
+		return nil, err
+	}
+	return []byte(f.outByCmd[key]), nil
+}
+
+func historyKey(args ...string) string {
+	return strings.Join(args, "\x00")
+}
+
+func TestResolveTriageAssignee_VerifiesSuggestedAssigneeInHistory(t *testing.T) {
+	runner := &fakeHistoryRunner{outByCmd: map[string]string{
+		historyKey("rev-parse", "--is-shallow-repository"):                            "false\n",
+		historyKey("log", "--format=%ae%x00%an", "--all", "--", "daemon/pipeline.go"): "123+alice@users.noreply.github.com\x00Alice\nbob@users.noreply.github.com\x00Bob\nalice@users.noreply.github.com\x00Alice\n",
+	}}
+	triage := Triage{
+		AffectedPaths:      []string{"daemon/pipeline.go"},
+		SuggestedAssignee:  "@alice",
+		AssigneeConfidence: "high",
+	}
+
+	assignee, source, _, evidence := resolveTriageAssignee(context.Background(), "/repo", "owner", triage, runner)
+	if assignee != "alice" || source != "suggested_assignee_verified" {
+		t.Fatalf("assignee/source = %q/%q, want alice/suggested_assignee_verified", assignee, source)
+	}
+	if len(evidence) == 0 || !strings.Contains(evidence[0], "@alice") {
+		t.Fatalf("expected alice evidence, got %v", evidence)
+	}
+}
+
+func TestResolveTriageAssignee_ReplacesHallucinatedSuggestedWithTopContributor(t *testing.T) {
+	runner := &fakeHistoryRunner{outByCmd: map[string]string{
+		historyKey("rev-parse", "--is-shallow-repository"):                            "false\n",
+		historyKey("log", "--format=%ae%x00%an", "--all", "--", "daemon/pipeline.go"): "alice@users.noreply.github.com\x00Alice\nbob@users.noreply.github.com\x00Bob\nalice@users.noreply.github.com\x00Alice\n",
+	}}
+	triage := Triage{
+		AffectedPaths:      []string{"daemon/pipeline.go"},
+		SuggestedAssignee:  "ghost",
+		AssigneeConfidence: "medium",
+	}
+
+	assignee, source, diagnostic, _ := resolveTriageAssignee(context.Background(), "/repo", "owner", triage, runner)
+	if assignee != "alice" || source != "history_top_contributor" {
+		t.Fatalf("assignee/source = %q/%q, want alice/history_top_contributor", assignee, source)
+	}
+	if !strings.Contains(diagnostic, "ghost") {
+		t.Fatalf("diagnostic should mention rejected suggestion, got %q", diagnostic)
+	}
+}
+
+func TestResolveTriageAssignee_LowConfidenceFallsBackToTriageOwner(t *testing.T) {
+	assignee, source, diagnostic, evidence := resolveTriageAssignee(context.Background(), "/repo", "owner", Triage{
+		AffectedPaths:      []string{"daemon/pipeline.go"},
+		SuggestedAssignee:  "alice",
+		AssigneeConfidence: "low",
+	}, &fakeHistoryRunner{})
+
+	if assignee != "owner" || source != "triage_owner" {
+		t.Fatalf("assignee/source = %q/%q, want owner/triage_owner", assignee, source)
+	}
+	if !strings.Contains(diagnostic, "confidence") {
+		t.Fatalf("diagnostic should mention confidence, got %q", diagnostic)
+	}
+	if len(evidence) == 0 || !strings.Contains(evidence[0], "triage_owner") {
+		t.Fatalf("expected fallback evidence, got %v", evidence)
+	}
+}
+
+func TestResolveTriageAssignee_ShallowHistoryFallsBackToTriageOwner(t *testing.T) {
+	runner := &fakeHistoryRunner{outByCmd: map[string]string{
+		historyKey("rev-parse", "--is-shallow-repository"): "true\n",
+	}}
+	assignee, source, diagnostic, _ := resolveTriageAssignee(context.Background(), "/repo", "owner", Triage{
+		AffectedPaths:      []string{"daemon/pipeline.go"},
+		SuggestedAssignee:  "alice",
+		AssigneeConfidence: "high",
+	}, runner)
+
+	if assignee != "owner" || source != "triage_owner" {
+		t.Fatalf("assignee/source = %q/%q, want owner/triage_owner", assignee, source)
+	}
+	if !strings.Contains(diagnostic, errShallowHistory.Error()) {
+		t.Fatalf("diagnostic should mention shallow history, got %q", diagnostic)
+	}
+}
+
+func TestContributorsForPaths_GitFailureReturnsError(t *testing.T) {
+	runner := &fakeHistoryRunner{
+		errByCmd: map[string]error{
+			historyKey("rev-parse", "--is-shallow-repository"): errors.New("git missing"),
+		},
+	}
+	_, err := contributorsForPaths(context.Background(), runner, "/repo", []string{"x.go"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSanitizeAffectedPaths(t *testing.T) {
+	got := sanitizeAffectedPaths([]string{
+		" daemon/internal/issues/pipeline.go ",
+		"../secret",
+		"/abs/path",
+		".git/config",
+		"daemon/internal/issues/pipeline.go",
+		`flutter_app\lib\main.dart`,
+	})
+	want := []string{"daemon/internal/issues/pipeline.go", "flutter_app/lib/main.dart"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sanitizeAffectedPaths = %#v, want %#v", got, want)
+	}
+}

--- a/daemon/internal/issues/triage_assignment_test.go
+++ b/daemon/internal/issues/triage_assignment_test.go
@@ -29,8 +29,8 @@ func historyKey(args ...string) string {
 
 func TestResolveTriageAssignee_VerifiesSuggestedAssigneeInHistory(t *testing.T) {
 	runner := &fakeHistoryRunner{outByCmd: map[string]string{
-		historyKey("rev-parse", "--is-shallow-repository"):                            "false\n",
-		historyKey("log", "--format=%ae%x00%an", "--all", "--", "daemon/pipeline.go"): "123+alice@users.noreply.github.com\x00Alice\nbob@users.noreply.github.com\x00Bob\nalice@users.noreply.github.com\x00Alice\n",
+		historyKey("rev-parse", "--is-shallow-repository"):                                                     "false\n",
+		historyKey("log", "--max-count=500", "--no-merges", "--format=%ae%x00%an", "--", "daemon/pipeline.go"): "123+alice@users.noreply.github.com\x00Alice\nbob@users.noreply.github.com\x00Bob\nalice@users.noreply.github.com\x00Alice\n",
 	}}
 	triage := Triage{
 		AffectedPaths:      []string{"daemon/pipeline.go"},
@@ -49,8 +49,8 @@ func TestResolveTriageAssignee_VerifiesSuggestedAssigneeInHistory(t *testing.T) 
 
 func TestResolveTriageAssignee_ReplacesHallucinatedSuggestedWithTopContributor(t *testing.T) {
 	runner := &fakeHistoryRunner{outByCmd: map[string]string{
-		historyKey("rev-parse", "--is-shallow-repository"):                            "false\n",
-		historyKey("log", "--format=%ae%x00%an", "--all", "--", "daemon/pipeline.go"): "alice@users.noreply.github.com\x00Alice\nbob@users.noreply.github.com\x00Bob\nalice@users.noreply.github.com\x00Alice\n",
+		historyKey("rev-parse", "--is-shallow-repository"):                                                     "false\n",
+		historyKey("log", "--max-count=500", "--no-merges", "--format=%ae%x00%an", "--", "daemon/pipeline.go"): "alice@users.noreply.github.com\x00Alice\nbob@users.noreply.github.com\x00Bob\nalice@users.noreply.github.com\x00Alice\n",
 	}}
 	triage := Triage{
 		AffectedPaths:      []string{"daemon/pipeline.go"},
@@ -85,6 +85,26 @@ func TestResolveTriageAssignee_LowConfidenceFallsBackToTriageOwner(t *testing.T)
 	}
 }
 
+func TestEnrichTriageResult_PreservesTentativeAssignee(t *testing.T) {
+	result := &IssueReviewResult{
+		Severity: "medium",
+		Triage: Triage{
+			Severity:           "medium",
+			SuggestedAssignee:  "alice",
+			TentativeAssignee:  "@bob",
+			AssigneeConfidence: "low",
+		},
+	}
+
+	enrichTriageResult(context.Background(), result, "", "owner", nil)
+	if result.Triage.TentativeAssignee != "bob" {
+		t.Fatalf("tentative assignee = %q, want bob", result.Triage.TentativeAssignee)
+	}
+	if result.Triage.AssignedAssignee != "owner" {
+		t.Fatalf("assigned assignee = %q, want owner fallback", result.Triage.AssignedAssignee)
+	}
+}
+
 func TestResolveTriageAssignee_ShallowHistoryFallsBackToTriageOwner(t *testing.T) {
 	runner := &fakeHistoryRunner{outByCmd: map[string]string{
 		historyKey("rev-parse", "--is-shallow-repository"): "true\n",
@@ -115,11 +135,27 @@ func TestContributorsForPaths_GitFailureReturnsError(t *testing.T) {
 	}
 }
 
+func TestContributorsForPaths_IgnoresPlainEmailLocalParts(t *testing.T) {
+	runner := &fakeHistoryRunner{outByCmd: map[string]string{
+		historyKey("rev-parse", "--is-shallow-repository"):                                       "false\n",
+		historyKey("log", "--max-count=500", "--no-merges", "--format=%ae%x00%an", "--", "x.go"): "victim@example.com\x00Victim\n123+alice@users.noreply.github.com\x00Alice\n",
+	}}
+
+	got, err := contributorsForPaths(context.Background(), runner, "/repo", []string{"x.go"})
+	if err != nil {
+		t.Fatalf("contributorsForPaths: %v", err)
+	}
+	if len(got) != 1 || got[0].login != "alice" {
+		t.Fatalf("contributors = %+v, want only alice from GitHub noreply email", got)
+	}
+}
+
 func TestSanitizeAffectedPaths(t *testing.T) {
 	got := sanitizeAffectedPaths([]string{
 		" daemon/internal/issues/pipeline.go ",
 		"../secret",
 		"/abs/path",
+		"-n",
 		".git/config",
 		"daemon/internal/issues/pipeline.go",
 		`flutter_app\lib\main.dart`,


### PR DESCRIPTION
## Summary

- Redefine issue triage output with affected area, affected paths, priority label, owner rationale, confidence, and evidence.
- Resolve issue ownership from AI output plus daemon-side validation against git history when a repo workdir is available.
- Fall back to configured `triage_owner` when confidence/evidence is insufficient, history is shallow/unavailable, or no safe assignee can be selected.
- Apply priority labels and issue assignees best-effort without failing the triage run.
- Store the richer triage payload in the existing `issue_reviews.triage` JSON field for forward-compatible UI/API use.

Closes #392

## Validation

- `make test-docker`