### PR TITLE
fix(issues): process promoted stages within grace

### DIFF
--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -280,18 +280,6 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 		return true, "already implemented (PR created)", nil
 	}
 
-	// A state-machine label promotion is real new work even when the label/comment
-	// update was produced by the bot inside RecomputeGrace. Without this adjacent
-	// stage check, an auto-promoted triage result can get stuck in refinement
-	// until a human makes another GitHub update. Non-adjacent mode differences
-	// still use the normal grace window, which preserves the develop-without-
-	// WorkDir downgrade dedup path.
-	if latestStage, latestOK := StageFromAction(latest.ActionTaken); latestOK {
-		if currentStage, currentOK := StageFromMode(issue.Mode); currentOK && isForwardStageAdvance(latestStage, currentStage) {
-			return false, "", nil
-		}
-	}
-
 	// Bot-comment dedup: if the most recent comment is from the bot AND the
 	// issue's current mode matches what was already done (ActionTaken), the
 	// updated_at bump was self-triggered — skip. When the mode changed
@@ -312,6 +300,15 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 			"repo", issue.Repo, "number", issue.Number, "err", fcErr)
 	} else if failCount >= MaxAutoImplementFailures {
 		return true, fmt.Sprintf("auto_implement failed %d times (cap %d), requires human intervention", failCount, MaxAutoImplementFailures), nil
+	}
+
+	// Any adjacent forward stage promotion is real new work, regardless of
+	// whether the bot or a human changed labels. Do not let RecomputeGrace hide
+	// triage -> refinement or refinement -> development.
+	if latestStage, latestOK := StageFromAction(latest.ActionTaken); latestOK {
+		if currentStage, currentOK := StageFromMode(issue.Mode); currentOK && isForwardStageAdvance(latestStage, currentStage) {
+			return false, "", nil
+		}
 	}
 
 	ref := latest.CommentedAt
@@ -394,7 +391,23 @@ func (f *Fetcher) auditManualStageChange(ctx context.Context, issue *github.Issu
 	})
 }
 
+var issueStageOrder = []IssueStage{
+	IssueStageTriage,
+	IssueStageRefinement,
+	IssueStageDevelopment,
+}
+
 func isForwardStageAdvance(from, to IssueStage) bool {
-	return (from == IssueStageTriage && to == IssueStageRefinement) ||
-		(from == IssueStageRefinement && to == IssueStageDevelopment)
+	fromIdx, fromOK := issueStageOrdinal(from)
+	toIdx, toOK := issueStageOrdinal(to)
+	return fromOK && toOK && toIdx == fromIdx+1
+}
+
+func issueStageOrdinal(stage IssueStage) (int, bool) {
+	for idx, candidate := range issueStageOrder {
+		if candidate == stage {
+			return idx, true
+		}
+	}
+	return 0, false
 }

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -280,6 +280,18 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 		return true, "already implemented (PR created)", nil
 	}
 
+	// A state-machine label promotion is real new work even when the label/comment
+	// update was produced by the bot inside RecomputeGrace. Without this adjacent
+	// stage check, an auto-promoted triage result can get stuck in refinement
+	// until a human makes another GitHub update. Non-adjacent mode differences
+	// still use the normal grace window, which preserves the develop-without-
+	// WorkDir downgrade dedup path.
+	if latestStage, latestOK := StageFromAction(latest.ActionTaken); latestOK {
+		if currentStage, currentOK := StageFromMode(issue.Mode); currentOK && isForwardStageAdvance(latestStage, currentStage) {
+			return false, "", nil
+		}
+	}
+
 	// Bot-comment dedup: if the most recent comment is from the bot AND the
 	// issue's current mode matches what was already done (ActionTaken), the
 	// updated_at bump was self-triggered — skip. When the mode changed
@@ -380,4 +392,9 @@ func (f *Fetcher) auditManualStageChange(ctx context.Context, issue *github.Issu
 		SuppressAudit:  alreadyAudited,
 		Broker:         f.stageBroker,
 	})
