### PR TITLE
fix(ui): hide Organizations filter at repo scope (#403)

### DIFF
--- a/docs/superpowers/specs/2026-05-07-issue-403-hide-organizations-repo-scope-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-403-hide-organizations-repo-scope-design.md
@@ -1,0 +1,105 @@
+# Issue #403 — Hide "Organizations" filter at repo scope (Issue Tracking)
+
+**Status:** Approved design, ready for implementation.
+**Branch:** `feat/hide-org-filter-403` (worktree at `.worktrees/hide-org-filter-403`).
+**Issue:** https://github.com/theburrowhub/heimdallm/issues/403
+
+## Goal
+
+Remove the **Organizations** filter from the Issue Tracking section of the repo detail screen (`flutter_app/lib/features/repositories/repo_detail_screen.dart`). At repo scope this filter is at best a no-op and at worst silently excludes the repo from issue tracking entirely — see the issue body's analysis of `daemon/internal/github/fetch_issues.go:164` (`repoBelongsToOrg`).
+
+The filter remains visible at the scopes where it has meaningful semantics:
+
+- Global Issue Tracking (`config_screen.dart`)
+- Org detail (`org_detail_screen.dart`)
+
+## Non-goals
+
+- The TOML / API contract is unchanged. `RepoConfig.issueOrganizations` remains a valid model field; legacy values persisted from before this change are preserved untouched.
+- The daemon-side `repoBelongsToOrg` filter is unchanged.
+- No daemon-side validation warning when `organizations` is set at repo scope. (Could be a separate follow-up if anyone is bitten by stale config in the wild.)
+
+## Approach
+
+Pure UI removal plus dead-code cleanup. Two files change.
+
+### 1. `flutter_app/lib/features/repositories/repo_detail_screen.dart`
+
+**Remove the field UI** (currently at lines 472-491):
+
+```dart
+const SizedBox(height: 10),
+AutocompleteChipField(
+  label: 'Organizations',
+  helper: 'GitHub org names to filter issues',
+  selectedValues:
+      _config.issueOrganizations ??
+      orgConfig?.issueOrganizations ??
+      appConfig.issueTracking.organizations,
+  availableOptions: appConfig.knownOrganizations,
+  isOverridden: _config.issueOrganizations != null,
+  inheritedLabel: source(
+    orgConfig?.issueOrganizations != null,
+  ),
+  globalHint: _joinList(
+    orgConfig?.issueOrganizations ??
+        appConfig.issueTracking.organizations,
+  ),
+  onChanged: (v) =>
+      _update(_config.copyWith(issueOrganizations: v)),
+  onReset: () => _resetField('issue_tracking/organizations'),
+),
+```
+
+The leading `SizedBox(height: 10)` separator must be removed along with the field — otherwise a phantom gap remains between **Default action** and **Assignees**.
+
+**Remove the dead diff branch** (currently at lines 203-204):
+
+```dart
+if (!_listsEqual(old.issueOrganizations, updated.issueOrganizations)) {
+  itDiff['organizations'] = updated.issueOrganizations ?? <String>[];
+}
+```
+
+Justification — `_config.issueOrganizations` is initialized exactly once from `appConfig.repoConfigs[repoName]` in `_initFrom` (guarded by `_initialized`). The only mutation point in this screen is the field's `onChanged` (line 489), and the only reset path is its `onReset` (line 490). With both gone, no code path in this screen can change `_config.issueOrganizations`, so the diff branch is unreachable. Per project convention we delete unreachable code rather than keep it as defensive insurance for hypothetical future regressions.
+
+### 2. `flutter_app/test/features/repositories/repo_detail_screen_test.dart` (new file)
+
+Mirror the structure of `flutter_app/test/features/organizations/org_detail_screen_test.dart`:
+
+- `MockApiClient extends Mock implements ApiClient`.
+- `tester.pumpWidget` a `ProviderScope` with overrides for:
+  - `apiClientProvider` → mock
+  - `configNotifierProvider` → real notifier (`ConfigNotifier.new`)
+  - `agentsProvider` → empty list
+- Stub `mockApi.fetchConfig()` to return a minimal config with a `repo_overrides` entry for the test repo (e.g. `theburrowhub/heimdallm`) where `issue_tracking.enabled = true` so the section renders fully.
+- Stub `mockApi.fetchRepoLabels(...)` and `mockApi.fetchRepoCollaborators(...)` (called by `_loadRepoMeta` at lines 49-65) to return empty lists. Without these the widget will throw inside `_loadRepoMeta` and the test will be flaky.
+- Pump the screen with `home: const RepoDetailScreen(repoName: 'theburrowhub/heimdallm')` and `pumpAndSettle()`.
+
+**Assertions:**
+
+- `expect(find.text('Organizations'), findsNothing);` — the regression guard.
+- Sanity checks that the surrounding fields still render (proving the section loaded, not that the test config was empty):
+  - `Assignees`, `Review-only labels`, `Skip labels`, `Filter mode`, `Default action`, `Prompt` — each `findsOneWidget`.
+
+## Verification
+
+Run from the worktree root:
+
+```bash
+cd flutter_app && flutter analyze
+cd flutter_app && flutter test
+```
+
+Both must pass clean. Then a manual spot-check via `make build-web`: open a repo detail page, confirm the Issue Tracking section renders cleanly without **Organizations**, the spacing between **Default action** and **Assignees** is correct, and a config save (e.g. toggling another field) still persists.
+
+## Files touched
+
+- `flutter_app/lib/features/repositories/repo_detail_screen.dart` — remove field UI (lines 472-491 + leading spacer) and dead diff branch (lines 203-204).
+- `flutter_app/test/features/repositories/repo_detail_screen_test.dart` — new file.
+
+## Out of scope (explicit)
+
+- `RepoConfig.issueOrganizations` field, `copyWith` parameter, JSON serialization, and TOML emission in `first_run_setup.dart` all remain. Legacy config files keep working unchanged.
+- No changes to `daemon/internal/github/fetch_issues.go` or `repoBelongsToOrg`.
+- No new daemon-side validation. No data migration.

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -200,9 +200,6 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
     if (!_listsEqual(old.developLabels, updated.developLabels)) {
       itDiff['develop_labels'] = updated.developLabels ?? <String>[];
     }
-    if (!_listsEqual(old.issueOrganizations, updated.issueOrganizations)) {
-      itDiff['organizations'] = updated.issueOrganizations ?? <String>[];
-    }
     if (!_listsEqual(old.issueAssignees, updated.issueAssignees)) {
       itDiff['assignees'] = updated.issueAssignees ?? <String>[];
     }
@@ -467,27 +464,6 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                     onChanged: (v) =>
                         _update(_config.copyWith(issueDefaultAction: v)),
                     onReset: () => _resetField('issue_tracking/default_action'),
-                  ),
-                  const SizedBox(height: 10),
-                  AutocompleteChipField(
-                    label: 'Organizations',
-                    helper: 'GitHub org names to filter issues',
-                    selectedValues:
-                        _config.issueOrganizations ??
-                        orgConfig?.issueOrganizations ??
-                        appConfig.issueTracking.organizations,
-                    availableOptions: appConfig.knownOrganizations,
-                    isOverridden: _config.issueOrganizations != null,
-                    inheritedLabel: source(
-                      orgConfig?.issueOrganizations != null,
-                    ),
-                    globalHint: _joinList(
-                      orgConfig?.issueOrganizations ??
-                          appConfig.issueTracking.organizations,
-                    ),
-                    onChanged: (v) =>
-                        _update(_config.copyWith(issueOrganizations: v)),
-                    onReset: () => _resetField('issue_tracking/organizations'),
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(

--- a/flutter_app/test/features/repositories/repo_detail_screen_test.dart
+++ b/flutter_app/test/features/repositories/repo_detail_screen_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/api/api_client.dart';
+import 'package:heimdallm/core/models/agent.dart';
+import 'package:heimdallm/features/agents/agents_screen.dart';
+import 'package:heimdallm/features/config/config_providers.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
+import 'package:heimdallm/features/repositories/repo_detail_screen.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  testWidgets(
+    'RepoDetailScreen hides Organizations filter in Issue Tracking',
+    (tester) async {
+      const repoName = 'theburrowhub/heimdallm';
+      final mockApi = MockApiClient();
+
+      when(() => mockApi.fetchConfig()).thenAnswer(
+        (_) async => {
+          'repositories': [repoName],
+          'server_port': 1,
+          'poll_interval': '60s',
+          'retention_days': 30,
+          'ai_primary': 'claude',
+          'ai_fallback': '',
+          'review_mode': 'single',
+          'issue_tracking': {'enabled': true},
+        },
+      );
+      when(() => mockApi.fetchRepoLabels(repoName))
+          .thenAnswer((_) async => <String>[]);
+      when(() => mockApi.fetchRepoCollaborators(repoName))
+          .thenAnswer((_) async => <String>[]);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiClientProvider.overrideWithValue(mockApi),
+            configNotifierProvider.overrideWith(ConfigNotifier.new),
+            agentsProvider.overrideWith((_) async => <ReviewPrompt>[]),
+          ],
+          child: const MaterialApp(
+            home: RepoDetailScreen(repoName: repoName),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Regression guard: Organizations field must not appear at repo scope.
+      expect(find.text('Organizations'), findsNothing);
+
+      // Sanity: surrounding Issue Tracking fields still render.
+      expect(find.text('Review-only labels'), findsOneWidget);
+      expect(find.text('Skip labels'), findsOneWidget);
+      expect(find.text('Filter mode'), findsOneWidget);
+      expect(find.text('Default action'), findsOneWidget);
+      expect(find.text('Assignees'), findsOneWidget);
+      expect(find.text('Prompt'), findsWidgets);
+    },
+  );
+}


