### PR TITLE
fix(issues): terminate auto_implement no-changes runs cleanly (#483)

### DIFF
--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -298,22 +298,12 @@ func (f *Fetcher) alreadyProcessed(issue *github.Issue) (bool, string, error) {
 		return true, "already implemented (PR created)", nil
 	}
 	if latest.ActionTaken == ActionAutoImplementNoChanges && issue.Mode == config.IssueModeDevelop {
-		// If the agent has produced an empty diff at or above the cap, stop
-		// retrying. Manual unblock paths: a retry marker (handled above
-		// before we reach this point), dismiss, or moving the issue back
-		// to a different stage label. See issue #433.
-		noChangesCount, ncErr := f.store.CountAutoImplementNoChanges(row.ID)
-		if ncErr != nil {
-			slog.Warn("issues fetcher: could not count no-changes auto_implement, falling through to legacy block",
-				"repo", issue.Repo, "number", issue.Number, "err", ncErr)
-			return true, "auto_implement produced no changes; waiting for manual retry", nil
-		}
-		if noChangesCount >= MaxAutoImplementNoChanges {
-			return true, fmt.Sprintf(
-				"auto_implement produced no changes %d times (cap %d); requires human intervention or retry marker",
-				noChangesCount, MaxAutoImplementNoChanges), nil
-		}
-		return true, "auto_implement produced no changes; waiting for manual retry", nil
+		// Back-compat skip for rows written before #483 added MarkerDone
+		// to the fallback comment. New no-changes runs are terminated by
+		// the marker scan above; reaching here means the row was stored
+		// without a marker, so we keep skipping until a human posts
+		// MarkerRetry (handled before this block).
+		return true, "auto_implement produced no changes (historical row, no done marker); add retry marker to reprocess", nil
 	}
 
 	// Bot-comment dedup: if the most recent comment is from the bot AND the

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -32,14 +32,6 @@ const RecomputeGrace = 30 * time.Second
 // See issue #223.
 const MaxAutoImplementFailures = 3
 
-// MaxAutoImplementNoChanges caps how many auto_implement_no_changes runs we
-// allow on a single issue before the fetcher permanently skips it. After the
-// agent has produced an empty diff this many times in a row, retrying is
-// almost certainly burning tokens for nothing — the issue needs more context,
-// a different agent, or a human. The retry marker / dismiss / mode change
-// path still unblocks the issue manually. See issue #433.
-const MaxAutoImplementNoChanges = 1
-
 // IssuesFetcher is the subset of github.Client that fetches classified
 // issues. Kept as an interface so the fetcher can be tested without an HTTP
 // server standing in.
@@ -63,10 +55,6 @@ type issueDedupStore interface {
 	// "auto_implement_failed" review rows for the issue. Used to enforce
 	// MaxAutoImplementFailures; see issue #223.
 	CountFailedAutoImplement(issueID int64) (int, error)
-	// CountAutoImplementNoChanges returns the number of stored
-	// "auto_implement_no_changes" review rows for the issue. Used to enforce
-	// MaxAutoImplementNoChanges; see issue #433.
-	CountAutoImplementNoChanges(issueID int64) (int, error)
 }
 
 // issueMarkerFetcher fetches comments for an issue so the fetcher can scan

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -494,7 +494,12 @@ func TestFetcher_DoesNotSkipBelowMaxAutoImplementFailures(t *testing.T) {
 	}
 }
 
-func TestFetcher_SkipsAutoImplementNoChangesUntilManualRetry(t *testing.T) {
+// TestAlreadyProcessed_HistoricalNoChangesRow_StillSkipped pins the
+// back-compat branch of the simplified dedup gate (#483): rows written
+// before MarkerDone was added to the fallback comment have no marker on
+// the issue but still carry ActionTaken=auto_implement_no_changes, so the
+// dedup gate must keep skipping them until a human posts MarkerRetry.
+func TestAlreadyProcessed_HistoricalNoChangesRow_StillSkipped(t *testing.T) {
 	reviewedAt := time.Now().Add(-10 * time.Minute)
 	issue := fixture(1, time.Now())
 	issue.Mode = config.IssueModeDevelop
@@ -507,26 +512,28 @@ func TestFetcher_SkipsAutoImplementNoChangesUntilManualRetry(t *testing.T) {
 				CreatedAt:   reviewedAt,
 				CommentedAt: reviewedAt,
 			},
-			noChangesCount: 1, // at the cap (MaxAutoImplementNoChanges = 1)
 		},
 	}}
+	// No comments at all — pre-#483 row that never got a MarkerDone.
+	mf := &fakeMarkerFetcher{commentsByKey: map[string][]github.Comment{}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, p)
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
 
 	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if processed != 0 || len(p.calls) != 0 {
-		t.Fatalf("no-changes auto_implement should wait for retry marker, processed=%d calls=%v", processed, p.calls)
+		t.Fatalf("historical no-changes row must still be skipped, processed=%d calls=%v", processed, p.calls)
 	}
 }
 
-func TestFetcher_AutoImplementNoChangesCapStopsLoop(t *testing.T) {
-	// Symmetric to MaxAutoImplementFailures: once the agent has produced
-	// an empty diff at or above MaxAutoImplementNoChanges, the fetcher must
-	// stop dispatching the issue regardless of updated_at bumps. Manual retry
-	// marker still bypasses this (handled before the cap check).
+// TestAlreadyProcessed_DoneMarkerSkipsBeforeDedupGate proves the
+// marker-first ordering: a no-changes row whose comment thread now
+// carries MarkerDone (the post-#483 happy path) is terminated by the
+// marker scan, not by the back-compat dedup gate. Without this ordering
+// the user could not see "done marker" in the skip reason.
+func TestAlreadyProcessed_DoneMarkerSkipsBeforeDedupGate(t *testing.T) {
 	reviewedAt := time.Now().Add(-10 * time.Minute)
 	issue := fixture(1, time.Now())
 	issue.Mode = config.IssueModeDevelop
@@ -539,25 +546,28 @@ func TestFetcher_AutoImplementNoChangesCapStopsLoop(t *testing.T) {
 				CreatedAt:   reviewedAt,
 				CommentedAt: reviewedAt,
 			},
-			noChangesCount: issues.MaxAutoImplementNoChanges + 5, // well over the cap
 		},
 	}}