+}
+
+func isForwardStageAdvance(from, to IssueStage) bool {
+	return (from == IssueStageTriage && to == IssueStageRefinement) ||
+		(from == IssueStageRefinement && to == IssueStageDevelopment)
 }

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -689,6 +689,65 @@ func TestFetcher_ModeChangeBypassesBotCommentCheck(t *testing.T) {
 	}
 }
 
+func TestFetcher_StageChangeBypassesGraceWindowToRunRefinement(t *testing.T) {
+	reviewedAt := time.Now().Add(-2 * time.Minute)
+	commentedAt := reviewedAt.Add(10 * time.Second)
+	issue := fixture(1, commentedAt.Add(5*time.Second))
+	issue.Mode = config.IssueModeRefinement
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row: &store.Issue{ID: 10, GithubID: issue.ID},
+			review: &store.IssueReview{
+				IssueID:     10,
+				CreatedAt:   reviewedAt,
+				CommentedAt: commentedAt,
+				ActionTaken: string(config.IssueModeReviewOnly),
+			},
+		},
+	}}
+	pub := &fakeIssuePublisher{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, &fakePipeline{})
+	f.SetPublisher(pub)
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", stagePipelineCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 1 || len(pub.refinement) != 1 || pub.refinement[0] != 1 {
+		t.Fatalf("stage change should run refinement despite grace window, processed=%d pub=%v", processed, pub.refinement)
+	}
+}
+
+func TestFetcher_StageChangeBypassesGraceWindowToRunDevelop(t *testing.T) {
+	reviewedAt := time.Now().Add(-2 * time.Minute)
+	commentedAt := reviewedAt.Add(10 * time.Second)
+	issue := fixture(2, commentedAt.Add(5*time.Second))
+	issue.ID = int64(2002)
+	issue.Mode = config.IssueModeDevelop
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row: &store.Issue{ID: 20, GithubID: issue.ID},
+			review: &store.IssueReview{
+				IssueID:     20,
+				CreatedAt:   reviewedAt,
+				CommentedAt: commentedAt,
+				ActionTaken: string(config.IssueModeRefinement),
+			},
+		},
+	}}
+	pub := &fakeIssuePublisher{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, &fakePipeline{})
+	f.SetPublisher(pub)
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", stagePipelineCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 1 || len(pub.implement) != 1 || pub.implement[0] != 2 {
+		t.Fatalf("stage change should run develop despite grace window, processed=%d pub=%v", processed, pub.implement)
+	}
+}
+
 func TestFetcher_ManualStageLabelChangeAuditsAndDispatchesNewStage(t *testing.T) {
 	now := time.Now()
 	issue := &github.Issue{

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -721,9 +721,13 @@ func TestFetcher_StageChangeBypassesGraceWindowToRunRefinement(t *testing.T) {
 func TestFetcher_StageChangeBypassesGraceWindowToRunDevelop(t *testing.T) {
 	reviewedAt := time.Now().Add(-2 * time.Minute)
 	commentedAt := reviewedAt.Add(10 * time.Second)
-	issue := fixture(2, commentedAt.Add(5*time.Second))
-	issue.ID = int64(2002)
-	issue.Mode = config.IssueModeDevelop
+	issue := &github.Issue{
+		ID:        2002,
+		Number:    2,
+		Repo:      "org/repo",
+		UpdatedAt: commentedAt.Add(5 * time.Second),
+		Mode:      config.IssueModeDevelop,
+	}
 	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
 		issue.ID: {
 			row: &store.Issue{ID: 20, GithubID: issue.ID},
@@ -745,6 +749,100 @@ func TestFetcher_StageChangeBypassesGraceWindowToRunDevelop(t *testing.T) {
 	}
 	if processed != 1 || len(pub.implement) != 1 || pub.implement[0] != 2 {
 		t.Fatalf("stage change should run develop despite grace window, processed=%d pub=%v", processed, pub.implement)
+	}
+}
+
+func TestFetcher_NonForwardStageChangesStillUseGraceWindow(t *testing.T) {
+	reviewedAt := time.Now().Add(-2 * time.Minute)
+	commentedAt := reviewedAt.Add(10 * time.Second)
+	cases := []struct {
+		name        string
+		number      int
+		actionTaken string
+		mode        config.IssueMode
+	}{
+		{
+			name:        "triage to development is non-adjacent",
+			number:      3,
+			actionTaken: string(config.IssueModeReviewOnly),
+			mode:        config.IssueModeDevelop,
+		},
+		{
+			name:        "development to refinement is backward",
+			number:      4,
+			actionTaken: string(config.IssueModeDevelop),
+			mode:        config.IssueModeRefinement,
+		},
+		{
+			name:        "refinement to refinement is same stage",
+			number:      5,
+			actionTaken: string(config.IssueModeRefinement),
+			mode:        config.IssueModeRefinement,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issue := fixture(tc.number, commentedAt.Add(5*time.Second))
+			issue.Mode = tc.mode
+			dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+				issue.ID: {
+					row: &store.Issue{ID: int64(tc.number), GithubID: issue.ID},
+					review: &store.IssueReview{
+						IssueID:     int64(tc.number),
+						CreatedAt:   reviewedAt,
+						CommentedAt: commentedAt,
+						ActionTaken: tc.actionTaken,
+					},
+				},
+			}}
+			pub := &fakeIssuePublisher{}
+			f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, &fakePipeline{})
+			f.SetPublisher(pub)
+
+			processed, err := f.ProcessRepo(context.Background(), "org/repo", stagePipelineCfg(), "alice", noOpts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if processed != 0 || len(pub.triage) != 0 || len(pub.refinement) != 0 || len(pub.implement) != 0 {
+				t.Fatalf("non-forward stage change should stay deduped within grace, processed=%d pub=%+v", processed, pub)
+			}
+		})
+	}
+}
+
+func TestFetcher_StageChangeDoesNotBypassAutoImplementFailureCap(t *testing.T) {
+	reviewedAt := time.Now().Add(-2 * time.Minute)
+	commentedAt := reviewedAt.Add(10 * time.Second)
+	issue := &github.Issue{
+		ID:        2006,
+		Number:    6,
+		Repo:      "org/repo",
+		UpdatedAt: commentedAt.Add(5 * time.Second),
+		Mode:      config.IssueModeDevelop,
+	}
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row: &store.Issue{ID: 60, GithubID: issue.ID},
+			review: &store.IssueReview{
+				IssueID:     60,
+				CreatedAt:   reviewedAt,
+				CommentedAt: commentedAt,
+				ActionTaken: string(config.IssueModeRefinement),
+			},
+			failedAutoImpl: issues.MaxAutoImplementFailures,
+		},
+	}}
+	pub := &fakeIssuePublisher{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, &fakePipeline{})
+	f.SetPublisher(pub)
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", stagePipelineCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 0 || len(pub.implement) != 0 {
+		t.Fatalf("failure cap should block develop even on stage advance, processed=%d pub=%v", processed, pub.implement)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Allow adjacent issue stage promotions (`triage -> refinement`, `refinement -> development`) to bypass the normal no-new-activity grace window.
- Keep non-adjacent mode differences on the existing grace path so develop-without-WorkDir fallback remains deduped.
- Add regression tests for refinement and develop dispatch immediately after a stored previous stage.

## Root Cause

In the #414 smoke test, triage completed and auto-promoted the issue to `heimdallm_refine`, but the promotion happened inside `RecomputeGrace` after the triage comment. `Fetcher.alreadyProcessed` skipped the issue as "no new activity since last review" before dispatching the newly classified refinement stage.

## Validation

- `make test-docker GO_TEST_ARGS="-run 'TestFetcher_StageChangeBypassesGraceWindow|TestFetcher_SkipsIssueAlreadyReviewedWithoutNewActivity|TestFetcher_SlowTriageDoesNotReloop|TestIntegration_FetcherDrivesPipelineEndToEnd' ./internal/issues/..."`
- `make test-docker`

Fixes #416.