### PR TITLE
feat(app): expose refinement labels config

### DIFF
--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -124,6 +124,7 @@ class RepoConfig {
 
   // Issue tracking overrides (null = inherit global)
   final List<String>? reviewOnlyLabels;
+  final List<String>? refinementLabels;
   final List<String>? skipLabels;
   final String? issueFilterMode;
   final String? issueDefaultAction;
@@ -156,6 +157,7 @@ class RepoConfig {
     this.promptId,
     this.reviewMode,
     this.reviewOnlyLabels,
+    this.refinementLabels,
     this.skipLabels,
     this.issueFilterMode,
     this.issueDefaultAction,
@@ -178,8 +180,8 @@ class RepoConfig {
     final issueActive =
         itEnabled == true ||
         (itEnabled != false &&
-            reviewOnlyLabels != null &&
-            reviewOnlyLabels!.isNotEmpty);
+            ((reviewOnlyLabels != null && reviewOnlyLabels!.isNotEmpty) ||
+                (refinementLabels != null && refinementLabels!.isNotEmpty)));
     final developActive =
         devEnabled == true ||
         (devEnabled != false &&
@@ -205,6 +207,7 @@ class RepoConfig {
       generatePRDescription != null ||
       developLabels != null ||
       reviewOnlyLabels != null ||
+      refinementLabels != null ||
       skipLabels != null ||
       issueFilterMode != null ||
       issueDefaultAction != null ||
@@ -230,6 +233,9 @@ class RepoConfig {
     if (itEnabled == false) return 'off';
     // Labels configured = implicitly active (matches daemon behavior)
     if (reviewOnlyLabels != null && reviewOnlyLabels!.isNotEmpty) return 'repo';
+    if (refinementLabels != null && refinementLabels!.isNotEmpty) {
+      return 'repo';
+    }
     return globalITEnabled ? 'global' : 'off';
   }
 
@@ -258,6 +264,7 @@ class RepoConfig {
     Object? promptId = _sentinel,
     Object? reviewMode = _sentinel,
     Object? reviewOnlyLabels = _sentinel,
+    Object? refinementLabels = _sentinel,
     Object? skipLabels = _sentinel,
     Object? issueFilterMode = _sentinel,
     Object? issueDefaultAction = _sentinel,
@@ -303,6 +310,9 @@ class RepoConfig {
       reviewOnlyLabels: reviewOnlyLabels == _sentinel
           ? this.reviewOnlyLabels
           : reviewOnlyLabels as List<String>?,
+      refinementLabels: refinementLabels == _sentinel
+          ? this.refinementLabels
+          : refinementLabels as List<String>?,
       skipLabels: skipLabels == _sentinel
           ? this.skipLabels
           : skipLabels as List<String>?,
@@ -361,6 +371,7 @@ class OrgConfig {
   final bool? itEnabled;
   final bool? devEnabled;
   final List<String>? reviewOnlyLabels;
+  final List<String>? refinementLabels;
   final List<String>? developLabels;
   final List<String>? skipLabels;
   final String? issueFilterMode;
@@ -388,6 +399,7 @@ class OrgConfig {
     this.itEnabled,
     this.devEnabled,
     this.reviewOnlyLabels,
+    this.refinementLabels,
     this.developLabels,
     this.skipLabels,
     this.issueFilterMode,
@@ -416,6 +428,7 @@ class OrgConfig {
       itEnabled != null ||
       devEnabled != null ||
       reviewOnlyLabels != null ||
+      refinementLabels != null ||
       developLabels != null ||
       skipLabels != null ||
       issueFilterMode != null ||
@@ -443,6 +456,7 @@ class OrgConfig {
     Object? itEnabled = _sentinel,
     Object? devEnabled = _sentinel,
     Object? reviewOnlyLabels = _sentinel,
+    Object? refinementLabels = _sentinel,
     Object? developLabels = _sentinel,
     Object? skipLabels = _sentinel,
     Object? issueFilterMode = _sentinel,
@@ -487,6 +501,9 @@ class OrgConfig {
     reviewOnlyLabels: reviewOnlyLabels == _sentinel
         ? this.reviewOnlyLabels
         : reviewOnlyLabels as List<String>?,
+    refinementLabels: refinementLabels == _sentinel
+        ? this.refinementLabels
+        : refinementLabels as List<String>?,
     developLabels: developLabels == _sentinel
         ? this.developLabels
         : developLabels as List<String>?,
@@ -519,6 +536,8 @@ class OrgConfig {
     final itRaw = json['issue_tracking'] as Map<String, dynamic>?;
     final hasReviewLabels =
         _nullableStringList(itRaw?['review_only_labels']) != null;
+    final hasRefinementLabels =
+        _nullableStringList(itRaw?['refinement_labels']) != null;
     final hasDevLabels = _nullableStringList(itRaw?['develop_labels']) != null;
     final itExplicit = itRaw != null && itRaw.containsKey('enabled')
         ? itRaw['enabled'] as bool?
@@ -541,10 +560,14 @@ class OrgConfig {
           _nonEmpty(json['issue_prompt']) ??
           (itRaw != null ? _nonEmpty(itRaw['issue_prompt']) : null),
       developPromptId: _nonEmpty(json['implement_prompt']),
-      itEnabled: itExplicit ?? (hasReviewLabels ? true : null),
+      itEnabled:
+          itExplicit ?? (hasReviewLabels || hasRefinementLabels ? true : null),
       devEnabled: devExplicit ?? (hasDevLabels ? true : null),
       reviewOnlyLabels: itRaw != null
           ? _nullableStringListAllowEmpty(itRaw['review_only_labels'])
+          : null,
+      refinementLabels: itRaw != null
+          ? _nullableStringListAllowEmpty(itRaw['refinement_labels'])
           : null,
       developLabels: itRaw != null
           ? _nullableStringListAllowEmpty(itRaw['develop_labels'])
@@ -603,6 +626,7 @@ class IssueTrackingConfig {
   final String filterMode; // "exclusive" | "inclusive"
   final String defaultAction; // "ignore" | "review_only"
   final List<String> developLabels;
+  final List<String> refinementLabels;
   final List<String> reviewOnlyLabels;
   final List<String> skipLabels;
   final List<String> organizations;
@@ -613,6 +637,7 @@ class IssueTrackingConfig {
     this.filterMode = 'exclusive',
     this.defaultAction = 'ignore',
     this.developLabels = const [],
+    this.refinementLabels = const [],
     this.reviewOnlyLabels = const [],
     this.skipLabels = const [],
     this.organizations = const [],
@@ -624,6 +649,7 @@ class IssueTrackingConfig {
     String? filterMode,
     String? defaultAction,
     List<String>? developLabels,
+    List<String>? refinementLabels,
     List<String>? reviewOnlyLabels,
     List<String>? skipLabels,
     List<String>? organizations,
@@ -633,6 +659,7 @@ class IssueTrackingConfig {
     filterMode: filterMode ?? this.filterMode,
     defaultAction: defaultAction ?? this.defaultAction,
     developLabels: developLabels ?? this.developLabels,
+    refinementLabels: refinementLabels ?? this.refinementLabels,
     reviewOnlyLabels: reviewOnlyLabels ?? this.reviewOnlyLabels,
     skipLabels: skipLabels ?? this.skipLabels,
     organizations: organizations ?? this.organizations,
@@ -644,6 +671,7 @@ class IssueTrackingConfig {
     'filter_mode': filterMode,
     'default_action': defaultAction,
     'develop_labels': developLabels,
+    'refinement_labels': refinementLabels,
     'review_only_labels': reviewOnlyLabels,
     'skip_labels': skipLabels,
     'organizations': organizations,
@@ -665,6 +693,7 @@ class IssueTrackingConfig {
           ? rawDefaultAction
           : 'ignore',
       developLabels: _stringList(json['develop_labels']),
+      refinementLabels: _stringList(json['refinement_labels']),
       reviewOnlyLabels: _stringList(json['review_only_labels']),
       skipLabels: _stringList(json['skip_labels']),
       organizations: _stringList(json['organizations']),
@@ -882,6 +911,8 @@ class AppConfig {
         // Derive enabled flags from reality: explicit enabled OR labels configured
         final hasReviewLabels =
             _nullableStringList(itRaw?['review_only_labels']) != null;
+        final hasRefinementLabels =
+            _nullableStringList(itRaw?['refinement_labels']) != null;
         final hasDevLabels =
             _nullableStringList(itRaw?['develop_labels']) != null;
         final itExplicit = itRaw != null && itRaw.containsKey('enabled')
@@ -897,7 +928,9 @@ class AppConfig {
             : null;
         configs[entry.key] = RepoConfig(
           prEnabled: existing?.prEnabled,
-          itEnabled: itExplicit ?? (hasReviewLabels ? true : null),
+          itEnabled:
+              itExplicit ??
+              (hasReviewLabels || hasRefinementLabels ? true : null),
           devEnabled: devExplicit ?? (hasDevLabels ? true : null),
           localDir: _nonEmpty(ov['local_dir']),
           triageOwner: _nonEmpty(ov['triage_owner']),
@@ -911,6 +944,9 @@ class AppConfig {
           promptId: _nonEmpty(ov['prompt']),
           reviewOnlyLabels: itRaw != null
               ? _nullableStringListAllowEmpty(itRaw['review_only_labels'])
+              : null,
+          refinementLabels: itRaw != null
+              ? _nullableStringListAllowEmpty(itRaw['refinement_labels'])
               : null,
           skipLabels: itRaw != null
               ? _nullableStringListAllowEmpty(itRaw['skip_labels'])

--- a/flutter_app/lib/core/setup/first_run_setup.dart
+++ b/flutter_app/lib/core/setup/first_run_setup.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import '../models/config_model.dart';
 import 'gh_cli.dart';
 
@@ -191,6 +192,7 @@ class FirstRunSetup {
   static String _tomlStringArray(List<String> values) =>
       '[${values.map((v) => '"${_tomlEscapeString(v)}"').join(', ')}]';
 
+  @visibleForTesting
   static String buildTomlForTesting(AppConfig config) => _buildToml(config);
 
   static String _buildToml(AppConfig config) {

--- a/flutter_app/lib/core/setup/first_run_setup.dart
+++ b/flutter_app/lib/core/setup/first_run_setup.dart
@@ -191,6 +191,8 @@ class FirstRunSetup {
   static String _tomlStringArray(List<String> values) =>
       '[${values.map((v) => '"${_tomlEscapeString(v)}"').join(', ')}]';
 
+  static String buildTomlForTesting(AppConfig config) => _buildToml(config);
+
   static String _buildToml(AppConfig config) {
     final buf = StringBuffer();
 
@@ -240,6 +242,11 @@ class FirstRunSetup {
     if (it.developLabels.isNotEmpty) {
       buf.writeln(
         'develop_labels = [${it.developLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]',
+      );
+    }
+    if (it.refinementLabels.isNotEmpty) {
+      buf.writeln(
+        'refinement_labels = [${it.refinementLabels.map((l) => '"${_tomlEscapeString(l)}"').join(', ')}]',
       );
     }
     if (it.reviewOnlyLabels.isNotEmpty) {
@@ -428,6 +435,7 @@ class FirstRunSetup {
         }
         final hasIT =
             oc.developLabels != null ||
+            oc.refinementLabels != null ||
             oc.reviewOnlyLabels != null ||
             oc.skipLabels != null ||
             oc.issueFilterMode != null ||
@@ -445,6 +453,11 @@ class FirstRunSetup {
           if (oc.developLabels != null) {
             buf.writeln(
               'develop_labels = ${_tomlStringArray(oc.developLabels!)}',
+            );
+          }
+          if (oc.refinementLabels != null) {
+            buf.writeln(
+              'refinement_labels = ${_tomlStringArray(oc.refinementLabels!)}',
             );
           }
           if (oc.reviewOnlyLabels != null) {
@@ -540,6 +553,7 @@ class FirstRunSetup {
         // Issue tracking overrides (sub-table — must come after all repo-level keys)
         final hasIT =
             rc.developLabels != null ||
+            rc.refinementLabels != null ||
             rc.reviewOnlyLabels != null ||
             rc.skipLabels != null ||
             rc.issueFilterMode != null ||
@@ -557,6 +571,11 @@ class FirstRunSetup {
           if (rc.developLabels != null) {
             buf.writeln(
               'develop_labels = ${_tomlStringArray(rc.developLabels!)}',
+            );
+          }
+          if (rc.refinementLabels != null) {
+            buf.writeln(
+              'refinement_labels = ${_tomlStringArray(rc.refinementLabels!)}',
             );
           }
           if (rc.reviewOnlyLabels != null) {

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -218,6 +218,9 @@ Map<String, dynamic> _computeIssueTrackingDiff(
   if (_listsDiffer(old.developLabels, updated.developLabels)) {
     diff['develop_labels'] = updated.developLabels;
   }
+  if (_listsDiffer(old.refinementLabels, updated.refinementLabels)) {
+    diff['refinement_labels'] = updated.refinementLabels;
+  }
   if (_listsDiffer(old.reviewOnlyLabels, updated.reviewOnlyLabels)) {
     diff['review_only_labels'] = updated.reviewOnlyLabels;
   }

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -439,6 +439,16 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         ),
         const SizedBox(height: 10),
         AutocompleteChipField(
+          label: 'Refinement labels',
+          helper: 'Issues with these labels get a deep implementation plan',
+          selectedValues: _issueTracking.refinementLabels,
+          availableOptions: const [],
+          onChanged: (v) => setState(() {
+            _issueTracking = _issueTracking.copyWith(refinementLabels: v ?? []);
+          }),
+        ),
+        const SizedBox(height: 10),
+        AutocompleteChipField(
           label: 'Skip labels',
           helper: 'Issues with these labels are ignored (highest priority)',
           selectedValues: _issueTracking.skipLabels,

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -291,7 +291,8 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                   const SizedBox(height: 10),
                   AutocompleteChipField(
                     label: 'Refinement labels',
-                    helper: 'Issues with these labels get a deep plan',
+                    helper:
+                        'Issues with these labels get a deep implementation plan',
                     selectedValues:
                         _config.refinementLabels ??
                         appConfig.issueTracking.refinementLabels,

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -150,6 +150,9 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
     if (!_listsEqual(old.reviewOnlyLabels, updated.reviewOnlyLabels)) {
       itDiff['review_only_labels'] = updated.reviewOnlyLabels ?? <String>[];
     }
+    if (!_listsEqual(old.refinementLabels, updated.refinementLabels)) {
+      itDiff['refinement_labels'] = updated.refinementLabels ?? <String>[];
+    }
     if (!_listsEqual(old.developLabels, updated.developLabels)) {
       itDiff['develop_labels'] = updated.developLabels ?? <String>[];
     }
@@ -284,6 +287,23 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                         _update(_config.copyWith(reviewOnlyLabels: v)),
                     onReset: () =>
                         _resetField('issue_tracking/review_only_labels'),
+                  ),
+                  const SizedBox(height: 10),
+                  AutocompleteChipField(
+                    label: 'Refinement labels',
+                    helper: 'Issues with these labels get a deep plan',
+                    selectedValues:
+                        _config.refinementLabels ??
+                        appConfig.issueTracking.refinementLabels,
+                    availableOptions: const <String>[],
+                    isOverridden: _config.refinementLabels != null,
+                    globalHint: _joinList(
+                      appConfig.issueTracking.refinementLabels,
+                    ),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(refinementLabels: v)),
+                    onReset: () =>
+                        _resetField('issue_tracking/refinement_labels'),
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -194,6 +194,9 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
     if (!_listsEqual(old.reviewOnlyLabels, updated.reviewOnlyLabels)) {
       itDiff['review_only_labels'] = updated.reviewOnlyLabels ?? <String>[];
     }
+    if (!_listsEqual(old.refinementLabels, updated.refinementLabels)) {
+      itDiff['refinement_labels'] = updated.refinementLabels ?? <String>[];
+    }
     if (!_listsEqual(old.skipLabels, updated.skipLabels)) {
       itDiff['skip_labels'] = updated.skipLabels ?? <String>[];
     }
@@ -418,6 +421,27 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                         _update(_config.copyWith(reviewOnlyLabels: v)),
                     onReset: () =>
                         _resetField('issue_tracking/review_only_labels'),
+                  ),
+                  const SizedBox(height: 10),
+                  AutocompleteChipField(
+                    label: 'Refinement labels',
+                    helper:
+                        'Issues with these labels get a deep implementation plan',
+                    selectedValues:
+                        _config.refinementLabels ??
+                        orgConfig?.refinementLabels ??
+                        appConfig.issueTracking.refinementLabels,
+                    availableOptions: _repoLabels,
+                    isOverridden: _config.refinementLabels != null,
+                    inheritedLabel: source(orgConfig?.refinementLabels != null),
+                    globalHint: _joinList(
+                      orgConfig?.refinementLabels ??
+                          appConfig.issueTracking.refinementLabels,
+                    ),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(refinementLabels: v)),
+                    onReset: () =>
+                        _resetField('issue_tracking/refinement_labels'),
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(

--- a/flutter_app/lib/features/repositories/widgets/led_source.dart
+++ b/flutter_app/lib/features/repositories/widgets/led_source.dart
@@ -67,7 +67,8 @@ String featureSourceLine({
       if (config.itEnabled == false) {
         return 'Source: disabled per-repo (itEnabled = false)';
       }
-      if ((config.reviewOnlyLabels ?? const []).isNotEmpty) {
+      if ((config.reviewOnlyLabels ?? const []).isNotEmpty ||
+          (config.refinementLabels ?? const []).isNotEmpty) {
         return 'Source: implied by per-repo labels';
       }
       if (orgConfig?.itEnabled == true) {
@@ -75,6 +76,7 @@ String featureSourceLine({
       }
       if (orgConfig?.itEnabled == false) return 'Source: disabled at org level';
       if ((orgConfig?.reviewOnlyLabels ?? const []).isNotEmpty ||
+          (orgConfig?.refinementLabels ?? const []).isNotEmpty ||
           (orgConfig?.developLabels ?? const []).isNotEmpty) {
         return 'Source: implied by org labels';
       }
@@ -123,12 +125,14 @@ bool _issueTrackingOn(
   if (config.itEnabled == true) return true;
   if (config.itEnabled == false) return false;
   if ((config.reviewOnlyLabels ?? const []).isNotEmpty ||
+      (config.refinementLabels ?? const []).isNotEmpty ||
       (config.developLabels ?? const []).isNotEmpty) {
     return true;
   }
   if (orgConfig?.itEnabled == true) return true;
   if (orgConfig?.itEnabled == false) return false;
   if ((orgConfig?.reviewOnlyLabels ?? const []).isNotEmpty ||
+      (orgConfig?.refinementLabels ?? const []).isNotEmpty ||
       (orgConfig?.developLabels ?? const []).isNotEmpty) {
     return true;
   }

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -7,6 +7,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:heimdallm/core/api/api_client.dart';
 import 'package:heimdallm/core/models/config_model.dart';
 import 'package:heimdallm/core/platform/platform_services_provider.dart';
+import 'package:heimdallm/core/setup/first_run_setup.dart';
 import 'package:heimdallm/features/config/config_providers.dart';
 import 'package:heimdallm/features/config/config_screen.dart';
 import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
@@ -103,6 +104,7 @@ void main() {
           'pr_reviewers': ['alice'],
           'issue_tracking': {
             'develop_labels': ['ready'],
+            'refinement_labels': ['needs-plan'],
           },
         },
       },
@@ -118,9 +120,10 @@ void main() {
     expect(org.autoPromoteRefinement, isTrue);
     expect(org.generatePRDescription, isFalse);
     expect(org.prReviewers, ['alice']);
-    expect(org.itEnabled, isNull);
+    expect(org.itEnabled, isTrue);
     expect(org.devEnabled, isTrue);
     expect(org.developLabels, ['ready']);
+    expect(org.refinementLabels, ['needs-plan']);
     expect(cfg.globalTriageOwner, 'global-owner');
     expect(cfg.globalCloneDir, '/work/global');
     expect(cfg.globalAutoPromoteTriage, isTrue);
@@ -153,12 +156,17 @@ void main() {
           'issue_tracking': {
             'enabled': false,
             'review_only_labels': <String>[],
+            'refinement_labels': <String>[],
           },
         },
       },
       'org_overrides': {
         'acme': {
-          'issue_tracking': {'enabled': false, 'develop_labels': <String>[]},
+          'issue_tracking': {
+            'enabled': false,
+            'develop_labels': <String>[],
+            'refinement_labels': <String>[],
+          },
         },
       },
     };
@@ -167,6 +175,7 @@ void main() {
     final repo = cfg.repoConfigs['acme/api']!;
     expect(repo.itEnabled, isFalse);
     expect(repo.reviewOnlyLabels, isEmpty);
+    expect(repo.refinementLabels, isEmpty);
     expect(repo.developPromptId, 'repo-impl');
     expect(repo.triageOwner, 'repo-owner');
     expect(repo.cloneDir, '/work/repo');
@@ -178,6 +187,71 @@ void main() {
     final org = cfg.orgConfigs['acme']!;
     expect(org.itEnabled, isFalse);
     expect(org.developLabels, isEmpty);
+    expect(org.refinementLabels, isEmpty);
+  });
+
+  test('AppConfig parses refinement labels at global, org, and repo scope', () {
+    final cfg = AppConfig.fromJson({
+      'repositories': <String>[],
+      'non_monitored': ['acme/api'],
+      'server_port': 1,
+      'poll_interval': '60s',
+      'retention_days': 30,
+      'ai_primary': 'claude',
+      'ai_fallback': '',
+      'review_mode': 'single',
+      'issue_tracking': {
+        'enabled': true,
+        'review_only_labels': ['global-triage'],
+        'refinement_labels': ['global-refine'],
+        'develop_labels': ['global-dev'],
+      },
+      'org_overrides': {
+        'acme': {
+          'issue_tracking': {
+            'refinement_labels': ['org-refine'],
+          },
+        },
+      },
+      'repo_overrides': {
+        'acme/api': {
+          'issue_tracking': {
+            'refinement_labels': ['repo-refine'],
+          },
+        },
+      },
+    });
+
+    expect(cfg.issueTracking.refinementLabels, ['global-refine']);
+    expect(cfg.issueTracking.toJson()['refinement_labels'], ['global-refine']);
+    expect(cfg.orgConfigs['acme']!.refinementLabels, ['org-refine']);
+    expect(cfg.orgConfigs['acme']!.itEnabled, isTrue);
+    expect(cfg.repoConfigs['acme/api']!.refinementLabels, ['repo-refine']);
+    expect(cfg.repoConfigs['acme/api']!.itEnabled, isTrue);
+    expect(cfg.repoConfigs['acme/api']!.isMonitored, isTrue);
+  });
+
+  test('FirstRunSetup serializes refinement labels in all scopes', () {
+    final toml = FirstRunSetup.buildTomlForTesting(
+      const AppConfig(
+        issueTracking: IssueTrackingConfig(
+          enabled: true,
+          refinementLabels: ['global-refine'],
+        ),
+        orgConfigs: {
+          'acme': OrgConfig(refinementLabels: ['org-refine']),
+        },
+        repoConfigs: {
+          'acme/api': RepoConfig(refinementLabels: ['repo-refine']),
+        },
+      ),
+    );
+
+    expect(toml, contains('refinement_labels = ["global-refine"]'));
+    expect(toml, contains('[ai.orgs."acme".issue_tracking]'));
+    expect(toml, contains('refinement_labels = ["org-refine"]'));
+    expect(toml, contains('[ai.repos."acme/api".issue_tracking]'));
+    expect(toml, contains('refinement_labels = ["repo-refine"]'));
   });
 
   test('OrgConfig derives enabled switches from label overrides', () {
@@ -194,6 +268,7 @@ void main() {
         'acme': {
           'issue_tracking': {
             'review_only_labels': ['needs-triage'],
+            'refinement_labels': ['needs-plan'],
             'develop_labels': ['ready'],
           },
         },
@@ -203,6 +278,40 @@ void main() {
     final org = cfg.orgConfigs['acme']!;
     expect(org.itEnabled, isTrue);
     expect(org.devEnabled, isTrue);
+    expect(org.refinementLabels, ['needs-plan']);
+  });
+
+  testWidgets('ConfigScreen exposes global refinement labels', (tester) async {
+    final mockApi = MockApiClient();
+    when(() => mockApi.fetchConfig()).thenAnswer(
+      (_) async => const AppConfig(
+        issueTracking: IssueTrackingConfig(enabled: true),
+      ).toJson(),
+    );
+    when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
+    when(() => mockApi.checkHealth()).thenAnswer((_) async => false);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiClientProvider.overrideWithValue(mockApi),
+          configNotifierProvider.overrideWith(ConfigNotifier.new),
+          platformServicesProvider.overrideWithValue(FakePlatformServices()),
+        ],
+        child: MaterialApp.router(
+          routerConfig: GoRouter(
+            routes: [
+              GoRoute(path: '/', builder: (_, __) => const ConfigScreen()),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review-only labels'), findsOneWidget);
+    expect(find.text('Refinement labels'), findsOneWidget);
+    expect(find.text('Develop labels'), findsNothing);
   });
 
   test('AppConfig exposes known autocomplete options', () {

--- a/flutter_app/test/features/organizations/org_detail_screen_test.dart
+++ b/flutter_app/test/features/organizations/org_detail_screen_test.dart
@@ -62,6 +62,7 @@ void main() {
     expect(find.text('Clone directory'), findsOneWidget);
     expect(find.text('Auto-promote triage'), findsOneWidget);
     expect(find.text('Auto-promote refinement'), findsOneWidget);
+    expect(find.text('Refinement labels'), findsOneWidget);
     expect(find.text('Generate PR description'), findsOneWidget);
     expect(find.text('Organizations'), findsOneWidget);
     expect(find.text('Assignees'), findsOneWidget);

--- a/flutter_app/test/features/repositories/repo_detail_screen_test.dart
+++ b/flutter_app/test/features/repositories/repo_detail_screen_test.dart
@@ -12,53 +12,53 @@ import 'package:mocktail/mocktail.dart';
 class MockApiClient extends Mock implements ApiClient {}
 
 void main() {
-  testWidgets(
-    'RepoDetailScreen hides Organizations filter in Issue Tracking',
-    (tester) async {
-      const repoName = 'theburrowhub/heimdallm';
-      final mockApi = MockApiClient();
+  testWidgets('RepoDetailScreen hides Organizations filter in Issue Tracking', (
+    tester,
+  ) async {
+    const repoName = 'theburrowhub/heimdallm';
+    final mockApi = MockApiClient();
 
-      when(() => mockApi.fetchConfig()).thenAnswer(
-        (_) async => {
-          'repositories': [repoName],
-          'server_port': 1,
-          'poll_interval': '60s',
-          'retention_days': 30,
-          'ai_primary': 'claude',
-          'ai_fallback': '',
-          'review_mode': 'single',
-          'issue_tracking': {'enabled': true},
-        },
-      );
-      when(() => mockApi.fetchRepoLabels(repoName))
-          .thenAnswer((_) async => <String>[]);
-      when(() => mockApi.fetchRepoCollaborators(repoName))
-          .thenAnswer((_) async => <String>[]);
+    when(() => mockApi.fetchConfig()).thenAnswer(
+      (_) async => {
+        'repositories': [repoName],
+        'server_port': 1,
+        'poll_interval': '60s',
+        'retention_days': 30,
+        'ai_primary': 'claude',
+        'ai_fallback': '',
+        'review_mode': 'single',
+        'issue_tracking': {'enabled': true},
+      },
+    );
+    when(
+      () => mockApi.fetchRepoLabels(repoName),
+    ).thenAnswer((_) async => <String>[]);
+    when(
+      () => mockApi.fetchRepoCollaborators(repoName),
+    ).thenAnswer((_) async => <String>[]);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            apiClientProvider.overrideWithValue(mockApi),
-            configNotifierProvider.overrideWith(ConfigNotifier.new),
-            agentsProvider.overrideWith((_) async => <ReviewPrompt>[]),
-          ],
-          child: const MaterialApp(
-            home: RepoDetailScreen(repoName: repoName),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiClientProvider.overrideWithValue(mockApi),
+          configNotifierProvider.overrideWith(ConfigNotifier.new),
+          agentsProvider.overrideWith((_) async => <ReviewPrompt>[]),
+        ],
+        child: const MaterialApp(home: RepoDetailScreen(repoName: repoName)),
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      // Regression guard: Organizations field must not appear at repo scope.
-      expect(find.text('Organizations'), findsNothing);
+    // Regression guard: Organizations field must not appear at repo scope.
+    expect(find.text('Organizations'), findsNothing);
 
-      // Sanity: surrounding Issue Tracking fields still render.
-      expect(find.text('Review-only labels'), findsOneWidget);
-      expect(find.text('Skip labels'), findsOneWidget);
-      expect(find.text('Filter mode'), findsOneWidget);
-      expect(find.text('Default action'), findsOneWidget);
-      expect(find.text('Assignees'), findsOneWidget);
-      expect(find.text('Prompt'), findsWidgets);
-    },
-  );
+    // Sanity: surrounding Issue Tracking fields still render.
+    expect(find.text('Review-only labels'), findsOneWidget);
+    expect(find.text('Refinement labels'), findsOneWidget);
+    expect(find.text('Skip labels'), findsOneWidget);
+    expect(find.text('Filter mode'), findsOneWidget);
+    expect(find.text('Default action'), findsOneWidget);
+    expect(find.text('Assignees'), findsOneWidget);
+    expect(find.text('Prompt'), findsWidgets);
+  });
 }

--- a/flutter_app/test/features/repositories/widgets/led_source_test.dart
+++ b/flutter_app/test/features/repositories/widgets/led_source_test.dart
@@ -5,38 +5,65 @@ import 'package:heimdallm/features/repositories/widgets/led_source.dart';
 
 void main() {
   const appConfig = AppConfig(
-    serverPort: 1, pollInterval: '60s', retentionDays: 30,
-    aiPrimary: 'claude', aiFallback: '', reviewMode: 'single',
+    serverPort: 1,
+    pollInterval: '60s',
+    retentionDays: 30,
+    aiPrimary: 'claude',
+    aiFallback: '',
+    reviewMode: 'single',
     repoConfigs: {'a/b': RepoConfig(prEnabled: true)},
     issueTracking: IssueTrackingConfig(enabled: true),
   );
 
   group('featureIsOn', () {
     test('PR explicit true → on', () {
-      expect(featureIsOn(
-        feature: Feature.prReview,
-        repo: 'a/b',
-        config: const RepoConfig(prEnabled: true),
-        appConfig: appConfig,
-      ), isTrue);
+      expect(
+        featureIsOn(
+          feature: Feature.prReview,
+          repo: 'a/b',
+          config: const RepoConfig(prEnabled: true),
+          appConfig: appConfig,
+        ),
+        isTrue,
+      );
     });
 
     test('Develop off when no local dir and no explicit devEnabled', () {
-      expect(featureIsOn(
-        feature: Feature.develop,
-        repo: 'a/b',
-        config: const RepoConfig(),  // no localDir, no devEnabled
-        appConfig: appConfig,
-      ), isFalse);
+      expect(
+        featureIsOn(
+          feature: Feature.develop,
+          repo: 'a/b',
+          config: const RepoConfig(), // no localDir, no devEnabled
+          appConfig: appConfig,
+        ),
+        isFalse,
+      );
     });
 
     test('Develop active with both devEnabled + local dir', () {
-      expect(featureIsOn(
-        feature: Feature.develop,
-        repo: 'a/b',
-        config: const RepoConfig(devEnabled: true, localDir: '/tmp/x'),
-        appConfig: appConfig,
-      ), isTrue);
+      expect(
+        featureIsOn(
+          feature: Feature.develop,
+          repo: 'a/b',
+          config: const RepoConfig(devEnabled: true, localDir: '/tmp/x'),
+          appConfig: appConfig,
+        ),
+        isTrue,
+      );
+    });
+
+    test('Issue tracking active with refinement labels only', () {
+      expect(
+        featureIsOn(
+          feature: Feature.issueTracking,
+          repo: 'a/b',
+          config: const RepoConfig(refinementLabels: ['needs-plan']),
+          appConfig: appConfig.copyWith(
+            issueTracking: const IssueTrackingConfig(enabled: false),
+          ),
+        ),
+        isTrue,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #408.

Adds `refinement_labels` to the Flutter app configuration surface so users can configure the full staged issue pipeline from the app instead of editing TOML manually.

## Changes

- Parse and serialize `refinement_labels` for global, org, and repo issue tracking config.
- Show `Refinement labels` chip fields in global config, org detail, and repo detail screens.
- Preserve repo > org > global inheritance semantics, including explicit empty overrides and reset behavior.
- Include refinement labels in first-run TOML serialization for global/org/repo scopes.
- Treat refinement-only label overrides as issue-tracking-active in model and LED source logic.

## Validation

- `flutter test test/features/config_test.dart test/features/repositories/repo_detail_screen_test.dart test/features/organizations/org_detail_screen_test.dart test/features/repositories/widgets/led_source_test.dart`
- `flutter analyze`
- `flutter test`
- `make build-web`