### PR TITLE
fix(server): strip dangerously_skip_perms from PATCH bodies (#477)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"13c5928f-827a-408a-a8e7-e9c5f58f4739","pid":70360,"procStart":"Mon May 11 11:55:26 2026","acquiredAt":1778573897562}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"13c5928f-827a-408a-a8e7-e9c5f58f4739","pid":70360,"procStart":"Mon May 11 11:55:26 2026","acquiredAt":1778573897562}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ docker/config/
 daemon/heimdallm
 cli/heimdallm-cli
 .superpowers/
+.claude/scheduled_tasks.lock

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -236,8 +236,13 @@ func (srv *Server) patchTOML(mutateFn func(m map[string]any) error) (map[string]
 	// merged map is validated and persisted. PUT rejects the key with
 	// a 400 via normalizeAgentConfigsForPut, but PATCH deep-merges
 	// arbitrary JSON, so the gate has to be enforced here regardless
-	// of which handler invoked patchTOML.
-	stripDangerousAgentFlags(m)
+	// of which handler invoked patchTOML. Audit-log non-zero strips so
+	// operators can detect bypass attempts even though they're now
+	// neutralized.
+	if stripped := stripDangerousAgentFlags(m); stripped > 0 {
+		slog.Warn("config: PATCH attempted to set dangerously_skip_perms; stripped (M-5 gate)",
+			"count", stripped)
+	}
 	if err := config.ValidateMap(m); err != nil {
 		return nil, err
 	}
@@ -1740,31 +1745,79 @@ func tailLines(f *os.File, n int) []string {
 	return lines
 }
 
+// dangerousAgentFlagKey names the security-gated flag that grants
+// `--dangerously-skip-permissions` to the AI CLI. Both
+// normalizeAgentConfigsForPut and stripDangerousAgentFlags reference
+// this constant so the M-5 denylist has a single source of truth.
+const dangerousAgentFlagKey = "dangerously_skip_perms"
+
 // stripDangerousAgentFlags removes the HTTP-forbidden
-// dangerously_skip_perms flag from every agent under ai.agents in a
-// merged config map. The flag is still settable via direct edits to
-// config.toml (security gate M-5: only filesystem-trusted inputs can
-// grant the AI permission-sandbox bypass), but never via the HTTP API.
+// dangerously_skip_perms flag from every agent map reachable in the
+// merged config: top-level ai.agents.<cli>, per-repo
+// ai.repos.<repo>.agents.<cli>, and per-org ai.orgs.<org>.agents.<cli>.
+// The flag is still settable via direct edits to config.toml
+// (security gate M-5: only filesystem-trusted inputs can grant the
+// permission-sandbox bypass), but never via the HTTP API.
+//
+// Returns the number of entries stripped so callers can audit-log
+// bypass attempts. Key comparison is case-insensitive because the
+// downstream koanf/mapstructure decoder is case-insensitive when
+// mapping into CLIAgentConfig.DangerouslySkipPerms — an exact-case
+// match would leave Dangerously_Skip_Perms / DANGEROUSLY_SKIP_PERMS
+// shaped payloads as a live bypass.
 //
 // Invoked from patchTOML so every PATCH endpoint (global, per-repo,
 // per-org) inherits the gate without each handler having to remember
 // to call it.
-func stripDangerousAgentFlags(m map[string]any) {
+func stripDangerousAgentFlags(m map[string]any) int {
+	if m == nil {
+		return 0
+	}
+	stripped := 0
+	scrub := func(agents map[string]any) {
+		for _, raw := range agents {
+			inner, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			for k := range inner {
+				if strings.EqualFold(k, dangerousAgentFlagKey) {
+					delete(inner, k)
+					stripped++
+				}
+			}
+		}
+	}
 	ai, ok := m["ai"].(map[string]any)
 	if !ok {
-		return
+		return 0
 	}
-	agents, ok := ai["agents"].(map[string]any)
-	if !ok {
-		return
+	if agents, ok := ai["agents"].(map[string]any); ok {
+		scrub(agents)
 	}
-	for _, raw := range agents {
-		inner, ok := raw.(map[string]any)
-		if !ok {
-			continue
+	if repos, ok := ai["repos"].(map[string]any); ok {
+		for _, raw := range repos {
+			repo, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if agents, ok := repo["agents"].(map[string]any); ok {
+				scrub(agents)
+			}
 		}
-		delete(inner, "dangerously_skip_perms")
 	}
+	if orgs, ok := ai["orgs"].(map[string]any); ok {
+		for _, raw := range orgs {
+			org, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if agents, ok := org["agents"].(map[string]any); ok {
+				scrub(agents)
+			}
+		}
+	}
+	return stripped
 }
 
 // normalizeAgentConfigsForPut validates the agent_configs payload from PUT
@@ -1793,11 +1846,11 @@ func normalizeAgentConfigsForPut(v any) (map[string]map[string]any, error) {
 		}
 		normalized := make(map[string]any, len(inner))
 		for k, val := range inner {
-			if k == "dangerously_skip_perms" {
+			if strings.EqualFold(k, dangerousAgentFlagKey) {
 				return nil, fmt.Errorf(
-					"agent_configs[%q].dangerously_skip_perms cannot be set via HTTP API; "+
+					"agent_configs[%q].%s cannot be set via HTTP API; "+
 						"configure it in config.toml under [ai.agents.%s] (security gate M-5)",
-					cli, cli)
+					cli, dangerousAgentFlagKey, cli)
 			}
 			if _, allowed := allowedAgentConfigSubkeys[k]; !allowed {
 				return nil, fmt.Errorf("agent_configs[%q]: unknown key %q", cli, k)

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -231,6 +231,13 @@ func (srv *Server) patchTOML(mutateFn func(m map[string]any) error) (map[string]
 	if err := mutateFn(m); err != nil {
 		return nil, err
 	}
+	// Defense-in-depth (security gate M-5): every PATCH path that
+	// touches ai.agents.* must drop dangerously_skip_perms before the
+	// merged map is validated and persisted. PUT rejects the key with
+	// a 400 via normalizeAgentConfigsForPut, but PATCH deep-merges
+	// arbitrary JSON, so the gate has to be enforced here regardless
+	// of which handler invoked patchTOML.
+	stripDangerousAgentFlags(m)
 	if err := config.ValidateMap(m); err != nil {
 		return nil, err
 	}
@@ -1731,6 +1738,33 @@ func tailLines(f *os.File, n int) []string {
 	// Seek file to end of last line read.
 	f.Seek(size, io.SeekStart) //nolint:errcheck
 	return lines
+}
+
+// stripDangerousAgentFlags removes the HTTP-forbidden
+// dangerously_skip_perms flag from every agent under ai.agents in a
+// merged config map. The flag is still settable via direct edits to
+// config.toml (security gate M-5: only filesystem-trusted inputs can
+// grant the AI permission-sandbox bypass), but never via the HTTP API.
+//
+// Invoked from patchTOML so every PATCH endpoint (global, per-repo,
+// per-org) inherits the gate without each handler having to remember
+// to call it.
+func stripDangerousAgentFlags(m map[string]any) {
+	ai, ok := m["ai"].(map[string]any)
+	if !ok {
+		return
+	}
+	agents, ok := ai["agents"].(map[string]any)
+	if !ok {
+		return
+	}
+	for _, raw := range agents {
+		inner, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		delete(inner, "dangerously_skip_perms")
+	}
 }
 
 // normalizeAgentConfigsForPut validates the agent_configs payload from PUT

--- a/daemon/internal/server/handlers_internal_test.go
+++ b/daemon/internal/server/handlers_internal_test.go
@@ -85,6 +85,67 @@ func TestDaemonLogPath_FallsBackToNativeWhenDataDirUnset(t *testing.T) {
 	}
 }
 
+// TestStripDangerousAgentFlags_HandlesUnexpectedShapes pins the
+// type-assertion guards: callers feed the scrubber a merged config
+// map whose interior types come from JSON decoding plus a TOML round
+// trip, and weird shapes (nil, scalars where maps are expected)
+// must never panic. PATCH validation enforces shape strictly today,
+// but the scrubber must remain safe even if a future ValidateMap
+// becomes more permissive.
+func TestStripDangerousAgentFlags_HandlesUnexpectedShapes(t *testing.T) {
+	cases := []map[string]any{
+		nil,
+		{},
+		{"ai": "not a map"},
+		{"ai": map[string]any{"agents": nil}},
+		{"ai": map[string]any{"agents": "string"}},
+		{"ai": map[string]any{"agents": map[string]any{"claude": nil}}},
+		{"ai": map[string]any{"agents": map[string]any{"claude": "string"}}},
+		{"ai": map[string]any{"repos": "string"}},
+		{"ai": map[string]any{"repos": map[string]any{"org/r": "string"}}},
+		{"ai": map[string]any{"repos": map[string]any{"org/r": map[string]any{"agents": "string"}}}},
+		{"ai": map[string]any{"orgs": map[string]any{"org": map[string]any{"agents": map[string]any{"claude": nil}}}}},
+	}
+	for _, m := range cases {
+		stripDangerousAgentFlags(m) // must not panic
+	}
+}
+
+func TestStripDangerousAgentFlags_ReportsCount(t *testing.T) {
+	m := map[string]any{
+		"ai": map[string]any{
+			"agents": map[string]any{
+				"claude": map[string]any{"dangerously_skip_perms": true, "permission_mode": "acceptEdits"},
+				"gemini": map[string]any{"DANGEROUSLY_SKIP_PERMS": true},
+			},
+			"repos": map[string]any{
+				"org/r": map[string]any{
+					"agents": map[string]any{
+						"claude": map[string]any{"Dangerously_Skip_Perms": true},
+					},
+				},
+			},
+			"orgs": map[string]any{
+				"org": map[string]any{
+					"agents": map[string]any{
+						"claude": map[string]any{"dangerously_skip_perms": true},
+					},
+				},
+			},
+		},
+	}
+	n := stripDangerousAgentFlags(m)
+	if n != 4 {
+		t.Fatalf("stripped count = %d, want 4 (global x2 + repo + org)", n)
+	}
+	ai := m["ai"].(map[string]any)
+	agents := ai["agents"].(map[string]any)
+	claude := agents["claude"].(map[string]any)
+	if claude["permission_mode"] != "acceptEdits" {
+		t.Errorf("permission_mode lost: %v", claude)
+	}
+}
+
 func TestDaemonLogPath_XDGStateHomeUsedWhenSet(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip("XDG path only used on non-darwin when HEIMDALLM_DATA_DIR is unset")

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1460,6 +1460,88 @@ func TestHandlePatchConfig_RepoListsWriteTOML(t *testing.T) {
 	}
 }
 
+func TestHandlePatchConfig_StripsDangerouslySkipPerms(t *testing.T) {
+	// Security gate M-5: PUT /config rejects dangerously_skip_perms with
+	// a 400. PATCH /config deep-merges arbitrary JSON; before this fix it
+	// silently persisted the flag, granting AI runs --dangerously-skip-
+	// permissions on the next reload. The PATCH path must scrub the flag
+	// out of every agent under ai.agents before validating + writing TOML
+	// so HTTP can never flip the toggle.
+	tomlContent := "[ai]\nprimary = \"claude\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	body := `{"ai":{"agents":{"claude":{"dangerously_skip_perms":true,"permission_mode":"acceptEdits"}}}}`
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH should succeed (other fields land), got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, err := config.ReadTOMLMap(tomlPath)
+	if err != nil {
+		t.Fatalf("read TOML after PATCH: %v", err)
+	}
+	ai, _ := m["ai"].(map[string]any)
+	agents, _ := ai["agents"].(map[string]any)
+	claude, ok := agents["claude"].(map[string]any)
+	if !ok {
+		t.Fatalf("ai.agents.claude missing after PATCH: %v", agents)
+	}
+	if _, present := claude["dangerously_skip_perms"]; present {
+		t.Fatalf("dangerously_skip_perms persisted via PATCH (M-5 bypass): %v", claude)
+	}
+	// Sanity: other legal fields landed so the strip is targeted, not nuking the whole section.
+	if claude["permission_mode"] != "acceptEdits" {
+		t.Errorf("permission_mode = %v, want acceptEdits (legal fields must still land)", claude["permission_mode"])
+	}
+}
+
+func TestHandlePatchConfig_StripsDangerouslySkipPermsAcrossAllAgents(t *testing.T) {
+	// Same gate applied to every CLI under ai.agents — an attacker may
+	// try flipping the flag on a less-watched agent.
+	tomlContent := "[ai]\nprimary = \"claude\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	body := `{"ai":{"agents":{` +
+		`"claude":{"dangerously_skip_perms":true},` +
+		`"gemini":{"dangerously_skip_perms":true},` +
+		`"codex":{"dangerously_skip_perms":true},` +
+		`"opencode":{"dangerously_skip_perms":true}` +
+		`}}}`
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH failed: %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, _ := config.ReadTOMLMap(tomlPath)
+	ai, _ := m["ai"].(map[string]any)
+	agents, _ := ai["agents"].(map[string]any)
+	for _, name := range []string{"claude", "gemini", "codex", "opencode"} {
+		inner, ok := agents[name].(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, present := inner["dangerously_skip_perms"]; present {
+			t.Errorf("dangerously_skip_perms persisted for %s (M-5 bypass)", name)
+		}
+	}
+}
+
 func TestHandlePatchConfig_RejectsNull(t *testing.T) {
 	tomlContent := "[ai]\nprimary = \"claude\"\n"
 	tomlPath := writeTempTOML(t, tomlContent)

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1503,6 +1503,128 @@ func TestHandlePatchConfig_StripsDangerouslySkipPerms(t *testing.T) {
 	}
 }
 
+func TestHandlePatchConfig_StripsDangerouslySkipPermsCaseInsensitive(t *testing.T) {
+	// JSON preserves key casing; the merged map then feeds into a
+	// Go struct via mapstructure/koanf, which is case-insensitive
+	// by default — so a payload using mixed/upper casing would
+	// otherwise bypass an exact-match strip.
+	tomlContent := "[ai]\nprimary = \"claude\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	body := `{"ai":{"agents":{` +
+		`"claude":{"Dangerously_Skip_Perms":true},` +
+		`"gemini":{"DANGEROUSLY_SKIP_PERMS":true},` +
+		`"codex":{"dANGEROUSLY_skip_perms":true}` +
+		`}}}`
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH should succeed, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, _ := config.ReadTOMLMap(tomlPath)
+	ai, _ := m["ai"].(map[string]any)
+	agents, _ := ai["agents"].(map[string]any)
+	for _, name := range []string{"claude", "gemini", "codex"} {
+		inner, ok := agents[name].(map[string]any)
+		if !ok {
+			continue
+		}
+		for k := range inner {
+			if strings.EqualFold(k, "dangerously_skip_perms") {
+				t.Errorf("case-variant %q persisted for %s (M-5 bypass)", k, name)
+			}
+		}
+	}
+}
+
+func TestHandlePatchConfig_StripsDangerouslySkipPermsInRepoOverride(t *testing.T) {
+	// Per-repo overrides land at ai.repos.<repo>.agents.<cli>.* in
+	// the merged map. The scrubber must walk those too so a buggy
+	// future schema or a koanf-style alias can't grant the flag via
+	// a non-top-level path.
+	tomlContent := "[ai]\nprimary = \"claude\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	body := `{"ai":{"repos":{"org/repo":{"agents":{"claude":{"dangerously_skip_perms":true}}}}}}`
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH should succeed, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, _ := config.ReadTOMLMap(tomlPath)
+	ai, _ := m["ai"].(map[string]any)
+	repos, _ := ai["repos"].(map[string]any)
+	repo, ok := repos["org/repo"].(map[string]any)
+	if !ok {
+		return
+	}
+	agents, ok := repo["agents"].(map[string]any)
+	if !ok {
+		return
+	}
+	claude, ok := agents["claude"].(map[string]any)
+	if !ok {
+		return
+	}
+	if _, present := claude["dangerously_skip_perms"]; present {
+		t.Fatalf("repo-level dangerously_skip_perms persisted (M-5 bypass): %v", claude)
+	}
+}
+
+func TestHandlePatchConfig_StripsDangerouslySkipPermsInOrgOverride(t *testing.T) {
+	tomlContent := "[ai]\nprimary = \"claude\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	body := `{"ai":{"orgs":{"org":{"agents":{"claude":{"dangerously_skip_perms":true}}}}}}`
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH should succeed, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, _ := config.ReadTOMLMap(tomlPath)
+	ai, _ := m["ai"].(map[string]any)
+	orgs, _ := ai["orgs"].(map[string]any)
+	org, ok := orgs["org"].(map[string]any)
+	if !ok {
+		return
+	}
+	agents, ok := org["agents"].(map[string]any)
+	if !ok {
+		return
+	}
+	claude, ok := agents["claude"].(map[string]any)
+	if !ok {
+		return
+	}
+	if _, present := claude["dangerously_skip_perms"]; present {
+		t.Fatalf("org-level dangerously_skip_perms persisted (M-5 bypass): %v", claude)
+	}
+}
+
 func TestHandlePatchConfig_StripsDangerouslySkipPermsAcrossAllAgents(t *testing.T) {
 	// Same gate applied to every CLI under ai.agents — an attacker may
 	// try flipping the flag on a less-watched agent.


### PR DESCRIPTION
## Summary

Closes #477. PUT /config validated `ai.agents.<cli>.dangerously_skip_perms` and 400'd if present (security gate M-5). PATCH /config took the deep-merge path through `patchTOML` with no equivalent denylist, so an attacker with a valid API token could persist the flag via:

```http
PATCH /config
{"ai":{"agents":{"claude":{"dangerously_skip_perms":true}}}}
```

The next AI invocation then ran with `--dangerously-skip-permissions`, bypassing the permission sandbox.

## Fix

`patchTOML` now invokes `stripDangerousAgentFlags(m)` between `mutateFn` and `ValidateMap`, so every PATCH endpoint (global, per-repo, per-org) inherits the gate without each handler having to remember. The scrubber walks `m["ai"]["agents"][*]` and deletes any `dangerously_skip_perms` key.

Direct edits to `config.toml` still flip the flag — the filesystem is the trusted boundary; HTTP is not. This matches the M-5 design.

## Test plan

- [x] `make test-docker` passes.
- [x] `TestHandlePatchConfig_StripsDangerouslySkipPerms` — single agent: flag stripped, legal fields land.
- [x] `TestHandlePatchConfig_StripsDangerouslySkipPermsAcrossAllAgents` — every agent (claude, gemini, codex, opencode).
- [x] Existing PUT tests still 400 on the same key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)