### PR TITLE
fix(notifications): migrate from local_notifier to flutter_local_notifications

### DIFF
--- a/flutter_app/devtools_options.yaml
+++ b/flutter_app/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/flutter_app/lib/core/platform/platform_services_desktop.dart
+++ b/flutter_app/lib/core/platform/platform_services_desktop.dart
@@ -144,6 +144,12 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
   // Notification plumbing. flutter_local_notifications wires onClick through
   // a single global callback (per payload) instead of per-instance handlers,
   // so we keep a small id → callback map here and use the id as payload.
+  //
+  // The map is bounded by `_maxNotifierHandlers` with FIFO eviction (Dart's
+  // default Map preserves insertion order). Without this, notifications that
+  // are dismissed or expire without being clicked would leak their closures
+  // indefinitely in a long-running tray app.
+  static const int _maxNotifierHandlers = 128;
   final FlutterLocalNotificationsPlugin _notifier =
       FlutterLocalNotificationsPlugin();
   final Map<int, VoidCallback> _notifierHandlers = {};
@@ -182,8 +188,18 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
     required String body,
     VoidCallback? onClick,
   }) {
-    final id = _nextNotifierId++;
-    if (onClick != null) _notifierHandlers[id] = onClick;
+    // Bitmask keeps the id in 32-bit positive range; some platform notifier
+    // backends use 32-bit ids internally, so we avoid relying on Dart's
+    // 64-bit ints surviving the boundary.
+    final id = _nextNotifierId = (_nextNotifierId + 1) & 0x7FFFFFFF;
+    if (onClick != null) {
+      _notifierHandlers[id] = onClick;
+      if (_notifierHandlers.length > _maxNotifierHandlers) {
+        // Drop the oldest handler. Map preserves insertion order, so the
+        // first key is the eldest entry.
+        _notifierHandlers.remove(_notifierHandlers.keys.first);
+      }
+    }
     _notifier.show(
       id: id,
       title: title,

--- a/flutter_app/lib/core/platform/platform_services_desktop.dart
+++ b/flutter_app/lib/core/platform/platform_services_desktop.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 import 'dart:ui' show VoidCallback;
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter/painting.dart' show Size;
-import 'package:local_notifier/local_notifier.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:window_manager/window_manager.dart';
 import '../api/api_client.dart';
@@ -17,9 +17,9 @@ import 'platform_services.dart';
 
 /// Desktop implementation of [PlatformServices].
 ///
-/// Wraps dart:io, tray_manager, window_manager, local_notifier, and the
-/// existing FirstRunSetup / DaemonLifecycle helpers so that shared code
-/// never has to import them directly.
+/// Wraps dart:io, tray_manager, window_manager, flutter_local_notifications,
+/// and the existing FirstRunSetup / DaemonLifecycle helpers so that shared
+/// code never has to import them directly.
 class DesktopPlatformServices with WindowListener implements PlatformServices {
   DesktopPlatformServices({
     int apiPort = 7842,
@@ -141,9 +141,39 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
     TrayMenu.instance.rebindNavigation(handler);
   }
 
+  // Notification plumbing. flutter_local_notifications wires onClick through
+  // a single global callback (per payload) instead of per-instance handlers,
+  // so we keep a small id → callback map here and use the id as payload.
+  final FlutterLocalNotificationsPlugin _notifier =
+      FlutterLocalNotificationsPlugin();
+  final Map<int, VoidCallback> _notifierHandlers = {};
+  int _nextNotifierId = 0;
+
   @override
   Future<void> setupNotifier({required String appName}) async {
-    await localNotifier.setup(appName: appName);
+    // appName is unused — the bundle's CFBundleName/Info.plist drives the
+    // notification source label on every platform. Kept in the signature so
+    // the abstract API stays platform-neutral.
+    await _notifier.initialize(
+      settings: const InitializationSettings(
+        macOS: DarwinInitializationSettings(
+          // Triggers UNUserNotificationCenter.requestAuthorization on first
+          // run — the modern Notification Center prompt, replacing the
+          // deprecated NSUserNotification path that silently failed on
+          // recent macOS (see issue #438).
+          requestAlertPermission: true,
+          requestSoundPermission: true,
+          requestBadgePermission: true,
+        ),
+        linux: LinuxInitializationSettings(defaultActionName: 'Open'),
+      ),
+      onDidReceiveNotificationResponse: (response) {
+        final id = int.tryParse(response.payload ?? '');
+        if (id == null) return;
+        final handler = _notifierHandlers.remove(id);
+        handler?.call();
+      },
+    );
   }
 
   @override
@@ -152,9 +182,18 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
     required String body,
     VoidCallback? onClick,
   }) {
-    final n = LocalNotification(title: title, body: body);
-    n.onClick = () => onClick?.call();
-    n.show();
+    final id = _nextNotifierId++;
+    if (onClick != null) _notifierHandlers[id] = onClick;
+    _notifier.show(
+      id: id,
+      title: title,
+      body: body,
+      notificationDetails: const NotificationDetails(
+        macOS: DarwinNotificationDetails(),
+        linux: LinuxNotificationDetails(),
+      ),
+      payload: id.toString(),
+    );
   }
 
   @override

--- a/flutter_app/linux/flutter/generated_plugin_registrant.cc
+++ b/flutter_app/linux/flutter/generated_plugin_registrant.cc
@@ -6,16 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <local_notifier/local_notifier_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) local_notifier_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "LocalNotifierPlugin");
-  local_notifier_plugin_register_with_registrar(local_notifier_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);

