### PR TITLE
fix(issues): scope staged pipeline by assignee

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -334,7 +334,7 @@ func main() {
 	// loginMu guards cachedLogin against concurrent reads/writes from the
 	// poll cycle and HTTP goroutines.
 	var loginMu sync.Mutex
-	var cachedLogin string
+	var cachedLogin = resolvedBotLogin
 
 	buildRunOpts := func(pr *gh.PullRequest, aiCfg config.RepoAI) pipeline.RunOptions {
 		cli := aiCfg.Primary
@@ -840,6 +840,14 @@ func main() {
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
+		loginMu.Lock()
+		authUser := cachedLogin
+		loginMu.Unlock()
+		var ok bool
+		repoIT, ok = issueTrackingWithAssigneeScope("triage-worker", msg.Repo, repoIT, authUser)
+		if !ok {
+			return
+		}
 		if !issueStageStillCurrent("triage-worker", ghIssue, repoIT, config.IssueModeReviewOnly) {
 			return
 		}
@@ -944,6 +952,14 @@ func main() {
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
+		loginMu.Lock()
+		authUser := cachedLogin
+		loginMu.Unlock()
+		var ok bool
+		repoIT, ok = issueTrackingWithAssigneeScope("refinement-worker", msg.Repo, repoIT, authUser)
+		if !ok {
+			return
+		}
 		if !issueStageStillCurrent("refinement-worker", ghIssue, repoIT, config.IssueModeRefinement) {
 			return
 		}
@@ -1013,6 +1029,14 @@ func main() {
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
+		loginMu.Lock()
+		authUser := cachedLogin
+		loginMu.Unlock()
+		var ok bool
+		repoIT, ok = issueTrackingWithAssigneeScope("implement-worker", msg.Repo, repoIT, authUser)
+		if !ok {
+			return
+		}
 		if !issueStageStillCurrent("implement-worker", ghIssue, repoIT, config.IssueModeDevelop) {
 			return
 		}
@@ -1240,6 +1264,10 @@ func main() {
 		nonMonList := append([]string(nil), c.GitHub.NonMonitored...)
 		localDirBaseList := append([]string(nil), c.GitHub.LocalDirBase...)
 		cfgMu.Unlock()
+		loginMu.Lock()
+		authUser := cachedLogin
+		loginMu.Unlock()
+		issueTracking := c.GitHub.IssueTracking.WithDefaultAssignee(authUser)
 		orgOverrides := make(map[string]map[string]any)
 		for org, ai := range c.AI.Orgs {
 			orgOverrides[org] = orgAIOverrideMap(ai)
@@ -1320,7 +1348,7 @@ func main() {
 			"ai_fallback":                 c.AI.Fallback,
 			"review_mode":                 c.AI.ReviewMode,
 			"retention_days":              c.Retention.MaxDays,
-			"issue_tracking":              c.GitHub.IssueTracking,
+			"issue_tracking":              issueTracking,
 			"repo_overrides":              repoOverrides,
 			"org_overrides":               orgOverrides,
 			"agent_configs":               agentConfigs,
@@ -2258,6 +2286,41 @@ type tier2Adapter struct {
 
 const breakerTripDedupTTL = 24 * time.Hour
 
+func (a *tier2Adapter) cachedAuthenticatedUser() string {
+	if a == nil || a.login == nil {
+		return ""
+	}
+	if a.loginMu == nil {
+		return *a.login
+	}
+	a.loginMu.Lock()
+	defer a.loginMu.Unlock()
+	return *a.login
+}
+
+func (a *tier2Adapter) resolveAuthenticatedUser() string {
+	if authUser := a.cachedAuthenticatedUser(); authUser != "" {
+		return authUser
+	}
+	if a == nil || a.ghClient == nil {
+		return ""
+	}
+	u, err := a.ghClient.AuthenticatedUser()
+	if err != nil {
+		return ""
+	}
+	if a.login != nil {
+		if a.loginMu == nil {
+			*a.login = u
+		} else {
+			a.loginMu.Lock()
+			*a.login = u
+			a.loginMu.Unlock()
+		}
+	}
+	return u
+}
+
 type breakerTripKey struct {
 	Repo    string
 	Number  int
@@ -2661,17 +2724,14 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 		return 0, nil
 	}
 
-	// Resolve authenticated user
-	a.loginMu.Lock()
-	authUser := *a.login
-	a.loginMu.Unlock()
-	if authUser == "" {
-		if u, err := a.ghClient.AuthenticatedUser(); err == nil {
-			authUser = u
-			a.loginMu.Lock()
-			*a.login = u
-			a.loginMu.Unlock()
-		}
+	// Resolve authenticated user before applying issue tracking defaults: an
+	// empty assignee list means "this daemon's user", not a shared queue.
+	authUser := a.resolveAuthenticatedUser()
+
+	var ok bool
+	repoIT, ok = issueTrackingWithAssigneeScope("tier2 issue processing", repo, repoIT, authUser)
+	if !ok {
+		return 0, nil
 	}
 
 	optsFor := func(issue *gh.Issue) (issuepipeline.RunOptions, bool) {
@@ -2786,12 +2846,21 @@ func (a *tier2Adapter) PromoteReady(ctx context.Context, repos []string) (int, e
 		repos []string
 	}
 
+	authUser := a.cachedAuthenticatedUser()
+
 	a.cfgMu.Lock()
 	c := *a.cfg
 	groupOrder := make([]string, 0, len(repos))
 	groups := make(map[string]*promoteGroup)
 	for _, repo := range repos {
 		it := c.IssueTrackingForRepo(repo)
+		if it.Enabled && len(it.BlockedLabels) > 0 && len(it.Assignees) == 0 && authUser == "" {
+			authUser = a.resolveAuthenticatedUser()
+		}
+		it, ok := issueTrackingWithAssigneeScope("tier2 issue promotion", repo, it, authUser)
+		if !ok {
+			continue
+		}
 		if it.Enabled && len(it.BlockedLabels) > 0 {
 			key := promoteIssueTrackingKey(it)
 			group := groups[key]
@@ -3399,6 +3468,12 @@ func issueStageStillCurrent(scope string, issue *gh.Issue, it config.IssueTracki
 			"repo", issue.Repo, "number", issue.Number)
 		return false
 	}
+	if !it.MatchesAssignees(issue.AssigneeLogins()) {
+		slog.Info(scope+": issue assigned outside this daemon scope, skipping stale job",
+			"repo", issue.Repo, "number", issue.Number,
+			"assignees", issue.AssigneeLogins(), "allowed_assignees", it.Assignees)
+		return false
+	}
 	// Best-effort stale-job guard: workers fetch the issue immediately before
 	// this check, so queued jobs whose labels changed since dispatch skip
 	// before running AI. A label edit after this fetch is handled by the next
@@ -3410,6 +3485,16 @@ func issueStageStillCurrent(scope string, issue *gh.Issue, it config.IssueTracki
 	slog.Info(scope+": issue stage changed before worker run, skipping stale job",
 		"repo", issue.Repo, "number", issue.Number, "want", want, "got", got, "labels", issue.LabelNames())
 	return false
+}
+
+func issueTrackingWithAssigneeScope(scope, repo string, it config.IssueTrackingConfig, defaultAssignee string) (config.IssueTrackingConfig, bool) {
+	it = it.WithDefaultAssignee(defaultAssignee)
+	if it.Enabled && len(it.Assignees) == 0 {
+		slog.Warn(scope+": issue tracking has no assignee scope; skipping issues for this repo",
+			"repo", repo)
+		return it, false
+	}
+	return it, true
 }
 
 func autoPromoteAfterStage(

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -348,11 +348,12 @@ func TestTier2AdapterPromoteReadyUsesOrgScopedIssueTracking(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/repo/issues":
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{
-					"number": 10,
-					"title":  "blocked",
-					"state":  "open",
-					"body":   "## Depends on\n- #5\n",
-					"labels": []map[string]string{{"name": "blocked"}},
+					"number":    10,
+					"title":     "blocked",
+					"state":     "open",
+					"body":      "## Depends on\n- #5\n",
+					"assignees": []map[string]string{{"login": "bot"}},
+					"labels":    []map[string]string{{"name": "blocked"}},
 				},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/repo/issues/10/sub_issues":
@@ -396,6 +397,7 @@ func TestTier2AdapterPromoteReadyUsesOrgScopedIssueTracking(t *testing.T) {
 		Enabled:       false,
 		FilterMode:    config.FilterModeExclusive,
 		DefaultAction: string(config.IssueModeIgnore),
+		Assignees:     []string{"bot"},
 		BlockedLabels: []string{"blocked"},
 		DevelopLabels: []string{"global-ready"},
 	}
@@ -439,21 +441,23 @@ func TestTier2AdapterPromoteReadyBatchesReposWithSameIssueTracking(t *testing.T)
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/a/issues":
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{
-					"number": 10,
-					"title":  "blocked a",
-					"state":  "open",
-					"body":   "## Depends on\n- org/shared#5\n",
-					"labels": []map[string]string{{"name": "blocked"}},
+					"number":    10,
+					"title":     "blocked a",
+					"state":     "open",
+					"body":      "## Depends on\n- org/shared#5\n",
+					"assignees": []map[string]string{{"login": "bot"}},
+					"labels":    []map[string]string{{"name": "blocked"}},
 				},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/b/issues":
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{
-					"number": 20,
-					"title":  "blocked b",
-					"state":  "open",
-					"body":   "## Depends on\n- org/shared#5\n",
-					"labels": []map[string]string{{"name": "blocked"}},
+					"number":    20,
+					"title":     "blocked b",
+					"state":     "open",
+					"body":      "## Depends on\n- org/shared#5\n",
+					"assignees": []map[string]string{{"login": "bot"}},
+					"labels":    []map[string]string{{"name": "blocked"}},
 				},
 			})
 		case r.Method == http.MethodGet && (r.URL.Path == "/repos/org/a/issues/10/sub_issues" || r.URL.Path == "/repos/org/b/issues/20/sub_issues"):
@@ -489,6 +493,7 @@ func TestTier2AdapterPromoteReadyBatchesReposWithSameIssueTracking(t *testing.T)
 		Enabled:       true,
 		FilterMode:    config.FilterModeExclusive,
 		DefaultAction: string(config.IssueModeIgnore),
+		Assignees:     []string{"bot"},
 		BlockedLabels: []string{"blocked"},
 		DevelopLabels: []string{"ready"},
 	}
@@ -517,6 +522,7 @@ func TestTier2AdapterPromoteReadyReportsAllGroupErrors(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.GitHub.IssueTracking = config.IssueTrackingConfig{
 		Enabled:       true,
+		Assignees:     []string{"alice"},
 		BlockedLabels: []string{"blocked"},
 	}
 	cfg.AI.Repos = map[string]config.RepoAI{

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -140,7 +140,9 @@ type IssueTrackingConfig struct {
 	Organizations []string `toml:"organizations" json:"organizations"`
 
 	// Assignees limits processing to issues assigned to these GitHub users.
-	// Empty = no assignee filter.
+	// Empty in raw config means "use the authenticated GitHub login" at
+	// runtime. A deliberately shared queue must be introduced explicitly; the
+	// issue pipeline must not treat an absent assignee filter as "anyone".
 	Assignees []string `toml:"assignees" json:"assignees"`
 
 	// DevelopLabels are labels that mark an issue as "please implement".
@@ -218,6 +220,50 @@ func (c IssueTrackingConfig) ResolvePromoteToLabel() string {
 		return c.DevelopLabels[0]
 	}
 	return ""
+}
+
+// WithDefaultAssignee returns a copy whose assignee scope falls back to the
+// authenticated GitHub login. This keeps issue processing single-owner by
+// default while preserving explicitly configured assignee lists.
+func (c IssueTrackingConfig) WithDefaultAssignee(login string) IssueTrackingConfig {
+	if len(c.Assignees) > 0 {
+		return c
+	}
+	login = strings.TrimSpace(strings.TrimLeft(login, "@"))
+	if login == "" {
+		return c
+	}
+	c.Assignees = []string{login}
+	return c
+}
+
+// MatchesAssignees reports whether the current assignee filter permits an
+// issue assigned to the provided GitHub logins. An inactive filter permits all;
+// an active filter never matches an unassigned issue.
+func (c IssueTrackingConfig) MatchesAssignees(assignees []string) bool {
+	if len(c.Assignees) == 0 {
+		return true
+	}
+	if len(assignees) == 0 {
+		return false
+	}
+	want := make(map[string]struct{}, len(c.Assignees))
+	for _, a := range c.Assignees {
+		a = strings.ToLower(strings.TrimSpace(strings.TrimLeft(a, "@")))
+		if a != "" {
+			want[a] = struct{}{}
+		}
+	}
+	if len(want) == 0 {
+		return false
+	}
+	for _, a := range assignees {
+		a = strings.ToLower(strings.TrimSpace(strings.TrimLeft(a, "@")))
+		if _, ok := want[a]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // Classify returns the processing mode for an issue given its labels.

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -497,6 +497,38 @@ func TestApplyDefaults_IssueTrackingPreservesExisting(t *testing.T) {
 	}
 }
 
+func TestIssueTrackingWithDefaultAssignee(t *testing.T) {
+	cfg := IssueTrackingConfig{Enabled: true}
+	got := cfg.WithDefaultAssignee("@alice")
+	if len(got.Assignees) != 1 || got.Assignees[0] != "alice" {
+		t.Fatalf("Assignees = %v, want [alice]", got.Assignees)
+	}
+	if len(cfg.Assignees) != 0 {
+		t.Fatalf("WithDefaultAssignee mutated receiver: %v", cfg.Assignees)
+	}
+}
+
+func TestIssueTrackingWithDefaultAssigneePreservesExplicitList(t *testing.T) {
+	cfg := IssueTrackingConfig{Enabled: true, Assignees: []string{"bob"}}
+	got := cfg.WithDefaultAssignee("alice")
+	if len(got.Assignees) != 1 || got.Assignees[0] != "bob" {
+		t.Fatalf("Assignees = %v, want explicit [bob]", got.Assignees)
+	}
+}
+
+func TestIssueTrackingMatchesAssignees(t *testing.T) {
+	cfg := IssueTrackingConfig{Assignees: []string{"Alice"}}
+	if !cfg.MatchesAssignees([]string{"bob", "alice"}) {
+		t.Fatal("expected case-insensitive assignee match")
+	}
+	if cfg.MatchesAssignees([]string{"bob"}) {
+		t.Fatal("unexpected assignee match")
+	}
+	if cfg.MatchesAssignees(nil) {
+		t.Fatal("unassigned issue must not match active assignee filter")
+	}
+}
+
 func TestApplyEnvOverrides_IssueTracking(t *testing.T) {
 	cfg := &Config{}
 	cfg.applyDefaults()

--- a/daemon/internal/github/fetch_issues.go
+++ b/daemon/internal/github/fetch_issues.go
@@ -166,7 +166,7 @@ func issueMatchesFilters(issue *Issue, repo string, cfg config.IssueTrackingConf
 	assigneeActive := len(cfg.Assignees) > 0
 
 	orgPass := !orgActive || repoBelongsToOrg(repo, cfg.Organizations)
-	assigneePass := !assigneeActive || hasAnyAssignee(issue.AssigneeLogins(), cfg.Assignees)
+	assigneePass := cfg.MatchesAssignees(issue.AssigneeLogins())
 
 	// No active filters → include.
 	if !orgActive && !assigneeActive {
@@ -205,25 +205,6 @@ func repoBelongsToOrg(repo string, orgs []string) bool {
 	owner := repo[:slash]
 	for _, o := range orgs {
 		if strings.EqualFold(strings.TrimSpace(o), owner) {
-			return true
-		}
-	}
-	return false
-}
-
-// hasAnyAssignee reports whether any entry in got is also in want. Empty
-// got never matches — an issue with no assignees never satisfies an active
-// assignee filter.
-func hasAnyAssignee(got, want []string) bool {
-	if len(got) == 0 || len(want) == 0 {
-		return false
-	}
-	wantSet := make(map[string]struct{}, len(want))
-	for _, w := range want {
-		wantSet[strings.ToLower(strings.TrimSpace(w))] = struct{}{}
-	}
-	for _, g := range got {
-		if _, ok := wantSet[strings.ToLower(strings.TrimSpace(g))]; ok {
 			return true
 		}
 	}

--- a/daemon/internal/github/fetch_issues_test.go
+++ b/daemon/internal/github/fetch_issues_test.go
@@ -18,13 +18,13 @@ import (
 // ── fixtures ─────────────────────────────────────────────────────────────────
 
 type issueFixture struct {
-	ID          int64
-	Number      int
-	Title       string
-	Labels      []string
-	Assignees   []string
-	CreatedAt   time.Time
-	IsPR        bool
+	ID        int64
+	Number    int
+	Title     string
+	Labels    []string
+	Assignees []string
+	CreatedAt time.Time
+	IsPR      bool
 }
 
 func (f issueFixture) marshal() map[string]any {
@@ -245,6 +245,40 @@ func TestFetchIssues_AssigneesFilter(t *testing.T) {
 	}
 }
 
+func TestFetchIssues_AssigneeScopedStageCanStartAtRefinement(t *testing.T) {
+	cfg := baseCfg()
+	cfg.RefinementLabels = []string{"refine"}
+	cfg.Assignees = []string{"bob"}
+	srv := issuesPageServer(t, map[int][]issueFixture{
+		1: {
+			{ID: 63, Number: 63, Title: "already triaged by another daemon", Assignees: []string{"bob"}, Labels: []string{"refine"}, CreatedAt: time.Now()},
+			{ID: 64, Number: 64, Title: "triage still mine", Assignees: []string{"bob"}, Labels: []string{"question"}, CreatedAt: time.Now()},
+			{ID: 65, Number: 65, Title: "belongs to alice", Assignees: []string{"alice"}, Labels: []string{"refine"}, CreatedAt: time.Now()},
+			{ID: 66, Number: 66, Title: "unassigned", Labels: []string{"refine"}, CreatedAt: time.Now()},
+		},
+	})
+	defer srv.Close()
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	got, err := client.FetchIssues("org/repo", cfg, "bob")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected only bob-scoped triage/refinement issues, got %+v", got)
+	}
+	modes := map[int]config.IssueMode{}
+	for _, issue := range got {
+		modes[issue.Number] = issue.Mode
+	}
+	if modes[63] != config.IssueModeRefinement {
+		t.Errorf("#63 should enter directly as refinement, got %q", modes[63])
+	}
+	if modes[64] != config.IssueModeReviewOnly {
+		t.Errorf("#64 should remain triage, got %q", modes[64])
+	}
+}
+
 // ── filter_mode ──────────────────────────────────────────────────────────────
 
 func TestFetchIssues_FilterModeExclusive_AllMustPass(t *testing.T) {
@@ -279,7 +313,7 @@ func TestFetchIssues_FilterModeInclusive_AtLeastOneDimensionPasses(t *testing.T)
 	cfg.Assignees = []string{"alice"}
 	srv := issuesPageServer(t, map[int][]issueFixture{
 		1: {
-			{ID: 80, Number: 80, Assignees: []string{"bob"}, Labels: []string{"bug"}, CreatedAt: time.Now()}, // org matches (we'll fetch via wanted-org)
+			{ID: 80, Number: 80, Assignees: []string{"bob"}, Labels: []string{"bug"}, CreatedAt: time.Now()},   // org matches (we'll fetch via wanted-org)
 			{ID: 81, Number: 81, Assignees: []string{"alice"}, Labels: []string{"bug"}, CreatedAt: time.Now()}, // assignee matches even in other-org
 		},
 	})

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -140,6 +140,12 @@ func (f *Fetcher) ProcessRepo(ctx context.Context, repo string, cfg config.Issue
 	if !cfg.Enabled {
 		return 0, nil
 	}
+	cfg = cfg.WithDefaultAssignee(authUser)
+	if len(cfg.Assignees) == 0 {
+		slog.Warn("issues fetcher: issue tracking has no assignee scope, skipping repo",
+			"repo", repo)
+		return 0, nil
+	}
 	if optsFor == nil {
 		return 0, fmt.Errorf("issues fetcher: nil OptionsFn")
 	}

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -18,8 +18,11 @@ import (
 // ── fetcher-only fakes ───────────────────────────────────────────────────────
 
 type fakeClient struct {
-	issues []*github.Issue
-	err    error
+	issues       []*github.Issue
+	err          error
+	calls        int
+	lastCfg      config.IssueTrackingConfig
+	lastAuthUser string
 }
 
 type fakeMarkerFetcher struct {
@@ -36,6 +39,9 @@ func (f *fakeMarkerFetcher) FetchIssueCommentsOnly(repo string, number int) ([]g
 }
 
 func (c *fakeClient) FetchIssues(repo string, cfg config.IssueTrackingConfig, authenticatedUser string) ([]*github.Issue, error) {
+	c.calls++
+	c.lastCfg = cfg
+	c.lastAuthUser = authenticatedUser
 	return c.issues, c.err
 }
 
@@ -215,6 +221,41 @@ func TestFetcher_FetchErrorIsFatalForThisRun(t *testing.T) {
 	_, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if err == nil {
 		t.Fatal("expected fetch error to surface")
+	}
+}
+
+func TestFetcher_DefaultsAssigneeScopeToAuthenticatedUser(t *testing.T) {
+	client := &fakeClient{issues: []*github.Issue{fixture(1, time.Now())}}
+	f := issues.NewFetcher(client, nil, &fakeDedup{byGithubID: map[int64]dedupEntry{}}, &fakePipeline{})
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 1 {
+		t.Fatalf("processed = %d, want 1", processed)
+	}
+	if len(client.lastCfg.Assignees) != 1 || client.lastCfg.Assignees[0] != "alice" {
+		t.Fatalf("FetchIssues cfg.Assignees = %v, want [alice]", client.lastCfg.Assignees)
+	}
+	if client.lastAuthUser != "alice" {
+		t.Fatalf("authenticatedUser = %q, want alice", client.lastAuthUser)
+	}
+}
+
+func TestFetcher_SkipsWhenAssigneeScopeUnavailable(t *testing.T) {
+	client := &fakeClient{issues: []*github.Issue{fixture(1, time.Now())}}
+	f := issues.NewFetcher(client, nil, &fakeDedup{byGithubID: map[int64]dedupEntry{}}, &fakePipeline{})
+
+	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "", noOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if processed != 0 {
+		t.Fatalf("processed = %d, want 0", processed)
+	}
+	if client.calls != 0 {
+		t.Fatalf("FetchIssues calls = %d, want 0 when scope is unavailable", client.calls)
 	}
 }
 

--- a/daemon/internal/issues/promoter.go
+++ b/daemon/internal/issues/promoter.go
@@ -76,6 +76,12 @@ func PromoteReady(ctx context.Context, c PromoteIssueClient, cfg config.IssueTra
 			if err := ctx.Err(); err != nil {
 				return promoted, err
 			}
+			if !cfg.MatchesAssignees(issue.AssigneeLogins()) {
+				slog.Debug("issues promote: skipping issue outside assignee scope",
+					"repo", repo, "issue", issue.Number,
+					"assignees", issue.AssigneeLogins(), "allowed_assignees", cfg.Assignees)
+				continue
+			}
 			blockedOnIssue := intersectLabels(issue.LabelNames(), blockedSet)
 			if len(blockedOnIssue) == 0 {
 				continue

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -29,14 +29,14 @@ repositories = ["org/repo1", "org/repo2"]
 # review comment (review_only) or opens an implementation PR
 # (auto_implement). Label classification precedence:
 #
-#   skip_labels  >  review_only_labels  >  develop_labels  >  default_action
+#   skip_labels  >  blocked_labels  >  review_only_labels  >  refinement_labels  >  develop_labels  >  default_action
 #
 # [github.issue_tracking]
 # enabled             = false
 # filter_mode         = "exclusive"              # "exclusive" (AND) | "inclusive" (OR)
 # default_action      = "ignore"                 # "ignore" | "review_only"
 # organizations       = ["your-org"]             # empty = any org in repositories
-# assignees           = ["your-username"]        # empty = any assignee (or unassigned)
+# assignees           = ["your-username"]        # empty defaults to authenticated GitHub login
 # develop_labels      = ["enhancement", "feature", "bug"]
 # refinement_labels   = ["refine", "needs-plan"]
 # review_only_labels  = ["question", "discussion", "analysis"]

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -377,6 +377,15 @@ organizations = ["myorg"]
 assignees     = ["myusername"]
 ```
 
+`assignees` is owner scope, not just a sort hint. When issue tracking is
+enabled and no assignees are configured, Heimdallm uses the authenticated
+GitHub login for that machine. That means each daemon processes only issues
+assigned to its operator by default; unassigned issues are ignored even if they
+carry a Heimdallm stage label. To hand work to another operator, triage can
+assign the issue to that user and move it to `refinement`; that user's
+Heimdallm can then continue directly from `refinement` without repeating
+triage.
+
 ### Dependency-based issue promotion
 
 Mark downstream issues `blocked` until their prerequisites close, then promote them automatically.
@@ -926,6 +935,7 @@ non_monitored = []
 #                                       # (see §6 Issue Tracking). Use "ignore" + explicit labels.
 # organizations  = ["myorg"]            # env: HEIMDALLM_ISSUE_ORGANIZATIONS
 # assignees      = ["myusername"]       # env: HEIMDALLM_ISSUE_ASSIGNEES
+#                                       # empty defaults to the authenticated GitHub login
 # develop_labels     = ["enhancement", "feature", "bug"]
 #                                       # env: HEIMDALLM_ISSUE_DEVELOP_LABELS
 # refinement_labels  = ["refine"]

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -510,7 +510,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         const SizedBox(height: 10),
         AutocompleteChipField(
           label: 'Assignees',
-          helper: 'Only process issues assigned to these users (empty = any)',
+          helper: 'Only process issues assigned to these users',
           selectedValues: _issueTracking.assignees,
           availableOptions: config.knownGitHubUsers,
           onChanged: (v) => setState(() {


### PR DESCRIPTION
## Summary
- default issue-tracking assignee scope to the authenticated GitHub login instead of treating empty config as a shared queue
- skip stale triage/refinement/development jobs when the issue has been reassigned outside this daemon's scope
- allow issues assigned to this daemon with a refinement label to enter refinement directly after another Heimdallm completed triage
- update docs/config copy and tests for assignee-scoped staged issue processing

## Tests
- `make test-docker GO_TEST_ARGS="-run 'Test(IssueTrackingWithDefaultAssignee|IssueTrackingMatchesAssignees|FetchIssues_AssigneeScopedStageCanStartAtRefinement|Fetcher_DefaultsAssigneeScopeToAuthenticatedUser|Fetcher_SkipsWhenAssigneeScopeUnavailable)' ./internal/config ./internal/github ./internal/issues"`