### PR TITLE
chore(flutter): bump go_router 14 → 17

### DIFF
--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -276,10 +276,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      sha256: "92d8cee7c57dff0a6c409c05597b460002434eccf7424a712283225b3962d03f"
       url: "https://pub.dev"
     source: hosted
-    version: "14.8.1"
+    version: "17.2.3"
   graphs:
     dependency: transitive
     description:

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^2.5.0
   http: ^1.2.0
-  go_router: ^14.0.0
+  go_router: ^17.0.0
   shared_preferences: ^2.2.0
   json_annotation: ^4.8.0
   tray_manager: ^0.5.2


### PR DESCRIPTION
Closes #443.

## Summary

Tier 3 bump (follow-up to #442 / #440). Spans two majors (15, 16) plus 17. Despite the version jump, **no code changes are required for this codebase** — verified empirically against each breaking-change area cited by upstream changelogs and the automated review.

## Why no code changes

Bot review flagged this as suspicious for a 3-major jump. Empirical verification per API:

| go_router 15/16/17 breaking surface | Used here? | Evidence |
|---|---|---|
| `GoRouter.optionURLReflectsImperativeAPIs` (removed) | ❌ No | `grep -rn optionURLReflectsImperativeAPIs flutter_app/` → 0 hits |
| `onException` / GoRoute `errorBuilder` callback semantics | ❌ No | `grep -rn onException flutter_app/lib flutter_app/test` → 0; the only `errorBuilder` in the tree is on `Image.asset` in `main.dart:264`, unrelated |
| `redirect` signature changes | ✅ 1 use, source-compatible | `router.dart:52`: `(context, state) => '/server?tab=logs'` — same `FutureOr<String?> Function(BuildContext, GoRouterState)` signature across v14→v17. `flutter analyze` would reject a mismatch |
| `ShellRoute` / `StatefulShellRoute` API tweaks | ❌ No | `grep -rn 'ShellRoute\|StatefulShellRoute' flutter_app/` → 0 hits |

The 54 `go_router` call sites use `GoRoute`, `GoRouter`, `context.go`, `context.push` — all source-stable across the bump.

## Test plan

- [x] `flutter analyze` — zero issues (would reject any signature mismatch in redirect or route constructors)
- [x] `flutter test` — 167/167. Tests in `config_test`, `dashboard_test`, `pr_detail_test` construct `GoRouter` directly with explicit routes, so any breaking change in route declaration or matcher behavior would surface here
- [x] Manual smoke test on macOS: tab navigation, back button at each nesting level, deep-link via notification click — all flows work as before
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)