### PR TITLE
fix(issues): scope triage breaker to triage runs

### DIFF
--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -420,12 +420,12 @@ func (p *Pipeline) Run(ctx context.Context, issue *github.Issue, opts RunOptions
 		return nil, fmt.Errorf("issues pipeline: refusing an ignore-classified issue (fetcher should have filtered it out)")
 	}
 
-	// Upsert + initial SSE events are common to both flows so we do them
+	// Upsert + initial SSE events are common to all flows so we do them
 	// here. issue_detected fires before the flow forks, issue_review_started
 	// fires after so the UI can show the correct "triaging" vs "implementing"
 	// copy — the runner sets the exact flavour it wants.
 	//
-	// Upsert runs BEFORE the circuit breaker so the breaker's per-issue
+	// For triage runs, upsert runs BEFORE the circuit breaker so its per-issue
 	// count (which keys on the internal store ID via issue_reviews.issue_id)
 	// sees the correct row. The upsert is idempotent — on a breaker-trip
 	// the issue row stays but no issue_reviews row is written for this
@@ -439,12 +439,14 @@ func (p *Pipeline) Run(ctx context.Context, issue *github.Issue, opts RunOptions
 		return nil, fmt.Errorf("issues pipeline: upsert issue: %w", err)
 	}
 
-	// Circuit breaker: hard cap on triage count per issue / per repo.
+	// Circuit breaker: hard cap on triage count per issue / per repo. It must
+	// not gate refinement or develop, otherwise a correctly promoted issue can
+	// get stuck after earlier triage/refinement activity.
 	// Runs AFTER the in-flight claim and upsert so it only fires when
 	// both dedup layers missed; returns *CircuitBreakerError so the
 	// caller (fetcher) can distinguish it from a genuine pipeline
 	// failure. See theburrowhub/heimdallm#292.
