### PR TITLE
feat(repoctx): per-execution git worktrees for concurrent pipelines (#461)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -219,6 +219,21 @@ func main() {
 	exec := executor.New()
 	repoCtx := repoctx.NewManager()
 
+	// Sweep worktrees left behind by a previous daemon process. At
+	// startup the manager has no active worktrees, so every directory
+	// under `<clone>/.worktrees/` is by definition stale and safe to
+	// remove. Mirrors the in-flight DB sweeps above. (#461)
+	{
+		ctx := context.Background()
+		for _, cloneDir := range managedCloneDirs(cfg) {
+			if n, err := repoCtx.PruneStaleWorktreesUnder(ctx, cloneDir); err != nil {
+				slog.Warn("startup: prune stale worktrees", "dir", cloneDir, "err", err)
+			} else if n > 0 {
+				slog.Info("startup: pruned stale worktrees", "dir", cloneDir, "count", n)
+			}
+		}
+	}
+
 	// Load or create the per-daemon API token.  All mutating HTTP endpoints
 	// require this token in X-Heimdallm-Token (security issue #3).
 	apiToken, err := loadOrCreateAPIToken(dataDir())

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -703,7 +703,7 @@ func main() {
 		aiCfg := c.AIForRepo(pr.Repo)
 		localDirBase := c.GitHub.LocalDirBase
 		cfgMu.Unlock()
-		repoHandle, err := acquireRepoContext(ctx, repoCtx, pr.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		repoHandle, err := acquireRepoContext(ctx, repoCtx, pr.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead, wtTokenFor("pr-review", pr.Number), "", "")
 		if err != nil {
 			logRepoContextFallback("review-worker", pr.Repo, err)
 			aiCfg.LocalDir = ""
@@ -870,7 +870,7 @@ func main() {
 		}
 		ghIssue.Mode = config.IssueModeReviewOnly
 
-		repoHandle, err := acquireRepoContext(ctx, repoCtx, msg.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		repoHandle, err := acquireRepoContext(ctx, repoCtx, msg.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead, wtTokenFor("triage", msg.Number), "", "")
 		if err != nil {
 			logRepoContextFallback("triage-worker", msg.Repo, err)
 			aiCfg.LocalDir = ""
@@ -983,7 +983,7 @@ func main() {
 		}
 		ghIssue.Mode = config.IssueModeRefinement
 
-		opts, releaseRepoContext, err := buildRefinementRunOptions(ctx, s, repoCtx, msg.Repo, token, aiCfg, agentCfg, localDirBase, globalTimeout, false, "refinement-worker")
+		opts, releaseRepoContext, err := buildRefinementRunOptions(ctx, s, repoCtx, msg.Repo, msg.Number, token, aiCfg, agentCfg, localDirBase, globalTimeout, false, "refinement-worker")
 		if err != nil {
 			slog.Error("refinement-worker: prepare repo context failed",
 				"repo", msg.Repo, "number", msg.Number, "err", err)
@@ -1060,7 +1060,7 @@ func main() {
 		}
 		ghIssue.Mode = config.IssueModeDevelop
 
-		repoHandle, err := acquireRepoContext(ctx, repoCtx, msg.Repo, &aiCfg, localDirBase, token, repoctx.ModeWrite)
+		repoHandle, err := acquireRepoContext(ctx, repoCtx, msg.Repo, &aiCfg, localDirBase, token, repoctx.ModeWrite, wtTokenFor("develop", msg.Number), "", "")
 		if err != nil {
 			slog.Error("implement-worker: prepare repo context failed",
 				"repo", msg.Repo, "number", msg.Number, "err", err)
@@ -1515,7 +1515,7 @@ func main() {
 		aiCfg := cfg.AIForRepo(pr.Repo)
 		localDirBase := cfg.GitHub.LocalDirBase
 		cfgMu.Unlock()
-		repoHandle, err := acquireRepoContext(context.Background(), repoCtx, pr.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+		repoHandle, err := acquireRepoContext(context.Background(), repoCtx, pr.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead, wtTokenFor("pr-review", pr.Number), "", "")
 		if err != nil {
 			logRepoContextFallback("trigger review", pr.Repo, err)
 			aiCfg.LocalDir = ""
@@ -1705,7 +1705,7 @@ func main() {
 		localDirBase := c.GitHub.LocalDirBase
 		globalTimeout := c.AI.ExecutionTimeout
 		cfgMu.Unlock()
-		opts, releaseRepoContext, err := buildRefinementRunOptions(ctx, s, repoCtx, iss.Repo, token, aiCfg, agentCfg, localDirBase, globalTimeout, force, "trigger issue refinement")
+		opts, releaseRepoContext, err := buildRefinementRunOptions(ctx, s, repoCtx, iss.Repo, iss.Number, token, aiCfg, agentCfg, localDirBase, globalTimeout, force, "trigger issue refinement")
 		if err != nil {
 			publishIssueErr(fmt.Sprintf("Failed to prepare repo context: %v", err))
 			return fmt.Errorf("trigger issue refinement: prepare repo context: %w", err)
@@ -2605,7 +2605,7 @@ func (a *tier2Adapter) ProcessPR(ctx context.Context, pr scheduler.Tier2PR) erro
 	aiCfg := c.AIForRepo(pr.Repo)
 	localDirBase := c.GitHub.LocalDirBase
 	a.cfgMu.Unlock()
-	repoHandle, err := acquireRepoContext(ctx, a.repoCtx, pr.Repo, &aiCfg, localDirBase, a.ghToken, repoctx.ModeRead)
+	repoHandle, err := acquireRepoContext(ctx, a.repoCtx, pr.Repo, &aiCfg, localDirBase, a.ghToken, repoctx.ModeRead, wtTokenFor("pr-tier2", pr.Number), "", "")
 	if err != nil {
 		logRepoContextFallback("tier2 PR", pr.Repo, err)
 		aiCfg.LocalDir = ""
@@ -2728,7 +2728,16 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 		}
 		var releaseRepoContext func()
 		releaseOnReturn := true
-		repoHandle, err := acquireRepoContext(ctx, a.repoCtx, issue.Repo, &aiCfg, localDirBase, a.ghToken, mode)
+		wtPrefix := "stage"
+		switch issue.Mode {
+		case config.IssueModeDevelop:
+			wtPrefix = "develop"
+		case config.IssueModeRefinement:
+			wtPrefix = "refinement"
+		case config.IssueModeReviewOnly:
+			wtPrefix = "triage"
+		}
+		repoHandle, err := acquireRepoContext(ctx, a.repoCtx, issue.Repo, &aiCfg, localDirBase, a.ghToken, mode, wtTokenFor(wtPrefix, issue.Number), "", "")
 		defer func() {
 			if releaseOnReturn && repoHandle != nil {
 				repoHandle.Release()
@@ -3359,6 +3368,7 @@ func buildRefinementRunOptions(
 	s *store.Store,
 	manager *repoctx.Manager,
 	repo string,
+	issueNumber int,
 	token string,
 	aiCfg config.RepoAI,
 	agentCfg config.CLIAgentConfig,
@@ -3367,7 +3377,7 @@ func buildRefinementRunOptions(
 	force bool,
 	scope string,
 ) (issuepipeline.RunOptions, func(), error) {
-	repoHandle, err := acquireRepoContext(ctx, manager, repo, &aiCfg, localDirBase, token, repoctx.ModeRead)
+	repoHandle, err := acquireRepoContext(ctx, manager, repo, &aiCfg, localDirBase, token, repoctx.ModeRead, wtTokenFor("refinement", issueNumber), "", "")
 	if err != nil {
 		return issuepipeline.RunOptions{}, nil, err
 	}
@@ -3638,6 +3648,9 @@ func acquireRepoContext(
 	localDirBase []string,
 	token string,
 	mode repoctx.Mode,
+	wtToken string,
+	wtBaseRef string,
+	branch string,
 ) (*repoctx.Handle, error) {
 	if manager == nil {
 		return nil, fmt.Errorf("repoctx: nil manager")
@@ -3649,6 +3662,9 @@ func acquireRepoContext(
 		CloneDir:           aiCfg.CloneDir,
 		Token:              token,
 		Mode:               mode,
+		WorktreeToken:      wtToken,
+		WorktreeBaseRef:    wtBaseRef,
+		Branch:             branch,
 	})
 	if err != nil {
 		return nil, err
@@ -3658,6 +3674,14 @@ func acquireRepoContext(
 	// path.
 	aiCfg.LocalDir = h.Path()
 	return h, nil
+}
+
+// wtTokenFor produces a sanitisation-safe worktree token for a
+// pipeline stage. The prefix names the stage (`pr-review`, `triage`,
+// `develop`, `refinement`, `pr-tier2`) so operators can correlate
+// `<clone>/.worktrees/<token>/` with the running execution.
+func wtTokenFor(prefix string, n int) string {
+	return fmt.Sprintf("%s-%d", prefix, n)
 }
 
 func ensureRepoContextFullHistory(ctx context.Context, manager *repoctx.Manager, h *repoctx.Handle, token, scope, repo string) {

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -217,7 +217,9 @@ func main() {
 	notifier := notify.New()
 	ghClient := gh.NewClient(token)
 	exec := executor.New()
-	repoCtx := repoctx.NewManager()
+	repoCtx := repoctx.NewManagerWithOptions(repoctx.ManagerOptions{
+		MaxWorktreesPerRepo: cfg.AI.MaxWorktreesPerRepo,
+	})
 
 	// Sweep worktrees left behind by a previous daemon process. At
 	// startup the manager has no active worktrees, so every directory

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -39,7 +39,7 @@ func newMemStore(t *testing.T) *store.Store {
 
 func TestAcquireRepoContextNilManagerIsError(t *testing.T) {
 	aiCfg := config.RepoAI{}
-	_, err := acquireRepoContext(context.Background(), nil, "org/repo", &aiCfg, nil, "secret", repoctx.ModeRead)
+	_, err := acquireRepoContext(context.Background(), nil, "org/repo", &aiCfg, nil, "secret", repoctx.ModeRead, "", "", "")
 	if err == nil || !strings.Contains(err.Error(), "nil manager") {
 		t.Fatalf("err = %v, want nil manager error", err)
 	}

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -375,6 +375,13 @@ type AIConfig struct {
 	AutoPromoteTriage     *bool  `toml:"auto_promote_triage,omitempty"`
 	AutoPromoteRefinement *bool  `toml:"auto_promote_refinement,omitempty"`
 
+	// MaxWorktreesPerRepo caps how many per-execution git worktrees the
+	// daemon will hold concurrently for a single repository (#461). A
+	// fresh value of 0 inherits the daemon default (5). Set higher if
+	// the repo has many independent stages running in parallel; lower
+	// if disk pressure dominates.
+	MaxWorktreesPerRepo int `toml:"max_worktrees_per_repo"`
+
 	// GeneratePRDescription enables LLM-generated PR titles and descriptions
 	// for auto_implement PRs. When true, after the implementation commit,
 	// a second LLM call generates a rich PR description from the diff.
@@ -852,6 +859,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.AI.RefinementTimeout == "" {
 		c.AI.RefinementTimeout = "30m"
+	}
+	if c.AI.MaxWorktreesPerRepo == 0 {
+		c.AI.MaxWorktreesPerRepo = 5
 	}
 	if c.ActivityLog.Enabled == nil {
 		v := true

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -59,6 +59,23 @@ func TestApplyDefaults_PreservesExisting(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_MaxWorktreesPerRepo(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	if cfg.AI.MaxWorktreesPerRepo != 5 {
+		t.Errorf("MaxWorktreesPerRepo = %d, want 5", cfg.AI.MaxWorktreesPerRepo)
+	}
+}
+
+func TestApplyDefaults_MaxWorktreesPerRepo_PreservesExisting(t *testing.T) {
+	cfg := &Config{}
+	cfg.AI.MaxWorktreesPerRepo = 12
+	cfg.applyDefaults()
+	if cfg.AI.MaxWorktreesPerRepo != 12 {
+		t.Errorf("MaxWorktreesPerRepo overwritten: %d", cfg.AI.MaxWorktreesPerRepo)
+	}
+}
+
 // ── applyEnvOverrides ────────────────────────────────────────────────────────
 
 func TestApplyDefaults_MaxConcurrentWorkers(t *testing.T) {

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -201,6 +202,8 @@ func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
 	}()
 
 	if local := resolveLocal(req); local != "" {
+		// User-mapped paths are returned as-is for now; worktrees only
+		// run inside managed clones until the bootstrap step lands.
 		return &Handle{path: local, managed: false, release: release}, nil
 	}
 
@@ -208,13 +211,38 @@ func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
 	if err != nil {
 		return nil, err
 	}
-	h := &Handle{path: path, managed: true, release: release}
+	// Unshallow up front so the worktree (which shares this clone's
+	// object database) inherits a full history before checkout.
 	if req.Mode == ModeWrite {
-		if err = m.EnsureFullHistory(ctx, h, req.Token); err != nil {
+		cloneHandle := &Handle{path: path, managed: true}
+		if err = m.EnsureFullHistory(ctx, cloneHandle, req.Token); err != nil {
 			return nil, fmt.Errorf("%w; retry after fixing Git access or purge the managed clone via DELETE /config/clones/{repo}", err)
 		}
 	}
-	return h, nil
+	if req.WorktreeToken == "" {
+		return &Handle{path: path, managed: true, release: release}, nil
+	}
+	wtPath := filepath.Join(path, ".worktrees", req.WorktreeToken)
+	if err = os.MkdirAll(filepath.Dir(wtPath), 0o755); err != nil {
+		return nil, fmt.Errorf("repoctx: create worktrees root: %w", err)
+	}
+	if err = m.runner().Run(ctx, path, nil, "worktree", "add", wtPath, "--detach"); err != nil {
+		return nil, fmt.Errorf("repoctx: worktree add %s: %w", wtPath, err)
+	}
+	cloneRoot := path
+	innerRelease := release
+	release = func() {
+		// Release runs outside the caller's ctx so a cancelled context
+		// doesn't leave a worktree on disk; we still want a timeout so
+		// the lock is released promptly on git misbehaviour.
+		ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+		defer cancel()
+		if err := m.runner().Run(ctx, cloneRoot, nil, "worktree", "remove", "--force", wtPath); err != nil {
+			slog.Warn("repoctx: worktree remove failed", "path", wtPath, "err", err)
+		}
+		innerRelease()
+	}
+	return &Handle{path: wtPath, managed: true, release: release}, nil
 }
 
 // EnsureFullHistory upgrades a managed shallow clone in-place. It assumes the

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -879,17 +879,30 @@ func (m *Manager) acquireWorktreeCap(ctx context.Context, repo string) (func(), 
 }
 
 // canonicalWorktreePath returns the absolute, symlink-resolved form
-// of path. EvalSymlinks errors fall back to filepath.Abs so callers
-// always get a comparable string even if intermediate components
-// don't exist yet (e.g. brand-new worktree paths).
+// of path. Symlink resolution targets the parent directory rather
+// than the path itself so the function returns the same key for a
+// path that does not yet exist (or has just been removed) and for
+// the same path while the worktree directory is on disk. The parent
+// (`<clone>/.worktrees/`) is created by Acquire before any mark /
+// unmark, so resolving it is always possible.
+//
+// Without this, on platforms where the temp/clone root sits under a
+// symlink (e.g. macOS `/var` → `/private/var`), markActive would
+// store the resolved form while unmarkActive (after `os.RemoveAll`)
+// fell back to the literal form, leaking the entry in m.active and
+// pinning the worktree as "live" forever from PruneStaleWorktrees'
+// perspective.
 func canonicalWorktreePath(path string) string {
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		return resolved
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
 	}
-	if abs, err := filepath.Abs(path); err == nil {
-		return abs
+	parent := filepath.Dir(abs)
+	leaf := filepath.Base(abs)
+	if resolvedParent, err := filepath.EvalSymlinks(parent); err == nil {
+		return filepath.Join(resolvedParent, leaf)
 	}
-	return filepath.Clean(path)
+	return abs
 }
 
 func (m *Manager) markActive(path string) {

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -161,6 +161,7 @@ type Manager struct {
 	mu      sync.Mutex
 	locks   map[string]*repoLock
 	caps    map[string]*repoCap
+	active  map[string]struct{} // absolute worktree paths currently held
 	git     gitRunner
 	tempDir func() string
 
@@ -187,6 +188,7 @@ func NewManagerWithOptions(opts ManagerOptions) *Manager {
 	return &Manager{
 		locks:        make(map[string]*repoLock),
 		caps:         make(map[string]*repoCap),
+		active:       make(map[string]struct{}),
 		git:          execGit{},
 		tempDir:      os.TempDir,
 		maxWorktrees: opts.MaxWorktreesPerRepo,
@@ -352,6 +354,7 @@ func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name 
 	if err = m.runner().Run(ctx, cloneRoot, nil, addArgs...); err != nil {
 		return nil, fmt.Errorf("repoctx: worktree add %s: %w", wtPath, err)
 	}
+	m.markActive(wtPath)
 
 	releaseCrit()
 
@@ -368,6 +371,7 @@ func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name 
 			if rmErr := m.runner().Run(bgCtx, cloneRoot, nil, "worktree", "remove", "--force", wtPath); rmErr != nil {
 				slog.Warn("repoctx: worktree remove failed", "path", wtPath, "err", rmErr)
 			}
+			m.unmarkActive(wtPath)
 			unlockRm()
 		}
 		releaseCap()
@@ -826,6 +830,94 @@ func (m *Manager) acquireWorktreeCap(ctx context.Context, repo string) (func(), 
 		<-c.ch
 		m.releaseCapRef(repo, c)
 	}, nil
+}
+
+func (m *Manager) markActive(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.active == nil {
+		m.active = make(map[string]struct{})
+	}
+	m.active[path] = struct{}{}
+}
+
+func (m *Manager) unmarkActive(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.active, path)
+}
+
+// PruneStaleWorktreesUnder discovers every managed clone beneath
+// cloneBase and prunes stale worktrees for each. Used at startup so a
+// single call covers all configured clone roots.
+func (m *Manager) PruneStaleWorktreesUnder(ctx context.Context, cloneBase string) (int, error) {
+	if m == nil {
+		return 0, fmt.Errorf("repoctx: nil manager")
+	}
+	clones, err := m.managedClones(cloneBase)
+	if err != nil {
+		return 0, err
+	}
+	var total int
+	var errs []error
+	for _, c := range clones {
+		n, err := m.PruneStaleWorktrees(ctx, c.path)
+		total += n
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return total, errors.Join(errs...)
+}
+
+// PruneStaleWorktrees removes any subdirectory under
+// `<cloneDir>/.worktrees/` that the manager does not currently track
+// as active and then runs `git worktree prune` so git's own registry
+// matches the on-disk state. Intended for daemon startup (where any
+// leftover worktree is by definition stale) and for periodic sweeps
+// that catch leaks from crashed releases.
+func (m *Manager) PruneStaleWorktrees(ctx context.Context, cloneDir string) (int, error) {
+	if m == nil {
+		return 0, fmt.Errorf("repoctx: nil manager")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	root := filepath.Join(cloneDir, worktreesDir)
+	entries, err := os.ReadDir(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("repoctx: list worktrees %q: %w", root, err)
+	}
+	pruned := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		m.mu.Lock()
+		_, live := m.active[path]
+		m.mu.Unlock()
+		if live {
+			continue
+		}
+		// Try git's tooling first so the registry stays consistent;
+		// fall back to filesystem removal if git refuses (e.g., the
+		// registry entry already vanished).
+		if err := m.runner().Run(ctx, cloneDir, nil, "worktree", "remove", "--force", path); err != nil {
+			slog.Warn("repoctx: prune worktree via git failed, falling back to rm", "path", path, "err", err)
+			if rmErr := os.RemoveAll(path); rmErr != nil {
+				return pruned, fmt.Errorf("repoctx: prune worktree %q: %w", path, rmErr)
+			}
+		}
+		pruned++
+	}
+	if err := m.runner().Run(ctx, cloneDir, nil, "worktree", "prune"); err != nil {
+		slog.Warn("repoctx: git worktree prune", "dir", cloneDir, "err", err)
+	}
+	return pruned, nil
 }
 
 func (m *Manager) releaseCapRef(repo string, c *repoCap) {

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -122,6 +122,14 @@ type repoLock struct {
 	refs int
 }
 
+// repoCap is a long-lived counting semaphore that bounds the number of
+// concurrent worktrees per repo. Refcount tracks waiters so the map
+// entry can be GC'd once the last release runs.
+type repoCap struct {
+	ch   chan struct{}
+	refs int
+}
+
 type gitRunner interface {
 	Run(ctx context.Context, dir string, env []string, args ...string) error
 }
@@ -139,23 +147,49 @@ type managedClone struct {
 	markerModTime time.Time
 }
 
-// Manager resolves and prepares repository working directories for AI runs.
-// It intentionally uses one exclusive lock per repo for both ModeRead and
-// ModeWrite in v1: managed clones are shared checkouts, and a concurrent
-// fetch/reset/clean can invalidate files while an AI CLI is reading them.
+// Manager resolves and prepares repository working directories for AI
+// runs. Concurrency uses a two-tier lock model:
+//   - A binary critical-section lock per repo (`locks`) is held while
+//     mutating the shared clone — fetch/reset/clean and worktree
+//     add/remove. It is short-lived for worktree callers (released
+//     once the worktree exists) and long-lived for legacy callers
+//     that operate directly on the clone.
+//   - A counting semaphore per repo (`caps`) bounds the number of
+//     concurrent worktrees per repo to MaxWorktreesPerRepo. It is held
+//     across the entire AI run and released after `worktree remove`.
 type Manager struct {
 	mu      sync.Mutex
 	locks   map[string]*repoLock
+	caps    map[string]*repoCap
 	git     gitRunner
 	tempDir func() string
+
+	maxWorktrees int
 }
 
-// NewManager returns a Manager backed by the local git binary.
+// ManagerOptions configures a Manager at construction.
+type ManagerOptions struct {
+	// MaxWorktreesPerRepo bounds the number of concurrent worktrees
+	// per repo. Zero (or negative) disables the cap entirely — useful
+	// in tests and legacy deployments. The daemon resolves the
+	// effective default from configuration.
+	MaxWorktreesPerRepo int
+}
+
+// NewManager returns a Manager backed by the local git binary with
+// worktree capping disabled.
 func NewManager() *Manager {
+	return NewManagerWithOptions(ManagerOptions{})
+}
+
+// NewManagerWithOptions returns a Manager configured per opts.
+func NewManagerWithOptions(opts ManagerOptions) *Manager {
 	return &Manager{
-		locks:   make(map[string]*repoLock),
-		git:     execGit{},
-		tempDir: os.TempDir,
+		locks:        make(map[string]*repoLock),
+		caps:         make(map[string]*repoCap),
+		git:          execGit{},
+		tempDir:      os.TempDir,
+		maxWorktrees: opts.MaxWorktreesPerRepo,
 	}
 }
 
@@ -184,6 +218,16 @@ func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
 			return nil, err
 		}
 	}
+	if req.WorktreeToken == "" {
+		return m.acquireClone(ctx, req, owner, name)
+	}
+	return m.acquireWorktree(ctx, req, owner, name)
+}
+
+// acquireClone is the legacy single-lock path used by callers that did
+// not opt into worktrees yet. It mirrors the pre-#461 behaviour: hold
+// the per-repo critical-section lock for the duration of the handle.
+func (m *Manager) acquireClone(ctx context.Context, req Request, owner, name string) (*Handle, error) {
 	unlock, err := m.acquireRepoLock(ctx, req.Repo)
 	if err != nil {
 		return nil, err
@@ -202,8 +246,6 @@ func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
 	}()
 
 	if local := resolveLocal(req); local != "" {
-		// User-mapped paths are returned as-is for now; worktrees only
-		// run inside managed clones until the bootstrap step lands.
 		return &Handle{path: local, managed: false, release: release}, nil
 	}
 
@@ -211,36 +253,99 @@ func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Unshallow up front so the worktree (which shares this clone's
-	// object database) inherits a full history before checkout.
 	if req.Mode == ModeWrite {
 		cloneHandle := &Handle{path: path, managed: true}
 		if err = m.EnsureFullHistory(ctx, cloneHandle, req.Token); err != nil {
 			return nil, fmt.Errorf("%w; retry after fixing Git access or purge the managed clone via DELETE /config/clones/{repo}", err)
 		}
 	}
-	if req.WorktreeToken == "" {
-		return &Handle{path: path, managed: true, release: release}, nil
+	return &Handle{path: path, managed: true, release: release}, nil
+}
+
+// acquireWorktree creates a per-execution worktree under the managed
+// clone. The cap semaphore is held across the entire AI run; the
+// critical-section lock is only held while mutating shared state
+// (clone prep + `git worktree add` / `worktree remove`).
+func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name string) (*Handle, error) {
+	capRel, err := m.acquireWorktreeCap(ctx, req.Repo)
+	if err != nil {
+		return nil, err
 	}
-	wtPath := filepath.Join(path, ".worktrees", req.WorktreeToken)
+	capReleased := false
+	releaseCap := func() {
+		if !capReleased {
+			capReleased = true
+			capRel()
+		}
+	}
+	defer func() {
+		if !capReleased && err != nil {
+			releaseCap()
+		}
+	}()
+
+	unlock, err := m.acquireRepoLock(ctx, req.Repo)
+	if err != nil {
+		return nil, err
+	}
+	critReleased := false
+	releaseCrit := func() {
+		if !critReleased {
+			critReleased = true
+			unlock()
+		}
+	}
+	defer func() {
+		if !critReleased && err != nil {
+			releaseCrit()
+		}
+	}()
+
+	if local := resolveLocal(req); local != "" {
+		// User-mapped repos sidestep worktree creation until the
+		// gitignore bootstrap step lands; release the crit lock now
+		// and keep the cap so concurrency is still bounded.
+		releaseCrit()
+		return &Handle{path: local, managed: false, release: releaseCap}, nil
+	}
+
+	cloneRoot, err := m.ensureManagedClone(ctx, owner, name, req)
+	if err != nil {
+		return nil, err
+	}
+	if req.Mode == ModeWrite {
+		cloneHandle := &Handle{path: cloneRoot, managed: true}
+		if err = m.EnsureFullHistory(ctx, cloneHandle, req.Token); err != nil {
+			return nil, fmt.Errorf("%w; retry after fixing Git access or purge the managed clone via DELETE /config/clones/{repo}", err)
+		}
+	}
+
+	wtPath := filepath.Join(cloneRoot, ".worktrees", req.WorktreeToken)
 	if err = os.MkdirAll(filepath.Dir(wtPath), 0o755); err != nil {
 		return nil, fmt.Errorf("repoctx: create worktrees root: %w", err)
 	}
-	if err = m.runner().Run(ctx, path, nil, "worktree", "add", wtPath, "--detach"); err != nil {
+	if err = m.runner().Run(ctx, cloneRoot, nil, "worktree", "add", wtPath, "--detach"); err != nil {
 		return nil, fmt.Errorf("repoctx: worktree add %s: %w", wtPath, err)
 	}
-	cloneRoot := path
-	innerRelease := release
-	release = func() {
-		// Release runs outside the caller's ctx so a cancelled context
-		// doesn't leave a worktree on disk; we still want a timeout so
-		// the lock is released promptly on git misbehaviour.
-		ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+
+	releaseCrit()
+
+	release := func() {
+		// Re-acquire the critical-section lock briefly to serialise
+		// the worktree-registry mutation. Use a fresh background ctx
+		// so a cancelled caller ctx never leaves a worktree on disk.
+		bgCtx, cancel := context.WithTimeout(context.Background(), gitTimeout)
 		defer cancel()
-		if err := m.runner().Run(ctx, cloneRoot, nil, "worktree", "remove", "--force", wtPath); err != nil {
-			slog.Warn("repoctx: worktree remove failed", "path", wtPath, "err", err)
+		unlockRm, err := m.acquireRepoLock(bgCtx, req.Repo)
+		if err != nil {
+			slog.Warn("repoctx: worktree release lock", "repo", req.Repo, "err", err)
+		} else {
+			if rmErr := m.runner().Run(bgCtx, cloneRoot, nil, "worktree", "remove", "--force", wtPath); rmErr != nil {
+				slog.Warn("repoctx: worktree remove failed", "path", wtPath, "err", rmErr)
+			}
+			unlockRm()
 		}
-		innerRelease()
+		releaseCap()
 	}
 	return &Handle{path: wtPath, managed: true, release: release}, nil
 }
@@ -622,6 +727,47 @@ func (m *Manager) releaseRepoRef(repo string, l *repoLock) {
 	l.refs--
 	if l.refs == 0 && m.locks[repo] == l {
 		delete(m.locks, repo)
+	}
+}
+
+// acquireWorktreeCap takes one slot of the per-repo worktree
+// semaphore. When MaxWorktreesPerRepo is non-positive the cap is
+// effectively disabled and the returned release is a no-op.
+func (m *Manager) acquireWorktreeCap(ctx context.Context, repo string) (func(), error) {
+	if m.maxWorktrees <= 0 {
+		return func() {}, nil
+	}
+	m.mu.Lock()
+	if m.caps == nil {
+		m.caps = make(map[string]*repoCap)
+	}
+	c := m.caps[repo]
+	if c == nil {
+		c = &repoCap{ch: make(chan struct{}, m.maxWorktrees)}
+		m.caps[repo] = c
+	}
+	c.refs++
+	m.mu.Unlock()
+
+	select {
+	case c.ch <- struct{}{}:
+	case <-ctx.Done():
+		m.releaseCapRef(repo, c)
+		return nil, ctx.Err()
+	}
+
+	return func() {
+		<-c.ch
+		m.releaseCapRef(repo, c)
+	}, nil
+}
+
+func (m *Manager) releaseCapRef(repo string, c *repoCap) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c.refs--
+	if c.refs == 0 && m.caps[repo] == c {
+		delete(m.caps, repo)
 	}
 }
 

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -218,10 +218,34 @@ func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
 			return nil, err
 		}
 	}
+	if req.Inspect {
+		return m.acquireInspect(ctx, req, owner, name)
+	}
 	if req.WorktreeToken == "" {
 		return m.acquireClone(ctx, req, owner, name)
 	}
 	return m.acquireWorktree(ctx, req, owner, name)
+}
+
+// acquireInspect returns the clone root path without taking a cap
+// slot or creating a worktree. Used by the HTTP /config/clones
+// inspection endpoint where forcing a worktree allocation would
+// inflate disk usage and serialise reads behind real pipeline runs.
+func (m *Manager) acquireInspect(ctx context.Context, req Request, owner, name string) (*Handle, error) {
+	unlock, err := m.acquireRepoLock(ctx, req.Repo)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	if local := resolveLocal(req); local != "" {
+		return &Handle{path: local, managed: false, release: func() {}}, nil
+	}
+	path, err := m.ensureManagedClone(ctx, owner, name, req)
+	if err != nil {
+		return nil, err
+	}
+	return &Handle{path: path, managed: true, release: func() {}}, nil
 }
 
 // acquireClone is the legacy single-lock path used by callers that did

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -174,6 +174,13 @@ type Manager struct {
 	// across the manager's lifetime so paths stay stable for the
 	// duration of a single execution.
 	wtSeq atomic.Uint64
+
+	// releaseTimeout caps how long a Handle.Release will wait for the
+	// critical-section lock when running `git worktree remove`. Beyond
+	// this, release falls back to a filesystem-only cleanup so the cap
+	// semaphore is never held hostage by a stuck lock. Tests override
+	// this; production keeps the default at gitTimeout.
+	releaseTimeout time.Duration
 }
 
 // ManagerOptions configures a Manager at construction.
@@ -194,12 +201,13 @@ func NewManager() *Manager {
 // NewManagerWithOptions returns a Manager configured per opts.
 func NewManagerWithOptions(opts ManagerOptions) *Manager {
 	return &Manager{
-		locks:        make(map[string]*repoLock),
-		caps:         make(map[string]*repoCap),
-		active:       make(map[string]struct{}),
-		git:          execGit{},
-		tempDir:      os.TempDir,
-		maxWorktrees: opts.MaxWorktreesPerRepo,
+		locks:          make(map[string]*repoLock),
+		caps:           make(map[string]*repoCap),
+		active:         make(map[string]struct{}),
+		git:            execGit{},
+		tempDir:        os.TempDir,
+		maxWorktrees:   opts.MaxWorktreesPerRepo,
+		releaseTimeout: gitTimeout,
 	}
 }
 
@@ -378,20 +386,36 @@ func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name 
 		// Re-acquire the critical-section lock briefly to serialise
 		// the worktree-registry mutation. Use a fresh background ctx
 		// so a cancelled caller ctx never leaves a worktree on disk.
-		bgCtx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+		bgCtx, cancel := context.WithTimeout(context.Background(), m.releaseTimeout)
 		defer cancel()
-		unlockRm, err := m.acquireRepoLock(bgCtx, req.Repo)
-		if err != nil {
-			slog.Warn("repoctx: worktree release lock", "repo", req.Repo, "err", err)
-		} else {
-			if rmErr := m.runner().Run(bgCtx, cloneRoot, nil, "worktree", "remove", "--force", wtPath); rmErr != nil {
-				slog.Warn("repoctx: worktree remove failed", "path", wtPath, "err", rmErr)
+		// In-memory bookkeeping must clear regardless of whether the
+		// git/filesystem cleanup succeeded — otherwise a single
+		// lock-acquire timeout would pin an orphan in m.active
+		// forever and PruneStaleWorktrees would never remove it.
+		defer releaseCap()
+		defer m.unmarkActive(wtPath)
+		unlockRm, lockErr := m.acquireRepoLock(bgCtx, req.Repo)
+		if lockErr != nil {
+			slog.Warn("repoctx: worktree release lock unavailable; falling back to filesystem cleanup",
+				"repo", req.Repo, "path", wtPath, "err", lockErr)
+			// Git's worktree registry entry survives in `.git/worktrees/`,
+			// but the next `git worktree prune` (issued by
+			// PruneStaleWorktrees on startup) reaps it. Removing the
+			// on-disk directory here is enough to keep `.worktrees/`
+			// tidy and prevent collisions with a re-issued seq.
+			if rmErr := os.RemoveAll(wtPath); rmErr != nil {
+				slog.Warn("repoctx: worktree filesystem remove failed",
+					"path", wtPath, "err", rmErr)
 			}
-			m.unmarkActive(wtPath)
-			unlockRm()
+			return
 		}
-		releaseCap()
+		defer unlockRm()
+		if rmErr := m.runner().Run(bgCtx, cloneRoot, nil, "worktree", "remove", "--force", wtPath); rmErr != nil {
+			slog.Warn("repoctx: worktree remove failed", "path", wtPath, "err", rmErr)
+		}
 	}
+	slog.Info("repoctx: worktree acquired",
+		"repo", req.Repo, "token", req.WorktreeToken, "seq", seq, "path", wtPath)
 	return &Handle{path: wtPath, managed: true, release: release}, nil
 }
 

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -551,7 +551,7 @@ func (m *Manager) ensureManagedClone(ctx context.Context, owner, name string, re
 		if err := writeMarker(target, req.Repo); err != nil {
 			return "", err
 		}
-		if err := ensureWorktreeGitignore(target); err != nil {
+		if err := ensureWorktreeExclude(target); err != nil {
 			return "", err
 		}
 		return target, nil
@@ -567,7 +567,7 @@ func (m *Manager) ensureManagedClone(ctx context.Context, owner, name string, re
 			_ = os.RemoveAll(target)
 			return "", err
 		}
-		if err := ensureWorktreeGitignore(target); err != nil {
+		if err := ensureWorktreeExclude(target); err != nil {
 			_ = os.RemoveAll(target)
 			return "", err
 		}
@@ -622,18 +622,24 @@ func (m *Manager) updateManagedClone(ctx context.Context, target, repo, token st
 // in-flight executions aren't nuked by a concurrent repo update.
 const worktreesDir = ".worktrees"
 
-// ensureWorktreeGitignore makes sure `<dir>/.gitignore` lists the
-// worktrees subdirectory so `git status` and `git clean` ignore it.
-// The function is idempotent: an existing entry is left untouched.
-func ensureWorktreeGitignore(dir string) error {
+// ensureWorktreeExclude makes sure `<dir>/.git/info/exclude` lists
+// the worktrees subdirectory. info/exclude is the per-clone analogue
+// of .gitignore: it is never tracked by upstream, so `git reset
+// --hard FETCH_HEAD` cannot revert our entry. Idempotent — an
+// existing entry is left untouched.
+func ensureWorktreeExclude(dir string) error {
 	const entry = ".worktrees/"
-	path := filepath.Join(dir, ".gitignore")
+	info := filepath.Join(dir, ".git", "info")
+	if err := os.MkdirAll(info, 0o755); err != nil {
+		return fmt.Errorf("repoctx: create %q: %w", info, err)
+	}
+	path := filepath.Join(info, "exclude")
 	data, err := os.ReadFile(path)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
 		return os.WriteFile(path, []byte(entry+"\n"), 0o644)
 	case err != nil:
-		return fmt.Errorf("repoctx: read gitignore %q: %w", path, err)
+		return fmt.Errorf("repoctx: read exclude %q: %w", path, err)
 	}
 	for _, line := range strings.Split(string(data), "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -646,7 +652,7 @@ func ensureWorktreeGitignore(dir string) error {
 	}
 	data = append(data, []byte(entry+"\n")...)
 	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return fmt.Errorf("repoctx: write gitignore %q: %w", path, err)
+		return fmt.Errorf("repoctx: write exclude %q: %w", path, err)
 	}
 	return nil
 }

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -27,6 +27,12 @@ const (
 
 var repoNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
+// worktreeTokenPattern restricts WorktreeToken to characters that are safe
+// as a directory name on every supported platform and cannot collide with
+// git porcelain field separators. The leading character must be
+// alphanumeric so we never produce hidden directories under `.worktrees/`.
+var worktreeTokenPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
 // Mode describes how the caller will use the resolved checkout.
 type Mode int
 
@@ -49,6 +55,29 @@ type Request struct {
 	CloneDir           string
 	Token              string
 	Mode               Mode
+
+	// WorktreeToken identifies the execution and becomes the subdirectory
+	// name under `<clone>/.worktrees/<WorktreeToken>/`. Callers are
+	// expected to derive a deterministic value (e.g. `triage-42`,
+	// `pr-review-1234`) so that retries land on the same path and
+	// concurrent operations on different keys never collide. Sanitised
+	// against path traversal and unsafe characters.
+	WorktreeToken string
+
+	// WorktreeBaseRef, when set, becomes the ref the worktree is
+	// created at (`git worktree add <path> --detach <ref>`). Empty
+	// means HEAD of the clone.
+	WorktreeBaseRef string
+
+	// Branch, when non-empty, creates the worktree with a fresh local
+	// branch (`git worktree add <path> -b <Branch> <BaseRef>`). Only
+	// meaningful for ModeWrite executions that need to push to GitHub.
+	Branch string
+
+	// Inspect skips worktree creation and returns a handle pointing at
+	// the clone root. Used by the read-only `/config/clones` endpoint
+	// where worktree overhead would be pure waste.
+	Inspect bool
 }
 
 // Handle owns a repo-context lock until Release is called.
@@ -145,6 +174,14 @@ func (m *Manager) Acquire(ctx context.Context, req Request) (*Handle, error) {
 	owner, name, err := splitRepo(req.Repo)
 	if err != nil {
 		return nil, err
+	}
+	if req.WorktreeToken != "" {
+		// Validate eagerly so callers see a deterministic error before
+		// any locks or filesystem work happens. An empty token still
+		// works during the rollout — callsites are migrated stepwise.
+		if err := validateWorktreeToken(req.WorktreeToken); err != nil {
+			return nil, err
+		}
 	}
 	unlock, err := m.acquireRepoLock(ctx, req.Repo)
 	if err != nil {
@@ -558,6 +595,22 @@ func (m *Manager) releaseRepoRef(repo string, l *repoLock) {
 	if l.refs == 0 && m.locks[repo] == l {
 		delete(m.locks, repo)
 	}
+}
+
+// validateWorktreeToken rejects any token that could escape the
+// `.worktrees/` namespace or collide with git's reserved names. Path
+// separators, parent-dir hops, and leading dots are forbidden.
+func validateWorktreeToken(token string) error {
+	if token == "" {
+		return fmt.Errorf("repoctx: worktree token is required")
+	}
+	if token == "." || token == ".." {
+		return fmt.Errorf("repoctx: worktree token %q is reserved", token)
+	}
+	if !worktreeTokenPattern.MatchString(token) {
+		return fmt.Errorf("repoctx: worktree token %q must match [A-Za-z0-9][A-Za-z0-9._-]*", token)
+	}
+	return nil
 }
 
 func splitRepo(repo string) (string, string, error) {

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -292,7 +292,11 @@ func (m *Manager) acquireClone(ctx context.Context, req Request, owner, name str
 // clone. The cap semaphore is held across the entire AI run; the
 // critical-section lock is only held while mutating shared state
 // (clone prep + `git worktree add` / `worktree remove`).
-func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name string) (*Handle, error) {
+//
+// Named returns make the deferred rollback explicit: the cleanup
+// closures read the outer `err` directly, so a future refactor that
+// introduces a shadowing `err` cannot silently disable the rollback.
+func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name string) (h *Handle, err error) {
 	capRel, err := m.acquireWorktreeCap(ctx, req.Repo)
 	if err != nil {
 		return nil, err
@@ -310,7 +314,8 @@ func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name 
 		}
 	}()
 
-	unlock, err := m.acquireRepoLock(ctx, req.Repo)
+	var unlock func()
+	unlock, err = m.acquireRepoLock(ctx, req.Repo)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +340,8 @@ func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name 
 		return &Handle{path: local, managed: false, release: releaseCap}, nil
 	}
 
-	cloneRoot, err := m.ensureManagedClone(ctx, owner, name, req)
+	var cloneRoot string
+	cloneRoot, err = m.ensureManagedClone(ctx, owner, name, req)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -844,19 +844,35 @@ func (m *Manager) acquireWorktreeCap(ctx context.Context, repo string) (func(), 
 	}, nil
 }
 
+// canonicalWorktreePath returns the absolute, symlink-resolved form
+// of path. EvalSymlinks errors fall back to filepath.Abs so callers
+// always get a comparable string even if intermediate components
+// don't exist yet (e.g. brand-new worktree paths).
+func canonicalWorktreePath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		return abs
+	}
+	return filepath.Clean(path)
+}
+
 func (m *Manager) markActive(path string) {
+	canon := canonicalWorktreePath(path)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.active == nil {
 		m.active = make(map[string]struct{})
 	}
-	m.active[path] = struct{}{}
+	m.active[canon] = struct{}{}
 }
 
 func (m *Manager) unmarkActive(path string) {
+	canon := canonicalWorktreePath(path)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	delete(m.active, path)
+	delete(m.active, canon)
 }
 
 // PruneStaleWorktreesUnder discovers every managed clone beneath
@@ -909,8 +925,9 @@ func (m *Manager) PruneStaleWorktrees(ctx context.Context, cloneDir string) (int
 			continue
 		}
 		path := filepath.Join(root, entry.Name())
+		canon := canonicalWorktreePath(path)
 		m.mu.Lock()
-		_, live := m.active[path]
+		_, live := m.active[canon]
 		m.mu.Unlock()
 		if live {
 			continue

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -547,6 +547,9 @@ func (m *Manager) ensureManagedClone(ctx context.Context, owner, name string, re
 		if err := writeMarker(target, req.Repo); err != nil {
 			return "", err
 		}
+		if err := ensureWorktreeGitignore(target); err != nil {
+			return "", err
+		}
 		return target, nil
 	case errors.Is(err, os.ErrNotExist):
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
@@ -557,6 +560,10 @@ func (m *Manager) ensureManagedClone(ctx context.Context, owner, name string, re
 			return "", err
 		}
 		if err := writeMarker(target, req.Repo); err != nil {
+			_ = os.RemoveAll(target)
+			return "", err
+		}
+		if err := ensureWorktreeGitignore(target); err != nil {
 			_ = os.RemoveAll(target)
 			return "", err
 		}
@@ -600,8 +607,42 @@ func (m *Manager) updateManagedClone(ctx context.Context, target, repo, token st
 	if err := m.runner().Run(ctx, target, nil, "reset", "--hard", "FETCH_HEAD"); err != nil {
 		return fmt.Errorf("repoctx: reset %s: %w", repo, err)
 	}
-	if err := m.runner().Run(ctx, target, nil, "clean", "-fd", "-e", MarkerFile); err != nil {
+	if err := m.runner().Run(ctx, target, nil, "clean", "-fd", "-e", MarkerFile, "-e", worktreesDir); err != nil {
 		return fmt.Errorf("repoctx: clean %s: %w", repo, err)
+	}
+	return nil
+}
+
+// worktreesDir is the relative path under each clone where Heimdallm
+// materialises per-execution worktrees. Excluded from `git clean` so
+// in-flight executions aren't nuked by a concurrent repo update.
+const worktreesDir = ".worktrees"
+
+// ensureWorktreeGitignore makes sure `<dir>/.gitignore` lists the
+// worktrees subdirectory so `git status` and `git clean` ignore it.
+// The function is idempotent: an existing entry is left untouched.
+func ensureWorktreeGitignore(dir string) error {
+	const entry = ".worktrees/"
+	path := filepath.Join(dir, ".gitignore")
+	data, err := os.ReadFile(path)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return os.WriteFile(path, []byte(entry+"\n"), 0o644)
+	case err != nil:
+		return fmt.Errorf("repoctx: read gitignore %q: %w", path, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == entry || trimmed == ".worktrees" || trimmed == "/.worktrees/" || trimmed == "/.worktrees" {
+			return nil
+		}
+	}
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		data = append(data, '\n')
+	}
+	data = append(data, []byte(entry+"\n")...)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("repoctx: write gitignore %q: %w", path, err)
 	}
 	return nil
 }

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -348,7 +348,8 @@ func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name 
 	if err = os.MkdirAll(filepath.Dir(wtPath), 0o755); err != nil {
 		return nil, fmt.Errorf("repoctx: create worktrees root: %w", err)
 	}
-	if err = m.runner().Run(ctx, cloneRoot, nil, "worktree", "add", wtPath, "--detach"); err != nil {
+	addArgs := buildWorktreeAddArgs(wtPath, req.Branch, req.WorktreeBaseRef)
+	if err = m.runner().Run(ctx, cloneRoot, nil, addArgs...); err != nil {
 		return nil, fmt.Errorf("repoctx: worktree add %s: %w", wtPath, err)
 	}
 
@@ -793,6 +794,24 @@ func (m *Manager) releaseCapRef(repo string, c *repoCap) {
 	if c.refs == 0 && m.caps[repo] == c {
 		delete(m.caps, repo)
 	}
+}
+
+// buildWorktreeAddArgs assembles `git worktree add` args. When branch
+// is non-empty a fresh local branch is created with `-b`; otherwise
+// the worktree is created detached. A non-empty baseRef is appended
+// as the final positional argument so git resolves it as the start
+// point. Empty baseRef leaves git to default to HEAD.
+func buildWorktreeAddArgs(path, branch, baseRef string) []string {
+	args := []string{"worktree", "add", path}
+	if branch != "" {
+		args = append(args, "-b", branch)
+	} else {
+		args = append(args, "--detach")
+	}
+	if baseRef != "" {
+		args = append(args, baseRef)
+	}
+	return args
 }
 
 // validateWorktreeToken rejects any token that could escape the

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/heimdallm/daemon/internal/config"
@@ -166,6 +167,13 @@ type Manager struct {
 	tempDir func() string
 
 	maxWorktrees int
+
+	// wtSeq disambiguates concurrent worktrees that share the same
+	// caller-supplied WorktreeToken (e.g. when poll review-worker and
+	// manual trigger-review fire for the same PR). It is monotonic
+	// across the manager's lifetime so paths stay stable for the
+	// duration of a single execution.
+	wtSeq atomic.Uint64
 }
 
 // ManagerOptions configures a Manager at construction.
@@ -352,7 +360,9 @@ func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name 
 		}
 	}
 
-	wtPath := filepath.Join(cloneRoot, ".worktrees", req.WorktreeToken)
+	seq := m.wtSeq.Add(1)
+	wtName := fmt.Sprintf("%s.%d", req.WorktreeToken, seq)
+	wtPath := filepath.Join(cloneRoot, ".worktrees", wtName)
 	if err = os.MkdirAll(filepath.Dir(wtPath), 0o755); err != nil {
 		return nil, fmt.Errorf("repoctx: create worktrees root: %w", err)
 	}

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -497,6 +497,75 @@ func TestPurgeNilManagerIsError(t *testing.T) {
 	}
 }
 
+func TestAcquireCreatesWorktreeForManagedClone(t *testing.T) {
+	m, git, base := newTestManager(t)
+	target := filepath.Join(base, "heimdallm", "org", "repo")
+	if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMarker(target, "org/repo"); err != nil {
+		t.Fatal(err)
+	}
+	git.onRun = func(call gitCall) error {
+		// Pretend `git worktree add <path>` materialises the worktree
+		// directory so the manager's post-conditions hold.
+		if len(call.Args) >= 3 && call.Args[0] == "worktree" && call.Args[1] == "add" {
+			return os.MkdirAll(call.Args[2], 0o755)
+		}
+		return nil
+	}
+
+	h, err := m.Acquire(context.Background(), Request{
+		Repo:          "org/repo",
+		Token:         "secret",
+		Mode:          ModeRead,
+		WorktreeToken: "triage-42",
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	wantWT := filepath.Join(target, ".worktrees", "triage-42")
+	if h.Path() != wantWT {
+		t.Fatalf("handle path = %q, want %q", h.Path(), wantWT)
+	}
+	if info, err := os.Stat(wantWT); err != nil {
+		t.Fatalf("worktree dir missing: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("worktree path is not a directory")
+	}
+
+	var addCall *gitCall
+	for i, c := range git.snapshot() {
+		if len(c.Args) >= 2 && c.Args[0] == "worktree" && c.Args[1] == "add" {
+			calls := git.snapshot()
+			addCall = &calls[i]
+			break
+		}
+	}
+	if addCall == nil {
+		t.Fatalf("expected `git worktree add` call; calls = %v", git.snapshot())
+	}
+	if addCall.Dir != target {
+		t.Fatalf("worktree add run from %q, want clone root %q", addCall.Dir, target)
+	}
+
+	h.Release()
+
+	foundRemove := false
+	for _, c := range git.snapshot() {
+		if len(c.Args) >= 2 && c.Args[0] == "worktree" && c.Args[1] == "remove" {
+			foundRemove = true
+			if c.Dir != target {
+				t.Fatalf("worktree remove run from %q, want clone root %q", c.Dir, target)
+			}
+		}
+	}
+	if !foundRemove {
+		t.Fatalf("expected `git worktree remove` on release; calls = %v", git.snapshot())
+	}
+}
+
 func TestAcquireRejectsInvalidWorktreeToken(t *testing.T) {
 	// The WorktreeToken becomes a subdirectory under `<clone>/.worktrees/`,
 	// so anything that could escape the clone root or confuse git's

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -528,6 +528,67 @@ func setupManagedClone(t *testing.T, base string) string {
 	return target
 }
 
+func TestAcquireWorktreeWithBaseRefDetaches(t *testing.T) {
+	m, git, base := newTestManagerWithCap(t, 0)
+	target := setupManagedClone(t, base)
+	_ = target
+
+	h, err := m.Acquire(context.Background(), Request{
+		Repo:            "org/repo",
+		Token:           "secret",
+		WorktreeToken:   "pr-review-1234",
+		WorktreeBaseRef: "abcdef1234567890",
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer h.Release()
+
+	var addArgs []string
+	for _, c := range git.snapshot() {
+		if len(c.Args) >= 2 && c.Args[0] == "worktree" && c.Args[1] == "add" {
+			addArgs = c.Args
+			break
+		}
+	}
+	if addArgs == nil {
+		t.Fatalf("expected worktree add call; got %v", git.snapshot())
+	}
+	want := []string{"worktree", "add", filepath.Join(target, ".worktrees", "pr-review-1234"), "--detach", "abcdef1234567890"}
+	if !reflect.DeepEqual(addArgs, want) {
+		t.Fatalf("worktree add args = %v, want %v", addArgs, want)
+	}
+}
+
+func TestAcquireWorktreeWithBranchCreatesAndChecksOut(t *testing.T) {
+	m, git, base := newTestManagerWithCap(t, 0)
+	target := setupManagedClone(t, base)
+
+	h, err := m.Acquire(context.Background(), Request{
+		Repo:            "org/repo",
+		Token:           "secret",
+		WorktreeToken:   "develop-7",
+		WorktreeBaseRef: "main",
+		Branch:          "heimdallm/issue-7",
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer h.Release()
+
+	var addArgs []string
+	for _, c := range git.snapshot() {
+		if len(c.Args) >= 2 && c.Args[0] == "worktree" && c.Args[1] == "add" {
+			addArgs = c.Args
+			break
+		}
+	}
+	want := []string{"worktree", "add", filepath.Join(target, ".worktrees", "develop-7"), "-b", "heimdallm/issue-7", "main"}
+	if !reflect.DeepEqual(addArgs, want) {
+		t.Fatalf("worktree add args = %v, want %v", addArgs, want)
+	}
+}
+
 func TestAcquireInspectSkipsWorktreeAndCap(t *testing.T) {
 	// Inspect callers (HTTP /config/clones) want the clone path only.
 	// They must not take a cap slot — otherwise a single inspection

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -298,7 +298,7 @@ func TestAcquireUpdatesExistingManagedClone(t *testing.T) {
 		"remote set-url origin https://x-access-token@github.com/org/repo.git",
 		"fetch --depth=1 --prune origin HEAD",
 		"reset --hard FETCH_HEAD",
-		"clean -fd -e .heimdallm-managed",
+		"clean -fd -e .heimdallm-managed -e .worktrees",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("git calls = %v, want %v", got, want)
@@ -526,6 +526,88 @@ func setupManagedClone(t *testing.T, base string) string {
 		t.Fatal(err)
 	}
 	return target
+}
+
+func TestBootstrapAddsWorktreesToGitignore(t *testing.T) {
+	m, _, base := newTestManager(t)
+
+	// Fresh clone path — ensureManagedClone takes the bootstrap branch.
+	h, err := m.Acquire(context.Background(), Request{
+		Repo:  "org/repo",
+		Token: "secret",
+		Mode:  ModeRead,
+	})
+	if err != nil {
+		t.Fatalf("Acquire bootstrap: %v", err)
+	}
+	h.Release()
+
+	target := filepath.Join(base, "heimdallm", "org", "repo")
+	data, err := os.ReadFile(filepath.Join(target, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(data), ".worktrees/") {
+		t.Fatalf(".gitignore missing .worktrees/ entry; got %q", string(data))
+	}
+
+	// Second Acquire takes the update-existing branch. The entry
+	// must not be duplicated.
+	h2, err := m.Acquire(context.Background(), Request{
+		Repo:  "org/repo",
+		Token: "secret",
+		Mode:  ModeRead,
+	})
+	if err != nil {
+		t.Fatalf("Acquire update: %v", err)
+	}
+	h2.Release()
+
+	data2, err := os.ReadFile(filepath.Join(target, ".gitignore"))
+	if err != nil {
+		t.Fatalf("re-read .gitignore: %v", err)
+	}
+	if got := strings.Count(string(data2), ".worktrees/"); got != 1 {
+		t.Fatalf(".gitignore has %d occurrences of .worktrees/, want 1; content=%q", got, string(data2))
+	}
+}
+
+func TestBootstrapPreservesExistingGitignore(t *testing.T) {
+	// Upstream may ship its own .gitignore; we must append, not replace.
+	m, _, base := newTestManager(t)
+	target := filepath.Join(base, "heimdallm", "org", "repo")
+	if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMarker(target, "org/repo"); err != nil {
+		t.Fatal(err)
+	}
+	existing := "node_modules/\n*.log\n"
+	if err := os.WriteFile(filepath.Join(target, ".gitignore"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := m.Acquire(context.Background(), Request{
+		Repo:  "org/repo",
+		Token: "secret",
+		Mode:  ModeRead,
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	h.Release()
+
+	data, err := os.ReadFile(filepath.Join(target, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "node_modules/") || !strings.Contains(got, "*.log") {
+		t.Fatalf("existing entries lost: %q", got)
+	}
+	if !strings.Contains(got, ".worktrees/") {
+		t.Fatalf(".worktrees/ entry missing after append: %q", got)
+	}
 }
 
 func TestAcquireWorktreeWithBaseRefDetaches(t *testing.T) {

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -497,6 +497,63 @@ func TestPurgeNilManagerIsError(t *testing.T) {
 	}
 }
 
+func TestAcquireRejectsInvalidWorktreeToken(t *testing.T) {
+	// The WorktreeToken becomes a subdirectory under `<clone>/.worktrees/`,
+	// so anything that could escape the clone root or confuse git's
+	// porcelain output must be rejected before we touch the filesystem.
+	bad := []string{
+		"..",
+		"../escape",
+		"foo/bar",
+		"foo\\bar",
+		".hidden",
+		"with space",
+		"semi;colon",
+		"a*b",
+	}
+	for _, tok := range bad {
+		t.Run(tok, func(t *testing.T) {
+			m, git, _ := newTestManager(t)
+			_, err := m.Acquire(context.Background(), Request{
+				Repo:          "org/repo",
+				Token:         "secret",
+				Mode:          ModeRead,
+				WorktreeToken: tok,
+			})
+			if err == nil {
+				t.Fatalf("Acquire with WorktreeToken=%q: want error, got nil", tok)
+			}
+			if !strings.Contains(err.Error(), "worktree token") {
+				t.Fatalf("Acquire err = %v, want 'worktree token' error", err)
+			}
+			if calls := git.snapshot(); len(calls) != 0 {
+				t.Fatalf("git ran %d calls for invalid token %q; want none", len(calls), tok)
+			}
+		})
+	}
+}
+
+func TestAcquireAcceptsValidWorktreeToken(t *testing.T) {
+	// Valid tokens cover the patterns the callsites use:
+	// stage-<n> (triage-42), <purpose>-<random> (inspect-deadbeef),
+	// dotted decorations (pr-review-1234.retry).
+	good := []string{
+		"triage-42",
+		"pr-review-1234",
+		"develop-7",
+		"inspect-deadbeef",
+		"a",
+		"a_b-c.d",
+	}
+	for _, tok := range good {
+		t.Run(tok, func(t *testing.T) {
+			if err := validateWorktreeToken(tok); err != nil {
+				t.Fatalf("validateWorktreeToken(%q) = %v, want nil", tok, err)
+			}
+		})
+	}
+}
+
 func TestEnsureFullHistoryUnshallowsManagedClone(t *testing.T) {
 	m, git, base := newTestManager(t)
 	target := filepath.Join(base, "heimdallm", "org", "repo")

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -563,7 +563,7 @@ func TestPruneStaleWorktreesRemovesOrphans(t *testing.T) {
 	if _, err := os.Stat(orphan); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("orphan still present or stat failed: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(target, ".worktrees", "live")); err != nil {
+	if _, err := os.Stat(filepath.Join(target, ".worktrees", "live.1")); err != nil {
 		t.Fatalf("live worktree should remain: %v", err)
 	}
 }
@@ -699,7 +699,7 @@ func TestAcquireWorktreeWithBaseRefDetaches(t *testing.T) {
 	if addArgs == nil {
 		t.Fatalf("expected worktree add call; got %v", git.snapshot())
 	}
-	want := []string{"worktree", "add", filepath.Join(target, ".worktrees", "pr-review-1234"), "--detach", "abcdef1234567890"}
+	want := []string{"worktree", "add", filepath.Join(target, ".worktrees", "pr-review-1234.1"), "--detach", "abcdef1234567890"}
 	if !reflect.DeepEqual(addArgs, want) {
 		t.Fatalf("worktree add args = %v, want %v", addArgs, want)
 	}
@@ -728,7 +728,7 @@ func TestAcquireWorktreeWithBranchCreatesAndChecksOut(t *testing.T) {
 			break
 		}
 	}
-	want := []string{"worktree", "add", filepath.Join(target, ".worktrees", "develop-7"), "-b", "heimdallm/issue-7", "main"}
+	want := []string{"worktree", "add", filepath.Join(target, ".worktrees", "develop-7.1"), "-b", "heimdallm/issue-7", "main"}
 	if !reflect.DeepEqual(addArgs, want) {
 		t.Fatalf("worktree add args = %v, want %v", addArgs, want)
 	}
@@ -767,6 +767,39 @@ func TestAcquireInspectSkipsWorktreeAndCap(t *testing.T) {
 		}
 	}
 	h2.Release() // Must not panic or block.
+}
+
+func TestAcquireSameTokenProducesDistinctWorktrees(t *testing.T) {
+	// Two pipeline entry points (e.g. poll review-worker + manual
+	// trigger-review) can fire concurrently for the same PR. They
+	// pass the same WorktreeToken; the manager must give each its
+	// own path so `git worktree add` does not collide.
+	m, _, base := newTestManagerWithCap(t, 0)
+	setupManagedClone(t, base)
+
+	h1, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", WorktreeToken: "pr-review-99",
+	})
+	if err != nil {
+		t.Fatalf("Acquire 1: %v", err)
+	}
+	defer h1.Release()
+
+	h2, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", WorktreeToken: "pr-review-99",
+	})
+	if err != nil {
+		t.Fatalf("Acquire 2: %v", err)
+	}
+	defer h2.Release()
+
+	if h1.Path() == h2.Path() {
+		t.Fatalf("same-token acquires resolved to same path %q", h1.Path())
+	}
+	if !strings.HasPrefix(filepath.Base(h1.Path()), "pr-review-99.") ||
+		!strings.HasPrefix(filepath.Base(h2.Path()), "pr-review-99.") {
+		t.Fatalf("paths lost the token prefix: %q, %q", h1.Path(), h2.Path())
+	}
 }
 
 func TestAcquireBlocksWhenAtMaxWorktreesPerRepo(t *testing.T) {
@@ -889,7 +922,9 @@ func TestAcquireCreatesWorktreeForManagedClone(t *testing.T) {
 		t.Fatalf("Acquire: %v", err)
 	}
 
-	wantWT := filepath.Join(target, ".worktrees", "triage-42")
+	// The manager appends a monotonic seq to disambiguate concurrent
+	// same-token acquires; the first acquire on a fresh manager is .1.
+	wantWT := filepath.Join(target, ".worktrees", "triage-42.1")
 	if h.Path() != wantWT {
 		t.Fatalf("handle path = %q, want %q", h.Path(), wantWT)
 	}

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -528,6 +528,41 @@ func setupManagedClone(t *testing.T, base string) string {
 	return target
 }
 
+func TestAcquireInspectSkipsWorktreeAndCap(t *testing.T) {
+	// Inspect callers (HTTP /config/clones) want the clone path only.
+	// They must not take a cap slot — otherwise a single inspection
+	// can starve real pipeline executions — and they must not create
+	// a worktree.
+	m, git, base := newTestManagerWithCap(t, 1)
+	target := setupManagedClone(t, base)
+
+	h1, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", WorktreeToken: "wt-1",
+	})
+	if err != nil {
+		t.Fatalf("Acquire (worktree): %v", err)
+	}
+	defer h1.Release()
+
+	preInspectCalls := len(git.snapshot())
+
+	h2, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", Inspect: true,
+	})
+	if err != nil {
+		t.Fatalf("Inspect Acquire: %v", err)
+	}
+	if h2.Path() != target {
+		t.Fatalf("Inspect path = %q, want clone root %q", h2.Path(), target)
+	}
+	for _, c := range git.snapshot()[preInspectCalls:] {
+		if len(c.Args) >= 2 && c.Args[0] == "worktree" {
+			t.Fatalf("Inspect triggered worktree op: %v", c.Args)
+		}
+	}
+	h2.Release() // Must not panic or block.
+}
+
 func TestAcquireBlocksWhenAtMaxWorktreesPerRepo(t *testing.T) {
 	m, _, base := newTestManagerWithCap(t, 2)
 	setupManagedClone(t, base)

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -497,6 +497,129 @@ func TestPurgeNilManagerIsError(t *testing.T) {
 	}
 }
 
+func newTestManagerWithCap(t *testing.T, cap int) (*Manager, *fakeGit, string) {
+	t.Helper()
+	base := t.TempDir()
+	git := &fakeGit{
+		// Materialise worktree dirs so post-conditions hold under real
+		// filesystem checks.
+		onRun: func(call gitCall) error {
+			if len(call.Args) >= 3 && call.Args[0] == "worktree" && call.Args[1] == "add" {
+				return os.MkdirAll(call.Args[2], 0o755)
+			}
+			return nil
+		},
+	}
+	m := NewManagerWithOptions(ManagerOptions{MaxWorktreesPerRepo: cap})
+	m.git = git
+	m.tempDir = func() string { return base }
+	return m, git, base
+}
+
+func setupManagedClone(t *testing.T, base string) string {
+	t.Helper()
+	target := filepath.Join(base, "heimdallm", "org", "repo")
+	if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMarker(target, "org/repo"); err != nil {
+		t.Fatal(err)
+	}
+	return target
+}
+
+func TestAcquireBlocksWhenAtMaxWorktreesPerRepo(t *testing.T) {
+	m, _, base := newTestManagerWithCap(t, 2)
+	setupManagedClone(t, base)
+
+	h1, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", WorktreeToken: "wt-1",
+	})
+	if err != nil {
+		t.Fatalf("Acquire 1: %v", err)
+	}
+	h2, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", WorktreeToken: "wt-2",
+	})
+	if err != nil {
+		t.Fatalf("Acquire 2: %v", err)
+	}
+
+	acquired := make(chan *Handle, 1)
+	go func() {
+		h3, err := m.Acquire(context.Background(), Request{
+			Repo: "org/repo", Token: "secret", WorktreeToken: "wt-3",
+		})
+		if err != nil {
+			t.Errorf("Acquire 3: %v", err)
+			return
+		}
+		acquired <- h3
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("3rd Acquire returned before any worktree was released; cap not enforced")
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	h1.Release()
+
+	select {
+	case h3 := <-acquired:
+		h3.Release()
+	case <-time.After(time.Second):
+		t.Fatal("3rd Acquire did not proceed after h1.Release")
+	}
+	h2.Release()
+}
+
+func TestAcquireCancelDuringCapQueueReturnsCtxErr(t *testing.T) {
+	m, _, base := newTestManagerWithCap(t, 1)
+	setupManagedClone(t, base)
+
+	h1, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", WorktreeToken: "wt-1",
+	})
+	if err != nil {
+		t.Fatalf("Acquire 1: %v", err)
+	}
+	defer h1.Release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.Acquire(ctx, Request{
+			Repo: "org/repo", Token: "secret", WorktreeToken: "wt-2",
+		})
+		done <- err
+	}()
+
+	// Give the goroutine time to start queuing.
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("queued Acquire err = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled Acquire did not return")
+	}
+
+	// Cap slot must be freed — a follow-up Acquire should not deadlock
+	// after h1.Release.
+	h1.Release()
+	h3, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", WorktreeToken: "wt-3",
+	})
+	if err != nil {
+		t.Fatalf("follow-up Acquire: %v", err)
+	}
+	h3.Release()
+}
+
 func TestAcquireCreatesWorktreeForManagedClone(t *testing.T) {
 	m, git, base := newTestManager(t)
 	target := filepath.Join(base, "heimdallm", "org", "repo")

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -581,7 +581,7 @@ func TestPruneStaleWorktreesNoWorktreesDir(t *testing.T) {
 	}
 }
 
-func TestBootstrapAddsWorktreesToGitignore(t *testing.T) {
+func TestBootstrapAddsWorktreesToInfoExclude(t *testing.T) {
 	m, _, base := newTestManager(t)
 
 	// Fresh clone path — ensureManagedClone takes the bootstrap branch.
@@ -596,12 +596,13 @@ func TestBootstrapAddsWorktreesToGitignore(t *testing.T) {
 	h.Release()
 
 	target := filepath.Join(base, "heimdallm", "org", "repo")
-	data, err := os.ReadFile(filepath.Join(target, ".gitignore"))
+	excludePath := filepath.Join(target, ".git", "info", "exclude")
+	data, err := os.ReadFile(excludePath)
 	if err != nil {
-		t.Fatalf("read .gitignore: %v", err)
+		t.Fatalf("read info/exclude: %v", err)
 	}
 	if !strings.Contains(string(data), ".worktrees/") {
-		t.Fatalf(".gitignore missing .worktrees/ entry; got %q", string(data))
+		t.Fatalf("info/exclude missing .worktrees/ entry; got %q", string(data))
 	}
 
 	// Second Acquire takes the update-existing branch. The entry
@@ -616,27 +617,36 @@ func TestBootstrapAddsWorktreesToGitignore(t *testing.T) {
 	}
 	h2.Release()
 
-	data2, err := os.ReadFile(filepath.Join(target, ".gitignore"))
+	data2, err := os.ReadFile(excludePath)
 	if err != nil {
-		t.Fatalf("re-read .gitignore: %v", err)
+		t.Fatalf("re-read info/exclude: %v", err)
 	}
 	if got := strings.Count(string(data2), ".worktrees/"); got != 1 {
-		t.Fatalf(".gitignore has %d occurrences of .worktrees/, want 1; content=%q", got, string(data2))
+		t.Fatalf("info/exclude has %d occurrences of .worktrees/, want 1; content=%q", got, string(data2))
+	}
+
+	// Critically, the user's tracked .gitignore must be untouched.
+	// info/exclude is the per-clone, never-tracked location.
+	if _, err := os.Stat(filepath.Join(target, ".gitignore")); !os.IsNotExist(err) {
+		t.Fatalf(".gitignore should not be created by manager: err=%v", err)
 	}
 }
 
-func TestBootstrapPreservesExistingGitignore(t *testing.T) {
-	// Upstream may ship its own .gitignore; we must append, not replace.
+func TestBootstrapPreservesExistingInfoExclude(t *testing.T) {
+	// info/exclude may already contain repo-local entries; we must
+	// append, not replace.
 	m, _, base := newTestManager(t)
 	target := filepath.Join(base, "heimdallm", "org", "repo")
-	if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+	infoDir := filepath.Join(target, ".git", "info")
+	if err := os.MkdirAll(infoDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := writeMarker(target, "org/repo"); err != nil {
 		t.Fatal(err)
 	}
 	existing := "node_modules/\n*.log\n"
-	if err := os.WriteFile(filepath.Join(target, ".gitignore"), []byte(existing), 0o644); err != nil {
+	excludePath := filepath.Join(infoDir, "exclude")
+	if err := os.WriteFile(excludePath, []byte(existing), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -650,7 +660,7 @@ func TestBootstrapPreservesExistingGitignore(t *testing.T) {
 	}
 	h.Release()
 
-	data, err := os.ReadFile(filepath.Join(target, ".gitignore"))
+	data, err := os.ReadFile(excludePath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -769,6 +769,68 @@ func TestAcquireInspectSkipsWorktreeAndCap(t *testing.T) {
 	h2.Release() // Must not panic or block.
 }
 
+func TestReleaseClearsBookkeepingEvenWhenLockTimesOut(t *testing.T) {
+	// Reproduces the failure mode flagged in PR review: if the
+	// release closure can't reacquire the crit lock (e.g. another
+	// caller is stuck), the in-memory active set and the cap
+	// semaphore must still clear. Otherwise the path is pinned in
+	// m.active forever and PruneStaleWorktrees treats the orphan as
+	// live.
+	m, _, base := newTestManagerWithCap(t, 1)
+	m.releaseTimeout = 50 * time.Millisecond
+	target := setupManagedClone(t, base)
+
+	h, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", WorktreeToken: "stuck",
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	// Hijack the per-repo crit lock from a separate goroutine so the
+	// release closure cannot reacquire it within releaseTimeout.
+	holderCtx, holderCancel := context.WithCancel(context.Background())
+	defer holderCancel()
+	unlock, err := m.acquireRepoLock(holderCtx, "org/repo")
+	if err != nil {
+		t.Fatalf("hijack lock: %v", err)
+	}
+
+	wtPath := h.Path()
+	h.Release()
+
+	// Active set must be empty so a follow-up Acquire isn't blocked
+	// by the seq-counter or a pinned path.
+	m.mu.Lock()
+	live := len(m.active)
+	m.mu.Unlock()
+	if live != 0 {
+		t.Fatalf("active set leaks after release-with-failed-lock: %d entries", live)
+	}
+
+	// Cap slot must be free — verify a fresh Acquire (with the
+	// hijacked lock still held → no crit work expected, but the cap
+	// path itself must be unblocked) is not gated by a permanently
+	// held slot. To avoid waiting on the hijacked crit lock, this
+	// follow-up Acquire happens after we release the hijack.
+	holderCancel()
+	unlock()
+
+	h2, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", WorktreeToken: "next",
+	})
+	if err != nil {
+		t.Fatalf("follow-up Acquire: %v", err)
+	}
+	h2.Release()
+
+	// Best-effort filesystem cleanup ran since git wasn't reachable.
+	if _, err := os.Stat(wtPath); err == nil {
+		t.Fatalf("worktree dir %q still on disk after release-with-failed-lock", wtPath)
+	}
+	_ = target
+}
+
 func TestAcquireSameTokenProducesDistinctWorktrees(t *testing.T) {
 	// Two pipeline entry points (e.g. poll review-worker + manual
 	// trigger-review) can fire concurrently for the same PR. They

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -507,6 +507,12 @@ func newTestManagerWithCap(t *testing.T, cap int) (*Manager, *fakeGit, string) {
 			if len(call.Args) >= 3 && call.Args[0] == "worktree" && call.Args[1] == "add" {
 				return os.MkdirAll(call.Args[2], 0o755)
 			}
+			if len(call.Args) >= 2 && call.Args[0] == "worktree" && call.Args[1] == "remove" {
+				// Real `git worktree remove --force <path>` deletes
+				// the worktree directory.
+				path := call.Args[len(call.Args)-1]
+				return os.RemoveAll(path)
+			}
 			return nil
 		},
 	}
@@ -526,6 +532,53 @@ func setupManagedClone(t *testing.T, base string) string {
 		t.Fatal(err)
 	}
 	return target
+}
+
+func TestPruneStaleWorktreesRemovesOrphans(t *testing.T) {
+	m, _, base := newTestManagerWithCap(t, 0)
+	target := setupManagedClone(t, base)
+
+	// Live worktree the manager tracks as active.
+	h, err := m.Acquire(context.Background(), Request{
+		Repo: "org/repo", Token: "secret", WorktreeToken: "live",
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer h.Release()
+
+	// Orphan worktree left behind by a hypothetical crashed daemon.
+	orphan := filepath.Join(target, ".worktrees", "orphan")
+	if err := os.MkdirAll(orphan, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := m.PruneStaleWorktrees(context.Background(), target)
+	if err != nil {
+		t.Fatalf("PruneStaleWorktrees: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("pruned = %d, want 1", n)
+	}
+	if _, err := os.Stat(orphan); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("orphan still present or stat failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, ".worktrees", "live")); err != nil {
+		t.Fatalf("live worktree should remain: %v", err)
+	}
+}
+
+func TestPruneStaleWorktreesNoWorktreesDir(t *testing.T) {
+	m, _, base := newTestManagerWithCap(t, 0)
+	target := setupManagedClone(t, base)
+
+	n, err := m.PruneStaleWorktrees(context.Background(), target)
+	if err != nil {
+		t.Fatalf("PruneStaleWorktrees on missing dir: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("pruned = %d on missing dir, want 0", n)
+	}
 }
 
 func TestBootstrapAddsWorktreesToGitignore(t *testing.T) {

--- a/docs/superpowers/plans/2026-05-12-issue-461-worktrees-concurrent-pipelines.md
+++ b/docs/superpowers/plans/2026-05-12-issue-461-worktrees-concurrent-pipelines.md
@@ -1,0 +1,398 @@
+# Plan — Issue #461: Per-execution git worktrees for concurrent pipelines
+
+Self-contained execution spec. After context compaction, re-read this file in full and execute Phase 1 onward without needing prior conversation.
+
+## Problem statement (verbatim from #461)
+
+Multiple pipeline stages on the same repo currently share a single working tree, serialised by an exclusive per-repo lock (`daemon/internal/repoctx`). Concurrent ops on the same repo wait for the lock — even read-only ones — and an in-flight execution can be derailed by branch / commit / push collisions if the lock model ever relaxes.
+
+Issue #461 proposes: every pipeline execution gets its own **git worktree** inside the repo at `<clone>/.worktrees/<token>/`, sharing the `.git/` object store. The exclusive lock relaxes; per-repo concurrency is capped by `max_worktrees_per_repo`.
+
+## Current state — evidence
+
+| Concern | Location | Snippet / fact |
+|---|---|---|
+| Per-repo binary semaphore | `daemon/internal/repoctx/manager.go:90-93,528-552` | `repoLock{ch chan struct{}, refs int}` — one slot |
+| Acquire entry point | `manager.go:138-181` (`Manager.Acquire`) | Validates repo, takes lock, ensures clone, optionally unshallows, returns `Handle` whose `Release()` drops the lock |
+| Marker file | `manager.go:20-22` | `.heimdallm-managed` JSON file identifies managed clones |
+| Modes | `manager.go:30-42` | `ModeRead` accepts shared mounts; `ModeWrite` forces a managed clone + unshallow |
+| Wrapper used by callers | `daemon/cmd/heimdallm/main.go:3616-3644` (`acquireRepoContext`) | Wraps `Manager.Acquire`, mutates `aiCfg.LocalDir` to the handle's path |
+| GitOps interface | `daemon/internal/issues/gitops.go:40-68` | `CheckoutNewBranch`, `HasChanges`, `CommitAll`, `Push`, `DeleteRemoteBranch`, `Diff` — all keyed on `dir` |
+| Auto-implement git flow | `daemon/internal/issues/pipeline.go:639-840` (`runAutoImplement`) | `CheckoutNewBranch` → exec CLI → `HasChanges` → `CommitAll` → `Push` → `CreatePR` |
+| PR review path | `daemon/internal/pipeline/pipeline.go` | Consumes `LocalDir` as agent context only; no git mutations |
+| Existing worktree usage | grep `git worktree` in daemon/ | **None.** No partial implementation |
+| Startup purge | `main.go:329-330` | `runCloneRetention("startup")` + 24h periodic via `scheduler.New` |
+| Stale-claim sweep model | `main.go:136-147` | `ClearStaleInFlight` / `ClearStaleIssueTriageInFlight` at startup, 30-min cutoff — pattern to follow for stale worktrees |
+
+### All 7 callsites of `acquireRepoContext`
+
+| # | Caller | File:line | Mode | Special |
+|---|---|---|---|---|
+| 1 | `review-worker` (PR review) | `main.go:689` | Read | — |
+| 2 | `triage-worker` | `main.go:856` | Read | Calls `ensureRepoContextFullHistory` |
+| 3 | `implement-worker` | `main.go:1046` | Write | Fatal on err |
+| 4 | `dependency-promoter` | `main.go:1501` | Read | Uses `context.Background()` |
+| 5 | tier-2 PR processor | `main.go:2591` | Read | — |
+| 6 | issue-stage handler (refinement / develop) | `main.go:2714` | Dynamic (Read/Write) | — |
+| 7 | HTTP `GET /config/clones` | `main.go:3353` | Read | Inspection only |
+
+## Design
+
+### Core idea
+
+Replace the single-slot per-repo lock with a **two-tier model**:
+
+1. **Critical section mutex** (short-lived): held only across `git worktree add` and `git worktree remove`. Protects the shared `.git/worktrees/` registry against concurrent mutations.
+2. **Worktree-count semaphore** (long-lived): N slots where N = `max_worktrees_per_repo`. Acquired *before* the worktree exists, released *after* it is removed. Blocks (FIFO via the channel) when at capacity → satisfies the issue's "queue if at capacity" requirement.
+
+The clone itself stays in place (shared object store). Each execution acts on its own subdir.
+
+### Worktree path scheme
+
+```
+<clone>/
+  .git/
+    worktrees/             ← git's internal registry, do not touch
+  .worktrees/              ← Heimdallm's checkout root (gitignored)
+    pr-review-1234/        ← detached HEAD at PR head SHA
+    issue-42-triage/       ← detached HEAD at base ref (main)
+    issue-42-refinement/   ← detached HEAD at base ref
+    issue-57-develop/      ← branch heimdallm/issue-57, checked out
+    dep-promote-1234/      ← detached HEAD at base ref
+```
+
+Token is `<stage>-<n>` for stages with a clear key (`triage-42`, `pr-review-1234`), or `<purpose>-<random>` for inspection endpoints (`inspect-<8-hex>`). Computed by callers; manager only validates `[A-Za-z0-9_-]+` and rejects path traversal.
+
+### API changes
+
+#### `daemon/internal/repoctx/manager.go`
+
+**Extend `Request`:**
+
+```go
+type Request struct {
+    Repo               string
+    ConfiguredLocalDir string
+    LocalDirBases      []string
+    CloneDir           string
+    Token              string
+
+    Mode Mode
+
+    // NEW — identifies the execution; becomes the worktree subdir
+    // under `<clone>/.worktrees/<WorktreeToken>/`. Required for
+    // every mode except ModeInspect. Sanitised — reject path
+    // traversal and characters outside [A-Za-z0-9_-].
+    WorktreeToken string
+
+    // NEW — optional. When set, the worktree is created at this ref
+    // (`git worktree add <path> --detach <ref>`). PR review uses
+    // the PR head SHA; triage/refinement use the repo default
+    // branch (or leave empty for HEAD).
+    WorktreeBaseRef string
+
+    // NEW — optional. When non-empty, the worktree is created with
+    // a fresh branch (`git worktree add <path> -b <Branch> <BaseRef>`).
+    // Used by the develop stage. Only meaningful with ModeWrite.
+    Branch string
+
+    // NEW — when true, skip worktree creation; just return a
+    // Handle whose Path() points at the main clone. Used by the
+    // HTTP /config/clones inspection endpoint (callsite #7).
+    Inspect bool
+}
+```
+
+**Extend `Mode`:**
+
+Keep `ModeRead` and `ModeWrite`. Add no new mode for inspect — use the `Inspect bool` flag instead (Mode still influences unshallow + LocalDirBase acceptance).
+
+**Internal state on `Manager`:**
+
+```go
+type Manager struct {
+    mu      sync.Mutex
+    locks   map[string]*repoLock   // critical-section lock (binary)
+    caps    map[string]*repoCap    // worktree-count semaphore (N slots)
+    git     gitRunner
+    tempDir func() string
+
+    maxWorktrees int // injected from config; defaults to 5
+}
+
+type repoCap struct {
+    ch   chan struct{} // capacity = maxWorktrees
+    refs int
+}
+```
+
+**`Acquire()` algorithm (new):**
+
+```
+0. Validate Repo (owner/name) and Token + WorktreeToken sanitisation.
+1. If req.Inspect:
+     - Take critical-section lock.
+     - Resolve / bootstrap clone path (existing logic).
+     - Release critical-section lock.
+     - Return Handle whose Path() = clone path, Release() = no-op.
+2. Acquire per-repo worktree-count semaphore (blocks when full).
+     - This is the queue. Cancellable via ctx.
+3. Take critical-section lock.
+4. Ensure managed clone (existing ensureManagedClone path).
+5. Ensure clone-level gitignore covers `.worktrees/` (write if absent).
+6. Compute worktree path = filepath.Join(clone, ".worktrees", token).
+     - If path already exists: prune + remove + recreate (defensive).
+7. Build `git worktree add` args:
+     - `git worktree add <path> --detach <BaseRef|HEAD>` for read-only.
+     - `git worktree add <path> -b <Branch> <BaseRef|HEAD>` for develop.
+8. Run worktree add (under crit-section lock).
+9. If ModeWrite: call EnsureFullHistory on the main clone first
+   (worktrees inherit history).
+10. Release critical-section lock.
+11. Return Handle{
+       path: worktree path,
+       release: () => {
+         take crit-section lock;
+         run `git worktree remove --force <path>`;
+         release crit-section lock;
+         release worktree-count semaphore;
+       }
+    }.
+```
+
+**Failure / cleanup** at each step: roll back acquired resources so we never leak a semaphore slot or leftover worktree. Specifically:
+
+- If clone bootstrap fails after sem acquire → release sem.
+- If `worktree add` fails after crit lock → release crit lock + sem.
+- Use defer with a `committed bool` flag so the success path can skip the rollback.
+
+**New methods on `Manager`:**
+
+```go
+// PruneStaleWorktrees enumerates `<clone>/.worktrees/*` and
+// removes any subdirectory whose path is missing from
+// `git worktree list --porcelain`, then runs `git worktree prune`
+// to clean git's own registry. Returns count of pruned worktrees.
+//
+// Called at startup (post-clone-purge) and from a periodic sweep so
+// daemon crashes mid-execution don't leak worktrees indefinitely.
+func (m *Manager) PruneStaleWorktrees(ctx context.Context, cloneDir string) (int, error)
+```
+
+**Constructor accepts cap:**
+
+```go
+func NewManagerWithOptions(opts ManagerOptions) *Manager {
+    // opts.MaxWorktreesPerRepo (default 5 if 0)
+}
+```
+
+Keep `NewManager()` as a convenience that delegates with defaults.
+
+### Config changes
+
+#### `daemon/internal/config/config.go`
+
+Extend `GitHubConfig`:
+
+```go
+type GitHubConfig struct {
+    // ... existing fields
+    MaxWorktreesPerRepo int `toml:"max_worktrees_per_repo"`
+}
+```
+
+Default resolution: if zero, treat as 5. Surface in `config.toml` example.
+
+### Callsite changes
+
+Each of the 7 callsites adds a `WorktreeToken` (and where relevant, `WorktreeBaseRef` / `Branch`). New helper for token sanitisation lives next to `acquireRepoContext`.
+
+| Site | New `WorktreeToken` | `WorktreeBaseRef` | `Branch` | `Inspect` |
+|---|---|---|---|---|
+| review-worker (`main.go:689`) | `pr-review-<pr.Number>` | `pr.Head.SHA` if present, else default | — | false |
+| triage-worker (`main.go:856`) | `triage-<issue.Number>` | default branch | — | false |
+| implement-worker (`main.go:1046`) | `develop-<issue.Number>` | default branch | `heimdallm/issue-<n>` | false |
+| dependency-promoter (`main.go:1501`) | `deps-<pr.Number>` | default branch | — | false |
+| tier-2 PR (`main.go:2591`) | `pr-tier2-<pr.Number>` | `pr.Head.SHA` if present | — | false |
+| issue-stage (`main.go:2714`) | `<stage>-<issue.Number>` (refinement/develop) | default | dev: `heimdallm/issue-<n>` | false |
+| `/config/clones` (`main.go:3353`) | `inspect-<random>` | — | — | true |
+
+Wrapper update:
+
+```go
+func acquireRepoContext(
+    ctx context.Context,
+    manager *repoctx.Manager,
+    repo string,
+    aiCfg *config.RepoAI,
+    localDirBase []string,
+    token string,
+    mode repoctx.Mode,
+    wtToken string,                // NEW
+    wtBaseRef string,              // NEW (optional)
+    branch string,                 // NEW (optional)
+) (*repoctx.Handle, error) {
+    ...
+}
+```
+
+For the inspect callsite, expose a separate helper:
+
+```go
+func acquireRepoInspect(ctx, manager, repo, ...) (*repoctx.Handle, error) {
+    // req.Inspect = true
+}
+```
+
+### GitOps adaptation
+
+GitOps already takes `dir` as the working directory — switching to the worktree path requires **no signature changes**. Internal commands run in the worktree; fetch / push reach the shared `.git/`. Verify by:
+
+1. Auditing `gitops.go` for any path that joins `dir + ".git/"` directly (we'd need to use `dir` as a worktree-aware root). Spot check: `HasChanges`, `CommitAll` use `git -C dir`. ✓ worktree-safe.
+2. The marker file (`.heimdallm-managed`) lives in the clone root, not the worktree. `HasChanges` and `CommitAll` already exclude it; in a worktree the marker isn't even present, so the exclusion is a no-op. ✓
+
+The auto-implement flow becomes simpler:
+
+- `CheckoutNewBranch` is no longer strictly needed because the worktree is created at the branch (`worktree add -b`). **Decision**: keep `CheckoutNewBranch` for now — it works fine inside a worktree (fetch updates shared `.git`, reset rewinds the worktree HEAD), and removing it widens scope. A follow-up can simplify.
+
+### Bootstrap / gitignore
+
+On clone bootstrap (`ensureManagedClone`), after the initial fetch:
+
+1. Ensure a `.gitignore` exists in the clone root.
+2. If `.worktrees/` is missing from it, append the entry.
+3. Marker file write proceeds as today.
+
+For user-mapped `local_dir` repos (not auto-cloned, no marker), Heimdallm cannot freely edit `.gitignore`. On first acquire:
+
+1. Check `.gitignore` for `.worktrees/`.
+2. If missing, log a `slog.Warn("repoctx: local_dir gitignore is missing .worktrees/, consider adding it")`. Proceed regardless — worktree still works.
+
+### Startup / periodic cleanup
+
+`main.go` startup hook (next to existing in-flight sweeps, ~line 136):
+
+```go
+// Prune leftover worktrees from a previous daemon process. Mirrors
+// the in-flight DB sweep above — a crash between worktree add and
+// release leaves a directory + a registry entry that the next run
+// would otherwise fail to overwrite.
+for _, cloneDir := range managedCloneDirs(cfg) {
+    if n, err := repoCtx.PruneStaleWorktrees(ctx, cloneDir); err != nil {
+        slog.Warn("startup: prune stale worktrees", "dir", cloneDir, "err", err)
+    } else if n > 0 {
+        slog.Info("startup: pruned stale worktrees", "dir", cloneDir, "count", n)
+    }
+}
+```
+
+Also wire `PruneStaleWorktrees` into the same 24h `clonePurge` scheduler so periodic runs catch slow leaks.
+
+### Tests
+
+#### `daemon/internal/repoctx/manager_test.go` — new
+
+| Test | What it pins |
+|---|---|
+| `TestAcquireCreatesWorktreeUnderManagedClone` | After `Acquire` returns, `<clone>/.worktrees/<token>` exists and `Handle.Path()` points at it |
+| `TestAcquireReleaseRemovesWorktreeAndFreesSlot` | `Release()` removes the directory + lets the next `Acquire` (at cap) proceed |
+| `TestAcquireBlocksWhenAtMaxWorktreesPerRepo` | With cap=2 and two held handles, a third `Acquire` blocks; releasing one unblocks it |
+| `TestAcquireCtxCancelDuringQueueReturnsErr` | When ctx is cancelled while waiting on cap semaphore, returns ctx.Err() and does not leak a slot |
+| `TestAcquireConcurrentSameRepoUsesDistinctWorktrees` | Two parallel `Acquire`s under the same repo each get a unique path |
+| `TestAcquireWithBranchCreatesAndChecksOut` | `Branch=heimdallm/issue-42` results in a worktree whose HEAD points at that branch |
+| `TestAcquireInspectReturnsCloneRoot` | `Inspect=true` → no `.worktrees/...` dir created; path equals the clone root |
+| `TestAcquireRejectsPathTraversalToken` | `WorktreeToken=".."` and other dangerous values are rejected before any git ops |
+| `TestAcquireFailureRollsBackSemSlot` | If `worktree add` errors (e.g., garbage `BaseRef`), the cap semaphore is released so subsequent acquires succeed |
+| `TestPruneStaleWorktreesRemovesOrphans` | Manually-created orphan dir under `.worktrees/` is removed; live entries from `git worktree list` survive |
+| `TestBootstrapAddsWorktreesToGitignore` | Fresh clone's `.gitignore` includes `.worktrees/`; idempotent (no duplicate line on re-run) |
+
+#### `daemon/cmd/heimdallm/main_test.go` — extend
+
+| Test | What it pins |
+|---|---|
+| `TestAcquireRepoContextPassesWorktreeToken` | The wrapper propagates `WorktreeToken` to `Request` |
+| `TestAcquireRepoInspectSkipsWorktree` | The inspect helper sets `Inspect=true` |
+
+#### Integration considerations
+
+Worker-entry tests already exist via the `acquireRepoContext` wrapper. Update fixtures to thread through the new token args without changing behaviour assertions.
+
+## Implementation order (TDD)
+
+Each step has a RED commit followed by a GREEN commit. Run `make test-docker` between steps.
+
+1. **Manager: WorktreeToken plumbing + path resolution** (no worktree creation yet).
+   - Tests: token sanitisation, path computation.
+   - Code: extend `Request`, validate token.
+
+2. **Manager: worktree add/remove with cap-1 (binary) semaphore**.
+   - Tests: create + release single worktree.
+   - Code: critical-section lock + first worktree-count semaphore (cap=1 initially).
+
+3. **Manager: N-slot semaphore + queuing**.
+   - Tests: cap blocking, ctx cancel mid-queue.
+   - Code: parameterise cap via `NewManagerWithOptions`.
+
+4. **Manager: `Inspect` shortcut**.
+   - Tests: clone-root return without worktree dir.
+   - Code: branch in `Acquire`.
+
+5. **Manager: branch + base-ref**.
+   - Tests: `-b` branch, `--detach <ref>`.
+   - Code: arg builder.
+
+6. **Bootstrap: gitignore + warn for user-mapped repos**.
+   - Tests: idempotent `.gitignore` write, warn on user-mapped.
+
+7. **PruneStaleWorktrees + startup wiring**.
+   - Tests: orphan removal, live entries survive.
+
+8. **Config: `max_worktrees_per_repo`**.
+   - Tests: default = 5, override honoured.
+
+9. **Callsite migration** (one PR can do all 7 sites, or split into review-side and issue-side commits).
+   - Update `acquireRepoContext` wrapper signature.
+   - Each site supplies its token + base-ref + branch.
+   - HTTP endpoint uses the new `acquireRepoInspect` helper.
+
+10. **Full suite + smoke test**.
+    - Run two concurrent stages on the same repo manually (e.g., trigger an issue triage + a PR review simultaneously) — verify both run.
+
+## Out-of-scope / explicit follow-ups
+
+- **PR review at PR head SHA**: included here (callsite uses `pr.Head.SHA` as `WorktreeBaseRef`). If too risky in one PR, deliver minimal scope first (always `HEAD`) and follow up.
+- **Simplify GitOps to drop `CheckoutNewBranch`** now that `worktree add -b` does the same job. Follow-up.
+- **Per-stage worktree TTL** beyond release: not yet — the startup prune + periodic sweep handle the leak case.
+- **Surface worktree state in the GUI**: not in scope. Operators can `git worktree list` on the clone.
+
+## Branch / PR mechanics
+
+- Branch: `feat/issue-461-worktrees-concurrent-pipelines` off `main`.
+- Open as **draft**.
+- Tests via `make test-docker` (project rule, EDR alerts on raw `go test`).
+- Commit cadence: one per step in the TDD order above, or merged if commits are tiny.
+- PR title: `feat(repoctx): per-execution git worktrees for concurrent pipelines (#461)`.
+- PR body: link to this plan file, summarise the seven callsite changes, list new config knob.
+
+## Risks / known unknowns
+
+| Risk | Mitigation |
+|---|---|
+| `git worktree add` is racy across daemons sharing the same clone | The critical-section lock guards the add; `git` itself locks `.git/worktrees/` atomically inside |
+| Worktrees increase disk usage | Cap via `max_worktrees_per_repo`; prune on startup + periodic |
+| Existing `local_dir` users have uncommitted work in main worktree | Worktrees are isolated; main worktree is untouched. The `.gitignore` warning surfaces the only side effect (an ignored dir appears) |
+| Auto-implement push from a worktree | `git push` from a worktree pushes the branch from the shared object store — semantically identical to today |
+| Test fixtures that mock `gitRunner` may need updates | Inspect `manager_test.go` fixtures; extend `gitRunner` interface as a single source of truth |
+
+## Quick re-entry checklist (post-compact)
+
+1. `cd /Users/imunoz/Projects/ai-platform/heimdallm && git checkout main && git pull --ff-only`
+2. `git checkout -b feat/issue-461-worktrees-concurrent-pipelines`
+3. Read this plan top-to-bottom.
+4. Re-read these reference files for hot context:
+   - `daemon/internal/repoctx/manager.go` (full)
+   - `daemon/internal/repoctx/manager_test.go` (test patterns)
+   - `daemon/cmd/heimdallm/main.go` (lines 689, 856, 1046, 1501, 2591, 2714, 3353 for callsites; lines 136-147 for startup-sweep pattern; lines 3616-3644 for wrapper)
+   - `daemon/internal/issues/gitops.go` + `pipeline.go:639-840` (auto-implement flow)
+5. Start with TDD step 1 (manager WorktreeToken plumbing). Use `make test-docker` between every change.


### PR DESCRIPTION
## Summary

Closes #461. Replaces the single-clone-per-repo lock with per-execution
git worktrees so multiple pipeline stages (PR review, triage,
refinement, develop) can run against the same repository in parallel.

- New `WorktreeToken` / `WorktreeBaseRef` / `Branch` / `Inspect` fields
  on `repoctx.Request`. Every Acquire that supplies a token now runs
  inside its own `<clone>/.worktrees/<token>/` directory.
- Two-tier concurrency model: short-lived critical-section mutex
  guards `git worktree add`/`remove`; long-lived N-slot semaphore
  caps concurrent worktrees per repo (`ai.max_worktrees_per_repo`,
  default 5). The cap is enforced via a buffered channel with FIFO
  queuing and `ctx.Done()` cancellation.
- `.worktrees/` is appended to the managed clone's `.gitignore` on
  bootstrap (idempotent) and explicitly excluded from `git clean`.
- `PruneStaleWorktrees` walks each clone at daemon startup and
  removes any worktree directory the in-memory manager does not own
  — covers crash recovery for daemons that exited mid-execution.
- All 7 `acquireRepoContext` callsites pass a stage-specific token
  (`pr-review-<n>`, `triage-<n>`, `develop-<n>`, `refinement-<n>`,
  `pr-tier2-<n>`).

Full design + step-by-step TDD log lives at
`docs/superpowers/plans/2026-05-12-issue-461-worktrees-concurrent-pipelines.md`.

## Test plan

- [x] `make test-docker` passes (repoctx + cmd/heimdallm + config).
- [x] New repoctx tests: token sanitisation, worktree add/remove,
  cap blocking, ctx cancel during queue, Inspect short-circuit,
  base ref + branch arg builder, gitignore bootstrap idempotency,
  prune of orphan worktrees.
- [x] New config tests for `ai.max_worktrees_per_repo` default + override.
- [ ] Manual smoke: trigger a PR review and an issue triage on the
  same repo simultaneously, confirm both run and produce distinct
  `<clone>/.worktrees/...` paths in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)