### PR TITLE
fix(github): paginate FetchCollaborators via Link header

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -943,29 +943,71 @@ func (c *Client) RemoveIssueLabel(repo string, number int, label string) error {
 	return nil
 }
 
-// FetchCollaborators returns the login names of repository collaborators.
+// parseNextLink extracts the URL whose rel parameter is "next" from a GitHub
+// Link header. Returns "" when no such URL exists. The header format is:
+//
+//	<https://api.github.com/...&page=2>; rel="next", <...>; rel="last"
+//
+// We do not pull in a parser dependency; a small string scan is sufficient.
+func parseNextLink(header string) string {
+	for _, part := range strings.Split(header, ",") {
+		segs := strings.Split(strings.TrimSpace(part), ";")
+		if len(segs) < 2 {
+			continue
+		}
+		urlPart := strings.TrimSpace(segs[0])
+		if !strings.HasPrefix(urlPart, "<") || !strings.HasSuffix(urlPart, ">") {
+			continue
+		}
+		linkURL := urlPart[1 : len(urlPart)-1]
+		for _, s := range segs[1:] {
+			s = strings.TrimSpace(s)
+			if s == `rel="next"` || s == "rel=next" {
+				return linkURL
+			}
+		}
+	}
+	return ""
+}
+
+// FetchCollaborators returns the login names of repository collaborators,
+// following GitHub's Link: rel="next" header to walk every page.
 func (c *Client) FetchCollaborators(repo string) ([]string, error) {
 	if repo == "" {
 		return nil, nil
 	}
-	resp, err := c.do("GET", fmt.Sprintf("/repos/%s/collaborators?per_page=100", repo), "application/vnd.github+json")
-	if err != nil {
-		return nil, fmt.Errorf("github: fetch collaborators: %w", err)
+	const maxPages = 100
+	path := fmt.Sprintf("/repos/%s/collaborators?per_page=100", repo)
+	var logins []string
+	for page := 0; page < maxPages; page++ {
+		resp, err := c.do("GET", path, "application/vnd.github+json")
+		if err != nil {
+			return nil, fmt.Errorf("github: fetch collaborators: %w", err)
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		linkHeader := resp.Header.Get("Link")
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("github: fetch collaborators %s: status %d", repo, resp.StatusCode)
+		}
+		var raw []struct {
+			Login string `json:"login"`
+		}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, fmt.Errorf("github: decode collaborators: %w", err)
+		}
+		for _, u := range raw {
+			logins = append(logins, u.Login)
+		}
+		next := parseNextLink(linkHeader)
+		if next == "" {
+			return logins, nil
+		}
+		nextURL, err := url.Parse(next)
+		if err != nil {
+			return nil, fmt.Errorf("github: parse next link %q: %w", next, err)
+		}
+		path = nextURL.RequestURI()
 	}
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("github: fetch collaborators %s: status %d", repo, resp.StatusCode)
-	}
-	var raw []struct {
-		Login string `json:"login"`
-	}
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, fmt.Errorf("github: decode collaborators: %w", err)
-	}
-	logins := make([]string, len(raw))
-	for i, u := range raw {
-		logins[i] = u.Login
-	}
-	return logins, nil
+	return nil, fmt.Errorf("github: fetch collaborators %s: pagination exceeded %d pages", repo, maxPages)
 }

--- a/daemon/internal/github/collaborators_test.go
+++ b/daemon/internal/github/collaborators_test.go
@@ -142,3 +142,94 @@ func TestFetchCollaborators_MidPaginationError(t *testing.T) {
 		t.Errorf("expected nil logins on error, got %v", got)
 	}
 }
+
+// TestFetchCollaborators_LinkHeaderVariants exercises parseNextLink through
+// FetchCollaborators by stubbing several Link header shapes and verifying
+// pagination terminates correctly when "next" is absent.
+func TestFetchCollaborators_LinkHeaderVariants(t *testing.T) {
+	cases := []struct {
+		name       string
+		linkHeader string
+		wantPages  int // how many pages we expect FetchCollaborators to fetch
+	}{
+		{
+			name:       "only_last_no_next",
+			linkHeader: `<https://example/api?page=5>; rel="last"`,
+			wantPages:  1,
+		},
+		{
+			name:       "empty_header",
+			linkHeader: ``,
+			wantPages:  1,
+		},
+		{
+			name:       "malformed_no_brackets",
+			linkHeader: `https://example/api?page=2; rel="next"`,
+			wantPages:  1,
+		},
+		{
+			name:       "malformed_no_rel",
+			linkHeader: `<https://example/api?page=2>`,
+			wantPages:  1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&calls, 1)
+				if tc.linkHeader != "" {
+					w.Header().Set("Link", tc.linkHeader)
+				}
+				_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "alice"}})
+			}))
+			defer srv.Close()
+
+			client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+			if _, err := client.FetchCollaborators("org/repo"); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := atomic.LoadInt32(&calls); int(got) != tc.wantPages {
+				t.Errorf("expected %d HTTP calls, got %d", tc.wantPages, got)
+			}
+		})
+	}
+
+	// Sanity case: a Link header containing both "next" and "last" must be
+	// followed for the "next" leg.
+	t.Run("next_and_last", func(t *testing.T) {
+		var srv *httptest.Server
+		var calls int32
+		srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			page := 1
+			if p := r.URL.Query().Get("page"); p != "" {
+				fmt.Sscanf(p, "%d", &page)
+			}
+			if page == 1 {
+				link := fmt.Sprintf(
+					`<%s/repos/org/repo/collaborators?per_page=100&page=2>; rel="next", `+
+						`<%s/repos/org/repo/collaborators?per_page=100&page=2>; rel="last"`,
+					srv.URL, srv.URL)
+				w.Header().Set("Link", link)
+				_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "alice"}})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "bob"}})
+		}))
+		defer srv.Close()
+
+		client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+		got, err := client.FetchCollaborators("org/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"alice", "bob"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("logins mismatch: got=%v, want=%v", got, want)
+		}
+		if c := atomic.LoadInt32(&calls); c != 2 {
+			t.Errorf("expected 2 HTTP calls, got %d", c)
+		}
+	})
+}

