### PR TITLE
fix(issues): dedupe stale stage promotion audits

### DIFF
--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -367,12 +367,13 @@ func (f *Fetcher) auditManualStageChange(ctx context.Context, issue *github.Issu
 		ref = latest.CreatedAt
 	}
 	alreadyAudited := hasStagePromotionCommentSince(comments, from, to, ref)
-	if alreadyAudited && stageTransitionApplied(issue, cfg, to) {
+	targetAudited := alreadyAudited || hasStagePromotionTargetCommentSince(comments, to, ref)
+	if targetAudited && stageTransitionApplied(issue, cfg, to) {
 		slog.Debug("issues fetcher: stage transition already audited since latest review",
 			"repo", issue.Repo, "number", issue.Number, "from", from, "to", to)
 		return nil
 	}
-	if alreadyAudited {
+	if targetAudited {
 		slog.Debug("issues fetcher: stage transition audit exists but labels need normalization",
 			"repo", issue.Repo, "number", issue.Number, "from", from, "to", to)
 	}
@@ -386,7 +387,7 @@ func (f *Fetcher) auditManualStageChange(ctx context.Context, issue *github.Issu
 		Trigger:        StagePromotionManualGitHub,
 		Time:           time.Now().UTC(),
 		RecentComments: comments,
-		SuppressAudit:  alreadyAudited,
+		SuppressAudit:  targetAudited,
 		Broker:         f.stageBroker,
 	})
 }

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -1010,6 +1010,60 @@ func TestFetcher_ManualStageLabelChangeRetriesLabelsWhenAuditExistsButLabelsAreS
 	}
 }
 
+func TestFetcher_ManualStageLabelChangeSkipsStaleFromWhenTargetAlreadyAudited(t *testing.T) {
+	now := time.Now()
+	issue := &github.Issue{
+		ID:        int64(1008),
+		Number:    8,
+		Repo:      "org/repo",
+		Title:     "Ready to build",
+		UpdatedAt: now,
+		Mode:      config.IssueModeDevelop,
+		Labels:    issueLabels("develop"),
+	}
+	latestReviewAt := now.Add(-5 * time.Minute)
+	dedup := &fakeDedup{byGithubID: map[int64]dedupEntry{
+		issue.ID: {
+			row: &store.Issue{ID: 17, GithubID: issue.ID},
+			review: &store.IssueReview{
+				IssueID:     17,
+				CommentedAt: latestReviewAt,
+				ActionTaken: string(config.IssueModeReviewOnly),
+			},
+		},
+	}}
+	auditAt := latestReviewAt.Add(time.Minute)
+	mf := &fakeMarkerFetcher{commentsByKey: map[string][]github.Comment{
+		"org/repo#8": {{
+			Author:    "heimdallm-bot",
+			CreatedAt: auditAt,
+			Body: issues.StagePromotionAuditComment(
+				issues.IssueStageRefinement,
+				issues.IssueStageDevelopment,
+				issues.StagePromotionAuto,
+				auditAt,
+			),
+		}},
+	}}
+	pub := &fakeIssuePublisher{}
+	stage := &fakeStageTransitionClient{}
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, &fakePipeline{})
+	f.SetPublisher(pub)
+	f.SetStageTransitioner(stage, nil)
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", stagePipelineCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 1 || len(pub.implement) != 1 || pub.implement[0] != 8 {
+		t.Fatalf("expected implement dispatch, processed=%d pub=%v", processed, pub.implement)
+	}
+	if len(stage.added) != 0 || len(stage.removed) != 0 || len(stage.comments) != 0 {
+		t.Fatalf("target-stage audit should suppress stale-from transition, added=%v removed=%v comments=%v",
+			stage.added, stage.removed, stage.comments)
+	}
+}
+
 func TestFetcher_ManualStageLabelChangeAuditsWhenExistingAuditIsDifferentTransition(t *testing.T) {
 	now := time.Now()
 	issue := &github.Issue{

--- a/daemon/internal/issues/stage_transition.go
+++ b/daemon/internal/issues/stage_transition.go
@@ -316,6 +316,21 @@ func hasStagePromotionCommentSince(comments []github.Comment, from, to IssueStag
 	return false
 }
 
+func hasStagePromotionTargetCommentSince(comments []github.Comment, to IssueStage, since time.Time) bool {
+	if since.IsZero() {
+		return false
+	}
+	for _, c := range comments {
+		if c.CreatedAt.IsZero() || c.CreatedAt.Before(since) {
+			continue
+		}
+		if stagePromotionCommentMatches(c.Body, "", to) {
+			return true
+		}
+	}
+	return false
+}
+
 // stagePromotionCommentMatches treats an empty from/to stage as "do not filter
 // on that field". This keeps recent-comment dedup compatible with older audit
 // comments that only need to prove the target stage was already recorded.


### PR DESCRIPTION
## What changed

- Dedupes manual stage-promotion audits by target stage as well as exact `from -> to` pair.
- Keeps label-normalization retry behavior when labels are stale, while suppressing duplicate audit comments.
- Adds regression coverage for the observed #414 case where `refinement -> development` was already audited but a stale local `from=triage` caused repeated `triage -> development` activity rows.

## Root cause

The manual GitHub label-change auditor only treated an audit as existing when the stored latest review's inferred `from` stage exactly matched the audit comment. If the latest stored review lagged behind the actual stage path, the issue could already have a valid `To: development` audit and normalized labels, but the fetcher still emitted another promotion event using the stale `from` stage.

## Validation

- `make test-docker GO_TEST_ARGS="-run TestFetcher_ManualStageLabelChange ./internal/issues"`
- `make test-docker`

Closes #424