### PR TITLE
chore(flutter): bump file_picker 8 → 11

### DIFF
--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -711,7 +711,7 @@ class _LocalDirFieldState extends State<_LocalDirField> {
   }
 
   Future<void> _pick() async {
-    final dir = await FilePicker.platform.getDirectoryPath(
+    final dir = await FilePicker.getDirectoryPath(
       dialogTitle: 'Select local repository directory',
       lockParentWindow: true,
     );

--- a/flutter_app/macos/Runner/DebugProfile.entitlements
+++ b/flutter_app/macos/Runner/DebugProfile.entitlements
@@ -11,5 +11,10 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<!-- Required by file_picker 11+ to open the native directory picker
+	     (RepoDetailScreen local-dir field). Sandbox stays off; this only
+	     declares the capability so file_picker's pre-flight check passes. -->
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/flutter_app/macos/Runner/Release.entitlements
+++ b/flutter_app/macos/Runner/Release.entitlements
@@ -7,5 +7,10 @@
 	<false/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<!-- Required by file_picker 11+ to open the native directory picker
+	     (RepoDetailScreen local-dir field). Sandbox stays off; this only
+	     declares the capability so file_picker's pre-flight check passes. -->
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -169,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.7"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   fake_async:
     dependency: transitive
     description:
@@ -197,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.7"
+    version: "11.0.2"
   fixnum:
     dependency: transitive
     description:

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   window_manager: ^0.5.1
   local_notifier: ^0.1.6
   url_launcher: ^6.3.2
-  file_picker: ^8.0.0
+  file_picker: ^11.0.0
   # package:web gives us typed bindings to Notification / window for the
   # web build's platform_services_web.dart. Already pulled in transitively
   # by flutter; declare it explicitly so the analyzer is happy.


### PR DESCRIPTION
Closes #441.

## Summary

Tier 3 bump from the dependency cleanup series (follow-up to #440 / #439).

### Commits

1. **`1fcbd9c`** — `file_picker` 8.3.7 → 11.0.2. v9 dropped the `FilePicker.platform` singleton and moved everything to direct static methods on `FilePicker`. The single call site (`RepoDetailScreen._pick`) was migrated by removing `.platform`. Picks up a new transitive `dbus 0.7.12` for the Linux backend.

2. **`df5c915`** — Adds `com.apple.security.files.user-selected.read-write` entitlement on macOS. v11 added a pre-flight check that refuses to open the native directory picker unless the app declares one of the user-selected file entitlements, even with the sandbox disabled. Without it, `getDirectoryPath` throws `PlatformException(ENTITLEMENT_NOT_FOUND)`. Sandbox stays off; this only declares the capability. Caught during smoke test.

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 167/167
- [x] Manual smoke test on macOS: directory picker opens, path persists in field, badge renders, survives app restart, cancel does nothing destructive
- [ ] CI green on the latest commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)