--- a/daemon/internal/github/collaborators_test.go
+++ b/daemon/internal/github/collaborators_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	gh "github.com/heimdallm/daemon/internal/github"
@@ -55,5 +56,37 @@ func TestFetchCollaborators_MultiPage(t *testing.T) {
 	want := []string{"alice", "bob", "carol", "dave", "eve"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("logins mismatch:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+// TestFetchCollaborators_SinglePage verifies that when the response has no
+// Link header (small repo, fits in one page) FetchCollaborators returns the
+// page's logins and stops after a single request.
+func TestFetchCollaborators_SinglePage(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		if r.URL.Path != "/repos/org/repo/collaborators" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]string{
+			{"login": "alice"},
+			{"login": "bob"},
+		})
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchCollaborators("org/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"alice", "bob"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("logins mismatch: got=%v, want=%v", got, want)
+	}
+	if c := atomic.LoadInt32(&calls); c != 1 {
+		t.Errorf("expected 1 HTTP call, got %d", c)
 	}
 }

--- a/daemon/internal/github/collaborators_test.go
+++ b/daemon/internal/github/collaborators_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -88,5 +89,26 @@ func TestFetchCollaborators_SinglePage(t *testing.T) {
 	}
 	if c := atomic.LoadInt32(&calls); c != 1 {
 		t.Errorf("expected 1 HTTP call, got %d", c)
+	}
+}
+
+// TestFetchCollaborators_RunawayCap verifies that an infinite Link: rel="next"
+// chain returns an error mentioning "pagination" rather than hanging.
+func TestFetchCollaborators_RunawayCap(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Link",
+			fmt.Sprintf(`<%s/repos/org/repo/collaborators?per_page=100&page=2>; rel="next"`, srv.URL))
+		_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "alice"}})
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	_, err := client.FetchCollaborators("org/repo")
+	if err == nil {
+		t.Fatal("expected error from runaway pagination, got nil")
+	}
+	if !strings.Contains(err.Error(), "pagination") {
+		t.Errorf("expected error mentioning 'pagination', got: %v", err)
 	}
 }

--- a/daemon/internal/github/collaborators_test.go
+++ b/daemon/internal/github/collaborators_test.go
@@ -1,0 +1,59 @@
+package github_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+// TestFetchCollaborators_MultiPage verifies that FetchCollaborators follows
+// the GitHub Link: rel="next" header across multiple pages and returns the
+// concatenated logins from every page in order.
+func TestFetchCollaborators_MultiPage(t *testing.T) {
+	pages := [][]string{
+		{"alice", "bob"},
+		{"carol", "dave"},
+		{"eve"},
+	}
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/repos/org/repo/collaborators", func(w http.ResponseWriter, r *http.Request) {
+		page := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			fmt.Sscanf(p, "%d", &page)
+		}
+		if page < 1 || page > len(pages) {
+			http.NotFound(w, r)
+			return
+		}
+		if page < len(pages) {
+			next := fmt.Sprintf(`<%s/repos/org/repo/collaborators?per_page=100&page=%d>; rel="next"`,
+				server.URL, page+1)
+			w.Header().Set("Link", next)
+		}
+		var raw []map[string]string
+		for _, login := range pages[page-1] {
+			raw = append(raw, map[string]string{"login": login})
+		}
+		_ = json.NewEncoder(w).Encode(raw)
+	})
+
+	client := gh.NewClient("fake", gh.WithBaseURL(server.URL))
+	got, err := client.FetchCollaborators("org/repo")
+	if err != nil {
+		t.Fatalf("FetchCollaborators: unexpected error: %v", err)
+	}
+
+	want := []string{"alice", "bob", "carol", "dave", "eve"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("logins mismatch:\n got=%v\nwant=%v", got, want)
+	}
+}

--- a/daemon/internal/github/collaborators_test.go
+++ b/daemon/internal/github/collaborators_test.go
@@ -112,3 +112,33 @@ func TestFetchCollaborators_RunawayCap(t *testing.T) {
 		t.Errorf("expected error mentioning 'pagination', got: %v", err)
 	}
 }
+
+// TestFetchCollaborators_MidPaginationError verifies that an HTTP 500 on a
+// later page causes FetchCollaborators to return an error and not a partial
+// (silently truncated) slice.
+func TestFetchCollaborators_MidPaginationError(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			fmt.Sscanf(p, "%d", &page)
+		}
+		if page == 1 {
+			w.Header().Set("Link",
+				fmt.Sprintf(`<%s/repos/org/repo/collaborators?per_page=100&page=2>; rel="next"`, srv.URL))
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "alice"}})
+			return
+		}
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchCollaborators("org/repo")
+	if err == nil {
+		t.Fatalf("expected error from mid-pagination 500, got nil and logins=%v", got)
+	}
+	if got != nil {
+		t.Errorf("expected nil logins on error, got %v", got)
+	}
+}

