### PR TITLE
feat(issues): add issue stage promotion state machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 > **Note:** Versions 0.1.0–0.1.3 were originally published under [`theburrowhub/heimdallr-docker`](https://github.com/theburrowhub/heimdallr-docker) (now archived). The project was unified into this repository and renamed to Heimdallm in v0.1.1.
 
+## Unreleased
+
+### Upgrade Notes
+
+* **issues:** issue classification now follows the state-machine order `skip > blocked > review_only > refinement > develop > default_action`. If a repo intentionally double-labels issues with triage/review and develop labels, the earlier stage now wins so Heimdallm does not skip triage or refinement during promotion.
+* **issues:** `auto_promote_triage` defaults on only when `refinement_labels` is configured. Repos without a refinement target keep their previous review-only behavior; set `auto_promote_triage = false` explicitly to keep refinement manual even when refinement labels exist.
+
 ## [0.6.12](https://github.com/theburrowhub/heimdallm/compare/v0.6.11...v0.6.12) (2026-05-01)
 
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ tagged with both a blocked and a develop label stays blocked until
 promotion. Stage promotion updates labels only; the next poll executes the newly visible stage. The feature is **opt-in**: leave `HEIMDALLM_ISSUE_BLOCKED_LABELS`
 empty and nothing about the existing pipeline changes.
 
+**Upgrade note for staged issues:** earlier-stage labels now win over later-stage labels. If you previously used overlapping triage/develop labels to force direct development, split them into dedicated labels or remove the triage label before applying the develop label. `auto_promote_triage` defaults on only when `refinement_labels` is configured; set it to `false` to keep refinement promotion manual.
+
 ### Automated install (for agents / scripts)
 
 See [LLM-HOW-TO-INSTALL.md](LLM-HOW-TO-INSTALL.md) for a step-by-step guide suitable for Claude Code, shell scripts, or any automation tool.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Heimdallm runs in the background and does three things, in parallel, at your con
 Watches the PRs where you're requested as a reviewer, runs an AI code review, and submits it to GitHub as your account. No copy-pasting, no manual prompting.
 
 ### 2. Issue triage & auto-implement
-Fetches issues from monitored repos, classifies them by label (`review_only` vs `auto_implement` vs `skip` vs `blocked`), and for the develop-track ones optionally **creates a branch, commits the change, and opens a PR** against your default branch — fully autonomous on the issues you mark for it. Issues can declare dependencies on other issues/PRs; Heimdallm holds them in a `blocked` state until the prerequisites close, then promotes them automatically.
+Fetches issues from monitored repos, classifies them by label (`review_only` triage, `refinement`, `develop` / `auto_implement`, `skip`, `blocked`), and can move issues through triage -> refinement -> development. Develop-track issues optionally **create a branch, commit the change, and open a PR** against your default branch. Issues can declare dependencies on other issues/PRs; Heimdallm holds them in a `blocked` state until the prerequisites close, then promotes them automatically.
 
 ### 3. Self-monitoring UI
 A Flutter Web dashboard (`:3000`) with Dashboard, PR list, Issue list, prompt/agent editor, live config editor, and a live log stream. Opens alongside the daemon in Docker mode.
@@ -22,7 +22,7 @@ A Flutter Web dashboard (`:3000`) with Dashboard, PR list, Issue list, prompt/ag
 ### Headline features
 
 - **Automatic reviews** — polls `review-requested:@me` on GitHub and submits reviews as your account
-- **Issue pipeline** — label-driven triage + optional auto-implement with branch/commit/PR cycle
+- **Issue pipeline** — label-driven triage, refinement planning, and optional auto-implement with branch/commit/PR cycle
 - **Issue dependencies** — mark downstream work with a `blocked` label; declare deps via a `## Depends on` body section *or* GitHub's native sub-issues; Heimdallm auto-promotes when all blockers close
 - **Configurable prompts** — general review, security audit, performance, architecture, or your own with `{diff}` `{title}` `{author}` `{comments}` placeholders, managed from the web UI at `/agents`
 - **Two feedback modes** — *single* (one consolidated review) or *multi* (one GitHub comment per issue + summary), globally and per repo
@@ -335,7 +335,7 @@ label:
    label(s), add `HEIMDALLM_ISSUE_PROMOTE_TO_LABEL`, and leave an audit
    comment listing each dep and its state at check time.
 6. The same poll cycle's fetch pass then classifies the promoted issue
-   normally and dispatches it to triage or auto-implement.
+   normally and dispatches it to triage, refinement, or auto-implement.
 
 Issues with a blocked label but **no declared deps in either source**
 stay blocked — the daemon won't guess when to unblock them. Remove the
@@ -344,9 +344,9 @@ a given issue, Heimdallm skips that issue for the current cycle rather
 than risk promoting on incomplete information.
 
 Classification precedence is
-`skip > blocked > review_only > develop > default_action`, so an issue
+`skip > blocked > review_only > refinement > develop > default_action`, so an issue
 tagged with both a blocked and a develop label stays blocked until
-promotion. The feature is **opt-in**: leave `HEIMDALLM_ISSUE_BLOCKED_LABELS`
+promotion. Stage promotion updates labels only; the next poll executes the newly visible stage. The feature is **opt-in**: leave `HEIMDALLM_ISSUE_BLOCKED_LABELS`
 empty and nothing about the existing pipeline changes.
 
 ### Automated install (for agents / scripts)

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -264,6 +264,12 @@ func (c *Client) TriggerIssueReview(id int64) error {
 	return err
 }
 
+// PromoteIssue moves an issue to its next configured stage by changing labels.
+func (c *Client) PromoteIssue(id int64) error {
+	_, err := c.do("POST", fmt.Sprintf("/issues/%d/promote", id))
+	return err
+}
+
 // Shutdown asks the daemon to stop gracefully.
 func (c *Client) Shutdown() error {
 	_, err := c.do("POST", "/shutdown")

--- a/cli/internal/cli/follow.go
+++ b/cli/internal/cli/follow.go
@@ -184,6 +184,11 @@ func formatEventData(data string) string {
 			parts = append(parts, from+" → "+to)
 		}
 	}
+	if from, ok := m["from_stage"].(string); ok {
+		if to, ok := m["to_stage"].(string); ok {
+			parts = append(parts, from+" → "+to)
+		}
+	}
 
 	if reason, ok := m["reason"].(string); ok && reason != "" {
 		parts = append(parts, styleMuted.Render(reason))

--- a/cli/internal/cli/promote_issue.go
+++ b/cli/internal/cli/promote_issue.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func newPromoteIssueCmd() *cobra.Command {
+	var repo string
+
+	cmd := &cobra.Command{
+		Use:   "promote-issue <number>",
+		Short: "Promote an issue to its next configured stage",
+		Long: "Move the issue identified by its GitHub number to the next stage by updating GitHub labels.\n" +
+			"Use --repo to specify the repository (required when the daemon monitors multiple repos).",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := clientFromContext(cmd.Context())
+			number, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid issue number: %w", err)
+			}
+
+			issues, err := c.ListIssues()
+			if err != nil {
+				return fmt.Errorf("fetching issues: %w", err)
+			}
+
+			var matched []int64
+			for _, iss := range issues {
+				if iss.Number == number && (repo == "" || iss.Repo == repo) {
+					matched = append(matched, iss.ID)
+				}
+			}
+
+			switch len(matched) {
+			case 0:
+				if repo != "" {
+					return fmt.Errorf("no issue #%d found in %s", number, repo)
+				}
+				return fmt.Errorf("no issue #%d found (try --repo org/repo)", number)
+			case 1:
+				if err := c.PromoteIssue(matched[0]); err != nil {
+					return fmt.Errorf("promoting issue: %w", err)
+				}
+				fmt.Printf("Promotion requested for issue #%d.\n", number)
+				return nil
+			default:
+				return fmt.Errorf("issue #%d exists in multiple repos — use --repo to disambiguate", number)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&repo, "repo", "", "repository slug (org/repo)")
+
+	return cmd
+}

--- a/cli/internal/cli/root.go
+++ b/cli/internal/cli/root.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/theburrowhub/heimdallm/cli/internal/api"
 	"github.com/spf13/cobra"
+	"github.com/theburrowhub/heimdallm/cli/internal/api"
 )
 
 // contextKey is an unexported type for context keys in this package.
@@ -88,6 +88,7 @@ func NewRootCmd(version string) *cobra.Command {
 		newFollowCmd(),
 		newReviewPRCmd(),
 		newReviewIssueCmd(),
+		newPromoteIssueCmd(),
 		newDismissIssueCmd(),
 		newUndismissIssueCmd(),
 		newConfigCmd(),

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -84,6 +84,10 @@ type sseMsg api.SSEEvent
 type sseDisconnectMsg struct{ err error }
 type sseReconnectMsg struct{}
 type shutdownMsg struct{ err error }
+type promoteIssueMsg struct {
+	id  int64
+	err error
+}
 
 func NewDashboard(host, token, version string) *Dashboard {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -179,6 +183,12 @@ func (d *Dashboard) listenSSE() tea.Cmd {
 func (d *Dashboard) shutdownDaemon() tea.Cmd {
 	return func() tea.Msg {
 		return shutdownMsg{err: d.client.Shutdown()}
+	}
+}
+
+func (d *Dashboard) promoteIssue(id int64) tea.Cmd {
+	return func() tea.Msg {
+		return promoteIssueMsg{id: id, err: d.client.PromoteIssue(id)}
 	}
 }
 
@@ -320,6 +330,17 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d.sseCancel()
 		}
 		return d, nil
+
+	case promoteIssueMsg:
+		d.refreshing = false
+		if msg.err != nil {
+			d.err = msg.err
+			d.connected = false
+			d.shutdownMessage = fmt.Sprintf("Promotion failed: %v", msg.err)
+			return d, nil
+		}
+		d.shutdownMessage = "Promotion requested"
+		return d, d.fetchData
 	}
 
 	return d, nil
@@ -426,6 +447,13 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else if d.activeTab == tabIssues && d.cursor < len(d.issues) {
 			d.openDetail()
 		}
+	case "p", "P":
+		if d.activeTab == tabIssues && d.cursor < len(d.issues) && canPromoteIssue(d.issues[d.cursor]) {
+			issue := d.issues[d.cursor]
+			d.refreshing = true
+			d.shutdownMessage = fmt.Sprintf("Promoting issue #%d...", issue.Number)
+			return d, d.promoteIssue(issue.ID)
+		}
 	case "r":
 		d.refreshing = true
 		return d, d.fetchData
@@ -465,6 +493,13 @@ func (d *Dashboard) handleDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return d, tea.Quit
 	case "esc", "enter":
 		d.showDetail = false
+	case "p", "P":
+		if d.activeTab == tabIssues && d.cursor < len(d.issues) && canPromoteIssue(d.issues[d.cursor]) {
+			issue := d.issues[d.cursor]
+			d.refreshing = true
+			d.shutdownMessage = fmt.Sprintf("Promoting issue #%d...", issue.Number)
+			return d, d.promoteIssue(issue.ID)
+		}
 	case "j", "down":
 		d.scrollDetailDown()
 	case "k", "up":
@@ -996,9 +1031,15 @@ func (d *Dashboard) renderHelp() string {
 		return helpStyle.Render("Stopping daemon...")
 	}
 	if d.showDetail {
+		if d.activeTab == tabIssues && d.cursor < len(d.issues) && canPromoteIssue(d.issues[d.cursor]) {
+			return helpStyle.Render("[esc]close  [p]romote  [j/k]scroll  [pgup/pgdn]page  [q]uit")
+		}
 		return helpStyle.Render("[esc]close  [j/k]scroll  [pgup/pgdn]page  [q]uit")
 	}
-	if d.activeTab == tabPRs || d.activeTab == tabIssues {
+	if d.activeTab == tabIssues {
+		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [p]romote  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
+	}
+	if d.activeTab == tabPRs {
 		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
 	}
 	return helpStyle.Render("[q]uit  [r]efresh  [s]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump  [G]follow")
@@ -1175,6 +1216,18 @@ func itemTypeStyle(itemType string) lipgloss.Style {
 		return lipgloss.NewStyle().Foreground(colorIssue)
 	default:
 		return lipgloss.NewStyle()
+	}
+}
+
+func canPromoteIssue(issue api.Issue) bool {
+	if issue.LatestReview == nil {
+		return false
+	}
+	switch issue.LatestReview.ActionTaken {
+	case "review_only", "refinement":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -335,7 +335,6 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		d.refreshing = false
 		if msg.err != nil {
 			d.err = msg.err
-			d.connected = false
 			d.shutdownMessage = fmt.Sprintf("Promotion failed: %v", msg.err)
 			return d, nil
 		}
@@ -448,11 +447,8 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			d.openDetail()
 		}
 	case "p", "P":
-		if d.activeTab == tabIssues && d.cursor < len(d.issues) && canPromoteIssue(d.issues[d.cursor]) {
-			issue := d.issues[d.cursor]
-			d.refreshing = true
-			d.shutdownMessage = fmt.Sprintf("Promoting issue #%d...", issue.Number)
-			return d, d.promoteIssue(issue.ID)
+		if cmd := d.promoteSelectedIssue(); cmd != nil {
+			return d, cmd
 		}
 	case "r":
 		d.refreshing = true
@@ -494,11 +490,8 @@ func (d *Dashboard) handleDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc", "enter":
 		d.showDetail = false
 	case "p", "P":
-		if d.activeTab == tabIssues && d.cursor < len(d.issues) && canPromoteIssue(d.issues[d.cursor]) {
-			issue := d.issues[d.cursor]
-			d.refreshing = true
-			d.shutdownMessage = fmt.Sprintf("Promoting issue #%d...", issue.Number)
-			return d, d.promoteIssue(issue.ID)
+		if cmd := d.promoteSelectedIssue(); cmd != nil {
+			return d, cmd
 		}
 	case "j", "down":
 		d.scrollDetailDown()
@@ -521,6 +514,19 @@ func (d *Dashboard) handleDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return d, nil
+}
+
+func (d *Dashboard) promoteSelectedIssue() tea.Cmd {
+	if d.activeTab != tabIssues || d.cursor >= len(d.issues) {
+		return nil
+	}
+	issue := d.issues[d.cursor]
+	if !canPromoteIssue(issue) {
+		return nil
+	}
+	d.refreshing = true
+	d.shutdownMessage = fmt.Sprintf("Promoting issue #%d...", issue.Number)
+	return d.promoteIssue(issue.ID)
 }
 
 func (d *Dashboard) openDetail() {

--- a/cli/internal/tui/logs.go
+++ b/cli/internal/tui/logs.go
@@ -126,6 +126,15 @@ func sseToLogLine(evt api.SSEEvent) logLine {
 		line.Badge = "ISSUE"
 		line.Action = "PROMOTED"
 		line.Status = logSuccess
+		from, _ := m["from_stage"].(string)
+		to, _ := m["to_stage"].(string)
+		if from == "" && to == "" {
+			from, _ = m["from_label"].(string)
+			to, _ = m["to_label"].(string)
+		}
+		if from != "" || to != "" {
+			line.Details = strings.TrimSpace(from + " -> " + to)
+		}
 
 	case "repo_discovered":
 		line.Badge = "REPO"

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -510,6 +510,7 @@ func main() {
 	publishPub := bus.NewPRPublishPublisher(conn)
 	issuePublisher := bus.NewIssuePublisher(conn)
 	issueFetcher.SetPublisher(issuePublisher)
+	issueFetcher.SetStageTransitioner(ghClient, broker)
 
 	// Shared rate limiter (was Pipeline.limiter).
 	limiter := scheduler.NewRateLimiter(4500)
@@ -819,7 +820,6 @@ func main() {
 				"repo", msg.Repo, "number", msg.Number, "err", err)
 			return
 		}
-		ghIssue.Mode = config.IssueModeReviewOnly
 
 		cfgMu.Lock()
 		c := *cfg
@@ -827,10 +827,16 @@ func main() {
 		if aiCfg.Primary == "" {
 			aiCfg.Primary = c.AI.Primary
 		}
+		repoIT := c.IssueTrackingForRepo(msg.Repo)
 		agentCfg := c.AgentConfigFor(aiCfg.Primary)
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
+		if !issueStageStillCurrent("triage-worker", ghIssue, repoIT, config.IssueModeReviewOnly) {
+			return
+		}
+		ghIssue.Mode = config.IssueModeReviewOnly
+
 		repoHandle, err := acquireRepoContext(ctx, repoCtx, msg.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
 		if err != nil {
 			logRepoContextFallback("triage-worker", msg.Repo, err)
@@ -881,9 +887,12 @@ func main() {
 			GeneratePRDescription:   aiCfg.GeneratePRDescription != nil && *aiCfg.GeneratePRDescription,
 		}
 
-		if _, err := issuePipe.Run(ctx, ghIssue, opts); err != nil {
+		rev, err := issuePipe.Run(ctx, ghIssue, opts)
+		if err != nil {
 			slog.Error("triage-worker: pipeline run failed",
 				"repo", msg.Repo, "number", msg.Number, "err", err)
+		} else if rev != nil && rev.ActionTaken == string(config.IssueModeReviewOnly) {
+			autoPromoteAfterStage(ctx, ghClient, broker, ghIssue, rev.IssueID, repoIT, aiCfg, issuepipeline.IssueStageTriage, "triage-worker")
 		}
 
 		// Enroll for state watching so closed/resolved issues update in the UI.
@@ -915,7 +924,6 @@ func main() {
 				"repo", msg.Repo, "number", msg.Number, "err", err)
 			return
 		}
-		ghIssue.Mode = config.IssueModeRefinement
 
 		cfgMu.Lock()
 		c := *cfg
@@ -923,10 +931,16 @@ func main() {
 		if aiCfg.Primary == "" {
 			aiCfg.Primary = c.AI.Primary
 		}
+		repoIT := c.IssueTrackingForRepo(msg.Repo)
 		agentCfg := c.AgentConfigFor(aiCfg.Primary)
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
+		if !issueStageStillCurrent("refinement-worker", ghIssue, repoIT, config.IssueModeRefinement) {
+			return
+		}
+		ghIssue.Mode = config.IssueModeRefinement
+
 		opts, releaseRepoContext, err := buildRefinementRunOptions(ctx, s, repoCtx, msg.Repo, token, aiCfg, agentCfg, localDirBase, globalTimeout, false, "refinement-worker")
 		if err != nil {
 			slog.Error("refinement-worker: prepare repo context failed",
@@ -943,9 +957,12 @@ func main() {
 			defer releaseRepoContext()
 		}
 
-		if _, err := issuePipe.Run(ctx, ghIssue, opts); err != nil {
+		rev, err := issuePipe.Run(ctx, ghIssue, opts)
+		if err != nil {
 			slog.Error("refinement-worker: pipeline run failed",
 				"repo", msg.Repo, "number", msg.Number, "err", err)
+		} else if rev != nil && rev.ActionTaken == string(config.IssueModeRefinement) {
+			autoPromoteAfterStage(ctx, ghClient, broker, ghIssue, rev.IssueID, repoIT, aiCfg, issuepipeline.IssueStageRefinement, "refinement-worker")
 		}
 
 		// Enroll for state watching so closed/resolved issues update in the UI.
@@ -976,7 +993,6 @@ func main() {
 				"repo", msg.Repo, "number", msg.Number, "err", err)
 			return
 		}
-		ghIssue.Mode = config.IssueModeDevelop
 
 		cfgMu.Lock()
 		c := *cfg
@@ -984,10 +1000,16 @@ func main() {
 		if aiCfg.Primary == "" {
 			aiCfg.Primary = c.AI.Primary
 		}
+		repoIT := c.IssueTrackingForRepo(msg.Repo)
 		agentCfg := c.AgentConfigFor(aiCfg.Primary)
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
+		if !issueStageStillCurrent("implement-worker", ghIssue, repoIT, config.IssueModeDevelop) {
+			return
+		}
+		ghIssue.Mode = config.IssueModeDevelop
+
 		repoHandle, err := acquireRepoContext(ctx, repoCtx, msg.Repo, &aiCfg, localDirBase, token, repoctx.ModeWrite)
 		if err != nil {
 			slog.Error("implement-worker: prepare repo context failed",
@@ -1697,9 +1719,12 @@ func main() {
 		return nil
 	})
 
-	// Wire the promote callback: runs the auto_implement pipeline for a review_only issue,
-	// effectively reclassifying it to develop from the UI without needing a GitHub label change.
+	// Wire the promote callback. Promotion only changes GitHub stage labels and
+	// records an audit comment; the next poll executes the newly-visible stage.
 	srv.SetTriggerPromoteFn(func(issueID int64) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
 		publishIssueErr := func(msg string) {
 			broker.Publish(sse.Event{
 				Type: sse.EventIssueReviewError,
@@ -1713,39 +1738,57 @@ func main() {
 			return fmt.Errorf("promote issue: get issue %d: %w", issueID, err)
 		}
 
-		// Read the repo-scoped issue tracking config to know which labels to
-		// add/remove. Org-level labels must behave the same as repo-level
-		// labels here, otherwise manual promotion would silently use globals.
+		ghIssue, err := ghClient.GetIssue(iss.Repo, iss.Number)
+		if err != nil {
+			publishIssueErr(fmt.Sprintf("Failed to fetch issue from GitHub: %v", err))
+			return fmt.Errorf("promote issue: fetch GitHub issue %s #%d: %w", iss.Repo, iss.Number, err)
+		}
+
 		cfgMu.Lock()
 		it := cfg.IssueTrackingForRepo(iss.Repo)
 		cfgMu.Unlock()
 
-		if len(it.DevelopLabels) == 0 {
-			publishIssueErr("No develop labels configured — cannot promote")
-			return fmt.Errorf("promote issue: no develop labels configured")
+		mode := it.Classify(ghIssue.LabelNames())
+		from, ok := issuepipeline.StageFromMode(mode)
+		if !ok {
+			msg := fmt.Sprintf("Issue is in %q mode and cannot be promoted", mode)
+			publishIssueErr(msg)
+			return fmt.Errorf("%w: %s", server.ErrPromoteConflict, msg)
 		}
-
-		slog.Info("promote issue: updating labels on GitHub",
-			"store_issue_id", issueID, "repo", iss.Repo, "number", iss.Number,
-			"add", it.DevelopLabels[0], "remove", it.ReviewOnlyLabels)
-
-		// Add the first develop label so the polling pipeline classifies as DEV.
-		if err := ghClient.AddIssueLabel(iss.Repo, iss.Number, it.DevelopLabels[0]); err != nil {
-			publishIssueErr(fmt.Sprintf("Failed to add develop label: %v", err))
-			return fmt.Errorf("promote issue: add label: %w", err)
-		}
-
-		// Remove review_only labels so classification is unambiguous.
-		for _, label := range it.ReviewOnlyLabels {
-			if err := ghClient.RemoveIssueLabel(iss.Repo, iss.Number, label); err != nil {
-				slog.Warn("promote issue: could not remove review_only label",
-					"label", label, "repo", iss.Repo, "number", iss.Number, "err", err)
-				// Non-fatal — the develop label is already set, classification will still prefer DEV.
+		to, err := issuepipeline.NextStage(from, it, true)
+		if err != nil {
+			publishIssueErr(fmt.Sprintf("Cannot promote issue: %v", err))
+			if errors.Is(err, issuepipeline.ErrStageTargetLabelMissing) || errors.Is(err, issuepipeline.ErrNoNextStage) {
+				return fmt.Errorf("%w: %v", server.ErrPromoteConflict, err)
 			}
+			return fmt.Errorf("promote issue: resolve next stage: %w", err)
 		}
 
-		slog.Info("promote issue: labels updated, polling will pick it up as DEV",
-			"store_issue_id", issueID, "repo", iss.Repo, "number", iss.Number)
+		comments, commentErr := ghClient.FetchIssueCommentsOnly(iss.Repo, iss.Number)
+		if commentErr != nil {
+			slog.Warn("promote issue: comment fetch failed, continuing without audit dedup context",
+				"repo", iss.Repo, "number", iss.Number, "err", commentErr)
+		}
+
+		slog.Info("promote issue: moving issue stage labels",
+			"store_issue_id", issueID, "repo", iss.Repo, "number", iss.Number, "from", from, "to", to)
+		if err := issuepipeline.TransitionIssueStage(ctx, ghClient, issuepipeline.StageTransition{
+			Issue:          ghIssue,
+			StoreIssueID:   issueID,
+			Config:         it,
+			From:           from,
+			To:             to,
+			Trigger:        issuepipeline.StagePromotionManualAPI,
+			Time:           time.Now().UTC(),
+			RecentComments: comments,
+			Broker:         broker,
+		}); err != nil {
+			publishIssueErr(fmt.Sprintf("Failed to promote issue: %v", err))
+			return fmt.Errorf("promote issue: transition stage: %w", err)
+		}
+
+		slog.Info("promote issue: labels updated; poll will execute the next stage",
+			"store_issue_id", issueID, "repo", iss.Repo, "number", iss.Number, "from", from, "to", to)
 		return nil
 	})
 
@@ -3323,6 +3366,88 @@ func sseData(v map[string]any) string {
 		return "{}"
 	}
 	return string(b)
+}
+
+func issueStageStillCurrent(scope string, issue *gh.Issue, it config.IssueTrackingConfig, want config.IssueMode) bool {
+	if issue == nil {
+		return false
+	}
+	if !it.Enabled {
+		slog.Info(scope+": issue tracking disabled before worker run, skipping stale job",
+			"repo", issue.Repo, "number", issue.Number)
+		return false
+	}
+	got := it.Classify(issue.LabelNames())
+	if got == want {
+		return true
+	}
+	slog.Info(scope+": issue stage changed before worker run, skipping stale job",
+		"repo", issue.Repo, "number", issue.Number, "want", want, "got", got, "labels", issue.LabelNames())
+	return false
+}
+
+func autoPromoteAfterStage(
+	ctx context.Context,
+	client *gh.Client,
+	broker issuepipeline.Publisher,
+	issue *gh.Issue,
+	storeIssueID int64,
+	it config.IssueTrackingConfig,
+	aiCfg config.RepoAI,
+	from issuepipeline.IssueStage,
+	scope string,
+) {
+	if !autoPromoteStageEnabled(aiCfg, from) {
+		return
+	}
+	to, err := issuepipeline.NextStage(from, it, false)
+	if err != nil {
+		if errors.Is(err, issuepipeline.ErrStageTargetLabelMissing) {
+			slog.Warn(scope+": auto-promote target label missing; leaving issue in current stage",
+				"repo", issue.Repo, "number", issue.Number, "from", from, "err", err)
+			return
+		}
+		slog.Warn(scope+": auto-promote skipped",
+			"repo", issue.Repo, "number", issue.Number, "from", from, "err", err)
+		return
+	}
+
+	comments, err := client.FetchIssueCommentsOnly(issue.Repo, issue.Number)
+	if err != nil {
+		slog.Warn(scope+": auto-promote comment fetch failed, continuing without audit dedup context",
+			"repo", issue.Repo, "number", issue.Number, "err", err)
+	}
+	if err := issuepipeline.TransitionIssueStage(ctx, client, issuepipeline.StageTransition{
+		Issue:          issue,
+		StoreIssueID:   storeIssueID,
+		Config:         it,
+		From:           from,
+		To:             to,
+		Trigger:        issuepipeline.StagePromotionAuto,
+		Time:           time.Now().UTC(),
+		RecentComments: comments,
+		Broker:         broker,
+	}); err != nil {
+		slog.Warn(scope+": auto-promote failed",
+			"repo", issue.Repo, "number", issue.Number, "from", from, "to", to, "err", err)
+	}
+}
+
+func autoPromoteStageEnabled(aiCfg config.RepoAI, stage issuepipeline.IssueStage) bool {
+	switch stage {
+	case issuepipeline.IssueStageTriage:
+		if aiCfg.AutoPromoteTriage == nil {
+			return true
+		}
+		return *aiCfg.AutoPromoteTriage
+	case issuepipeline.IssueStageRefinement:
+		if aiCfg.AutoPromoteRefinement == nil {
+			return false
+		}
+		return *aiCfg.AutoPromoteRefinement
+	default:
+		return false
+	}
 }
 
 func acquireRepoContext(

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -3377,6 +3377,10 @@ func issueStageStillCurrent(scope string, issue *gh.Issue, it config.IssueTracki
 			"repo", issue.Repo, "number", issue.Number)
 		return false
 	}
+	// Best-effort stale-job guard: workers fetch the issue immediately before
+	// this check, so queued jobs whose labels changed since dispatch skip
+	// before running AI. A label edit after this fetch is handled by the next
+	// poll rather than adding another GitHub round-trip here.
 	got := it.Classify(issue.LabelNames())
 	if got == want {
 		return true
@@ -3397,7 +3401,7 @@ func autoPromoteAfterStage(
 	from issuepipeline.IssueStage,
 	scope string,
 ) {
-	if !autoPromoteStageEnabled(aiCfg, from) {
+	if !autoPromoteStageEnabled(aiCfg, it, from) {
 		return
 	}
 	to, err := issuepipeline.NextStage(from, it, false)
@@ -3433,11 +3437,14 @@ func autoPromoteAfterStage(
 	}
 }
 
-func autoPromoteStageEnabled(aiCfg config.RepoAI, stage issuepipeline.IssueStage) bool {
+func autoPromoteStageEnabled(aiCfg config.RepoAI, it config.IssueTrackingConfig, stage issuepipeline.IssueStage) bool {
 	switch stage {
 	case issuepipeline.IssueStageTriage:
 		if aiCfg.AutoPromoteTriage == nil {
-			return true
+			// Default-on only after the operator has configured a refinement
+			// target. Legacy review_only-only deployments keep their prior
+			// behavior instead of gaining autonomous label transitions.
+			return hasConfiguredLabel(it.RefinementLabels)
 		}
 		return *aiCfg.AutoPromoteTriage
 	case issuepipeline.IssueStageRefinement:
@@ -3448,6 +3455,15 @@ func autoPromoteStageEnabled(aiCfg config.RepoAI, stage issuepipeline.IssueStage
 	default:
 		return false
 	}
+}
+
+func hasConfiguredLabel(labels []string) bool {
+	for _, label := range labels {
+		if strings.TrimSpace(label) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func acquireRepoContext(

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/heimdallm/daemon/internal/bus"
 	"github.com/heimdallm/daemon/internal/config"
 	gh "github.com/heimdallm/daemon/internal/github"
+	issuepipeline "github.com/heimdallm/daemon/internal/issues"
 	"github.com/heimdallm/daemon/internal/repoctx"
 	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
@@ -41,6 +42,25 @@ func TestAcquireRepoContextNilManagerIsError(t *testing.T) {
 	_, err := acquireRepoContext(context.Background(), nil, "org/repo", &aiCfg, nil, "secret", repoctx.ModeRead)
 	if err == nil || !strings.Contains(err.Error(), "nil manager") {
 		t.Fatalf("err = %v, want nil manager error", err)
+	}
+}
+
+func TestAutoPromoteTriageSmartDefaultRequiresRefinementLabel(t *testing.T) {
+	aiCfg := config.RepoAI{}
+	it := config.IssueTrackingConfig{}
+	if autoPromoteStageEnabled(aiCfg, it, issuepipeline.IssueStageTriage) {
+		t.Fatal("unset auto_promote_triage without refinement labels should preserve legacy manual behavior")
+	}
+
+	it.RefinementLabels = []string{"heimdallm-refine"}
+	if !autoPromoteStageEnabled(aiCfg, it, issuepipeline.IssueStageTriage) {
+		t.Fatal("unset auto_promote_triage with refinement labels should adopt the staged default")
+	}
+
+	disabled := false
+	aiCfg.AutoPromoteTriage = &disabled
+	if autoPromoteStageEnabled(aiCfg, it, issuepipeline.IssueStageTriage) {
+		t.Fatal("explicit auto_promote_triage=false should win over refinement labels")
 	}
 }
 

--- a/daemon/internal/activity/recorder.go
+++ b/daemon/internal/activity/recorder.go
@@ -271,15 +271,22 @@ func (r *Recorder) recordIssuePromoted(ev sse.Event) error {
 		from = p.FromStage
 		to = p.ToStage
 	}
+	details := map[string]any{}
+	if p.FromStage != "" || p.ToStage != "" {
+		details["from_stage"] = p.FromStage
+		details["to_stage"] = p.ToStage
+	} else {
+		details["from_label"] = p.FromLabel
+		details["to_label"] = p.ToLabel
+	}
+	if p.Trigger != "" {
+		details["trigger"] = p.Trigger
+	}
+	if p.Reason != "" {
+		details["reason"] = p.Reason
+	}
 	_, err := r.store.InsertActivity(time.Now(), orgOf(p.Repo), p.Repo, "issue",
 		p.IssueNumber, p.IssueTitle, "promote",
-		from+" → "+to, map[string]any{
-			"from_label": p.FromLabel,
-			"to_label":   p.ToLabel,
-			"from_stage": p.FromStage,
-			"to_stage":   p.ToStage,
-			"trigger":    p.Trigger,
-			"reason":     p.Reason,
-		})
+		from+" → "+to, details)
 	return err
 }

--- a/daemon/internal/activity/recorder.go
+++ b/daemon/internal/activity/recorder.go
@@ -257,16 +257,28 @@ func (r *Recorder) recordIssuePromoted(ev sse.Event) error {
 		IssueTitle  string `json:"issue_title"`
 		FromLabel   string `json:"from_label"`
 		ToLabel     string `json:"to_label"`
+		FromStage   string `json:"from_stage"`
+		ToStage     string `json:"to_stage"`
+		Trigger     string `json:"trigger"`
 		Reason      string `json:"reason"`
 	}
 	if err := decode(ev.Data, &p); err != nil {
 		return err
 	}
+	from := p.FromLabel
+	to := p.ToLabel
+	if p.FromStage != "" || p.ToStage != "" {
+		from = p.FromStage
+		to = p.ToStage
+	}
 	_, err := r.store.InsertActivity(time.Now(), orgOf(p.Repo), p.Repo, "issue",
 		p.IssueNumber, p.IssueTitle, "promote",
-		p.FromLabel+" → "+p.ToLabel, map[string]any{
+		from+" → "+to, map[string]any{
 			"from_label": p.FromLabel,
 			"to_label":   p.ToLabel,
+			"from_stage": p.FromStage,
+			"to_stage":   p.ToStage,
+			"trigger":    p.Trigger,
 			"reason":     p.Reason,
 		})
 	return err

--- a/daemon/internal/activity/recorder_test.go
+++ b/daemon/internal/activity/recorder_test.go
@@ -290,6 +290,35 @@ func TestRecorder_IssueStagePromoted(t *testing.T) {
 	if got.details["trigger"] != "manual API" {
 		t.Errorf("details: %+v", got.details)
 	}
+	if _, ok := got.details["from_label"]; ok {
+		t.Errorf("stage event should not persist empty legacy label details: %+v", got.details)
+	}
+}
+
+func TestRecorder_IssueStagePromotedPrefersStageDetailsOverLegacyLabels(t *testing.T) {
+	_, fs, events := newTestRecorder(t)
+	payload, _ := json.Marshal(map[string]any{
+		"repo":         "acme/api",
+		"issue_number": 44,
+		"issue_title":  "Plan implementation",
+		"from_label":   "blocked",
+		"to_label":     "ready",
+		"from_stage":   "triage",
+		"to_stage":     "refinement",
+	})
+	events <- sse.Event{Type: sse.EventIssuePromoted, Data: string(payload)}
+	waitFor(t, func() bool { return fs.count() == 1 })
+
+	got := fs.at(0)
+	if got.outcome != "triage → refinement" {
+		t.Errorf("outcome: %s", got.outcome)
+	}
+	if got.details["from_stage"] != "triage" || got.details["to_stage"] != "refinement" {
+		t.Errorf("stage details: %+v", got.details)
+	}
+	if _, ok := got.details["from_label"]; ok {
+		t.Errorf("stage event should omit legacy label details even when payload has them: %+v", got.details)
+	}
 }
 
 func TestRecorder_UnknownEventIsIgnored(t *testing.T) {

--- a/daemon/internal/activity/recorder_test.go
+++ b/daemon/internal/activity/recorder_test.go
@@ -270,6 +270,28 @@ func TestRecorder_IssuePromoted(t *testing.T) {
 	}
 }
 
+func TestRecorder_IssueStagePromoted(t *testing.T) {
+	_, fs, events := newTestRecorder(t)
+	payload, _ := json.Marshal(map[string]any{
+		"repo":         "acme/api",
+		"issue_number": 43,
+		"issue_title":  "Plan implementation",
+		"from_stage":   "triage",
+		"to_stage":     "refinement",
+		"trigger":      "manual API",
+	})
+	events <- sse.Event{Type: sse.EventIssuePromoted, Data: string(payload)}
+	waitFor(t, func() bool { return fs.count() == 1 })
+
+	got := fs.at(0)
+	if got.action != "promote" || got.outcome != "triage → refinement" {
+		t.Errorf("action/outcome: %s/%s", got.action, got.outcome)
+	}
+	if got.details["trigger"] != "manual API" {
+		t.Errorf("details: %+v", got.details)
+	}
+}
+
 func TestRecorder_UnknownEventIsIgnored(t *testing.T) {
 	_, fs, events := newTestRecorder(t)
 	events <- sse.Event{Type: "review_started", Data: "{}"}

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -121,14 +121,12 @@ const (
 //
 // Classification precedence (applied in Classify):
 //
-//	skip_labels  >  blocked_labels  >  develop_labels  >  refinement_labels  >  review_only_labels  >  default_action
+//	skip_labels  >  blocked_labels  >  review_only_labels  >  refinement_labels  >  develop_labels  >  default_action
 //
-// develop_labels intentionally takes precedence over review_only_labels: when
-// an issue carries both a "please implement" label and a "please review only"
-// label, the operator intent is auto_implement (the stronger action). This
-// prevents misclassification as IT (review_only) when labels overlap, which
-// would otherwise cause an infinite retry loop if the daemon later tried to
-// auto-implement an issue that was already classified as IT. See issue #223.
+// The stage labels intentionally prefer the earliest configured state. If an
+// issue is temporarily double-labelled during a transition, triage wins over
+// refinement, and refinement wins over development, so Heimdallm never skips
+// ahead silently.
 type IssueTrackingConfig struct {
 	Enabled bool `toml:"enabled" json:"enabled"`
 
@@ -149,15 +147,12 @@ type IssueTrackingConfig struct {
 	DevelopLabels []string `toml:"develop_labels" json:"develop_labels"`
 
 	// RefinementLabels are labels that mark an issue as "deeply investigate
-	// and produce an implementation plan". This is the v1 trigger for the
-	// refinement stage; automatic triage -> refinement promotion is owned by
-	// the issue state machine work.
+	// and produce an implementation plan". This is the trigger for the
+	// refinement stage and the target for triage -> refinement promotion.
 	RefinementLabels []string `toml:"refinement_labels" json:"refinement_labels"`
 
 	// ReviewOnlyLabels are labels that mark an issue as "please analyse and
-	// comment only". DevelopLabels take precedence over ReviewOnlyLabels when
-	// both are present on the same issue — the operator explicitly tagged it
-	// for implementation, which is the stronger intent. See issue #223.
+	// comment only". In the issue state machine this is the triage stage.
 	ReviewOnlyLabels []string `toml:"review_only_labels" json:"review_only_labels"`
 
 	// SkipLabels are labels that opt an issue out of processing entirely.
@@ -230,10 +225,10 @@ func (c IssueTrackingConfig) ResolvePromoteToLabel() string {
 // underlying labels API is case-preserving but the UI is not, so users
 // routinely mix "Bug" and "bug" in practice.
 //
-// Precedence: skip > blocked > develop > refinement > review_only > default_action.
-// develop beats review_only so that an issue tagged with both a DEV label and
-// an IT label is always auto-implemented, never silently downgraded to
-// review_only. This prevents the infinite retry loop described in issue #223.
+// Precedence: skip > blocked > review_only > refinement > develop > default_action.
+// The stage order follows the state machine: triage (review_only) comes before
+// refinement, which comes before development. This keeps messy multi-label
+// states recoverable by choosing the earliest stage instead of jumping ahead.
 func (c IssueTrackingConfig) Classify(labels []string) IssueMode {
 	set := make(map[string]struct{}, len(labels))
 	for _, l := range labels {
@@ -245,16 +240,14 @@ func (c IssueTrackingConfig) Classify(labels []string) IssueMode {
 	if labelSetIntersects(set, c.BlockedLabels) {
 		return IssueModeBlocked
 	}
-	// develop takes precedence over review_only: when both are present the
-	// operator wants auto_implement (the stronger action). See issue #223.
-	if labelSetIntersects(set, c.DevelopLabels) {
-		return IssueModeDevelop
+	if labelSetIntersects(set, c.ReviewOnlyLabels) {
+		return IssueModeReviewOnly
 	}
 	if labelSetIntersects(set, c.RefinementLabels) {
 		return IssueModeRefinement
 	}
-	if labelSetIntersects(set, c.ReviewOnlyLabels) {
-		return IssueModeReviewOnly
+	if labelSetIntersects(set, c.DevelopLabels) {
+		return IssueModeDevelop
 	}
 	switch strings.ToLower(c.DefaultAction) {
 	case "review_only":

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -683,11 +683,9 @@ func TestClassify_Precedence(t *testing.T) {
 		want   IssueMode
 	}{
 		{"skip wins over review_only + develop", []string{"wontfix", "question", "bug"}, IssueModeIgnore},
-		// develop beats review_only when both are present (#223): the operator
-		// tagged with a DEV label, so auto_implement is the intended action.
-		{"develop wins over review_only when both present", []string{"question", "bug"}, IssueModeDevelop},
-		{"develop wins over refinement when both present", []string{"refine", "bug"}, IssueModeDevelop},
-		{"refinement wins over review_only when both present", []string{"refine", "question"}, IssueModeRefinement},
+		{"review_only wins over refinement + develop", []string{"question", "refine", "bug"}, IssueModeReviewOnly},
+		{"review_only wins over develop when both present", []string{"question", "bug"}, IssueModeReviewOnly},
+		{"refinement wins over develop when both present", []string{"refine", "bug"}, IssueModeRefinement},
 		{"develop only", []string{"bug"}, IssueModeDevelop},
 		{"refinement only", []string{"refine"}, IssueModeRefinement},
 		{"review_only only", []string{"question"}, IssueModeReviewOnly},
@@ -704,10 +702,10 @@ func TestClassify_Precedence(t *testing.T) {
 }
 
 func TestClassify_BlockedPrecedence(t *testing.T) {
-	// Precedence must be: skip > blocked > develop > refinement > review_only > default.
+	// Precedence must be: skip > blocked > review_only > refinement > develop > default.
 	// Blocked slots in between skip (don't touch it) and develop/review_only
 	// (blocked is cheaper than any processing — we haven't even confirmed we
-	// want to run it yet). develop beats review_only per issue #223.
+	// want to run it yet). Stage labels then prefer the earliest state.
 	cfg := IssueTrackingConfig{
 		SkipLabels:       []string{"wontfix"},
 		BlockedLabels:    []string{"blocked"},
@@ -726,8 +724,7 @@ func TestClassify_BlockedPrecedence(t *testing.T) {
 		{"blocked wins over refinement", []string{"blocked", "refine"}, IssueModeBlocked},
 		{"blocked wins over develop", []string{"blocked", "bug"}, IssueModeBlocked},
 		{"blocked alone", []string{"blocked"}, IssueModeBlocked},
-		// develop beats review_only when both present (#223)
-		{"develop wins over review_only without blocked", []string{"question", "bug"}, IssueModeDevelop},
+		{"review_only wins over develop without blocked", []string{"question", "bug"}, IssueModeReviewOnly},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/daemon/internal/github/fetch_issues.go
+++ b/daemon/internal/github/fetch_issues.go
@@ -48,9 +48,8 @@ const maxIssuePages = 10
 //     dimension is "active" only when its configured list is non-empty.
 //
 //  4. Sorts: issues assigned to authenticatedUser first, then the rest;
-//     within each group review_only before develop (review is cheap, develop
-//     is expensive, so it clears the queue faster); within each mode oldest
-//     first so long-pending issues move forward.
+//     within each group triage (review_only) before refinement before develop;
+//     within each mode oldest first so long-pending issues move forward.
 //
 // The store-level "skip already processed without new activity" check is
 // intentionally not here — it needs the local store and belongs to the
@@ -259,11 +258,23 @@ func sortIssuesByPriority(issues []*Issue, authenticatedUser string) {
 		if am != bm {
 			return am // mine first
 		}
-		aDev := a.Mode == config.IssueModeDevelop
-		bDev := b.Mode == config.IssueModeDevelop
-		if aDev != bDev {
-			return !aDev // review_only (develop=false) first
+		ar, br := issueModeRank(a.Mode), issueModeRank(b.Mode)
+		if ar != br {
+			return ar < br
 		}
 		return a.CreatedAt.Before(b.CreatedAt) // older first
 	})
+}
+
+func issueModeRank(mode config.IssueMode) int {
+	switch mode {
+	case config.IssueModeReviewOnly:
+		return 0
+	case config.IssueModeRefinement:
+		return 1
+	case config.IssueModeDevelop:
+		return 2
+	default:
+		return 3
+	}
 }

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -94,6 +94,9 @@ type Fetcher struct {
 	pipeline  PipelineRunner
 	publisher IssuePublisher // optional — when set, publishes to NATS instead of running pipeline
 	botLogin  string         // GitHub login of the bot — used to ignore self-triggered updated_at bumps
+
+	stageClient StageTransitionClient
+	stageBroker Publisher
 }
 
 // NewFetcher wires the orchestrator. All dependencies are interfaces so
@@ -115,6 +118,14 @@ func (f *Fetcher) SetPublisher(p IssuePublisher) {
 // breaking the re-triage loop described in #362.
 func (f *Fetcher) SetBotLogin(login string) {
 	f.botLogin = login
+}
+
+// SetStageTransitioner enables audit + normalization when a user manually
+// changes stage labels on GitHub. The next poll sees the new classification,
+// records the transition, and then dispatches the new stage normally.
+func (f *Fetcher) SetStageTransitioner(client StageTransitionClient, broker Publisher) {
+	f.stageClient = client
+	f.stageBroker = broker
 }
 
 // ProcessRepo fetches every eligible issue for one repo and dispatches it to
@@ -160,6 +171,10 @@ func (f *Fetcher) ProcessRepo(ctx context.Context, repo string, cfg config.Issue
 			slog.Debug("issues fetcher: skipping issue",
 				"repo", repo, "number", issue.Number, "reason", reason)
 			continue
+		}
+		if err := f.auditManualStageChange(ctx, issue, cfg); err != nil {
+			slog.Warn("issues fetcher: manual stage transition audit failed",
+				"repo", repo, "number", issue.Number, "err", err)
 		}
 
 		if f.publisher != nil {
@@ -296,4 +311,55 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 		return true, "no new activity since last review", nil
 	}
 	return false, "", nil
+}
+
+func (f *Fetcher) auditManualStageChange(ctx context.Context, issue *github.Issue, cfg config.IssueTrackingConfig) error {
+	if f.stageClient == nil || issue == nil {
+		return nil
+	}
+	to, ok := StageFromMode(issue.Mode)
+	if !ok {
+		return nil
+	}
+	row, err := f.store.GetIssueByGithubID(issue.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+	latest, err := f.store.LatestIssueReview(row.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+	from, ok := StageFromAction(latest.ActionTaken)
+	if !ok || from == to {
+		return nil
+	}
+
+	var comments []github.Comment
+	if f.comments != nil {
+		got, err := f.comments.FetchIssueCommentsOnly(issue.Repo, issue.Number)
+		if err != nil {
+			slog.Warn("issues fetcher: manual stage audit comment fetch failed, continuing without dedup context",
+				"repo", issue.Repo, "number", issue.Number, "err", err)
+		} else {
+			comments = got
+		}
+	}
+
+	return TransitionIssueStage(ctx, f.stageClient, StageTransition{
+		Issue:          issue,
+		StoreIssueID:   row.ID,
+		Config:         cfg,
+		From:           from,
+		To:             to,
+		Trigger:        StagePromotionManualGitHub,
+		Time:           time.Now().UTC(),
+		RecentComments: comments,
+		Broker:         f.stageBroker,
+	})
 }

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,6 +107,33 @@ type fakeIssuePublisher struct {
 	triage     []int
 	refinement []int
 	implement  []int
+}
+
+type fakeStageTransitionClient struct {
+	created  []string
+	added    []string
+	removed  []string
+	comments []string
+}
+
+func (f *fakeStageTransitionClient) CreateLabel(repo, name, color, description string) error {
+	f.created = append(f.created, name)
+	return nil
+}
+
+func (f *fakeStageTransitionClient) AddLabels(repo string, number int, labels []string) error {
+	f.added = append(f.added, strings.Join(labels, ","))
+	return nil
+}
+
+func (f *fakeStageTransitionClient) RemoveLabels(repo string, number int, labels []string) error {
+	f.removed = append(f.removed, strings.Join(labels, ","))
+	return nil
+}
+
+func (f *fakeStageTransitionClient) PostComment(repo string, number int, body string) (time.Time, error) {
+	f.comments = append(f.comments, body)
+	return time.Now().UTC(), nil
 }
 
 func (f *fakeIssuePublisher) PublishIssueTriage(ctx context.Context, repo string, number int, githubID int64) error {
@@ -641,6 +669,56 @@ func TestFetcher_ModeChangeBypassesBotCommentCheck(t *testing.T) {
 	}
 	if processed != 1 {
 		t.Errorf("mode change should bypass bot-comment check, got processed=%d", processed)
+	}
+}
+
+func TestFetcher_ManualStageLabelChangeAuditsAndDispatchesNewStage(t *testing.T) {
+	now := time.Now()
+	issue := &github.Issue{
+		ID:        int64(1002),
+		Number:    2,
+		Repo:      "org/repo",
+		Title:     "Needs plan",
+		UpdatedAt: now,
+		Mode:      config.IssueModeRefinement,
+	}
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row: &store.Issue{ID: 11, GithubID: issue.ID},
+			review: &store.IssueReview{
+				IssueID:     11,
+				CommentedAt: now.Add(-2 * time.Minute),
+				ActionTaken: string(config.IssueModeReviewOnly),
+			},
+		},
+	}}
+	mf := &fakeMarkerFetcher{commentsByKey: map[string][]github.Comment{"org/repo#2": {}}}
+	pub := &fakeIssuePublisher{}
+	stage := &fakeStageTransitionClient{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, &fakePipeline{})
+	f.SetPublisher(pub)
+	f.SetStageTransitioner(stage, nil)
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", config.IssueTrackingConfig{
+		Enabled:          true,
+		ReviewOnlyLabels: []string{"triage"},
+		RefinementLabels: []string{"refine"},
+		DevelopLabels:    []string{"develop"},
+	}, "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 1 || len(pub.refinement) != 1 || pub.refinement[0] != 2 {
+		t.Fatalf("expected refinement dispatch, processed=%d pub=%v", processed, pub.refinement)
+	}
+	if len(stage.added) != 1 || stage.added[0] != "refine" {
+		t.Fatalf("stage added = %v, want [refine]", stage.added)
+	}
+	if len(stage.removed) != 1 || stage.removed[0] != "triage,develop" {
+		t.Fatalf("stage removed = %v, want [triage,develop]", stage.removed)
+	}
+	if len(stage.comments) != 1 || !strings.Contains(stage.comments[0], "manual GitHub label change") {
+		t.Fatalf("stage audit comment = %q, want manual GitHub trigger", stage.comments)
 	}
 }
 

--- a/daemon/internal/issues/stage_transition.go
+++ b/daemon/internal/issues/stage_transition.go
@@ -1,0 +1,303 @@
+package issues
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/sse"
+)
+
+type IssueStage string
+
+const (
+	IssueStageTriage      IssueStage = "triage"
+	IssueStageRefinement  IssueStage = "refinement"
+	IssueStageDevelopment IssueStage = "development"
+)
+
+type StagePromotionTrigger string
+
+const (
+	StagePromotionManualAPI    StagePromotionTrigger = "manual API"
+	StagePromotionManualGitHub StagePromotionTrigger = "manual GitHub label change"
+	StagePromotionAuto         StagePromotionTrigger = "auto-promote"
+)
+
+const (
+	stagePromotionHeading = "🤖 **Heimdallm stage promotion**"
+	stagePromotionWindow  = 2 * time.Minute
+)
+
+var (
+	ErrStageTargetLabelMissing = errors.New("stage target label missing")
+	ErrNoNextStage             = errors.New("issue has no next stage")
+)
+
+// StageTransitionClient is the GitHub surface needed to move an issue between
+// issue pipeline stages. It is intentionally separate from the dependency
+// promoter's client: stage promotion has a different contract and label order.
+type StageTransitionClient interface {
+	AddLabels(repo string, number int, labels []string) error
+	RemoveLabels(repo string, number int, labels []string) error
+	CreateLabel(repo, name, color, description string) error
+	PostComment(repo string, number int, body string) (time.Time, error)
+}
+
+type StageTransition struct {
+	Issue          *github.Issue
+	StoreIssueID   int64
+	Config         config.IssueTrackingConfig
+	From           IssueStage
+	To             IssueStage
+	Trigger        StagePromotionTrigger
+	Time           time.Time
+	RecentComments []github.Comment
+	Broker         Publisher
+}
+
+func StageFromMode(mode config.IssueMode) (IssueStage, bool) {
+	switch mode {
+	case config.IssueModeReviewOnly:
+		return IssueStageTriage, true
+	case config.IssueModeRefinement:
+		return IssueStageRefinement, true
+	case config.IssueModeDevelop:
+		return IssueStageDevelopment, true
+	default:
+		return "", false
+	}
+}
+
+func StageFromAction(action string) (IssueStage, bool) {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case string(config.IssueModeReviewOnly), "triage":
+		return IssueStageTriage, true
+	case string(config.IssueModeRefinement):
+		return IssueStageRefinement, true
+	case string(config.IssueModeDevelop), "auto_implement":
+		return IssueStageDevelopment, true
+	default:
+		return "", false
+	}
+}
+
+func NextStage(stage IssueStage, cfg config.IssueTrackingConfig, allowLegacyDevelopment bool) (IssueStage, error) {
+	switch stage {
+	case IssueStageTriage:
+		if firstNonBlank(cfg.RefinementLabels) != "" {
+			return IssueStageRefinement, nil
+		}
+		if allowLegacyDevelopment && firstNonBlank(cfg.DevelopLabels) != "" {
+			return IssueStageDevelopment, nil
+		}
+		return "", fmt.Errorf("%w: no refinement_labels configured", ErrStageTargetLabelMissing)
+	case IssueStageRefinement:
+		if firstNonBlank(cfg.DevelopLabels) != "" {
+			return IssueStageDevelopment, nil
+		}
+		return "", fmt.Errorf("%w: no develop_labels configured", ErrStageTargetLabelMissing)
+	case IssueStageDevelopment:
+		return "", fmt.Errorf("%w: already in development stage", ErrNoNextStage)
+	default:
+		return "", fmt.Errorf("%w: unknown issue stage %q", ErrNoNextStage, stage)
+	}
+}
+
+func TransitionIssueStage(ctx context.Context, client StageTransitionClient, tr StageTransition) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if client == nil {
+		return fmt.Errorf("stage promotion: nil GitHub client")
+	}
+	if tr.Issue == nil {
+		return fmt.Errorf("stage promotion: nil issue")
+	}
+	if tr.From == "" || tr.To == "" {
+		return fmt.Errorf("stage promotion: from/to stages are required")
+	}
+	if tr.From == tr.To {
+		return nil
+	}
+	now := tr.Time
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	targetLabel := stageTargetLabel(tr.Config, tr.To)
+	if targetLabel == "" {
+		return fmt.Errorf("%w: no label configured for %s", ErrStageTargetLabelMissing, tr.To)
+	}
+
+	ensureStageLabel(client, tr.Issue.Repo, targetLabel, tr.To)
+
+	// ADD before REMOVE. If add succeeds and remove fails, the issue is still in
+	// a coherent, recoverable multi-label state. The classifier's "earliest stage
+	// wins" rule prevents accidental forward progress until cleanup succeeds.
+	if err := client.AddLabels(tr.Issue.Repo, tr.Issue.Number, []string{targetLabel}); err != nil {
+		return fmt.Errorf("stage promotion: add target label %q: %w", targetLabel, err)
+	}
+
+	remove := stageLabelsExcept(tr.Config, tr.To, targetLabel)
+	if err := client.RemoveLabels(tr.Issue.Repo, tr.Issue.Number, remove); err != nil {
+		return fmt.Errorf("stage promotion: remove previous stage labels: %w", err)
+	}
+
+	commented := false
+	if !hasRecentStagePromotionComment(tr.RecentComments, tr.To, now) {
+		body := StagePromotionAuditComment(tr.From, tr.To, tr.Trigger, now)
+		if _, err := client.PostComment(tr.Issue.Repo, tr.Issue.Number, body); err != nil {
+			slog.Warn("stage promotion: audit comment failed",
+				"repo", tr.Issue.Repo, "issue", tr.Issue.Number, "from", tr.From, "to", tr.To, "err", err)
+		} else {
+			commented = true
+		}
+	}
+
+	if tr.Broker != nil {
+		publishStagePromotionEvent(tr.Broker, tr.Issue, tr.StoreIssueID, tr.From, tr.To, tr.Trigger, now, commented)
+	}
+	return nil
+}
+
+func StagePromotionAuditComment(from, to IssueStage, trigger StagePromotionTrigger, ts time.Time) string {
+	return fmt.Sprintf("%s\n\n- From: `%s`\n- To: `%s`\n- Trigger: `%s`\n- Time: `%s`\n",
+		stagePromotionHeading, from, to, trigger, ts.UTC().Format(time.RFC3339))
+}
+
+func stageTargetLabel(cfg config.IssueTrackingConfig, stage IssueStage) string {
+	switch stage {
+	case IssueStageTriage:
+		return firstNonBlank(cfg.ReviewOnlyLabels)
+	case IssueStageRefinement:
+		return firstNonBlank(cfg.RefinementLabels)
+	case IssueStageDevelopment:
+		return firstNonBlank(cfg.DevelopLabels)
+	default:
+		return ""
+	}
+}
+
+func stageLabelsExcept(cfg config.IssueTrackingConfig, keep IssueStage, targetLabel string) []string {
+	keepSet := lowerSet(stageLabels(cfg, keep))
+	targetKey := strings.ToLower(strings.TrimSpace(targetLabel))
+	outSet := make(map[string]struct{})
+	var out []string
+	for _, stage := range []IssueStage{IssueStageTriage, IssueStageRefinement, IssueStageDevelopment} {
+		if stage == keep {
+			continue
+		}
+		for _, label := range stageLabels(cfg, stage) {
+			clean := strings.TrimSpace(label)
+			if clean == "" {
+				continue
+			}
+			key := strings.ToLower(clean)
+			if key == targetKey {
+				continue
+			}
+			if _, keep := keepSet[key]; keep {
+				continue
+			}
+			if _, seen := outSet[key]; seen {
+				continue
+			}
+			outSet[key] = struct{}{}
+			out = append(out, clean)
+		}
+	}
+	return out
+}
+
+func stageLabels(cfg config.IssueTrackingConfig, stage IssueStage) []string {
+	switch stage {
+	case IssueStageTriage:
+		return cfg.ReviewOnlyLabels
+	case IssueStageRefinement:
+		return cfg.RefinementLabels
+	case IssueStageDevelopment:
+		return cfg.DevelopLabels
+	default:
+		return nil
+	}
+}
+
+func firstNonBlank(labels []string) string {
+	for _, label := range labels {
+		if clean := strings.TrimSpace(label); clean != "" {
+			return clean
+		}
+	}
+	return ""
+}
+
+func ensureStageLabel(client StageTransitionClient, repo, label string, stage IssueStage) {
+	if label == "" {
+		return
+	}
+	color, description := stageLabelMetadata(stage)
+	if err := client.CreateLabel(repo, label, color, description); err != nil {
+		slog.Warn("stage promotion: ensure label failed, continuing with add",
+			"repo", repo, "label", label, "stage", stage, "err", err)
+	}
+}
+
+func stageLabelMetadata(stage IssueStage) (string, string) {
+	switch stage {
+	case IssueStageTriage:
+		return "1d76db", "Heimdallm: triage issue"
+	case IssueStageRefinement:
+		return "5319e7", "Heimdallm: refine implementation plan"
+	case IssueStageDevelopment:
+		return "0e8a16", "Heimdallm: auto-implement issue"
+	default:
+		return "ededed", "Heimdallm issue stage"
+	}
+}
+
+func hasRecentStagePromotionComment(comments []github.Comment, to IssueStage, now time.Time) bool {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	toLine := fmt.Sprintf("- To: `%s`", to)
+	for _, c := range comments {
+		if c.CreatedAt.IsZero() || now.Sub(c.CreatedAt) > stagePromotionWindow || c.CreatedAt.After(now.Add(stagePromotionWindow)) {
+			continue
+		}
+		if strings.Contains(c.Body, stagePromotionHeading) && strings.Contains(c.Body, toLine) {
+			return true
+		}
+	}
+	return false
+}
+
+func publishStagePromotionEvent(broker Publisher, issue *github.Issue, storeIssueID int64, from, to IssueStage, trigger StagePromotionTrigger, ts time.Time, commented bool) {
+	payload := map[string]any{
+		"repo":            issue.Repo,
+		"number":          issue.Number,
+		"issue_number":    issue.Number,
+		"issue_title":     issue.Title,
+		"github_issue_id": issue.ID,
+		"from_stage":      string(from),
+		"to_stage":        string(to),
+		"trigger":         string(trigger),
+		"time":            ts.UTC().Format(time.RFC3339),
+		"audit_comment":   commented,
+	}
+	if storeIssueID > 0 {
+		payload["issue_id"] = storeIssueID
+	}
+	if b, err := json.Marshal(payload); err == nil {
+		broker.Publish(sse.Event{Type: sse.EventIssuePromoted, Data: string(b)})
+	}
+}

--- a/daemon/internal/issues/stage_transition_test.go
+++ b/daemon/internal/issues/stage_transition_test.go
@@ -1,0 +1,150 @@
+package issues
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/github"
+)
+
+type fakeStageClient struct {
+	ops       []string
+	comments  []string
+	createErr error
+	addErr    error
+	removeErr error
+}
+
+func (f *fakeStageClient) CreateLabel(repo, name, color, description string) error {
+	f.ops = append(f.ops, "create:"+name)
+	return f.createErr
+}
+
+func (f *fakeStageClient) AddLabels(repo string, number int, labels []string) error {
+	f.ops = append(f.ops, "add:"+strings.Join(labels, ","))
+	return f.addErr
+}
+
+func (f *fakeStageClient) RemoveLabels(repo string, number int, labels []string) error {
+	f.ops = append(f.ops, "remove:"+strings.Join(labels, ","))
+	return f.removeErr
+}
+
+func (f *fakeStageClient) PostComment(repo string, number int, body string) (time.Time, error) {
+	f.ops = append(f.ops, "comment")
+	f.comments = append(f.comments, body)
+	return time.Now().UTC(), nil
+}
+
+func stageCfg() config.IssueTrackingConfig {
+	return config.IssueTrackingConfig{
+		Enabled:          true,
+		ReviewOnlyLabels: []string{"triage"},
+		RefinementLabels: []string{"refine"},
+		DevelopLabels:    []string{"develop"},
+	}
+}
+
+func stageIssue() *github.Issue {
+	return &github.Issue{
+		ID:     99,
+		Repo:   "org/repo",
+		Number: 7,
+		Title:  "Refine me",
+	}
+}
+
+func TestNextStage(t *testing.T) {
+	cfg := stageCfg()
+	if got, err := NextStage(IssueStageTriage, cfg, false); err != nil || got != IssueStageRefinement {
+		t.Fatalf("triage next = %q, %v; want refinement", got, err)
+	}
+	if got, err := NextStage(IssueStageRefinement, cfg, false); err != nil || got != IssueStageDevelopment {
+		t.Fatalf("refinement next = %q, %v; want development", got, err)
+	}
+	if _, err := NextStage(IssueStageDevelopment, cfg, false); !errors.Is(err, ErrNoNextStage) {
+		t.Fatalf("development next err = %v, want ErrNoNextStage", err)
+	}
+
+	cfg.RefinementLabels = nil
+	if _, err := NextStage(IssueStageTriage, cfg, false); !errors.Is(err, ErrStageTargetLabelMissing) {
+		t.Fatalf("triage without refinement err = %v, want ErrStageTargetLabelMissing", err)
+	}
+	if got, err := NextStage(IssueStageTriage, cfg, true); err != nil || got != IssueStageDevelopment {
+		t.Fatalf("legacy triage next = %q, %v; want development", got, err)
+	}
+}
+
+func TestTransitionIssueStage_AddsBeforeRemovingAndAudits(t *testing.T) {
+	fake := &fakeStageClient{}
+	err := TransitionIssueStage(context.Background(), fake, StageTransition{
+		Issue:        stageIssue(),
+		StoreIssueID: 12,
+		Config:       stageCfg(),
+		From:         IssueStageTriage,
+		To:           IssueStageRefinement,
+		Trigger:      StagePromotionManualAPI,
+		Time:         time.Date(2026, 5, 7, 12, 43, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("TransitionIssueStage: %v", err)
+	}
+	wantOps := []string{"create:refine", "add:refine", "remove:triage,develop", "comment"}
+	if strings.Join(fake.ops, "|") != strings.Join(wantOps, "|") {
+		t.Fatalf("ops = %v, want %v", fake.ops, wantOps)
+	}
+	if len(fake.comments) != 1 || !strings.Contains(fake.comments[0], "- From: `triage`") || !strings.Contains(fake.comments[0], "- To: `refinement`") {
+		t.Fatalf("audit comment not rendered as expected: %q", fake.comments)
+	}
+}
+
+func TestTransitionIssueStage_MissingTargetLabelFailsBeforeMutating(t *testing.T) {
+	cfg := stageCfg()
+	cfg.RefinementLabels = nil
+	fake := &fakeStageClient{}
+	err := TransitionIssueStage(context.Background(), fake, StageTransition{
+		Issue:   stageIssue(),
+		Config:  cfg,
+		From:    IssueStageTriage,
+		To:      IssueStageRefinement,
+		Trigger: StagePromotionAuto,
+	})
+	if !errors.Is(err, ErrStageTargetLabelMissing) {
+		t.Fatalf("err = %v, want ErrStageTargetLabelMissing", err)
+	}
+	if len(fake.ops) != 0 {
+		t.Fatalf("unexpected mutations before target validation: %v", fake.ops)
+	}
+}
+
+func TestTransitionIssueStage_DeduplicatesRecentAuditComment(t *testing.T) {
+	now := time.Date(2026, 5, 7, 12, 43, 0, 0, time.UTC)
+	fake := &fakeStageClient{}
+	err := TransitionIssueStage(context.Background(), fake, StageTransition{
+		Issue:        stageIssue(),
+		StoreIssueID: 12,
+		Config:       stageCfg(),
+		From:         IssueStageTriage,
+		To:           IssueStageRefinement,
+		Trigger:      StagePromotionAuto,
+		Time:         now,
+		RecentComments: []github.Comment{
+			{
+				CreatedAt: now.Add(-time.Minute),
+				Body:      stagePromotionHeading + "\n\n- To: `refinement`\n",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("TransitionIssueStage: %v", err)
+	}
+	for _, op := range fake.ops {
+		if op == "comment" {
+			t.Fatalf("dedup should skip audit comment, ops=%v", fake.ops)
+		}
+	}
+}

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -28,6 +28,10 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
+// ErrPromoteConflict is returned by the promote callback when the request is
+// syntactically valid but the issue is not currently in a promotable stage.
+var ErrPromoteConflict = errors.New("issue promotion conflict")
+
 // Server holds the HTTP router, SSE broker, store, and optional pipeline.
 type Server struct {
 	store                *store.Store
@@ -171,8 +175,7 @@ func (srv *Server) SetTriggerIssueRefineFn(fn func(issueID int64, force bool) er
 }
 
 // SetTriggerPromoteFn wires the promote callback called by POST /issues/{id}/promote.
-// The callback must run the auto_implement pipeline for the given issue regardless
-// of its current classification (review_only → develop promotion).
+// The callback moves stage labels only; the poll cycle executes the new stage.
 func (srv *Server) SetTriggerPromoteFn(fn func(issueID int64) error) {
 	srv.triggerPromoteFn = fn
 }
@@ -1228,10 +1231,9 @@ func (srv *Server) handleTriggerIssueRefine(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "refinement queued"})
 }
 
-// handlePromoteIssue promotes a review_only-classified issue to auto_implement,
-// triggering the full develop pipeline immediately without waiting for a label
-// change on GitHub. It shares the same semaphore as review and triage so total
-// concurrent AI processes stay bounded.
+// handlePromoteIssue moves an issue to its next configured stage by updating
+// GitHub labels. It does not run AI work directly; the next poll sees the new
+// labels and dispatches refinement/development through the normal workers.
 func (srv *Server) handlePromoteIssue(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	if err != nil {
@@ -1242,19 +1244,20 @@ func (srv *Server) handlePromoteIssue(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "promote trigger not configured", http.StatusServiceUnavailable)
 		return
 	}
-	select {
-	case srv.reviewSem <- struct{}{}:
-	default:
-		http.Error(w, `{"error":"too many concurrent reviews — try again later"}`, http.StatusTooManyRequests)
+	if _, err := srv.store.GetIssue(id); err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
-	go func() {
-		defer func() { <-srv.reviewSem }()
-		if err := srv.triggerPromoteFn(id); err != nil {
-			slog.Error("promote issue failed", "issue_id", id, "err", err)
+	if err := srv.triggerPromoteFn(id); err != nil {
+		slog.Error("promote issue failed", "issue_id", id, "err", err)
+		if errors.Is(err, ErrPromoteConflict) {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
 		}
-	}()
-	writeJSON(w, http.StatusAccepted, map[string]string{"status": "promote queued"})
+		http.Error(w, "promote failed", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]string{"status": "promotion applied"})
 }
 
 func (srv *Server) handleRepoLabels(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -175,7 +175,8 @@ func (srv *Server) SetTriggerIssueRefineFn(fn func(issueID int64, force bool) er
 }
 
 // SetTriggerPromoteFn wires the promote callback called by POST /issues/{id}/promote.
-// The callback moves stage labels only; the poll cycle executes the new stage.
+// The callback validates and applies a stage-label transition only. The poll
+// cycle executes the new stage after it observes the updated GitHub labels.
 func (srv *Server) SetTriggerPromoteFn(fn func(issueID int64) error) {
 	srv.triggerPromoteFn = fn
 }

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -628,7 +628,7 @@ func TestHandlerPromoteIssue(t *testing.T) {
 	}
 	var body map[string]string
 	json.NewDecoder(w.Body).Decode(&body)
-	if body["status"] != "promote queued" {
+	if body["status"] != "promotion applied" {
 		t.Errorf("promote issue: unexpected body %v", body)
 	}
 
@@ -639,6 +639,27 @@ func TestHandlerPromoteIssue(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Error("promote callback not called within 2s")
+	}
+}
+
+func TestHandlerPromoteIssue_Conflict(t *testing.T) {
+	srv, s := setupServer(t)
+	now := time.Now()
+	id, _ := s.UpsertIssue(&store.Issue{
+		GithubID: 802, Repo: "org/r", Number: 22, Title: "t",
+		Body: "b", Author: "a", Assignees: `[]`, Labels: `[]`,
+		State: "open", CreatedAt: now, FetchedAt: now,
+	})
+
+	srv.SetTriggerPromoteFn(func(issueID int64) error {
+		return fmt.Errorf("%w: already in development", server.ErrPromoteConflict)
+	})
+
+	req := httptest.NewRequest("POST", "/issues/"+itoa(id)+"/promote", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("promote issue: status %d, want 409; body: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/daemon/internal/sse/broker.go
+++ b/daemon/internal/sse/broker.go
@@ -18,7 +18,7 @@ const (
 	EventIssueRefinementDone  = "issue_refinement_done"
 	EventIssueImplemented     = "issue_implemented" // reserved for #27 (auto_implement PR created)
 	EventIssueReviewError     = "issue_review_error"
-	EventIssuePromoted        = "issue_promoted" // #113: promoter flipped blocked → promote-to label
+	EventIssuePromoted        = "issue_promoted" // issue stage/dependency label promotion
 
 	// EventRepoDiscovered fires when the poll cycle sees a PR whose repo
 	// is not yet in monitored or non-monitored. Payload: {"repo": "org/name"}.

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -324,12 +324,12 @@ Promotion changes only GitHub labels; the next poll cycle executes the newly vis
 | `triage` / `review_only` | `refinement` | Manual Promote, `auto_promote_triage = true`, or replacing the label on GitHub |
 | `refinement` | `development` | Manual Promote, `auto_promote_refinement = true`, or replacing the label on GitHub |
 
-Manual promotion from triage falls back to `develop_labels` only for legacy configs that have no `refinement_labels`. Auto-promotion does not skip refinement: if `auto_promote_triage = true` but no refinement label is configured, the daemon logs a warning and leaves the issue in triage.
+Manual promotion from triage falls back to `develop_labels` only for legacy configs that have no `refinement_labels`. Auto-promotion does not skip refinement: when `auto_promote_triage` is unset, it defaults on only if `refinement_labels` is configured. If `auto_promote_triage = true` but no refinement label is configured, the daemon logs a warning and leaves the issue in triage.
 
 ```toml
 [ai]
-auto_promote_triage = true       # default when unset
-auto_promote_refinement = false  # default when unset
+auto_promote_triage = true       # unset = true only when refinement_labels is configured
+auto_promote_refinement = false  # unset = false
 ```
 
 > **Warning — `default_action = "review_only"` can cause re-processing loops and excessive API costs.**
@@ -955,7 +955,7 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # Issue pipeline ownership and promotion defaults.
 # triage_owner = "alice"
 # clone_dir = "/home/heimdallm/repos/worktrees"
-# auto_promote_triage = true
+# auto_promote_triage = true      # unset = true only when refinement_labels is configured
 # auto_promote_refinement = false
 
 # Generate LLM-produced PR titles and descriptions for auto_implement PRs.

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -250,7 +250,7 @@ The per-agent override takes precedence when set (see [AI Agents](#7-ai-agents))
 
 ## 6. Issue Tracking
 
-The issue tracking pipeline fetches open GitHub issues from monitored repos, classifies them by label, and — depending on the classification — posts an AI analysis comment (`review_only`) or creates a branch, commits the fix, and opens a PR (`develop` / `auto_implement`).
+The issue tracking pipeline fetches open GitHub issues from monitored repos, classifies them by label, and moves them through the stage sequence `triage` (`review_only`) -> `refinement` -> `development` (`develop` / `auto_implement`).
 
 ### Enabling
 
@@ -286,7 +286,7 @@ filter_mode = "exclusive"
 Labels are matched case-insensitively. Precedence from highest to lowest:
 
 ```
-skip_labels  >  blocked_labels  >  review_only_labels  >  develop_labels  >  default_action
+skip_labels  >  blocked_labels  >  review_only_labels  >  refinement_labels  >  develop_labels  >  default_action
 ```
 
 | Field | Env var | Description |
@@ -294,11 +294,13 @@ skip_labels  >  blocked_labels  >  review_only_labels  >  develop_labels  >  def
 | `skip_labels` | `HEIMDALLM_ISSUE_SKIP_LABELS` | Issues with these labels are ignored entirely |
 | `blocked_labels` | `HEIMDALLM_ISSUE_BLOCKED_LABELS` | Issues held until all dependencies close, then promoted |
 | `review_only_labels` | `HEIMDALLM_ISSUE_REVIEW_ONLY_LABELS` | AI posts a triage comment, no implementation |
+| `refinement_labels` | `HEIMDALLM_ISSUE_REFINEMENT_LABELS` | AI reads the repo and posts a structured implementation plan |
 | `develop_labels` | `HEIMDALLM_ISSUE_DEVELOP_LABELS` | AI implements the issue (branch + commit + PR) |
 | `default_action` | `HEIMDALLM_ISSUE_DEFAULT_ACTION` | Applied when no label matches; `ignore` or `review_only` |
 
 ```bash
 HEIMDALLM_ISSUE_DEVELOP_LABELS=enhancement,feature,bug
+HEIMDALLM_ISSUE_REFINEMENT_LABELS=needs-plan
 HEIMDALLM_ISSUE_REVIEW_ONLY_LABELS=question,discussion,analysis
 HEIMDALLM_ISSUE_SKIP_LABELS=wontfix,duplicate,invalid
 HEIMDALLM_ISSUE_DEFAULT_ACTION=ignore
@@ -307,9 +309,27 @@ HEIMDALLM_ISSUE_DEFAULT_ACTION=ignore
 ```toml
 [github.issue_tracking]
 develop_labels     = ["enhancement", "feature", "bug"]
+refinement_labels  = ["needs-plan"]
 review_only_labels = ["question", "discussion", "analysis"]
 skip_labels        = ["wontfix", "duplicate", "invalid"]
 default_action     = "ignore"
+```
+
+### Stage promotion
+
+Promotion changes only GitHub labels; the next poll cycle executes the newly visible stage. This keeps manual API/UI/CLI promotion, auto-promotion, and manual label swaps on GitHub on the same path.
+
+| From | To | Trigger |
+|---|---|---|
+| `triage` / `review_only` | `refinement` | Manual Promote, `auto_promote_triage = true`, or replacing the label on GitHub |
+| `refinement` | `development` | Manual Promote, `auto_promote_refinement = true`, or replacing the label on GitHub |
+
+Manual promotion from triage falls back to `develop_labels` only for legacy configs that have no `refinement_labels`. Auto-promotion does not skip refinement: if `auto_promote_triage = true` but no refinement label is configured, the daemon logs a warning and leaves the issue in triage.
+
+```toml
+[ai]
+auto_promote_triage = true       # default when unset
+auto_promote_refinement = false  # default when unset
 ```
 
 > **Warning — `default_action = "review_only"` can cause re-processing loops and excessive API costs.**
@@ -321,6 +341,7 @@ default_action     = "ignore"
 > | Label | Action |
 > |---|---|
 > | A dedicated develop label (e.g. `heimdallm-develop`) | Auto-implement: creates branch + PR |
+> | A dedicated refinement label (e.g. `heimdallm-refine`) | Deep planning: AI reads the repo and posts subtasks |
 > | A dedicated triage label (e.g. `heimdallm-triage`) | Review only: AI analyses and comments once |
 > | No matching label | Ignored (safe default) |
 >
@@ -336,6 +357,7 @@ default_action     = "ignore"
 > organizations  = ["myorg"]
 > assignees      = ["myusername"]
 > develop_labels     = ["heimdallm-develop"]
+> refinement_labels  = ["heimdallm-refine"]
 > review_only_labels = ["heimdallm-triage"]
 > skip_labels        = ["wontfix", "duplicate", "invalid"]
 > ```

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -402,8 +402,8 @@ class ApiClient {
     }
   }
 
-  /// Promotes a review_only-classified issue to auto_implement, triggering the
-  /// full develop pipeline without requiring a GitHub label change.
+  /// Moves an issue to the next configured stage by updating GitHub labels.
+  /// The daemon poller executes the new stage after it observes the label swap.
   Future<void> promoteIssue(int issueId) async {
     final resp = await _client.post(
       _uri('/issues/$issueId/promote'),

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -166,6 +166,24 @@ void _handleSseEvent(Ref ref, SseEvent event) {
         }
         ref.read(issueListRefreshProvider.notifier).update((s) => s + 1);
 
+      case 'issue_refinement_done':
+      case 'issue_implemented':
+      case 'issue_promoted':
+        final rawNumber = data['number'] ?? data['issue_number'];
+        final issueNumber = (rawNumber as num?)?.toInt();
+        final issueKey = (repo.isNotEmpty && issueNumber != null)
+            ? '$repo:$issueNumber'
+            : null;
+        if (issueKey != null) {
+          ref
+              .read(reviewingIssuesProvider.notifier)
+              .update((s) => s.difference({issueKey}));
+          ref
+              .read(promotingIssuesProvider.notifier)
+              .update((s) => s.difference({issueKey}));
+        }
+        ref.read(issueListRefreshProvider.notifier).update((s) => s + 1);
+
       case 'issue_review_error':
         final issueNumber = (data['number'] as num?)?.toInt();
         final issueKey = (repo.isNotEmpty && issueNumber != null)

--- a/flutter_app/lib/features/issues/issue_detail_screen.dart
+++ b/flutter_app/lib/features/issues/issue_detail_screen.dart
@@ -48,13 +48,16 @@ class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
       ref.invalidate(issuesProvider);
       if (context.mounted) {
         context.canPop() ? context.pop() : context.go('/');
-        showToast(context, 'Issue dismissed',
-            duration: const Duration(seconds: 5),
-            actionLabel: 'Undo',
-            onAction: () async {
-              await api.undismissIssue(widget.issueId);
-              ref.invalidate(issuesProvider);
-            });
+        showToast(
+          context,
+          'Issue dismissed',
+          duration: const Duration(seconds: 5),
+          actionLabel: 'Undo',
+          onAction: () async {
+            await api.undismissIssue(widget.issueId);
+            ref.invalidate(issuesProvider);
+          },
+        );
       }
     } catch (e) {
       if (!context.mounted) return;
@@ -68,7 +71,7 @@ class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
     try {
       await api.promoteIssue(widget.issueId);
       ref.invalidate(issueDetailProvider(widget.issueId));
-      if (mounted) showToast(context, 'Promoted to auto-implement');
+      if (mounted) showToast(context, 'Stage promotion requested');
     } catch (e) {
       _stopReviewing();
       if (mounted) showToast(context, 'Error: $e', isError: true);
@@ -108,11 +111,29 @@ class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
                 _stopReviewing();
                 ref.invalidate(issueDetailProvider(widget.issueId));
               }
+            case 'issue_refinement_done':
+              if (issueId == widget.issueId) {
+                _stopReviewing();
+                ref.invalidate(issueDetailProvider(widget.issueId));
+              }
+            case 'issue_implemented':
+              if (issueId == widget.issueId) {
+                _stopReviewing();
+                ref.invalidate(issueDetailProvider(widget.issueId));
+              }
+            case 'issue_promoted':
+              if (issueId == widget.issueId) {
+                _stopReviewing();
+                ref.invalidate(issueDetailProvider(widget.issueId));
+                ref.invalidate(issuesProvider);
+              }
             case 'issue_review_error':
               if (issueId == widget.issueId) {
                 _stopReviewing();
                 final error = data['error'] as String? ?? 'Unknown error';
-                if (mounted) showToast(context, 'Review failed: $error', isError: true);
+                if (mounted) {
+                  showToast(context, 'Review failed: $error', isError: true);
+                }
               }
           }
         } catch (_) {}
@@ -126,7 +147,8 @@ class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
 
     final reviewKey = issue != null ? '${issue.repo}:${issue.number}' : null;
     final isReviewingShared =
-        reviewKey != null && ref.watch(reviewingIssuesProvider).contains(reviewKey);
+        reviewKey != null &&
+        ref.watch(reviewingIssuesProvider).contains(reviewKey);
     final reviewing = _reviewing || isReviewingShared;
 
     return Scaffold(
@@ -141,8 +163,10 @@ class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
             const Padding(
               padding: EdgeInsets.symmetric(horizontal: 16),
               child: SizedBox(
-                  width: 20, height: 20,
-                  child: CircularProgressIndicator(strokeWidth: 2)),
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
             )
           else ...[
             ElevatedButton.icon(
@@ -150,11 +174,11 @@ class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
               label: Text(hasReviews ? 'Re-review' : 'Review'),
               onPressed: _trigger,
             ),
-            if (hasReviews && reviews.last.actionTaken == 'review_only') ...[
+            if (hasReviews && _canPromoteAction(reviews.last.actionTaken)) ...[
               const SizedBox(width: 8),
               ElevatedButton.icon(
                 icon: const Icon(Icons.rocket_launch, size: 16),
-                label: const Text('Promote to Dev'),
+                label: Text(_promoteLabel(reviews.last.actionTaken)),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Theme.of(context).colorScheme.secondary,
                   foregroundColor: Theme.of(context).colorScheme.onSecondary,
@@ -177,7 +201,9 @@ class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
           if (reviewing)
             LinearProgressIndicator(
               minHeight: 3,
-              backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+              backgroundColor: Theme.of(
+                context,
+              ).colorScheme.surfaceContainerHighest,
             ),
           Expanded(
             child: detailAsync.when(
@@ -188,7 +214,10 @@ class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
                 final reviews = data['reviews'] as List<TrackedIssueReview>;
                 return Row(
                   children: [
-                    Expanded(flex: 2, child: _ReviewPanel(issue: issue, reviews: reviews)),
+                    Expanded(
+                      flex: 2,
+                      child: _ReviewPanel(issue: issue, reviews: reviews),
+                    ),
                     const VerticalDivider(width: 1),
                     Expanded(flex: 1, child: _IssueMetaPanel(issue: issue)),
                   ],
@@ -201,6 +230,12 @@ class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
     );
   }
 }
+
+bool _canPromoteAction(String action) =>
+    action == 'review_only' || action == 'refinement';
+
+String _promoteLabel(String action) =>
+    action == 'refinement' ? 'Promote to Dev' : 'Promote Stage';
 
 class _ReviewPanel extends StatelessWidget {
   final TrackedIssue issue;
@@ -215,8 +250,10 @@ class _ReviewPanel extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(issue.title, style: Theme.of(context).textTheme.headlineSmall),
-          Text('${issue.repo} #${issue.number} by ${issue.author}',
-              style: Theme.of(context).textTheme.bodySmall),
+          Text(
+            '${issue.repo} #${issue.number} by ${issue.author}',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
           const SizedBox(height: 16),
           if (reviews.isEmpty)
             const Text('No reviews yet.')
@@ -243,17 +280,26 @@ class _IssueReviewCard extends StatelessWidget {
           children: [
             Row(
               children: [
-                Text('Reviewed by ${review.cliUsed}',
-                    style: Theme.of(context).textTheme.labelSmall),
+                Text(
+                  'Reviewed by ${review.cliUsed}',
+                  style: Theme.of(context).textTheme.labelSmall,
+                ),
                 const SizedBox(width: 8),
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.surfaceContainerHighest,
                     borderRadius: BorderRadius.circular(4),
                   ),
-                  child: Text(review.actionTaken,
-                      style: const TextStyle(fontSize: 10)),
+                  child: Text(
+                    review.actionTaken,
+                    style: const TextStyle(fontSize: 10),
+                  ),
                 ),
                 const Spacer(),
                 SeverityBadge(severity: review.severity),
@@ -263,7 +309,10 @@ class _IssueReviewCard extends StatelessWidget {
             Text(review.summary),
             if (review.category.isNotEmpty) ...[
               const SizedBox(height: 8),
-              Text('Classification', style: Theme.of(context).textTheme.labelMedium),
+              Text(
+                'Classification',
+                style: Theme.of(context).textTheme.labelMedium,
+              ),
               Padding(
                 padding: const EdgeInsets.only(top: 4, left: 8),
                 child: Text('Category: ${review.category}'),
@@ -271,18 +320,23 @@ class _IssueReviewCard extends StatelessWidget {
             ],
             if (review.suggestions.isNotEmpty) ...[
               const SizedBox(height: 8),
-              Text('Suggestions', style: Theme.of(context).textTheme.labelMedium),
-              ...review.suggestions.map((s) => Padding(
-                    padding: const EdgeInsets.only(top: 4, left: 8),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Icon(Icons.lightbulb_outline, size: 14),
-                        const SizedBox(width: 4),
-                        Expanded(child: Text(s.toString())),
-                      ],
-                    ),
-                  )),
+              Text(
+                'Suggestions',
+                style: Theme.of(context).textTheme.labelMedium,
+              ),
+              ...review.suggestions.map(
+                (s) => Padding(
+                  padding: const EdgeInsets.only(top: 4, left: 8),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Icon(Icons.lightbulb_outline, size: 14),
+                      const SizedBox(width: 4),
+                      Expanded(child: Text(s.toString())),
+                    ],
+                  ),
+                ),
+              ),
             ],
           ],
         ),
@@ -308,8 +362,11 @@ class _IssueMetaPanel extends StatelessWidget {
           _row(context, 'Number', '#${issue.number}'),
           _row(context, 'Author', issue.author),
           _row(context, 'State', issue.state),
-          _row(context, 'Created',
-              issue.createdAt.toLocal().toString().substring(0, 16)),
+          _row(
+            context,
+            'Created',
+            issue.createdAt.toLocal().toString().substring(0, 16),
+          ),
           if (issue.assignees.isNotEmpty)
             _row(context, 'Assignees', issue.assignees.join(', ')),
           if (issue.labels.isNotEmpty) ...[
@@ -318,11 +375,16 @@ class _IssueMetaPanel extends StatelessWidget {
               spacing: 4,
               runSpacing: 4,
               children: issue.labels
-                  .map((l) => Chip(
-                        label: Text(l.toString(), style: const TextStyle(fontSize: 11)),
-                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        visualDensity: VisualDensity.compact,
-                      ))
+                  .map(
+                    (l) => Chip(
+                      label: Text(
+                        l.toString(),
+                        style: const TextStyle(fontSize: 11),
+                      ),
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  )
                   .toList(),
             ),
           ],
@@ -332,7 +394,8 @@ class _IssueMetaPanel extends StatelessWidget {
             label: const Text('Open on GitHub'),
             onPressed: () {
               final uri = Uri.tryParse(
-                  'https://github.com/${issue.repo}/issues/${issue.number}');
+                'https://github.com/${issue.repo}/issues/${issue.number}',
+              );
               if (uri != null) launchUrl(uri);
             },
           ),
@@ -347,9 +410,12 @@ class _IssueMetaPanel extends StatelessWidget {
       child: Row(
         children: [
           SizedBox(
-              width: 72,
-              child: Text('$label:',
-                  style: const TextStyle(fontWeight: FontWeight.w600))),
+            width: 72,
+            child: Text(
+              '$label:',
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+          ),
           Expanded(child: Text(value)),
         ],
       ),

--- a/flutter_app/lib/features/issues/issues_providers.dart
+++ b/flutter_app/lib/features/issues/issues_providers.dart
@@ -9,7 +9,7 @@ final issueListRefreshProvider = StateProvider<int>((ref) => 0);
 /// Tracks issues currently being reviewed, keyed by "repo:issueNumber".
 final reviewingIssuesProvider = StateProvider<Set<String>>((ref) => const {});
 
-/// Tracks issues currently being promoted to develop, keyed by "repo:issueNumber".
+/// Tracks issues currently being promoted to their next stage, keyed by "repo:issueNumber".
 final promotingIssuesProvider = StateProvider<Set<String>>((ref) => const {});
 
 final issuesProvider = FutureProvider<List<TrackedIssue>>((ref) async {
@@ -19,8 +19,10 @@ final issuesProvider = FutureProvider<List<TrackedIssue>>((ref) async {
   return api.fetchIssues(states: filters.states.toList());
 });
 
-final issueDetailProvider =
-    FutureProvider.family<Map<String, dynamic>, int>((ref, issueId) async {
+final issueDetailProvider = FutureProvider.family<Map<String, dynamic>, int>((
+  ref,
+  issueId,
+) async {
   ref.watch(sseStreamProvider);
   final api = ref.watch(apiClientProvider);
   return api.fetchIssue(issueId);

--- a/flutter_app/lib/features/issues/issues_screen.dart
+++ b/flutter_app/lib/features/issues/issues_screen.dart
@@ -8,6 +8,7 @@ import '../dashboard/dashboard_providers.dart';
 import 'issues_providers.dart';
 
 const _actionReviewOnly = 'review_only';
+const _actionRefinement = 'refinement';
 
 /// Filter state for the issues list.
 final _repoFilterProvider = StateProvider<String?>((ref) => null);
@@ -54,7 +55,10 @@ class IssuesScreen extends ConsumerWidget {
               padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
               child: Row(
                 children: [
-                  Text('Repo:', style: TextStyle(fontSize: 12, color: Colors.grey.shade500)),
+                  Text(
+                    'Repo:',
+                    style: TextStyle(fontSize: 12, color: Colors.grey.shade500),
+                  ),
                   const SizedBox(width: 8),
                   DropdownButton<String?>(
                     value: repoFilter,
@@ -63,14 +67,21 @@ class IssuesScreen extends ConsumerWidget {
                     underline: const SizedBox.shrink(),
                     items: [
                       const DropdownMenuItem(value: null, child: Text('All')),
-                      ...repos.map((r) =>
-                          DropdownMenuItem(value: r, child: Text(r, style: const TextStyle(fontSize: 13)))),
+                      ...repos.map(
+                        (r) => DropdownMenuItem(
+                          value: r,
+                          child: Text(r, style: const TextStyle(fontSize: 13)),
+                        ),
+                      ),
                     ],
-                    onChanged: (v) => ref.read(_repoFilterProvider.notifier).state = v,
+                    onChanged: (v) =>
+                        ref.read(_repoFilterProvider.notifier).state = v,
                   ),
                   const Spacer(),
-                  Text('${filtered.length} issue${filtered.length == 1 ? '' : 's'}',
-                      style: TextStyle(fontSize: 12, color: Colors.grey.shade500)),
+                  Text(
+                    '${filtered.length} issue${filtered.length == 1 ? '' : 's'}',
+                    style: TextStyle(fontSize: 12, color: Colors.grey.shade500),
+                  ),
                 ],
               ),
             ),
@@ -101,24 +112,32 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
   String get _reviewKey => '${widget.issue.repo}:${widget.issue.number}';
 
   Future<void> _triggerReview() async {
-    ref.read(reviewingIssuesProvider.notifier).update((s) => {...s, _reviewKey});
+    ref
+        .read(reviewingIssuesProvider.notifier)
+        .update((s) => {...s, _reviewKey});
     try {
       await ref.read(apiClientProvider).triggerIssueReview(widget.issue.id);
     } catch (e) {
-      ref.read(reviewingIssuesProvider.notifier).update((s) => s.difference({_reviewKey}));
+      ref
+          .read(reviewingIssuesProvider.notifier)
+          .update((s) => s.difference({_reviewKey}));
       if (mounted) showToast(context, 'Error: $e', isError: true);
     }
   }
 
   Future<void> _promote() async {
-    ref.read(promotingIssuesProvider.notifier).update((s) => {...s, _reviewKey});
+    ref
+        .read(promotingIssuesProvider.notifier)
+        .update((s) => {...s, _reviewKey});
     try {
       await ref.read(apiClientProvider).promoteIssue(widget.issue.id);
-      if (mounted) showToast(context, 'Promoted to Develop — pipeline queued');
+      if (mounted) showToast(context, 'Stage promotion requested');
     } catch (e) {
       if (mounted) showToast(context, 'Error: $e', isError: true);
     } finally {
-      ref.read(promotingIssuesProvider.notifier).update((s) => s.difference({_reviewKey}));
+      ref
+          .read(promotingIssuesProvider.notifier)
+          .update((s) => s.difference({_reviewKey}));
     }
   }
 
@@ -128,13 +147,16 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
       await api.dismissIssue(widget.issue.id);
       ref.invalidate(issuesProvider);
       if (mounted) {
-        showToast(context, 'Issue #${widget.issue.number} dismissed',
-            duration: const Duration(seconds: 5),
-            actionLabel: 'Undo',
-            onAction: () async {
-              await api.undismissIssue(widget.issue.id);
-              ref.invalidate(issuesProvider);
-            });
+        showToast(
+          context,
+          'Issue #${widget.issue.number} dismissed',
+          duration: const Duration(seconds: 5),
+          actionLabel: 'Undo',
+          onAction: () async {
+            await api.undismissIssue(widget.issue.id);
+            ref.invalidate(issuesProvider);
+          },
+        );
       }
     } catch (e) {
       if (mounted) showToast(context, 'Error: $e', isError: true);
@@ -148,10 +170,11 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
     final isReviewing = ref.watch(reviewingIssuesProvider).contains(_reviewKey);
     final isPromoting = ref.watch(promotingIssuesProvider).contains(_reviewKey);
     final severity = issue.latestReview?.severity ?? '';
-    // Show "Promote to Develop" only when the latest review action was review_only
-    // and not currently running either pipeline on this issue.
-    final canPromote = reviewed &&
-        issue.latestReview!.actionTaken == _actionReviewOnly &&
+    // Promote only when the latest issue artifact represents a stage that has
+    // a possible successor in the state machine.
+    final canPromote =
+        reviewed &&
+        _canPromoteAction(issue.latestReview!.actionTaken) &&
         !isReviewing &&
         !isPromoting;
 
@@ -166,14 +189,15 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
             children: [
               // Severity bar
               Container(
-                width: 4, height: 48,
+                width: 4,
+                height: 48,
                 margin: const EdgeInsets.only(right: 12),
                 decoration: BoxDecoration(
                   color: isReviewing
                       ? Theme.of(context).colorScheme.primary
                       : reviewed
-                          ? _severityColor(severity)
-                          : Colors.grey.shade600,
+                      ? _severityColor(severity)
+                      : Colors.grey.shade600,
                   borderRadius: BorderRadius.circular(2),
                 ),
               ),
@@ -182,30 +206,46 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(issue.title,
-                        style: const TextStyle(fontWeight: FontWeight.w600),
-                        maxLines: 1, overflow: TextOverflow.ellipsis),
+                    Text(
+                      issue.title,
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
                     const SizedBox(height: 4),
                     Row(
                       children: [
                         Flexible(
-                          child: Text('${issue.repo} · #${issue.number} · ${issue.author}',
-                              style: Theme.of(context).textTheme.bodySmall,
-                              overflow: TextOverflow.ellipsis),
+                          child: Text(
+                            '${issue.repo} · #${issue.number} · ${issue.author}',
+                            style: Theme.of(context).textTheme.bodySmall,
+                            overflow: TextOverflow.ellipsis,
+                          ),
                         ),
                         const SizedBox(width: 8),
-                        ...issue.labels.take(3).map((l) => Padding(
-                              padding: const EdgeInsets.only(right: 4),
-                              child: Container(
-                                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-                                decoration: BoxDecoration(
-                                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                                  borderRadius: BorderRadius.circular(4),
+                        ...issue.labels
+                            .take(3)
+                            .map(
+                              (l) => Padding(
+                                padding: const EdgeInsets.only(right: 4),
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 6,
+                                    vertical: 1,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.surfaceContainerHighest,
+                                    borderRadius: BorderRadius.circular(4),
+                                  ),
+                                  child: Text(
+                                    l.toString(),
+                                    style: const TextStyle(fontSize: 10),
+                                  ),
                                 ),
-                                child: Text(l.toString(),
-                                    style: const TextStyle(fontSize: 10)),
                               ),
-                            )),
+                            ),
                       ],
                     ),
                   ],
@@ -218,7 +258,8 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
                 children: [
                   if (isReviewing || isPromoting)
                     SizedBox(
-                      width: 18, height: 18,
+                      width: 18,
+                      height: 18,
                       child: CircularProgressIndicator(
                         strokeWidth: 2,
                         color: isPromoting
@@ -236,8 +277,9 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
                       height: 28,
                       child: ElevatedButton(
                         style: ElevatedButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(horizontal: 10),
-                            textStyle: const TextStyle(fontSize: 12)),
+                          padding: const EdgeInsets.symmetric(horizontal: 10),
+                          textStyle: const TextStyle(fontSize: 12),
+                        ),
                         onPressed: _triggerReview,
                         child: const Text('Review'),
                       ),
@@ -248,12 +290,19 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
                         height: 28,
                         child: ElevatedButton(
                           style: ElevatedButton.styleFrom(
-                              padding: const EdgeInsets.symmetric(horizontal: 10),
-                              textStyle: const TextStyle(fontSize: 12),
-                              backgroundColor: Theme.of(context).colorScheme.secondary,
-                              foregroundColor: Theme.of(context).colorScheme.onSecondary),
+                            padding: const EdgeInsets.symmetric(horizontal: 10),
+                            textStyle: const TextStyle(fontSize: 12),
+                            backgroundColor: Theme.of(
+                              context,
+                            ).colorScheme.secondary,
+                            foregroundColor: Theme.of(
+                              context,
+                            ).colorScheme.onSecondary,
+                          ),
                           onPressed: _promote,
-                          child: const Text('Promote to Dev'),
+                          child: Text(
+                            _promoteLabel(issue.latestReview!.actionTaken),
+                          ),
                         ),
                       ),
                     ],
@@ -274,20 +323,38 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
     );
   }
 
+  bool _canPromoteAction(String action) =>
+      action == _actionReviewOnly || action == _actionRefinement;
+
+  String _promoteLabel(String action) =>
+      action == _actionRefinement ? 'Promote to Dev' : 'Promote';
+
   Widget _chip(String label, Color color) => Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-        decoration: BoxDecoration(color: color, borderRadius: BorderRadius.circular(4)),
-        child: Text(label,
-            style: const TextStyle(
-                color: Colors.white, fontSize: 11, fontWeight: FontWeight.w600)),
-      );
+    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+    decoration: BoxDecoration(
+      color: color,
+      borderRadius: BorderRadius.circular(4),
+    ),
+    child: Text(
+      label,
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: 11,
+        fontWeight: FontWeight.w600,
+      ),
+    ),
+  );
 
   Color _severityColor(String s) {
     switch (s.toLowerCase()) {
-      case 'critical': return Colors.red.shade900;
-      case 'high':     return Colors.red.shade700;
-      case 'medium':   return Colors.orange.shade700;
-      default:         return Colors.green.shade700;
+      case 'critical':
+        return Colors.red.shade900;
+      case 'high':
+        return Colors.red.shade700;
+      case 'medium':
+        return Colors.orange.shade700;
+      default:
+        return Colors.green.shade700;
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #395.

Adds the issue stage state machine for `triage -> refinement -> development` while keeping the legacy `review_only` action name for stored triage rows and existing APIs.

## What changed

- Adds a stage transition helper that moves GitHub labels add-first/remove-after, creates target labels best-effort, posts audit comments, deduplicates recent promotion audits, and emits `issue_promoted` SSE events.
- Updates issue classification precedence to `skip > blocked > review_only > refinement > develop > default_action` so temporary multi-label states prefer the earliest stage.
- Changes `POST /issues/{id}/promote` to apply label transitions only; the next poll executes the new stage through the normal worker path.
- Adds auto-promotion after successful triage/refinement with `auto_promote_triage` defaulting on and `auto_promote_refinement` defaulting off.
- Detects manual GitHub label swaps on the next poll, posts an audit comment, and dispatches the newly visible stage.
- Adds CLI/TUI promotion support and updates Flutter issue screens/SSE handling for stage promotion.
- Updates README and configuration guide for the staged issue pipeline.

## Validation

- `make test-docker`
- CLI `go test ./...` inside Docker
- `flutter test`
- `flutter analyze`
- `make build-web`

## Notes

Local unrelated files were left out of the commit: `flutter_app/pubspec.lock` and `flutter_app/flutter_01.png`.