### PR TITLE
chore(flutter): bump in-constraint deps + flutter_lints 3 → 6

### DIFF
--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -1,5 +1,5 @@
 /// Per-agent CLI execution settings.
-/// Stored under ai.agents.<name> in config.toml.
+/// Stored under `ai.agents.<name>` in config.toml.
 class CLIAgentConfig {
   final String model; // --model value ('' = use CLI default)
   final int maxTurns; // claude: --max-turns (0 = not set)

--- a/flutter_app/lib/features/agents/agents_screen.dart
+++ b/flutter_app/lib/features/agents/agents_screen.dart
@@ -509,7 +509,7 @@ class _SectionHeader extends StatelessWidget {
         Text(title, style: Theme.of(context).textTheme.titleSmall
             ?.copyWith(fontWeight: FontWeight.bold)),
         const Spacer(),
-        if (trailing != null) trailing!,
+        ?trailing,
       ]),
     );
   }

--- a/flutter_app/lib/features/cli_agents/cli_agents_screen.dart
+++ b/flutter_app/lib/features/cli_agents/cli_agents_screen.dart
@@ -97,7 +97,7 @@ class _CLIAgentsScreenState extends ConsumerState<CLIAgentsScreen> {
 
     return configAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (_, __) => const Center(child: Text('Could not load config')),
+      error: (_, _) => const Center(child: Text('Could not load config')),
       data: (config) {
         _initFrom(config);
         return Column(

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -133,7 +133,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       ),
       body: configAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, __) => Center(
+        error: (e, _) => Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -194,7 +194,7 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
       ),
       body: configAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (_, __) => const Center(child: Text('Could not load config')),
+        error: (_, _) => const Center(child: Text('Could not load config')),
         data: (appConfig) {
           _initFrom(appConfig);
           final prompts =

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -277,7 +277,7 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
       ),
       body: configAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (_, __) => const Center(child: Text('Could not load config')),
+        error: (_, _) => const Center(child: Text('Could not load config')),
         data: (appConfig) {
           _initFrom(appConfig);
           final prompts =

--- a/flutter_app/lib/features/repositories/repos_screen.dart
+++ b/flutter_app/lib/features/repositories/repos_screen.dart
@@ -183,7 +183,7 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
 
     return configAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (_, __) => const Center(child: Text('Could not load config')),
+      error: (_, _) => const Center(child: Text('Could not load config')),
       data: (config) {
         _initFrom(config);
 

--- a/flutter_app/lib/features/repositories/widgets/local_dir_resolution.dart
+++ b/flutter_app/lib/features/repositories/widgets/local_dir_resolution.dart
@@ -18,7 +18,7 @@ class LocalDirResolution {
   /// Daemon-detected path (from `localDirsDetected` on AppConfig). Only
   /// meaningful when `configured` is null — when both exist, `effective`
   /// resolves to `configured`. When detection is the only source, the UI
-  /// paints it blue ("Auto: <name>").
+  /// paints it blue (`"Auto: <name>"`).
   final String? detected;
 
   const LocalDirResolution({this.configured, this.detected});
@@ -31,7 +31,7 @@ class LocalDirResolution {
   /// icon + text off this.
   bool get hasDir => (effective ?? '').isNotEmpty;
 
-  /// True when the UI should label the badge "Auto: <name>" in blue —
+  /// True when the UI should label the badge `"Auto: <name>"` in blue —
   /// i.e. no explicit configuration, only the bind-mount fallback kicked in.
   bool get isAutoDetected => configured == null && (detected ?? '').isNotEmpty;
 

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -261,7 +261,7 @@ class _SplashApp extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Image.asset('assets/icon.png', width: 96, height: 96,
-                  errorBuilder: (_, __, ___) => const Icon(Icons.shield, size: 96)),
+                  errorBuilder: (_, _, _) => const Icon(Icons.shield, size: 96)),
               const SizedBox(height: 24),
               const Text('Heimdallm',
                   style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold)),

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -396,10 +396,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -745,10 +745,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   tray_manager:
     dependency: "direct main"
     description:

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -226,10 +226,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "6.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -364,10 +364,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "6.1.0"
   local_notifier:
     dependency: "direct main"
     description:

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: aadd943f4f8cc946882c954c187e6115a84c98c81ad1d9c6cbf0895a8c85da9c
+      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.5"
+    version: "4.0.6"
   build_config:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "521daf8d189deb79ba474e43a696b41c49fb3987818dbacf3308f1e03673a75e"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.1"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "0730c18c770d05636a8f945c32a4d7d81cb6e0f0148c8db4ad12e7748f7e49af"
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.5"
+    version: "8.12.6"
   characters:
     dependency: transitive
     description:
@@ -129,14 +129,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
-  code_builder:
-    dependency: transitive
-    description:
-      name: code_builder
-      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.11.1"
   collection:
     dependency: transitive
     description:
@@ -340,10 +332,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: fbcf404b03520e6e795f6b9b39badb2b788407dfc0a50cf39158a6ae1ca78925
+      sha256: "2c15e78e1cc6e62aadecf59f81566fd56829713d96a8c4177699e2b2e17f20db"
       url: "https://pub.dev"
     source: hosted
-    version: "6.13.1"
+    version: "6.13.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -436,10 +428,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mocktail
-      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   package_config:
     dependency: transitive
     description:
@@ -673,18 +665,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "732792cfd197d2161a65bb029606a46e0a18ff30ef9e141a7a82172b05ea8ecd"
+      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.2.3"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "1d3b229b2934034fb2e691fbb3d53e0f75a4af7b1407f88425ed8f209bcb1b8f"
+      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.11"
+    version: "1.3.12"
   source_span:
     dependency: transitive
     description:
@@ -817,10 +809,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -849,10 +841,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.0
+  flutter_lints: ^6.0.0
   json_serializable: ^6.7.0
   build_runner: ^2.4.0
   mocktail: ^1.0.0

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -42,7 +42,7 @@ void main() {
         child: MaterialApp.router(
           routerConfig: GoRouter(
             routes: [
-              GoRoute(path: '/', builder: (_, __) => const ConfigScreen()),
+              GoRoute(path: '/', builder: (_, _) => const ConfigScreen()),
             ],
           ),
         ),
@@ -301,7 +301,7 @@ void main() {
         child: MaterialApp.router(
           routerConfig: GoRouter(
             routes: [
-              GoRoute(path: '/', builder: (_, __) => const ConfigScreen()),
+              GoRoute(path: '/', builder: (_, _) => const ConfigScreen()),
             ],
           ),
         ),

--- a/flutter_app/test/features/dashboard_test.dart
+++ b/flutter_app/test/features/dashboard_test.dart
@@ -80,7 +80,7 @@ Future<void> _pumpOfflineDashboard(
       child: MaterialApp.router(
         routerConfig: GoRouter(
           routes: [
-            GoRoute(path: '/', builder: (_, __) => const DashboardScreen()),
+            GoRoute(path: '/', builder: (_, _) => const DashboardScreen()),
           ],
         ),
       ),
@@ -167,7 +167,7 @@ void main() {
         child: MaterialApp.router(
           routerConfig: GoRouter(
             routes: [
-              GoRoute(path: '/', builder: (_, __) => const DashboardScreen()),
+              GoRoute(path: '/', builder: (_, _) => const DashboardScreen()),
             ],
           ),
         ),
@@ -192,7 +192,7 @@ void main() {
         child: MaterialApp.router(
           routerConfig: GoRouter(
             routes: [
-              GoRoute(path: '/', builder: (_, __) => const DashboardScreen()),
+              GoRoute(path: '/', builder: (_, _) => const DashboardScreen()),
             ],
           ),
         ),

--- a/flutter_app/test/features/pr_detail_test.dart
+++ b/flutter_app/test/features/pr_detail_test.dart
@@ -25,7 +25,7 @@ void main() {
         ],
         child: MaterialApp.router(
           routerConfig: GoRouter(routes: [
-            GoRoute(path: '/', builder: (_, __) => const SizedBox()),
+            GoRoute(path: '/', builder: (_, _) => const SizedBox()),
             GoRoute(path: '/prs/:id', builder: (ctx, state) =>
                 PRDetailScreen(prId: int.parse(state.pathParameters['id']!))),
           ], initialLocation: '/prs/1'),

--- a/flutter_app/test/features/repositories/widgets/bulk_actions_bar_test.dart
+++ b/flutter_app/test/features/repositories/widgets/bulk_actions_bar_test.dart
@@ -15,7 +15,7 @@ void main() {
         Feature.issueTracking: null,
         Feature.develop: false,
       },
-      onApply: (_, __) {},
+      onApply: (_, _) {},
       onClear: () {},
     )));
     expect(find.text('3 selected'), findsOneWidget);
@@ -31,7 +31,7 @@ void main() {
         Feature.issueTracking: null,
         Feature.develop: false,
       },
-      onApply: (_, __) {},
+      onApply: (_, _) {},
       onClear: () {},
     )));
     expect(find.text('MIXED'), findsOneWidget);
@@ -66,7 +66,7 @@ void main() {
         Feature.issueTracking: true,
         Feature.develop: true,
       },
-      onApply: (_, __) {},
+      onApply: (_, _) {},
       onClear: () => cleared = true,
     )));
     await tester.tap(find.text('Clear'));


### PR DESCRIPTION
Closes #439.

## Summary

Shrinks the noisy `flutter pub outdated` list and refreshes dev tooling without touching runtime behavior. Three commits, each revertible independently.

- `e780d50` — Transitive `matcher` / `test_api` bumps already in `pubspec.lock`
- `b014f76` — `flutter pub upgrade`: 10 in-constraint bumps (`build_runner` 2.13.1 → 2.15.0, `built_value`, `json_serializable`, `mocktail`, `source_gen`, `source_helper`, `url_launcher_web`, `vm_service`, `build`)
- `fd4c759` — `flutter_lints` 3 → 6 + cleanup of 18 new info-level lints (`unnecessary_underscores`, `unintended_html_in_doc_comment`, `use_null_aware_elements`)

Deliberately **not** bundled here (each gets its own PR + smoke test):
- `file_picker` 8 → 11 (runtime, API breaking change in v9)
- `go_router` 14 → 17 (route declaration changes)
- `flutter_riverpod` 2 → 3 (proper migration)

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 167/167
- [x] macOS smoke test — Repositories / Agents / PRs tabs all render and operate as before
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)