### PR TITLE
feat: add issue refinement stage

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -927,7 +927,7 @@ func main() {
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
-		repoHandle, err := acquireRepoContext(ctx, repoCtx, msg.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		opts, releaseRepoContext, err := buildRefinementRunOptions(ctx, s, repoCtx, msg.Repo, token, aiCfg, agentCfg, localDirBase, globalTimeout, false, "refinement-worker")
 		if err != nil {
 			slog.Error("refinement-worker: prepare repo context failed",
 				"repo", msg.Repo, "number", msg.Number, "err", err)
@@ -939,50 +939,8 @@ func main() {
 			})
 			return
 		}
-		if repoHandle != nil {
-			defer repoHandle.Release()
-			ensureRepoContextFullHistory(ctx, repoCtx, repoHandle, token, "refinement-worker", msg.Repo)
-		}
-
-		extraFlags := agentCfg.ExtraFlags
-		if extraFlags != "" {
-			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
-				slog.Warn("refinement-worker: extra_flags rejected", "err", err)
-				extraFlags = ""
-			}
-		}
-
-		issuePrompt, issueInstructions := resolveIssuePrompt(s, aiCfg.IssuePrompt, agentCfg.PromptID)
-		implPrompt, implInstructions := resolveImplementPrompt(s, aiCfg.ImplementPrompt, agentCfg.PromptID)
-
-		opts := issuepipeline.RunOptions{
-			GitHubToken: token,
-			Primary:     aiCfg.Primary,
-			Fallback:    aiCfg.Fallback,
-			ExecOpts: executor.ExecOptions{
-				Model:                agentCfg.Model,
-				MaxTurns:             agentCfg.MaxTurns,
-				ApprovalMode:         agentCfg.ApprovalMode,
-				ExtraFlags:           extraFlags,
-				WorkDir:              aiCfg.LocalDir,
-				Effort:               agentCfg.Effort,
-				PermissionMode:       agentCfg.PermissionMode,
-				Bare:                 agentCfg.Bare,
-				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
-				NoSessionPersistence: agentCfg.NoSessionPersistence,
-				Timeout:              resolveRefinementTimeout(aiCfg.RefinementTimeout, globalTimeout, agentCfg.ExecutionTimeout),
-			},
-			IssuePromptOverride:         issuePrompt,
-			IssueInstructions:           issueInstructions,
-			TriageOwner:                 aiCfg.TriageOwner,
-			ImplementPromptOverride:     implPrompt,
-			ImplementInstructions:       implInstructions,
-			PRReviewers:                 aiCfg.PRReviewers,
-			PRAssignee:                  aiCfg.PRAssignee,
-			PRLabels:                    aiCfg.PRLabels,
-			PRDraft:                     aiCfg.PRDraft != nil && *aiCfg.PRDraft,
-			GeneratePRDescription:       aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
-			RequireWorkDirForRefinement: true,
+		if releaseRepoContext != nil {
+			defer releaseRepoContext()
 		}
 
 		if _, err := issuePipe.Run(ctx, ghIssue, opts); err != nil {
@@ -990,6 +948,9 @@ func main() {
 				"repo", msg.Repo, "number", msg.Number, "err", err)
 		}
 
+		// Enroll for state watching so closed/resolved issues update in the UI.
+		// Runs even after pipeline failure, matching triage/implement: state
+		// tracking is independent of whether the refinement artifact completed.
 		if err := watchStore.Enroll(ctx, "issue", msg.Repo, msg.Number, msg.GithubID); err != nil {
 			slog.Warn("refinement-worker: failed to enroll watch",
 				"repo", msg.Repo, "number", msg.Number, "err", err)
@@ -1681,7 +1642,7 @@ func main() {
 
 	// Wire the issue-refinement trigger callback: run deep repo investigation on a stored issue.
 	srv.SetTriggerIssueRefineFn(func(issueID int64, force bool) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		publishIssueErr := func(msg string) {
@@ -1705,64 +1666,22 @@ func main() {
 		ghIssue.Mode = config.IssueModeRefinement
 
 		cfgMu.Lock()
-		aiCfg := cfg.AIForRepo(iss.Repo)
+		c := *cfg
+		aiCfg := c.AIForRepo(iss.Repo)
 		if aiCfg.Primary == "" {
-			aiCfg.Primary = cfg.AI.Primary
+			aiCfg.Primary = c.AI.Primary
 		}
-		agentCfg := cfg.AgentConfigFor(aiCfg.Primary)
-		localDirBase := cfg.GitHub.LocalDirBase
-		globalTimeout := cfg.AI.ExecutionTimeout
+		agentCfg := c.AgentConfigFor(aiCfg.Primary)
+		localDirBase := c.GitHub.LocalDirBase
+		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
-		repoHandle, err := acquireRepoContext(ctx, repoCtx, iss.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		opts, releaseRepoContext, err := buildRefinementRunOptions(ctx, s, repoCtx, iss.Repo, token, aiCfg, agentCfg, localDirBase, globalTimeout, force, "trigger issue refinement")
 		if err != nil {
 			publishIssueErr(fmt.Sprintf("Failed to prepare repo context: %v", err))
 			return fmt.Errorf("trigger issue refinement: prepare repo context: %w", err)
 		}
-		if repoHandle != nil {
-			defer repoHandle.Release()
-			ensureRepoContextFullHistory(ctx, repoCtx, repoHandle, token, "trigger issue refinement", iss.Repo)
-		}
-
-		extraFlags := agentCfg.ExtraFlags
-		if extraFlags != "" {
-			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
-				slog.Warn("triggerIssueRefine: extra_flags rejected", "err", err)
-				extraFlags = ""
-			}
-		}
-
-		issuePrompt, issueInstructions := resolveIssuePrompt(s, aiCfg.IssuePrompt, agentCfg.PromptID)
-		implPrompt, implInstructions := resolveImplementPrompt(s, aiCfg.ImplementPrompt, agentCfg.PromptID)
-
-		opts := issuepipeline.RunOptions{
-			GitHubToken: token,
-			Primary:     aiCfg.Primary,
-			Fallback:    aiCfg.Fallback,
-			ExecOpts: executor.ExecOptions{
-				Model:                agentCfg.Model,
-				MaxTurns:             agentCfg.MaxTurns,
-				ApprovalMode:         agentCfg.ApprovalMode,
-				ExtraFlags:           extraFlags,
-				WorkDir:              aiCfg.LocalDir,
-				Effort:               agentCfg.Effort,
-				PermissionMode:       agentCfg.PermissionMode,
-				Bare:                 agentCfg.Bare,
-				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
-				NoSessionPersistence: agentCfg.NoSessionPersistence,
-				Timeout:              resolveRefinementTimeout(aiCfg.RefinementTimeout, globalTimeout, agentCfg.ExecutionTimeout),
-			},
-			IssuePromptOverride:         issuePrompt,
-			IssueInstructions:           issueInstructions,
-			TriageOwner:                 aiCfg.TriageOwner,
-			ImplementPromptOverride:     implPrompt,
-			ImplementInstructions:       implInstructions,
-			PRReviewers:                 aiCfg.PRReviewers,
-			PRAssignee:                  aiCfg.PRAssignee,
-			PRLabels:                    aiCfg.PRLabels,
-			PRDraft:                     aiCfg.PRDraft != nil && *aiCfg.PRDraft,
-			GeneratePRDescription:       aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
-			Force:                       force,
-			RequireWorkDirForRefinement: true,
+		if releaseRepoContext != nil {
+			defer releaseRepoContext()
 		}
 
 		slog.Info("trigger issue refinement: running pipeline",
@@ -1986,17 +1905,18 @@ func resolveExecutionTimeout(globalTimeout, agentTimeout string) time.Duration {
 	return 0
 }
 
-// resolveRefinementTimeout uses the same per-agent override semantics as the
-// other CLI runs, with a stage-specific fallback that defaults higher than the
-// executor's 5m process cap.
+// resolveRefinementTimeout lets the stage-specific cap win over generic
+// per-agent/global execution timeouts. Refinement is expected to inspect the
+// repo and git history, so the default intentionally runs longer than normal
+// review/develop executor calls.
 func resolveRefinementTimeout(refinementTimeout, globalTimeout, agentTimeout string) time.Duration {
-	if agentTimeout != "" {
-		if d, err := time.ParseDuration(agentTimeout); err == nil && d > 0 {
+	if refinementTimeout != "" {
+		if d, err := time.ParseDuration(refinementTimeout); err == nil && d > 0 {
 			return d
 		}
 	}
-	if refinementTimeout != "" {
-		if d, err := time.ParseDuration(refinementTimeout); err == nil && d > 0 {
+	if agentTimeout != "" {
+		if d, err := time.ParseDuration(agentTimeout); err == nil && d > 0 {
 			return d
 		}
 	}
@@ -2751,6 +2671,10 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 
 		issuePrompt, issueInstructions := resolveIssuePrompt(a.store, aiCfg.IssuePrompt, agentCfg.PromptID)
 		implPrompt, implInstructions := resolveImplementPrompt(a.store, aiCfg.ImplementPrompt, agentCfg.PromptID)
+		execTimeout := resolveExecutionTimeout(globalTimeout, agentCfg.ExecutionTimeout)
+		if issue.Mode == config.IssueModeRefinement {
+			execTimeout = resolveRefinementTimeout(aiCfg.RefinementTimeout, globalTimeout, agentCfg.ExecutionTimeout)
+		}
 
 		opts := issuepipeline.RunOptions{
 			GitHubToken: a.ghToken,
@@ -2767,7 +2691,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 				Bare:                 agentCfg.Bare,
 				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
 				NoSessionPersistence: agentCfg.NoSessionPersistence,
-				Timeout:              resolveExecutionTimeout(globalTimeout, agentCfg.ExecutionTimeout),
+				Timeout:              execTimeout,
 			},
 			IssuePromptOverride:         issuePrompt,
 			IssueInstructions:           issueInstructions,
@@ -2782,9 +2706,6 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 			RequireWorkDirForDevelop:    requireWorkDir,
 			RequireWorkDirForRefinement: requireRefinementWorkDir,
 			ReleaseRepoContext:          releaseRepoContext,
-		}
-		if issue.Mode == config.IssueModeRefinement {
-			opts.ExecOpts.Timeout = resolveRefinementTimeout(aiCfg.RefinementTimeout, globalTimeout, agentCfg.ExecutionTimeout)
 		}
 		releaseOnReturn = false
 		return opts, true
@@ -3324,6 +3245,73 @@ func resolveImplementPrompt(s *store.Store, repoPromptID, agentPromptID string) 
 		return a.ImplementPrompt, ""
 	}
 	return "", a.ImplementInstructions
+}
+
+func buildRefinementRunOptions(
+	ctx context.Context,
+	s *store.Store,
+	manager *repoctx.Manager,
+	repo string,
+	token string,
+	aiCfg config.RepoAI,
+	agentCfg config.CLIAgentConfig,
+	localDirBase []string,
+	globalTimeout string,
+	force bool,
+	scope string,
+) (issuepipeline.RunOptions, func(), error) {
+	repoHandle, err := acquireRepoContext(ctx, manager, repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+	if err != nil {
+		return issuepipeline.RunOptions{}, nil, err
+	}
+	var releaseRepoContext func()
+	if repoHandle != nil {
+		releaseRepoContext = repoHandle.Release
+		ensureRepoContextFullHistory(ctx, manager, repoHandle, token, scope, repo)
+	}
+
+	extraFlags := agentCfg.ExtraFlags
+	if extraFlags != "" {
+		if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+			slog.Warn(scope+": extra_flags rejected", "err", err)
+			extraFlags = ""
+		}
+	}
+
+	issuePrompt, issueInstructions := resolveIssuePrompt(s, aiCfg.IssuePrompt, agentCfg.PromptID)
+	implPrompt, implInstructions := resolveImplementPrompt(s, aiCfg.ImplementPrompt, agentCfg.PromptID)
+
+	opts := issuepipeline.RunOptions{
+		GitHubToken: token,
+		Primary:     aiCfg.Primary,
+		Fallback:    aiCfg.Fallback,
+		ExecOpts: executor.ExecOptions{
+			Model:                agentCfg.Model,
+			MaxTurns:             agentCfg.MaxTurns,
+			ApprovalMode:         agentCfg.ApprovalMode,
+			ExtraFlags:           extraFlags,
+			WorkDir:              aiCfg.LocalDir,
+			Effort:               agentCfg.Effort,
+			PermissionMode:       agentCfg.PermissionMode,
+			Bare:                 agentCfg.Bare,
+			DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
+			NoSessionPersistence: agentCfg.NoSessionPersistence,
+			Timeout:              resolveRefinementTimeout(aiCfg.RefinementTimeout, globalTimeout, agentCfg.ExecutionTimeout),
+		},
+		IssuePromptOverride:         issuePrompt,
+		IssueInstructions:           issueInstructions,
+		TriageOwner:                 aiCfg.TriageOwner,
+		ImplementPromptOverride:     implPrompt,
+		ImplementInstructions:       implInstructions,
+		PRReviewers:                 aiCfg.PRReviewers,
+		PRAssignee:                  aiCfg.PRAssignee,
+		PRLabels:                    aiCfg.PRLabels,
+		PRDraft:                     aiCfg.PRDraft != nil && *aiCfg.PRDraft,
+		GeneratePRDescription:       aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+		Force:                       force,
+		RequireWorkDirForRefinement: true,
+	}
+	return opts, releaseRepoContext, nil
 }
 
 // sseData serializes a map to a compact JSON string for SSE event Data fields.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -904,6 +904,107 @@ func main() {
 		}
 	}()
 
+	// ── NATS issue refinement worker ────────────────────────────────────
+	// Consumes refinement requests published by the Fetcher when it classifies
+	// an issue as refinement. Refinement is read-only but requires a full local
+	// checkout so the agent can inspect code and git history.
+	refinementHandler := func(ctx context.Context, msg bus.IssueMsg) {
+		ghIssue, err := ghClient.GetIssue(msg.Repo, msg.Number)
+		if err != nil {
+			slog.Error("refinement-worker: fetch issue from GitHub",
+				"repo", msg.Repo, "number", msg.Number, "err", err)
+			return
+		}
+		ghIssue.Mode = config.IssueModeRefinement
+
+		cfgMu.Lock()
+		c := *cfg
+		aiCfg := c.AIForRepo(msg.Repo)
+		if aiCfg.Primary == "" {
+			aiCfg.Primary = c.AI.Primary
+		}
+		agentCfg := c.AgentConfigFor(aiCfg.Primary)
+		localDirBase := c.GitHub.LocalDirBase
+		globalTimeout := c.AI.ExecutionTimeout
+		cfgMu.Unlock()
+		repoHandle, err := acquireRepoContext(ctx, repoCtx, msg.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		if err != nil {
+			slog.Error("refinement-worker: prepare repo context failed",
+				"repo", msg.Repo, "number", msg.Number, "err", err)
+			broker.Publish(sse.Event{
+				Type: sse.EventIssueReviewError,
+				Data: sseData(map[string]any{
+					"repo": msg.Repo, "number": msg.Number, "error": err.Error(),
+				}),
+			})
+			return
+		}
+		if repoHandle != nil {
+			defer repoHandle.Release()
+			ensureRepoContextFullHistory(ctx, repoCtx, repoHandle, token, "refinement-worker", msg.Repo)
+		}
+
+		extraFlags := agentCfg.ExtraFlags
+		if extraFlags != "" {
+			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+				slog.Warn("refinement-worker: extra_flags rejected", "err", err)
+				extraFlags = ""
+			}
+		}
+
+		issuePrompt, issueInstructions := resolveIssuePrompt(s, aiCfg.IssuePrompt, agentCfg.PromptID)
+		implPrompt, implInstructions := resolveImplementPrompt(s, aiCfg.ImplementPrompt, agentCfg.PromptID)
+
+		opts := issuepipeline.RunOptions{
+			GitHubToken: token,
+			Primary:     aiCfg.Primary,
+			Fallback:    aiCfg.Fallback,
+			ExecOpts: executor.ExecOptions{
+				Model:                agentCfg.Model,
+				MaxTurns:             agentCfg.MaxTurns,
+				ApprovalMode:         agentCfg.ApprovalMode,
+				ExtraFlags:           extraFlags,
+				WorkDir:              aiCfg.LocalDir,
+				Effort:               agentCfg.Effort,
+				PermissionMode:       agentCfg.PermissionMode,
+				Bare:                 agentCfg.Bare,
+				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
+				NoSessionPersistence: agentCfg.NoSessionPersistence,
+				Timeout:              resolveRefinementTimeout(aiCfg.RefinementTimeout, globalTimeout, agentCfg.ExecutionTimeout),
+			},
+			IssuePromptOverride:         issuePrompt,
+			IssueInstructions:           issueInstructions,
+			TriageOwner:                 aiCfg.TriageOwner,
+			ImplementPromptOverride:     implPrompt,
+			ImplementInstructions:       implInstructions,
+			PRReviewers:                 aiCfg.PRReviewers,
+			PRAssignee:                  aiCfg.PRAssignee,
+			PRLabels:                    aiCfg.PRLabels,
+			PRDraft:                     aiCfg.PRDraft != nil && *aiCfg.PRDraft,
+			GeneratePRDescription:       aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+			RequireWorkDirForRefinement: true,
+		}
+
+		if _, err := issuePipe.Run(ctx, ghIssue, opts); err != nil {
+			slog.Error("refinement-worker: pipeline run failed",
+				"repo", msg.Repo, "number", msg.Number, "err", err)
+		}
+
+		if err := watchStore.Enroll(ctx, "issue", msg.Repo, msg.Number, msg.GithubID); err != nil {
+			slog.Warn("refinement-worker: failed to enroll watch",
+				"repo", msg.Repo, "number", msg.Number, "err", err)
+		}
+	}
+
+	refinementW := worker.NewRefinementWorker(conn, maxWorkers, refinementHandler)
+	refinementWCtx, refinementWCancel := context.WithCancel(context.Background())
+	defer refinementWCancel()
+	go func() {
+		if err := refinementW.Start(refinementWCtx); err != nil {
+			slog.Error("refinement worker stopped", "err", err)
+		}
+	}()
+
 	// ── NATS issue implement worker ─────────────────────────────────────
 	// Consumes implement requests published by the Fetcher when it classifies
 	// an issue as develop. Same config resolution as triage, different mode.
@@ -1237,6 +1338,7 @@ func main() {
 			"activity_log_retention_days": ptrIntOr(c.ActivityLog.RetentionDays, 90),
 			"issue_prompt":                c.AI.IssuePrompt,
 			"implement_prompt":            c.AI.ImplementPrompt,
+			"refinement_timeout":          c.AI.RefinementTimeout,
 			"triage_owner":                c.AI.TriageOwner,
 			"clone_dir":                   c.AI.CloneDir,
 			"generate_pr_description":     c.AI.GeneratePRDescription,
@@ -1577,6 +1679,105 @@ func main() {
 		return nil
 	})
 
+	// Wire the issue-refinement trigger callback: run deep repo investigation on a stored issue.
+	srv.SetTriggerIssueRefineFn(func(issueID int64, force bool) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
+
+		publishIssueErr := func(msg string) {
+			broker.Publish(sse.Event{
+				Type: sse.EventIssueReviewError,
+				Data: sseData(map[string]any{"issue_id": issueID, "error": msg}),
+			})
+		}
+
+		iss, err := s.GetIssue(issueID)
+		if err != nil {
+			publishIssueErr(fmt.Sprintf("Issue not found: %v", err))
+			return fmt.Errorf("trigger issue refinement: get issue %d: %w", issueID, err)
+		}
+
+		ghIssue, err := ghClient.GetIssue(iss.Repo, iss.Number)
+		if err != nil {
+			publishIssueErr(fmt.Sprintf("Failed to fetch issue from GitHub: %v", err))
+			return fmt.Errorf("trigger issue refinement: fetch GitHub issue %s #%d: %w", iss.Repo, iss.Number, err)
+		}
+		ghIssue.Mode = config.IssueModeRefinement
+
+		cfgMu.Lock()
+		aiCfg := cfg.AIForRepo(iss.Repo)
+		if aiCfg.Primary == "" {
+			aiCfg.Primary = cfg.AI.Primary
+		}
+		agentCfg := cfg.AgentConfigFor(aiCfg.Primary)
+		localDirBase := cfg.GitHub.LocalDirBase
+		globalTimeout := cfg.AI.ExecutionTimeout
+		cfgMu.Unlock()
+		repoHandle, err := acquireRepoContext(ctx, repoCtx, iss.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		if err != nil {
+			publishIssueErr(fmt.Sprintf("Failed to prepare repo context: %v", err))
+			return fmt.Errorf("trigger issue refinement: prepare repo context: %w", err)
+		}
+		if repoHandle != nil {
+			defer repoHandle.Release()
+			ensureRepoContextFullHistory(ctx, repoCtx, repoHandle, token, "trigger issue refinement", iss.Repo)
+		}
+
+		extraFlags := agentCfg.ExtraFlags
+		if extraFlags != "" {
+			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+				slog.Warn("triggerIssueRefine: extra_flags rejected", "err", err)
+				extraFlags = ""
+			}
+		}
+
+		issuePrompt, issueInstructions := resolveIssuePrompt(s, aiCfg.IssuePrompt, agentCfg.PromptID)
+		implPrompt, implInstructions := resolveImplementPrompt(s, aiCfg.ImplementPrompt, agentCfg.PromptID)
+
+		opts := issuepipeline.RunOptions{
+			GitHubToken: token,
+			Primary:     aiCfg.Primary,
+			Fallback:    aiCfg.Fallback,
+			ExecOpts: executor.ExecOptions{
+				Model:                agentCfg.Model,
+				MaxTurns:             agentCfg.MaxTurns,
+				ApprovalMode:         agentCfg.ApprovalMode,
+				ExtraFlags:           extraFlags,
+				WorkDir:              aiCfg.LocalDir,
+				Effort:               agentCfg.Effort,
+				PermissionMode:       agentCfg.PermissionMode,
+				Bare:                 agentCfg.Bare,
+				DangerouslySkipPerms: agentCfg.DangerouslySkipPerms,
+				NoSessionPersistence: agentCfg.NoSessionPersistence,
+				Timeout:              resolveRefinementTimeout(aiCfg.RefinementTimeout, globalTimeout, agentCfg.ExecutionTimeout),
+			},
+			IssuePromptOverride:         issuePrompt,
+			IssueInstructions:           issueInstructions,
+			TriageOwner:                 aiCfg.TriageOwner,
+			ImplementPromptOverride:     implPrompt,
+			ImplementInstructions:       implInstructions,
+			PRReviewers:                 aiCfg.PRReviewers,
+			PRAssignee:                  aiCfg.PRAssignee,
+			PRLabels:                    aiCfg.PRLabels,
+			PRDraft:                     aiCfg.PRDraft != nil && *aiCfg.PRDraft,
+			GeneratePRDescription:       aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+			Force:                       force,
+			RequireWorkDirForRefinement: true,
+		}
+
+		slog.Info("trigger issue refinement: running pipeline",
+			"store_issue_id", issueID, "repo", iss.Repo, "number", iss.Number, "force", force)
+
+		_, err = issuePipe.Run(ctx, ghIssue, opts)
+		if err != nil {
+			broker.Publish(sse.Event{Type: sse.EventIssueReviewError, Data: sseData(map[string]any{
+				"issue_id": issueID, "repo": iss.Repo, "error": err.Error(),
+			})})
+			return err
+		}
+		return nil
+	})
+
 	// Wire the promote callback: runs the auto_implement pipeline for a review_only issue,
 	// effectively reclassifying it to develop from the UI without needing a GitHub label change.
 	srv.SetTriggerPromoteFn(func(issueID int64) error {
@@ -1783,6 +1984,23 @@ func resolveExecutionTimeout(globalTimeout, agentTimeout string) time.Duration {
 	}
 	// Zero = executor uses its default (5m)
 	return 0
+}
+
+// resolveRefinementTimeout uses the same per-agent override semantics as the
+// other CLI runs, with a stage-specific fallback that defaults higher than the
+// executor's 5m process cap.
+func resolveRefinementTimeout(refinementTimeout, globalTimeout, agentTimeout string) time.Duration {
+	if agentTimeout != "" {
+		if d, err := time.ParseDuration(agentTimeout); err == nil && d > 0 {
+			return d
+		}
+	}
+	if refinementTimeout != "" {
+		if d, err := time.ParseDuration(refinementTimeout); err == nil && d > 0 {
+			return d
+		}
+	}
+	return resolveExecutionTimeout(globalTimeout, "")
 }
 
 // ── Standalone poller functions (replaced Pipeline goroutines) ───────────
@@ -2484,9 +2702,12 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 		a.cfgMu.Unlock()
 		mode := repoctx.ModeRead
 		requireWorkDir := false
+		requireRefinementWorkDir := false
 		if issue.Mode == config.IssueModeDevelop {
 			mode = repoctx.ModeWrite
 			requireWorkDir = true
+		} else if issue.Mode == config.IssueModeRefinement {
+			requireRefinementWorkDir = true
 		}
 		var releaseRepoContext func()
 		releaseOnReturn := true
@@ -2497,7 +2718,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 			}
 		}()
 		if err != nil {
-			if issue.Mode == config.IssueModeDevelop {
+			if issue.Mode == config.IssueModeDevelop || issue.Mode == config.IssueModeRefinement {
 				slog.Error("issue poll: prepare repo context failed",
 					"repo", issue.Repo, "number", issue.Number, "err", err)
 				if a.broker != nil {
@@ -2514,7 +2735,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 			}
 			aiCfg.LocalDir = ""
 		} else if repoHandle != nil {
-			if issue.Mode == config.IssueModeReviewOnly {
+			if issue.Mode == config.IssueModeReviewOnly || issue.Mode == config.IssueModeRefinement {
 				ensureRepoContextFullHistory(ctx, a.repoCtx, repoHandle, a.ghToken, "issue poll", issue.Repo)
 			}
 			releaseRepoContext = repoHandle.Release
@@ -2548,18 +2769,22 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 				NoSessionPersistence: agentCfg.NoSessionPersistence,
 				Timeout:              resolveExecutionTimeout(globalTimeout, agentCfg.ExecutionTimeout),
 			},
-			IssuePromptOverride:      issuePrompt,
-			IssueInstructions:        issueInstructions,
-			TriageOwner:              aiCfg.TriageOwner,
-			ImplementPromptOverride:  implPrompt,
-			ImplementInstructions:    implInstructions,
-			PRReviewers:              aiCfg.PRReviewers,
-			PRAssignee:               aiCfg.PRAssignee,
-			PRLabels:                 aiCfg.PRLabels,
-			PRDraft:                  aiCfg.PRDraft != nil && *aiCfg.PRDraft,
-			GeneratePRDescription:    aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
-			RequireWorkDirForDevelop: requireWorkDir,
-			ReleaseRepoContext:       releaseRepoContext,
+			IssuePromptOverride:         issuePrompt,
+			IssueInstructions:           issueInstructions,
+			TriageOwner:                 aiCfg.TriageOwner,
+			ImplementPromptOverride:     implPrompt,
+			ImplementInstructions:       implInstructions,
+			PRReviewers:                 aiCfg.PRReviewers,
+			PRAssignee:                  aiCfg.PRAssignee,
+			PRLabels:                    aiCfg.PRLabels,
+			PRDraft:                     aiCfg.PRDraft != nil && *aiCfg.PRDraft,
+			GeneratePRDescription:       aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
+			RequireWorkDirForDevelop:    requireWorkDir,
+			RequireWorkDirForRefinement: requireRefinementWorkDir,
+			ReleaseRepoContext:          releaseRepoContext,
+		}
+		if issue.Mode == config.IssueModeRefinement {
+			opts.ExecOpts.Timeout = resolveRefinementTimeout(aiCfg.RefinementTimeout, globalTimeout, agentCfg.ExecutionTimeout)
 		}
 		releaseOnReturn = false
 		return opts, true
@@ -3186,6 +3411,7 @@ func repoAIOverrideMap(ai config.RepoAI) map[string]any {
 		Prompt:                ai.Prompt,
 		IssuePrompt:           ai.IssuePrompt,
 		ImplementPrompt:       ai.ImplementPrompt,
+		RefinementTimeout:     ai.RefinementTimeout,
 		TriageOwner:           ai.TriageOwner,
 		CloneDir:              ai.CloneDir,
 		AutoPromoteTriage:     ai.AutoPromoteTriage,
@@ -3220,6 +3446,7 @@ func orgAIOverrideMap(ai config.OrgAI) map[string]any {
 		Prompt:                ai.Prompt,
 		IssuePrompt:           ai.IssuePrompt,
 		ImplementPrompt:       ai.ImplementPrompt,
+		RefinementTimeout:     ai.RefinementTimeout,
 		TriageOwner:           ai.TriageOwner,
 		CloneDir:              ai.CloneDir,
 		AutoPromoteTriage:     ai.AutoPromoteTriage,
@@ -3240,6 +3467,7 @@ type aiOverrideFields struct {
 	Prompt                string
 	IssuePrompt           string
 	ImplementPrompt       string
+	RefinementTimeout     string
 	TriageOwner           string
 	CloneDir              string
 	AutoPromoteTriage     *bool
@@ -3260,6 +3488,9 @@ func addCommonAIOverrideFields(out map[string]any, fields aiOverrideFields) {
 	}
 	if fields.ImplementPrompt != "" {
 		out["implement_prompt"] = fields.ImplementPrompt
+	}
+	if fields.RefinementTimeout != "" {
+		out["refinement_timeout"] = fields.RefinementTimeout
 	}
 	if fields.TriageOwner != "" {
 		out["triage_owner"] = fields.TriageOwner
@@ -3306,6 +3537,9 @@ func issueTrackingOverrideMap(ov *config.IssueTrackingOverride) map[string]any {
 	}
 	if ov.DevelopLabels != nil {
 		out["develop_labels"] = ov.DevelopLabels
+	}
+	if ov.RefinementLabels != nil {
+		out["refinement_labels"] = ov.RefinementLabels
 	}
 	if ov.ReviewOnlyLabels != nil {
 		out["review_only_labels"] = ov.ReviewOnlyLabels

--- a/daemon/cmd/heimdallm/main_interval_test.go
+++ b/daemon/cmd/heimdallm/main_interval_test.go
@@ -33,3 +33,22 @@ func TestParseDiscoveryIntervalUsesPollDefaultWhenBothInvalid(t *testing.T) {
 		t.Fatalf("parseDiscoveryInterval(empty, invalid) = %v, want %v", got, want)
 	}
 }
+
+func TestResolveRefinementTimeoutPrecedence(t *testing.T) {
+	got := resolveRefinementTimeout("30m", "20m", "5m")
+	if got != 30*time.Minute {
+		t.Fatalf("resolveRefinementTimeout(30m, 20m, 5m) = %v, want 30m", got)
+	}
+}
+
+func TestResolveRefinementTimeoutFallsBackToAgentThenGlobal(t *testing.T) {
+	got := resolveRefinementTimeout("", "20m", "5m")
+	if got != 5*time.Minute {
+		t.Fatalf("resolveRefinementTimeout(empty, 20m, 5m) = %v, want 5m", got)
+	}
+
+	got = resolveRefinementTimeout("", "20m", "")
+	if got != 20*time.Minute {
+		t.Fatalf("resolveRefinementTimeout(empty, 20m, empty) = %v, want 20m", got)
+	}
+}

--- a/daemon/internal/bus/integration_test.go
+++ b/daemon/internal/bus/integration_test.go
@@ -178,6 +178,48 @@ func TestIntegration_IssueImplementFlow(t *testing.T) {
 	}
 }
 
+// TestIntegration_IssueRefinementFlow publishes an IssueMsg to the refinement
+// subject and verifies the RefinementWorker handler receives the correct data.
+func TestIntegration_IssueRefinementFlow(t *testing.T) {
+	env := newTestEnv(t)
+	conn := env.bus.Conn()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	received := make(chan bus.IssueMsg, 1)
+	handler := func(_ context.Context, msg bus.IssueMsg) {
+		received <- msg
+	}
+
+	w := worker.NewRefinementWorker(conn, 3, handler)
+	go func() {
+		if err := w.Start(ctx); err != nil {
+			t.Errorf("refinement-worker start: %v", err)
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	pub := bus.NewIssuePublisher(conn)
+	if err := pub.PublishIssueRefinement(ctx, "org/refine-repo", 88, 11111); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case msg := <-received:
+		if msg.Repo != "org/refine-repo" {
+			t.Errorf("Repo = %q, want %q", msg.Repo, "org/refine-repo")
+		}
+		if msg.Number != 88 {
+			t.Errorf("Number = %d, want 88", msg.Number)
+		}
+		if msg.GithubID != 11111 {
+			t.Errorf("GithubID = %d, want 11111", msg.GithubID)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler not called within timeout")
+	}
+}
+
 // TestIntegration_StateCheckFlow enrolls an item in WatchStore, publishes a
 // StateCheckMsg, starts a StateWorker with a handler returning changed=false,
 // and verifies the backoff is increased.

--- a/daemon/internal/bus/messages.go
+++ b/daemon/internal/bus/messages.go
@@ -22,8 +22,8 @@ type PRPublishMsg struct {
 	ReviewID int64 `json:"review_id"`
 }
 
-// IssueMsg is published on SubjIssueTriage or SubjIssueImplement.
-// The subject distinguishes the workflow; the payload is the same.
+// IssueMsg is published on issue workflow subjects. The subject distinguishes
+// triage, refinement, and implement; the payload is the same.
 type IssueMsg struct {
 	Repo     string `json:"repo"`
 	Number   int    `json:"number"`

--- a/daemon/internal/bus/publisher.go
+++ b/daemon/internal/bus/publisher.go
@@ -90,7 +90,7 @@ type NATSIssuePublisher struct {
 	conn *nats.Conn
 }
 
-// NewIssuePublisher creates a publisher for issue triage and implement subjects.
+// NewIssuePublisher creates a publisher for issue triage, refinement, and implement subjects.
 func NewIssuePublisher(conn *nats.Conn) *NATSIssuePublisher {
 	return &NATSIssuePublisher{conn: conn}
 }
@@ -103,6 +103,18 @@ func (p *NATSIssuePublisher) PublishIssueTriage(_ context.Context, repo string, 
 	}
 	if err := p.conn.Publish(SubjIssueTriage, data); err != nil {
 		return fmt.Errorf("bus: publish issue triage: %w", err)
+	}
+	return nil
+}
+
+// PublishIssueRefinement publishes a refinement issue to the refinement subject.
+func (p *NATSIssuePublisher) PublishIssueRefinement(_ context.Context, repo string, number int, githubID int64) error {
+	data, err := Encode(IssueMsg{Repo: repo, Number: number, GithubID: githubID})
+	if err != nil {
+		return fmt.Errorf("bus: encode issue refinement: %w", err)
+	}
+	if err := p.conn.Publish(SubjIssueRefinement, data); err != nil {
+		return fmt.Errorf("bus: publish issue refinement: %w", err)
 	}
 	return nil
 }

--- a/daemon/internal/bus/publisher_test.go
+++ b/daemon/internal/bus/publisher_test.go
@@ -185,6 +185,38 @@ func TestIssuePublisher_Implement(t *testing.T) {
 	}
 }
 
+func TestIssuePublisher_Refinement(t *testing.T) {
+	env := newTestEnv(t)
+	conn := env.bus.Conn()
+	ctx := context.Background()
+
+	ch := make(chan *nats.Msg, 1)
+	sub, err := conn.ChanSubscribe(bus.SubjIssueRefinement, ch)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	pub := bus.NewIssuePublisher(conn)
+	if err := pub.PublishIssueRefinement(ctx, "org/repo", 30, 777); err != nil {
+		t.Fatalf("PublishIssueRefinement: %v", err)
+	}
+	conn.Flush()
+
+	select {
+	case m := <-ch:
+		var got bus.IssueMsg
+		if err := bus.Decode(m.Data, &got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if got.Repo != "org/repo" || got.Number != 30 || got.GithubID != 777 {
+			t.Errorf("unexpected: %+v", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
 func TestStateCheckPublisher_Publish(t *testing.T) {
 	env := newTestEnv(t)
 	conn := env.bus.Conn()

--- a/daemon/internal/bus/subjects.go
+++ b/daemon/internal/bus/subjects.go
@@ -13,8 +13,9 @@ const (
 	SubjPRPublish = "heimdallm.pr.publish"
 
 	// Issue workflow
-	SubjIssueTriage    = "heimdallm.issue.triage"
-	SubjIssueImplement = "heimdallm.issue.implement"
+	SubjIssueTriage     = "heimdallm.issue.triage"
+	SubjIssueRefinement = "heimdallm.issue.refinement"
+	SubjIssueImplement  = "heimdallm.issue.implement"
 
 	// State checking
 	SubjStateCheck = "heimdallm.state.check"
@@ -31,6 +32,7 @@ const (
 	SubjEventPRDetected      = "heimdallm.events.pr_detected"
 	SubjEventIssueDetected   = "heimdallm.events.issue_detected"
 	SubjEventIssueTriage     = "heimdallm.events.issue_review_completed"
+	SubjEventIssueRefinement = "heimdallm.events.issue_refinement_done"
 	SubjEventIssueImplement  = "heimdallm.events.issue_implemented"
 	SubjEventIssueState      = "heimdallm.events.issue_state_changed"
 	SubjEventRepoDiscovered  = "heimdallm.events.repo_discovered"

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -103,6 +103,7 @@ const (
 	IssueModeIgnore     IssueMode = "ignore"
 	IssueModeBlocked    IssueMode = "blocked"
 	IssueModeDevelop    IssueMode = "develop"
+	IssueModeRefinement IssueMode = "refinement"
 	IssueModeReviewOnly IssueMode = "review_only"
 )
 
@@ -120,7 +121,7 @@ const (
 //
 // Classification precedence (applied in Classify):
 //
-//	skip_labels  >  blocked_labels  >  develop_labels  >  review_only_labels  >  default_action
+//	skip_labels  >  blocked_labels  >  develop_labels  >  refinement_labels  >  review_only_labels  >  default_action
 //
 // develop_labels intentionally takes precedence over review_only_labels: when
 // an issue carries both a "please implement" label and a "please review only"
@@ -147,6 +148,12 @@ type IssueTrackingConfig struct {
 	// DevelopLabels are labels that mark an issue as "please implement".
 	DevelopLabels []string `toml:"develop_labels" json:"develop_labels"`
 
+	// RefinementLabels are labels that mark an issue as "deeply investigate
+	// and produce an implementation plan". This is the v1 trigger for the
+	// refinement stage; automatic triage -> refinement promotion is owned by
+	// the issue state machine work.
+	RefinementLabels []string `toml:"refinement_labels" json:"refinement_labels"`
+
 	// ReviewOnlyLabels are labels that mark an issue as "please analyse and
 	// comment only". DevelopLabels take precedence over ReviewOnlyLabels when
 	// both are present on the same issue — the operator explicitly tagged it
@@ -171,8 +178,8 @@ type IssueTrackingConfig struct {
 	// promotion has no target and blocked issues would stick forever.
 	PromoteToLabel string `toml:"promote_to_label" json:"promote_to_label"`
 
-	// DefaultAction is applied when an issue carries no label from any of
-	// the three lists above. Must be "ignore" or "review_only".
+	// DefaultAction is applied when an issue carries no label from any
+	// configured mode list above. Must be "ignore" or "review_only".
 	DefaultAction string `toml:"default_action" json:"default_action"`
 }
 
@@ -223,7 +230,7 @@ func (c IssueTrackingConfig) ResolvePromoteToLabel() string {
 // underlying labels API is case-preserving but the UI is not, so users
 // routinely mix "Bug" and "bug" in practice.
 //
-// Precedence: skip > blocked > develop > review_only > default_action.
+// Precedence: skip > blocked > develop > refinement > review_only > default_action.
 // develop beats review_only so that an issue tagged with both a DEV label and
 // an IT label is always auto-implemented, never silently downgraded to
 // review_only. This prevents the infinite retry loop described in issue #223.
@@ -242,6 +249,9 @@ func (c IssueTrackingConfig) Classify(labels []string) IssueMode {
 	// operator wants auto_implement (the stronger action). See issue #223.
 	if labelSetIntersects(set, c.DevelopLabels) {
 		return IssueModeDevelop
+	}
+	if labelSetIntersects(set, c.RefinementLabels) {
+		return IssueModeRefinement
 	}
 	if labelSetIntersects(set, c.ReviewOnlyLabels) {
 		return IssueModeReviewOnly
@@ -304,6 +314,10 @@ type AIConfig struct {
 	// ImplementPrompt is the global default agent profile ID for auto-implement.
 	// Per-repo overrides in [ai.repos.<name>] take precedence.
 	ImplementPrompt string `toml:"implement_prompt"`
+	// RefinementTimeout caps the deep-investigation stage. It defaults higher
+	// than the general executor timeout because refinement is expected to read
+	// the repository and build an implementation plan.
+	RefinementTimeout string `toml:"refinement_timeout"`
 
 	// Future issue pipeline fields. They are parsed and resolved through the
 	// same repo > org > global hierarchy so follow-up pipeline work can consume
@@ -332,6 +346,7 @@ type RepoAI struct {
 	// ImplementInstructions fields drive the auto_implement code-generation
 	// prompt for this repo. Overrides agent-level and global default.
 	ImplementPrompt       string `toml:"implement_prompt"`
+	RefinementTimeout     string `toml:"refinement_timeout"`
 	Fallback              string `toml:"fallback"`
 	ReviewMode            string `toml:"review_mode"` // "" = inherit global
 	LocalDir              string `toml:"local_dir"`   // local repo path for full-repo analysis
@@ -377,6 +392,7 @@ type IssueTrackingOverride struct {
 	Organizations    []string   `toml:"organizations,omitempty" json:"organizations,omitempty"`
 	Assignees        []string   `toml:"assignees,omitempty" json:"assignees,omitempty"`
 	DevelopLabels    []string   `toml:"develop_labels,omitempty" json:"develop_labels,omitempty"`
+	RefinementLabels []string   `toml:"refinement_labels,omitempty" json:"refinement_labels,omitempty"`
 	ReviewOnlyLabels []string   `toml:"review_only_labels,omitempty" json:"review_only_labels,omitempty"`
 	SkipLabels       []string   `toml:"skip_labels,omitempty" json:"skip_labels,omitempty"`
 	BlockedLabels    []string   `toml:"blocked_labels,omitempty" json:"blocked_labels,omitempty"`
@@ -391,6 +407,7 @@ type OrgAI struct {
 	Prompt                string `toml:"prompt"`
 	IssuePrompt           string `toml:"issue_prompt"`
 	ImplementPrompt       string `toml:"implement_prompt"`
+	RefinementTimeout     string `toml:"refinement_timeout"`
 	Fallback              string `toml:"fallback"`
 	ReviewMode            string `toml:"review_mode"`
 	LocalDir              string `toml:"local_dir"`
@@ -541,6 +558,7 @@ func (c *Config) AIForRepo(repo string) RepoAI {
 		ReviewMode:            c.AI.ReviewMode,
 		IssuePrompt:           c.AI.IssuePrompt,
 		ImplementPrompt:       c.AI.ImplementPrompt,
+		RefinementTimeout:     c.AI.RefinementTimeout,
 		PRReviewers:           gReviewers,
 		PRLabels:              gLabels,
 		PRAssignee:            gAssignee,
@@ -572,6 +590,7 @@ func applyOrgAI(out *RepoAI, o OrgAI) {
 		Prompt:                o.Prompt,
 		IssuePrompt:           o.IssuePrompt,
 		ImplementPrompt:       o.ImplementPrompt,
+		RefinementTimeout:     o.RefinementTimeout,
 		LocalDir:              o.LocalDir,
 		TriageOwner:           o.TriageOwner,
 		CloneDir:              o.CloneDir,
@@ -593,6 +612,7 @@ func applyRepoAI(out *RepoAI, r RepoAI) {
 		Prompt:                r.Prompt,
 		IssuePrompt:           r.IssuePrompt,
 		ImplementPrompt:       r.ImplementPrompt,
+		RefinementTimeout:     r.RefinementTimeout,
 		LocalDir:              r.LocalDir,
 		TriageOwner:           r.TriageOwner,
 		CloneDir:              r.CloneDir,
@@ -613,6 +633,7 @@ type scopedAIFields struct {
 	Prompt                string
 	IssuePrompt           string
 	ImplementPrompt       string
+	RefinementTimeout     string
 	LocalDir              string
 	TriageOwner           string
 	CloneDir              string
@@ -643,6 +664,9 @@ func applyScopedAI(out *RepoAI, fields scopedAIFields) {
 	}
 	if fields.ImplementPrompt != "" {
 		out.ImplementPrompt = fields.ImplementPrompt
+	}
+	if fields.RefinementTimeout != "" {
+		out.RefinementTimeout = fields.RefinementTimeout
 	}
 	if fields.LocalDir != "" {
 		out.LocalDir = fields.LocalDir
@@ -700,6 +724,9 @@ func applyIssueTrackingOverride(merged *IssueTrackingConfig, ov *IssueTrackingOv
 	if ov.DevelopLabels != nil {
 		merged.DevelopLabels = ov.DevelopLabels
 	}
+	if ov.RefinementLabels != nil {
+		merged.RefinementLabels = ov.RefinementLabels
+	}
 	if ov.ReviewOnlyLabels != nil {
 		merged.ReviewOnlyLabels = ov.ReviewOnlyLabels
 	}
@@ -724,7 +751,7 @@ func applyIssueTrackingOverride(merged *IssueTrackingConfig, ov *IssueTrackingOv
 	if ov.Assignees != nil {
 		merged.Assignees = ov.Assignees
 	}
-	if ov.Enabled == nil && (len(ov.DevelopLabels) > 0 || len(ov.ReviewOnlyLabels) > 0) {
+	if ov.Enabled == nil && (len(ov.DevelopLabels) > 0 || len(ov.RefinementLabels) > 0 || len(ov.ReviewOnlyLabels) > 0) {
 		merged.Enabled = true
 	}
 	if ov.Enabled != nil {
@@ -774,6 +801,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.AI.ReviewMode == "" {
 		c.AI.ReviewMode = "single"
+	}
+	if c.AI.RefinementTimeout == "" {
+		c.AI.RefinementTimeout = "30m"
 	}
 	if c.ActivityLog.Enabled == nil {
 		v := true
@@ -839,6 +869,9 @@ func (c *Config) applyEnvOverrides() {
 	}
 	if v := os.Getenv("HEIMDALLM_EXECUTION_TIMEOUT"); v != "" {
 		c.AI.ExecutionTimeout = v
+	}
+	if v := os.Getenv("HEIMDALLM_REFINEMENT_TIMEOUT"); v != "" {
+		c.AI.RefinementTimeout = v
 	}
 	if v := os.Getenv("HEIMDALLM_RETENTION_DAYS"); v != "" {
 		if d, err := strconv.Atoi(v); err == nil {
@@ -928,6 +961,9 @@ func (c *Config) applyIssueTrackingEnv() {
 	}
 	if list, ok := csvEnv("HEIMDALLM_ISSUE_DEVELOP_LABELS"); ok {
 		c.GitHub.IssueTracking.DevelopLabels = list
+	}
+	if list, ok := csvEnv("HEIMDALLM_ISSUE_REFINEMENT_LABELS"); ok {
+		c.GitHub.IssueTracking.RefinementLabels = list
 	}
 	if list, ok := csvEnv("HEIMDALLM_ISSUE_REVIEW_ONLY_LABELS"); ok {
 		c.GitHub.IssueTracking.ReviewOnlyLabels = list

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -1018,6 +1018,9 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("config: agents[%s].approval_mode: %w", name, err)
 		}
 	}
+	if err := c.validateRefinementTimeouts(); err != nil {
+		return err
+	}
 	if err := c.validateDiscovery(); err != nil {
 		return err
 	}
@@ -1124,6 +1127,39 @@ func (c *Config) validateOrgKeys() error {
 		if err := ValidateOrgSlug(org); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (c *Config) validateRefinementTimeouts() error {
+	if err := validatePositiveDuration("ai.refinement_timeout", c.AI.RefinementTimeout); err != nil {
+		return err
+	}
+	for org, ai := range c.AI.Orgs {
+		path := fmt.Sprintf(`ai.orgs.%q.refinement_timeout`, org)
+		if err := validatePositiveDuration(path, ai.RefinementTimeout); err != nil {
+			return err
+		}
+	}
+	for repo, ai := range c.AI.Repos {
+		path := fmt.Sprintf(`ai.repos.%q.refinement_timeout`, repo)
+		if err := validatePositiveDuration(path, ai.RefinementTimeout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePositiveDuration(path, raw string) error {
+	if raw == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return fmt.Errorf("config: %s %q is invalid: %w", path, raw, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("config: %s %q must be positive", path, raw)
 	}
 	return nil
 }

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -196,6 +196,57 @@ func TestValidate_AllValidIntervals(t *testing.T) {
 	}
 }
 
+func TestValidate_InvalidRefinementTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "global",
+			cfg: Config{
+				AI: AIConfig{Primary: "claude", RefinementTimeout: "30 m"},
+			},
+			want: "ai.refinement_timeout",
+		},
+		{
+			name: "org",
+			cfg: Config{
+				AI: AIConfig{
+					Primary: "claude",
+					Orgs: map[string]OrgAI{
+						"org": {RefinementTimeout: "-1m"},
+					},
+				},
+			},
+			want: `ai.orgs."org".refinement_timeout`,
+		},
+		{
+			name: "repo",
+			cfg: Config{
+				AI: AIConfig{
+					Primary: "claude",
+					Repos: map[string]RepoAI{
+						"org/repo": {RefinementTimeout: "0s"},
+					},
+				},
+			},
+			want: `ai.repos."org/repo".refinement_timeout`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if err == nil {
+				t.Fatal("Validate() = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate() error = %v, want path %q", err, tc.want)
+			}
+		})
+	}
+}
+
 // ── Topic-based discovery ────────────────────────────────────────────────────
 
 func TestApplyDefaults_DiscoveryIntervalUnsetWhenTopicSet(t *testing.T) {

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -427,6 +427,9 @@ func TestApplyDefaults_IssueTracking(t *testing.T) {
 	if cfg.GitHub.IssueTracking.Enabled {
 		t.Error("Enabled should default to false")
 	}
+	if cfg.AI.RefinementTimeout != "30m" {
+		t.Errorf("RefinementTimeout = %q, want 30m", cfg.AI.RefinementTimeout)
+	}
 }
 
 func TestApplyDefaults_IssueTrackingPreservesExisting(t *testing.T) {
@@ -453,8 +456,10 @@ func TestApplyEnvOverrides_IssueTracking(t *testing.T) {
 	t.Setenv("HEIMDALLM_ISSUE_ORGANIZATIONS", "freepik-company, theburrowhub")
 	t.Setenv("HEIMDALLM_ISSUE_ASSIGNEES", "sergiotejon")
 	t.Setenv("HEIMDALLM_ISSUE_DEVELOP_LABELS", "enhancement,feature, bug")
+	t.Setenv("HEIMDALLM_ISSUE_REFINEMENT_LABELS", "refine,needs-plan")
 	t.Setenv("HEIMDALLM_ISSUE_REVIEW_ONLY_LABELS", "question,discussion")
 	t.Setenv("HEIMDALLM_ISSUE_SKIP_LABELS", "wontfix")
+	t.Setenv("HEIMDALLM_REFINEMENT_TIMEOUT", "45m")
 
 	cfg.applyEnvOverrides()
 
@@ -477,11 +482,17 @@ func TestApplyEnvOverrides_IssueTracking(t *testing.T) {
 	if len(it.DevelopLabels) != 3 || it.DevelopLabels[2] != "bug" {
 		t.Errorf("DevelopLabels = %v", it.DevelopLabels)
 	}
+	if len(it.RefinementLabels) != 2 || it.RefinementLabels[1] != "needs-plan" {
+		t.Errorf("RefinementLabels = %v", it.RefinementLabels)
+	}
 	if len(it.ReviewOnlyLabels) != 2 {
 		t.Errorf("ReviewOnlyLabels = %v", it.ReviewOnlyLabels)
 	}
 	if len(it.SkipLabels) != 1 {
 		t.Errorf("SkipLabels = %v", it.SkipLabels)
+	}
+	if cfg.AI.RefinementTimeout != "45m" {
+		t.Errorf("RefinementTimeout = %q, want 45m", cfg.AI.RefinementTimeout)
 	}
 }
 
@@ -611,6 +622,7 @@ func TestClassify_Precedence(t *testing.T) {
 	cfg := IssueTrackingConfig{
 		SkipLabels:       []string{"wontfix"},
 		ReviewOnlyLabels: []string{"question", "discussion"},
+		RefinementLabels: []string{"refine"},
 		DevelopLabels:    []string{"bug", "enhancement"},
 		DefaultAction:    string(IssueModeIgnore),
 	}
@@ -623,7 +635,10 @@ func TestClassify_Precedence(t *testing.T) {
 		// develop beats review_only when both are present (#223): the operator
 		// tagged with a DEV label, so auto_implement is the intended action.
 		{"develop wins over review_only when both present", []string{"question", "bug"}, IssueModeDevelop},
+		{"develop wins over refinement when both present", []string{"refine", "bug"}, IssueModeDevelop},
+		{"refinement wins over review_only when both present", []string{"refine", "question"}, IssueModeRefinement},
 		{"develop only", []string{"bug"}, IssueModeDevelop},
+		{"refinement only", []string{"refine"}, IssueModeRefinement},
 		{"review_only only", []string{"question"}, IssueModeReviewOnly},
 		{"unrelated labels fall back to default_action=ignore", []string{"help-wanted"}, IssueModeIgnore},
 		{"no labels fall back to default_action=ignore", nil, IssueModeIgnore},
@@ -638,13 +653,14 @@ func TestClassify_Precedence(t *testing.T) {
 }
 
 func TestClassify_BlockedPrecedence(t *testing.T) {
-	// Precedence must be: skip > blocked > develop > review_only > default.
+	// Precedence must be: skip > blocked > develop > refinement > review_only > default.
 	// Blocked slots in between skip (don't touch it) and develop/review_only
 	// (blocked is cheaper than any processing — we haven't even confirmed we
 	// want to run it yet). develop beats review_only per issue #223.
 	cfg := IssueTrackingConfig{
 		SkipLabels:       []string{"wontfix"},
 		BlockedLabels:    []string{"blocked"},
+		RefinementLabels: []string{"refine"},
 		ReviewOnlyLabels: []string{"question"},
 		DevelopLabels:    []string{"bug"},
 		DefaultAction:    string(IssueModeIgnore),
@@ -656,6 +672,7 @@ func TestClassify_BlockedPrecedence(t *testing.T) {
 	}{
 		{"skip wins over blocked", []string{"wontfix", "blocked", "bug"}, IssueModeIgnore},
 		{"blocked wins over review_only", []string{"blocked", "question"}, IssueModeBlocked},
+		{"blocked wins over refinement", []string{"blocked", "refine"}, IssueModeBlocked},
 		{"blocked wins over develop", []string{"blocked", "bug"}, IssueModeBlocked},
 		{"blocked alone", []string{"blocked"}, IssueModeBlocked},
 		// develop beats review_only when both present (#223)
@@ -1570,6 +1587,7 @@ func TestIssueTrackingForRepo_OrgOverride(t *testing.T) {
 		Enabled:          true,
 		FilterMode:       FilterModeExclusive,
 		DevelopLabels:    []string{"global-dev"},
+		RefinementLabels: []string{"global-refine"},
 		ReviewOnlyLabels: []string{"global-review"},
 		SkipLabels:       []string{"global-skip"},
 		BlockedLabels:    []string{"global-blocked"},
@@ -1581,6 +1599,7 @@ func TestIssueTrackingForRepo_OrgOverride(t *testing.T) {
 			IssueTracking: &IssueTrackingOverride{
 				FilterMode:       FilterModeInclusive,
 				DevelopLabels:    []string{"org-dev"},
+				RefinementLabels: []string{"org-refine"},
 				ReviewOnlyLabels: []string{"org-review"},
 				BlockedLabels:    []string{"org-blocked"},
 				PromoteToLabel:   "org-ready",
@@ -1597,6 +1616,9 @@ func TestIssueTrackingForRepo_OrgOverride(t *testing.T) {
 	}
 	if len(got.DevelopLabels) != 1 || got.DevelopLabels[0] != "org-dev" {
 		t.Errorf("develop_labels = %v, want org override", got.DevelopLabels)
+	}
+	if len(got.RefinementLabels) != 1 || got.RefinementLabels[0] != "org-refine" {
+		t.Errorf("refinement_labels = %v, want org override", got.RefinementLabels)
 	}
 	if len(got.SkipLabels) != 1 || got.SkipLabels[0] != "global-skip" {
 		t.Errorf("skip_labels = %v, want inherited global skip label", got.SkipLabels)

--- a/daemon/internal/config/store.go
+++ b/daemon/internal/config/store.go
@@ -80,6 +80,8 @@ func (c *Config) ApplyStore(rows map[string]string) error {
 			shadow.AI.Fallback = raw
 		case "review_mode":
 			shadow.AI.ReviewMode = raw
+		case "refinement_timeout":
+			shadow.AI.RefinementTimeout = raw
 		case "repositories":
 			var repos []string
 			if err := json.Unmarshal([]byte(raw), &repos); err != nil {

--- a/daemon/internal/github/fetch_issues.go
+++ b/daemon/internal/github/fetch_issues.go
@@ -161,7 +161,7 @@ func (c *Client) fetchIssuesPage(repo string, page int) ([]*Issue, error) {
 // issueMatchesFilters applies organizations + assignees + filter_mode.
 // The label dimension is handled up-stream (cfg.Classify + ignore short-
 // circuit), so by the time we get here the issue is known to be
-// review_only or develop.
+// review_only, refinement, or develop.
 func issueMatchesFilters(issue *Issue, repo string, cfg config.IssueTrackingConfig) bool {
 	orgActive := len(cfg.Organizations) > 0
 	assigneeActive := len(cfg.Assignees) > 0
@@ -233,9 +233,9 @@ func hasAnyAssignee(got, want []string) bool {
 
 // sortIssuesByPriority applies the ordering described in FetchIssues:
 //
-//	1) assigned-to-authenticatedUser before everyone else
-//	2) review_only before develop (review is cheap, clears the queue faster)
-//	3) oldest first
+//  1. assigned-to-authenticatedUser before everyone else
+//  2. non-develop modes before develop (review/refinement are read-only)
+//  3. oldest first
 //
 // sort.SliceStable keeps the GitHub response order within otherwise-equal
 // issues (GitHub returns newest-updated first), making the tertiary

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -74,6 +74,7 @@ type issueMarkerFetcher interface {
 // Fetcher, ProcessRepo publishes to NATS instead of calling pipeline.Run.
 type IssuePublisher interface {
 	PublishIssueTriage(ctx context.Context, repo string, number int, githubID int64) error
+	PublishIssueRefinement(ctx context.Context, repo string, number int, githubID int64) error
 	PublishIssueImplement(ctx context.Context, repo string, number int, githubID int64) error
 }
 
@@ -166,6 +167,8 @@ func (f *Fetcher) ProcessRepo(ctx context.Context, repo string, cfg config.Issue
 			switch issue.Mode {
 			case config.IssueModeReviewOnly:
 				pubErr = f.publisher.PublishIssueTriage(ctx, issue.Repo, issue.Number, issue.ID)
+			case config.IssueModeRefinement:
+				pubErr = f.publisher.PublishIssueRefinement(ctx, issue.Repo, issue.Number, issue.ID)
 			case config.IssueModeDevelop:
 				pubErr = f.publisher.PublishIssueImplement(ctx, issue.Repo, issue.Number, issue.ID)
 			default:

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -102,6 +102,27 @@ func (f *fakePipeline) Run(ctx context.Context, issue *github.Issue, opts issues
 	return &store.IssueReview{IssueID: int64(issue.Number), ActionTaken: string(config.IssueModeReviewOnly)}, nil
 }
 
+type fakeIssuePublisher struct {
+	triage     []int
+	refinement []int
+	implement  []int
+}
+
+func (f *fakeIssuePublisher) PublishIssueTriage(ctx context.Context, repo string, number int, githubID int64) error {
+	f.triage = append(f.triage, number)
+	return nil
+}
+
+func (f *fakeIssuePublisher) PublishIssueRefinement(ctx context.Context, repo string, number int, githubID int64) error {
+	f.refinement = append(f.refinement, number)
+	return nil
+}
+
+func (f *fakeIssuePublisher) PublishIssueImplement(ctx context.Context, repo string, number int, githubID int64) error {
+	f.implement = append(f.implement, number)
+	return nil
+}
+
 func noOpts(_ *github.Issue) (issues.RunOptions, bool) { return issues.RunOptions{}, true }
 
 func fixture(number int, updated time.Time) *github.Issue {
@@ -620,5 +641,28 @@ func TestFetcher_ModeChangeBypassesBotCommentCheck(t *testing.T) {
 	}
 	if processed != 1 {
 		t.Errorf("mode change should bypass bot-comment check, got processed=%d", processed)
+	}
+}
+
+func TestFetcher_PublishesRefinementMode(t *testing.T) {
+	now := time.Now()
+	issue := fixture(9, now)
+	issue.Mode = config.IssueModeRefinement
+	pub := &fakeIssuePublisher{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, &fakeDedup{}, &fakePipeline{})
+	f.SetPublisher(pub)
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 1 {
+		t.Fatalf("processed = %d, want 1", processed)
+	}
+	if len(pub.refinement) != 1 || pub.refinement[0] != 9 {
+		t.Fatalf("refinement publishes = %v, want [9]", pub.refinement)
+	}
+	if len(pub.triage) != 0 || len(pub.implement) != 0 {
+		t.Fatalf("unexpected publishes triage=%v implement=%v", pub.triage, pub.implement)
 	}
 }

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -165,6 +165,35 @@ type PRDescription struct {
 	Body  string `json:"body"`
 }
 
+// RefinementResult is the structured deep-investigation output produced by
+// the refinement stage before development.
+type RefinementResult struct {
+	AnalysisSummary     string              `json:"analysis_summary"`
+	AffectedAreas       []RefinementArea    `json:"affected_areas"`
+	Subtasks            []RefinementSubtask `json:"subtasks"`
+	ImplementationOrder []string            `json:"implementation_order"`
+	Assumptions         []string            `json:"assumptions"`
+	OpenQuestions       []string            `json:"open_questions"`
+	Risks               []string            `json:"risks"`
+	TestPlan            []string            `json:"test_plan"`
+}
+
+type RefinementArea struct {
+	Path    string   `json:"path"`
+	Symbols []string `json:"symbols"`
+	Reason  string   `json:"reason"`
+}
+
+type RefinementSubtask struct {
+	ID             string   `json:"id"`
+	Description    string   `json:"description"`
+	AffectedFiles  []string `json:"affected_files"`
+	Symbols        []string `json:"symbols"`
+	ExpectedChange string   `json:"expected_change"`
+	Complexity     string   `json:"complexity"`
+	Dependencies   []string `json:"dependencies"`
+}
+
 // RunOptions carries per-execution settings derived from global + repo +
 // agent config by the caller.
 //
@@ -208,10 +237,17 @@ type RunOptions struct {
 	// When false (default), the pipeline uses the template strings.
 	GeneratePRDescription bool
 
+	// Force bypasses refinement idempotency for manual reruns.
+	Force bool
+
 	// RequireWorkDirForDevelop turns the historical develop→review_only
 	// fallback into a hard error. Production auto-clone callers set this so
 	// an auto_implement run never silently proceeds without a writable checkout.
 	RequireWorkDirForDevelop bool
+
+	// RequireWorkDirForRefinement records the production contract explicitly:
+	// refinement needs full repository context and must not degrade to issue-only.
+	RequireWorkDirForRefinement bool
 
 	// ReleaseRepoContext releases a checkout handle acquired by the caller.
 	// It is intentionally a one-shot cleanup hook rather than another source
@@ -257,6 +293,7 @@ type issueStore interface {
 	UpsertIssue(i *store.Issue) (int64, error)
 	InsertIssueReview(r *store.IssueReview) (int64, error)
 	LatestIssueReview(issueID int64) (*store.IssueReview, error)
+	LatestIssueReviewByAction(issueID int64, action string) (*store.IssueReview, error)
 	UpsertPR(pr *store.PR) (int64, error)
 	ClaimIssueTriageInFlight(issueID int64, updatedAt string) (bool, error)
 	ReleaseIssueTriageInFlight(issueID int64, updatedAt string) error
@@ -376,6 +413,9 @@ func (p *Pipeline) Run(ctx context.Context, issue *github.Issue, opts RunOptions
 			"repo", issue.Repo, "issue", issue.Number)
 		effective = config.IssueModeReviewOnly
 	}
+	if effective == config.IssueModeRefinement && workDir == "" {
+		return nil, fmt.Errorf("issues pipeline: refinement mode requires local repo context")
+	}
 	if effective == config.IssueModeIgnore {
 		return nil, fmt.Errorf("issues pipeline: refusing an ignore-classified issue (fetcher should have filtered it out)")
 	}
@@ -430,6 +470,8 @@ func (p *Pipeline) Run(ctx context.Context, issue *github.Issue, opts RunOptions
 	switch effective {
 	case config.IssueModeReviewOnly:
 		return p.runReviewOnly(ctx, issue, issueID, workDir, opts)
+	case config.IssueModeRefinement:
+		return p.runRefinement(ctx, issue, issueID, workDir, opts)
 	case config.IssueModeDevelop:
 		return p.runAutoImplement(ctx, issue, issueID, workDir, opts)
 	default:
@@ -625,19 +667,15 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 		return nil, fmt.Errorf("issues pipeline: detect CLI: %w", err)
 	}
 
-	// Build re-triage context if a previous review exists for this issue.
+	// Build prior-issue context. Prefer the latest refinement plan when it
+	// exists so auto_implement can execute the researched plan; otherwise fall
+	// back to the historical triage context.
 	var triageCtx string
-	prevReview, _ := p.store.LatestIssueReview(issueID)
-	if prevReview != nil {
-		triageCtx = buildTriageContext(
-			prevReview.Triage,
-			prevReview.Suggestions,
-			prevReview.Summary,
-			extractSeverity(prevReview.Triage),
-			prevReview.CreatedAt,
-			comments,
-			p.botLogin,
-		)
+	prevRefinement, _ := p.store.LatestIssueReviewByAction(issueID, string(config.IssueModeRefinement))
+	if prevRefinement != nil {
+		triageCtx = buildIssueRunContext(prevRefinement, comments, p.botLogin)
+	} else if prevReview, _ := p.store.LatestIssueReview(issueID); prevReview != nil {
+		triageCtx = buildIssueRunContext(prevReview, comments, p.botLogin)
 	}
 
 	// Agent profile customization: ImplementPromptOverride replaces the entire
@@ -935,9 +973,9 @@ func parseIssueResult(data []byte) (*IssueReviewResult, error) {
 // store keeps assignees and labels as JSON arrays (`[]` when empty), matching
 // the schema introduced in #24.
 //
-// The issue's processing mode (review_only vs develop) is intentionally not
-// part of store.Issue — the issues table captures the issue itself, while
-// the mode of *each triage run* lives on issue_reviews.action_taken. That
+// The issue's processing mode is intentionally not part of store.Issue — the
+// issues table captures the issue itself, while the mode of *each pipeline
+// run* lives on issue_reviews.action_taken. That
 // separation lets a single issue accumulate multiple reviews across mode
 // changes (e.g. initial review_only → later auto_implement in #27) without
 // losing the history.

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -2,6 +2,7 @@ package issues_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,6 +34,7 @@ type fakeStore struct {
 
 	latestReview    *store.IssueReview
 	latestReviewErr error
+	latestByAction  map[string]*store.IssueReview
 
 	// in-flight claim state (#292). claims is keyed on "issueID|updatedAt"
 	// so tests can assert claims / releases without racing the map.
@@ -75,6 +77,15 @@ func (f *fakeStore) LatestIssueReview(issueID int64) (*store.IssueReview, error)
 		return nil, f.latestReviewErr
 	}
 	return f.latestReview, nil
+}
+
+func (f *fakeStore) LatestIssueReviewByAction(issueID int64, action string) (*store.IssueReview, error) {
+	if f.latestByAction != nil {
+		if rev, ok := f.latestByAction[action]; ok {
+			return rev, nil
+		}
+	}
+	return nil, sql.ErrNoRows
 }
 
 func (f *fakeStore) UpsertPR(pr *store.PR) (int64, error) {
@@ -386,6 +397,40 @@ const validResult = `
 }
 `
 
+const validRefinementResult = `
+{
+  "analysis_summary": "Login failures route through the auth middleware and session store. The implementation should add a regression test, then adjust the middleware error handling so storage failures return a controlled response.",
+  "affected_areas": [
+    {"path": "daemon/internal/auth/middleware.go", "symbols": ["Authenticate"], "reason": "request authentication lives here"}
+  ],
+  "subtasks": [
+    {
+      "id": "task-1",
+      "description": "Add a failing regression test for the login error path.",
+      "affected_files": ["daemon/internal/auth/middleware_test.go"],
+      "symbols": ["TestAuthenticateStorageFailure"],
+      "expected_change": "test captures the 500 regression",
+      "complexity": "low",
+      "dependencies": []
+    },
+    {
+      "id": "task-2",
+      "description": "Handle session store failures without panicking.",
+      "affected_files": ["daemon/internal/auth/middleware.go"],
+      "symbols": ["Authenticate"],
+      "expected_change": "return a controlled error response",
+      "complexity": "medium",
+      "dependencies": ["task-1"]
+    }
+  ],
+  "implementation_order": ["task-1", "task-2"],
+  "assumptions": ["auth middleware owns login validation"],
+  "open_questions": [],
+  "risks": ["session behavior may differ across storage backends"],
+  "test_plan": ["make test-docker GO_TEST_ARGS=\"./internal/auth/...\""]
+}
+`
+
 func newIssue(mode config.IssueMode) *github.Issue {
 	return &github.Issue{
 		ID:        12345,
@@ -540,6 +585,65 @@ func TestPipeline_FirstTriageHasNoReTriageContext(t *testing.T) {
 	}
 }
 
+func TestPipeline_RunRefinementHappyPath(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(validRefinementResult)}
+	broker := &fakeBroker{}
+	p := issues.New(s, gh, exec, nil, broker, nil)
+
+	issue := newIssue(config.IssueModeRefinement)
+	rev, err := p.Run(context.Background(), issue, issues.RunOptions{
+		Primary:                     "claude",
+		ExecOpts:                    executor.ExecOptions{WorkDir: "/tmp/repo"},
+		RequireWorkDirForRefinement: true,
+	})
+	if err != nil {
+		t.Fatalf("run refinement: %v", err)
+	}
+	if rev == nil {
+		t.Fatal("nil refinement review returned")
+	}
+	if len(gh.postCalls) != 1 {
+		t.Fatalf("expected 1 refinement comment, got %d", len(gh.postCalls))
+	}
+	if !strings.Contains(gh.postCalls[0].Body, "Heimdallm refinement") {
+		t.Errorf("refinement comment missing heading: %q", gh.postCalls[0].Body)
+	}
+	if !strings.Contains(gh.postCalls[0].Body, "task-2") {
+		t.Errorf("refinement comment missing subtask: %q", gh.postCalls[0].Body)
+	}
+	if len(s.reviews) != 1 {
+		t.Fatalf("expected 1 review stored, got %d", len(s.reviews))
+	}
+	stored := s.reviews[0]
+	if stored.ActionTaken != string(config.IssueModeRefinement) {
+		t.Errorf("action_taken=%q, want refinement", stored.ActionTaken)
+	}
+	if !strings.Contains(stored.RefinementData, `"analysis_summary"`) {
+		t.Errorf("refinement_data not persisted: %q", stored.RefinementData)
+	}
+	if stored.Triage != "{}" {
+		t.Errorf("triage for refinement = %q, want {}", stored.Triage)
+	}
+	types := broker.types()
+	want := []string{sse.EventIssueDetected, sse.EventIssueReviewStarted, sse.EventIssueRefinementDone}
+	if !stringsEqual(types, want) {
+		t.Errorf("SSE sequence = %v, want %v", types, want)
+	}
+}
+
+func TestPipeline_RefinementRequiresWorkDir(t *testing.T) {
+	p := issues.New(&fakeStore{}, &fakeGH{}, &fakeExec{}, nil, &fakeBroker{}, nil)
+	_, err := p.Run(context.Background(), newIssue(config.IssueModeRefinement), issues.RunOptions{Primary: "claude"})
+	if err == nil {
+		t.Fatal("expected refinement without WorkDir to fail")
+	}
+	if !strings.Contains(err.Error(), "refinement mode requires local repo context") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestPipeline_ReTriageLatestReviewErrorIsNonFatal(t *testing.T) {
 	s := &fakeStore{
 		latestReviewErr: errors.New("database locked"),
@@ -609,6 +713,51 @@ func autoImplementRunOptions() issues.RunOptions {
 		Primary:     "claude",
 		ExecOpts:    executor.ExecOptions{WorkDir: "/tmp/repo"},
 		GitHubToken: "ghs_fake_token",
+	}
+}
+
+func TestPipeline_AutoImplementInjectsPreviousRefinement(t *testing.T) {
+	s := &fakeStore{
+		latestByAction: map[string]*store.IssueReview{
+			string(config.IssueModeRefinement): {
+				Summary:        "plan exists",
+				RefinementData: validRefinementResult,
+				ActionTaken:    string(config.IssueModeRefinement),
+				CreatedAt:      time.Now().Add(-1 * time.Hour),
+			},
+		},
+	}
+	gh := &fakeGH{defaultBranch: "main", createPRNumber: 123}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("done")}
+	git := &fakeGit{hasChanges: true}
+	p := issues.New(s, gh, exec, git, &fakeBroker{}, nil)
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(exec.lastPrompt, "Previous refinement plan") {
+		t.Fatalf("implement prompt should include previous refinement plan, got: %s", exec.lastPrompt)
+	}
+	if !strings.Contains(exec.lastPrompt, "task-2") {
+		t.Errorf("implement prompt should include refinement subtasks, got: %s", exec.lastPrompt)
+	}
+}
+
+func TestPipeline_AutoImplementWithoutRefinementKeepsPromptCompatible(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{defaultBranch: "main", createPRNumber: 123}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("done")}
+	git := &fakeGit{hasChanges: true}
+	p := issues.New(s, gh, exec, git, &fakeBroker{}, nil)
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.Contains(exec.lastPrompt, "Previous refinement plan") {
+		t.Fatalf("implement prompt unexpectedly includes refinement context: %s", exec.lastPrompt)
+	}
+	if !strings.Contains(exec.lastPrompt, "Implement what the issue asks for") {
+		t.Errorf("implement prompt lost default instructions: %s", exec.lastPrompt)
 	}
 }
 

--- a/daemon/internal/issues/prompt.go
+++ b/daemon/internal/issues/prompt.go
@@ -218,6 +218,77 @@ func BuildImplementPrompt(ctx PromptContext) string {
 	return buildDefaultImplementPrompt(ctx, "")
 }
 
+// BuildRefinementPrompt formats the prompt for the deep unattended
+// investigation stage. It deliberately has no custom-template variant yet:
+// the output schema is a contract consumed by downstream auto_implement.
+func BuildRefinementPrompt(ctx PromptContext) string {
+	var sb strings.Builder
+
+	sb.WriteString("You are Heimdallm, a senior engineering agent performing deep unattended refinement for a GitHub issue.\n")
+	sb.WriteString("You have READ access to the repository in the current working directory. Investigate the codebase before answering.\n")
+	sb.WriteString("Your job is to turn the issue into a concrete, auditable implementation plan for a later developer or agent.\n")
+	sb.WriteString("Do not modify files. Do not ask the user questions. Resolve ambiguity from code, docs, tests, and git history when possible.\n")
+	sb.WriteString("Only list open_questions for information you actively looked for and could not determine from the repository.\n\n")
+
+	sb.WriteString(fmt.Sprintf("Repository: %s\n", ctx.Repo))
+	sb.WriteString(fmt.Sprintf("Issue: #%d — %s\n", ctx.Number, ctx.Title))
+	sb.WriteString(fmt.Sprintf("Author: @%s\n", ctx.Author))
+	if len(ctx.Labels) > 0 {
+		sb.WriteString("Labels: " + strings.Join(ctx.Labels, ", ") + "\n")
+	}
+	if len(ctx.Assignees) > 0 {
+		sb.WriteString("Assignees: " + strings.Join(ctx.Assignees, ", ") + "\n")
+	}
+	sb.WriteString("\n")
+
+	body := strings.TrimSpace(ctx.Body)
+	if body == "" {
+		body = "(empty issue body)"
+	}
+	if len(body) > maxBodyBytes {
+		body = body[:maxBodyBytes] + "\n... (truncated)"
+	}
+	sb.WriteString("<issue_body>\n")
+	sb.WriteString(body)
+	sb.WriteString("\n</issue_body>\n\n")
+
+	if comments := formatComments(ctx.Comments); comments != "" {
+		sb.WriteString(comments)
+		sb.WriteString("\n")
+	}
+
+	if ctx.TriageContext != "" {
+		sb.WriteString(ctx.TriageContext)
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("Investigate these sources before producing the plan:\n")
+	sb.WriteString("- Relevant source files, tests, package/module boundaries, and local architecture.\n")
+	sb.WriteString("- README/docs/configuration files when they explain expected behavior.\n")
+	sb.WriteString("- Git history for likely affected paths when ownership or intent is unclear.\n")
+	sb.WriteString("- Existing patterns in nearby code; prefer extending them over inventing new abstractions.\n\n")
+
+	sb.WriteString("Return a single JSON object, and nothing else, with this exact shape:\n")
+	sb.WriteString("{\n")
+	sb.WriteString(`  "analysis_summary": "3-6 sentence technical summary of what must change and why",` + "\n")
+	sb.WriteString(`  "affected_areas": [` + "\n")
+	sb.WriteString(`    {"path": "relative/path.go", "symbols": ["FunctionName"], "reason": "why this area matters"}` + "\n")
+	sb.WriteString("  ],\n")
+	sb.WriteString(`  "subtasks": [` + "\n")
+	sb.WriteString(`    {"id": "task-1", "description": "concrete task", "affected_files": ["relative/path.go"], "symbols": ["FunctionName"], "expected_change": "specific expected change", "complexity": "low|medium|high", "dependencies": []}` + "\n")
+	sb.WriteString("  ],\n")
+	sb.WriteString(`  "implementation_order": ["task-1"],` + "\n")
+	sb.WriteString(`  "assumptions": ["assumption grounded in code evidence"],` + "\n")
+	sb.WriteString(`  "open_questions": ["question only if repository evidence was insufficient"],` + "\n")
+	sb.WriteString(`  "risks": ["risk area and why"],` + "\n")
+	sb.WriteString(`  "test_plan": ["specific test or verification step"]` + "\n")
+	sb.WriteString("}\n")
+	sb.WriteString("Every subtask id must be stable, unique, and referenced by dependencies/implementation_order when needed. Do not include files outside this repository as subtasks; mention cross-repo needs as open_questions.\n")
+	sb.WriteString("Do not wrap the JSON in prose or code fences.\n")
+
+	return sb.String()
+}
+
 func buildDefaultImplementPrompt(ctx PromptContext, customInstructions string) string {
 	var sb strings.Builder
 

--- a/daemon/internal/issues/refinement.go
+++ b/daemon/internal/issues/refinement.go
@@ -1,0 +1,493 @@
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+const maxRefinementCommentBytes = 60 * 1000
+
+func (p *Pipeline) runRefinement(ctx context.Context, issue *github.Issue, issueID int64, workDir string, opts RunOptions) (*store.IssueReview, error) {
+	_ = ctx // reserved for executor/gh cancellation when those deps accept one
+
+	latestRefinement, latestErr := p.store.LatestIssueReviewByAction(issueID, string(config.IssueModeRefinement))
+	if latestErr != nil && !errorsIsNoRows(latestErr) {
+		slog.Warn("issues pipeline: latest refinement lookup failed, proceeding",
+			"repo", issue.Repo, "number", issue.Number, "err", latestErr)
+	}
+	if latestRefinement != nil && !opts.Force && refinementIsFresh(issue, latestRefinement) {
+		slog.Info("issues pipeline: refinement already fresh, skipping",
+			"repo", issue.Repo, "number", issue.Number)
+		return nil, nil
+	}
+
+	p.publish(sse.EventIssueReviewStarted, map[string]any{
+		"issue_id": issueID, "number": issue.Number, "repo": issue.Repo, "mode": "refinement",
+	})
+	if p.notify != nil {
+		p.notify.Notify("Issue Refinement Started", fmt.Sprintf("%s #%d", issue.Repo, issue.Number))
+	}
+
+	comments, err := p.gh.FetchIssueCommentsOnly(issue.Repo, issue.Number)
+	if err != nil {
+		slog.Warn("issues pipeline: failed to fetch comments for refinement, proceeding without",
+			"repo", issue.Repo, "number", issue.Number, "err", err)
+		comments = nil
+	}
+
+	var humanComments []github.Comment
+	for _, c := range comments {
+		if p.botLogin != "" && strings.EqualFold(c.Author, p.botLogin) {
+			continue
+		}
+		humanComments = append(humanComments, c)
+	}
+
+	prevContext := ""
+	prevReview, _ := p.store.LatestIssueReview(issueID)
+	if prevReview != nil {
+		prevContext = buildIssueRunContext(prevReview, comments, p.botLogin)
+	}
+
+	prompt := BuildRefinementPrompt(PromptContext{
+		Repo:          issue.Repo,
+		Number:        issue.Number,
+		Title:         issue.Title,
+		Author:        issue.User.Login,
+		Labels:        issue.LabelNames(),
+		Assignees:     issue.AssigneeLogins(),
+		Body:          issue.Body,
+		Comments:      humanComments,
+		HasLocalDir:   workDir != "",
+		TriageContext: prevContext,
+	})
+
+	cli, err := p.executor.Detect(opts.Primary, opts.Fallback)
+	if err != nil {
+		p.publishError(issueID, issue, fmt.Errorf("detect CLI: %w", err))
+		return nil, fmt.Errorf("issues pipeline: detect CLI: %w", err)
+	}
+	raw, err := p.executor.ExecuteRaw(cli, prompt, opts.ExecOpts)
+	if err != nil {
+		p.publishError(issueID, issue, fmt.Errorf("execute %s: %w", cli, err))
+		return nil, fmt.Errorf("issues pipeline: execute %s: %w", cli, err)
+	}
+	result, err := parseRefinementResult(raw)
+	if err != nil {
+		p.publishError(issueID, issue, err)
+		return nil, fmt.Errorf("issues pipeline: parse refinement result: %w", err)
+	}
+
+	refinementJSON, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("issues pipeline: marshal refinement: %w", err)
+	}
+	body, truncated := BuildRefinementMarkdownComment(result)
+	if truncated {
+		slog.Warn("issues pipeline: refinement comment truncated",
+			"repo", issue.Repo, "number", issue.Number, "limit", maxRefinementCommentBytes)
+	}
+	commentedAt, postErr := p.gh.PostComment(issue.Repo, issue.Number, body)
+	if postErr != nil {
+		slog.Warn("issues pipeline: refinement PostComment failed, review will be stored locally only",
+			"repo", issue.Repo, "number", issue.Number, "err", postErr)
+	}
+
+	rev := &store.IssueReview{
+		IssueID:        issueID,
+		CLIUsed:        cli,
+		Summary:        result.AnalysisSummary,
+		Triage:         "{}",
+		RefinementData: string(refinementJSON),
+		Suggestions:    "[]",
+		ActionTaken:    string(config.IssueModeRefinement),
+		CreatedAt:      time.Now().UTC(),
+		CommentedAt:    commentedAt,
+	}
+	revID, err := p.store.InsertIssueReview(rev)
+	if err != nil {
+		return nil, fmt.Errorf("issues pipeline: store refinement: %w", err)
+	}
+	rev.ID = revID
+
+	p.publish(sse.EventIssueRefinementDone, map[string]any{
+		"issue_id": issueID, "number": issue.Number, "repo": issue.Repo,
+		"post_ok": postErr == nil, "truncated": truncated,
+	})
+	if p.notify != nil {
+		p.notify.Notify("Issue Refinement Complete", fmt.Sprintf("%s #%d", issue.Repo, issue.Number))
+	}
+	slog.Info("issues pipeline: refinement complete",
+		"repo", issue.Repo, "number", issue.Number, "posted", postErr == nil)
+	return rev, nil
+}
+
+func errorsIsNoRows(err error) bool {
+	return err == nil || errors.Is(err, sql.ErrNoRows)
+}
+
+func refinementIsFresh(issue *github.Issue, latest *store.IssueReview) bool {
+	if latest == nil {
+		return false
+	}
+	ref := latest.CommentedAt
+	if ref.IsZero() {
+		ref = latest.CreatedAt
+	}
+	if issue.UpdatedAt.IsZero() {
+		return true
+	}
+	return !issue.UpdatedAt.After(ref.Add(RecomputeGrace))
+}
+
+func parseRefinementResult(data []byte) (*RefinementResult, error) {
+	clean := executor.StripToJSON(data)
+	var r RefinementResult
+	if err := json.Unmarshal(clean, &r); err != nil {
+		return nil, fmt.Errorf("issues pipeline: parse refinement JSON: %w (raw: %.200s)", err, clean)
+	}
+	if err := sanitizeAndValidateRefinement(&r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func sanitizeAndValidateRefinement(r *RefinementResult) error {
+	r.AnalysisSummary = strings.TrimSpace(r.AnalysisSummary)
+	if r.AnalysisSummary == "" {
+		return fmt.Errorf("refinement result missing analysis_summary")
+	}
+	if len(r.Subtasks) == 0 {
+		return fmt.Errorf("refinement result missing subtasks")
+	}
+
+	areas := make([]RefinementArea, 0, len(r.AffectedAreas))
+	for _, area := range r.AffectedAreas {
+		paths := sanitizeAffectedPaths([]string{area.Path})
+		if len(paths) == 0 {
+			continue
+		}
+		area.Path = paths[0]
+		area.Symbols = cleanStringList(area.Symbols, 20)
+		area.Reason = strings.TrimSpace(area.Reason)
+		areas = append(areas, area)
+	}
+	r.AffectedAreas = areas
+
+	ids := make(map[string]struct{}, len(r.Subtasks))
+	for i := range r.Subtasks {
+		st := &r.Subtasks[i]
+		st.ID = strings.TrimSpace(st.ID)
+		if st.ID == "" {
+			return fmt.Errorf("refinement subtask at index %d missing id", i)
+		}
+		if _, exists := ids[st.ID]; exists {
+			return fmt.Errorf("refinement subtask id %q is duplicated", st.ID)
+		}
+		ids[st.ID] = struct{}{}
+		st.Description = strings.TrimSpace(st.Description)
+		if st.Description == "" {
+			return fmt.Errorf("refinement subtask %q missing description", st.ID)
+		}
+		st.AffectedFiles = sanitizeAffectedPaths(st.AffectedFiles)
+		st.Symbols = cleanStringList(st.Symbols, 30)
+		st.ExpectedChange = strings.TrimSpace(st.ExpectedChange)
+		st.Complexity = normalizeComplexity(st.Complexity)
+		st.Dependencies = cleanStringList(st.Dependencies, 30)
+	}
+	for _, st := range r.Subtasks {
+		for _, dep := range st.Dependencies {
+			if dep == st.ID {
+				return fmt.Errorf("refinement subtask %q depends on itself", st.ID)
+			}
+			if _, ok := ids[dep]; !ok {
+				return fmt.Errorf("refinement subtask %q depends on unknown id %q", st.ID, dep)
+			}
+		}
+	}
+
+	r.ImplementationOrder = cleanStringList(r.ImplementationOrder, len(r.Subtasks))
+	if len(r.ImplementationOrder) == 0 {
+		r.ImplementationOrder = make([]string, 0, len(r.Subtasks))
+		for _, st := range r.Subtasks {
+			r.ImplementationOrder = append(r.ImplementationOrder, st.ID)
+		}
+	} else {
+		ordered := make(map[string]struct{}, len(r.ImplementationOrder))
+		for _, id := range r.ImplementationOrder {
+			ordered[id] = struct{}{}
+		}
+		for _, st := range r.Subtasks {
+			if _, ok := ordered[st.ID]; !ok {
+				r.ImplementationOrder = append(r.ImplementationOrder, st.ID)
+			}
+		}
+	}
+	if err := validateImplementationOrder(r); err != nil {
+		return err
+	}
+	r.Assumptions = cleanStringList(r.Assumptions, 50)
+	r.OpenQuestions = cleanStringList(r.OpenQuestions, 50)
+	r.Risks = cleanStringList(r.Risks, 50)
+	r.TestPlan = cleanStringList(r.TestPlan, 50)
+	return nil
+}
+
+func validateImplementationOrder(r *RefinementResult) error {
+	pos := make(map[string]int, len(r.ImplementationOrder))
+	for i, id := range r.ImplementationOrder {
+		pos[id] = i
+	}
+	for _, id := range r.ImplementationOrder {
+		found := false
+		for _, st := range r.Subtasks {
+			if st.ID == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("implementation_order references unknown id %q", id)
+		}
+	}
+	for _, st := range r.Subtasks {
+		stPos, ok := pos[st.ID]
+		if !ok {
+			continue
+		}
+		for _, dep := range st.Dependencies {
+			depPos, ok := pos[dep]
+			if ok && depPos > stPos {
+				return fmt.Errorf("implementation_order places %q before dependency %q", st.ID, dep)
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeComplexity(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "low", "medium", "high":
+		return strings.ToLower(strings.TrimSpace(s))
+	default:
+		return "medium"
+	}
+}
+
+func cleanStringList(in []string, max int) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, item := range in {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+		if max > 0 && len(out) >= max {
+			break
+		}
+	}
+	return out
+}
+
+func BuildRefinementMarkdownComment(r *RefinementResult) (string, bool) {
+	body := renderRefinementMarkdown(r, false)
+	if len(body) <= maxRefinementCommentBytes {
+		return body, false
+	}
+	body = renderRefinementMarkdown(r, true)
+	if len(body) <= maxRefinementCommentBytes {
+		return body, true
+	}
+	note := "\n\n> Truncated to fit GitHub's comment size limit. The complete JSON refinement is stored locally in `refinement_data`.\n"
+	limit := maxRefinementCommentBytes - len(note)
+	if limit < 0 {
+		limit = maxRefinementCommentBytes
+		note = ""
+	}
+	return body[:limit] + note, true
+}
+
+func renderRefinementMarkdown(r *RefinementResult, compact bool) string {
+	var sb strings.Builder
+	sb.WriteString("## Heimdallm refinement\n\n")
+	if r.AnalysisSummary != "" {
+		sb.WriteString(r.AnalysisSummary)
+		sb.WriteString("\n\n")
+	}
+	writeAreas(&sb, r.AffectedAreas, compact)
+	writeSubtasks(&sb, r.Subtasks, compact)
+	writeStringSection(&sb, "Implementation order", r.ImplementationOrder, compact, 40)
+	writeStringSection(&sb, "Assumptions", r.Assumptions, compact, 10)
+	writeStringSection(&sb, "Open questions", r.OpenQuestions, compact, 10)
+	writeStringSection(&sb, "Risks", r.Risks, compact, 10)
+	writeStringSection(&sb, "Test plan", r.TestPlan, compact, 10)
+	if compact {
+		sb.WriteString("> Some sections were shortened to fit GitHub's comment size limit. The complete JSON refinement is stored locally in `refinement_data`.\n\n")
+	}
+	sb.WriteString("---\n*refinement mode · reviewed by Heimdallm*")
+	return sb.String()
+}
+
+func writeAreas(sb *strings.Builder, areas []RefinementArea, compact bool) {
+	if len(areas) == 0 {
+		return
+	}
+	sb.WriteString("### Affected areas\n\n")
+	limit := len(areas)
+	if compact && limit > 20 {
+		limit = 20
+	}
+	for _, area := range areas[:limit] {
+		sb.WriteString(fmt.Sprintf("- `%s`", area.Path))
+		if len(area.Symbols) > 0 {
+			sb.WriteString(fmt.Sprintf(" (%s)", strings.Join(area.Symbols, ", ")))
+		}
+		if area.Reason != "" {
+			sb.WriteString(": " + maybeShorten(area.Reason, compact, 400))
+		}
+		sb.WriteString("\n")
+	}
+	writeTruncatedCount(sb, len(areas), limit)
+	sb.WriteString("\n")
+}
+
+func writeSubtasks(sb *strings.Builder, tasks []RefinementSubtask, compact bool) {
+	if len(tasks) == 0 {
+		return
+	}
+	sb.WriteString("### Subtasks\n\n")
+	limit := len(tasks)
+	if compact && limit > 40 {
+		limit = 40
+	}
+	for _, st := range tasks[:limit] {
+		sb.WriteString(fmt.Sprintf("- **%s** (%s): %s\n", st.ID, st.Complexity, maybeShorten(st.Description, compact, 500)))
+		if len(st.AffectedFiles) > 0 {
+			sb.WriteString(fmt.Sprintf("  - Files: `%s`\n", strings.Join(st.AffectedFiles, "`, `")))
+		}
+		if len(st.Symbols) > 0 {
+			sb.WriteString(fmt.Sprintf("  - Symbols: %s\n", strings.Join(st.Symbols, ", ")))
+		}
+		if st.ExpectedChange != "" {
+			sb.WriteString(fmt.Sprintf("  - Expected change: %s\n", maybeShorten(st.ExpectedChange, compact, 500)))
+		}
+		if len(st.Dependencies) > 0 {
+			sb.WriteString(fmt.Sprintf("  - Depends on: %s\n", strings.Join(st.Dependencies, ", ")))
+		}
+	}
+	writeTruncatedCount(sb, len(tasks), limit)
+	sb.WriteString("\n")
+}
+
+func writeStringSection(sb *strings.Builder, title string, items []string, compact bool, compactLimit int) {
+	if len(items) == 0 {
+		return
+	}
+	sb.WriteString("### " + title + "\n\n")
+	limit := len(items)
+	if compact && limit > compactLimit {
+		limit = compactLimit
+	}
+	for _, item := range items[:limit] {
+		sb.WriteString("- " + maybeShorten(item, compact, 500) + "\n")
+	}
+	writeTruncatedCount(sb, len(items), limit)
+	sb.WriteString("\n")
+}
+
+func writeTruncatedCount(sb *strings.Builder, total, shown int) {
+	if shown < total {
+		sb.WriteString(fmt.Sprintf("- ... %d more omitted from the GitHub comment\n", total-shown))
+	}
+}
+
+func maybeShorten(s string, compact bool, limit int) string {
+	s = strings.TrimSpace(s)
+	if !compact || len(s) <= limit {
+		return s
+	}
+	if limit < 20 {
+		return s[:limit]
+	}
+	return s[:limit-15] + "... (truncated)"
+}
+
+func buildIssueRunContext(prev *store.IssueReview, comments []github.Comment, botLogin string) string {
+	if prev == nil {
+		return ""
+	}
+	if prev.ActionTaken == string(config.IssueModeRefinement) && prev.RefinementData != "" {
+		return buildRefinementContext(prev.RefinementData, prev.Summary, prev.CreatedAt)
+	}
+	return buildTriageContext(
+		prev.Triage,
+		prev.Suggestions,
+		prev.Summary,
+		extractSeverity(prev.Triage),
+		prev.CreatedAt,
+		comments,
+		botLogin,
+	)
+}
+
+func buildRefinementContext(refinementJSON, summary string, createdAt time.Time) string {
+	if refinementJSON == "" {
+		return ""
+	}
+	var r RefinementResult
+	if err := json.Unmarshal([]byte(refinementJSON), &r); err != nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Previous refinement plan\n\n")
+	if !createdAt.IsZero() {
+		b.WriteString(fmt.Sprintf("Created at: %s\n\n", createdAt.UTC().Format(time.RFC3339)))
+	}
+	if r.AnalysisSummary != "" {
+		b.WriteString("Summary: " + r.AnalysisSummary + "\n\n")
+	} else if summary != "" {
+		b.WriteString("Summary: " + summary + "\n\n")
+	}
+	if len(r.Subtasks) > 0 {
+		b.WriteString("Subtasks:\n")
+		for _, st := range r.Subtasks {
+			b.WriteString(fmt.Sprintf("- %s: %s\n", st.ID, st.Description))
+		}
+		b.WriteString("\n")
+	}
+	if len(r.ImplementationOrder) > 0 {
+		b.WriteString("Implementation order: " + strings.Join(r.ImplementationOrder, ", ") + "\n\n")
+	}
+	if len(r.Risks) > 0 {
+		b.WriteString("Risks:\n")
+		for _, risk := range r.Risks {
+			b.WriteString("- " + risk + "\n")
+		}
+		b.WriteString("\n")
+	}
+	if len(r.TestPlan) > 0 {
+		b.WriteString("Test plan:\n")
+		for _, step := range r.TestPlan {
+			b.WriteString("- " + step + "\n")
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -40,6 +40,7 @@ type Server struct {
 	shutdownFn           func()
 	triggerReviewFn      func(prID int64) error
 	triggerIssueReviewFn func(issueID int64) error
+	triggerIssueRefineFn func(issueID int64, force bool) error
 	triggerPromoteFn     func(issueID int64) error
 	cleanCloneFn         func(ctx context.Context, repo string) error
 	cleanClonesFn        func(ctx context.Context) (int, error)
@@ -164,6 +165,11 @@ func (srv *Server) SetTriggerIssueReviewFn(fn func(issueID int64) error) {
 	srv.triggerIssueReviewFn = fn
 }
 
+// SetTriggerIssueRefineFn wires the refinement trigger called by POST /issues/{id}/refine.
+func (srv *Server) SetTriggerIssueRefineFn(fn func(issueID int64, force bool) error) {
+	srv.triggerIssueRefineFn = fn
+}
+
 // SetTriggerPromoteFn wires the promote callback called by POST /issues/{id}/promote.
 // The callback must run the auto_implement pipeline for the given issue regardless
 // of its current classification (review_only → develop promotion).
@@ -267,6 +273,7 @@ func (srv *Server) buildRouter() chi.Router {
 	r.Get("/issues", srv.handleListIssues)
 	r.Get("/issues/{id}", srv.handleGetIssue)
 	r.Post("/issues/{id}/review", srv.handleTriggerIssueReview)
+	r.Post("/issues/{id}/refine", srv.handleTriggerIssueRefine)
 	r.Post("/issues/{id}/promote", srv.handlePromoteIssue)
 	r.Post("/issues/{id}/dismiss", srv.handleDismissIssue)
 	r.Post("/issues/{id}/undismiss", srv.handleUndismissIssue)
@@ -408,12 +415,13 @@ func (srv *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 // readOnlyConfigKeys below) is rejected with HTTP 400 to prevent arbitrary
 // data injection into the configs table (security issue #4).
 var validConfigKeys = map[string]struct{}{
-	"poll_interval":  {},
-	"ai_primary":     {},
-	"ai_fallback":    {},
-	"review_mode":    {},
-	"retention_days": {},
-	"issue_tracking": {},
+	"poll_interval":      {},
+	"ai_primary":         {},
+	"ai_fallback":        {},
+	"review_mode":        {},
+	"refinement_timeout": {},
+	"retention_days":     {},
+	"issue_tracking":     {},
 }
 
 // readOnlyConfigKeys are keys that GET /config returns (so the web UI can
@@ -511,6 +519,17 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		}
 		if _, valid := validReviewModes[s]; !valid {
 			http.Error(w, "review_mode must be one of: single, multi", http.StatusBadRequest)
+			return
+		}
+	}
+	if v, ok := body["refinement_timeout"]; ok {
+		s, isStr := v.(string)
+		if !isStr {
+			http.Error(w, "refinement_timeout must be a string", http.StatusBadRequest)
+			return
+		}
+		if d, err := time.ParseDuration(s); err != nil || d <= 0 {
+			http.Error(w, "refinement_timeout must be a positive duration, e.g. 30m", http.StatusBadRequest)
 			return
 		}
 	}
@@ -1039,15 +1058,16 @@ type issueResponse struct {
 // issueReviewResponse wraps a store.IssueReview, parsing Triage/Suggestions
 // JSON strings into structured objects.
 type issueReviewResponse struct {
-	ID          int64           `json:"id"`
-	IssueID     int64           `json:"issue_id"`
-	CLIUsed     string          `json:"cli_used"`
-	Summary     string          `json:"summary"`
-	Triage      json.RawMessage `json:"triage"`
-	Suggestions json.RawMessage `json:"suggestions"`
-	ActionTaken string          `json:"action_taken"`
-	PRCreated   int             `json:"pr_created"`
-	CreatedAt   time.Time       `json:"created_at"`
+	ID             int64           `json:"id"`
+	IssueID        int64           `json:"issue_id"`
+	CLIUsed        string          `json:"cli_used"`
+	Summary        string          `json:"summary"`
+	Triage         json.RawMessage `json:"triage"`
+	RefinementData json.RawMessage `json:"refinement_data,omitempty"`
+	Suggestions    json.RawMessage `json:"suggestions"`
+	ActionTaken    string          `json:"action_taken"`
+	PRCreated      int             `json:"pr_created"`
+	CreatedAt      time.Time       `json:"created_at"`
 }
 
 func toIssueResponse(iss *store.Issue, rev *store.IssueReview) issueResponse {
@@ -1067,7 +1087,7 @@ func toIssueResponse(iss *store.Issue, rev *store.IssueReview) issueResponse {
 }
 
 func toIssueReviewResponse(r *store.IssueReview) *issueReviewResponse {
-	return &issueReviewResponse{
+	resp := &issueReviewResponse{
 		ID: r.ID, IssueID: r.IssueID, CLIUsed: r.CLIUsed,
 		Summary:     r.Summary,
 		Triage:      json.RawMessage(r.Triage),
@@ -1075,6 +1095,10 @@ func toIssueReviewResponse(r *store.IssueReview) *issueReviewResponse {
 		ActionTaken: r.ActionTaken, PRCreated: r.PRCreated,
 		CreatedAt: r.CreatedAt,
 	}
+	if r.RefinementData != "" {
+		resp.RefinementData = json.RawMessage(r.RefinementData)
+	}
+	return resp
 }
 
 func (srv *Server) handleListIssues(w http.ResponseWriter, r *http.Request) {
@@ -1170,6 +1194,38 @@ func (srv *Server) handleTriggerIssueReview(w http.ResponseWriter, r *http.Reque
 		}
 	}()
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "review queued"})
+}
+
+func (srv *Server) handleTriggerIssueRefine(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	if srv.triggerIssueRefineFn == nil {
+		http.Error(w, "issue refinement trigger not configured", http.StatusServiceUnavailable)
+		return
+	}
+	if _, err := srv.store.GetIssue(id); err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	force := strings.EqualFold(r.URL.Query().Get("force"), "true") || r.URL.Query().Get("force") == "1"
+	// Shared semaphore with PR reviews and issue triage because refinement
+	// also launches an AI CLI process.
+	select {
+	case srv.reviewSem <- struct{}{}:
+	default:
+		http.Error(w, `{"error":"too many concurrent reviews — try again later"}`, http.StatusTooManyRequests)
+		return
+	}
+	go func() {
+		defer func() { <-srv.reviewSem }()
+		if err := srv.triggerIssueRefineFn(id, force); err != nil {
+			slog.Error("trigger issue refinement failed", "issue_id", id, "force", force, "err", err)
+		}
+	}()
+	writeJSON(w, http.StatusAccepted, map[string]string{"status": "refinement queued"})
 }
 
 // handlePromoteIssue promotes a review_only-classified issue to auto_implement,

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -537,6 +537,74 @@ func TestHandlerTriggerIssueReview_NotConfigured(t *testing.T) {
 	}
 }
 
+func TestHandlerTriggerIssueRefine(t *testing.T) {
+	srv, s := setupServer(t)
+	now := time.Now()
+	id, _ := s.UpsertIssue(&store.Issue{
+		GithubID: 610, Repo: "org/r", Number: 15, Title: "t",
+		Body: "b", Author: "a", Assignees: `[]`, Labels: `[]`,
+		State: "open", CreatedAt: now, FetchedAt: now,
+	})
+
+	type call struct {
+		id    int64
+		force bool
+	}
+	triggered := make(chan call, 1)
+	srv.SetTriggerIssueRefineFn(func(issueID int64, force bool) error {
+		triggered <- call{id: issueID, force: force}
+		return nil
+	})
+
+	req := httptest.NewRequest("POST", "/issues/"+itoa(id)+"/refine?force=true", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("trigger issue refine: status %d, body: %s", w.Code, w.Body.String())
+	}
+
+	select {
+	case got := <-triggered:
+		if got.id != id || !got.force {
+			t.Errorf("triggered with %+v, expected id=%d force=true", got, id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("refine callback not called within 2s")
+	}
+}
+
+func TestHandlerTriggerIssueRefine_NotConfigured(t *testing.T) {
+	srv, s := setupServer(t)
+	now := time.Now()
+	id, _ := s.UpsertIssue(&store.Issue{
+		GithubID: 611, Repo: "org/r", Number: 16, Title: "t",
+		Body: "b", Author: "a", Assignees: `[]`, Labels: `[]`,
+		State: "open", CreatedAt: now, FetchedAt: now,
+	})
+
+	req := httptest.NewRequest("POST", "/issues/"+itoa(id)+"/refine", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when refine not configured, got %d", w.Code)
+	}
+}
+
+func TestHandlerTriggerIssueRefine_NotFound(t *testing.T) {
+	srv, _ := setupServer(t)
+	srv.SetTriggerIssueRefineFn(func(issueID int64, force bool) error {
+		t.Fatalf("callback should not be called for unknown issue")
+		return nil
+	})
+
+	req := httptest.NewRequest("POST", "/issues/999/refine", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown issue, got %d", w.Code)
+	}
+}
+
 func TestHandlerPromoteIssue(t *testing.T) {
 	srv, s := setupServer(t)
 	now := time.Now()
@@ -632,6 +700,7 @@ func TestIssueEndpointsRequireAuthWhenTokenSet(t *testing.T) {
 	// POST endpoints — protected via method-based auth (all POST requires token)
 	postPaths := []string{
 		"/issues/" + issueID + "/review",
+		"/issues/" + issueID + "/refine",
 		"/issues/" + issueID + "/promote",
 		"/issues/" + issueID + "/dismiss",
 		"/issues/" + issueID + "/undismiss",

--- a/daemon/internal/sse/broker.go
+++ b/daemon/internal/sse/broker.go
@@ -15,6 +15,7 @@ const (
 	EventIssueDetected        = "issue_detected"
 	EventIssueReviewStarted   = "issue_review_started"
 	EventIssueReviewCompleted = "issue_review_completed"
+	EventIssueRefinementDone  = "issue_refinement_done"
 	EventIssueImplemented     = "issue_implemented" // reserved for #27 (auto_implement PR created)
 	EventIssueReviewError     = "issue_review_error"
 	EventIssuePromoted        = "issue_promoted" // #113: promoter flipped blocked → promote-to label

--- a/daemon/internal/store/issues.go
+++ b/daemon/internal/store/issues.go
@@ -32,16 +32,17 @@ type Issue struct {
 // see #26). `PRCreated` stores the GitHub PR number when auto_implement opened
 // one, or zero otherwise.
 type IssueReview struct {
-	ID          int64     `json:"id"`
-	IssueID     int64     `json:"issue_id"`
-	CLIUsed     string    `json:"cli_used"`
-	Summary     string    `json:"summary"`
-	Triage      string    `json:"triage"`      // JSON object {severity, category, ...}
-	Suggestions string    `json:"suggestions"` // JSON array
-	ActionTaken string    `json:"action_taken"`
-	PRCreated   int       `json:"pr_created"`
-	CreatedAt   time.Time `json:"created_at"`
-	CommentedAt time.Time `json:"commented_at"`
+	ID             int64     `json:"id"`
+	IssueID        int64     `json:"issue_id"`
+	CLIUsed        string    `json:"cli_used"`
+	Summary        string    `json:"summary"`
+	Triage         string    `json:"triage"`                    // JSON object {severity, category, ...}
+	RefinementData string    `json:"refinement_data,omitempty"` // JSON object for refinement runs
+	Suggestions    string    `json:"suggestions"`               // JSON array
+	ActionTaken    string    `json:"action_taken"`
+	PRCreated      int       `json:"pr_created"`
+	CreatedAt      time.Time `json:"created_at"`
+	CommentedAt    time.Time `json:"commented_at"`
 }
 
 // UpsertIssue inserts or updates an issue keyed on github_id. The dismissed
@@ -196,9 +197,9 @@ func (s *Store) InsertIssueReview(r *IssueReview) (int64, error) {
 		commentedAt = r.CommentedAt.UTC().Format(sqliteTimeFormat)
 	}
 	res, err := s.db.Exec(`
-		INSERT INTO issue_reviews (issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at, commented_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, r.IssueID, r.CLIUsed, r.Summary, r.Triage, r.Suggestions, r.ActionTaken, r.PRCreated,
+		INSERT INTO issue_reviews (issue_id, cli_used, summary, triage, refinement_data, suggestions, action_taken, pr_created, created_at, commented_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, r.IssueID, r.CLIUsed, r.Summary, r.Triage, r.RefinementData, r.Suggestions, r.ActionTaken, r.PRCreated,
 		r.CreatedAt.UTC().Format(sqliteTimeFormat),
 		commentedAt,
 	)
@@ -211,7 +212,7 @@ func (s *Store) InsertIssueReview(r *IssueReview) (int64, error) {
 // ListIssueReviews returns every review for an issue, newest first.
 func (s *Store) ListIssueReviews(issueID int64) ([]*IssueReview, error) {
 	rows, err := s.db.Query(
-		`SELECT id, issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at, COALESCE(commented_at,'')
+		`SELECT id, issue_id, cli_used, summary, triage, COALESCE(refinement_data,''), suggestions, action_taken, pr_created, created_at, COALESCE(commented_at,'')
 		 FROM issue_reviews WHERE issue_id = ? ORDER BY created_at DESC`,
 		issueID,
 	)
@@ -234,9 +235,20 @@ func (s *Store) ListIssueReviews(issueID int64) ([]*IssueReview, error) {
 // sql.ErrNoRows if none exists yet.
 func (s *Store) LatestIssueReview(issueID int64) (*IssueReview, error) {
 	row := s.db.QueryRow(
-		`SELECT id, issue_id, cli_used, summary, triage, suggestions, action_taken, pr_created, created_at, COALESCE(commented_at,'')
+		`SELECT id, issue_id, cli_used, summary, triage, COALESCE(refinement_data,''), suggestions, action_taken, pr_created, created_at, COALESCE(commented_at,'')
 		 FROM issue_reviews WHERE issue_id = ? ORDER BY created_at DESC LIMIT 1`,
 		issueID,
+	)
+	return scanIssueReview(row)
+}
+
+// LatestIssueReviewByAction returns the newest review row for a given action,
+// or sql.ErrNoRows when that action has not run for the issue yet.
+func (s *Store) LatestIssueReviewByAction(issueID int64, action string) (*IssueReview, error) {
+	row := s.db.QueryRow(
+		`SELECT id, issue_id, cli_used, summary, triage, COALESCE(refinement_data,''), suggestions, action_taken, pr_created, created_at, COALESCE(commented_at,'')
+		 FROM issue_reviews WHERE issue_id = ? AND action_taken = ? ORDER BY created_at DESC LIMIT 1`,
+		issueID, action,
 	)
 	return scanIssueReview(row)
 }
@@ -282,7 +294,7 @@ func scanIssueReview(s scanner) (*IssueReview, error) {
 	var r IssueReview
 	var createdAt, commentedAt string
 	if err := s.Scan(&r.ID, &r.IssueID, &r.CLIUsed, &r.Summary, &r.Triage,
-		&r.Suggestions, &r.ActionTaken, &r.PRCreated, &createdAt, &commentedAt); err != nil {
+		&r.RefinementData, &r.Suggestions, &r.ActionTaken, &r.PRCreated, &createdAt, &commentedAt); err != nil {
 		return nil, fmt.Errorf("store: scan issue review: %w", err)
 	}
 	var err error

--- a/daemon/internal/store/issues_test.go
+++ b/daemon/internal/store/issues_test.go
@@ -1,8 +1,8 @@
 package store_test
 
 import (
-	"errors"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -174,14 +174,15 @@ func TestIssueReview_InsertAndList(t *testing.T) {
 	issueID, _ := s.UpsertIssue(newIssue(209, 23))
 
 	rev := &store.IssueReview{
-		IssueID:     issueID,
-		CLIUsed:     "claude",
-		Summary:     "looks like a config bug",
-		Triage:      `{"severity":"medium","category":"config"}`,
-		Suggestions: `["document the flag","add a validation step"]`,
-		ActionTaken: "review_only",
-		PRCreated:   0,
-		CreatedAt:   time.Now().UTC().Truncate(time.Second),
+		IssueID:        issueID,
+		CLIUsed:        "claude",
+		Summary:        "looks like a config bug",
+		Triage:         `{"severity":"medium","category":"config"}`,
+		RefinementData: `{"analysis_summary":"plan"}`,
+		Suggestions:    `["document the flag","add a validation step"]`,
+		ActionTaken:    "review_only",
+		PRCreated:      0,
+		CreatedAt:      time.Now().UTC().Truncate(time.Second),
 	}
 	revID, err := s.InsertIssueReview(rev)
 	if err != nil {
@@ -200,6 +201,16 @@ func TestIssueReview_InsertAndList(t *testing.T) {
 	}
 	if reviews[0].Triage != rev.Triage {
 		t.Errorf("triage mismatch: %q", reviews[0].Triage)
+	}
+	if reviews[0].RefinementData != rev.RefinementData {
+		t.Errorf("refinement_data mismatch: %q", reviews[0].RefinementData)
+	}
+	latestRef, err := s.LatestIssueReviewByAction(issueID, "review_only")
+	if err != nil {
+		t.Fatalf("latest by action: %v", err)
+	}
+	if latestRef.ID != revID {
+		t.Errorf("LatestIssueReviewByAction ID = %d, want %d", latestRef.ID, revID)
 	}
 }
 

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -103,6 +103,7 @@ CREATE TABLE IF NOT EXISTS issue_reviews (
   cli_used     TEXT NOT NULL,
   summary      TEXT NOT NULL,
   triage       TEXT NOT NULL,
+  refinement_data TEXT NOT NULL DEFAULT '',
   suggestions  TEXT NOT NULL DEFAULT '[]',
   action_taken TEXT NOT NULL DEFAULT 'review_only',
   pr_created   INTEGER NOT NULL DEFAULT 0,
@@ -188,6 +189,7 @@ func Open(dsn string) (*Store, error) {
 		db.Exec("UPDATE agents SET is_default_dev = is_default")
 	}
 	db.Exec("ALTER TABLE issue_reviews ADD COLUMN commented_at DATETIME NOT NULL DEFAULT ''")
+	db.Exec("ALTER TABLE issue_reviews ADD COLUMN refinement_data TEXT NOT NULL DEFAULT ''")
 	// Covering index for the circuit-breaker counters (see issue #243).
 	// CREATE INDEX IF NOT EXISTS is idempotent; safe on every startup.
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_reviews_pr_created ON reviews(pr_id, created_at)")

--- a/daemon/internal/worker/refinement.go
+++ b/daemon/internal/worker/refinement.go
@@ -1,0 +1,75 @@
+// daemon/internal/worker/refinement.go
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/nats-io/nats.go"
+)
+
+// RefinementWorker consumes issue refinement requests from NATS and delegates
+// to a handler that runs the issue pipeline in Refinement mode.
+type RefinementWorker struct {
+	conn      *nats.Conn
+	handler   func(ctx context.Context, msg bus.IssueMsg)
+	semaphore chan struct{}
+}
+
+// NewRefinementWorker creates a worker that subscribes to the issue refinement subject.
+func NewRefinementWorker(conn *nats.Conn, maxConcurrent int, handler func(context.Context, bus.IssueMsg)) *RefinementWorker {
+	if maxConcurrent <= 0 {
+		maxConcurrent = 1
+	}
+	return &RefinementWorker{
+		conn:      conn,
+		handler:   handler,
+		semaphore: make(chan struct{}, maxConcurrent),
+	}
+}
+
+// Start subscribes and blocks until ctx is cancelled.
+func (w *RefinementWorker) Start(ctx context.Context) error {
+	sub, err := w.conn.Subscribe(bus.SubjIssueRefinement, func(msg *nats.Msg) {
+		var issueMsg bus.IssueMsg
+		if err := bus.Decode(msg.Data, &issueMsg); err != nil {
+			slog.Error("refinement-worker: decode message", "err", err)
+			return
+		}
+
+		select {
+		case w.semaphore <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
+
+		go func() {
+			defer func() { <-w.semaphore }()
+
+			slog.Info("refinement-worker: processing",
+				"repo", issueMsg.Repo, "number", issueMsg.Number, "github_id", issueMsg.GithubID)
+
+			w.safeHandle(ctx, issueMsg)
+		}()
+	})
+	if err != nil {
+		return err
+	}
+	defer sub.Unsubscribe()
+
+	<-ctx.Done()
+	return nil
+}
+
+func (w *RefinementWorker) safeHandle(ctx context.Context, msg bus.IssueMsg) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("refinement-worker: handler panic",
+				"repo", msg.Repo, "number", msg.Number, "panic", r,
+				"stack", string(debug.Stack()))
+		}
+	}()
+	w.handler(ctx, msg)
+}

--- a/daemon/internal/worker/refinement_test.go
+++ b/daemon/internal/worker/refinement_test.go
@@ -1,0 +1,51 @@
+// daemon/internal/worker/refinement_test.go
+package worker_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/heimdallm/daemon/internal/worker"
+)
+
+func TestRefinementWorker_ConsumesAndCallsHandler(t *testing.T) {
+	b := newTestBus(t)
+	conn := b.Conn()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var (
+		mu       sync.Mutex
+		received []bus.IssueMsg
+	)
+	handler := func(_ context.Context, msg bus.IssueMsg) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, msg)
+	}
+
+	w := worker.NewRefinementWorker(conn, 3, handler)
+	go func() { w.Start(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+
+	pub := bus.NewIssuePublisher(conn)
+	if err := pub.PublishIssueRefinement(ctx, "org/repo", 88, 123456); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("expected 1, got %d", len(received))
+	}
+	msg := received[0]
+	if msg.Repo != "org/repo" || msg.Number != 88 || msg.GithubID != 123456 {
+		t.Errorf("unexpected: %+v", msg)
+	}
+}

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -38,6 +38,7 @@ repositories = ["org/repo1", "org/repo2"]
 # organizations       = ["your-org"]             # empty = any org in repositories
 # assignees           = ["your-username"]        # empty = any assignee (or unassigned)
 # develop_labels      = ["enhancement", "feature", "bug"]
+# refinement_labels   = ["refine", "needs-plan"]
 # review_only_labels  = ["question", "discussion", "analysis"]
 # skip_labels         = ["wontfix", "duplicate", "invalid"]
 
@@ -47,6 +48,7 @@ primary = "claude"
 # fallback = "gemini"
 review_mode = "single"   # "single" or "multi"
 # execution_timeout = "20m"   # default: 5m; increase for complex auto_implement
+# refinement_timeout = "30m"  # deep issue refinement
 # triage_owner = "muriano"
 # clone_dir = "/repos/worktrees"
 # auto_promote_triage = true
@@ -105,6 +107,7 @@ review_mode = "single"   # "single" or "multi"
 # prompt = "org-pr-review-profile"
 # issue_prompt = "org-issue-triage-profile"
 # implement_prompt = "org-implementation-profile"
+# refinement_timeout = "30m"
 # triage_owner = "muriano"
 # clone_dir = "/repos/freepik-worktrees"
 # auto_promote_triage = true
@@ -118,6 +121,7 @@ review_mode = "single"   # "single" or "multi"
 # [ai.orgs."freepik-company".issue_tracking]
 # enabled = true
 # develop_labels = ["heimdallm-develop"]
+# refinement_labels = ["heimdallm-refine"]
 # review_only_labels = ["heimdallm-triage"]
 # skip_labels = ["wontfix"]
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -508,6 +508,7 @@ review_mode  = "multi"
 prompt       = "org-pr-review-profile"
 issue_prompt = "org-issue-triage-profile"
 implement_prompt = "org-implementation-profile"
+refinement_timeout = "30m"
 triage_owner = "alice"
 clone_dir = "/home/heimdallm/repos/myorg-worktrees"
 auto_promote_triage = true
@@ -522,6 +523,7 @@ pr_draft     = false
 [ai.orgs."myorg".issue_tracking]
 enabled            = true
 develop_labels     = ["heimdallm-develop"]
+refinement_labels  = ["heimdallm-refine"]
 review_only_labels = ["heimdallm-triage"]
 skip_labels        = ["wontfix"]
 
@@ -904,6 +906,8 @@ non_monitored = []
 # assignees      = ["myusername"]       # env: HEIMDALLM_ISSUE_ASSIGNEES
 # develop_labels     = ["enhancement", "feature", "bug"]
 #                                       # env: HEIMDALLM_ISSUE_DEVELOP_LABELS
+# refinement_labels  = ["refine"]
+#                                       # env: HEIMDALLM_ISSUE_REFINEMENT_LABELS
 # review_only_labels = ["question", "discussion", "analysis"]
 #                                       # env: HEIMDALLM_ISSUE_REVIEW_ONLY_LABELS
 # skip_labels        = ["wontfix", "duplicate", "invalid"]
@@ -924,6 +928,7 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 
 # Global execution timeout for AI CLI calls.
 # execution_timeout = "20m"   # default: 5m — env: HEIMDALLM_EXECUTION_TIMEOUT
+# refinement_timeout = "30m"  # deep issue refinement — env: HEIMDALLM_REFINEMENT_TIMEOUT
 
 # Issue pipeline ownership and promotion defaults.
 # triage_owner = "alice"
@@ -992,6 +997,7 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # prompt = "org-pr-review-profile"
 # issue_prompt = "org-issue-triage-profile"
 # implement_prompt = "org-implementation-profile"
+# refinement_timeout = "30m"
 # triage_owner = "alice"
 # clone_dir = "/home/heimdallm/repos/myorg-worktrees"
 # auto_promote_triage = true
@@ -1005,6 +1011,7 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # [ai.orgs."myorg".issue_tracking]
 # enabled = true
 # develop_labels = ["heimdallm-develop"]
+# refinement_labels = ["heimdallm-refine"]
 # review_only_labels = ["heimdallm-triage"]
 # skip_labels = ["wontfix"]
 


### PR DESCRIPTION
Closes #393

## Summary
- Adds issue refinement as a first-class issue mode, triggered by configured refinement labels or the manual refine endpoint.
- Adds refinement config, timeout inheritance, NATS publishing/worker wiring, SSE completion events, and SQLite persistence via `refinement_data`.
- Runs refinement with full repository context, validates the structured plan, posts a GitHub comment, and stores the full JSON result.
- Feeds the latest refinement plan into `auto_implement` when available, while preserving the existing no-refinement fallback.

## Scope notes
- Refinement v1 is label/manual triggered. The automatic triage -> refinement -> develop promotion flow is intentionally left for #395.
- Refinement does not mutate GitHub labels or assignees; it only comments, persists the result, and emits events.
- No Flutter UI changes are included in this PR.

## Validation
- `make test-docker`