### PR TITLE
chore(flutter): migrate to flutter_riverpod 3

### DIFF
--- a/flutter_app/lib/core/state/local_state_notifier.dart
+++ b/flutter_app/lib/core/state/local_state_notifier.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Drop-in replacement for Riverpod 2's `StateProvider`. Exposes the same
+/// `.set(T)` / `.update((T)=>T)` ergonomics so existing call sites keep their
+/// shape; the only consumer-side change is `notifier.state = v` → `.set(v)`.
+class LocalStateNotifier<T> extends Notifier<T> {
+  LocalStateNotifier(this._initial);
+  final T _initial;
+
+  @override
+  T build() => _initial;
+
+  void set(T value) => state = value;
+  void update(T Function(T) updater) => state = updater(state);
+}

--- a/flutter_app/lib/features/activity/activity_providers.dart
+++ b/flutter_app/lib/features/activity/activity_providers.dart
@@ -121,6 +121,10 @@ const _activityLogEventTypes = {
 /// Implemented as a Notifier (not `Provider<void>`) so it integrates cleanly with
 /// Riverpod 3's lifecycle: when the screen watches it, the notifier stays
 /// alive, and the nested `ref.listen(sseStreamProvider, ...)` stays subscribed.
+/// The provider is declared without `.autoDispose`, so it relies on v3's
+/// default keep-alive semantics — adding `.autoDispose` here would re-introduce
+/// the "paused while between watchers" behaviour this notifier was created to
+/// avoid.
 class ActivityLiveRefreshNotifier extends Notifier<void> {
   @override
   void build() {

--- a/flutter_app/lib/features/activity/activity_providers.dart
+++ b/flutter_app/lib/features/activity/activity_providers.dart
@@ -3,13 +3,15 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/activity.dart';
+import '../../core/state/local_state_notifier.dart';
 import '../dashboard/dashboard_providers.dart'
     show apiClientProvider, sseStreamProvider;
 
 /// Notifier managing the current query (date, range, filter sets).
 /// Widgets read & mutate this; the entries provider watches it.
-class ActivityQueryNotifier extends StateNotifier<ActivityQuery> {
-  ActivityQueryNotifier() : super(_today());
+class ActivityQueryNotifier extends Notifier<ActivityQuery> {
+  @override
+  ActivityQuery build() => _today();
 
   static ActivityQuery _today() {
     final now = DateTime.now();
@@ -88,11 +90,14 @@ class ActivityQueryNotifier extends StateNotifier<ActivityQuery> {
 
 /// Current query state.
 final activityQueryProvider =
-    StateNotifierProvider<ActivityQueryNotifier, ActivityQuery>(
-      (ref) => ActivityQueryNotifier(),
+    NotifierProvider<ActivityQueryNotifier, ActivityQuery>(
+      ActivityQueryNotifier.new,
     );
 
-final activityLiveUpdatesProvider = StateProvider<bool>((ref) => false);
+final activityLiveUpdatesProvider =
+    NotifierProvider<LocalStateNotifier<bool>, bool>(
+      () => LocalStateNotifier<bool>(false),
+    );
 
 const _activityLiveRefreshDelay = Duration(milliseconds: 750);
 
@@ -109,26 +114,38 @@ const _activityLogEventTypes = {
 
 /// Installs the live-mode SSE listener for ActivityScreen.
 ///
-/// This provider is intentionally side-effectful: the screen must watch it so
+/// This notifier is intentionally side-effectful: the screen must watch it so
 /// live mode refreshes the persisted activity query when activity-log events
 /// arrive. Events that are not recorded in `activity_log` are ignored.
-final activityLiveRefreshProvider = Provider<void>((ref) {
-  if (!ref.watch(activityLiveUpdatesProvider)) return;
+///
+/// Implemented as a Notifier (not `Provider<void>`) so it integrates cleanly with
+/// Riverpod 3's lifecycle: when the screen watches it, the notifier stays
+/// alive, and the nested `ref.listen(sseStreamProvider, ...)` stays subscribed.
+class ActivityLiveRefreshNotifier extends Notifier<void> {
+  @override
+  void build() {
+    if (!ref.watch(activityLiveUpdatesProvider)) return;
 
-  Timer? debounce;
-  ref.onDispose(() => debounce?.cancel());
+    Timer? debounce;
+    ref.onDispose(() => debounce?.cancel());
 
-  ref.listen(sseStreamProvider, (previous, next) {
-    next.whenData((event) {
-      if (!_activityLogEventTypes.contains(event.type)) return;
-      debounce?.cancel();
-      debounce = Timer(_activityLiveRefreshDelay, () {
-        ref.invalidate(activityEntriesProvider);
-        ref.invalidate(activityOptionsProvider);
+    ref.listen(sseStreamProvider, (previous, next) {
+      next.whenData((event) {
+        if (!_activityLogEventTypes.contains(event.type)) return;
+        debounce?.cancel();
+        debounce = Timer(_activityLiveRefreshDelay, () {
+          ref.invalidate(activityEntriesProvider);
+          ref.invalidate(activityOptionsProvider);
+        });
       });
     });
-  });
-});
+  }
+}
+
+final activityLiveRefreshProvider =
+    NotifierProvider<ActivityLiveRefreshNotifier, void>(
+      ActivityLiveRefreshNotifier.new,
+    );
 
 /// Entries for the current query. Watches the query so filter changes
 /// trigger a refetch automatically.

--- a/flutter_app/lib/features/activity/activity_screen.dart
+++ b/flutter_app/lib/features/activity/activity_screen.dart
@@ -25,11 +25,11 @@ class ActivityScreen extends ConsumerWidget {
     final optionsAsync = ref.watch(activityOptionsProvider);
 
     final optionEntries =
-        optionsAsync.valueOrNull?.entries ??
-        async.valueOrNull?.entries ??
+        optionsAsync.value?.entries ??
+        async.value?.entries ??
         const <ActivityEntry>[];
     final usingFallbackOptions =
-        optionsAsync.valueOrNull == null && async.valueOrNull != null;
+        optionsAsync.value == null && async.value != null;
     final orgs = _sortedDistinct(optionEntries.map((e) => e.org));
     final repos = _sortedDistinct(optionEntries.map((e) => e.repo));
     final outcomes = _sortedDistinct(optionEntries.map((e) => e.outcome));
@@ -169,7 +169,7 @@ class _DatePickerBar extends ConsumerWidget {
             label: const Text('Live'),
             selected: live,
             onSelected: (v) =>
-                ref.read(activityLiveUpdatesProvider.notifier).state = v,
+                ref.read(activityLiveUpdatesProvider.notifier).set(v),
           ),
           const SizedBox(width: 4),
           IconButton(

--- a/flutter_app/lib/features/agents/agents_screen.dart
+++ b/flutter_app/lib/features/agents/agents_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/agent.dart';
+import '../../shared/widgets/keep_alive_tab.dart';
 import '../../shared/widgets/toast.dart';
 import '../dashboard/dashboard_providers.dart';
 
@@ -73,25 +74,31 @@ class _PromptsView extends ConsumerWidget {
           Expanded(
             child: TabBarView(
               children: [
-                _CategoryTab(
-                  category: PromptCategory.prReview,
-                  prompts: prompts,
-                  presets: ReviewPrompt.presets,
-                  emptyMessage: 'Add a preset or create a custom prompt.',
+                KeepAliveTab(
+                  child: _CategoryTab(
+                    category: PromptCategory.prReview,
+                    prompts: prompts,
+                    presets: ReviewPrompt.presets,
+                    emptyMessage: 'Add a preset or create a custom prompt.',
+                  ),
                 ),
-                _CategoryTab(
-                  category: PromptCategory.issueTriage,
-                  prompts: prompts,
-                  presets: ReviewPrompt.issueTriagePresets,
-                  emptyMessage:
-                      'Tap a preset above or create a custom prompt to customise how issues are analysed.',
+                KeepAliveTab(
+                  child: _CategoryTab(
+                    category: PromptCategory.issueTriage,
+                    prompts: prompts,
+                    presets: ReviewPrompt.issueTriagePresets,
+                    emptyMessage:
+                        'Tap a preset above or create a custom prompt to customise how issues are analysed.',
+                  ),
                 ),
-                _CategoryTab(
-                  category: PromptCategory.development,
-                  prompts: prompts,
-                  presets: ReviewPrompt.developmentPresets,
-                  emptyMessage:
-                      'Tap a preset above or create a custom prompt to customise auto-implementation.',
+                KeepAliveTab(
+                  child: _CategoryTab(
+                    category: PromptCategory.development,
+                    prompts: prompts,
+                    presets: ReviewPrompt.developmentPresets,
+                    emptyMessage:
+                        'Tap a preset above or create a custom prompt to customise auto-implementation.',
+                  ),
                 ),
               ],
             ),

--- a/flutter_app/lib/features/cli_agents/cli_agents_screen.dart
+++ b/flutter_app/lib/features/cli_agents/cli_agents_screen.dart
@@ -58,7 +58,7 @@ class _CLIAgentsScreenState extends ConsumerState<CLIAgentsScreen> {
   }
 
   Future<void> _autoSave() async {
-    final current = ref.read(configNotifierProvider).valueOrNull;
+    final current = ref.read(configNotifierProvider).value;
     if (current == null) return;
     await _save(current);
   }
@@ -93,7 +93,7 @@ class _CLIAgentsScreenState extends ConsumerState<CLIAgentsScreen> {
   @override
   Widget build(BuildContext context) {
     final configAsync = ref.watch(configNotifierProvider);
-    final prompts = ref.watch(agentsProvider).valueOrNull ?? [];
+    final prompts = ref.watch(agentsProvider).value ?? [];
 
     return configAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -33,7 +33,7 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
   /// Optimistic: updates UI state immediately, sends PATCH in background,
   /// then reconciles with the daemon's authoritative response.
   Future<void> save(AppConfig updated) async {
-    final current = state.valueOrNull;
+    final current = state.value;
     if (current == null) return;
     final api = ref.read(apiClientProvider);
     final diff = _computeGlobalDiff(current, updated);

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -121,7 +121,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   @override
   Widget build(BuildContext context) {
     final configAsync = ref.watch(configNotifierProvider);
-    final daemonRunning = ref.watch(daemonHealthProvider).valueOrNull ?? false;
+    final daemonRunning = ref.watch(daemonHealthProvider).value ?? false;
 
     return Scaffold(
       appBar: AppBar(
@@ -663,7 +663,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     required String? value,
     required ValueChanged<String?> onChanged,
   }) {
-    final agents = ref.watch(agentsProvider).valueOrNull ?? [];
+    final agents = ref.watch(agentsProvider).value ?? [];
     final effective = (value != null && agents.any((a) => a.id == value))
         ? value
         : null;

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -64,14 +64,19 @@ class PrListRefreshNotifier extends Notifier<int> {
       // When SSE (re)connects after being disconnected, refresh the PR list
       // to catch up on any events that arrived during the disconnection window.
       if (!(prev?.hasValue ?? false) && next.hasValue) {
-        Future.microtask(() => state++);
+        Future.microtask(() {
+          // Guard against the notifier being disposed between scheduling and
+          // running the microtask — e.g. provider rebuild on SSE reconnect.
+          // Riverpod 3 exposes `ref.mounted` for exactly this race.
+          if (!ref.mounted) return;
+          state++;
+        });
       }
       next.whenData((event) => _handleSseEvent(ref, event));
     });
     return 0;
   }
 
-  void bump() => state++;
   void update(int Function(int) updater) => state = updater(state);
 }
 

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -5,6 +5,7 @@ import '../../core/api/api_client.dart';
 import '../../core/api/sse_client.dart';
 import '../../core/models/pr.dart';
 import '../../core/platform/platform_services_provider.dart';
+import '../../core/state/local_state_notifier.dart';
 import '../../main.dart' show sendPRNotification;
 import '../issues/issues_providers.dart';
 import '../stats/stats_filters.dart';
@@ -29,10 +30,16 @@ final sseStreamProvider = StreamProvider<SseEvent>((ref) {
 /// `circuit_breaker_tripped` SSE handler and cleared by the dashboard's
 /// dismiss button — the user must acknowledge the event so cost spikes
 /// can't slip by silently (regression guard for the 2026-04-22 runaway).
-final circuitBreakerProvider = StateProvider<String?>((ref) => null);
+final circuitBreakerProvider =
+    NotifierProvider<LocalStateNotifier<String?>, String?>(
+      () => LocalStateNotifier<String?>(null),
+    );
 
 /// Tracks whether the desktop app is trying to spawn the daemon.
-final daemonStartingProvider = StateProvider<bool>((ref) => false);
+final daemonStartingProvider =
+    NotifierProvider<LocalStateNotifier<bool>, bool>(
+      () => LocalStateNotifier<bool>(false),
+    );
 
 /// Tracks PRs currently being reviewed, keyed by "repo:prNumber". Used to
 /// show spinners in the tile list and detail view.
@@ -44,24 +51,32 @@ final daemonStartingProvider = StateProvider<bool>((ref) => false);
 /// is the recovery path for missed SSE events — the broker drops events
 /// silently on subscriber back-pressure, so we can't rely on
 /// `review_completed` always arriving to clear the spinner.
-final reviewingPRsProvider = StateProvider<Map<String, int>>(
-  (ref) => const <String, int>{},
-);
+final reviewingPRsProvider =
+    NotifierProvider<LocalStateNotifier<Map<String, int>>, Map<String, int>>(
+      () => LocalStateNotifier<Map<String, int>>(const <String, int>{}),
+    );
 
 /// Increments on review_completed and on SSE reconnects (to catch up on missed events).
-final StateProvider<int> prListRefreshProvider = StateProvider<int>((ref) {
-  ref.listen<AsyncValue<SseEvent>>(sseStreamProvider, (prev, next) {
-    // When SSE (re)connects after being disconnected, refresh the PR list
-    // to catch up on any events that arrived during the disconnection window.
-    if (!(prev?.hasValue ?? false) && next.hasValue) {
-      Future.microtask(
-        () => ref.read(prListRefreshProvider.notifier).update((s) => s + 1),
-      );
-    }
-    next.whenData((event) => _handleSseEvent(ref, event));
-  });
-  return 0;
-});
+class PrListRefreshNotifier extends Notifier<int> {
+  @override
+  int build() {
+    ref.listen<AsyncValue<SseEvent>>(sseStreamProvider, (prev, next) {
+      // When SSE (re)connects after being disconnected, refresh the PR list
+      // to catch up on any events that arrived during the disconnection window.
+      if (!(prev?.hasValue ?? false) && next.hasValue) {
+        Future.microtask(() => state++);
+      }
+      next.whenData((event) => _handleSseEvent(ref, event));
+    });
+    return 0;
+  }
+
+  void bump() => state++;
+  void update(int Function(int) updater) => state = updater(state);
+}
+
+final prListRefreshProvider =
+    NotifierProvider<PrListRefreshNotifier, int>(PrListRefreshNotifier.new);
 
 void _handleSseEvent(Ref ref, SseEvent event) {
   try {
@@ -116,7 +131,7 @@ void _handleSseEvent(Ref ref, SseEvent event) {
               .update((s) => Map.of(s)..remove(key));
         } else if (prId != null) {
           // Look up by store ID from cached PR list
-          final prs = ref.read(prsProvider).valueOrNull ?? [];
+          final prs = ref.read(prsProvider).value ?? [];
           final pr = prs.where((p) => p.id == prId).firstOrNull;
           if (pr != null) {
             final k = '${pr.repo}:${pr.number}';
@@ -200,8 +215,8 @@ void _handleSseEvent(Ref ref, SseEvent event) {
         final repo = data['repo'] as String? ?? 'unknown';
         final prNumber = (data['pr_number'] as num?)?.toInt() ?? 0;
         final reason = data['reason'] as String? ?? '';
-        ref.read(circuitBreakerProvider.notifier).state =
-            '$repo #$prNumber — $reason';
+        ref.read(circuitBreakerProvider.notifier).set(
+            '$repo #$prNumber — $reason');
     }
   } catch (_) {}
 }
@@ -230,7 +245,7 @@ int _baselineReviewId(Ref ref, {required String repo, required int prNumber}) {
   // arrives before the initial /prs fetch). 0 is the same baseline used
   // for a first-review: as soon as the PR list populates with a non-zero
   // latestReview.id, reconciliation will clear the stale entry.
-  final prs = ref.read(prsProvider).valueOrNull ?? const <PR>[];
+  final prs = ref.read(prsProvider).value ?? const <PR>[];
   final pr = prs
       .where((p) => p.repo == repo && p.number == prNumber)
       .firstOrNull;
@@ -250,7 +265,7 @@ void _reconcileReviewingPRs(Ref ref, List<PR> prs) {
       if (current.isEmpty) return;
       final next = reconcileReviewing(current, prs);
       if (next.length != current.length) {
-        ref.read(reviewingPRsProvider.notifier).state = next;
+        ref.read(reviewingPRsProvider.notifier).set(next);
       }
     } catch (_) {
       // ref may be disposed if the provider was rebuilt between scheduling
@@ -300,7 +315,7 @@ final statsProvider = FutureProvider<Map<String, dynamic>>((ref) async {
 void _rebuildTray(Ref ref, List<PR> prs) {
   Future(() async {
     try {
-      final me = ref.read(meProvider).valueOrNull;
+      final me = ref.read(meProvider).value;
       // Don't build tray until we know the username — without it the
       // author filter falls back to '' and shows the user's own PRs.
       if (me == null || me.isEmpty) return;

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -28,7 +28,7 @@ class DashboardScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final cbMessage = ref.watch(circuitBreakerProvider);
-    final daemonRunning = ref.watch(daemonHealthProvider).valueOrNull ?? false;
+    final daemonRunning = ref.watch(daemonHealthProvider).value ?? false;
     final daemonStarting = ref.watch(daemonStartingProvider);
     return DefaultTabController(
       length: 6,
@@ -92,7 +92,7 @@ class DashboardScreen extends ConsumerWidget {
               CircuitBreakerBanner(
                 message: cbMessage,
                 onDismiss: () =>
-                    ref.read(circuitBreakerProvider.notifier).state = null,
+                    ref.read(circuitBreakerProvider.notifier).set(null),
               ),
             const Expanded(
               child: TabBarView(
@@ -319,8 +319,8 @@ class _ActivityTabState extends ConsumerState<_ActivityTab> {
       return _errorView(context, prsAsync.error!);
     }
 
-    final prs = prsAsync.valueOrNull ?? [];
-    final issues = issuesAsync.valueOrNull ?? [];
+    final prs = prsAsync.value ?? [];
+    final issues = issuesAsync.value ?? [];
 
     // Collect all known repos for the filter bar.
     final allRepos = <String>{

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/models/pr.dart';
 import '../../core/models/tracked_issue.dart';
+import '../../shared/widgets/keep_alive_tab.dart';
 import '../../shared/widgets/severity_badge.dart';
 import '../../shared/widgets/state_badge.dart';
 import '../../shared/widgets/toast.dart';
@@ -97,12 +98,12 @@ class DashboardScreen extends ConsumerWidget {
             const Expanded(
               child: TabBarView(
                 children: [
-                  _ActivityTab(),
-                  ActivityScreen(),
-                  ReposScreen(),
-                  AgentsScreen(),
-                  CLIAgentsScreen(),
-                  StatsScreen(),
+                  KeepAliveTab(child: _ActivityTab()),
+                  KeepAliveTab(child: ActivityScreen()),
+                  KeepAliveTab(child: ReposScreen()),
+                  KeepAliveTab(child: AgentsScreen()),
+                  KeepAliveTab(child: CLIAgentsScreen()),
+                  KeepAliveTab(child: StatsScreen()),
                 ],
               ),
             ),

--- a/flutter_app/lib/features/issues/issue_detail_screen.dart
+++ b/flutter_app/lib/features/issues/issue_detail_screen.dart
@@ -140,7 +140,7 @@ class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
       });
     });
 
-    final detailData = detailAsync.valueOrNull;
+    final detailData = detailAsync.value;
     final reviews = detailData?['reviews'] as List<TrackedIssueReview>? ?? [];
     final hasReviews = reviews.isNotEmpty;
     final issue = detailData?['issue'] as TrackedIssue?;

--- a/flutter_app/lib/features/issues/issues_providers.dart
+++ b/flutter_app/lib/features/issues/issues_providers.dart
@@ -1,16 +1,26 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/tracked_issue.dart';
+import '../../core/state/local_state_notifier.dart';
 import '../dashboard/activity_filters.dart';
 import '../dashboard/dashboard_providers.dart';
 
 /// Counter incremented by SSE events to trigger issue list refresh.
-final issueListRefreshProvider = StateProvider<int>((ref) => 0);
+final issueListRefreshProvider =
+    NotifierProvider<LocalStateNotifier<int>, int>(
+      () => LocalStateNotifier<int>(0),
+    );
 
 /// Tracks issues currently being reviewed, keyed by "repo:issueNumber".
-final reviewingIssuesProvider = StateProvider<Set<String>>((ref) => const {});
+final reviewingIssuesProvider =
+    NotifierProvider<LocalStateNotifier<Set<String>>, Set<String>>(
+      () => LocalStateNotifier<Set<String>>(const {}),
+    );
 
 /// Tracks issues currently being promoted to their next stage, keyed by "repo:issueNumber".
-final promotingIssuesProvider = StateProvider<Set<String>>((ref) => const {});
+final promotingIssuesProvider =
+    NotifierProvider<LocalStateNotifier<Set<String>>, Set<String>>(
+      () => LocalStateNotifier<Set<String>>(const {}),
+    );
 
 final issuesProvider = FutureProvider<List<TrackedIssue>>((ref) async {
   ref.watch(issueListRefreshProvider);

--- a/flutter_app/lib/features/issues/issues_screen.dart
+++ b/flutter_app/lib/features/issues/issues_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../core/models/tracked_issue.dart';
+import '../../core/state/local_state_notifier.dart';
 import '../../shared/widgets/severity_badge.dart';
 import '../../shared/widgets/toast.dart';
 import '../dashboard/dashboard_providers.dart';
@@ -11,7 +12,10 @@ const _actionReviewOnly = 'review_only';
 const _actionRefinement = 'refinement';
 
 /// Filter state for the issues list.
-final _repoFilterProvider = StateProvider<String?>((ref) => null);
+final _repoFilterProvider =
+    NotifierProvider<LocalStateNotifier<String?>, String?>(
+      () => LocalStateNotifier<String?>(null),
+    );
 
 class IssuesScreen extends ConsumerWidget {
   const IssuesScreen({super.key});
@@ -75,7 +79,7 @@ class IssuesScreen extends ConsumerWidget {
                       ),
                     ],
                     onChanged: (v) =>
-                        ref.read(_repoFilterProvider.notifier).state = v,
+                        ref.read(_repoFilterProvider.notifier).set(v),
                   ),
                   const Spacer(),
                   Text(

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -198,7 +198,7 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
         data: (appConfig) {
           _initFrom(appConfig);
           final prompts =
-              ref.watch(agentsProvider).valueOrNull ?? <ReviewPrompt>[];
+              ref.watch(agentsProvider).value ?? <ReviewPrompt>[];
           final promptOptions = prompts.map((p) => p.id).toList();
 
           return SingleChildScrollView(

--- a/flutter_app/lib/features/pr_detail/pr_detail_providers.dart
+++ b/flutter_app/lib/features/pr_detail/pr_detail_providers.dart
@@ -7,7 +7,7 @@ final prDetailProvider = FutureProvider.family<Map<String, dynamic>, int>((ref, 
   return api.fetchPR(prId);
 });
 
-class ReviewTriggerNotifier extends AutoDisposeAsyncNotifier<void> {
+class ReviewTriggerNotifier extends AsyncNotifier<void> {
   @override
   Future<void> build() async {}
 

--- a/flutter_app/lib/features/pr_detail/pr_detail_screen.dart
+++ b/flutter_app/lib/features/pr_detail/pr_detail_screen.dart
@@ -87,8 +87,8 @@ class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
           final data = jsonDecode(event.data) as Map<String, dynamic>;
           final prId = (data['pr_id'] as num?)?.toInt();
           final prNumber = (data['pr_number'] as num?)?.toInt();
-          final currentPrNumber = detailAsync.valueOrNull?['pr'] is PR
-              ? (detailAsync.valueOrNull!['pr'] as PR).number
+          final currentPrNumber = detailAsync.value?['pr'] is PR
+              ? (detailAsync.value!['pr'] as PR).number
               : null;
 
           switch (event.type) {
@@ -112,7 +112,7 @@ class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
       });
     });
 
-    final detailData = detailAsync.valueOrNull;
+    final detailData = detailAsync.value;
     final reviews = detailData?['reviews'] as List<Review>? ?? [];
     final hasReviews = reviews.isNotEmpty;
     final pr = detailData?['pr'] as PR?;

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -85,7 +85,7 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
 
       final monitoringChanged = previous.isMonitored != _config.isMonitored;
       if (monitoringChanged) {
-        final current = ref.read(configNotifierProvider).valueOrNull;
+        final current = ref.read(configNotifierProvider).value;
         if (current != null) {
           final updatedRepos = Map<String, RepoConfig>.from(
             current.repoConfigs,
@@ -281,7 +281,7 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
         data: (appConfig) {
           _initFrom(appConfig);
           final prompts =
-              ref.watch(agentsProvider).valueOrNull ?? <ReviewPrompt>[];
+              ref.watch(agentsProvider).value ?? <ReviewPrompt>[];
           final orgName = widget.repoName.contains('/')
               ? widget.repoName.split('/').first
               : widget.repoName;

--- a/flutter_app/lib/features/repositories/repos_screen.dart
+++ b/flutter_app/lib/features/repositories/repos_screen.dart
@@ -157,7 +157,7 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
   }
 
   Future<void> _autoSave() async {
-    final current = ref.read(configNotifierProvider).valueOrNull;
+    final current = ref.read(configNotifierProvider).value;
     if (current == null) return;
     if (mounted) setState(() => _syncStatus = _SyncStatus.saving);
     final updated = current.copyWith(repoConfigs: Map.from(_repoConfigs));

--- a/flutter_app/lib/features/server/server_actions.dart
+++ b/flutter_app/lib/features/server/server_actions.dart
@@ -56,7 +56,7 @@ Future<void> startDaemon(BuildContext context, WidgetRef ref) async {
     return;
   }
 
-  ref.read(daemonStartingProvider.notifier).state = true;
+  ref.read(daemonStartingProvider.notifier).set(true);
   try {
     await platform.spawnDaemon(binaryPath);
     final api = ref.read(apiClientProvider);
@@ -80,7 +80,7 @@ Future<void> startDaemon(BuildContext context, WidgetRef ref) async {
   } catch (e) {
     if (context.mounted) showToast(context, 'Error: $e', isError: true);
   } finally {
-    ref.read(daemonStartingProvider.notifier).state = false;
+    ref.read(daemonStartingProvider.notifier).set(false);
   }
 }
 
@@ -115,7 +115,7 @@ Future<void> refreshWhenDaemonStops(
 /// Restart banner after a Listen URL change.
 Future<void> restartDaemon(BuildContext context, WidgetRef ref) async {
   final api = ref.read(apiClientProvider);
-  ref.read(daemonStartingProvider.notifier).state = true;
+  ref.read(daemonStartingProvider.notifier).set(true);
   try {
     await api.shutdownDaemon();
     if (!context.mounted) return;
@@ -142,7 +142,7 @@ Future<void> restartDaemon(BuildContext context, WidgetRef ref) async {
   } catch (e) {
     if (context.mounted) showToast(context, 'Error: $e', isError: true);
   } finally {
-    ref.read(daemonStartingProvider.notifier).state = false;
+    ref.read(daemonStartingProvider.notifier).set(false);
   }
 }
 

--- a/flutter_app/lib/features/server/server_screen.dart
+++ b/flutter_app/lib/features/server/server_screen.dart
@@ -38,7 +38,7 @@ class _ServerScreenState extends ConsumerState<ServerScreen>
 
   @override
   Widget build(BuildContext context) {
-    final daemonRunning = ref.watch(daemonHealthProvider).valueOrNull ?? false;
+    final daemonRunning = ref.watch(daemonHealthProvider).value ?? false;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Server'),

--- a/flutter_app/lib/features/server/server_screen.dart
+++ b/flutter_app/lib/features/server/server_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../shared/widgets/keep_alive_tab.dart';
 import '../config/config_providers.dart';
 import '../logs/logs_screen.dart' show LogsView;
 import 'widgets/events_tab.dart';
@@ -58,13 +59,17 @@ class _ServerScreenState extends ConsumerState<ServerScreen>
       body: TabBarView(
         controller: _controller,
         children: [
-          const StatusTab(),
-          daemonRunning
-              ? const EventsTab()
-              : const _DaemonStoppedPlaceholder(label: 'live events'),
-          daemonRunning
-              ? const LogsView()
-              : const _DaemonStoppedPlaceholder(label: 'logs'),
+          const KeepAliveTab(child: StatusTab()),
+          KeepAliveTab(
+            child: daemonRunning
+                ? const EventsTab()
+                : const _DaemonStoppedPlaceholder(label: 'live events'),
+          ),
+          KeepAliveTab(
+            child: daemonRunning
+                ? const LogsView()
+                : const _DaemonStoppedPlaceholder(label: 'logs'),
+          ),
         ],
       ),
     );

--- a/flutter_app/lib/features/server/widgets/status_tab.dart
+++ b/flutter_app/lib/features/server/widgets/status_tab.dart
@@ -36,13 +36,13 @@ class _StatusTabState extends ConsumerState<StatusTab> {
 
   @override
   Widget build(BuildContext context) {
-    final config = ref.watch(configNotifierProvider).valueOrNull;
+    final config = ref.watch(configNotifierProvider).value;
     if (config == null) {
       return const Center(child: CircularProgressIndicator());
     }
     _initialBindAddr ??= config.bindAddr ?? '127.0.0.1';
     _initialPort ??= config.serverPort;
-    final daemonRunning = ref.watch(daemonHealthProvider).valueOrNull ?? false;
+    final daemonRunning = ref.watch(daemonHealthProvider).value ?? false;
     final daemonStarting = ref.watch(daemonStartingProvider);
 
     return SingleChildScrollView(
@@ -296,7 +296,7 @@ class _StartStopButton extends ConsumerWidget {
 class _HealthSummary extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final detail = ref.watch(serverHealthDetailProvider).valueOrNull;
+    final detail = ref.watch(serverHealthDetailProvider).value;
     if (detail == null) return const SizedBox.shrink();
     final parts = <String>[];
     if (detail.version != null && detail.version!.isNotEmpty) {

--- a/flutter_app/lib/features/stats/stats_filter_bar.dart
+++ b/flutter_app/lib/features/stats/stats_filter_bar.dart
@@ -47,8 +47,8 @@ class StatsFilterBar extends ConsumerWidget {
                   final org = r.contains('/') ? r.split('/').first : r;
                   return selectedOrgs.isEmpty || selectedOrgs.contains(org);
                 }).toSet();
-                ref.read(statsFiltersProvider.notifier).state =
-                    filters.copyWith(orgs: selectedOrgs, repos: validRepos);
+                ref.read(statsFiltersProvider.notifier).set(
+                    filters.copyWith(orgs: selectedOrgs, repos: validRepos));
               },
             ),
 
@@ -61,8 +61,8 @@ class StatsFilterBar extends ConsumerWidget {
               allItems: visibleRepos.toList()..sort(),
               selected: filters.repos,
               onChanged: (repos) {
-                ref.read(statsFiltersProvider.notifier).state =
-                    filters.copyWith(repos: repos);
+                ref.read(statsFiltersProvider.notifier).set(
+                    filters.copyWith(repos: repos));
               },
             ),
 
@@ -73,8 +73,8 @@ class StatsFilterBar extends ConsumerWidget {
               label: const Text('Reset', style: TextStyle(fontSize: 12)),
               visualDensity: VisualDensity.compact,
               onPressed: () {
-                ref.read(statsFiltersProvider.notifier).state =
-                    const StatsFilters();
+                ref.read(statsFiltersProvider.notifier).set(
+                    const StatsFilters());
               },
             ),
         ],

--- a/flutter_app/lib/features/stats/stats_filters.dart
+++ b/flutter_app/lib/features/stats/stats_filters.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/state/local_state_notifier.dart';
+
 /// Filter state for the Stats view — org and repo multi-select.
 class StatsFilters {
   final Set<String> orgs;
@@ -17,4 +19,6 @@ class StatsFilters {
 }
 
 final statsFiltersProvider =
-    StateProvider<StatsFilters>((ref) => const StatsFilters());
+    NotifierProvider<LocalStateNotifier<StatsFilters>, StatsFilters>(
+      () => LocalStateNotifier<StatsFilters>(const StatsFilters()),
+    );

--- a/flutter_app/lib/features/stats/stats_screen.dart
+++ b/flutter_app/lib/features/stats/stats_screen.dart
@@ -12,8 +12,8 @@ class StatsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final statsAsync = ref.watch(statsProvider);
-    final prs = ref.watch(prsProvider).valueOrNull ?? <PR>[];
-    final issues = ref.watch(issuesProvider).valueOrNull ?? <TrackedIssue>[];
+    final prs = ref.watch(prsProvider).value ?? <PR>[];
+    final issues = ref.watch(issuesProvider).value ?? <TrackedIssue>[];
 
     final allRepos = <String>{
       ...prs.map((p) => p.repo),

--- a/flutter_app/lib/shared/widgets/keep_alive_tab.dart
+++ b/flutter_app/lib/shared/widgets/keep_alive_tab.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// Wraps a TabBarView child so it survives tab switches.
+///
+/// Flutter's TabBarView disposes off-screen children by default, which under
+/// Riverpod 3 means any provider whose only listener was that tab gets paused
+/// (and `ref.invalidate` won't fire a rebuild without an active listener).
+/// Re-entering the tab then renders an empty/stale frame while the chain
+/// reactivates — surfaced as the "click twice to open" feel.
+///
+/// Wrapping each tab body in this widget pins the tab to the element tree via
+/// AutomaticKeepAliveClientMixin, so its `ref.watch` calls stay active across
+/// tab switches and the downstream providers never enter the paused state.
+class KeepAliveTab extends StatefulWidget {
+  final Widget child;
+  const KeepAliveTab({super.key, required this.child});
+
+  @override
+  State<KeepAliveTab> createState() => _KeepAliveTabState();
+}
+
+class _KeepAliveTabState extends State<KeepAliveTab>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.child;
+  }
+}

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   cli_util:
     dependency: transitive
     description:
@@ -145,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.15.0"
   cross_file:
     dependency: transitive
     description:
@@ -250,10 +266,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      sha256: "4e166be88e1dbbaa34a280bdb744aeae73b7ef25fdf8db7a3bb776760a3648e2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.3.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -264,6 +280,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -440,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -540,10 +572,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      sha256: "8c22216be8ad3ef2b44af3a329693558c98eca7b8bd4ef495c92db0bba279f83"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.2.1"
   screen_retriever:
     dependency: transitive
     description:
@@ -648,6 +680,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -685,6 +733,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.12"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -741,6 +805,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test:
+    dependency: transitive
+    description:
+      name: test
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
@@ -749,6 +821,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.16"
   tray_manager:
     dependency: "direct main"
     description:
@@ -885,6 +965,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   win32:
     dependency: transitive
     description:

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_riverpod: ^2.5.0
+  flutter_riverpod: ^3.0.0
   http: ^1.2.0
   go_router: ^17.0.0
   shared_preferences: ^2.2.0

--- a/flutter_app/test/features/activity/activity_providers_test.dart
+++ b/flutter_app/test/features/activity/activity_providers_test.dart
@@ -197,8 +197,13 @@ void main() {
         c.dispose();
       });
 
-      c.read(activityLiveUpdatesProvider.notifier).state = true;
-      c.read(activityLiveRefreshProvider);
+      c.read(activityLiveUpdatesProvider.notifier).set(true);
+      // Riverpod 3: providers without active listeners get paused and
+      // ref.invalidate no longer forces an immediate rebuild. The screen
+      // would ref.watch the refresh + entries providers; in tests we have
+      // to attach explicit listeners so the chain stays awake.
+      c.listen(activityLiveRefreshProvider, (_, _) {});
+      c.listen(activityEntriesProvider, (_, _) {});
       await c.read(activityEntriesProvider.future);
       expect(calls, 1);
 

--- a/flutter_app/test/features/activity/activity_screen_test.dart
+++ b/flutter_app/test/features/activity/activity_screen_test.dart
@@ -30,7 +30,7 @@ ProviderScope _scope({required AsyncValue<ActivityPage> value}) {
     if (value is AsyncError) {
       throw (value as AsyncError).error;
     }
-    return (value.valueOrNull)!;
+    return (value.value)!;
   }
 
   return ProviderScope(

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -366,6 +366,10 @@ void main() {
       githubToken: 'fake-token',
     );
     final container = ProviderContainer(
+      // Riverpod 3 retries failed providers by default; saveAndStartDaemon's
+      // health check is expected to fail in this test, so disable retries to
+      // avoid pending timers after the test body returns.
+      retry: (_, _) => null,
       overrides: [platformServicesProvider.overrideWithValue(platform)],
     );
     addTearDown(container.dispose);
@@ -399,6 +403,10 @@ void main() {
         githubToken: 'fake-token',
       );
       final container = ProviderContainer(
+        // Riverpod 3 retries failed providers by default; saveAndStartDaemon's
+        // health check is expected to fail in this test, so disable retries to
+        // avoid pending timers after the test body returns.
+        retry: (_, _) => null,
         overrides: [platformServicesProvider.overrideWithValue(platform)],
       );
       addTearDown(container.dispose);


### PR DESCRIPTION
Closes #445.

## Summary

Final Tier 3 bump (closes the deps-cleanup series started with #439). flutter_riverpod 2.6.1 → 3.3.1: ~80 sites across 26 files in the core migration commit, plus a follow-up that compensates for v3's stricter provider lifecycle in tab navigation.

## Migration breakdown (commit `14bff17`)

| Area | Sites | Change |
|---|---|---|
| `AsyncValue.valueOrNull` → `.value` | 27 | v3 removed `valueOrNull`; `.value` returns `T?` now |
| `StateProvider<T>` → `NotifierProvider<LocalStateNotifier<T>, T>` | 11 | v3 moves `StateProvider` to legacy. New helper `LocalStateNotifier<T>` (under `core/state/`) keeps `.set(T)` / `.update((T)=>T)` ergonomics so consumers stay close to the old shape |
| `extends StateNotifier<T>` → `extends Notifier<T>` | 1 | `ActivityQueryNotifier`: constructor body moves into `build()` override |
| `Provider<void>` side-effect → `Notifier<void>` | 1 | `activityLiveRefreshProvider` re-implemented as `ActivityLiveRefreshNotifier`; integrates cleanly with v3 lifecycle when watched |
| `AutoDisposeAsyncNotifier` → `AsyncNotifier` | 1 | v3 fuses them; `.autoDispose` modifier stays on provider declaration |
| `.notifier.state = v` → `.notifier.set(v)` | 12 | Consumer-side; `update((s)=>...)` callers unchanged thanks to helper |

## Tab keep-alive fix (commit `39eb9d1`)

Smoke testing surfaced an intermittent "click tab twice to open" feel after the migration. Root cause: Riverpod 3 pauses providers without active listeners, and Flutter's `TabBarView` disposes off-screen children — so switching away from a tab released the only `ref.watch` keeping its providers awake. Re-entering rendered an empty frame while the chain reactivated.

Added a `KeepAliveTab` wrapper (`AutomaticKeepAliveClientMixin`) and applied it to the three `TabBarView`s with persistent provider state:
- Dashboard tabs (Activity / Activity Log / Repositories / Prompts / Agents / Stats)
- Agents prompt-category tabs (PR Review / Issue Triage / Development)
- Server tabs (Status / Events / Logs)

The modal-internal TabBarView in the agents prompt editor is left untouched — that one is recreated per dialog open.

## v3 behaviour changes that needed test compensation

- **Providers without active listeners get paused** in v3. Production paths use `ref.watch` and are fine; tests have to attach explicit listeners (`c.listen`).
- **`ref.invalidate` no longer forces a rebuild** without an active listener. Same compensation in the affected test.
- **New auto-retry timer** can outlive a test if a provider's build throws. The two `saveAndStartDaemon` tests now pass `retry: (_, _) => null` to disable retry for that container.

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 167/167
- [x] Manual smoke test on macOS: dashboard, PR list, activity live mode, repositories, agents config save, stats filters, server tab
- [x] Tab switching is now consistently single-click after the keep-alive fix
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)