### PR TITLE
fix(issues): add Dismiss button to dashboard activity list tiles

### DIFF
--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -665,14 +665,43 @@ class _PRTileState extends ConsumerState<_PRTile> {
   }
 }
 
-class _IssueActivityTile extends StatelessWidget {
+class _IssueActivityTile extends ConsumerStatefulWidget {
   final TrackedIssue issue;
   const _IssueActivityTile({required this.issue});
 
-  String get _type => _itemType(_IssueItem(issue));
+  @override
+  ConsumerState<_IssueActivityTile> createState() =>
+      _IssueActivityTileState();
+}
+
+class _IssueActivityTileState extends ConsumerState<_IssueActivityTile> {
+  String get _type => _itemType(_IssueItem(widget.issue));
+
+  Future<void> _dismiss() async {
+    final api = ref.read(apiClientProvider);
+    try {
+      await api.dismissIssue(widget.issue.id);
+      ref.invalidate(issuesProvider);
+      if (mounted) {
+        showToast(
+          context,
+          'Issue #${widget.issue.number} dismissed',
+          duration: const Duration(seconds: 5),
+          actionLabel: 'Undo',
+          onAction: () async {
+            await api.undismissIssue(widget.issue.id);
+            ref.invalidate(issuesProvider);
+          },
+        );
+      }
+    } catch (e) {
+      if (mounted) showToast(context, 'Error: $e', isError: true);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
+    final issue = widget.issue;
     final reviewed = issue.latestReview != null;
     final severity = issue.latestReview?.severity ?? '';
 
@@ -727,27 +756,40 @@ class _IssueActivityTile extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: 12),
-                if (reviewed)
-                  SeverityBadge(severity: severity)
-                else
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 8,
-                      vertical: 3,
-                    ),
-                    decoration: BoxDecoration(
-                      color: Colors.grey.shade700,
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    child: const Text(
-                      'PENDING',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 11,
-                        fontWeight: FontWeight.w600,
+                // Trailing: severity/PENDING badge + dismiss — mirrors _PRTile.
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (reviewed)
+                      SeverityBadge(severity: severity)
+                    else
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 3,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.grey.shade700,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: const Text(
+                          'PENDING',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
                       ),
+                    IconButton(
+                      icon: const Icon(Icons.close, size: 14),
+                      tooltip: 'Dismiss issue',
+                      color: Colors.grey.shade600,
+                      visualDensity: VisualDensity.compact,
+                      onPressed: _dismiss,
                     ),
-                  ),
+                  ],
+                ),
               ],
             ),
           ),


### PR DESCRIPTION
Closes #447.

## Problem

`_IssueActivityTile` in the dashboard's Activity tab (list view) was missing the close-icon dismiss button that `_PRTile` already has alongside the severity / PENDING badge. So triage / refinement / development issues had no way to dismiss directly from the list — the action existed only on the dedicated `/issues` route (`issues_screen.dart` already wires it on `_IssueTile`).

## Fix

Mirrors the `_PRTile` pattern:

- Convert `_IssueActivityTile` to a `ConsumerStatefulWidget` (it now needs `ref` for `dismissIssue`/`undismissIssue` + provider invalidation)
- Add `_dismiss()`: optimistic call to `api.dismissIssue(issue.id)`, invalidate `issuesProvider`, show 5s toast with an **Undo** action that re-fires `api.undismissIssue(...)`
- Drop in a compact `IconButton(Icons.close, size: 14)` in the trailing row, right after the severity badge

## Out of scope (intentional)

- **Grid view** (`_ActivityGridTile`): PRs don't have dismiss in grid either; adding it would clutter the small cards and break visual parity. List view is the natural place.
- **TUI** (mentioned in the issue body): kept this PR Flutter-only for a reviewable diff. Will follow up separately if needed.

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 167/167
- [ ] Manual smoke test on macOS:
  - Open dashboard → Activity tab → list view
  - Pick an issue → click the X → toast appears with "Undo"
  - Issue disappears from list; SnackBar's "Undo" restores it
  - Same in the dedicated /issues page (untouched, should keep working)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)