### PR TITLE
fix(server): structured event cards in Events tab (#453)

### DIFF
--- a/flutter_app/lib/features/server/event_summary.dart
+++ b/flutter_app/lib/features/server/event_summary.dart
@@ -1,132 +1,342 @@
 import 'package:flutter/material.dart';
 
-/// One-line human summary for an SSE event payload, used by the Server
-/// screen's Live Events tab. Pure function — no widget dependencies.
-String summarize(String type, Map<String, dynamic> payload) {
-  String repoRef() {
-    final repo = payload['repo'] as String?;
-    final number = payload['number'];
-    if (repo != null && number != null) return '$repo#$number';
-    if (repo != null) return repo;
-    return '';
-  }
+/// EventStatus drives the colour + icon family of a row. Kept narrow on
+/// purpose — adding a new bucket should be deliberate.
+enum EventStatus {
+  /// Work that just started and may still be running (review_started,
+  /// issue_review_started, polling_started, …).
+  started,
 
+  /// Terminal-success: review_completed, issue_implemented, polling_completed.
+  succeeded,
+
+  /// Terminal-failure: review_error, issue_review_error.
+  failed,
+
+  /// Intentionally not run: review_skipped, dismissed, dedup hit.
+  skipped,
+
+  /// Operator/observation-only: pr_detected, repo_discovered, state changes.
+  info,
+
+  /// Soft-warning: circuit_breaker_tripped, stage promotion.
+  warning,
+}
+
+/// FormattedEvent is the structured view of an SSE event for the Server
+/// section's Live Events tab. Pure data class — the rendering widget
+/// decides how to lay out the fields.
+///
+/// Why structured instead of a single string: #453 — the previous
+/// summarize() collapsed everything into a one-liner, so the GUI either
+/// dumped raw JSON on expand or showed a wall of underscored type names
+/// like `polling_started`. With the fields split, the row can show a
+/// human-readable label (`Polling started`) up top and the target /
+/// details on a second line, and the JSON expand stays as a debugging
+/// fallback rather than the primary view.
+@immutable
+class FormattedEvent {
+  /// Human-readable title: `Review started`, `Issue triaged`, etc.
+  /// Capitalised, no underscores, no event-id leakage.
+  final String label;
+
+  /// Subject of the event when known: `org/repo#42` for a PR, `org/repo`
+  /// for repo-scoped events, empty for global events (polling cycle).
+  final String target;
+
+  /// Extra context: agent name, duration, stage transition, error reason.
+  /// Rendered as separator-joined or chip-style spans by the row widget.
+  final List<String> details;
+
+  /// Status bucket — drives icon + colour. See [EventStatus].
+  final EventStatus status;
+
+  /// Glyph for the row. Kept separate from status so type-specific icons
+  /// (sync_alt for promotion, warning_amber for breaker) survive while
+  /// the colour palette stays tied to status.
+  final IconData icon;
+
+  /// Accent colour applied to the icon + status indicator.
+  final Color color;
+
+  const FormattedEvent({
+    required this.label,
+    required this.target,
+    required this.details,
+    required this.status,
+    required this.icon,
+    required this.color,
+  });
+}
+
+/// Palette tied to [EventStatus]. Hex values match the prior glyphFor()
+/// choices so the visual continuity carries over from the old one-line
+/// renderer.
+const _statusColors = <EventStatus, Color>{
+  EventStatus.started: Color(0xFFFFB347), // orange
+  EventStatus.succeeded: Color(0xFF6CCA6C), // green
+  EventStatus.failed: Color(0xFFFF6B6B), // red
+  EventStatus.skipped: Color(0xFF888888), // gray
+  EventStatus.info: Color(0xFF6CA0FF), // blue
+  EventStatus.warning: Color(0xFFB070FF), // purple
+};
+
+Color _color(EventStatus s) => _statusColors[s]!;
+
+/// Build a [FormattedEvent] from the raw SSE wire payload. Each branch
+/// owns its label + status + icon + which payload keys feed the target
+/// and details fields. The default branch keeps unknown event types
+/// renderable — degrade gracefully instead of dropping the row.
+FormattedEvent format(String type, Map<String, dynamic> payload) {
   switch (type) {
     case 'pr_detected':
-      return 'pr_detected  ${repoRef()}'.trimRight();
+      return FormattedEvent(
+        label: 'PR detected',
+        target: _repoRef(payload),
+        details: const [],
+        status: EventStatus.info,
+        icon: Icons.fiber_manual_record,
+        color: _color(EventStatus.info),
+      );
     case 'review_started':
-      final agent = payload['agent'] as String?;
-      final ref = repoRef();
-      return agent != null && agent.isNotEmpty
-          ? 'review_started  $ref ($agent)'
-          : 'review_started  $ref';
+      return FormattedEvent(
+        label: 'Review started',
+        target: _repoRef(payload),
+        details: _agentDetails(payload),
+        status: EventStatus.started,
+        icon: Icons.play_arrow,
+        color: _color(EventStatus.started),
+      );
     case 'review_completed':
-      final dur = _durationLabel(payload['duration_ms']);
-      return dur != null
-          ? 'review_completed  ${repoRef()} in $dur'
-          : 'review_completed  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Review completed',
+        target: _repoRef(payload),
+        details: _durationDetails(payload),
+        status: EventStatus.succeeded,
+        icon: Icons.check,
+        color: _color(EventStatus.succeeded),
+      );
     case 'review_error':
-      return 'review_error  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Review failed',
+        target: _repoRef(payload),
+        details: _errorDetails(payload),
+        status: EventStatus.failed,
+        icon: Icons.close,
+        color: _color(EventStatus.failed),
+      );
     case 'review_skipped':
-      final reason = payload['reason'] as String?;
-      return reason != null
-          ? 'review_skipped  ${repoRef()} ($reason)'
-          : 'review_skipped  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Review skipped',
+        target: _repoRef(payload),
+        details: _reasonDetails(payload),
+        status: EventStatus.skipped,
+        icon: Icons.remove,
+        color: _color(EventStatus.skipped),
+      );
     case 'issue_detected':
-      return 'issue_detected  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Issue detected',
+        target: _repoRef(payload),
+        details: const [],
+        status: EventStatus.info,
+        icon: Icons.fiber_manual_record,
+        color: _color(EventStatus.info),
+      );
     case 'issue_review_started':