+	mf := &fakeMarkerFetcher{commentsByKey: map[string][]github.Comment{
+		"org/repo#1": {{Body: issues.MarkerDone + "\nfallback comment", CreatedAt: time.Now()}},
+	}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, p)
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
 
 	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if processed != 0 || len(p.calls) != 0 {
-		t.Fatalf("over-cap issue must not be processed, processed=%d calls=%v", processed, p.calls)
+		t.Fatalf("done marker must skip ahead of dedup gate, processed=%d calls=%v", processed, p.calls)
 	}
 }
 
-func TestFetcher_AutoImplementNoChangesCountErrFallsThrough(t *testing.T) {
-	// A flaky CountAutoImplementNoChanges must not block the existing
-	// "wait for manual retry" skip — degrade gracefully like the failure cap
-	// does (TestFetcher_CountFailedAutoImplErrDoesNotSkip).
+// TestAlreadyProcessed_RetryMarker_ReprocessesNoChanges proves the
+// retry escape hatch is actually reachable now that the dedup gate no
+// longer unconditionally swallows no-changes rows. Pre-#483, the gate
+// short-circuited before any marker check could reopen the issue.
+func TestAlreadyProcessed_RetryMarker_ReprocessesNoChanges(t *testing.T) {
 	reviewedAt := time.Now().Add(-10 * time.Minute)
 	issue := fixture(1, time.Now())
 	issue.Mode = config.IssueModeDevelop
@@ -570,18 +580,23 @@ func TestFetcher_AutoImplementNoChangesCountErrFallsThrough(t *testing.T) {
 				CreatedAt:   reviewedAt,
 				CommentedAt: reviewedAt,
 			},
-			noChangesErr: errors.New("db timeout"),
+		},
+	}}
+	mf := &fakeMarkerFetcher{commentsByKey: map[string][]github.Comment{
+		"org/repo#1": {
+			{Body: issues.MarkerDone + "\nfallback comment", CreatedAt: time.Now().Add(-5 * time.Minute)},
+			{Body: issues.MarkerRetry + "\nplease retry", CreatedAt: time.Now()},
 		},
 	}}
 	p := &fakePipeline{}
-	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, nil, dedup, p)
+	f := issues.NewFetcher(&fakeClient{issues: []*github.Issue{issue}}, mf, dedup, p)
 
 	processed, err := f.ProcessRepo(context.Background(), "org/repo", enabledCfg(), "alice", noOpts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if processed != 0 || len(p.calls) != 0 {
-		t.Fatalf("count error must still skip, processed=%d calls=%v", processed, p.calls)
+	if processed != 1 || len(p.calls) != 1 {
+		t.Fatalf("retry marker must reopen a no-changes row, processed=%d calls=%v", processed, p.calls)
 	}
 }
 

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -549,10 +549,12 @@ func TestAlreadyProcessed_DoneMarkerSkipsBeforeDedupGate(t *testing.T) {
 	}
 }
 
