### PR TITLE
feat(tui): Server tab (#397, PR 2/2)

### DIFF
--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -1125,12 +1125,12 @@ func (d *Dashboard) renderHelp() string {
 		return helpStyle.Render("[esc]close  [j/k]scroll  [pgup/pgdn]page  [q]uit")
 	}
 	if d.activeTab == tabIssues {
-		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [p]romote  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
+		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [p]romote  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-7]jump")
 	}
 	if d.activeTab == tabPRs {
-		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump")
+		return helpStyle.Render("[q]uit  [r]efresh  [s]top  [enter]detail  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-7]jump")
 	}
-	return helpStyle.Render("[q]uit  [r]efresh  [s]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-6]jump  [G]follow")
+	return helpStyle.Render("[q]uit  [r]efresh  [s]top  [tab]switch  [j/k]scroll  [pgup/pgdn]page  [1-7]jump  [G]follow")
 }
 
 func (d *Dashboard) contentHeight() int {

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -281,7 +281,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return d, nil
 
 	case sseMsg:
-		itemType, info := formatSSEData(msg.Data)
+		itemType, info := formatSSEData(msg.Type, msg.Data)
 		line := activityLine{
 			Time:     time.Now().Format("15:04"),
 			Event:    msg.Type,
@@ -1155,10 +1155,22 @@ func formatActivityTime(ts string) string {
 	return t.Format("15:04")
 }
 
-func formatSSEData(data string) (itemType string, info string) {
+func formatSSEData(eventType, data string) (itemType string, info string) {
 	var m map[string]any
 	if err := json.Unmarshal([]byte(data), &m); err != nil {
 		return "", data
+	}
+
+	switch eventType {
+	case "polling_started":
+		kind, _ := m["kind"].(string)
+		repos, _ := m["repos"].([]any)
+		return "", fmt.Sprintf("%s (%d repos)", kind, len(repos))
+	case "polling_completed":
+		kind, _ := m["kind"].(string)
+		count := toInt(m["count"])
+		ms := toInt(m["duration_ms"])
+		return "", fmt.Sprintf("%s %d items in %dms", kind, count, ms)
 	}
 
 	parts := make([]string, 0)

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -952,8 +952,8 @@ func (d *Dashboard) renderServer(height int) string {
 	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Uptime", uptime))
 
 	// Bind addr / port — sourced from d.config (last successful /config fetch)
-	bindAddr := "(unavailable)"
-	port := "(unavailable)"
+	bindAddr := mutedNote.Render("(unavailable)")
+	port := mutedNote.Render("(unavailable)")
 	if d.config != nil {
 		if v, ok := d.config["bind_addr"].(string); ok && v != "" {
 			bindAddr = v

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -22,9 +22,10 @@ const (
 	tabConfig
 	tabStats
 	tabLogs
+	tabServer
 )
 
-var tabNames = []string{"Activity", "PRs", "Issues", "Config", "Stats", "Logs"}
+var tabNames = []string{"Activity", "PRs", "Issues", "Config", "Stats", "Logs", "Server"}
 
 type Dashboard struct {
 	client *api.Client
@@ -476,6 +477,9 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "6":
 		d.activeTab = tabLogs
 		d.cursor = 0
+	case "7":
+		d.activeTab = tabServer
+		d.cursor = 0
 	}
 	return d, nil
 }
@@ -737,6 +741,8 @@ func (d *Dashboard) renderContent(height int) string {
 		return d.renderStats(height)
 	case tabLogs:
 		return d.renderLogs(height)
+	case tabServer:
+		return d.renderServer(height)
 	}
 	return ""
 }
@@ -908,6 +914,82 @@ func (d *Dashboard) renderConfig(height int) string {
 	if ind := scrollIndicator(start, end, len(lines)); ind != "" {
 		b.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Render(ind))
 	}
+	return b.String()
+}
+
+func (d *Dashboard) serverStatusBadge() string {
+	if d.shutdownInFlight {
+		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).Render("● stopping...")
+	}
+	if !d.connected {
+		return lipgloss.NewStyle().Foreground(colorMuted).Render("● stopped")
+	}
+	return lipgloss.NewStyle().Foreground(colorSuccess).Bold(true).Render("● running")
+}
+
+func (d *Dashboard) renderServer(height int) string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Render("  Server"))
+	b.WriteString("\n")
+	b.WriteString("  " + strings.Repeat("─", 64))
+	b.WriteString("\n")
+
+	mutedNote := lipgloss.NewStyle().Foreground(colorMuted)
+
+	// Status row
+	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Status", d.serverStatusBadge()))
+
+	// Version row — d.version is the build-time version passed into NewDashboard
+	version := d.version
+	if version == "" {
+		version = mutedNote.Render("(unknown)")
+	}
+	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Version", version))
+
+	// Uptime row
+	uptime := time.Since(d.startTime).Truncate(time.Second).String()
+	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Uptime", uptime))
+
+	// Bind addr / port — sourced from d.config (last successful /config fetch)
+	bindAddr := "(unavailable)"
+	port := "(unavailable)"
+	if d.config != nil {
+		if v, ok := d.config["bind_addr"].(string); ok && v != "" {
+			bindAddr = v
+		} else {
+			bindAddr = mutedNote.Render("(default: 127.0.0.1)")
+		}
+		if n := toInt(d.config["server_port"]); n != 0 {
+			port = fmt.Sprintf("%d", n)
+		}
+	}
+
+	b.WriteString(fmt.Sprintf("  %-10s %s   %s\n", "Bind addr", bindAddr,
+		mutedNote.Render("(read-only — edit ~/.config/heimdallm/config.toml)")))
+	b.WriteString(fmt.Sprintf("  %-10s %s   %s\n", "Port", port,
+		mutedNote.Render("(read-only)")))
+
+	b.WriteString("\n")
+
+	// Help line — only show Stop hint when daemon is up.
+	if d.connected && !d.shutdownInFlight {
+		b.WriteString("  " + helpStyle.Render("[s] Stop daemon   [r] Refresh"))
+	} else if d.shutdownInFlight {
+		b.WriteString("  " + helpStyle.Render("[r] Refresh"))
+	} else {
+		b.WriteString("  " + helpStyle.Render("[r] Refresh   (start the daemon from your shell)"))
+	}
+	b.WriteString("\n\n")
+
+	b.WriteString("  ")
+	b.WriteString(mutedNote.Render(
+		"Restarting requires running heimdalld again from your shell"))
+	b.WriteString("\n  ")
+	b.WriteString(mutedNote.Render(
+		"or service manager (TUI cannot spawn the daemon)."))
+	b.WriteString("\n")
+
 	return b.String()
 }
 

--- a/cli/internal/tui/format_sse_test.go
+++ b/cli/internal/tui/format_sse_test.go
@@ -1,0 +1,74 @@
+package tui
+
+import "testing"
+
+func TestFormatSSEData(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		data      string
+		wantType  string
+		wantInfo  string
+	}{
+		{
+			name:      "review_completed with repo + pr_number + severity",
+			eventType: "review_completed",
+			data:      `{"repo":"acme/foo","pr_number":42,"severity":"high"}`,
+			wantType:  "pr",
+			wantInfo:  "acme/foo PR #42 [high]",
+		},
+		{
+			name:      "issue_review_completed with repo + issue_number",
+			eventType: "issue_review_completed",
+			data:      `{"repo":"acme/foo","issue_number":7}`,
+			wantType:  "issue",
+			wantInfo:  "acme/foo Issue #7",
+		},
+		{
+			name:      "polling_started renders kind + repo count",
+			eventType: "polling_started",
+			data:      `{"kind":"prs","repos":["acme/foo","acme/bar"]}`,
+			wantType:  "",
+			wantInfo:  "prs (2 repos)",
+		},
+		{
+			name:      "polling_completed renders kind + count + duration",
+			eventType: "polling_completed",
+			data:      `{"kind":"issues","count":5,"duration_ms":800}`,
+			wantType:  "",
+			wantInfo:  "issues 5 items in 800ms",
+		},
+		{
+			name:      "polling_started with empty repos list",
+			eventType: "polling_started",
+			data:      `{"kind":"prs","repos":[]}`,
+			wantType:  "",
+			wantInfo:  "prs (0 repos)",
+		},
+		{
+			name:      "unknown event with no recognizable fields falls back to raw",
+			eventType: "mystery",
+			data:      `{"foo":"bar"}`,
+			wantType:  "",
+			wantInfo:  `{"foo":"bar"}`,
+		},
+		{
+			name:      "malformed JSON returns raw data",
+			eventType: "polling_started",
+			data:      "not json",
+			wantType:  "",
+			wantInfo:  "not json",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotInfo := formatSSEData(tt.eventType, tt.data)
+			if gotType != tt.wantType {
+				t.Errorf("type: got %q want %q", gotType, tt.wantType)
+			}
+			if gotInfo != tt.wantInfo {
+				t.Errorf("info: got %q want %q", gotInfo, tt.wantInfo)
+			}
+		})
+	}
+}