-      final agent = payload['agent'] as String?;
-      return agent != null
-          ? 'issue_review_started  ${repoRef()} ($agent)'
-          : 'issue_review_started  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Triage started',
+        target: _repoRef(payload),
+        details: _agentDetails(payload),
+        status: EventStatus.started,
+        icon: Icons.play_arrow,
+        color: _color(EventStatus.started),
+      );
     case 'issue_review_completed':
-      final dur = _durationLabel(payload['duration_ms']);
-      return dur != null
-          ? 'issue_review_completed  ${repoRef()} in $dur'
-          : 'issue_review_completed  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Triage completed',
+        target: _repoRef(payload),
+        details: _durationDetails(payload),
+        status: EventStatus.succeeded,
+        icon: Icons.check,
+        color: _color(EventStatus.succeeded),
+      );
     case 'issue_refinement_done':
-      return 'issue_refinement_done  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Refinement completed',
+        target: _repoRef(payload),
+        details: _durationDetails(payload),
+        status: EventStatus.succeeded,
+        icon: Icons.check,
+        color: _color(EventStatus.succeeded),
+      );
     case 'issue_implemented':
-      return 'issue_implemented  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Issue implemented',
+        target: _repoRef(payload),
+        details: _durationDetails(payload),
+        status: EventStatus.succeeded,
+        icon: Icons.check,
+        color: _color(EventStatus.succeeded),
+      );
     case 'issue_review_error':
-      return 'issue_review_error  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Triage failed',
+        target: _repoRef(payload),
+        details: _errorDetails(payload),
+        status: EventStatus.failed,
+        icon: Icons.close,
+        color: _color(EventStatus.failed),
+      );
     case 'issue_promoted':
-      final from = payload['from_stage'] as String?;
-      final to = payload['to_stage'] as String?;
-      if (from != null && to != null) {
-        return 'issue_promoted  ${repoRef()}  $from → $to';
-      }
-      return 'issue_promoted  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Stage promoted',
+        target: _repoRef(payload),
+        details: _stageDetails(payload),
+        status: EventStatus.warning,
+        icon: Icons.sync_alt,
+        color: _color(EventStatus.warning),
+      );
     case 'pr_state_changed':
+      return FormattedEvent(
+        label: 'PR state changed',
+        target: _repoRef(payload),
+        details: _stateChangeDetails(payload),
+        status: EventStatus.info,
+        icon: Icons.sync_alt,
+        color: _color(EventStatus.info),
+      );
     case 'issue_state_changed':
-      final from = payload['old_state'] ?? payload['from'];
-      final to = payload['new_state'] ?? payload['to'];
-      if (from != null && to != null) {
-        return '$type  ${repoRef()}  $from → $to';
-      }
-      return '$type  ${repoRef()}';
+      return FormattedEvent(
+        label: 'Issue state changed',
+        target: _repoRef(payload),
+        details: _stateChangeDetails(payload),
+        status: EventStatus.info,
+        icon: Icons.sync_alt,
+        color: _color(EventStatus.info),
+      );
     case 'circuit_breaker_tripped':
-      final reason = payload['reason'] as String?;
-      return reason != null
-          ? 'circuit_breaker_tripped  $reason'
-          : 'circuit_breaker_tripped';
+      return FormattedEvent(
+        label: 'Circuit breaker tripped',
+        target: _repoRef(payload),
+        details: _reasonDetails(payload),
+        status: EventStatus.warning,
+        icon: Icons.warning_amber,
+        color: _color(EventStatus.warning),
+      );
     case 'repo_discovered':
-      final repo = payload['repo'] as String? ?? '';
-      return 'repo_discovered  $repo'.trimRight();
+      return FormattedEvent(
+        label: 'Repo discovered',
+        target: (payload['repo'] as String?) ?? '',
+        details: const [],
+        status: EventStatus.info,
+        icon: Icons.add,
+        color: _color(EventStatus.info),
+      );
     case 'polling_started':
-      final kind = payload['kind'] as String? ?? '';
-      final repos = (payload['repos'] as List?) ?? const [];
-      return 'polling_started  $kind (${repos.length} repos)';
+      return FormattedEvent(
+        label: 'Polling started',
+        target: '',
+        details: _pollingStartDetails(payload),
+        status: EventStatus.started,
+        icon: Icons.more_horiz,
+        color: _color(EventStatus.started),
+      );
     case 'polling_completed':
-      final kind = payload['kind'] as String? ?? '';
-      final count = payload['count'] ?? 0;
-      final ms = payload['duration_ms'] ?? 0;
-      return 'polling_completed  $kind  $count items in ${ms}ms';
+      return FormattedEvent(
+        label: 'Polling completed',
+        target: '',
+        details: _pollingCompletedDetails(payload),
+        status: EventStatus.succeeded,
+        icon: Icons.circle_outlined,
+        color: _color(EventStatus.succeeded),
+      );
     default:
-      final repo = repoRef();
-      return repo.isNotEmpty ? '$type  $repo' : type;
+      return FormattedEvent(
+        label: type,
+        target: _repoRef(payload),
+        details: const [],
+        status: EventStatus.info,
+        icon: Icons.label_outline,
+        color: const Color(0xFFD4D4D4),
+      );
   }