-// TestAlreadyProcessed_RetryMarker_ReprocessesNoChanges proves the
-// retry escape hatch is actually reachable now that the dedup gate no
-// longer unconditionally swallows no-changes rows. Pre-#483, the gate
-// short-circuited before any marker check could reopen the issue.
+// TestAlreadyProcessed_RetryMarker_ReprocessesNoChanges pins the retry
+// escape hatch on a no-changes row. The marker scan already ran before
+// the dedup gate pre-#483, so this is the documented user workflow —
+// what the test really protects against is a future refactor that
+// moves the dedup gate above the marker scan or that drops the retry
+// override for the ActionAutoImplementNoChanges branch.
 func TestAlreadyProcessed_RetryMarker_ReprocessesNoChanges(t *testing.T) {
 	reviewedAt := time.Now().Add(-10 * time.Minute)
 	issue := fixture(1, time.Now())

--- a/daemon/internal/issues/fetcher_test.go
+++ b/daemon/internal/issues/fetcher_test.go
@@ -52,8 +52,6 @@ type dedupEntry struct {
 	revErr            error
 	failedAutoImpl    int // stub for CountFailedAutoImplement
 	failedAutoImplErr error
-	noChangesCount    int // stub for CountAutoImplementNoChanges
-	noChangesErr      error
 }
 
 type fakeDedup struct {
@@ -93,18 +91,6 @@ func (d *fakeDedup) CountFailedAutoImplement(issueID int64) (int, error) {
 				return 0, e.failedAutoImplErr
 			}
 			return e.failedAutoImpl, nil
-		}
-	}
-	return 0, nil
-}
-
-func (d *fakeDedup) CountAutoImplementNoChanges(issueID int64) (int, error) {
-	for _, e := range d.byGithubID {
-		if e.row != nil && e.row.ID == issueID {
-			if e.noChangesErr != nil {
-				return 0, e.noChangesErr
-			}
-			return e.noChangesCount, nil
 		}
 	}
 	return 0, nil

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -897,7 +897,7 @@ func (p *Pipeline) autoImplementNoChangesFallback(issue *github.Issue, issueID i
 	body := fmt.Sprintf(
 		"%s\n## ⚠️ Heimdallm auto-implement skipped\n\n"+
 			"The agent looked at #%d but left the working tree unchanged — it likely needs a human decision or more context than the issue alone provides.\n\n"+
-			"To retry auto-implementation, post a new comment containing a Heimdallm `heimdallm:retry` marker (see the configuration guide's issue-tracking section for the exact syntax). To stop here, remove the develop label.\n\n"+
+			"To retry auto-implementation, post a new comment containing a Heimdallm `heimdallm:retry` marker (see the configuration guide's `auto_implement` section for the exact syntax). To stop here, remove the develop label.\n\n"+
 			"---\n*auto_implement → review_only fallback · Heimdallm*",
 		MarkerDone, issue.Number,
 	)

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -887,12 +887,16 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 // implement" escape hatch fired. We post a review_only-style comment so the
 // issue still gets acknowledged and the user sees why no PR appeared.
 func (p *Pipeline) autoImplementNoChangesFallback(issue *github.Issue, issueID int64, cli string) (*store.IssueReview, error) {
+	// MarkerDone makes this a terminal state for the fetcher's marker scan
+	// (#483): without it, the fallback row collides with the dedup gate on
+	// every poll and the issue sits in limbo. MarkerRetry is named inline
+	// so the user can find the escape hatch without grepping source.
 	body := fmt.Sprintf(
-		"## ⚠️ Heimdallm auto-implement skipped\n\n"+
+		"%s\n## ⚠️ Heimdallm auto-implement skipped\n\n"+
 			"The agent looked at #%d but left the working tree unchanged — it likely needs a human decision or more context than the issue alone provides.\n\n"+
-			"Add more details and a retry marker to run auto-implementation again, or remove the develop label to stop here.\n\n"+
+			"To retry auto-implementation, add a `%s` marker comment (or edit the issue body to include it). To stop here, remove the develop label.\n\n"+
 			"---\n*auto_implement → review_only fallback · Heimdallm*",
-		issue.Number,
+		MarkerDone, issue.Number, MarkerRetry,
 	)
 	commentedAt, postErr := p.gh.PostComment(issue.Repo, issue.Number, body)
 	if postErr != nil {
@@ -916,9 +920,14 @@ func (p *Pipeline) autoImplementNoChangesFallback(issue *github.Issue, issueID i
 	}
 	rev.ID = revID
 
-	p.publish(sse.EventIssueReviewCompleted, map[string]any{
+	// EventIssueReviewError (not Completed) so the UI renders a
+	// needs-attention card; the reason field disambiguates the cause for
+	// Flutter-side copy (#483).
+	p.publish(sse.EventIssueReviewError, map[string]any{
 		"issue_id": issueID, "number": issue.Number, "repo": issue.Repo,
-		"mode": "auto_implement_no_changes", "post_ok": postErr == nil,
+		"reason":  "auto_implement_no_changes",
+		"post_ok": postErr == nil,
+		"message": "Agent left the working tree unchanged; add a retry marker to retry or close the issue.",
 	})
 	slog.Info("issues pipeline: auto_implement had no changes, posted fallback comment",
 		"repo", issue.Repo, "number", issue.Number, "posted", postErr == nil)

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -889,14 +889,17 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 func (p *Pipeline) autoImplementNoChangesFallback(issue *github.Issue, issueID int64, cli string) (*store.IssueReview, error) {
 	// MarkerDone makes this a terminal state for the fetcher's marker scan
 	// (#483): without it, the fallback row collides with the dedup gate on
-	// every poll and the issue sits in limbo. MarkerRetry is named inline
-	// so the user can find the escape hatch without grepping source.
+	// every poll and the issue sits in limbo. We deliberately do NOT embed
+	// the MarkerRetry literal in the body — ScanMarkers prioritises Retry
+	// over Done within a single comment, so the very next poll would
+	// reprocess the issue. The retry instructions reference the token by
+	// keyword instead and point at the configuration guide.
 	body := fmt.Sprintf(
 		"%s\n## ⚠️ Heimdallm auto-implement skipped\n\n"+
 			"The agent looked at #%d but left the working tree unchanged — it likely needs a human decision or more context than the issue alone provides.\n\n"+
-			"To retry auto-implementation, add a `%s` marker comment (or edit the issue body to include it). To stop here, remove the develop label.\n\n"+
+			"To retry auto-implementation, post a new comment containing a Heimdallm `heimdallm:retry` marker (see the configuration guide's issue-tracking section for the exact syntax). To stop here, remove the develop label.\n\n"+
 			"---\n*auto_implement → review_only fallback · Heimdallm*",
-		MarkerDone, issue.Number, MarkerRetry,
+		MarkerDone, issue.Number,
 	)
 	commentedAt, postErr := p.gh.PostComment(issue.Repo, issue.Number, body)
 	if postErr != nil {
@@ -921,13 +924,16 @@ func (p *Pipeline) autoImplementNoChangesFallback(issue *github.Issue, issueID i
 	rev.ID = revID
 
 	// EventIssueReviewError (not Completed) so the UI renders a
-	// needs-attention card; the reason field disambiguates the cause for
-	// Flutter-side copy (#483).
+	// needs-attention card. The `error` field follows the convention of
+	// other EventIssueReviewError emitters (Flutter's `_errorDetails` and
+	// the detail toast both read it); `reason` is a machine-readable cause
+	// kept distinct so future UI work can render reason-specific copy
+	// without parsing the human string (#483).
 	p.publish(sse.EventIssueReviewError, map[string]any{
 		"issue_id": issueID, "number": issue.Number, "repo": issue.Repo,
 		"reason":  "auto_implement_no_changes",
 		"post_ok": postErr == nil,
-		"message": "Agent left the working tree unchanged; add a retry marker to retry or close the issue.",
+		"error":   "Agent left the working tree unchanged; post a retry marker comment to retry, or close the issue.",
 	})
 	slog.Info("issues pipeline: auto_implement had no changes, posted fallback comment",
 		"repo", issue.Repo, "number", issue.Number, "posted", postErr == nil)

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -1027,10 +1027,73 @@ func TestPipeline_AutoImplementNoChangesRecordsTerminalNoChanges(t *testing.T) {
 		t.Errorf("PRCreated=%d, want 0", rev.PRCreated)
 	}
 
-	// SSE completes with review_completed, not implemented.
+	// SSE completes with review_error so the UI renders a needs-attention
+	// card instead of a clean success state (#483).
 	types := broker.types()
-	if types[len(types)-1] != sse.EventIssueReviewCompleted {
-		t.Errorf("last event = %q, want issue_review_completed", types[len(types)-1])
+	if types[len(types)-1] != sse.EventIssueReviewError {
+		t.Errorf("last event = %q, want issue_review_error", types[len(types)-1])
+	}
+}
+
+// TestAutoImplementNoChangesFallback_PostsDoneMarker pins #483 fix A:
+// the fallback comment must carry MarkerDone so the fetcher's marker scan
+// (which runs before the dedup gate) terminates the issue cleanly. The
+// body must also surface MarkerRetry as the documented escape hatch so a
+// user can opt back in without grepping source.
+func TestAutoImplementNoChangesFallback_PostsDoneMarker(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{defaultBranch: "main"}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("nothing to do")}
+	git := &fakeGit{hasChanges: false}
+	p := issues.New(s, gh, exec, git, &fakeBroker{}, nil)
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if len(gh.postCalls) != 1 {
+		t.Fatalf("expected 1 fallback PostComment, got %d", len(gh.postCalls))
+	}
+	body := gh.postCalls[0].Body
+	if !strings.Contains(body, issues.MarkerDone) {
+		t.Errorf("fallback body missing MarkerDone (%q):\n%s", issues.MarkerDone, body)
+	}
+	if !strings.Contains(body, issues.MarkerRetry) {
+		t.Errorf("fallback body missing MarkerRetry hint (%q):\n%s", issues.MarkerRetry, body)
+	}
+}
+
+// TestAutoImplementNoChangesFallback_EmitsReviewError pins #483 fix B:
+// the SSE event must be issue_review_error (needs-attention) rather than
+// issue_review_completed (clean success), with reason=auto_implement_no_changes
+// so Flutter can render a distinct copy.
+func TestAutoImplementNoChangesFallback_EmitsReviewError(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{defaultBranch: "main"}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("nothing to do")}
+	git := &fakeGit{hasChanges: false}
+	broker := &fakeBroker{}
+	p := issues.New(s, gh, exec, git, broker, nil)
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	types := broker.types()
+	if len(types) == 0 {
+		t.Fatalf("no events published")
+	}
+	last := broker.event(len(types) - 1)
+	if last.Type != sse.EventIssueReviewError {
+		t.Fatalf("last event type = %q, want %q", last.Type, sse.EventIssueReviewError)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(last.Data), &payload); err != nil {
+		t.Fatalf("event payload not JSON: %v (data=%q)", err, last.Data)
+	}
+	if payload["reason"] != "auto_implement_no_changes" {
+		t.Errorf("payload reason = %v, want %q", payload["reason"], "auto_implement_no_changes")
 	}
 }
 

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -1037,9 +1037,7 @@ func TestPipeline_AutoImplementNoChangesRecordsTerminalNoChanges(t *testing.T) {
 
 // TestAutoImplementNoChangesFallback_PostsDoneMarker pins #483 fix A:
 // the fallback comment must carry MarkerDone so the fetcher's marker scan
-// (which runs before the dedup gate) terminates the issue cleanly. The
-// body must also surface MarkerRetry as the documented escape hatch so a
-// user can opt back in without grepping source.
+// (which runs before the dedup gate) terminates the issue cleanly.
 func TestAutoImplementNoChangesFallback_PostsDoneMarker(t *testing.T) {
 	s := &fakeStore{}
 	gh := &fakeGH{defaultBranch: "main"}
@@ -1058,8 +1056,33 @@ func TestAutoImplementNoChangesFallback_PostsDoneMarker(t *testing.T) {
 	if !strings.Contains(body, issues.MarkerDone) {
 		t.Errorf("fallback body missing MarkerDone (%q):\n%s", issues.MarkerDone, body)
 	}
-	if !strings.Contains(body, issues.MarkerRetry) {
-		t.Errorf("fallback body missing MarkerRetry hint (%q):\n%s", issues.MarkerRetry, body)
+}
+
+// TestAutoImplementNoChangesFallback_BodyScansAsDone is the regression
+// pin for a draft of #483 where the fallback body included the literal
+// MarkerRetry token as a copy-pasteable retry hint. Within a single
+// comment ScanMarkers gives Retry priority over Done, so the very next
+// poll would treat the fallback comment itself as a retry signal and
+// re-run auto_implement — defeating the entire fix. Pass the real body
+// through the scanner and assert MarkerResultDone.
+func TestAutoImplementNoChangesFallback_BodyScansAsDone(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{defaultBranch: "main"}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("nothing to do")}
+	git := &fakeGit{hasChanges: false}
+	p := issues.New(s, gh, exec, git, &fakeBroker{}, nil)
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(gh.postCalls) != 1 {
+		t.Fatalf("expected 1 fallback PostComment, got %d", len(gh.postCalls))
+	}
+	body := gh.postCalls[0].Body
+	got := issues.ScanMarkers([]github.Comment{{Body: body}})
+	if got != issues.MarkerResultDone {
+		t.Fatalf("ScanMarkers on fallback body = %d, want MarkerResultDone (%d)\nbody:\n%s",
+			got, issues.MarkerResultDone, body)
 	}
 }
 
@@ -1094,6 +1117,13 @@ func TestAutoImplementNoChangesFallback_EmitsReviewError(t *testing.T) {
 	}
 	if payload["reason"] != "auto_implement_no_changes" {
 		t.Errorf("payload reason = %v, want %q", payload["reason"], "auto_implement_no_changes")
+	}
+	// The error field follows the convention of the other ReviewError
+	// emitters (Flutter reads payload["error"] in both the activity row
+	// renderer and the issue-detail toast — without it the user sees
+	// "Review failed: Unknown error").
+	if err, _ := payload["error"].(string); err == "" {
+		t.Errorf("payload missing error field; have %v", payload)
 	}
 }
 

--- a/daemon/internal/store/issues.go
+++ b/daemon/internal/store/issues.go
@@ -271,25 +271,6 @@ func (s *Store) CountFailedAutoImplement(issueID int64) (int, error) {
 	return n, nil
 }
 
-// CountAutoImplementNoChanges returns how many auto_implement_no_changes rows
-// the issue has accumulated. A successful auto_implement run lands a row with
-// action_taken="auto_implement" and pr_created>0 which the fetcher's
-// "already implemented" branch (fetcher.go) skips before the cap is consulted,
-// so a true success short-circuits the loop without needing a counter reset.
-// The cap exists so the daemon eventually stops re-running an agent that
-// keeps producing empty diffs run after run (#433 — staged loop).
-func (s *Store) CountAutoImplementNoChanges(issueID int64) (int, error) {
-	row := s.db.QueryRow(
-		`SELECT COUNT(*) FROM issue_reviews WHERE issue_id = ? AND action_taken = 'auto_implement_no_changes'`,
-		issueID,
-	)
-	var n int
-	if err := row.Scan(&n); err != nil {
-		return 0, fmt.Errorf("store: count no-changes auto_implement for issue %d: %w", issueID, err)
-	}
-	return n, nil
-}
-
 func scanIssue(s scanner) (*Issue, error) {
 	var i Issue
 	var createdAt, fetchedAt string

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -368,6 +368,12 @@ auto_promote_refinement = true   # unset = true only when develop_labels is conf
 > skip_labels        = ["wontfix", "duplicate", "invalid"]
 > ```
 
+> **When `auto_implement` produces no changes**
+>
+> If the agent runs to completion but leaves the working tree untouched (because the issue lacks enough context, the prompt's "leave untouched if you cannot implement" escape hatch fired, etc.), the daemon reaches a terminal state rather than retrying on every poll. The fallback comment posted on the issue carries a hidden `<!-- heimdallm:done -->` marker so the fetcher's marker scan skips the issue on subsequent ticks. The SSE event surfaced to the UI is `issue_review_error` with `reason: "auto_implement_no_changes"`, rendered as a needs-attention card — not a clean success.
+>
+> To reopen the issue for another auto-implement attempt, post a comment containing `<!-- heimdallm:retry -->` (or remove the develop label to stop here). The retry marker overrides the done marker and forces reprocessing. Issues stored before this behaviour landed (no marker on the comment) keep skipping with reason `auto_implement produced no changes (historical row, no done marker); add retry marker to reprocess` until you post the retry marker manually.
+
 > **Security — `auto_implement` and untrusted issue authors**
 >
 > The body, title, and quoted comments of every processed issue are user-submitted input. When `auto_implement` is enabled, that input becomes part of the prompt sent to an AI CLI with **write access** to the repository checkout. A maliciously crafted issue (the classic "prompt injection" attack) could try to instruct the AI to read sensitive files from the worktree and embed them in the resulting commit.

--- a/docs/superpowers/plans/2026-05-13-issue-483-auto-implement-no-changes-limbo.md
+++ b/docs/superpowers/plans/2026-05-13-issue-483-auto-implement-no-changes-limbo.md
@@ -1,0 +1,165 @@
+# Plan — Issue #483: auto_implement no-changes limbo
+
+Closes `theburrowhub/heimdallm#483`. Three small fixes inside the
+`auto_implement` no-changes fallback path so the issue reaches a
+clean terminal state instead of silently looping in the fetcher.
+
+## Problem statement (verbatim from the issue)
+
+When `auto_implement` runs but the agent produces no changes, the
+daemon posts a fallback comment and stores
+`ActionTaken: "auto_implement_no_changes"` — but does **not** post
+a `MarkerDone` marker. On every subsequent poll, both branches of
+the dedup gate in `fetcher.go:300-317` return `skip=true`, so the
+issue is silently ignored every poll cycle. The log fills with
+"skipping issue" debug entries, the UI shows it stuck in
+"develop" with no activity, and the user gets a "death spiral"
+perception even though the daemon is healthy.
+
+Two related defects:
+
+1. `autoImplementNoChangesFallback` (`pipeline.go:889-925`) omits
+   `MarkerDone` from the comment body. Compare with the success
+   path (`pipeline.go:842-844`) which prepends it.
+2. The dedup gate (`fetcher.go:300-317`) is functionally a
+   no-op: both the cap-exceeded branch and the cap-not-yet-hit
+   branch return `skip=true`. The `MaxAutoImplementNoChanges = 1`
+   cap therefore has no effect — the issue can never be retried
+   automatically without a `MarkerRetry`.
+
+## Current state — evidence
+
+| Concern | Location | Snippet / fact |
+|---|---|---|
+| Marker scan in fetcher | `fetcher.go:269-276` | `ScanMarkers(comments)` is run BEFORE the dedup gate. A `MarkerDone` short-circuits to `(true, "done marker", nil)` immediately. |
+| Success path posts MarkerDone | `pipeline.go:841-844` | `linkBackBody := fmt.Sprintf("%s\n✅ ...", MarkerDone, ...)` |
+| No-changes path does NOT | `pipeline.go:890-896` | `body := fmt.Sprintf("## ⚠️ Heimdallm auto-implement skipped\n\n...")` — no MarkerDone |
+| Dead dedup gate | `fetcher.go:300-317` | Both `if noChangesCount >= MaxAutoImplementNoChanges` and the fall-through return `skip=true`. The cap-check has no behavioural effect. |
+| Cap constant | `fetcher.go:41` | `const MaxAutoImplementNoChanges = 1` |
+| Current SSE emit | `pipeline.go:919-922` | `EventIssueReviewCompleted` with `mode: "auto_implement_no_changes"` — UI renders this as a "completed" success state. |
+| Available event for terminal-needs-attention | `sse/broker.go:21` | `EventIssueReviewError = "issue_review_error"` already exists and the UI renders it as a red/warn state. |
+| Tests touching this surface | `pipeline_test.go:1015-1030`, `fetcher_test.go:500-590` | The pipeline test only asserts `ActionTaken`; the fetcher tests verify the dedup gate as a "skip permanently" path. |
+
+## Design
+
+Three sub-fixes, in TDD order:
+
+### A. Add `MarkerDone` to the fallback comment body
+
+Prepend the marker to the comment body so the fetcher's marker
+scan (which runs before the dedup gate) treats the issue as
+terminal:
+
+```go
+body := fmt.Sprintf(
+    "%s\n## ⚠️ Heimdallm auto-implement skipped\n\n"+
+        "The agent looked at #%d but left the working tree unchanged — it likely needs a human decision or more context than the issue alone provides.\n\n"+
+        "Add a `%s` marker (or remove this marker) and a retry marker (`%s`) to run auto-implementation again, or remove the develop label to stop here.\n\n"+
+        "---\n*auto_implement → review_only fallback · Heimdallm*",
+    MarkerDone, issue.Number, MarkerDone, MarkerRetry,
+)
+```
+
+The marker is invisible in the rendered GitHub comment (HTML
+comment syntax) but visible in raw markdown. After this change:
+
+- New no-changes runs reach the fetcher's marker scan first
+  (`ScanMarkers → MarkerResultDone → skip with "done marker"`)
+  before ever touching the dedup gate.
+- A user who wants to retry adds `MarkerRetry` to a comment;
+  `ScanMarkers` returns `MarkerResultRetry` and the issue is
+  reprocessed (existing behaviour, now actually reachable).
+
+### B. Switch the SSE event from `*ReviewCompleted` to `*ReviewError`
+
+`EventIssueReviewCompleted` is interpreted by the UI as a clean
+success state. A no-changes run is **not** clean: the user needs
+to either supply more context + retry or close the issue. Switch
+to `EventIssueReviewError` so the UI renders it as a
+needs-attention card:
+
+```go
+p.publish(sse.EventIssueReviewError, map[string]any{
+    "issue_id": issueID, "number": issue.Number, "repo": issue.Repo,
+    "reason":   "auto_implement_no_changes",
+    "post_ok":  postErr == nil,
+    "message":  "Agent left the working tree unchanged; add MarkerRetry to retry or close the issue.",
+})
+```
+
+`ActionTaken` in the store stays
+`ActionAutoImplementNoChanges` for back-compat with the existing
+counter logic and Flutter consumers that already read this
+column.
+
+### C. Simplify the now-back-compat dedup gate
+
+After (A), every NEW no-changes run posts `MarkerDone`, so the
+fetcher's marker scan handles the skip. The dedup gate at
+`fetcher.go:300-317` only matters for **historical rows** that
+were written before the fix landed (no MarkerDone in the
+comment, but `ActionTaken: auto_implement_no_changes` in the
+store). Collapse the gate to a single unconditional skip with a
+clearer reason — the cap-based logic was never load-bearing:
+
+```go
+if latest.ActionTaken == ActionAutoImplementNoChanges && issue.Mode == config.IssueModeDevelop {
+    // Back-compat path for rows written before #483's MarkerDone
+    // fix. New no-changes runs are terminated by MarkerDone in
+    // the comment scan above; this block only triggers on legacy
+    // store rows that never got the marker. Add a MarkerRetry
+    // comment to reopen.
+    return true, "auto_implement produced no changes (historical row, no done marker); add retry marker to reprocess", nil
+}
+```
+
+`MaxAutoImplementNoChanges` and `CountAutoImplementNoChanges`
+become unreferenced. Leave the constant for the activity-log
+consumers but stop calling the counter. Open a separate cleanup
+issue if we want to delete the column.
+
+## Tests
+
+| Test | What it pins |
+|---|---|
+| `TestAutoImplementNoChangesFallback_PostsDoneMarker` | The PostComment body contains `MarkerDone` (and `MarkerRetry` as the retry hint). |
+| `TestAutoImplementNoChangesFallback_EmitsReviewError` | The SSE event is `EventIssueReviewError` with `reason="auto_implement_no_changes"`, not `EventIssueReviewCompleted`. |
+| `TestAlreadyProcessed_DoneMarkerSkipsBeforeDedupGate` | A row with `ActionTaken=auto_implement_no_changes` AND `MarkerDone` in comments returns `(true, "done marker", nil)` — proves the marker-first ordering. |
+| `TestAlreadyProcessed_HistoricalNoChangesRow_StillSkipped` | A row with `ActionTaken=auto_implement_no_changes` AND no marker (back-compat) still returns skip with the new historical-row reason. |
+| `TestAlreadyProcessed_RetryMarker_ReprocessesNoChanges` | A row with `ActionTaken=auto_implement_no_changes` AND a `MarkerRetry` in comments returns `(false, "", nil)` — retry path actually reachable now. |
+
+## Implementation order (TDD)
+
+1. **RED+GREEN (A)**: failing test asserts `MarkerDone` in fallback comment body; add the marker.
+2. **RED+GREEN (B)**: failing test asserts `EventIssueReviewError` emission; switch event type + payload.
+3. **RED+GREEN (C)**: failing test asserts retry path becomes reachable for legacy rows once a `MarkerRetry` is posted; collapse the dedup gate.
+4. **Docs**: short note in `configuration-guide.md` near the auto_implement section explaining the new terminal-state semantics and the retry escape hatch.
+
+## Re-entry checklist (post-compact)
+
+1. `cd /Users/imunoz/Projects/ai-platform/heimdallm && git checkout main && git pull --ff-only`
+2. `git checkout -b fix/issue-483-auto-implement-no-changes-limbo`
+3. Read this plan top-to-bottom.
+4. Hot-context files to re-read:
+   - `daemon/internal/issues/pipeline.go` (lines 810–930 for the success + fallback paths)
+   - `daemon/internal/issues/fetcher.go` (lines 240–340 for `alreadyProcessed` + dedup gate)
+   - `daemon/internal/issues/markers.go` (whole file — short)
+   - `daemon/internal/issues/pipeline_test.go` (existing fallback test around line 1015)
+   - `daemon/internal/issues/fetcher_test.go` (existing dedup tests around line 500)
+   - `daemon/internal/sse/broker.go` (event constants)
+5. Start with TDD step 1 (RED test for MarkerDone in fallback body). Use `make test-docker` between every change.
+6. Branch name: `fix/issue-483-auto-implement-no-changes-limbo`. PR opens as **draft**.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Flutter UI doesn't recognise `EventIssueReviewError` with this reason | Event type itself is already handled; the `reason` field is new but Flutter unmarshals open-ended JSON. Worst case: existing red card without specific reason copy. |
+| Activity log queries on `ActionTaken="auto_implement_no_changes"` break if we change it | `ActionTaken` value is unchanged in the store; only the SSE event type changes. |
+| Historical rows in production stores stay stuck even after the fix | The back-compat path explicitly accepts them; user can manually post `MarkerRetry` to reopen. Migration is not in scope (no DB rewrite). |
+
+## Out of scope (follow-ups)
+
+- Delete the `MaxAutoImplementNoChanges` constant and `CountAutoImplementNoChanges` store method once we are confident no legacy rows remain.
+- Flutter-side rendering polish: distinct icon/colour for `reason=auto_implement_no_changes` vs other `*ReviewError` causes.
+- A daemon admin endpoint to bulk-mark historical no-changes rows with `MarkerDone` to clean up old fleet state.

--- a/docs/superpowers/plans/2026-05-13-issue-483-auto-implement-no-changes-limbo.md
+++ b/docs/superpowers/plans/2026-05-13-issue-483-auto-implement-no-changes-limbo.md
@@ -2,10 +2,28 @@
 
 > **Status: DONE.** Landed in PR #488 (2026-05-13). Kept as historical
 > reference alongside other completed plans in this directory; the PR
-> description carries the merge-ready summary. See the PR review for
-> the follow-up polish (marker-collision fix, Flutter `error` payload
-> alignment, `NEEDS ATTENTION` badge, dead-code removal) that landed on
-> top of the original three sub-fixes described below.
+> description carries the merge-ready summary. The body below reflects
+> the original plan written before context-compact and has not been
+> rewritten to match the final shape — three changes shipped that the
+> plan called "follow-up" or did not anticipate, do not treat the
+> snippets below as the implementation spec:
+>
+> - `MaxAutoImplementNoChanges` constant and the
+>   `CountAutoImplementNoChanges` interface + store method were
+>   **deleted** in this PR (the plan parked them as out-of-scope
+>   cleanup).
+> - The SSE payload uses `error` (not `message`), aligning with the
+>   convention of every other `EventIssueReviewError` emitter and the
+>   Flutter renderer.
+> - The fallback body deliberately does **not** embed the literal
+>   `MarkerRetry` token because `ScanMarkers` prioritises Retry over
+>   Done within a single comment; the body references the marker by
+>   keyword and points at the configuration guide instead.
+> - Flutter side: new `AttentionBadge` widget + side-bar tint replace
+>   the misleading green LOW chip on `auto_implement_no_changes` rows
+>   across the dashboard tile/grid, the issues list and the issue
+>   detail review header. `dashboard_providers.dart` also now bumps
+>   `issueListRefreshProvider` on `issue_review_error`.
 
 Closes `theburrowhub/heimdallm#483`. Three small fixes inside the
 `auto_implement` no-changes fallback path so the issue reaches a

--- a/docs/superpowers/plans/2026-05-13-issue-483-auto-implement-no-changes-limbo.md
+++ b/docs/superpowers/plans/2026-05-13-issue-483-auto-implement-no-changes-limbo.md
@@ -1,5 +1,12 @@
 # Plan — Issue #483: auto_implement no-changes limbo
 
+> **Status: DONE.** Landed in PR #488 (2026-05-13). Kept as historical
+> reference alongside other completed plans in this directory; the PR
+> description carries the merge-ready summary. See the PR review for
+> the follow-up polish (marker-collision fix, Flutter `error` payload
+> alignment, `NEEDS ATTENTION` badge, dead-code removal) that landed on
+> top of the original three sub-fixes described below.
+
 Closes `theburrowhub/heimdallm#483`. Three small fixes inside the
 `auto_implement` no-changes fallback path so the issue reaches a
 clean terminal state instead of silently looping in the fetcher.

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -214,6 +214,11 @@ void _handleSseEvent(Ref ref, SseEvent event) {
               .read(reviewingIssuesProvider.notifier)
               .update((s) => s.difference({issueKey}));
         }
+        // Terminal failure — bump the list refresh so the issue's row
+        // re-fetches its latest review state (e.g. the new
+        // auto_implement_no_changes terminal state from #483), matching
+        // the behaviour of the other terminal issue events above.
+        ref.read(issueListRefreshProvider.notifier).update((s) => s + 1);
 
       // ── Circuit breaker ────────────────────────────────────────────────
       case 'circuit_breaker_tripped':

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -728,7 +728,9 @@ class _IssueActivityTileState extends ConsumerState<_IssueActivityTile> {
                   height: 48,
                   margin: const EdgeInsets.only(right: 12),
                   decoration: BoxDecoration(
-                    color: reviewed
+                    color: needsAttention
+                        ? Colors.deepOrange.shade700
+                        : reviewed
                         ? _severityColor(severity)
                         : Colors.grey.shade600,
                     borderRadius: BorderRadius.circular(2),

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/models/pr.dart';
 import '../../core/models/tracked_issue.dart';
 import '../../shared/widgets/keep_alive_tab.dart';
+import '../../shared/widgets/attention_badge.dart';
 import '../../shared/widgets/severity_badge.dart';
 import '../../shared/widgets/state_badge.dart';
 import '../../shared/widgets/toast.dart';
@@ -704,6 +705,12 @@ class _IssueActivityTileState extends ConsumerState<_IssueActivityTile> {
     final issue = widget.issue;
     final reviewed = issue.latestReview != null;
     final severity = issue.latestReview?.severity ?? '';
+    // auto_implement_no_changes is a terminal "needs attention" state —
+    // the review row has an empty triage block (severity defaults to
+    // LOW/green), which would otherwise misrepresent it as a clean low
+    // severity result. See #483.
+    final needsAttention =
+        issue.latestReview?.actionTaken == 'auto_implement_no_changes';
 
     return Opacity(
       opacity: issue.state == 'open' ? 1.0 : 0.6,
@@ -760,7 +767,9 @@ class _IssueActivityTileState extends ConsumerState<_IssueActivityTile> {
                 Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (reviewed)
+                    if (needsAttention)
+                      const AttentionBadge()
+                    else if (reviewed)
                       SeverityBadge(severity: severity)
                     else
                       Container(
@@ -826,6 +835,7 @@ class _ActivityGridTile extends StatelessWidget {
     final String title;
     final String subtitle;
     final String? severity;
+    final bool needsAttention;
     final DateTime timestamp;
 
     switch (item) {
@@ -836,6 +846,7 @@ class _ActivityGridTile extends StatelessWidget {
         title = pr.title;
         subtitle = '${pr.repo} #${pr.number} · ${pr.author}';
         severity = pr.latestReview?.severity;
+        needsAttention = false;
         timestamp = pr.updatedAt;
       case _IssueItem(:final issue):
         final isDev = issue.latestReview?.actionTaken == 'auto_implement';
@@ -844,6 +855,11 @@ class _ActivityGridTile extends StatelessWidget {
         state = issue.state;
         title = issue.title;
         subtitle = '${issue.repo} #${issue.number} · ${issue.author}';
+        // Terminal no-changes rows have an empty triage block — render
+        // them as a NEEDS ATTENTION chip instead of a misleading green
+        // LOW badge (#483).
+        needsAttention =
+            issue.latestReview?.actionTaken == 'auto_implement_no_changes';
         severity = issue.latestReview?.severity;
         timestamp = issue.fetchedAt;
     }
@@ -900,7 +916,10 @@ class _ActivityGridTile extends StatelessWidget {
               const Spacer(),
               Row(
                 children: [
-                  if (severity != null) SeverityBadge(severity: severity),
+                  if (needsAttention)
+                    const AttentionBadge()
+                  else if (severity != null)
+                    SeverityBadge(severity: severity),
                   const Spacer(),
                   Text(
                     _timeAgo(timestamp),

--- a/flutter_app/lib/features/issues/issue_detail_screen.dart
+++ b/flutter_app/lib/features/issues/issue_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../core/models/tracked_issue.dart';
+import '../../shared/widgets/attention_badge.dart';
 import '../../shared/widgets/severity_badge.dart';
 import '../../shared/widgets/toast.dart';
 import '../dashboard/dashboard_providers.dart';
@@ -302,7 +303,10 @@ class _IssueReviewCard extends StatelessWidget {
                   ),
                 ),
                 const Spacer(),
-                SeverityBadge(severity: review.severity),
+                if (review.actionTaken == 'auto_implement_no_changes')
+                  const AttentionBadge()
+                else
+                  SeverityBadge(severity: review.severity),
               ],
             ),
             const SizedBox(height: 8),

--- a/flutter_app/lib/features/issues/issues_screen.dart
+++ b/flutter_app/lib/features/issues/issues_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../core/models/tracked_issue.dart';
 import '../../core/state/local_state_notifier.dart';
+import '../../shared/widgets/attention_badge.dart';
 import '../../shared/widgets/severity_badge.dart';
 import '../../shared/widgets/toast.dart';
 import '../dashboard/dashboard_providers.dart';
@@ -174,6 +175,11 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
     final isReviewing = ref.watch(reviewingIssuesProvider).contains(_reviewKey);
     final isPromoting = ref.watch(promotingIssuesProvider).contains(_reviewKey);
     final severity = issue.latestReview?.severity ?? '';
+    // Terminal no-changes rows have an empty triage block (severity
+    // defaults to LOW/green); render a NEEDS ATTENTION chip instead so
+    // the list signals the row needs human input (#483).
+    final needsAttention =
+        issue.latestReview?.actionTaken == 'auto_implement_no_changes';
     // Promote only when the latest issue artifact represents a stage that has
     // a possible successor in the state machine.
     final canPromote =
@@ -271,6 +277,8 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
                             : Theme.of(context).colorScheme.primary,
                       ),
                     )
+                  else if (needsAttention)
+                    const AttentionBadge()
                   else if (reviewed)
                     SeverityBadge(severity: severity)
                   else

--- a/flutter_app/lib/features/issues/issues_screen.dart
+++ b/flutter_app/lib/features/issues/issues_screen.dart
@@ -205,6 +205,8 @@ class _IssueTileState extends ConsumerState<_IssueTile> {
                 decoration: BoxDecoration(
                   color: isReviewing
                       ? Theme.of(context).colorScheme.primary
+                      : needsAttention
+                      ? Colors.deepOrange.shade700
                       : reviewed
                       ? _severityColor(severity)
                       : Colors.grey.shade600,

--- a/flutter_app/lib/shared/widgets/attention_badge.dart
+++ b/flutter_app/lib/shared/widgets/attention_badge.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+/// AttentionBadge surfaces a non-severity terminal state that a user
+/// needs to look at — currently the only producer is
+/// `auto_implement_no_changes`, where the agent ran to completion but
+/// left the working tree untouched (#483). Rendering the row's stored
+/// severity here would be misleading (the triage block is empty, so it
+/// defaults to LOW/green) and contradicts the SSE event the daemon
+/// publishes alongside the row (`issue_review_error`).
+class AttentionBadge extends StatelessWidget {
+  final String label;
+
+  const AttentionBadge({super.key, this.label = 'NEEDS ATTENTION'});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: Colors.deepOrange.shade700,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes #483.

`auto_implement` runs that produce no changes left the issue in limbo:
the fallback comment lacked `MarkerDone`, so the fetcher's dedup gate
(both branches `skip=true`) silently ignored the issue every poll cycle.

### What changed

- **`MarkerDone` in fallback body** (`pipeline.go`): prepend the done
  marker to the fallback comment so the fetcher's marker scan
  terminates the issue on the next tick. The body references the
  retry marker **by keyword** (`heimdallm:retry`), pointing at the
  configuration guide's `auto_implement` section — the literal token
  cannot appear in the same comment as `MarkerDone` because
  `ScanMarkers` prioritises Retry over Done within a single comment.

- **SSE event** (`pipeline.go`): switch
  `EventIssueReviewCompleted` → `EventIssueReviewError` with
  `reason="auto_implement_no_changes"` and a human `error` field that
  follows the convention of every other `EventIssueReviewError`
  emitter (Flutter's event row + detail toast both read `error`).

- **Dedup gate** (`fetcher.go`): collapse the now-back-compat block to
  a single unconditional skip with a clearer reason for legacy rows
  written before `MarkerDone` landed on the fallback comment. The
  cap-based logic was never load-bearing (both branches returned
  `skip=true`).

- **Dead code removed**: `MaxAutoImplementNoChanges` constant, the
  `CountAutoImplementNoChanges` interface method, the store-level
  query and the `fakeDedup` stub all disappear in this PR — no
  follow-up needed.

- **Flutter UI** (`flutter_app/`): new `AttentionBadge` widget and a
  deep-orange side-bar tint render `auto_implement_no_changes` rows
  as `NEEDS ATTENTION` across the dashboard tile, the activity grid,
  the issues list and the issue-detail review header (otherwise the
  empty triage block would have surfaced them as green LOW).
  `dashboard_providers.dart` also now bumps `issueListRefreshProvider`
  on `issue_review_error`, matching the other terminal issue events.

`ActionTaken` in the store stays `ActionAutoImplementNoChanges` so the
activity-log queries and Flutter consumers that already key off the
column keep working.

Doc note added to `configuration-guide.md` explaining the terminal
state and the retry escape hatch. The plan in
`docs/superpowers/plans/` is committed for historical reference (same
convention as other completed plans in that directory); its body is
the pre-implementation draft and carries an explicit `Status: DONE`
banner noting which decisions changed during execution.

## Test plan
- [x] `TestAutoImplementNoChangesFallback_PostsDoneMarker` (RED → GREEN)
- [x] `TestAutoImplementNoChangesFallback_BodyScansAsDone` — passes the real fallback body through `ScanMarkers` and asserts `MarkerResultDone`, regression pin for the marker-collision draft caught in review
- [x] `TestAutoImplementNoChangesFallback_EmitsReviewError` — asserts the event type, `reason` and `error` fields
- [x] `TestPipeline_AutoImplementNoChangesRecordsTerminalNoChanges` updated to expect `EventIssueReviewError`
- [x] `TestAlreadyProcessed_DoneMarkerSkipsBeforeDedupGate` (marker-first ordering)
- [x] `TestAlreadyProcessed_HistoricalNoChangesRow_StillSkipped` (back-compat path for legacy rows without `MarkerDone`)
- [x] `TestAlreadyProcessed_RetryMarker_ReprocessesNoChanges` (retry escape hatch)
- [x] Deleted `TestFetcher_AutoImplementNoChangesCapStopsLoop` and `TestFetcher_AutoImplementNoChangesCountErrFallsThrough` — they exercised the cap logic that no longer exists
- [x] `make test-docker` green
- [x] `flutter analyze` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)