--- a/cli/internal/tui/logs.go
+++ b/cli/internal/tui/logs.go
@@ -147,7 +147,7 @@ func sseToLogLine(evt api.SSEEvent) logLine {
 		line.Badge = "EVENT"
 		line.Action = strings.ToUpper(evt.Type)
 		line.Status = logNeutral
-		_, line.Target = formatSSEData(evt.Data)
+		_, line.Target = formatSSEData(evt.Type, evt.Data)
 		return line
 	}
 

--- a/docs/superpowers/plans/2026-05-08-issue-397-tui-server-tab.md
+++ b/docs/superpowers/plans/2026-05-08-issue-397-tui-server-tab.md
@@ -1,0 +1,538 @@
+# TUI Server Tab Implementation Plan (#397, PR 2/2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a 7th "Server" tab to the TUI dashboard that consolidates operational status (running/stopped, version, uptime, listen URL display) plus a small polish so the daemon's `polling_started` / `polling_completed` events render with kind/count/duration instead of raw JSON.
+
+**Architecture:** Single-file change to `cli/internal/tui/dashboard.go` (new tab constant, key shortcut, render dispatch arm, `renderServer` + `serverStatusBadge` helpers, extended `formatSSEData`) plus a one-line update at the existing call site in `cli/internal/tui/logs.go` and a new `cli/internal/tui/format_sse_test.go`. No new dependencies. ~100-150 net lines of Go.
+
+**Tech Stack:** Go 1.25, Bubble Tea + Lipgloss (already in `cli/go.mod`).
+
+**Standing rules from the user:**
+- Never commit to `main`. Work on `feat/tui-server-tab-397` inside `.worktrees/tui-server-397`.
+- Verification runs through the cached `heimdallm-verify` Docker image (no host Go).
+- Each plan task ends in a commit; surface code for review before pushing.
+
+---
+
+## File Structure
+
+### Modified
+- `cli/internal/tui/dashboard.go` — add `tabServer` constant + `tabNames` entry + `case "7"` shortcut + render-dispatch arm + `renderServer` + `serverStatusBadge` + extend `formatSSEData` signature and add `polling_*` cases.
+- `cli/internal/tui/logs.go` — update the one `formatSSEData` call site at line 150 to pass `evt.Type`.
+
+### New
+- `cli/internal/tui/format_sse_test.go` — table-driven tests for the formatter.
+
+### Style names (from `cli/internal/tui/styles.go` — already defined, do NOT add)
+- `colorSuccess` — green (running indicator).
+- `colorWarning` — orange (stopping indicator, also currently used by `renderStatus` for both `stopping...` and `refreshing...`).
+- `colorMuted` — grey (stopped / unavailable).
+- The spec mentioned `colorOk`; that name does **not** exist in this codebase. Use `colorSuccess`.
+
+---
+
+## Task ordering rationale
+
+TDD-first for the parser change (well-bounded, easy to test in isolation), then the new tab, then verification. Three tasks total — the work is small.
+
+---
+
+### Task 1: TDD `formatSSEData` extension
+
+**Files:**
+- Modify: `cli/internal/tui/dashboard.go` (the `formatSSEData` function at line 1158-1190; one call site at line 284).
+- Modify: `cli/internal/tui/logs.go` (one call site at line 150).
+- Create: `cli/internal/tui/format_sse_test.go`.
+
+- [ ] **Step 1.1: Write the failing test**
+
+Create `cli/internal/tui/format_sse_test.go`:
+
+```go
+package tui
+
+import "testing"
+
+func TestFormatSSEData(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		data      string
+		wantType  string
+		wantInfo  string
+	}{
+		{
+			name:      "review_completed with repo + pr_number + severity",
+			eventType: "review_completed",
+			data:      `{"repo":"acme/foo","pr_number":42,"severity":"high"}`,
+			wantType:  "pr",
+			wantInfo:  "acme/foo PR #42 [high]",
+		},
+		{
+			name:      "issue_review_completed with repo + issue_number",
+			eventType: "issue_review_completed",
+			data:      `{"repo":"acme/foo","issue_number":7}`,
+			wantType:  "issue",
+			wantInfo:  "acme/foo Issue #7",
+		},
+		{
+			name:      "polling_started renders kind + repo count",
+			eventType: "polling_started",
+			data:      `{"kind":"prs","repos":["acme/foo","acme/bar"]}`,
+			wantType:  "",
+			wantInfo:  "prs (2 repos)",
+		},
+		{
+			name:      "polling_completed renders kind + count + duration",
+			eventType: "polling_completed",
+			data:      `{"kind":"issues","count":5,"duration_ms":800}`,
+			wantType:  "",
+			wantInfo:  "issues 5 items in 800ms",
+		},
+		{
+			name:      "polling_started with empty repos list",
+			eventType: "polling_started",
+			data:      `{"kind":"prs","repos":[]}`,
+			wantType:  "",
+			wantInfo:  "prs (0 repos)",
+		},
+		{
+			name:      "unknown event with no recognizable fields falls back to raw",
+			eventType: "mystery",
+			data:      `{"foo":"bar"}`,
+			wantType:  "",
+			wantInfo:  `{"foo":"bar"}`,
+		},
+		{
+			name:      "malformed JSON returns raw data",
+			eventType: "polling_started",
+			data:      "not json",
+			wantType:  "",
+			wantInfo:  "not json",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotInfo := formatSSEData(tt.eventType, tt.data)
+			if gotType != tt.wantType {
+				t.Errorf("type: got %q want %q", gotType, tt.wantType)
+			}
+			if gotInfo != tt.wantInfo {
+				t.Errorf("info: got %q want %q", gotInfo, tt.wantInfo)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify go test ./internal/tui -run TestFormatSSEData -v 2>&1 | tail -10`
+Expected: FAIL with a build error like `too many arguments in call to formatSSEData` (because the existing signature is `formatSSEData(data string)`, not `formatSSEData(eventType, data)`).
+
+- [ ] **Step 1.3: Update `formatSSEData` signature and add `polling_*` cases**
+
+In `cli/internal/tui/dashboard.go`, replace the existing function at line 1158-1190:
+
+```go
+func formatSSEData(data string) (itemType string, info string) {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(data), &m); err != nil {
+		return "", data
+	}
+
+	parts := make([]string, 0)
+	if repo, ok := m["repo"]; ok {
+		parts = append(parts, fmt.Sprintf("%v", repo))
+	}
+	if num, ok := m["pr_number"]; ok {
+		itemType = "pr"
+		n := toInt(num)
+		if n != 0 {
+			parts = append(parts, fmt.Sprintf("PR #%d", n))
+		}
+	}
+	if num, ok := m["issue_number"]; ok {
+		itemType = "issue"
+		n := toInt(num)
+		if n != 0 {
+			parts = append(parts, fmt.Sprintf("Issue #%d", n))
+		}
+	}
+	if sev, ok := m["severity"]; ok {
+		parts = append(parts, fmt.Sprintf("[%v]", sev))
+	}
+
+	if len(parts) > 0 {
+		return itemType, strings.Join(parts, " ")
+	}
+	return itemType, data
+}
+```
+
+with the new version:
+
+```go
+func formatSSEData(eventType, data string) (itemType string, info string) {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(data), &m); err != nil {
+		return "", data
+	}
+
+	switch eventType {
+	case "polling_started":
+		kind, _ := m["kind"].(string)
+		repos, _ := m["repos"].([]any)
+		return "", fmt.Sprintf("%s (%d repos)", kind, len(repos))
+	case "polling_completed":
+		kind, _ := m["kind"].(string)
+		count := toInt(m["count"])
+		ms := toInt(m["duration_ms"])
+		return "", fmt.Sprintf("%s %d items in %dms", kind, count, ms)
+	}
+
+	parts := make([]string, 0)
+	if repo, ok := m["repo"]; ok {
+		parts = append(parts, fmt.Sprintf("%v", repo))
+	}
+	if num, ok := m["pr_number"]; ok {
+		itemType = "pr"
+		n := toInt(num)
+		if n != 0 {
+			parts = append(parts, fmt.Sprintf("PR #%d", n))
+		}
+	}
+	if num, ok := m["issue_number"]; ok {
+		itemType = "issue"
+		n := toInt(num)
+		if n != 0 {
+			parts = append(parts, fmt.Sprintf("Issue #%d", n))
+		}
+	}
+	if sev, ok := m["severity"]; ok {
+		parts = append(parts, fmt.Sprintf("[%v]", sev))
+	}
+
+	if len(parts) > 0 {
+		return itemType, strings.Join(parts, " ")
+	}
+	return itemType, data
+}
+```
+
+- [ ] **Step 1.4: Update the two call sites**
+
+In `cli/internal/tui/dashboard.go` line 284, change:
+
+```go
+		itemType, info := formatSSEData(msg.Data)
+```
+
+to:
+
+```go
+		itemType, info := formatSSEData(msg.Type, msg.Data)
+```
+
+In `cli/internal/tui/logs.go` line 150, change:
+
+```go
+		_, line.Target = formatSSEData(evt.Data)
+```
+
+to:
+
+```go
+		_, line.Target = formatSSEData(evt.Type, evt.Data)
+```
+
+- [ ] **Step 1.5: Run tests to verify they pass**
+
+Run: `docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify go test ./internal/tui -run TestFormatSSEData -v 2>&1 | tail -15`
+Expected: All 7 sub-tests PASS.
+
+- [ ] **Step 1.6: Run the full `cli` test suite to confirm no regressions**
+
+Run: `docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify go test ./... -count=1 -timeout=60s 2>&1 | tail -10`
+Expected: all packages PASS (or "no test files" for packages without tests). No build errors.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add cli/internal/tui/dashboard.go cli/internal/tui/logs.go cli/internal/tui/format_sse_test.go
+git commit -m "feat(tui): render polling_* events with kind/count/duration
+
+formatSSEData gains an eventType parameter and dedicated cases for
+polling_started ('<kind> (<n> repos)') and polling_completed
+('<kind> <count> items in <ms>ms'). Without this they fell through
+to raw JSON in the Activity tab. Updates the two call sites
+(dashboard.go and logs.go) for the new signature.
+
+Refs #397"
+```
+
+---
+
+### Task 2: Add the Server tab
+
+**Files:**
+- Modify: `cli/internal/tui/dashboard.go` (tab enum at lines 18-25, `tabNames` at line 27, key handler around line 461-478, `renderContent` switch at line 727-740; add new `renderServer` + `serverStatusBadge` near the other render functions).
+
+- [ ] **Step 2.1: Add the `tabServer` constant and tab label**
+
+In `cli/internal/tui/dashboard.go`, replace the `const ( … )` block at lines 18-25 with:
+
+```go
+const (
+	tabActivity tab = iota
+	tabPRs
+	tabIssues
+	tabConfig
+	tabStats
+	tabLogs
+	tabServer
+)
+```
+
+and replace `tabNames` at line 27 with:
+
+```go
+var tabNames = []string{"Activity", "PRs", "Issues", "Config", "Stats", "Logs", "Server"}
+```
+
+- [ ] **Step 2.2: Add the number-key shortcut**
+
+In `cli/internal/tui/dashboard.go`, find the existing `case "1":` ... `case "6":` block in `handleKey` (lines 461-478). After the `case "6":` arm and before the closing `}`, add:
+
+```go
+		case "7":
+			d.activeTab = tabServer
+			d.cursor = 0
+```
+
+- [ ] **Step 2.3: Wire the new tab into the render dispatch**
+
+In `cli/internal/tui/dashboard.go`, in `renderContent` (around line 727-740), add a new case after `case tabLogs:` and before the closing `}`:
+
+```go
+	case tabServer:
+		return d.renderServer(height)
+```
+
+So the full switch becomes:
+
+```go
+	switch d.activeTab {
+	case tabActivity:
+		return d.renderActivity(height)
+	case tabPRs:
+		return d.renderPRs(height)
+	case tabIssues:
+		return d.renderIssues(height)
+	case tabConfig:
+		return d.renderConfig(height)
+	case tabStats:
+		return d.renderStats(height)
+	case tabLogs:
+		return d.renderLogs(height)
+	case tabServer:
+		return d.renderServer(height)
+	}
+```
+
+- [ ] **Step 2.4: Implement `serverStatusBadge`**
+
+In `cli/internal/tui/dashboard.go`, add a new helper. Place it just before `renderServer` (which is added in the next step). The function should mirror the existing `renderStatus` pattern at line 657-672:
+
+```go
+func (d *Dashboard) serverStatusBadge() string {
+	if d.shutdownInFlight {
+		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).Render("● stopping...")
+	}
+	if !d.connected {
+		return lipgloss.NewStyle().Foreground(colorMuted).Render("● stopped")
+	}
+	return lipgloss.NewStyle().Foreground(colorSuccess).Bold(true).Render("● running")
+}
+```
+
+- [ ] **Step 2.5: Implement `renderServer`**
+
+In `cli/internal/tui/dashboard.go`, add `renderServer` immediately after `serverStatusBadge` (insert both near the other `render*` functions, e.g. just before `renderStats` at line 914, or just after `renderLogs` — anywhere alongside its peers):
+
+```go
+func (d *Dashboard) renderServer(height int) string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Render("  Server"))
+	b.WriteString("\n")
+	b.WriteString("  " + strings.Repeat("─", 64))
+	b.WriteString("\n")
+
+	mutedNote := lipgloss.NewStyle().Foreground(colorMuted)
+
+	// Status row
+	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Status", d.serverStatusBadge()))
+
+	// Version row — d.version is the build-time version passed into NewDashboard
+	version := d.version
+	if version == "" {
+		version = mutedNote.Render("(unknown)")
+	}
+	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Version", version))
+
+	// Uptime row
+	uptime := time.Since(d.startTime).Truncate(time.Second).String()
+	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Uptime", uptime))
+
+	// Bind addr / port — sourced from d.config (last successful /config fetch)
+	bindAddr := "(unavailable)"
+	port := "(unavailable)"
+	if d.config != nil {
+		if v, ok := d.config["bind_addr"].(string); ok && v != "" {
+			bindAddr = v
+		} else {
+			bindAddr = mutedNote.Render("(default: 127.0.0.1)")
+		}
+		if n := toInt(d.config["server_port"]); n != 0 {
+			port = fmt.Sprintf("%d", n)
+		}
+	}
+
+	b.WriteString(fmt.Sprintf("  %-10s %s   %s\n", "Bind addr", bindAddr,
+		mutedNote.Render("(read-only — edit ~/.config/heimdallm/config.toml)")))
+	b.WriteString(fmt.Sprintf("  %-10s %s   %s\n", "Port", port,
+		mutedNote.Render("(read-only)")))
+
+	b.WriteString("\n")
+
+	// Help line — only show Stop hint when daemon is up.
+	if d.connected && !d.shutdownInFlight {
+		b.WriteString("  " + helpStyle.Render("[s] Stop daemon   [r] Refresh"))
+	} else if d.shutdownInFlight {
+		b.WriteString("  " + helpStyle.Render("[r] Refresh"))
+	} else {
+		b.WriteString("  " + helpStyle.Render("[r] Refresh   (start the daemon from your shell)"))
+	}
+	b.WriteString("\n\n")
+
+	b.WriteString("  ")
+	b.WriteString(mutedNote.Render(
+		"Restarting requires running heimdalld again from your shell"))
+	b.WriteString("\n  ")
+	b.WriteString(mutedNote.Render(
+		"or service manager (TUI cannot spawn the daemon)."))
+	b.WriteString("\n")
+
+	return b.String()
+}
+```
+
+- [ ] **Step 2.6: Build to verify wiring**
+
+Run: `docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify go build ./...`
+Expected: builds clean.
+
+- [ ] **Step 2.7: Run the full `cli` test suite**
+
+Run: `docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify go test ./... -count=1 -timeout=60s 2>&1 | tail -10`
+Expected: all PASS.
+
+- [ ] **Step 2.8: Run `go vet` and `gofmt -d` to catch any subtle issues**
+
+Run: `docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify go vet ./... 2>&1 | tail -5`
+Expected: empty output (no vet issues).
+
+Run: `docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify gofmt -d ./internal/tui 2>&1 | head -20`
+Expected: empty output (no formatting deltas).
+
+- [ ] **Step 2.9: Commit**
+
+```bash
+git add cli/internal/tui/dashboard.go
+git commit -m "feat(tui): add Server tab with operational pane (#397)
+
+A 7th tab consolidating daemon status (running indicator, version,
+uptime) and listen URL display (bind addr + port, read-only). Help
+line surfaces the existing s/S Stop binding and r/R Refresh. Pane
+explains restart must be done from the shell or service manager —
+the TUI cannot spawn the daemon.
+
+Reachable via number key 7 or via the existing tab/h/l navigation.
+
+Refs #397"
+```
+
+---
+
+### Task 3: Final verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 3.1: Run `make verify-linux` from the worktree**
+
+Run: `cd /home/vbueno/Desarrollo/workspaces/heimdallm-002/.worktrees/tui-server-397 && make verify-linux 2>&1 | tail -10`
+Expected: exit 0, "✅ Linux build verification passed".
+
+- [ ] **Step 3.2: Targeted `cli` checks against the cached image**
+
+Run: `docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify go test ./... -count=1 -timeout=60s 2>&1 | tail -8`
+Expected: every package `ok` or `[no test files]`. The new `TestFormatSSEData` must appear and PASS.
+
+Run: `docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify go vet ./... 2>&1 | tail -5`
+Expected: empty.
+
+Run: `docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify gofmt -d ./internal/tui 2>&1 | head -10`
+Expected: empty.
+
+- [ ] **Step 3.3: Manual smoke check**
+
+Build the CLI from the worktree:
+
+```bash
+cd /home/vbueno/Desarrollo/workspaces/heimdallm-002/.worktrees/tui-server-397
+docker run --rm -v "$PWD:/app" -w /app/cli heimdallm-verify go build -o /tmp/heimdallm-cli ./cmd/heimdallm-cli
+```
+
+(Or build natively if the host has Go installed.) Run it against a local daemon and walk through:
+
+1. Press `7` → confirm Server tab is visible with Running indicator, version, uptime, bind addr `127.0.0.1`, port `7842`.
+2. Confirm the help line shows `[s] Stop daemon   [r] Refresh`.
+3. Press `s` → confirm `Stop daemon? y/n` confirmation appears in the status bar.
+4. Press `n` → confirm cancel.
+5. Press `s`, then `y` → confirm Server tab indicator transitions to `● stopping...` (warning color) then `● stopped` (muted) once the daemon goes away. Confirm the Stop hint disappears.
+6. Restart the daemon manually (`./heimdalld &` in another shell) and wait ~10s for the next tick → confirm the indicator returns to `● running`.
+7. Wait for a poll cycle (~60s default) → switch to **Activity** tab → confirm `polling_started` and `polling_completed` events appear with formatted info (`prs (N repos)`, `prs N items in Mms`), not raw JSON.
+8. Confirm `tab` and `shift+tab` cycle through all 7 tabs in order.
+
+If any of these fail, fix the regression in a follow-up task or commit. Otherwise no commit needed for Task 3.
+
+- [ ] **Step 3.4: Mark plan complete**
+
+The branch is ready for review. Do not push or open a PR until the user explicitly approves (per standing rules — wait for explicit user authorization before pushing or creating PRs).
+
+---
+
+## Spec coverage check
+
+| Spec section | Covered by |
+|---|---|
+| Component 1: Tab constant + label | Task 2, Step 2.1 |
+| Component 2: Number-key shortcut for `7` | Task 2, Step 2.2 |
+| Component 3: `renderServer(height int) string` | Task 2, Step 2.5 |
+| Component 4: `serverStatusBadge() string` | Task 2, Step 2.4 |
+| Component 5: `formatSSEData` extension | Task 1, Step 1.3 |
+| Component 6: `format_sse_test.go` (new) | Task 1, Step 1.1 |
+| Edge cases: daemon stopped, malformed payload, key collisions, port type | Implicit in `renderServer` and `formatSSEData` cases; tested via Task 1 (parser) and verified manually in Task 3 |
+| Out-of-scope items | Respected: no listen URL editing; no Restart action; no tab reorganization; no daemon-side changes; no new dependencies |
+
+No spec sections are unaccounted for.
+
+## Self-review notes
+
+- **Type / signature consistency:** `formatSSEData(eventType, data string)` is used identically in Task 1 (impl + test + both call sites). `serverStatusBadge() string` and `renderServer(height int) string` are used as defined in Task 2.
+- **Style names:** `colorSuccess`, `colorWarning`, `colorMuted` exist in `styles.go` (verified at exploration). The spec mentioned `colorOk`; this plan uses `colorSuccess` (the actual constant). Captured under "File structure" at the top.
+- **No placeholders.** Each step has the actual code or command. `(default: 127.0.0.1)` and `(unavailable)` are explicit fallbacks.
+- **Frequent commits.** Two implementation commits + one verification task. Each commit leaves the tree compilable.
+- **Spec relationship to PR 1:** noted at the top — this PR can ship before, after, or independently. Live `polling_*` event verification (Step 3.3 part 7) requires the daemon from PR 1; the unit tests don't.

--- a/docs/superpowers/specs/2026-05-08-issue-397-tui-server-tab-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-397-tui-server-tab-design.md
@@ -1,0 +1,335 @@
+# Issue #397 — TUI Server tab (PR 2 of 2)
+
+**Status:** Draft, pending user review.
+**Branch:** `feat/tui-server-tab-397` (worktree at `.worktrees/tui-server-397`).
+**Issue:** https://github.com/theburrowhub/heimdallm/issues/397
+**Companion PR:** https://github.com/theburrowhub/heimdallm/pull/406 — GUI Server section (PR 1).
+
+## Goal
+
+Add a 7th **"Server"** tab to the TUI dashboard that consolidates operational status (running indicator, version, uptime, listen URL display) alongside the existing Stop control. Polish the existing live-event surface so the new `polling_started` / `polling_completed` events emitted by the daemon (PR 1) render with meaningful info instead of raw JSON.
+
+## Why this shape
+
+The TUI already covers most of what the GUI's "Server section" provides:
+
+| GUI's Server tab | TUI today |
+|---|---|
+| **Status** (running, listen URL, version, uptime) | Scattered: status bar shows version + uptime; nothing surfaces the listen URL; no consolidated "operations" pane. |
+| **Events** (live SSE feed) | The **Activity** tab is already a live SSE consumer (prepends every event to a 100-line ring buffer at `dashboard.go:283-307`). |
+| **Logs** | The **Logs** tab already exists and works the same way as the GUI's. |
+| **Listen URL editor** | Config tab is **read-only**. No `bubbles/textinput` or `huh` dependency in `cli/go.mod`. |
+| **Restart action** | Possible to call `/shutdown`, but no `Process.start` equivalent — TUI cannot respawn the daemon. |
+| **Stop action** | Already wired via `s/S` key with `y/n` confirmation (`dashboard.go:457-460`). |
+
+So the truly missing pieces are: (a) a consolidated **Server** pane that surfaces operational state and the listen URL, and (b) human-readable rendering for `polling_*` events in Activity. Everything else either already exists or is intentionally out of scope.
+
+## Non-goals
+
+- **Listen URL editing in the TUI.** Read-only display only. The pane prints a one-liner: *"edit `~/.config/heimdallm/config.toml` and restart the daemon"*. Adding edit capability would mean introducing `bubbles/textinput` (or `huh`) and building edit-mode focus management — disproportionate scope for an operator tool that's typically used over SSH where editing TOML is a one-line operation.
+- **Restart from the TUI.** TUI has no equivalent of the desktop app's `Process.start`; it can only stop. Surfacing a "Restart" hint for an operation the TUI cannot complete is worse UX than not mentioning it. The pane explains: *"Restarting requires running `heimdalld` again from your shell or service manager."*
+- **Reorganizing existing tabs.** Activity stays as a top-level live-event surface (it already does that job well). Logs stays at top-level. The Server tab is purely additive.
+- **Sub-tabs inside Server.** Single-pane layout. Easier to read, one less navigation concept to learn.
+- **Tests for `renderServer` itself.** No precedent in the TUI for widget-level rendering tests; would require terminal-output capture. Manual visual verification is the convention.
+
+## Components
+
+### 1. New tab constant + label
+
+**File:** `cli/internal/tui/dashboard.go` (around lines 18-27).
+
+```go
+const (
+    tabActivity tab = iota
+    tabPRs
+    tabIssues
+    tabConfig
+    tabStats
+    tabLogs
+    tabServer  // new
+)
+
+var tabNames = []string{"Activity", "PRs", "Issues", "Config", "Stats", "Logs", "Server"}
+```
+
+### 2. Number-key shortcut
+
+**File:** `cli/internal/tui/dashboard.go` (the existing `case "1"` ... `case "6"` block in `handleKey`, around lines 461-478).
+
+Add at the end of that block:
+
+```go
+case "7":
+    d.activeTab = tabServer
+    d.cursor = 0
+```
+
+Number `7` is currently free. The existing `tab` / `shift+tab` / `h` / `l` / `right` / `left` keys cycle through tabs in order, so the new tab is reachable that way too without further changes — `len(tabNames)` already drives the modulo arithmetic at lines 378 and 381.
+
+### 3. `renderServer(height int) string`
+
+**File:** `cli/internal/tui/dashboard.go` (new function, placed alongside the other `render*` functions like `renderStats` at line 914).
+
+Renders the Server pane using only state that already exists on the `Dashboard` struct: `d.config`, `d.startTime`, `d.version`, `d.connected`, `d.shutdownInFlight`, `d.shutdownMessage`. **No new state, no new API calls.**
+
+Layout:
+
+```
+  Server
+  ────────────────────────────────────────────────────────────────
+  Status     ● running
+  Version    v0.6.13
+  Uptime     3h 22m
+  Bind addr  127.0.0.1   (read-only — edit ~/.config/heimdallm/config.toml)
+  Port       7842        (read-only)
+
+  [s] Stop daemon   [r] Refresh
+
+  Restarting requires running heimdalld again from your shell
+  or service manager (TUI cannot spawn the daemon).
+```
+
+When `d.connected == false` or `d.config == nil`:
+- Status indicator becomes `● stopped` in the muted color.
+- Bind addr / Port show `(unavailable)` in the muted color.
+- The `[s] Stop daemon` hint disappears (no daemon to stop).
+
+While `d.shutdownInFlight == true`:
+- Status indicator becomes `● stopping...` in the warning color.
+- Hints disabled.
+
+The `View()` switch (around dashboard.go:723-740, the `renderContent` function) gets a new `case tabServer: return d.renderServer(height)` arm.
+
+### 4. `serverStatusBadge() string`
+
+Small private helper (also new in `dashboard.go`) returning the colored status pill. Mirrors the existing `daemonStatusLabel` pattern at line 657-672 (the `renderStatus` function the status bar uses). Reuses `colorOk`, `colorWarning`, `colorMuted` from `styles.go`.
+
+```go
+func (d *Dashboard) serverStatusBadge() string {
+    if d.shutdownInFlight {
+        return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).Render("● stopping...")
+    }
+    if !d.connected {
+        return lipgloss.NewStyle().Foreground(colorMuted).Render("● stopped")
+    }
+    return lipgloss.NewStyle().Foreground(colorOk).Bold(true).Render("● running")
+}
+```
+
+### 5. `formatSSEData` extensions for `polling_*` events
+
+**File:** `cli/internal/tui/dashboard.go` (the existing function at line 1158-1190).
+
+Today the function inspects the JSON payload for keys it recognizes (`repo`, `pr_number`, `issue_number`, `severity`) and falls through to raw JSON for unknown shapes. With the daemon's PR 1 emitting `polling_started` and `polling_completed`, the payload shape is `{kind, repos:[…]}` and `{kind, count, duration_ms}` respectively — none of the existing keys match, so the events render as raw JSON.
+
+We change `formatSSEData` to accept the event type and add type-specific formatters:
+
+```go
+func formatSSEData(eventType, data string) (itemType string, info string) {
+    var m map[string]any
+    if err := json.Unmarshal([]byte(data), &m); err != nil {
+        return "", data
+    }
+
+    switch eventType {
+    case "polling_started":
+        kind, _ := m["kind"].(string)
+        repos, _ := m["repos"].([]any)
+        return "", fmt.Sprintf("%s (%d repos)", kind, len(repos))
+    case "polling_completed":
+        kind, _ := m["kind"].(string)
+        count := toInt(m["count"])
+        ms := toInt(m["duration_ms"])
+        return "", fmt.Sprintf("%s %d items in %dms", kind, count, ms)
+    }
+
+    // Existing logic — unchanged.
+    parts := make([]string, 0)
+    if repo, ok := m["repo"]; ok {
+        parts = append(parts, fmt.Sprintf("%v", repo))
+    }
+    if num, ok := m["pr_number"]; ok {
+        itemType = "pr"
+        n := toInt(num)
+        if n != 0 {
+            parts = append(parts, fmt.Sprintf("PR #%d", n))
+        }
+    }
+    if num, ok := m["issue_number"]; ok {
+        itemType = "issue"
+        n := toInt(num)
+        if n != 0 {
+            parts = append(parts, fmt.Sprintf("Issue #%d", n))
+        }
+    }
+    if sev, ok := m["severity"]; ok {
+        parts = append(parts, fmt.Sprintf("[%v]", sev))
+    }
+
+    if len(parts) > 0 {
+        return itemType, strings.Join(parts, " ")
+    }
+    return itemType, data
+}
+```
+
+Two call sites must be updated:
+- `cli/internal/tui/dashboard.go:284` — change `formatSSEData(msg.Data)` to `formatSSEData(msg.Type, msg.Data)`.
+- `cli/internal/tui/logs.go:150` — change `formatSSEData(evt.Data)` to `formatSSEData(evt.Type, evt.Data)`.
+
+### 6. `format_sse_test.go` (new)
+
+**File:** `cli/internal/tui/format_sse_test.go` (new).
+
+Table-driven test covering each notable case:
+
+```go
+package tui
+
+import "testing"
+
+func TestFormatSSEData(t *testing.T) {
+    tests := []struct {
+        name      string
+        eventType string
+        data      string
+        wantType  string
+        wantInfo  string
+    }{
+        {
+            name:      "review_completed with repo + pr_number + severity",
+            eventType: "review_completed",
+            data:      `{"repo":"acme/foo","pr_number":42,"severity":"high"}`,
+            wantType:  "pr",
+            wantInfo:  "acme/foo PR #42 [high]",
+        },
+        {
+            name:      "polling_started renders kind + repo count",
+            eventType: "polling_started",
+            data:      `{"kind":"prs","repos":["acme/foo","acme/bar"]}`,
+            wantType:  "",
+            wantInfo:  "prs (2 repos)",
+        },
+        {
+            name:      "polling_completed renders kind + count + duration",
+            eventType: "polling_completed",
+            data:      `{"kind":"issues","count":5,"duration_ms":800}`,
+            wantType:  "",
+            wantInfo:  "issues 5 items in 800ms",
+        },
+        {
+            name:      "unknown event falls back to raw JSON",
+            eventType: "mystery",
+            data:      `{"foo":"bar"}`,
+            wantType:  "",
+            wantInfo:  `{"foo":"bar"}`,
+        },
+        {
+            name:      "malformed JSON returns raw data",
+            eventType: "polling_started",
+            data:      "not json",
+            wantType:  "",
+            wantInfo:  "not json",
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            gotType, gotInfo := formatSSEData(tt.eventType, tt.data)
+            if gotType != tt.wantType {
+                t.Errorf("type: got %q want %q", gotType, tt.wantType)
+            }
+            if gotInfo != tt.wantInfo {
+                t.Errorf("info: got %q want %q", gotInfo, tt.wantInfo)
+            }
+        })
+    }
+}
+```
+
+## Architecture
+
+Single-file change: existing `cli/internal/tui/dashboard.go` (plus the one-line call-site update in `logs.go`). No new files in `lib/`. One new test file. **No new dependencies.** Roughly 100-150 net lines of Go.
+
+The TUI's existing model already has every piece of state we need:
+- `d.config["bind_addr"]` / `d.config["server_port"]` — fetched on tick from `/config`. Cast via existing `toInt` helper at line 1170.
+- `d.version` — passed into `NewDashboard`.
+- `d.startTime` — captured in `NewDashboard`.
+- `d.connected` — already toggled from SSE / fetch failures.
+- `d.shutdownInFlight` / `d.shutdownMessage` — already used for the `s/S` flow.
+
+## Data flow
+
+```
+                       tickMsg (10s)
+                           ↓
+   d.fetchData ─────────▶ /config
+                           ↓
+                    d.config["bind_addr"], d.config["server_port"]
+                           ↓
+                    renderServer(height)  ◀─── d.startTime, d.version, d.connected
+                           ↓
+                    View() composes tabs + content
+
+   SSE event ──▶ formatSSEData(type, data) ──▶ activityLine ──▶ Activity tab
+   (polling_*)              (extended)
+                           ↘
+                            sseToLogLine(...) ──▶ Logs tab
+```
+
+## Edge cases
+
+- **Daemon stopped, TUI still open.** `d.config` is nil (last fetch failed); `d.connected` is false. Server pane renders `Status: ● stopped`, `Bind addr: (unavailable)`, `Port: (unavailable)`. Stop hint hidden. Help text suggests starting the daemon.
+- **Bind addr absent from config.** Older daemons without `bind_addr` set in TOML — `d.config["bind_addr"]` is nil; render `(default: 127.0.0.1)` in the muted color.
+- **Polling event with malformed payload.** `formatSSEData` falls through to the existing default branch (raw JSON). Same behavior as today for unknown event types.
+- **Tab key collisions.** `7` is currently free. `tab` / `shift+tab` / `h` / `l` already iterate via modulo on `len(tabNames)`, so they pick up the new tab automatically.
+- **Config value type for port.** Daemon emits `server_port` as a JSON number → unmarshals to `float64` → cast via `toInt`. Same pattern as existing config rendering.
+
+## Testing
+
+- **Unit:** `cli/internal/tui/format_sse_test.go` (new) — table-driven coverage of `formatSSEData` for `review_completed`, `polling_started`, `polling_completed`, unknown event, and malformed JSON.
+- **No widget test for `renderServer`.** No precedent in the TUI; would require terminal-output capture. Verification is manual + analyzer + `go test`.
+
+## Verification
+
+- `make verify-linux` (full Docker pipeline). The CLI is built but not exercised end-to-end inside the verify image; the unit tests cover the changed surface.
+- `cd cli && go test ./...` — including the new `format_sse_test.go`.
+- `cd cli && go vet ./...` and `gofmt -d cli/` — should be clean.
+- **Manual:**
+  - Build CLI (`make build` from worktree, then run `./cli/cmd/heimdallm-cli/heimdallm-cli` against a local daemon).
+  - Press `7` → confirm Server tab renders with running indicator, version, uptime, bind addr, port.
+  - Trigger a poll cycle (60s wait or kick a `/reload` if available); confirm `polling_started` / `polling_completed` appear in Activity tab with formatted info, not raw JSON.
+  - Press `s` → confirm `y/n` confirmation; press `y` → confirm Server tab status indicator changes to `stopping...` then `stopped`. Verify Stop hint disappears.
+  - Hide a daemon (kill the process) and reopen TUI without it running → confirm Server tab shows stopped state cleanly.
+
+## Files touched (summary)
+
+**Modified:**
+- `cli/internal/tui/dashboard.go` — add `tabServer` constant, extend `tabNames`, add `case "7"` shortcut, add `renderServer` + `serverStatusBadge`, wire `tabServer` into the `renderContent` switch, extend `formatSSEData` to accept event type and handle `polling_*` payloads, update one call site (line 284).
+- `cli/internal/tui/logs.go` — update the one `formatSSEData` call site (line 150) to pass `evt.Type`.
+
+**New:**
+- `cli/internal/tui/format_sse_test.go` — table-driven tests for the formatter.
+
+## Open items resolved at implementation
+
+These are deliberately small things confirmed when actually editing:
+
+1. **Exact placement of `case "7"`** — slot it after the existing `case "6"` arm in `handleKey`. Verified in plan.
+2. **Position of `tabServer` in `tabNames`** — appended last (rightmost) so existing tab muscle memory (1-6) is unchanged.
+3. **Color names from `styles.go`** — `colorOk`, `colorWarning`, `colorMuted` exist (verified at exploration). `colorBadge` etc. may also be used in `serverStatusBadge` for the dot character; mirror what `renderStatus` does.
+
+## Out of scope (explicit)
+
+- TUI cannot spawn the daemon: no Restart action, no spawn helper, no `Process.start` equivalent.
+- No editing of listen URL, prompts, or any other config from within the TUI in this PR.
+- No reorganization of the existing tab list. Activity, Logs, Config remain top-level and unchanged.
+- No daemon-side changes. PR 1 already shipped `polling_*` event constants and emission. This PR only consumes them.
+- No new TUI dependencies (`bubbles/textinput`, `huh`, etc.) — the design avoids any feature that would require them.
+
+## Relationship to PR 1 (#406)
+
+This PR can be **merged before, after, or independently of PR 1**:
+
+- The unit tests in `format_sse_test.go` exercise the formatter against literal strings (`"polling_started"`, `"polling_completed"`); they pass regardless of whether the daemon is currently emitting those events.
+- The Server tab itself reads only existing daemon state (`/config`, `/health` via the shared status, uptime).
+- The manual verification step that observes live `polling_*` events in the Activity tab requires PR 1 (or its equivalent daemon build) to be deployed against the running daemon. If PR 1 is not yet merged at the time this PR ships, that one verification step is moot until PR 1 lands — the rest still works.


### PR DESCRIPTION
Refs #397. **Scope: TUI only.** Companion to PR #406 (GUI Server section).

## Summary

Adds a 7th **Server** tab to the TUI dashboard that consolidates daemon operational status — running indicator, version, uptime, listen URL display — alongside the existing Stop control. Polishes the live event surface so the daemon's `polling_started` / `polling_completed` events render with `<kind> (<n> repos)` / `<kind> <count> items in <ms>ms` instead of raw JSON.

## What's where

| File | Change |
|---|---|
| `cli/internal/tui/dashboard.go` | New `tabServer` constant + `tabNames` entry. New `case ""7""` shortcut. New `renderServer(height int)` method (~65 lines) and `serverStatusBadge()` helper. Existing `formatSSEData` gains an `eventType` parameter and dedicated cases for `polling_started` / `polling_completed`. Help text strings updated `[1-6]jump` → `[1-7]jump` at the three render sites that show them. |
| `cli/internal/tui/logs.go` | One-line update at the existing `formatSSEData` call site to pass `evt.Type`. |
| `cli/internal/tui/format_sse_test.go` (new) | 7 table-driven sub-tests covering review_completed, issue_review_completed, polling_started, polling_completed, polling_started with empty repos, unknown event fallback, malformed JSON. |

**Net:** ~100 lines in `dashboard.go`, 1 line in `logs.go`, 74-line test file. No new dependencies — the TUI's existing Bubble Tea + Lipgloss stack is used as-is.

## Server pane layout

```
  Server
  ────────────────────────────────────────────────────────────────
  Status     ● running
  Version    v0.6.13
  Uptime     3h 22m
  Bind addr  127.0.0.1   (read-only — edit ~/.config/heimdallm/config.toml)
  Port       7842        (read-only)

  [s] Stop daemon   [r] Refresh

  Restarting requires running heimdalld again from your shell
  or service manager (TUI cannot spawn the daemon).