-	if p.breaker != nil {
+	if p.breaker != nil && effective == config.IssueModeReviewOnly {
 		tripped, reason, err := p.store.CheckIssueCircuitBreaker(issueID, issue.Repo, *p.breaker)
 		if err != nil {
 			slog.Warn("issues pipeline: circuit breaker check failed, proceeding",

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -633,6 +633,29 @@ func TestPipeline_RunRefinementHappyPath(t *testing.T) {
 	}
 }
 
+func TestPipeline_CircuitBreakerDoesNotGateRefinement(t *testing.T) {
+	s := &fakeStore{
+		breakerTripped: true,
+		breakerReason:  "triage cap reached",
+	}
+	gh := &fakeGH{}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte(validRefinementResult)}
+	p := issues.New(s, gh, exec, nil, &fakeBroker{}, nil)
+	p.SetCircuitBreakerLimits(&store.IssueCircuitBreakerLimits{PerIssue24h: 3, PerRepoHr: 10})
+
+	rev, err := p.Run(context.Background(), newIssue(config.IssueModeRefinement), issues.RunOptions{
+		Primary:                     "claude",
+		ExecOpts:                    executor.ExecOptions{WorkDir: "/tmp/repo"},
+		RequireWorkDirForRefinement: true,
+	})
+	if err != nil {
+		t.Fatalf("refinement should not be blocked by the triage circuit breaker: %v", err)
+	}
+	if rev == nil || rev.ActionTaken != string(config.IssueModeRefinement) {
+		t.Fatalf("review = %+v, want refinement review", rev)
+	}
+}
+
 func TestPipeline_RefinementRequiresWorkDir(t *testing.T) {
 	p := issues.New(&fakeStore{}, &fakeGH{}, &fakeExec{}, nil, &fakeBroker{}, nil)
 	_, err := p.Run(context.Background(), newIssue(config.IssueModeRefinement), issues.RunOptions{Primary: "claude"})
@@ -833,6 +856,26 @@ func TestPipeline_AutoImplementHappyPath(t *testing.T) {
 	// Prompt was the implement flavour, not the triage JSON instruction.
 	if !strings.Contains(exec.lastPrompt, "Implement what the issue asks for") {
 		t.Errorf("prompt should be the implement flavour")
+	}
+}
+
+func TestPipeline_CircuitBreakerDoesNotGateDevelop(t *testing.T) {
+	s := &fakeStore{
+		breakerTripped: true,
+		breakerReason:  "triage cap reached",
+	}
+	gh := &fakeGH{defaultBranch: "main", createPRNumber: 123}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("done")}
+	git := &fakeGit{hasChanges: true}
+	p := issues.New(s, gh, exec, git, &fakeBroker{}, nil)
+	p.SetCircuitBreakerLimits(&store.IssueCircuitBreakerLimits{PerIssue24h: 3, PerRepoHr: 10})
+
+	rev, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions())
+	if err != nil {
+		t.Fatalf("develop should not be blocked by the triage circuit breaker: %v", err)
+	}
+	if rev == nil || rev.ActionTaken != string(config.IssueModeDevelop) {
+		t.Fatalf("review = %+v, want develop review", rev)
 	}
 }
 

--- a/daemon/internal/store/issue_circuitbreaker.go
+++ b/daemon/internal/store/issue_circuitbreaker.go
@@ -5,18 +5,17 @@ import (
 	"time"
 )
 
-// CountIssueReviewsForIssue returns the number of reviews for the given
-// issue whose created_at is at or after `since`. Mirrors
-// CountReviewsForPR from the PR side; used by the issue-triage circuit
-// breaker to cap runaway re-triage loops (see theburrowhub/heimdallm#292).
+// CountIssueReviewsForIssue returns the number of triage reviews for the
+// given issue whose created_at is at or after `since`. Refinement/develop
+// rows do not consume the triage breaker budget.
 func (s *Store) CountIssueReviewsForIssue(issueID int64, since time.Time) (int, error) {
 	var n int
 	err := s.db.QueryRow(
-		"SELECT COUNT(*) FROM issue_reviews WHERE issue_id = ? AND created_at >= ?",
+		"SELECT COUNT(*) FROM issue_reviews WHERE issue_id = ? AND created_at >= ? AND action_taken = 'review_only'",
 		issueID, since.UTC().Format(sqliteTimeFormat),
 	).Scan(&n)
 	if err != nil {
-		return 0, fmt.Errorf("store: count issue reviews for issue: %w", err)
+		return 0, fmt.Errorf("store: count issue triages for issue: %w", err)
 	}
 	return n, nil
 }
@@ -29,7 +28,7 @@ func (s *Store) CountIssueTriagesForRepo(repo string, since time.Time) (int, err
 	err := s.db.QueryRow(`
 		SELECT COUNT(*) FROM issue_reviews r
 		JOIN issues i ON r.issue_id = i.id
-		WHERE i.repo = ? AND r.created_at >= ?`,
+		WHERE i.repo = ? AND r.created_at >= ? AND r.action_taken = 'review_only'`,
 		repo, since.UTC().Format(sqliteTimeFormat),
 	).Scan(&n)
 	if err != nil {

--- a/daemon/internal/store/issue_circuitbreaker_test.go
+++ b/daemon/internal/store/issue_circuitbreaker_test.go
@@ -9,13 +9,18 @@ import (
 
 func seedIssueReview(t *testing.T, s *store.Store, issueID int64, at time.Time) {
 	t.Helper()
+	seedIssueReviewWithAction(t, s, issueID, at, "review_only")
+}
+
+func seedIssueReviewWithAction(t *testing.T, s *store.Store, issueID int64, at time.Time, action string) {
+	t.Helper()
 	if _, err := s.InsertIssueReview(&store.IssueReview{
 		IssueID:     issueID,
 		CLIUsed:     "claude",
 		Summary:     "s",
 		Triage:      "{}",
 		Suggestions: "[]",
-		ActionTaken: "review_only",
+		ActionTaken: action,
 		CreatedAt:   at,
 	}); err != nil {
 		t.Fatalf("insert review: %v", err)
@@ -50,6 +55,31 @@ func TestCountIssueReviewsForIssue_CountsWithinWindow(t *testing.T) {
 	}
 }
 
+func TestCountIssueReviewsForIssue_IgnoresNonTriageActions(t *testing.T) {
+	s := newTestStore(t)
+	issueID, err := s.UpsertIssue(&store.Issue{
+		GithubID: 1, Repo: "org/r", Number: 1,
+		Title: "t", Author: "a", State: "open",
+		CreatedAt: time.Now(), FetchedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().Add(-10 * time.Minute)
+	seedIssueReview(t, s, issueID, now)
+	seedIssueReviewWithAction(t, s, issueID, now.Add(time.Minute), "refinement")
+	seedIssueReviewWithAction(t, s, issueID, now.Add(2*time.Minute), "develop")
+
+	n, err := s.CountIssueReviewsForIssue(issueID, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("want only the triage review counted, got %d", n)
+	}
+}
+
 func TestCountIssueTriagesForRepo_CountsAcrossIssues(t *testing.T) {
 	s := newTestStore(t)
 	for i := int64(1); i <= 3; i++ {
@@ -78,6 +108,29 @@ func TestCountIssueTriagesForRepo_CountsAcrossIssues(t *testing.T) {
 	}
 	if n != 3 {
 		t.Errorf("want 3 triages in org/r in last hour, got %d", n)
+	}
+}
+
+func TestCountIssueTriagesForRepo_IgnoresNonTriageActions(t *testing.T) {
+	s := newTestStore(t)
+	for i, action := range []string{"review_only", "refinement", "develop"} {
+		id, err := s.UpsertIssue(&store.Issue{
+			GithubID: int64(i + 1), Repo: "org/r", Number: i + 1,
+			Title: "t", Author: "a", State: "open",
+			CreatedAt: time.Now(), FetchedAt: time.Now(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		seedIssueReviewWithAction(t, s, id, time.Now().Add(-10*time.Minute), action)
+	}
+
+	n, err := s.CountIssueTriagesForRepo("org/r", time.Now().Add(-1*time.Hour))
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("want only the triage review counted, got %d", n)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Run the issue circuit breaker only for effective triage/review_only runs, so promoted refinement/develop stages are not blocked by prior triage activity.
- Count only `action_taken='review_only'` rows in issue triage breaker budgets; refinement/develop rows no longer consume triage quota.
- Add regression coverage for refinement/develop with a tripped triage breaker and for store-level action filtering.

## Root Cause

In the #414 smoke test, the daemon correctly classified the issue as refinement and queued the `refinement-worker`, but `Pipeline.Run` checked the issue circuit breaker before dispatching on mode. The breaker was originally designed to cap runaway triage/re-triage loops, but with staged issue processing it also blocked refinement/develop once a promoted issue had enough prior issue_reviews rows.

## Validation

- `make test-docker GO_TEST_ARGS="-run 'TestPipeline_CircuitBreakerDoesNotGate|TestCountIssueReviewsForIssue_IgnoresNonTriageActions|TestCountIssueTriagesForRepo_IgnoresNonTriageActions|TestCheckIssueCircuitBreaker|TestPipeline_RunRefinementHappyPath|TestPipeline_AutoImplementHappyPath' ./internal/issues/... ./internal/store/..."`
- `make test-docker`

Fixes #418.