### PR DESCRIPTION
Closes #403.

## Summary

The **Issue Tracking → Organizations** field on the repo detail screen has no valid use case at repo scope:

| Operator action | Effect |
|---|---|
| Leaves it empty | Inherits global/org config — *the only correct behavior* |
| Types the repo's own org | No-op (the daemon's `repoBelongsToOrg` check at `daemon/internal/github/fetch_issues.go:164` trivially matches the repo's owner against the list) |
| Types any other value | The repo is **silently excluded from issue tracking entirely** — issues from `freepik-company/foo` never match a filter that requires `theburrowhub` |

The filter is only meaningful at scopes where multiple orgs are involved. It stays visible in **global Issue Tracking** (`config_screen.dart`) and on the **org detail screen** (`org_detail_screen.dart`). The **Assignees** field stays at repo scope — it remains a meaningful per-user filter.

## Why hide instead of disable + tooltip

Hiding is cleaner: the field has no valid use case at repo scope. A "configure at higher scope" tooltip preserves visual symmetry but invites operators to fill the field anyway and break their tracking. We optimize for the common case (operator does the right thing automatically) over the rare case (someone wonders where the field went).

## Changes

- **`flutter_app/lib/features/repositories/repo_detail_screen.dart`**
  - Removed the `AutocompleteChipField` for Organizations from the Issue Tracking section (and its leading `SizedBox` separator, otherwise we'd leave a phantom gap between Default action and Assignees).
  - Removed the now-unreachable diff branch in `_computeRepoDiff` for `issueOrganizations`. With the field removed, no code path in this screen can mutate `_config.issueOrganizations` — `_initFrom` runs once (guarded by `_initialized`), the field's `onChanged`/`onReset` are gone, and no other call site touches that field via `copyWith`. Per project hygiene we delete dead code rather than keep it as defensive insurance.

- **`flutter_app/test/features/repositories/repo_detail_screen_test.dart`** (new)
  - Pumps `RepoDetailScreen` with a mocked `ApiClient` (mirrors `flutter_app/test/features/organizations/org_detail_screen_test.dart`).
  - Regression guard: `expect(find.text('Organizations'), findsNothing)`.
  - Sanity asserts the surrounding Issue Tracking fields (`Review-only labels`, `Skip labels`, `Filter mode`, `Default action`, `Assignees`, `Prompt`) still render — proves the section actually loaded.

- **`docs/superpowers/specs/2026-05-07-issue-403-hide-organizations-repo-scope-design.md`** (new)
  - Design notes capturing the rationale, files touched, and explicit out-of-scope items.

## Out of scope

- The **TOML / API contract is unchanged**. `RepoConfig.issueOrganizations` stays in the model with its `copyWith` parameter, JSON parser, and TOML emitter (`first_run_setup.dart`). Legacy config files that already have `issue_tracking.organizations = […]` at repo scope keep working untouched — the value is just no longer reachable from the UI.
- No changes to the daemon's `repoBelongsToOrg` filter or any daemon-side code.
- No new daemon-side validation that warns when `organizations` is set at repo scope. (Could be a useful follow-up if anyone is bitten by stale config in the wild — out of scope here.)

## Verification

- ✅ `make verify-linux` (full Docker pipeline: daemon tests + flutter pub get + flutter test + builds): exit 0
- ✅ `cd flutter_app && flutter test`: 147/147 passing, including the new `RepoDetailScreen hides Organizations filter in Issue Tracking`
- ✅ `cd flutter_app && flutter analyze`: clean (no issues)

## Test plan

- [ ] Open a repo detail screen in the app (e.g. via `make build-web`); confirm the Issue Tracking section renders without **Organizations** and the spacing between **Default action** and **Assignees** looks right.
- [ ] Toggle another field in Issue Tracking (e.g. **Skip labels**) and confirm the autosave still works (no regression in `_computeRepoDiff` from removing the dead branch).
- [ ] Confirm **Organizations** still renders on the **org detail screen** and on the **global Issue Tracking** config screen.
- [ ] (Optional) Load a config that already has `issue_tracking.organizations = ["x"]` under a `repo_overrides` entry and confirm the value is preserved on disk after the screen loads/saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)