```

When the daemon is stopped or unreachable: status indicator is muted `● stopped`, bind addr / port show `(unavailable)` muted, the Stop hint disappears, and the help line says \"start the daemon from your shell\".
While shutdown is in flight: indicator is `● stopping...` in warning color.

## Out of scope (deliberate)

- **Listen URL editing** — the Config tab is read-only today and adding edit mode would mean introducing `bubbles/textinput` (or `huh`) and managing focus state. Operator edits TOML directly.
- **Restart from TUI** — TUI has no `Process.start` equivalent; can only stop. Surfacing a restart action that the TUI can't actually perform would be worse UX than the explicit \"run heimdalld from your shell\" note.
- **Reorganizing existing tabs** — Activity stays as the live-event surface (it already prepends every SSE event to a 100-line ring buffer), Logs stays at top-level. Server is purely additive.
- **Sub-tabs inside Server** — single-pane layout. The GUI sibling has 3 sub-tabs because Status/Events/Logs are visually distinct surfaces; the TUI already has Activity and Logs as top-level tabs, so subdividing Server would duplicate them.
- **Daemon-side changes** — none. PR #406 already shipped the `polling_*` event constants + emission. This PR only consumes them.

## Relationship to PR #406

This PR can ship before, after, or independently of PR #406. The unit tests for `formatSSEData` exercise literal event-type strings and pass regardless of whether the daemon is currently emitting them. The Server pane reads only existing daemon state (`d.config`, `d.startTime`, `d.version`). The manual verification step that observes live `polling_*` events in Activity requires PR #406's daemon build to be deployed — until then that one step is moot, the rest still works.

## Verification

- ✅ `make verify-linux` (full Docker pipeline): exit 0
- ✅ `cd cli && go test ./... -count=1`: all green, including the new `TestFormatSSEData` (7/7 sub-tests passing)
- ✅ `go vet ./...`: clean
- ✅ `gofmt -d ./internal/tui`: clean
- ✅ Per-commit spec + quality reviews and a final cumulative review approved for merge.

## Test plan

- [ ] Build CLI from this branch and run against a local daemon.
- [ ] Press `7` → Server tab opens; confirm `● running`, current version, uptime ticking, bind addr `127.0.0.1`, port `7842`, the read-only notes, and the `[s] Stop daemon   [r] Refresh` help line.
- [ ] Press `s` → status-bar prompts `Stop daemon? y/n`. Press `n` → cancel; press `s` then `y` → Server pane indicator goes `● stopping...` → `● stopped`; Stop hint disappears; help line updates to advise starting the daemon from the shell.
- [ ] Restart the daemon manually (`./heimdalld &`); within ~10 s the indicator returns to `● running`.
- [ ] Wait ~60 s for a poll cycle → switch to **Activity** tab → confirm `polling_started` appears as `prs (N repos)` and `polling_completed` as `prs N items in M ms`, not raw JSON. (Requires PR #406's daemon to be running — otherwise polling events aren't emitted.)
- [ ] Press `tab` / `shift+tab` repeatedly → confirm the cursor cycles through all 7 tabs in order.

## Companion docs in this PR

- `docs/superpowers/specs/2026-05-08-issue-397-tui-server-tab-design.md`
- `docs/superpowers/plans/2026-05-08-issue-397-tui-server-tab.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)