--- a/docs/superpowers/plans/2026-05-08-collaborators-pagination.md
+++ b/docs/superpowers/plans/2026-05-08-collaborators-pagination.md
@@ -1,0 +1,657 @@
+# Collaborators Pagination Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `daemon/internal/github.Client.FetchCollaborators` return the full collaborator list by paginating through GitHub's `Link: rel="next"` header instead of stopping after one page of 100.
+
+**Architecture:** Two-piece change in a single file. (1) A new private helper `parseNextLink` that extracts the `rel="next"` URL from a GitHub `Link` header; (2) `FetchCollaborators` becomes a loop that keeps fetching until the `Link` header has no `rel="next"`, capped at 100 pages so a malformed header from GitHub can never hang the daemon. Tests are black-box (matching the package's existing `github_test` convention) and exercise pagination behavior through the public function with an `httptest` server.
+
+**Tech Stack:** Go (1.x, whatever the repo currently uses), standard library only (`net/http`, `net/http/httptest`, `net/url`, `strings`). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-collaborators-pagination-design.md`
+
+---
+
+## File Structure
+
+- **Modify:** `daemon/internal/github/client.go`
+  - Replace the body of `FetchCollaborators` (currently lines 947-971) with a paginating loop.
+  - Add a new unexported helper `parseNextLink(string) string` adjacent to `FetchCollaborators`.
+- **Create:** `daemon/internal/github/collaborators_test.go`
+  - New black-box test file (`package github_test`), matching the convention used by `repos_test.go`, `fetch_issues_test.go`, etc.
+  - Holds all new tests for `FetchCollaborators` pagination behavior. Kept separate from `repos_test.go` so the diff is reviewable in isolation.
+
+## Implementation Notes
+
+- `c.do(method, path, accept)` prepends `c.baseURL` to `path`, so `path` must be a relative URI (path + query). GitHub's `Link` header gives an absolute URL like `https://api.github.com/repositories/123/collaborators?per_page=100&page=2`. We extract its path + query with `net/url.Parse(...).RequestURI()` and pass that to `c.do`. This works against both real GitHub and `httptest` servers configured with `WithBaseURL`, because the test server's `Link` header points back to its own URL, whose `RequestURI()` is what `c.baseURL+path` reconstructs.
+- The current implementation reads the body via `io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))`. We keep that per-page; no need to grow `maxBodyBytes` since each page is at most ~100 collaborators.
+- Each page's response body must be closed before moving on, even when status != 200.
+- We do NOT introduce white-box tests (no `package github` test file) — the package is uniformly black-box today, and `parseNextLink` is fully covered by the integration tests through `FetchCollaborators`.
+
+---
+
+## Task 1: Failing test for multi-page traversal
+
+**Why first:** This is the core behavior the bug requires. Writing it before the implementation keeps us honest — the implementation must satisfy this test, not the other way around.
+
+**Files:**
+- Create: `daemon/internal/github/collaborators_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `daemon/internal/github/collaborators_test.go` with this exact content:
+
+```go
+package github_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+// TestFetchCollaborators_MultiPage verifies that FetchCollaborators follows
+// the GitHub Link: rel="next" header across multiple pages and returns the
+// concatenated logins from every page in order.
+func TestFetchCollaborators_MultiPage(t *testing.T) {
+	pages := [][]string{
+		{"alice", "bob"},
+		{"carol", "dave"},
+		{"eve"},
+	}
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/repos/org/repo/collaborators", func(w http.ResponseWriter, r *http.Request) {
+		page := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			fmt.Sscanf(p, "%d", &page)
+		}
+		if page < 1 || page > len(pages) {
+			http.NotFound(w, r)
+			return
+		}
+		if page < len(pages) {
+			next := fmt.Sprintf(`<%s/repos/org/repo/collaborators?per_page=100&page=%d>; rel="next"`,
+				server.URL, page+1)
+			w.Header().Set("Link", next)
+		}
+		var raw []map[string]string
+		for _, login := range pages[page-1] {
+			raw = append(raw, map[string]string{"login": login})
+		}
+		_ = json.NewEncoder(w).Encode(raw)
+	})
+
+	client := gh.NewClient("fake", gh.WithBaseURL(server.URL))
+	got, err := client.FetchCollaborators("org/repo")
+	if err != nil {
+		t.Fatalf("FetchCollaborators: unexpected error: %v", err)
+	}
+
+	want := []string{"alice", "bob", "carol", "dave", "eve"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("logins mismatch:\n got=%v\nwant=%v", got, want)
+	}
+}
+```
+
+Tasks 3-6 will append more tests and incrementally introduce additional imports (`sync/atomic`, `strings`). For now this minimal import set is sufficient.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run from the repo root:
+```bash
+cd .worktrees/collaborators-pagination && go test ./daemon/internal/github/ -run TestFetchCollaborators_MultiPage -v
+```
+
+Expected: **FAIL** with a logins mismatch — `got=[alice bob]`, `want=[alice bob carol dave eve]`. This is because `FetchCollaborators` today only fetches page 1 and ignores the `Link` header.
+
+If the test fails for a different reason (compile error, etc.), stop and fix that before continuing.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+cd .worktrees/collaborators-pagination
+git add daemon/internal/github/collaborators_test.go
+git commit -m "test: add failing multi-page test for FetchCollaborators"
+```
+
+---
+
+## Task 2: Implement pagination
+
+**Files:**
+- Modify: `daemon/internal/github/client.go` (replace body of `FetchCollaborators`, currently lines 946-971; add new helper `parseNextLink` adjacent to it).
+
+- [ ] **Step 1: Add the `parseNextLink` helper**
+
+In `daemon/internal/github/client.go`, immediately above the existing `FetchCollaborators` function (around line 946), insert:
+
+```go
+// parseNextLink extracts the URL whose rel parameter is "next" from a GitHub
+// Link header. Returns "" when no such URL exists. The header format is:
+//
+//	<https://api.github.com/...&page=2>; rel="next", <...>; rel="last"
+//
+// We do not pull in a parser dependency; a small string scan is sufficient.
+func parseNextLink(header string) string {
+	for _, part := range strings.Split(header, ",") {
+		segs := strings.Split(strings.TrimSpace(part), ";")
+		if len(segs) < 2 {
+			continue
+		}
+		urlPart := strings.TrimSpace(segs[0])
+		if !strings.HasPrefix(urlPart, "<") || !strings.HasSuffix(urlPart, ">") {
+			continue
+		}
+		linkURL := urlPart[1 : len(urlPart)-1]
+		for _, s := range segs[1:] {
+			s = strings.TrimSpace(s)
+			if s == `rel="next"` || s == "rel=next" {
+				return linkURL
+			}
+		}
+	}
+	return ""
+}
+```
+
+- [ ] **Step 2: Replace the body of `FetchCollaborators`**
+
+Replace the existing function body (lines 947-971 in `client.go`):
+
+```go
+// FetchCollaborators returns the login names of repository collaborators.
+func (c *Client) FetchCollaborators(repo string) ([]string, error) {
+	if repo == "" {
+		return nil, nil
+	}
+	resp, err := c.do("GET", fmt.Sprintf("/repos/%s/collaborators?per_page=100", repo), "application/vnd.github+json")
+	if err != nil {
+		return nil, fmt.Errorf("github: fetch collaborators: %w", err)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github: fetch collaborators %s: status %d", repo, resp.StatusCode)
+	}
+	var raw []struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("github: decode collaborators: %w", err)
+	}
+	logins := make([]string, len(raw))
+	for i, u := range raw {
+		logins[i] = u.Login
+	}
+	return logins, nil
+}
+```
+
+with the paginating version:
+
+```go
+// FetchCollaborators returns the login names of repository collaborators,
+// following GitHub's Link: rel="next" header to walk every page.
+func (c *Client) FetchCollaborators(repo string) ([]string, error) {
+	if repo == "" {
+		return nil, nil
+	}
+	const maxPages = 100
+	path := fmt.Sprintf("/repos/%s/collaborators?per_page=100", repo)
+	var logins []string
+	for page := 0; page < maxPages; page++ {
+		resp, err := c.do("GET", path, "application/vnd.github+json")
+		if err != nil {
+			return nil, fmt.Errorf("github: fetch collaborators: %w", err)
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		linkHeader := resp.Header.Get("Link")
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("github: fetch collaborators %s: status %d", repo, resp.StatusCode)
+		}
+		var raw []struct {
+			Login string `json:"login"`
+		}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, fmt.Errorf("github: decode collaborators: %w", err)
+		}
+		for _, u := range raw {
+			logins = append(logins, u.Login)
+		}
+		next := parseNextLink(linkHeader)
+		if next == "" {
+			return logins, nil
+		}
+		nextURL, err := url.Parse(next)
+		if err != nil {
+			return nil, fmt.Errorf("github: parse next link %q: %w", next, err)
+		}
+		path = nextURL.RequestURI()
+	}
+	return nil, fmt.Errorf("github: fetch collaborators %s: pagination exceeded %d pages", repo, maxPages)
+}
+```
+
+Note: `url` is already imported (`net/url`, line 10) and `strings` is already imported (line 14). No new imports needed.
+
+- [ ] **Step 3: Run the multi-page test to verify it passes**
+
+```bash
+cd .worktrees/collaborators-pagination && go test ./daemon/internal/github/ -run TestFetchCollaborators_MultiPage -v
+```
+
+Expected: **PASS**.
+
+- [ ] **Step 4: Run the full package's tests to confirm no regressions**
+
+```bash
+cd .worktrees/collaborators-pagination && go test ./daemon/internal/github/ -v
+```
+
+Expected: all tests in the package PASS, including the new one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/collaborators-pagination
+git add daemon/internal/github/client.go
+git commit -m "fix(github): paginate FetchCollaborators via Link header"
+```
+
+---
+
+## Task 3: Test single-page behavior (no `Link` header)
+
+**Files:**
+- Modify: `daemon/internal/github/collaborators_test.go`
+
+- [ ] **Step 1: Append the test**
+
+Append to `collaborators_test.go`:
+
+```go
+// TestFetchCollaborators_SinglePage verifies that when the response has no
+// Link header (small repo, fits in one page) FetchCollaborators returns the
+// page's logins and stops after a single request.
+func TestFetchCollaborators_SinglePage(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		if r.URL.Path != "/repos/org/repo/collaborators" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]string{
+			{"login": "alice"},
+			{"login": "bob"},
+		})
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchCollaborators("org/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"alice", "bob"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("logins mismatch: got=%v, want=%v", got, want)
+	}
+	if c := atomic.LoadInt32(&calls); c != 1 {
+		t.Errorf("expected 1 HTTP call, got %d", c)
+	}
+}
+```
+
+This requires `sync/atomic` in the imports. Update the import block in `collaborators_test.go`:
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync/atomic"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cd .worktrees/collaborators-pagination && go test ./daemon/internal/github/ -run TestFetchCollaborators_SinglePage -v
+```
+
+Expected: **PASS**.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd .worktrees/collaborators-pagination
+git add daemon/internal/github/collaborators_test.go
+git commit -m "test: cover single-page FetchCollaborators path"
+```
+
+---
+
+## Task 4: Test runaway pagination cap
+
+**Files:**
+- Modify: `daemon/internal/github/collaborators_test.go`
+
+- [ ] **Step 1: Append the test**
+
+```go
+// TestFetchCollaborators_RunawayCap verifies that an infinite Link: rel="next"
+// chain returns an error mentioning "pagination" rather than hanging.
+func TestFetchCollaborators_RunawayCap(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Link",
+			fmt.Sprintf(`<%s/repos/org/repo/collaborators?per_page=100&page=2>; rel="next"`, srv.URL))
+		_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "alice"}})
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	_, err := client.FetchCollaborators("org/repo")
+	if err == nil {
+		t.Fatal("expected error from runaway pagination, got nil")
+	}
+	if !strings.Contains(err.Error(), "pagination") {
+		t.Errorf("expected error mentioning 'pagination', got: %v", err)
+	}
+}
+```
+
+This requires `strings` in the imports. Update the import block:
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+```
+
+- [ ] **Step 2: Run the test (expect it to complete in seconds, not hang)**
+
+```bash
+cd .worktrees/collaborators-pagination && go test ./daemon/internal/github/ -run TestFetchCollaborators_RunawayCap -timeout 30s -v
+```
+
+Expected: **PASS**, completing well under the 30-second timeout. (The cap is 100 pages; against an in-process httptest server this finishes in tens of milliseconds.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd .worktrees/collaborators-pagination
+git add daemon/internal/github/collaborators_test.go
+git commit -m "test: cover FetchCollaborators runaway pagination cap"
+```
+
+---
+
+## Task 5: Test mid-pagination HTTP error
+
+**Files:**
+- Modify: `daemon/internal/github/collaborators_test.go`
+
+- [ ] **Step 1: Append the test**
+
+```go
+// TestFetchCollaborators_MidPaginationError verifies that an HTTP 500 on a
+// later page causes FetchCollaborators to return an error and not a partial
+// (silently truncated) slice.
+func TestFetchCollaborators_MidPaginationError(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			fmt.Sscanf(p, "%d", &page)
+		}
+		if page == 1 {
+			w.Header().Set("Link",
+				fmt.Sprintf(`<%s/repos/org/repo/collaborators?per_page=100&page=2>; rel="next"`, srv.URL))
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "alice"}})
+			return
+		}
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchCollaborators("org/repo")
+	if err == nil {
+		t.Fatalf("expected error from mid-pagination 500, got nil and logins=%v", got)
+	}
+	if got != nil {
+		t.Errorf("expected nil logins on error, got %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cd .worktrees/collaborators-pagination && go test ./daemon/internal/github/ -run TestFetchCollaborators_MidPaginationError -v
+```
+
+Expected: **PASS**.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd .worktrees/collaborators-pagination
+git add daemon/internal/github/collaborators_test.go
+git commit -m "test: cover FetchCollaborators mid-pagination error"
+```
+
+---
+
+## Task 6: Test `Link` header parsing variants (through public function)
+
+This task replaces the spec's planned standalone `parseNextLink` unit tests with black-box coverage through `FetchCollaborators`, matching the package's testing convention (no white-box test files exist anywhere in `daemon/internal/github/`).
+
+**Files:**
+- Modify: `daemon/internal/github/collaborators_test.go`
+
+- [ ] **Step 1: Append the test**
+
+```go
+// TestFetchCollaborators_LinkHeaderVariants exercises parseNextLink through
+// FetchCollaborators by stubbing several Link header shapes and verifying
+// pagination terminates correctly when "next" is absent.
+func TestFetchCollaborators_LinkHeaderVariants(t *testing.T) {
+	cases := []struct {
+		name       string
+		linkHeader string
+		wantPages  int // how many pages we expect FetchCollaborators to fetch
+	}{
+		{
+			name:       "only_last_no_next",
+			linkHeader: `<https://example/api?page=5>; rel="last"`,
+			wantPages:  1,
+		},
+		{
+			name:       "empty_header",
+			linkHeader: ``,
+			wantPages:  1,
+		},
+		{
+			name:       "malformed_no_brackets",
+			linkHeader: `https://example/api?page=2; rel="next"`,
+			wantPages:  1,
+		},
+		{
+			name:       "malformed_no_rel",
+			linkHeader: `<https://example/api?page=2>`,
+			wantPages:  1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&calls, 1)
+				if tc.linkHeader != "" {
+					w.Header().Set("Link", tc.linkHeader)
+				}
+				_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "alice"}})
+			}))
+			defer srv.Close()
+
+			client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+			if _, err := client.FetchCollaborators("org/repo"); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := atomic.LoadInt32(&calls); int(got) != tc.wantPages {
+				t.Errorf("expected %d HTTP calls, got %d", tc.wantPages, got)
+			}
+		})
+	}
+
+	// Sanity case: a Link header containing both "next" and "last" must be
+	// followed for the "next" leg.
+	t.Run("next_and_last", func(t *testing.T) {
+		var srv *httptest.Server
+		var calls int32
+		srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			page := 1
+			if p := r.URL.Query().Get("page"); p != "" {
+				fmt.Sscanf(p, "%d", &page)
+			}
+			if page == 1 {
+				link := fmt.Sprintf(
+					`<%s/repos/org/repo/collaborators?per_page=100&page=2>; rel="next", `+
+						`<%s/repos/org/repo/collaborators?per_page=100&page=2>; rel="last"`,
+					srv.URL, srv.URL)
+				w.Header().Set("Link", link)
+				_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "alice"}})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "bob"}})
+		}))
+		defer srv.Close()
+
+		client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+		got, err := client.FetchCollaborators("org/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"alice", "bob"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("logins mismatch: got=%v, want=%v", got, want)
+		}
+		if c := atomic.LoadInt32(&calls); c != 2 {
+			t.Errorf("expected 2 HTTP calls, got %d", c)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cd .worktrees/collaborators-pagination && go test ./daemon/internal/github/ -run TestFetchCollaborators_LinkHeaderVariants -v
+```
+
+Expected: **PASS** for all subtests (`only_last_no_next`, `empty_header`, `malformed_no_brackets`, `malformed_no_rel`, `next_and_last`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd .worktrees/collaborators-pagination
+git add daemon/internal/github/collaborators_test.go
+git commit -m "test: cover Link header parsing variants in FetchCollaborators"
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full daemon test suite**
+
+```bash
+cd .worktrees/collaborators-pagination && go test ./daemon/...
+```
+
+Expected: all tests PASS. If anything outside `daemon/internal/github/` fails, investigate — `FetchCollaborators` is called by handlers (`daemon/internal/server/handlers.go`), so a regression would most likely surface there.
+
+- [ ] **Step 2: Run `go vet`**
+
+```bash
+cd .worktrees/collaborators-pagination && go vet ./daemon/...
+```
+
+Expected: no output (no vet warnings).
+
+- [ ] **Step 3: Run the project's standard verification target if available**
+
+```bash
+cd .worktrees/collaborators-pagination && make verify-linux
+```
+
+If `make verify-linux` is not the right target for this repo, fall back to:
+
+```bash
+cd .worktrees/collaborators-pagination && make test
+```
+
+Expected: green.
+
+(Per repo convention, `make verify-linux` must run from the worktree directory, not from the main checkout.)
+
+- [ ] **Step 4: Confirm no leftover changes**
+
+```bash
+cd .worktrees/collaborators-pagination && git status
+```
+
+Expected: `working tree clean`. All changes from Tasks 1-6 should be committed.
+
+- [ ] **Step 5: View the diff against `main` for a final read-through**
+
+```bash
+cd .worktrees/collaborators-pagination && git log --oneline origin/main..HEAD && echo '---' && git diff origin/main..HEAD -- daemon/internal/github/
+```
+
+Expected: 6 commits (one failing test, one fix, four follow-up tests). The diff in `client.go` should be the small `parseNextLink` helper plus the rewritten `FetchCollaborators` body — nothing else.
+
+---
+
+## Self-Review Notes (for the plan author)
+
+- **Spec coverage:**
+  - Goal (paginate via Link header) → Task 2.
+  - Safety bound (`maxPages = 100`) → Task 2 + Task 4.
+  - Error handling (HTTP non-200, malformed link, runaway) → Tasks 4, 5, 6.
+  - Tests 1-4 from spec → Tasks 1, 3, 4, 5.
+  - Spec test 5 (`parseNextLink` unit cases) → Task 6, replanned as black-box subtests through `FetchCollaborators` because the package has no white-box test files; this is documented in the task header.
+  - Non-goals (no caching, no UI changes, no other endpoints) → respected; nothing in the plan touches `flutter_app`, caching, or other GitHub endpoints.
+- **Placeholder scan:** none.
+- **Type consistency:** `parseNextLink(string) string` and `FetchCollaborators(repo string) ([]string, error)` are referenced consistently. The error message string `"github: fetch collaborators %s: pagination exceeded %d pages"` in Task 2 is matched by the assertion `strings.Contains(err.Error(), "pagination")` in Task 4. Aligned.

--- a/docs/superpowers/specs/2026-05-08-collaborators-pagination-design.md
+++ b/docs/superpowers/specs/2026-05-08-collaborators-pagination-design.md
@@ -1,0 +1,154 @@
+# Paginate `FetchCollaborators` against the GitHub API
+
+**Date:** 2026-05-08
+**Branch:** `fix/collaborators-pagination`
+**Scope:** Bug fix in `daemon/internal/github/client.go`
+
+## Problem
+
+The Issue Triage assignee combobox in `flutter_app` lets the user pick a GitHub
+login as the issue assignee. Its options come from a merge of two sources:
+
+1. `_repoCollaborators` — fetched from `GET /api/repos/{repo}/collaborators`,
+   which is served by the daemon's `Client.FetchCollaborators` against
+   `GET /repos/{owner}/{repo}/collaborators` on GitHub.
+2. `appConfig.knownGitHubUsers` — logins already saved in user config
+   (existing PR reviewers, prior assignees, etc.).
+
+For repositories in the `freepik-company` organization, several legitimate
+collaborators (e.g. `vbuenog`, `dieloren`) do not appear in the combobox even
+though they are members of the org and have repo access via team grants.
+
+### Root cause
+
+`Client.FetchCollaborators` (`daemon/internal/github/client.go:947`) issues a
+single request to `?per_page=100` and returns whatever fits on page 1. There is
+no pagination loop. For the representative repo `freepik-company/ai-platform-iqs-v3`
+the full collaborator list contains 253 users, so 153 of them — including
+`vbuenog` and `dieloren` — are silently dropped.
+
+Verified with the `gh` CLI:
+- `gh api repos/freepik-company/ai-platform-iqs-v3/collaborators?per_page=100`
+  returns exactly 100 logins; `vbuenog` and `dieloren` are absent.
+- The same request with `--paginate` returns 253 logins, with both users present.
+- `gh api orgs/freepik-company/members/vbuenog` and `…/dieloren` both return
+  `HTTP 204` (confirmed members).
+
+## Goal
+
+Return the complete list of collaborators from `Client.FetchCollaborators`,
+regardless of how many pages GitHub splits the response into.
+
+## Non-goals
+
+- Caching collaborator lists. Today's behavior fetches on demand; that doesn't
+  change here.
+- Replacing the data source with `/orgs/{org}/members` (a previously discussed
+  alternative — option B). Out of scope; the current "repo collaborators"
+  semantics are kept.
+- Auditing other GitHub list endpoints in the daemon for the same bug. Only
+  `FetchCollaborators` is changed.
+- Any UI changes in `flutter_app`. The combobox already merges and dedupes the
+  list it receives.
+
+## Design
+
+### Pagination strategy
+
+GitHub returns a `Link` header on paginated responses with a
+`<url>; rel="next"` segment when there is another page. We follow that header
+until it is absent. This is GitHub's documented mechanism and is robust to
+filtered responses where a page may be shorter than `per_page` even though more
+data follows.
+
+Pseudocode:
+
+```
+url := "/repos/{repo}/collaborators?per_page=100"
+for page := 0; page < maxPages; page++ {
+    resp := c.do("GET", url, ...)
+    // status check, decode, append logins
+    next := parseNextLink(resp.Header.Get("Link"))
+    if next == "" {
+        return logins, nil
+    }
+    url = next
+}
+return nil, fmt.Errorf("github: collaborators pagination exceeded %d pages", maxPages)
+```
+
+The `next` URL returned by GitHub is absolute (e.g.
+`https://api.github.com/repositories/.../collaborators?per_page=100&page=2`).
+`Client.do` already accepts a path; we will need it to also accept absolute
+URLs, or we strip the API base prefix before passing it. The simpler change:
+extract just the path + query from the absolute `next` URL and pass that to
+`c.do`. This keeps `c.do`'s contract unchanged.
+
+### Safety bound
+
+`maxPages` is set to **100** (i.e. up to 10,000 collaborators). A repo with
+more collaborators than that is implausible; if we ever hit the cap, returning
+an error is preferable to silently truncating — that is exactly the failure
+mode we are removing.
+
+### Error handling
+
+- HTTP non-200 on any page → return error, same as today.
+- `json.Unmarshal` failure on any page → return error.
+- Malformed or absent `Link` header on a non-final page → treated as "no next",
+  pagination stops. This matches GitHub's contract: absence of `rel="next"`
+  means no more pages.
+- `maxPages` exceeded → return error (`github: collaborators pagination exceeded N pages`).
+
+### `Link` header parsing
+
+A small helper, `parseNextLink(header string) string`, returns the URL whose
+`rel` parameter equals `next`, or `""` if none. Uses standard string parsing
+— no new dependency. Lives in the same file (`client.go`) as a private
+function. Format reminder:
+
+```
+Link: <https://api.github.com/...&page=2>; rel="next", <https://api.github.com/...&page=4>; rel="last"
+```
+
+## Testing
+
+All tests live in `daemon/internal/github/client_test.go` (or a new file in the
+same package if that one doesn't exist) and use `httptest.NewServer` to stub
+GitHub.
+
+1. **Single page, no `Link` header.** Server returns one page of N<100 users
+   with no `Link`. Assert the function returns exactly those logins. (Covers
+   the small-repo path that already worked.)
+2. **Multi-page traversal.** Server is configured with three pages: pages 1
+   and 2 carry `Link: <…page=N+1>; rel="next"`, page 3 has no `Link`. Assert
+   all logins from all pages are returned in order.
+3. **Runaway cap.** Server always returns a `Link: rel="next"` pointing back
+   to itself. Assert the function returns an error mentioning "pagination" and
+   does not loop forever (test passes within a sane time budget).
+4. **HTTP error mid-pagination.** Page 1 returns 200 with `rel="next"`, page 2
+   returns 500. Assert the function returns an error and does not return a
+   partial slice.
+5. **`parseNextLink` unit cases.** Header with both `next` and `last`,
+   header with only `last`, empty header, malformed header. Confirm correct URL
+   extracted (or empty string).
+
+No integration tests against real GitHub — keeps the suite hermetic, matches
+the existing pattern in this package.
+
+## Risk and rollback
+
+- The change is additive in behavior: small repos still work the same way (one
+  request, no `Link` header → loop exits after page 1). Risk is low.
+- If a malformed `Link` header from GitHub somehow caused infinite loops, the
+  `maxPages` cap converts that into a loud error rather than a hang.
+- Rollback is a single-file revert of `daemon/internal/github/client.go`.
+
+## Out of scope but worth noting
+
+- The Flutter combobox does not surface fetch errors clearly — if
+  `FetchCollaborators` fails, the user only sees `knownGitHubUsers`. That is a
+  pre-existing behavior, unchanged here.
+- The same pagination pattern likely applies to other GitHub list calls in
+  this client (e.g. issue list, label list). Tracked separately; not addressed
+  in this change to keep the diff focused.


### PR DESCRIPTION
## Summary

Some GitHub users (e.g. `vbuenog`, `dieloren`) were missing from the **Issue Triage assignee combobox** in the Flutter UI on every repository whose collaborator list exceeds 100 entries. This PR fixes the underlying daemon bug so the combobox shows the complete list of collaborators GitHub returns for the repo.

## Root cause

The combobox is populated by merging two sources: collaborators returned by `GET /api/repos/{repo}/collaborators` (served by the daemon) and logins already saved in user config (`knownGitHubUsers`). The daemon's `Client.FetchCollaborators` (`daemon/internal/github/client.go`) called `GET /repos/{owner}/{repo}/collaborators?per_page=100` exactly once and returned whatever fit on page 1 — there was **no pagination**.

Verified with the `gh` CLI against `freepik-company/ai-platform-iqs-v3`:

| Check | Result |
|---|---|
| Total collaborators returned with full pagination | **253** |
| Collaborators returned by the daemon today (page 1 only) | **100** |
| `vbuenog` / `dieloren` on page 1 | ❌ neither |
| `vbuenog` / `dieloren` past page 1 | ✅ both present |
| Both are confirmed `freepik-company` org members (`HTTP 204` from `/orgs/freepik-company/members/{login}`) | ✅ |

So 153 of 253 collaborators were silently dropped on this repo, including these two users.

## Change

- **`daemon/internal/github/client.go`** — `FetchCollaborators` now follows GitHub's `Link: rel=\"next\"` header until exhausted, accumulating logins from every page. A new unexported helper `parseNextLink(string) string` extracts the `next` URL from the `Link` header.
- **Pagination strategy** — uses GitHub's documented `Link: rel=\"next\"` mechanism (not page-count math), which is robust to filtered responses where a page may be shorter than `per_page` even though more data follows.
- **Safety bound** — capped at 100 pages (~10,000 collaborators). If the cap is reached, the function returns a loud error mentioning \"pagination\" rather than silently truncating (which is precisely the failure mode this PR fixes). Malformed `Link` headers also fall through to a clean stop instead of looping forever.
- **`c.do` contract preserved** — the absolute `next` URL from GitHub is parsed with `net/url` and `RequestURI()` (path + query) is passed to `c.do`, so `c.baseURL` remains the source of truth for both real GitHub and `httptest` servers.

## Out of scope

- No caching of the collaborators list (today's behavior fetches on demand; unchanged).
- No switch to `/orgs/{org}/members` as the data source (a possible alternative discussed during design — kept the existing repo-collaborators semantics).
- No audit of other GitHub list endpoints in the daemon. Other endpoints likely have the same bug, but the change is intentionally focused on the one observed.
- No UI changes in `flutter_app` — the combobox already merges and dedupes the list it receives.

## Tests

New black-box tests in `daemon/internal/github/collaborators_test.go` (matching the existing `package github_test` convention; uses `httptest.NewServer`):

- `TestFetchCollaborators_MultiPage` — server returns 3 pages with `Link: rel=\"next\"` on pages 1 & 2; asserts all logins from all pages are concatenated in order.
- `TestFetchCollaborators_SinglePage` — no `Link` header → exactly one HTTP call, single-page logins returned.
- `TestFetchCollaborators_RunawayCap` — server always returns `Link: rel=\"next\"` pointing back to itself → returns an error mentioning \"pagination\" and terminates well under the test timeout.
- `TestFetchCollaborators_MidPaginationError` — page 1 returns 200 with `next`, page 2 returns 500 → returns an error and a `nil` slice (no silent partial success).
- `TestFetchCollaborators_LinkHeaderVariants` — exercises `parseNextLink` indirectly through `FetchCollaborators` for: `only_last_no_next`, `empty_header`, `malformed_no_brackets`, `malformed_no_rel`, and a `next_and_last` sanity case where both `rel` values are present and `next` is followed correctly.

## Test plan

- [ ] CI green (`go test ./daemon/...` and `go vet ./daemon/...`).
- [ ] After merge, open the Issue Triage section in the Flutter UI for a Freepik repo with >100 collaborators and confirm `vbuenog`, `dieloren`, and other previously-missing org members now appear in the assignee combobox.

## Docs

- Spec: `docs/superpowers/specs/2026-05-08-collaborators-pagination-design.md`
- Plan: `docs/superpowers/plans/2026-05-08-collaborators-pagination.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)