+}
+
+/// `org/repo#42` for PR/issue-scoped events, `org/repo` for repo-only.
+String _repoRef(Map<String, dynamic> payload) {
+  final repo = payload['repo'] as String?;
+  final number = payload['number'];
+  if (repo != null && number != null) return '$repo#$number';
+  if (repo != null) return repo;
+  return '';
+}
+
+List<String> _agentDetails(Map<String, dynamic> payload) {
+  final agent = payload['agent'] as String?;
+  if (agent == null || agent.isEmpty) return const [];
+  return [agent];
+}
+
+List<String> _durationDetails(Map<String, dynamic> payload) {
+  final label = _durationLabel(payload['duration_ms']);
+  return label == null ? const [] : [label];
+}
+
+List<String> _errorDetails(Map<String, dynamic> payload) {
+  final err = payload['error'] as String?;
+  if (err == null || err.isEmpty) return const [];
+  // Errors can be long — truncate at the row level so the chip stays
+  // readable. The full string remains accessible via the row's expand.
+  if (err.length > 80) return ['${err.substring(0, 77)}…'];
+  return [err];
+}
+
+List<String> _reasonDetails(Map<String, dynamic> payload) {
+  final reason = payload['reason'] as String?;
+  if (reason == null || reason.isEmpty) return const [];
+  return [reason];
+}
+
+List<String> _stageDetails(Map<String, dynamic> payload) {
+  final from = payload['from_stage'] as String?;
+  final to = payload['to_stage'] as String?;
+  final trigger = payload['trigger'] as String?;
+  final out = <String>[];
+  if (from != null && to != null) out.add('$from → $to');
+  if (trigger != null && trigger.isNotEmpty) out.add(trigger);
+  return out;
+}
+
+List<String> _stateChangeDetails(Map<String, dynamic> payload) {
+  final from = payload['old_state'] ?? payload['from'];
+  final to = payload['new_state'] ?? payload['to'];
+  if (from != null && to != null) return ['$from → $to'];
+  return const [];
+}
+
+List<String> _pollingStartDetails(Map<String, dynamic> payload) {
+  final kind = payload['kind'] as String? ?? '';
+  final repos = (payload['repos'] as List?) ?? const [];
+  final out = <String>[];
+  if (kind.isNotEmpty) out.add(kind);
+  out.add('${repos.length} repos');
+  return out;
+}
+
+List<String> _pollingCompletedDetails(Map<String, dynamic> payload) {
+  final kind = payload['kind'] as String? ?? '';
+  final count = payload['count'] ?? 0;
+  final dur = _durationLabel(payload['duration_ms']);
+  final out = <String>[];
+  if (kind.isNotEmpty) out.add(kind);
+  out.add('$count items');
+  if (dur != null) out.add(dur);
+  return out;
 }
 
 String? _durationLabel(dynamic ms) {
   if (ms is! num) return null;
   if (ms < 1000) return '${ms}ms';
   return '${(ms / 1000).toStringAsFixed(1)}s';
-}
-
-/// Glyph (icon + color) for an event type, used by the Live Events row
-/// renderer.
-({IconData icon, Color color}) glyphFor(String type) {
-  switch (type) {
-    case 'pr_detected':
-    case 'issue_detected':
-      return (icon: Icons.fiber_manual_record, color: const Color(0xFF6CA0FF));
-    case 'review_started':
-    case 'issue_review_started':
-      return (icon: Icons.play_arrow, color: const Color(0xFFFFB347));
-    case 'review_completed':
-    case 'issue_review_completed':
-    case 'issue_implemented':
-    case 'issue_refinement_done':
-      return (icon: Icons.check, color: const Color(0xFF6CCA6C));
-    case 'review_error':
-    case 'issue_review_error':
-      return (icon: Icons.close, color: const Color(0xFFFF6B6B));
-    case 'review_skipped':
-      return (icon: Icons.remove, color: const Color(0xFF888888));
-    case 'issue_promoted':
-    case 'pr_state_changed':
-    case 'issue_state_changed':
-      return (icon: Icons.sync_alt, color: const Color(0xFFB070FF));
-    case 'circuit_breaker_tripped':
-      return (icon: Icons.warning_amber, color: const Color(0xFFFFB347));
-    case 'repo_discovered':
-      return (icon: Icons.add, color: const Color(0xFF6CA0FF));
-    case 'polling_started':
-      return (icon: Icons.more_horiz, color: const Color(0xFF888888));
-    case 'polling_completed':
-      return (icon: Icons.circle_outlined, color: const Color(0xFF888888));
-    default:
-      return (icon: Icons.label_outline, color: const Color(0xFFD4D4D4));
-  }
 }