--- a/flutter_app/linux/flutter/generated_plugins.cmake
+++ b/flutter_app/linux/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  local_notifier
   screen_retriever_linux
   tray_manager
   url_launcher_linux

--- a/flutter_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import file_picker
-import local_notifier
+import flutter_local_notifications
 import screen_retriever_macos
 import shared_preferences_foundation
 import tray_manager
@@ -15,7 +15,7 @@ import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
-  LocalNotifierPlugin.register(with: registry.registrar(forPlugin: "LocalNotifierPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))

--- a/flutter_app/macos/Podfile.lock
+++ b/flutter_app/macos/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - file_picker (0.0.1):
     - FlutterMacOS
-  - FlutterMacOS (1.0.0)
-  - local_notifier (0.1.0):
+  - flutter_local_notifications (0.0.1):
     - FlutterMacOS
+  - FlutterMacOS (1.0.0)
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
@@ -18,8 +18,8 @@ PODS:
 
 DEPENDENCIES:
   - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
+  - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - local_notifier (from `Flutter/ephemeral/.symlinks/plugins/local_notifier/macos`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - tray_manager (from `Flutter/ephemeral/.symlinks/plugins/tray_manager/macos`)
@@ -29,10 +29,10 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   file_picker:
     :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
+  flutter_local_notifications:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  local_notifier:
-    :path: Flutter/ephemeral/.symlinks/plugins/local_notifier/macos
   screen_retriever_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
   shared_preferences_foundation:
@@ -46,8 +46,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
+  flutter_local_notifications: 1fc7ffb10a83d6a2eeeeddb152d43f1944b0aad0
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  local_notifier: ebf072651e35ae5e47280ad52e2707375cb2ae4e
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   tray_manager: a104b5c81b578d83f3c3d0f40a997c8b10810166

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -254,6 +254,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "21.0.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -400,14 +432,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
-  local_notifier:
-    dependency: "direct main"
-    description:
-      name: local_notifier
-      sha256: f6cfc933c6fbc961f4e52b5c880f68e41b2d3cd29aad557cc654fd211093a025
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.6"
   logging:
     dependency: transitive
     description:
@@ -829,6 +853,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.16"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.0"
   tray_manager:
     dependency: "direct main"
     description:
@@ -909,14 +941,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.5"
-  uuid:
-    dependency: transitive
-    description:
-      name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:
@@ -1015,4 +1039,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  flutter: ">=3.38.1"

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   json_annotation: ^4.8.0
   tray_manager: ^0.5.2
   window_manager: ^0.5.1
-  local_notifier: ^0.1.6
+  flutter_local_notifications: ^21.0.0
   url_launcher: ^6.3.2
   file_picker: ^11.0.0
   # package:web gives us typed bindings to Notification / window for the


### PR DESCRIPTION
Closes #438.

## Problem

The `local_notifier` package's macOS backend is built on `NSUserNotification` / `NSUserNotificationCenter`, deprecated by Apple in macOS 10.14 (2018). On recent macOS releases the system increasingly drops notifications posted through this path with no error, no banner, and no entry in Notification Center — exactly the "stopped working" symptom @Muriano reported. Permissions don't help because the API path itself is the deprecated one.

## Fix

Swap `local_notifier ^0.1.6` → `flutter_local_notifications ^21.0.0`, whose macOS backend uses **`UNUserNotificationCenter`** (the modern User Notifications framework). On first run the plugin calls `requestAuthorization` and macOS shows the standard permission prompt; subsequent notifications go through the normal Notification Center pipeline.

The new dependency also covers Linux (libnotify via dbus), so the team member on Linux keeps working without a code branch.

## API shape

The `PlatformServices.showNotification` / `setupNotifier` abstract surface is unchanged — callers in `main.dart` aren't touched. Internal differences absorbed inside `DesktopPlatformServices`:

| Before (`local_notifier`) | After (`flutter_local_notifications`) |
|---|---|
| `LocalNotification(title:body:)` → `n.onClick = ...; n.show()` | `_notifier.show(id:title:body:notificationDetails:payload:)` |
| Per-instance `onClick` callback | Global `onDidReceiveNotificationResponse`, dispatched via a `Map<int, VoidCallback>` keyed by the notification id (passed as `payload`) |
| `localNotifier.setup(appName:)` | `_notifier.initialize(settings: InitializationSettings(macOS:..., linux:...), onDidReceiveNotificationResponse: ...)` |

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 167/167
- [ ] Manual smoke test on macOS: trigger a review, expect a system notification banner and an entry in Notification Center; click → app focuses + navigates to PR detail
- [ ] @Muriano confirms notifications now appear on his machine
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)