--- a/flutter_app/lib/features/server/event_summary.dart
+++ b/flutter_app/lib/features/server/event_summary.dart
@@ -71,17 +71,18 @@ class FormattedEvent {
 
 /// Palette tied to [EventStatus]. Hex values match the prior glyphFor()
 /// choices so the visual continuity carries over from the old one-line
-/// renderer.
-const _statusColors = <EventStatus, Color>{
-  EventStatus.started: Color(0xFFFFB347), // orange
-  EventStatus.succeeded: Color(0xFF6CCA6C), // green
-  EventStatus.failed: Color(0xFFFF6B6B), // red
-  EventStatus.skipped: Color(0xFF888888), // gray
-  EventStatus.info: Color(0xFF6CA0FF), // blue
-  EventStatus.warning: Color(0xFFB070FF), // purple
-};
-
-Color _color(EventStatus s) => _statusColors[s]!;
+/// renderer. A switch expression — rather than a map + `!` — keeps the
+/// match exhaustive at compile time so adding a new [EventStatus] won't
+/// silently regress to a runtime null when the enum drifts ahead of the
+/// palette.
+Color _color(EventStatus s) => switch (s) {
+      EventStatus.started => const Color(0xFFFFB347), // orange
+      EventStatus.succeeded => const Color(0xFF6CCA6C), // green
+      EventStatus.failed => const Color(0xFFFF6B6B), // red
+      EventStatus.skipped => const Color(0xFF888888), // gray
+      EventStatus.info => const Color(0xFF6CA0FF), // blue
+      EventStatus.warning => const Color(0xFFB070FF), // purple
+    };
 
 /// Build a [FormattedEvent] from the raw SSE wire payload. Each branch
 /// owns its label + status + icon + which payload keys feed the target

--- a/flutter_app/lib/features/server/widgets/event_row.dart
+++ b/flutter_app/lib/features/server/widgets/event_row.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+import '../event_summary.dart';
+
+/// One row of the Server > Events tab. Renders the structured fields of
+/// the underlying [FormattedEvent] (label + icon up top, target + chip-
+/// style details below) and, when [expanded] is true, the pretty-printed
+/// raw JSON payload as a debugging fallback.
+///
+/// Kept as a public widget so widget tests can exercise the visual
+/// contract (icon, label, target, chips) without standing up the full
+/// events tab + SSE client.
+class EventRow extends StatelessWidget {
+  const EventRow({
+    super.key,
+    required this.timestamp,
+    required this.type,
+    required this.payload,
+    required this.rawData,
+    required this.expanded,
+    required this.onTap,
+  });
+
+  final DateTime timestamp;
+  final String type;
+  final Map<String, dynamic> payload;
+  final String rawData;
+  final bool expanded;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ev = format(type, payload);
+    final ts = formatTimestamp(timestamp);
+    // Pull surface + secondary-text colours from the theme so the row
+    // renders correctly in both light and dark mode (#453).
+    final scheme = Theme.of(context).colorScheme;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Icon(ev.icon, color: ev.color, size: 18),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    ev.label,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                Text(
+                  ts,
+                  style: TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 11,
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+            if (ev.target.isNotEmpty || ev.details.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(left: 28, top: 2),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 2,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    if (ev.target.isNotEmpty)
+                      Text(
+                        ev.target,
+                        style: TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 12,
+                          color: scheme.onSurfaceVariant,
+                        ),
+                      ),
+                    for (final d in ev.details) _DetailChip(text: d),
+                  ],
+                ),
+              ),
+            if (expanded)
+              Container(
+                margin: const EdgeInsets.only(left: 28, top: 6),
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: scheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: SelectableText(
+                  _pretty(rawData),
+                  style: TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 11,
+                    color: scheme.onSurface,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _pretty(String raw) {
+    try {
+      return const JsonEncoder.withIndent('  ').convert(jsonDecode(raw));
+    } catch (_) {
+      return raw;
+    }
+  }
+}
+
+/// `hh:mm:ss` for the right-aligned timestamp column.
+String formatTimestamp(DateTime t) {
+  final hh = t.hour.toString().padLeft(2, '0');
+  final mm = t.minute.toString().padLeft(2, '0');
+  final ss = t.second.toString().padLeft(2, '0');
+  return '$hh:$mm:$ss';
+}
+
+/// Subtle pill-style chip for one detail span (agent, duration, …).
+/// Kept light-weight (no Material Chip) so dozens of rows stay snappy.
+class _DetailChip extends StatelessWidget {
+  const _DetailChip({required this.text});
+  final String text;
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(3),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(fontSize: 11, color: scheme.onSurfaceVariant),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/features/server/widgets/events_tab.dart
+++ b/flutter_app/lib/features/server/widgets/events_tab.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/api/sse_client.dart';
 import '../../../core/platform/platform_services_provider.dart';
 import '../event_summary.dart';
+import 'event_row.dart';
 
 /// Server > Events tab — operational dashboard of live SSE events.
 ///
@@ -131,8 +132,11 @@ class _EventsTabState extends ConsumerState<EventsTab> {
                   itemCount: visible.length,
                   itemBuilder: (context, i) {
                     final row = visible[i];
-                    return _Row(
-                      row: row,
+                    return EventRow(
+                      timestamp: row.timestamp,
+                      type: row.type,
+                      payload: row.payload,
+                      rawData: row.rawData,
                       expanded: _expanded.contains(row.id),
                       onTap: () => setState(() {
                         _expanded.contains(row.id) ? _expanded.remove(row.id) : _expanded.add(row.id);
@@ -175,136 +179,6 @@ class _EventRow {
     required this.payload,
     required this.rawData,
   });
-}
-
-class _Row extends StatelessWidget {
-  const _Row({required this.row, required this.expanded, required this.onTap});
-  final _EventRow row;
-  final bool expanded;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final ev = format(row.type, row.payload);
-    final ts = _formatTimestamp(row.timestamp);
-    // Pull surface + secondary-text colours from the theme so the row
-    // renders correctly in both light and dark mode. The previous
-    // hardcoded #F5F5F5 / #555555 left the JSON expand and detail chips
-    // washed out and unreadable on dark backgrounds (#453).
-    final scheme = Theme.of(context).colorScheme;
-
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Icon(ev.icon, color: ev.color, size: 18),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    ev.label,
-                    style: const TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-                Text(
-                  ts,
-                  style: TextStyle(
-                    fontFamily: 'monospace',
-                    fontSize: 11,
-                    color: scheme.onSurfaceVariant,
-                  ),
-                ),
-              ],
-            ),
-            if (ev.target.isNotEmpty || ev.details.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.only(left: 28, top: 2),
-                child: Wrap(
-                  spacing: 8,
-                  runSpacing: 2,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  children: [
-                    if (ev.target.isNotEmpty)
-                      Text(
-                        ev.target,
-                        style: TextStyle(
-                          fontFamily: 'monospace',
-                          fontSize: 12,
-                          color: scheme.onSurfaceVariant,
-                        ),
-                      ),
-                    for (final d in ev.details) _DetailChip(text: d),
-                  ],
-                ),
-              ),
-            if (expanded)
-              Container(
-                margin: const EdgeInsets.only(left: 28, top: 6),
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: scheme.surfaceContainerHighest,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                child: SelectableText(
-                  _pretty(row.rawData),
-                  style: TextStyle(
-                    fontFamily: 'monospace',
-                    fontSize: 11,
-                    color: scheme.onSurface,
-                  ),
-                ),
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  static String _formatTimestamp(DateTime t) {
-    final hh = t.hour.toString().padLeft(2, '0');
-    final mm = t.minute.toString().padLeft(2, '0');
-    final ss = t.second.toString().padLeft(2, '0');
-    return '$hh:$mm:$ss';
-  }
-
-  String _pretty(String raw) {
-    try {
-      return const JsonEncoder.withIndent('  ').convert(jsonDecode(raw));
-    } catch (_) {
-      return raw;
-    }
-  }
-}
-
-/// Subtle pill-style chip for one detail span (agent, duration, …).
-/// Kept light-weight (no Material Chip) so dozens of rows stay snappy.
-/// Colours pulled from the theme so the chip stays legible in dark mode.
-class _DetailChip extends StatelessWidget {
-  const _DetailChip({required this.text});
-  final String text;
-  @override
-  Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-      decoration: BoxDecoration(
-        color: scheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(3),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(fontSize: 11, color: scheme.onSurfaceVariant),
-      ),
-    );
-  }
 }
 
 class _Toolbar extends StatelessWidget {

--- a/flutter_app/lib/features/server/widgets/events_tab.dart
+++ b/flutter_app/lib/features/server/widgets/events_tab.dart
@@ -118,10 +118,12 @@ class _EventsTabState extends ConsumerState<EventsTab> {
         ),
         Expanded(
           child: visible.isEmpty
-              ? const Center(
+              ? Center(
                   child: Text(
                     'Waiting for events. Polling cycle runs every 60 s by default.',
-                    style: TextStyle(color: Colors.grey),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
                   ),
                 )
               : ListView.builder(
@@ -185,6 +187,11 @@ class _Row extends StatelessWidget {
   Widget build(BuildContext context) {
     final ev = format(row.type, row.payload);
     final ts = _formatTimestamp(row.timestamp);
+    // Pull surface + secondary-text colours from the theme so the row
+    // renders correctly in both light and dark mode. The previous
+    // hardcoded #F5F5F5 / #555555 left the JSON expand and detail chips
+    // washed out and unreadable on dark backgrounds (#453).
+    final scheme = Theme.of(context).colorScheme;
 
     return InkWell(
       onTap: onTap,
@@ -209,10 +216,10 @@ class _Row extends StatelessWidget {
                 ),
                 Text(
                   ts,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontFamily: 'monospace',
                     fontSize: 11,
-                    color: Colors.grey,
+                    color: scheme.onSurfaceVariant,
                   ),
                 ),
               ],
@@ -228,10 +235,10 @@ class _Row extends StatelessWidget {
                     if (ev.target.isNotEmpty)
                       Text(
                         ev.target,
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontFamily: 'monospace',
                           fontSize: 12,
-                          color: Color(0xFF555555),
+                          color: scheme.onSurfaceVariant,
                         ),
                       ),
                     for (final d in ev.details) _DetailChip(text: d),
@@ -243,12 +250,16 @@ class _Row extends StatelessWidget {
                 margin: const EdgeInsets.only(left: 28, top: 6),
                 padding: const EdgeInsets.all(8),
                 decoration: BoxDecoration(
-                  color: const Color(0xFFF5F5F5),
+                  color: scheme.surfaceContainerHighest,
                   borderRadius: BorderRadius.circular(4),
                 ),
                 child: SelectableText(
                   _pretty(row.rawData),
-                  style: const TextStyle(fontFamily: 'monospace', fontSize: 11),
+                  style: TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 11,
+                    color: scheme.onSurface,
+                  ),
                 ),
               ),
           ],
@@ -275,20 +286,22 @@ class _Row extends StatelessWidget {
 
 /// Subtle pill-style chip for one detail span (agent, duration, …).
 /// Kept light-weight (no Material Chip) so dozens of rows stay snappy.
+/// Colours pulled from the theme so the chip stays legible in dark mode.
 class _DetailChip extends StatelessWidget {
   const _DetailChip({required this.text});
   final String text;
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
       decoration: BoxDecoration(
-        color: const Color(0xFFEFEFEF),
+        color: scheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(3),
       ),
       child: Text(
         text,
-        style: const TextStyle(fontSize: 11, color: Color(0xFF333333)),
+        style: TextStyle(fontSize: 11, color: scheme.onSurfaceVariant),
       ),
     );
   }
@@ -327,8 +340,10 @@ class _Toolbar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-      decoration: const BoxDecoration(
-        border: Border(bottom: BorderSide(color: Color(0xFFE0E0E0))),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: Theme.of(context).dividerColor),
+        ),
       ),
       child: Wrap(
         spacing: 8,

--- a/flutter_app/lib/features/server/widgets/events_tab.dart
+++ b/flutter_app/lib/features/server/widgets/events_tab.dart
@@ -8,6 +8,17 @@ import '../../../core/api/sse_client.dart';
 import '../../../core/platform/platform_services_provider.dart';
 import '../event_summary.dart';
 
+/// Server > Events tab — operational dashboard of live SSE events.
+///
+/// Each event is rendered through [format] (see event_summary.dart) so
+/// the row shows a human title (e.g. "Review completed"), the target
+/// repo/PR/issue, and chip-style details (agent, duration, reason)
+/// instead of the raw event type name plus a JSON dump (#453). The full
+/// JSON payload is still accessible by clicking a row to expand.
+///
+/// Newest events appear at the top so the operator can read top-down
+/// without chasing the scroll; auto-scroll keeps the view pinned to the
+/// freshest row until paused.
 class EventsTab extends ConsumerStatefulWidget {
   const EventsTab({super.key});
   @override
@@ -16,11 +27,15 @@ class EventsTab extends ConsumerStatefulWidget {
 
 class _EventsTabState extends ConsumerState<EventsTab> {
   static const _maxEvents = 500;
+  // Newest at index 0. Render order matches insertion order.
   final _events = <_EventRow>[];
   SseClient? _client;
   StreamSubscription<SseEvent>? _sub;
   final _scroll = ScrollController();
+  // Expanded rows are keyed by the row's monotonic id (set on insert) so
+  // a prepend doesn't shift previously-expanded indices.
   final _expanded = <int>{};
+  int _nextRowId = 0;
   bool _autoScroll = true;
   final Set<String> _enabledGroups = {'pr', 'issue', 'polling', 'state', 'circuit_breaker'};
   String _searchQuery = '';
@@ -60,19 +75,23 @@ class _EventsTabState extends ConsumerState<EventsTab> {
       payload = const {};
     }
     setState(() {
-      _events.add(_EventRow(
+      final row = _EventRow(
+        id: _nextRowId++,
         timestamp: DateTime.now(),
         type: ev.type,
         payload: payload,
         rawData: ev.data,
-      ));
+      );
+      _events.insert(0, row);
       while (_events.length > _maxEvents) {
-        _events.removeAt(0);
+        final dropped = _events.removeLast();
+        _expanded.remove(dropped.id);
       }
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_autoScroll && _scroll.hasClients) {
-        _scroll.jumpTo(_scroll.position.maxScrollExtent);
+        // Newest is at the top — pin to 0.
+        _scroll.jumpTo(0);
       }
     });
   }
@@ -90,12 +109,8 @@ class _EventsTabState extends ConsumerState<EventsTab> {
           onAutoScrollChanged: (v) => setState(() => _autoScroll = v),
           onGroupToggled: (g) => setState(() {
             _enabledGroups.contains(g) ? _enabledGroups.remove(g) : _enabledGroups.add(g);
-            _expanded.clear();
           }),
-          onSearchChanged: (q) => setState(() {
-            _searchQuery = q;
-            _expanded.clear();
-          }),
+          onSearchChanged: (q) => setState(() => _searchQuery = q),
           onClear: () => setState(() {
             _events.clear();
             _expanded.clear();
@@ -112,13 +127,16 @@ class _EventsTabState extends ConsumerState<EventsTab> {
               : ListView.builder(
                   controller: _scroll,
                   itemCount: visible.length,
-                  itemBuilder: (context, i) => _Row(
-                    row: visible[i],
-                    expanded: _expanded.contains(i),
-                    onTap: () => setState(() {
-                      _expanded.contains(i) ? _expanded.remove(i) : _expanded.add(i);
-                    }),
-                  ),
+                  itemBuilder: (context, i) {
+                    final row = visible[i];
+                    return _Row(
+                      row: row,
+                      expanded: _expanded.contains(row.id),
+                      onTap: () => setState(() {
+                        _expanded.contains(row.id) ? _expanded.remove(row.id) : _expanded.add(row.id);
+                      }),
+                    );
+                  },
                 ),
         ),
       ],
@@ -128,17 +146,28 @@ class _EventsTabState extends ConsumerState<EventsTab> {
   bool _isVisible(_EventRow row) {
     if (!_enabledGroups.contains(_groupOf(row.type))) return false;
     if (_searchQuery.isEmpty) return true;
-    final summary = summarize(row.type, row.payload).toLowerCase();
-    return summary.contains(_searchQuery.toLowerCase());
+    final q = _searchQuery.toLowerCase();
+    final ev = format(row.type, row.payload);
+    if (ev.label.toLowerCase().contains(q)) return true;
+    if (ev.target.toLowerCase().contains(q)) return true;
+    for (final d in ev.details) {
+      if (d.toLowerCase().contains(q)) return true;
+    }
+    if (row.type.toLowerCase().contains(q)) return true;
+    return false;
   }
 }
 
 class _EventRow {
+  /// Stable id assigned on insert; survives the FIFO trim so expand
+  /// state doesn't latch onto the wrong row when older entries drop off.
+  final int id;
   final DateTime timestamp;
   final String type;
   final Map<String, dynamic> payload;
   final String rawData;
   const _EventRow({
+    required this.id,
     required this.timestamp,
     required this.type,
     required this.payload,
@@ -154,36 +183,64 @@ class _Row extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final glyph = glyphFor(row.type);
-    final hh = row.timestamp.hour.toString().padLeft(2, '0');
-    final mm = row.timestamp.minute.toString().padLeft(2, '0');
-    final ss = row.timestamp.second.toString().padLeft(2, '0');
+    final ev = format(row.type, row.payload);
+    final ts = _formatTimestamp(row.timestamp);
+
     return InkWell(
       onTap: onTap,
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                Text('$hh:$mm:$ss',
-                    style: const TextStyle(
-                        fontFamily: 'monospace', fontSize: 12, color: Colors.grey)),
-                const SizedBox(width: 12),
-                Icon(glyph.icon, color: glyph.color, size: 16),
-                const SizedBox(width: 8),
+                Icon(ev.icon, color: ev.color, size: 18),
+                const SizedBox(width: 10),
                 Expanded(
                   child: Text(
-                    summarize(row.type, row.payload),
-                    style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+                    ev.label,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                Text(
+                  ts,
+                  style: const TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 11,
+                    color: Colors.grey,
                   ),
                 ),
               ],
             ),
+            if (ev.target.isNotEmpty || ev.details.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(left: 28, top: 2),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 2,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    if (ev.target.isNotEmpty)
+                      Text(
+                        ev.target,
+                        style: const TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 12,
+                          color: Color(0xFF555555),
+                        ),
+                      ),
+                    for (final d in ev.details) _DetailChip(text: d),
+                  ],
+                ),
+              ),
             if (expanded)
               Container(
-                margin: const EdgeInsets.only(left: 60, top: 4),
+                margin: const EdgeInsets.only(left: 28, top: 6),
                 padding: const EdgeInsets.all(8),
                 decoration: BoxDecoration(
                   color: const Color(0xFFF5F5F5),
@@ -191,7 +248,7 @@ class _Row extends StatelessWidget {
                 ),
                 child: SelectableText(
                   _pretty(row.rawData),
-                  style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+                  style: const TextStyle(fontFamily: 'monospace', fontSize: 11),
                 ),
               ),
           ],
@@ -200,12 +257,40 @@ class _Row extends StatelessWidget {
     );
   }
 
+  static String _formatTimestamp(DateTime t) {
+    final hh = t.hour.toString().padLeft(2, '0');
+    final mm = t.minute.toString().padLeft(2, '0');
+    final ss = t.second.toString().padLeft(2, '0');
+    return '$hh:$mm:$ss';
+  }
+
   String _pretty(String raw) {
     try {
       return const JsonEncoder.withIndent('  ').convert(jsonDecode(raw));
     } catch (_) {
       return raw;
     }
+  }
+}
+
+/// Subtle pill-style chip for one detail span (agent, duration, …).
+/// Kept light-weight (no Material Chip) so dozens of rows stay snappy.
+class _DetailChip extends StatelessWidget {
+  const _DetailChip({required this.text});
+  final String text;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: const Color(0xFFEFEFEF),
+        borderRadius: BorderRadius.circular(3),
+      ),
+      child: Text(
+        text,
+        style: const TextStyle(fontSize: 11, color: Color(0xFF333333)),
+      ),
+    );
   }
 }
 

--- a/flutter_app/test/features/server/event_summary_test.dart
+++ b/flutter_app/test/features/server/event_summary_test.dart
@@ -2,96 +2,147 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdallm/features/server/event_summary.dart';
 
 void main() {
-  group('summarize', () {
-    test('review_started includes repo, number, agent', () {
-      final s = summarize('review_started', {
+  group('format', () {
+    test('review_started returns human label, target, and agent detail', () {
+      final ev = format('review_started', {
         'pr_id': 1,
         'repo': 'acme/foo',
         'number': 42,
         'agent': 'claude',
       });
-      expect(s, contains('acme/foo'));
-      expect(s, contains('#42'));
-      expect(s, contains('claude'));
+      expect(ev.label, 'Review started');
+      expect(ev.target, 'acme/foo#42');
+      expect(ev.details, contains('claude'));
+      expect(ev.status, EventStatus.started);
     });
 
     test('review_completed includes duration when present', () {
-      final s = summarize('review_completed', {
+      final ev = format('review_completed', {
         'repo': 'acme/foo',
         'number': 42,
         'duration_ms': 4200,
       });
-      expect(s, contains('acme/foo'));
-      expect(s, contains('#42'));
-      expect(s, contains('4.2s'));
+      expect(ev.label, 'Review completed');
+      expect(ev.target, 'acme/foo#42');
+      expect(ev.details, contains('4.2s'));
+      expect(ev.status, EventStatus.succeeded);
     });
 
-    test('issue_promoted includes stage transition when payload has it', () {
-      final s = summarize('issue_promoted', {
+    test('review_completed omits duration chip when payload lacks it', () {
+      final ev = format('review_completed', {
+        'repo': 'acme/foo',
+        'number': 42,
+      });
+      expect(ev.details, isEmpty);
+    });
+
+    test('review_error surfaces the error reason in details', () {
+      final ev = format('review_error', {
+        'repo': 'acme/foo',
+        'number': 42,
+        'error': 'connection refused',
+      });
+      expect(ev.label, 'Review failed');
+      expect(ev.status, EventStatus.failed);
+      expect(ev.details, contains('connection refused'));
+    });
+
+    test('review_error truncates very long error messages', () {
+      final ev = format('review_error', {
+        'repo': 'acme/foo',
+        'error': 'x' * 200,
+      });
+      expect(ev.details.length, 1);
+      expect(ev.details.first.length, lessThanOrEqualTo(80));
+      expect(ev.details.first, endsWith('…'));
+    });
+
+    test('issue_promoted spells out the stage transition', () {
+      final ev = format('issue_promoted', {
         'repo': 'acme/foo',
         'number': 7,
         'from_stage': 'triage',
         'to_stage': 'refinement',
+        'trigger': 'auto-promote',
       });
-      expect(s, contains('acme/foo'));
-      expect(s, contains('#7'));
-      expect(s, contains('triage'));
-      expect(s, contains('refinement'));
+      expect(ev.label, 'Stage promoted');
+      expect(ev.target, 'acme/foo#7');
+      expect(ev.details, contains('triage → refinement'));
+      expect(ev.details, contains('auto-promote'));
+      expect(ev.status, EventStatus.warning);
     });
 
     test('polling_started includes kind and repo count', () {
-      final s = summarize('polling_started', {
+      final ev = format('polling_started', {
         'kind': 'prs',
         'repos': ['acme/foo', 'acme/bar'],
       });
-      expect(s, contains('prs'));
-      expect(s, contains('2'));
+      expect(ev.label, 'Polling started');
+      expect(ev.target, isEmpty);
+      expect(ev.details, containsAllInOrder(<String>['prs', '2 repos']));
+      expect(ev.status, EventStatus.started);
     });
 
-    test('polling_completed includes kind, count, duration', () {
-      final s = summarize('polling_completed', {
+    test('polling_completed includes kind, count, and duration', () {
+      final ev = format('polling_completed', {
         'kind': 'issues',
         'count': 5,
         'duration_ms': 800,
       });
-      expect(s, contains('issues'));
-      expect(s, contains('5'));
-      expect(s, contains('800'));
+      expect(ev.label, 'Polling completed');
+      expect(ev.details, contains('issues'));
+      expect(ev.details, contains('5 items'));
+      expect(ev.details, contains('800ms'));
+      expect(ev.status, EventStatus.succeeded);
     });
 
-    test('circuit_breaker_tripped includes reason', () {
-      final s = summarize('circuit_breaker_tripped', {
+    test('circuit_breaker_tripped surfaces reason and uses warning status', () {
+      final ev = format('circuit_breaker_tripped', {
         'reason': '5 failures/30s',
       });
-      expect(s, contains('5 failures/30s'));
+      expect(ev.label, 'Circuit breaker tripped');
+      expect(ev.details, contains('5 failures/30s'));
+      expect(ev.status, EventStatus.warning);
     });
 
-    test('unknown event type falls back to type-only', () {
-      final s = summarize('mystery_event', {'foo': 'bar'});
-      expect(s, contains('mystery_event'));
-    });
-  });
-
-  group('glyphFor', () {
-    test('known types return non-empty icon and a color', () {
-      for (final t in [
-        'pr_detected',
-        'review_started',
-        'review_completed',
-        'review_error',
-        'issue_promoted',
-        'polling_started',
-        'polling_completed',
-        'circuit_breaker_tripped',
-      ]) {
-        final g = glyphFor(t);
-        expect(g.icon, isNotNull, reason: '$t has no icon');
-      }
+    test('repo_discovered uses repo as target without number', () {
+      final ev = format('repo_discovered', {
+        'repo': 'acme/foo',
+      });
+      expect(ev.label, 'Repo discovered');
+      expect(ev.target, 'acme/foo');
+      expect(ev.details, isEmpty);
     });
 
-    test('unknown types fall back to a default glyph', () {
-      final g = glyphFor('mystery');
-      expect(g.icon, isNotNull);
+    test('pr_state_changed shows the transition chip', () {
+      final ev = format('pr_state_changed', {
+        'repo': 'acme/foo',
+        'number': 42,
+        'old_state': 'open',
+        'new_state': 'closed',
+      });
+      expect(ev.label, 'PR state changed');
+      expect(ev.details, contains('open → closed'));
+    });
+
+    test('issue_review_started maps to Triage started label', () {
+      // The fetcher publishes review_only as "Triage" in the staged
+      // pipeline language — keep the label aligned with how operators
+      // refer to the stage in the docs and the issue tracking UI.
+      final ev = format('issue_review_started', {
+        'repo': 'acme/foo',
+        'number': 7,
+      });
+      expect(ev.label, 'Triage started');
+    });
+
+    test('unknown event type degrades gracefully to its raw type', () {
+      // The renderer must still draw the row — losing visibility on a
+      // brand-new event type is worse than showing its raw identifier.
+      final ev = format('mystery_event', {'foo': 'bar', 'repo': 'acme/foo'});
+      expect(ev.label, 'mystery_event');
+      expect(ev.target, 'acme/foo');
+      expect(ev.status, EventStatus.info);
     });
   });
 }

--- a/flutter_app/test/features/server/widgets/event_row_test.dart
+++ b/flutter_app/test/features/server/widgets/event_row_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:heimdallm/features/server/widgets/event_row.dart';
+
+void main() {
+  // The EventRow widget is the visual contract for the Server > Events
+  // tab. The pure-function format() tests cover the data side; these
+  // widget tests pin the layout so a refactor can't silently drop the
+  // icon, label, target, or chip slots that #453 introduced.
+
+  Future<void> pumpRow(
+    WidgetTester tester, {
+    required String type,
+    required Map<String, dynamic> payload,
+    bool expanded = false,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EventRow(
+            timestamp: DateTime(2026, 5, 12, 9, 41, 7),
+            type: type,
+            payload: payload,
+            rawData: '{}',
+            expanded: expanded,
+            onTap: () {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders human label, target, and chips for review_completed',
+      (tester) async {
+    await pumpRow(
+      tester,
+      type: 'review_completed',
+      payload: {
+        'repo': 'acme/foo',
+        'number': 42,
+        'duration_ms': 1500,
+      },
+    );
+
+    expect(find.text('Review completed'), findsOneWidget);
+    expect(find.text('acme/foo#42'), findsOneWidget);
+    expect(find.text('1.5s'), findsOneWidget);
+    expect(find.text('09:41:07'), findsOneWidget);
+    // Status icon is present (any IconData satisfies — colour is the
+    // contract, not the specific glyph).
+    expect(find.byType(Icon), findsOneWidget);
+  });
+
+  testWidgets('omits target + chip wrap when payload has neither',
+      (tester) async {
+    // polling_started carries no target but does carry chips; flip to
+    // an unknown event with empty payload to exercise the empty wrap.
+    await pumpRow(tester, type: 'mystery_event', payload: const {});
+
+    // Label still renders (raw type as fallback).
+    expect(find.text('mystery_event'), findsOneWidget);
+    // No Wrap child — keeps the row compact when there's nothing extra.
+    expect(find.byType(Wrap), findsNothing);
+  });
+
+  testWidgets('renders multiple detail chips for polling_started',
+      (tester) async {
+    await pumpRow(
+      tester,
+      type: 'polling_started',
+      payload: {
+        'kind': 'prs',
+        'repos': ['acme/a', 'acme/b', 'acme/c'],
+      },
+    );
+
+    expect(find.text('Polling started'), findsOneWidget);
+    expect(find.text('prs'), findsOneWidget);
+    expect(find.text('3 repos'), findsOneWidget);
+  });
+
+  testWidgets('shows JSON expand block when expanded is true',
+      (tester) async {
+    await pumpRow(
+      tester,
+      type: 'review_completed',
+      payload: {'repo': 'acme/foo'},
+      expanded: true,
+    );
+
+    // The JSON pretty-print includes the SelectableText widget; the
+    // expand block is the only thing on the row that uses it.
+    expect(find.byType(SelectableText), findsOneWidget);
+  });
+
+  testWidgets('hides JSON expand block when expanded is false',
+      (tester) async {
+    await pumpRow(
+      tester,
+      type: 'review_completed',
+      payload: {'repo': 'acme/foo'},
+    );
+
+    expect(find.byType(SelectableText), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #453. The Server > Events tab rendered events as a single one-liner mixing the raw event identifier with the rest of the payload, and the click-to-expand fell back to a raw JSON dump. For high-volume events like \`polling_started\` (whose payload includes a list of dozens of repo names) the tab looked like an unstructured dump.

## Changes

### `lib/features/server/event_summary.dart`
- New \`FormattedEvent\` data class with explicit fields: \`label\`, \`target\`, \`details\`, \`status\`, \`icon\`, \`color\`.
- New \`EventStatus\` enum (\`started\` / \`succeeded\` / \`failed\` / \`skipped\` / \`info\` / \`warning\`) — centralises the colour palette so the row renderer doesn't repeat the per-type colour table.
- New \`format(type, payload)\` is the single source of truth; it replaces both \`summarize\` and \`glyphFor\`. Adding a new event type is one switch case + one enum value.
- Default branch keeps unknown event types renderable instead of dropping the row.

### \`lib/features/server/widgets/events_tab.dart\`
- Two-line layout per row: \`[icon] [Human label]            hh:mm:ss\` on top, \`target · chip · chip\` below.
- Newest at top: events insert at index 0 and auto-scroll pins to position 0.
- Rows carry a stable monotonic id so the FIFO trim and prepend can't shift expand state onto the wrong row.
- Search matches \`label\`, \`target\`, every detail chip, AND the raw type — the filter keeps working for operators familiar with the old identifiers.

### Tests
- Migrated from substring assertions on \`summarize()\` output to typed assertions on \`FormattedEvent\` fields.
- New cases: long \`review_error\` truncation, \`polling_started\` chip ordering, \`pr_state_changed\` transition formatting, graceful degradation for unknown types.

## Test plan
- [x] \`flutter test\` — 171 tests pass.
- [x] \`flutter analyze lib/features/server/event_summary.dart lib/features/server/widgets/events_tab.dart\` — no issues.
- [ ] Manual: open the GUI, trigger a polling cycle, confirm rows render as structured cards with human labels and chips instead of a JSON wall.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)