### PR TITLE
fix(rename): propagate GitHub repo/org renames across daemon state (#489)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -714,6 +714,30 @@ func main() {
 			runTier2(ctx, adapter, limiter, prReviewPublisher, broker, tier2ConfigFn, tier2RepoConcurrencyFn, reposChan, pollInterval, coldStart)
 		}()
 
+		// Repo/org rename probe (#489). Detects when GitHub has
+		// renamed a monitored repo (or its parent org) and dispatches
+		// the reconciler to propagate the new slug across SQLite,
+		// config TOML, in-memory config, and worktrees. Interval "0"
+		// disables — operators can still trigger rename manually via
+		// POST /admin/repo-rename. The probe runs its own goroutine
+		// because its cadence (1h default) is orders of magnitude
+		// longer than Tier 2's, and we want it independent of Tier 2
+		// failures.
+		cfgMu.Lock()
+		renameInterval := parseRenameProbeInterval(cfg.AI.RepoRenameCheckInterval)
+		cfgMu.Unlock()
+		if renameInterval > 0 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				probe := newRenameProbe(ctx, cfg, &cfgMu, ghClient, s, repoCtx, broker, cfgPath, renameInterval)
+				probe.Run(ctx)
+			}()
+			slog.Info("rename probe: started", "interval", renameInterval)
+		} else {
+			slog.Info("rename probe: disabled (ai.repo_rename_check_interval=0)")
+		}
+
 		slog.Info("pollers: started",
 			"discovery", discoveryInterval,
 			"poll", pollInterval)

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -325,9 +325,10 @@ func main() {
 	// Manual rename trigger for POST /admin/repo-rename (#489).
 	// Constructs a one-shot reconciler with the same deps the probe
 	// uses so manual triggers and automatic detection share idempotency
-	// guarantees end-to-end.
+	// guarantees end-to-end. Reuses srv.TOMLMu() so the rewrite races
+	// safely with concurrent PATCH /config writes.
 	srv.SetRepoRenameFn(func(ctx context.Context, oldRepo, newRepo string) error {
-		reconciler := newRenameReconciler(cfg, &cfgMu, s, repoCtx, broker, cfgPath)
+		reconciler := newRenameReconciler(cfg, &cfgMu, srv.TOMLMu(), s, repoCtx, broker, cfgPath)
 		return reconciler.Run(ctx, oldRepo, newRepo)
 	})
 	srv.SetCleanClonesFn(func(ctx context.Context) (int, error) {
@@ -738,7 +739,7 @@ func main() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				probe := newRenameProbe(ctx, cfg, &cfgMu, ghClient, s, repoCtx, broker, cfgPath, renameInterval)
+				probe := newRenameProbe(ctx, cfg, &cfgMu, srv.TOMLMu(), ghClient, s, repoCtx, broker, cfgPath, renameInterval)
 				probe.Run(ctx)
 			}()
 			slog.Info("rename probe: started", "interval", renameInterval)

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -322,6 +322,14 @@ func main() {
 		cfgMu.Unlock()
 		return repoCtx.Purge(ctx, repo, aiCfg.CloneDir)
 	})
+	// Manual rename trigger for POST /admin/repo-rename (#489).
+	// Constructs a one-shot reconciler with the same deps the probe
+	// uses so manual triggers and automatic detection share idempotency
+	// guarantees end-to-end.
+	srv.SetRepoRenameFn(func(ctx context.Context, oldRepo, newRepo string) error {
+		reconciler := newRenameReconciler(cfg, &cfgMu, s, repoCtx, broker, cfgPath)
+		return reconciler.Run(ctx, oldRepo, newRepo)
+	})
 	srv.SetCleanClonesFn(func(ctx context.Context) (int, error) {
 		cfgMu.Lock()
 		cfgSnap := cfg

--- a/daemon/cmd/heimdallm/main_rename.go
+++ b/daemon/cmd/heimdallm/main_rename.go
@@ -14,10 +14,18 @@ import (
 	"github.com/heimdallm/daemon/internal/store"
 )
 
+// minRenameProbeInterval is the lower bound enforced on operator
+// input. Below 1 minute the probe would burn GitHub rate-limit
+// budget (one GET per repo per tick) for no real detection gain —
+// renames are by nature rare events. Misconfigurations get clamped
+// up with an audit-log warn rather than silently honoured.
+const minRenameProbeInterval = time.Minute
+
 // parseRenameProbeInterval parses the operator-facing duration string
 // for `ai.repo_rename_check_interval`. Empty / unparseable falls back
 // to 1h; literal "0" returns 0 so the caller knows the probe is
-// disabled. Returning <= 0 from here is the disable signal.
+// disabled. Returning <= 0 from here is the disable signal. Positive
+// values below minRenameProbeInterval are clamped up.
 func parseRenameProbeInterval(raw string) time.Duration {
 	if raw == "0" {
 		return 0
@@ -30,6 +38,11 @@ func parseRenameProbeInterval(raw string) time.Duration {
 		slog.Warn("rename probe: unparseable interval, falling back to default",
 			"raw", raw, "default", rename.DefaultProbeInterval)
 		return rename.DefaultProbeInterval
+	}
+	if d < minRenameProbeInterval {
+		slog.Warn("rename probe: interval below floor, clamping",
+			"raw", raw, "floor", minRenameProbeInterval)
+		return minRenameProbeInterval
 	}
 	return d
 }

--- a/daemon/cmd/heimdallm/main_rename.go
+++ b/daemon/cmd/heimdallm/main_rename.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/rename"
+	"github.com/heimdallm/daemon/internal/repoctx"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// parseRenameProbeInterval parses the operator-facing duration string
+// for `ai.repo_rename_check_interval`. Empty / unparseable falls back
+// to 1h; literal "0" returns 0 so the caller knows the probe is
+// disabled. Returning <= 0 from here is the disable signal.
+func parseRenameProbeInterval(raw string) time.Duration {
+	if raw == "0" {
+		return 0
+	}
+	if raw == "" {
+		return rename.DefaultProbeInterval
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		slog.Warn("rename probe: unparseable interval, falling back to default",
+			"raw", raw, "default", rename.DefaultProbeInterval)
+		return rename.DefaultProbeInterval
+	}
+	return d
+}
+
+// tomlPersister adapts config.RenameRepoInTOML to rename.Persister so
+// the rename package does not depend on the config package directly
+// (keeps the internal/rename surface small and testable with fakes).
+type tomlPersister struct{}
+
+func (tomlPersister) Rename(path, oldRepo, newRepo string) error {
+	return config.RenameRepoInTOML(path, oldRepo, newRepo)
+}
+
+// renameRepoListFn returns the currently-configured monitored repo
+// set (excluding non_monitored) under cfgMu so the probe observes
+// runtime config reloads.
+func renameRepoListFn(cfg *config.Config, cfgMu *sync.Mutex) func() []string {
+	return func() []string {
+		cfgMu.Lock()
+		defer cfgMu.Unlock()
+		// Probe operates on the explicitly-configured set only —
+		// discovery-only repos are excluded because the probe writes
+		// into config TOML on a rename, and rewriting an entry the
+		// operator never explicitly added would surprise them. The
+		// next discovery cycle re-publishes the canonical name
+		// regardless, so coverage isn't lost.
+		out := make([]string, 0, len(cfg.GitHub.Repositories))
+		out = append(out, cfg.GitHub.Repositories...)
+		return out
+	}
+}
+
+// newRenameProbe constructs the Reconciler + Probe with their real
+// daemon deps. It is invoked once per pollers cycle (re-construction
+// is safe; the probe is goroutine-local), but called from a single
+// goroutine in startPollers so there is no concurrent-construction
+// concern.
+func newRenameProbe(
+	_ context.Context,
+	cfg *config.Config,
+	cfgMu *sync.Mutex,
+	ghClient *gh.Client,
+	s *store.Store,
+	repoCtx *repoctx.Manager,
+	broker *sse.Broker,
+	cfgPath string,
+	interval time.Duration,
+) *rename.Probe {
+	reconciler := newRenameReconciler(cfg, cfgMu, s, repoCtx, broker, cfgPath)
+	return rename.NewProbe(rename.ProbeDeps{
+		Probe:      ghClient,
+		Dispatcher: reconciler,
+		Repos:      renameRepoListFn(cfg, cfgMu),
+		Interval:   interval,
+	})
+}
+
+// newRenameReconciler is the constructor seam that the admin endpoint
+// (step 8) and the probe share — both wire the same dependencies.
+//
+// CloneDir comes from the global AI default rather than per-repo
+// AIForRepo: the rename probe purges the OLD slug whose per-repo
+// override is about to be removed, so reading the global default is
+// the only path that stays valid across the rename. Operators with
+// per-repo CloneDir overrides should rely on next-acquire reclone to
+// repopulate under the new override.
+func newRenameReconciler(
+	cfg *config.Config,
+	cfgMu *sync.Mutex,
+	s *store.Store,
+	repoCtx *repoctx.Manager,
+	broker *sse.Broker,
+	cfgPath string,
+) *rename.Reconciler {
+	cfgMu.Lock()
+	cloneDir := cfg.AI.CloneDir
+	cfgMu.Unlock()
+	if cloneDir == "" {
+		cloneDir = repoctx.DefaultCloneDir()
+	}
+	return rename.NewReconciler(rename.Deps{
+		Store:     s,
+		Persister: tomlPersister{},
+		Purger:    repoCtx,
+		Publisher: broker,
+		CfgMu:     cfgMu,
+		ApplyConfig: func(oldRepo, newRepo string) {
+			cfg.ApplyRename(oldRepo, newRepo)
+		},
+		CfgPath:  cfgPath,
+		CloneDir: cloneDir,
+	})
+}

--- a/daemon/cmd/heimdallm/main_rename.go
+++ b/daemon/cmd/heimdallm/main_rename.go
@@ -71,6 +71,7 @@ func newRenameProbe(
 	_ context.Context,
 	cfg *config.Config,
 	cfgMu *sync.Mutex,
+	tomlMu *sync.Mutex,
 	ghClient *gh.Client,
 	s *store.Store,
 	repoCtx *repoctx.Manager,
@@ -78,7 +79,7 @@ func newRenameProbe(
 	cfgPath string,
 	interval time.Duration,
 ) *rename.Probe {
-	reconciler := newRenameReconciler(cfg, cfgMu, s, repoCtx, broker, cfgPath)
+	reconciler := newRenameReconciler(cfg, cfgMu, tomlMu, s, repoCtx, broker, cfgPath)
 	return rename.NewProbe(rename.ProbeDeps{
 		Probe:      ghClient,
 		Dispatcher: reconciler,
@@ -88,7 +89,9 @@ func newRenameProbe(
 }
 
 // newRenameReconciler is the constructor seam that the admin endpoint
-// (step 8) and the probe share — both wire the same dependencies.
+// (step 8) and the probe share — both wire the same dependencies,
+// including the shared tomlMu that serializes config-TOML writes with
+// the HTTP PATCH handlers (#489 race fix).
 //
 // CloneDir comes from the global AI default rather than per-repo
 // AIForRepo: the rename probe purges the OLD slug whose per-repo
@@ -99,6 +102,7 @@ func newRenameProbe(
 func newRenameReconciler(
 	cfg *config.Config,
 	cfgMu *sync.Mutex,
+	tomlMu *sync.Mutex,
 	s *store.Store,
 	repoCtx *repoctx.Manager,
 	broker *sse.Broker,
@@ -116,6 +120,7 @@ func newRenameReconciler(
 		Purger:    repoCtx,
 		Publisher: broker,
 		CfgMu:     cfgMu,
+		TOMLMu:    tomlMu,
 		ApplyConfig: func(oldRepo, newRepo string) {
 			cfg.ApplyRename(oldRepo, newRepo)
 		},

--- a/daemon/cmd/heimdallm/main_rename_interval_test.go
+++ b/daemon/cmd/heimdallm/main_rename_interval_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/rename"
+)
+
+// TestParseRenameProbeInterval_DisabledByZero pins the operator
+// escape hatch — "0" returns 0 so the wiring in main.go knows to
+// skip starting the probe goroutine entirely.
+func TestParseRenameProbeInterval_DisabledByZero(t *testing.T) {
+	if got := parseRenameProbeInterval("0"); got != 0 {
+		t.Errorf(`parseRenameProbeInterval("0") = %v, want 0 (disabled)`, got)
+	}
+}
+
+// TestParseRenameProbeInterval_EmptyUsesDefault pins the
+// applyDefaults contract: an empty string after config-load means
+// the operator left the knob untouched, so use the default cadence.
+func TestParseRenameProbeInterval_EmptyUsesDefault(t *testing.T) {
+	if got := parseRenameProbeInterval(""); got != rename.DefaultProbeInterval {
+		t.Errorf(`parseRenameProbeInterval("") = %v, want %v`, got, rename.DefaultProbeInterval)
+	}
+}
+
+// TestParseRenameProbeInterval_UnparseableUsesDefault keeps a typo
+// (e.g. "1hour" instead of "1h") from disabling the probe silently.
+func TestParseRenameProbeInterval_UnparseableUsesDefault(t *testing.T) {
+	if got := parseRenameProbeInterval("not a duration"); got != rename.DefaultProbeInterval {
+		t.Errorf(`unparseable input = %v, want %v`, got, rename.DefaultProbeInterval)
+	}
+}
+
+// TestParseRenameProbeInterval_ClampsBelowFloor protects GitHub
+// rate-limit budget against an operator setting an aggressively
+// low interval (e.g. "1s" while debugging). The probe fires one
+// GET per monitored repo per tick; <1m is never the right answer.
+func TestParseRenameProbeInterval_ClampsBelowFloor(t *testing.T) {
+	for _, raw := range []string{"1s", "30s", "59s"} {
+		got := parseRenameProbeInterval(raw)
+		if got != minRenameProbeInterval {
+			t.Errorf(`parseRenameProbeInterval(%q) = %v, want %v (clamped to floor)`,
+				raw, got, minRenameProbeInterval)
+		}
+	}
+}
+
+// TestParseRenameProbeInterval_HonoursValueAtOrAboveFloor pins the
+// non-clamp path so the floor only kicks in for values that need
+// it — operator-specified 1m or above passes through unchanged.
+func TestParseRenameProbeInterval_HonoursValueAtOrAboveFloor(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"1m", time.Minute},
+		{"5m", 5 * time.Minute},
+		{"2h", 2 * time.Hour},
+	}
+	for _, c := range cases {
+		got := parseRenameProbeInterval(c.raw)
+		if got != c.want {
+			t.Errorf(`parseRenameProbeInterval(%q) = %v, want %v`, c.raw, got, c.want)
+		}
+	}
+}

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -395,6 +395,14 @@ type AIConfig struct {
 	// (scheduler.RateLimiter) still throttles network usage.
 	Tier2RepoConcurrency int `toml:"tier2_repo_concurrency"`
 
+	// RepoRenameCheckInterval controls how often the rename probe
+	// queries GitHub for each monitored repo's canonical full_name
+	// to detect a repo or org rename (#489). Empty string falls back
+	// to the daemon default (1h). Setting "0" disables the probe
+	// entirely; operators can still trigger renames manually via
+	// POST /admin/repo-rename.
+	RepoRenameCheckInterval string `toml:"repo_rename_check_interval"`
+
 	// GeneratePRDescription enables LLM-generated PR titles and descriptions
 	// for auto_implement PRs. When true, after the implementation commit,
 	// a second LLM call generates a rich PR description from the diff.
@@ -931,6 +939,10 @@ func (c *Config) applyDefaults() {
 	}
 	if c.AI.Tier2RepoConcurrency == 0 {
 		c.AI.Tier2RepoConcurrency = DefaultTier2RepoConcurrency
+	}
+	// Empty string falls back to 1h. "0" stays "0" — operator-disabled.
+	if c.AI.RepoRenameCheckInterval == "" {
+		c.AI.RepoRenameCheckInterval = "1h"
 	}
 	// Review-state vigilance defaults (#482). The Enabled flag is NOT
 	// touched here — it must stay false unless the operator explicitly

--- a/daemon/internal/config/writer_rename.go
+++ b/daemon/internal/config/writer_rename.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"strings"
+)
+
+// RenameRepoInTOML rewrites the config TOML at `path` to move every
+// reference to `oldRepo` over to `newRepo`. It is the persistence
+// half of the #489 rename pipeline — the in-memory config is updated
+// separately by the reconciler under cfgMu.
+//
+// Surfaces it touches:
+//   - `[github] repositories = [...]` and `non_monitored = [...]`
+//   - `[ai.repos."<oldRepo>"]` → `[ai.repos."<newRepo>"]`
+//   - `[ai.orgs."<oldOrg>"]`   → `[ai.orgs."<newOrg>"]` *only when the
+//     org component differs between old and new* (org rename case).
+//
+// All other keys in the TOML round-trip through `map[string]any` so
+// operator-only sections that the daemon does not model survive the
+// rewrite intact.
+//
+// If `oldRepo` is not present anywhere in the file the function still
+// rewrites the TOML (byte-equivalent content) so callers do not need
+// to special-case the no-op path; this keeps the contract uniform and
+// the audit trail at the SQLite layer authoritative.
+func RenameRepoInTOML(path, oldRepo, newRepo string) error {
+	m, err := ReadTOMLMap(path)
+	if err != nil {
+		return err
+	}
+
+	oldOrg, newOrg := orgOf(oldRepo), orgOf(newRepo)
+
+	// 1. github.repositories / github.non_monitored: rewrite slices in place.
+	if gh, ok := m["github"].(map[string]any); ok {
+		gh["repositories"] = replaceInTOMLList(gh["repositories"], oldRepo, newRepo)
+		gh["non_monitored"] = replaceInTOMLList(gh["non_monitored"], oldRepo, newRepo)
+	}
+
+	// 2. ai.repos.<old> -> ai.repos.<new>.
+	if ai, ok := m["ai"].(map[string]any); ok {
+		if repos, ok := ai["repos"].(map[string]any); ok {
+			if v, has := repos[oldRepo]; has {
+				delete(repos, oldRepo)
+				repos[newRepo] = v
+			}
+		}
+		// 3. ai.orgs.<oldOrg> -> ai.orgs.<newOrg> only when the org changed.
+		if oldOrg != "" && newOrg != "" && oldOrg != newOrg {
+			if orgs, ok := ai["orgs"].(map[string]any); ok {
+				if v, has := orgs[oldOrg]; has {
+					delete(orgs, oldOrg)
+					orgs[newOrg] = v
+				}
+			}
+		}
+	}
+
+	return AtomicWriteTOML(path, m)
+}
+
+// replaceInTOMLList walks a `[]any` of strings and substitutes any
+// match for `old` with `new`, preserving order and length. Returns the
+// input unchanged when it is nil or not a list of strings; the caller
+// must handle the original value type.
+func replaceInTOMLList(raw any, old, new string) any {
+	list, ok := raw.([]any)
+	if !ok {
+		return raw
+	}
+	out := make([]any, len(list))
+	for i, item := range list {
+		if s, ok := item.(string); ok && s == old {
+			out[i] = new
+			continue
+		}
+		out[i] = item
+	}
+	return out
+}
+
+// orgOf returns the owner segment of a `owner/name` slug, or "" when
+// the input is malformed. The reconciler pre-validates inputs against
+// the GitHub canonical response, so this helper is defensive — the
+// empty return collapses the org-rename branch to a no-op.
+func orgOf(repo string) string {
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		return ""
+	}
+	return parts[0]
+}

--- a/daemon/internal/config/writer_rename.go
+++ b/daemon/internal/config/writer_rename.go
@@ -90,3 +90,45 @@ func orgOf(repo string) string {
 	}
 	return parts[0]
 }
+
+// ApplyRename mutates the in-memory Config in place to reflect a
+// repo rename `oldRepo`→`newRepo`. The caller must hold cfgMu while
+// invoking this — every running goroutine that reads cfg.GitHub.* or
+// cfg.AI.Repos / cfg.AI.Orgs takes cfgMu, so the mutation is safe
+// only when serialised with those readers.
+//
+// Mirror of RenameRepoInTOML's surface coverage: Repositories,
+// NonMonitored, AI.Repos[<repo>], and AI.Orgs[<org>] when the org
+// component changed between old and new.
+func (c *Config) ApplyRename(oldRepo, newRepo string) {
+	c.GitHub.Repositories = replaceInStringSlice(c.GitHub.Repositories, oldRepo, newRepo)
+	c.GitHub.NonMonitored = replaceInStringSlice(c.GitHub.NonMonitored, oldRepo, newRepo)
+	if c.AI.Repos != nil {
+		if v, ok := c.AI.Repos[oldRepo]; ok {
+			delete(c.AI.Repos, oldRepo)
+			c.AI.Repos[newRepo] = v
+		}
+	}
+	oldOrg, newOrg := orgOf(oldRepo), orgOf(newRepo)
+	if oldOrg != "" && newOrg != "" && oldOrg != newOrg && c.AI.Orgs != nil {
+		if v, ok := c.AI.Orgs[oldOrg]; ok {
+			delete(c.AI.Orgs, oldOrg)
+			c.AI.Orgs[newOrg] = v
+		}
+	}
+}
+
+func replaceInStringSlice(in []string, old, new string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]string, len(in))
+	for i, s := range in {
+		if s == old {
+			out[i] = new
+		} else {
+			out[i] = s
+		}
+	}
+	return out
+}

--- a/daemon/internal/config/writer_rename.go
+++ b/daemon/internal/config/writer_rename.go
@@ -23,6 +23,21 @@ import (
 // rewrites the TOML (byte-equivalent content) so callers do not need
 // to special-case the no-op path; this keeps the contract uniform and
 // the audit trail at the SQLite layer authoritative.
+//
+// LIMITATIONS — the rewrite goes through BurntSushi/toml's
+// `map[string]any` round-trip, which is lossy for surface details
+// that have no representation in the decoded map:
+//   - Comments anywhere in the file are dropped.
+//   - Key order inside a table is determined by the encoder, not by
+//     the original on-disk order.
+//   - Blank lines between sections are not preserved.
+//
+// This matches the behaviour of every other path in the daemon that
+// writes config.toml (PATCH /config and friends all go through
+// AtomicWriteTOML with the same round-trip). Operators relying on
+// hand-formatted comments should keep a separate copy or pin them
+// in a comment block that the daemon does not parse — there is no
+// `# heimdallm:` magic that survives the rewrite today.
 func RenameRepoInTOML(path, oldRepo, newRepo string) error {
 	m, err := ReadTOMLMap(path)
 	if err != nil {

--- a/daemon/internal/config/writer_rename_test.go
+++ b/daemon/internal/config/writer_rename_test.go
@@ -176,6 +176,61 @@ implement_prompt = "fast"
 	}
 }
 
+// TestConfig_ApplyRename_AllSurfaces pins the in-memory mutation
+// contract that complements RenameRepoInTOML on disk. The reconciler
+// invokes both under cfgMu so they must agree on which fields move.
+func TestConfig_ApplyRename_AllSurfaces(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.Repositories = []string{"foo/bar", "acme/old", "x/y"}
+	cfg.GitHub.NonMonitored = []string{"acme/old", "z/z"}
+	cfg.AI.Repos = map[string]config.RepoAI{
+		"acme/old": {Primary: "claude"},
+		"foo/bar":  {Primary: "gemini"},
+	}
+	cfg.AI.Orgs = map[string]config.OrgAI{
+		"acme": {IssuePrompt: "org-default"},
+	}
+
+	// Org rename: acme/old → widget/api flips BOTH the repo key and
+	// the parent org key.
+	cfg.ApplyRename("acme/old", "widget/api")
+
+	wantRepos := []string{"foo/bar", "widget/api", "x/y"}
+	if !reflect.DeepEqual(cfg.GitHub.Repositories, wantRepos) {
+		t.Errorf("Repositories = %v, want %v", cfg.GitHub.Repositories, wantRepos)
+	}
+	wantNon := []string{"widget/api", "z/z"}
+	if !reflect.DeepEqual(cfg.GitHub.NonMonitored, wantNon) {
+		t.Errorf("NonMonitored = %v, want %v", cfg.GitHub.NonMonitored, wantNon)
+	}
+	if _, has := cfg.AI.Repos["acme/old"]; has {
+		t.Error("AI.Repos still keyed on acme/old after rename")
+	}
+	if _, has := cfg.AI.Repos["widget/api"]; !has {
+		t.Error("AI.Repos missing widget/api after rename")
+	}
+	if _, has := cfg.AI.Orgs["acme"]; has {
+		t.Error("AI.Orgs still keyed on acme after org rename")
+	}
+	if _, has := cfg.AI.Orgs["widget"]; !has {
+		t.Error("AI.Orgs missing widget after org rename")
+	}
+}
+
+// TestConfig_ApplyRename_SameOrgLeavesOrgsMap pins the org-not-changed
+// path: a within-org rename must NOT touch AI.Orgs at all.
+func TestConfig_ApplyRename_SameOrgLeavesOrgsMap(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.AI.Repos = map[string]config.RepoAI{"acme/old": {Primary: "claude"}}
+	cfg.AI.Orgs = map[string]config.OrgAI{"acme": {IssuePrompt: "p"}}
+
+	cfg.ApplyRename("acme/old", "acme/new")
+
+	if _, has := cfg.AI.Orgs["acme"]; !has {
+		t.Error("AI.Orgs[acme] dropped on within-org rename")
+	}
+}
+
 func toStringSlice(v any) []string {
 	if v == nil {
 		return nil

--- a/daemon/internal/config/writer_rename_test.go
+++ b/daemon/internal/config/writer_rename_test.go
@@ -247,4 +247,3 @@ func toStringSlice(v any) []string {
 	}
 	return out
 }
-

--- a/daemon/internal/config/writer_rename_test.go
+++ b/daemon/internal/config/writer_rename_test.go
@@ -1,0 +1,195 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/config"
+)
+
+// writeConfigFile writes contents to a temp config path and returns it.
+// Each test gets its own t.TempDir so the AtomicWriteTOML rename never
+// clobbers another fixture.
+func writeConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func readBack(t *testing.T, path string) map[string]any {
+	t.Helper()
+	m, err := config.ReadTOMLMap(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	return m
+}
+
+func TestRenameRepoInTOML_RenamesAIRepoKey(t *testing.T) {
+	path := writeConfigFile(t, `
+[ai]
+
+[ai.repos."acme/old"]
+issue_prompt = "issue-deep"
+implement_prompt = "impl-fast"
+`)
+
+	if err := config.RenameRepoInTOML(path, "acme/old", "acme/new"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	m := readBack(t, path)
+	ai := m["ai"].(map[string]any)
+	repos := ai["repos"].(map[string]any)
+	if _, has := repos["acme/old"]; has {
+		t.Error("old key still present")
+	}
+	newBlock, ok := repos["acme/new"].(map[string]any)
+	if !ok {
+		t.Fatalf("new key missing or wrong type: %T", repos["acme/new"])
+	}
+	if newBlock["issue_prompt"] != "issue-deep" || newBlock["implement_prompt"] != "impl-fast" {
+		t.Errorf("values not preserved across rename: %+v", newBlock)
+	}
+}
+
+func TestRenameRepoInTOML_UpdatesRepositoriesList(t *testing.T) {
+	path := writeConfigFile(t, `
+[github]
+repositories = ["foo/bar", "acme/old", "x/y"]
+`)
+
+	if err := config.RenameRepoInTOML(path, "acme/old", "acme/new"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	m := readBack(t, path)
+	gh := m["github"].(map[string]any)
+	got := toStringSlice(gh["repositories"])
+	want := []string{"foo/bar", "acme/new", "x/y"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("repositories = %v, want %v (order preserved)", got, want)
+	}
+}
+
+func TestRenameRepoInTOML_UpdatesNonMonitoredList(t *testing.T) {
+	path := writeConfigFile(t, `
+[github]
+non_monitored = ["a/b", "acme/old", "c/d"]
+`)
+
+	if err := config.RenameRepoInTOML(path, "acme/old", "acme/new"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	got := toStringSlice(readBack(t, path)["github"].(map[string]any)["non_monitored"])
+	want := []string{"a/b", "acme/new", "c/d"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("non_monitored = %v, want %v", got, want)
+	}
+}
+
+func TestRenameRepoInTOML_PreservesUnrelatedTopLevelKeys(t *testing.T) {
+	path := writeConfigFile(t, `
+[github]
+repositories = ["acme/old"]
+
+[ai.repos."acme/old"]
+issue_prompt = "p"
+
+[operator_custom]
+totally_not_modeled = "value-that-must-survive"
+nested_count = 7
+`)
+
+	if err := config.RenameRepoInTOML(path, "acme/old", "acme/new"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	m := readBack(t, path)
+	custom, ok := m["operator_custom"].(map[string]any)
+	if !ok {
+		t.Fatalf("operator_custom dropped or wrong type: %T", m["operator_custom"])
+	}
+	if custom["totally_not_modeled"] != "value-that-must-survive" {
+		t.Errorf("custom string lost: %+v", custom)
+	}
+	// TOML integers come back as int64 via the BurntSushi decoder.
+	if n, _ := custom["nested_count"].(int64); n != 7 {
+		t.Errorf("custom int lost: %+v", custom)
+	}
+}
+
+func TestRenameRepoInTOML_NoOpWhenOldAbsent(t *testing.T) {
+	path := writeConfigFile(t, `
+[github]
+repositories = ["foo/bar"]
+`)
+
+	if err := config.RenameRepoInTOML(path, "acme/old", "acme/new"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	got := toStringSlice(readBack(t, path)["github"].(map[string]any)["repositories"])
+	if !reflect.DeepEqual(got, []string{"foo/bar"}) {
+		t.Errorf("repositories perturbed by no-op: %v", got)
+	}
+}
+
+func TestRenameRepoInTOML_RenamesAIOrgKeyWhenOrgChanged(t *testing.T) {
+	// Org rename: every repo under acme flips to widget. The
+	// reconciler invokes RenameRepoInTOML once per repo; the org map
+	// key must also move when the org component differs.
+	path := writeConfigFile(t, `
+[ai.orgs."acme"]
+issue_prompt = "org-default"
+
+[ai.repos."acme/api"]
+implement_prompt = "fast"
+`)
+
+	if err := config.RenameRepoInTOML(path, "acme/api", "widget/api"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	m := readBack(t, path)
+	ai := m["ai"].(map[string]any)
+	orgs, _ := ai["orgs"].(map[string]any)
+	if orgs == nil {
+		t.Fatal("ai.orgs section dropped")
+	}
+	if _, has := orgs["acme"]; has {
+		t.Error("old org key still present after org rename")
+	}
+	widget, ok := orgs["widget"].(map[string]any)
+	if !ok {
+		t.Fatalf("new org key missing: %+v", orgs)
+	}
+	if widget["issue_prompt"] != "org-default" {
+		t.Errorf("org values not preserved: %+v", widget)
+	}
+}
+
+func toStringSlice(v any) []string {
+	if v == nil {
+		return nil
+	}
+	raw, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		if s, ok := e.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+

--- a/daemon/internal/github/canonical.go
+++ b/daemon/internal/github/canonical.go
@@ -1,0 +1,44 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// GetCanonicalFullName returns the current canonical `owner/name` for
+// the repository at `repo`. GitHub transparently 301s the API when a
+// repo has been renamed, and the JSON response carries the fresh
+// `full_name` regardless of which slug the request used, so this is a
+// one-shot rename detector with no special redirect handling needed.
+//
+// Callers compare the result to the input: when they differ, dispatch
+// the rename reconciler. A 404 (returned as *APIError with
+// StatusCode=404) means the repo was deleted, not renamed, and is
+// handled separately by the caller (typically a "repo unreachable"
+// SSE event, not a rename).
+func (c *Client) GetCanonicalFullName(repo string) (string, error) {
+	resp, err := c.do("GET", "/repos/"+repo, "application/vnd.github+json")
+	if err != nil {
+		return "", fmt.Errorf("github: get canonical full_name: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if resp.StatusCode != http.StatusOK {
+		return "", &APIError{
+			StatusCode: resp.StatusCode,
+			Body:       safeTruncate(string(body), maxErrBodyLen),
+		}
+	}
+	var out struct {
+		FullName string `json:"full_name"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", fmt.Errorf("github: decode canonical full_name: %w", err)
+	}
+	if out.FullName == "" {
+		return "", fmt.Errorf("github: canonical full_name empty for %q", repo)
+	}
+	return out.FullName, nil
+}

--- a/daemon/internal/github/canonical_test.go
+++ b/daemon/internal/github/canonical_test.go
@@ -1,0 +1,59 @@
+package github_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+// TestGetCanonicalFullName_ReturnsNewSlug pins the contract used by the
+// rename probe (#489): calling GET /repos/{owner}/{repo} against the OLD
+// slug returns the canonical, current `full_name` because GitHub
+// transparently 301s the request and the upstream JSON always carries
+// the up-to-date name. Detection is then a simple string compare.
+func TestGetCanonicalFullName_ReturnsNewSlug(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/acme/old" {
+			t.Errorf("path = %q, want /repos/acme/old", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"full_name":"acme/new","name":"new","owner":{"login":"acme"}}`))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, err := c.GetCanonicalFullName("acme/old")
+	if err != nil {
+		t.Fatalf("GetCanonicalFullName: %v", err)
+	}
+	if got != "acme/new" {
+		t.Errorf("canonical = %q, want acme/new", got)
+	}
+}
+
+// TestGetCanonicalFullName_404_PropagatesAPIError ensures a deleted-repo
+// response is distinguishable from a rename: callers treat *APIError
+// with StatusCode=404 as "repo unreachable", which routes to a separate
+// SSE event instead of the rename reconciler.
+func TestGetCanonicalFullName_404_PropagatesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	_, err := c.GetCanonicalFullName("acme/gone")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+	var apiErr *gh.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode = %d, want 404", apiErr.StatusCode)
+	}
+}

--- a/daemon/internal/rename/integration_test.go
+++ b/daemon/internal/rename/integration_test.go
@@ -1,0 +1,142 @@
+package rename_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/rename"
+)
+
+// TestProbe_RecoversAcrossTicksWhenPersisterFails is the end-to-end
+// regression test for the partial-failure recovery contract (#489
+// review feedback). It does NOT call Reconciler.Run directly — it
+// drives two real Probe.Tick invocations against a shared Reconciler
+// and verifies the daemon's normal probe loop converges after the
+// persister recovers, mirroring the in-process flow.
+//
+// Pre-fix bugs this test pins:
+//
+//  1. Mutating in-memory config BEFORE the persister means
+//     Probe.Repos() returns the new slug on the second tick → no
+//     mismatch → no Run dispatch → state stuck.
+//  2. Returning early on store.applied=false skips downstream on the
+//     second tick even if it does dispatch.
+//
+// The fix is the combination of (a) reversing ApplyConfig + Persister
+// ordering and (b) removing the applied=false short-circuit.
+func TestProbe_RecoversAcrossTicksWhenPersisterFails(t *testing.T) {
+	// In-memory cfg.Repositories shadow. ApplyConfig mutates it
+	// under reposMu, Repos() reads it under the same mutex — the
+	// real wiring uses cfgMu identically.
+	var reposMu sync.Mutex
+	repos := []string{"acme/old"}
+
+	applyConfig := func(oldRepo, newRepo string) {
+		// Caller already holds reposMu (passed as CfgMu).
+		for i, r := range repos {
+			if r == oldRepo {
+				repos[i] = newRepo
+			}
+		}
+	}
+	reposFn := func() []string {
+		reposMu.Lock()
+		defer reposMu.Unlock()
+		out := make([]string, len(repos))
+		copy(out, repos)
+		return out
+	}
+
+	store := &fakeStore{applied: true}
+	persister := &fakePersister{err: errors.New("disk full")}
+	purger := &fakePurger{}
+	publisher := &fakePublisher{}
+
+	rec := rename.NewReconciler(rename.Deps{
+		Store:       store,
+		Persister:   persister,
+		Purger:      purger,
+		Publisher:   publisher,
+		CfgMu:       &reposMu,
+		TOMLMu:      &sync.Mutex{},
+		ApplyConfig: applyConfig,
+		CfgPath:     "/tmp/test/config.toml",
+		CloneDir:    "/tmp/test/clones",
+	})
+
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/old": {canonical: "acme/new"},
+			"acme/new": {canonical: "acme/new"},
+		},
+	}
+	probe := rename.NewProbe(rename.ProbeDeps{
+		Probe:      canonical,
+		Dispatcher: rec,
+		Repos:      reposFn,
+	})
+
+	// ─── Tick #1: persister fails ─────────────────────────────────
+	probe.Tick(context.Background())
+
+	reposMu.Lock()
+	current := append([]string(nil), repos...)
+	reposMu.Unlock()
+	if len(current) != 1 || current[0] != "acme/old" {
+		t.Fatalf("after tick #1 with persister failure: repos = %v, want [acme/old] — in-memory mutation must not happen when the persister fails or the probe loses the mismatch signal", current)
+	}
+	if publisher.calls != 0 {
+		t.Errorf("after tick #1: SSE fired %d times, want 0", publisher.calls)
+	}
+	if purger.calls != 0 {
+		t.Errorf("after tick #1: purger called %d times, want 0", purger.calls)
+	}
+
+	// ─── Recovery: simulate the persister coming back, and the store
+	// idempotency guard returning applied=false because the audit row
+	// from tick #1 is still on record. ──────────────────────────────
+	persister.err = nil
+	store.applied = false
+
+	// ─── Tick #2: probe re-observes the old slug (in-memory still
+	// unmutated), re-dispatches Run, and the full downstream now
+	// completes — converging the state. ─────────────────────────────
+	probe.Tick(context.Background())
+
+	reposMu.Lock()
+	current = append([]string(nil), repos...)
+	reposMu.Unlock()
+	if len(current) != 1 || current[0] != "acme/new" {
+		t.Fatalf("after tick #2 recovery: repos = %v, want [acme/new]", current)
+	}
+	if purger.calls != 1 {
+		t.Errorf("after tick #2: purger.calls = %d, want 1", purger.calls)
+	}
+	if publisher.calls != 1 {
+		t.Errorf("after tick #2: publisher.calls = %d, want 1", publisher.calls)
+	}
+	if !strings.Contains(publisher.events[0].Data, `"new_repo":"acme/new"`) {
+		t.Errorf("recovery SSE payload: %s", publisher.events[0].Data)
+	}
+
+	// ─── Tick #3: state is now settled. Probe sees the new slug,
+	// canonical(new) == new, no mismatch, no dispatch, no further
+	// side effects. This is the steady-state property the
+	// applied=false guard used to enforce (incorrectly, by eating
+	// every downstream call). Now it falls out of the probe's
+	// canonical-name compare. ───────────────────────────────────────
+	probe.Tick(context.Background())
+
+	if publisher.calls != 1 {
+		t.Errorf("after tick #3: SSE storm — publisher.calls = %d, want 1 (probe must not redispatch when canonical matches)", publisher.calls)
+	}
+	if purger.calls != 1 {
+		t.Errorf("after tick #3: purger.calls = %d, want 1", purger.calls)
+	}
+	if store.calls != 2 {
+		t.Errorf("after tick #3: store.calls = %d, want 2 (one per tick that dispatched; tick #3 should not have dispatched)", store.calls)
+	}
+}

--- a/daemon/internal/rename/probe.go
+++ b/daemon/internal/rename/probe.go
@@ -93,7 +93,16 @@ func (p *Probe) Tick(ctx context.Context) {
 // is synchronous — a single slow GET (canonical lookup of one repo)
 // is bounded by the GitHub client timeout, so a stuck tick cannot
 // stack up beyond one interval window.
+//
+// Fires one Tick immediately on start so the daemon detects renames
+// that happened while it was offline without waiting a full
+// interval (default 1h) — operator-visible latency after a restart
+// would otherwise be unbounded by the probe cadence alone.
 func (p *Probe) Run(ctx context.Context) {
+	p.Tick(ctx)
+	if ctx.Err() != nil {
+		return
+	}
 	ticker := time.NewTicker(p.deps.Interval)
 	defer ticker.Stop()
 	for {

--- a/daemon/internal/rename/probe.go
+++ b/daemon/internal/rename/probe.go
@@ -1,0 +1,107 @@
+package rename
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+// DefaultProbeInterval is the cadence the rename probe uses when the
+// operator did not configure `ai.repo_rename_check_interval`. Renames
+// are rare events; an hour is the right tradeoff between detection
+// latency and GitHub rate-limit consumption (one GET per repo per
+// tick).
+const DefaultProbeInterval = time.Hour
+
+// CanonicalProbe wraps the single GitHub call the probe needs.
+// *github.Client satisfies it via GetCanonicalFullName.
+type CanonicalProbe interface {
+	GetCanonicalFullName(repo string) (string, error)
+}
+
+// Dispatcher hides the heavy Reconciler behind a one-method interface
+// so the probe can be tested without constructing every reconciler
+// dep. *Reconciler satisfies it.
+type Dispatcher interface {
+	Run(ctx context.Context, oldRepo, newRepo string) error
+}
+
+// ProbeDeps configures the Probe. Repos is a function (not a slice)
+// because the monitored repository set can change at runtime — the
+// probe must observe the current list on every tick.
+type ProbeDeps struct {
+	Probe      CanonicalProbe
+	Dispatcher Dispatcher
+	Repos      func() []string
+
+	// Interval defaults to DefaultProbeInterval when zero.
+	Interval time.Duration
+}
+
+// Probe periodically asks GitHub for the canonical full_name of each
+// monitored repo and dispatches the rename reconciler on a mismatch.
+type Probe struct {
+	deps ProbeDeps
+}
+
+// NewProbe constructs a Probe ready to Tick or Run.
+func NewProbe(deps ProbeDeps) *Probe {
+	if deps.Interval <= 0 {
+		deps.Interval = DefaultProbeInterval
+	}
+	return &Probe{deps: deps}
+}
+
+// Tick performs one iteration: probe every repo currently in the
+// monitored set, dispatch the reconciler for each mismatch. Errors
+// from GitHub (404, transport) skip the repo for this tick without
+// failing the whole iteration — the probe is best-effort and the
+// next tick retries naturally.
+func (p *Probe) Tick(ctx context.Context) {
+	repos := p.deps.Repos()
+	for _, repo := range repos {
+		if ctx.Err() != nil {
+			return
+		}
+		canonical, err := p.deps.Probe.GetCanonicalFullName(repo)
+		if err != nil {
+			var apiErr *gh.APIError
+			if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+				slog.Info("rename probe: repo unreachable (404)", "repo", repo)
+				continue
+			}
+			slog.Debug("rename probe: canonical lookup failed",
+				"repo", repo, "err", err)
+			continue
+		}
+		if canonical == "" || canonical == repo {
+			continue
+		}
+		slog.Info("rename probe: detected rename",
+			"old_repo", repo, "new_repo", canonical)
+		if err := p.deps.Dispatcher.Run(ctx, repo, canonical); err != nil {
+			slog.Error("rename probe: dispatcher failed",
+				"old_repo", repo, "new_repo", canonical, "err", err)
+		}
+	}
+}
+
+// Run drives the probe at deps.Interval until ctx is done. Each Tick
+// is synchronous — a single slow GET (canonical lookup of one repo)
+// is bounded by the GitHub client timeout, so a stuck tick cannot
+// stack up beyond one interval window.
+func (p *Probe) Run(ctx context.Context) {
+	ticker := time.NewTicker(p.deps.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.Tick(ctx)
+		}
+	}
+}

--- a/daemon/internal/rename/probe_test.go
+++ b/daemon/internal/rename/probe_test.go
@@ -1,0 +1,149 @@
+package rename_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/rename"
+)
+
+// fakeCanonical is the GH-side dep for the probe: for each `repo`
+// queried, returns either canonical, err. Keyed by the input slug.
+type fakeCanonical struct {
+	results map[string]canonicalResult
+	calls   int
+	mu      sync.Mutex
+}
+
+type canonicalResult struct {
+	canonical string
+	err       error
+}
+
+func (f *fakeCanonical) GetCanonicalFullName(repo string) (string, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	r := f.results[repo]
+	return r.canonical, r.err
+}
+
+// fakeDispatcher records reconciler invocations so the test can pin
+// which (old, new) pairs the probe dispatched. Concrete *Reconciler
+// is too heavy to construct in a probe test; the Dispatcher interface
+// keeps the probe loosely coupled.
+type fakeDispatcher struct {
+	calls    int
+	gotPairs [][2]string
+	err      error
+}
+
+func (f *fakeDispatcher) Run(_ context.Context, oldRepo, newRepo string) error {
+	f.calls++
+	f.gotPairs = append(f.gotPairs, [2]string{oldRepo, newRepo})
+	return f.err
+}
+
+func newProbe(t *testing.T, canonical *fakeCanonical, dispatcher *fakeDispatcher,
+	repos []string,
+) *rename.Probe {
+	t.Helper()
+	return rename.NewProbe(rename.ProbeDeps{
+		Probe:      canonical,
+		Dispatcher: dispatcher,
+		Repos:      func() []string { return repos },
+	})
+}
+
+func TestRenameProbe_DispatchesReconcilerOnMismatch(t *testing.T) {
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/old": {canonical: "acme/new"},
+		},
+	}
+	dispatcher := &fakeDispatcher{}
+	p := newProbe(t, canonical, dispatcher, []string{"acme/old"})
+
+	p.Tick(context.Background())
+
+	if dispatcher.calls != 1 {
+		t.Fatalf("dispatcher.calls = %d, want 1", dispatcher.calls)
+	}
+	if dispatcher.gotPairs[0] != [2]string{"acme/old", "acme/new"} {
+		t.Errorf("dispatched pair = %v, want (acme/old, acme/new)", dispatcher.gotPairs[0])
+	}
+}
+
+func TestRenameProbe_NoOpWhenCanonicalMatches(t *testing.T) {
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/foo": {canonical: "acme/foo"},
+			"acme/bar": {canonical: "acme/bar"},
+		},
+	}
+	dispatcher := &fakeDispatcher{}
+	p := newProbe(t, canonical, dispatcher, []string{"acme/foo", "acme/bar"})
+
+	p.Tick(context.Background())
+
+	if dispatcher.calls != 0 {
+		t.Errorf("dispatcher.calls = %d, want 0 (no mismatches)", dispatcher.calls)
+	}
+	if canonical.calls != 2 {
+		t.Errorf("canonical.calls = %d, want 2 (one per repo)", canonical.calls)
+	}
+}
+
+func TestRenameProbe_404FromGH_DoesNotDispatch(t *testing.T) {
+	// A 404 means the repo was deleted, not renamed. The probe MUST
+	// NOT dispatch the reconciler (renaming to "" would corrupt the
+	// store + config). Out-of-scope for this PR: emitting a separate
+	// "repo unreachable" SSE event; for now the probe logs and skips.
+	apiErr := &gh.APIError{StatusCode: http.StatusNotFound, Body: "Not Found"}
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/gone":      {err: apiErr},
+			"acme/healthy":   {canonical: "acme/healthy"},
+			"acme/renamed":   {canonical: "acme/new-name"},
+		},
+	}
+	dispatcher := &fakeDispatcher{}
+	p := newProbe(t, canonical, dispatcher,
+		[]string{"acme/gone", "acme/healthy", "acme/renamed"})
+
+	p.Tick(context.Background())
+
+	// Only the actual rename triggers a dispatch; the 404 and the
+	// match are skipped.
+	if dispatcher.calls != 1 {
+		t.Fatalf("dispatcher.calls = %d, want 1", dispatcher.calls)
+	}
+	if dispatcher.gotPairs[0] != [2]string{"acme/renamed", "acme/new-name"} {
+		t.Errorf("dispatched pair = %v, want (acme/renamed, acme/new-name)", dispatcher.gotPairs[0])
+	}
+}
+
+// TestRenameProbe_NonAPIError_DoesNotDispatch belt-and-braces: a
+// generic (network) error from GitHub also must not trigger a rename.
+// The plan only spells out three tests but this one falls naturally
+// out of the same defensive guard, so it tags along to lock the
+// invariant. Kept light to honour "tests pin behaviour, not coverage".
+func TestRenameProbe_NonAPIError_DoesNotDispatch(t *testing.T) {
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/flaky": {err: errors.New("connection reset")},
+		},
+	}
+	dispatcher := &fakeDispatcher{}
+	p := newProbe(t, canonical, dispatcher, []string{"acme/flaky"})
+
+	p.Tick(context.Background())
+
+	if dispatcher.calls != 0 {
+		t.Errorf("dispatcher.calls = %d, want 0 on transport error", dispatcher.calls)
+	}
+}

--- a/daemon/internal/rename/probe_test.go
+++ b/daemon/internal/rename/probe_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	gh "github.com/heimdallm/daemon/internal/github"
 	"github.com/heimdallm/daemon/internal/rename"
@@ -124,6 +125,62 @@ func TestRenameProbe_404FromGH_DoesNotDispatch(t *testing.T) {
 	}
 	if dispatcher.gotPairs[0] != [2]string{"acme/renamed", "acme/new-name"} {
 		t.Errorf("dispatched pair = %v, want (acme/renamed, acme/new-name)", dispatcher.gotPairs[0])
+	}
+}
+
+// TestRenameProbe_Run_FiresInitialTickBeforeIntervalElapses pins
+// the "no offline-rename blind spot after restart" invariant: the
+// first Tick runs immediately on Run start, not after one interval
+// window. Without this, a rename that happened while the daemon
+// was down sat undetected for up to `Interval` (default 1h) after
+// the next start.
+func TestRenameProbe_Run_FiresInitialTickBeforeIntervalElapses(t *testing.T) {
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/old": {canonical: "acme/new"},
+		},
+	}
+	dispatcher := &fakeDispatcher{}
+	// Interval far longer than the test wait — any dispatch in the
+	// test window must come from the initial Tick, not the loop.
+	p := rename.NewProbe(rename.ProbeDeps{
+		Probe:      canonical,
+		Dispatcher: dispatcher,
+		Repos:      func() []string { return []string{"acme/old"} },
+		Interval:   time.Hour,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.Run(ctx)
+		close(done)
+	}()
+
+	// Poll for the dispatch caused by the initial Tick. Generous
+	// budget so a slow CI host doesn't false-flag, but well below
+	// the 1h interval that the loop tick would need.
+	deadline := time.After(2 * time.Second)
+	for {
+		canonical.mu.Lock()
+		calls := canonical.calls
+		canonical.mu.Unlock()
+		if calls >= 1 && dispatcher.calls >= 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("initial tick did not fire within budget: canonical.calls=%d, dispatcher.calls=%d",
+				calls, dispatcher.calls)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
 	}
 }
 

--- a/daemon/internal/rename/reconciler.go
+++ b/daemon/internal/rename/reconciler.go
@@ -1,0 +1,173 @@
+// Package rename owns the cross-subsystem reconciliation that runs
+// when a GitHub repository or its parent organisation is renamed.
+//
+// The detection probe (Tier 2 / Tier 4) calls Reconciler.Run on a
+// mismatch between the configured slug and GitHub's canonical
+// `full_name`. The reconciler then propagates the new slug through
+// every surface that keys on `owner/name`: the SQLite store, the
+// in-memory config, the on-disk TOML, the on-disk worktree, and the
+// SSE event stream that wakes Flutter.
+//
+// See `docs/superpowers/plans/2026-05-14-issue-489-repo-org-rename.md`
+// for the full design.
+package rename
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/heimdallm/daemon/internal/sse"
+)
+
+// ErrInvalidRepoSlug is returned by Run when either slug is empty,
+// identical to the other, or malformed. Detection callers pre-validate
+// against the GitHub response, so reaching this in production usually
+// indicates a programming bug or a manual admin endpoint invocation.
+var ErrInvalidRepoSlug = errors.New("rename: invalid repo slug")
+
+// Store is the SQLite-side dependency. *store.Store satisfies it via
+// its RenameRepo method.
+type Store interface {
+	// RenameRepo moves every row keyed on oldRepo to newRepo and
+	// writes an audit row, idempotent across calls. Returns
+	// applied=true when this invocation produced state change,
+	// applied=false when the audit table already recorded the same
+	// rename.
+	RenameRepo(oldRepo, newRepo string) (applied bool, err error)
+}
+
+// Persister rewrites the config TOML on disk. config.RenameRepoInTOML
+// satisfies this via a thin wrapper in main.go.
+type Persister interface {
+	Rename(path, oldRepo, newRepo string) error
+}
+
+// Purger drops the on-disk worktree for the OLD slug so the next
+// acquire on the NEW slug clones fresh. *repoctx.Manager satisfies
+// this signature.
+type Purger interface {
+	Purge(ctx context.Context, repo, cloneDir string) error
+}
+
+// Publisher fans the rename event out to SSE subscribers.
+// *sse.Broker satisfies this.
+type Publisher interface {
+	Publish(e sse.Event)
+}
+
+// Deps is the constructor input — all dependencies plus the cfgMu
+// and the in-memory config mutator the daemon owns.
+type Deps struct {
+	Store     Store
+	Persister Persister
+	Purger    Purger
+	Publisher Publisher
+
+	// CfgMu serializes config mutation + persistence. The reconciler
+	// holds it across ApplyConfig + Persister.Rename so concurrent
+	// readers never see disk/memory drift.
+	CfgMu sync.Locker
+
+	// ApplyConfig mutates the in-memory config in place (rename keys
+	// in Repositories, NonMonitored, AI.Repos, AI.Orgs as applicable).
+	// Invoked under CfgMu between the store commit and the disk write.
+	ApplyConfig func(oldRepo, newRepo string)
+
+	CfgPath  string // path to the config TOML to rewrite
+	CloneDir string // base directory for managed worktrees
+}
+
+// Reconciler runs the rename pipeline. Construct one per daemon and
+// reuse it across all rename invocations.
+type Reconciler struct {
+	deps Deps
+}
+
+// NewReconciler returns a Reconciler that uses the supplied deps.
+// The constructor does not validate deps — missing fields surface as
+// nil-pointer panics on the first Run, which is the desired
+// fail-fast behaviour during daemon wiring.
+func NewReconciler(deps Deps) *Reconciler {
+	return &Reconciler{deps: deps}
+}
+
+// Run reconciles oldRepo→newRepo across every surface. It is safe to
+// call repeatedly with the same pair: the store-level idempotency
+// guard short-circuits the call before any side effects fire, so the
+// detection probe can invoke Run on every tick without consequence.
+func (r *Reconciler) Run(ctx context.Context, oldRepo, newRepo string) error {
+	if err := validatePair(oldRepo, newRepo); err != nil {
+		return err
+	}
+
+	// 1. Authoritative state move: SQLite + audit row in one TX.
+	applied, err := r.deps.Store.RenameRepo(oldRepo, newRepo)
+	if err != nil {
+		return fmt.Errorf("rename: store: %w", err)
+	}
+	if !applied {
+		// Already on record — every downstream surface should be in
+		// the renamed state already, so we exit silently. This is
+		// the post-restart / probe-loop path.
+		return nil
+	}
+
+	// 2. Config mutation + on-disk rewrite under cfgMu so readers
+	//    that hold the lock cannot observe a half-applied state.
+	r.deps.CfgMu.Lock()
+	r.deps.ApplyConfig(oldRepo, newRepo)
+	cfgErr := r.deps.Persister.Rename(r.deps.CfgPath, oldRepo, newRepo)
+	r.deps.CfgMu.Unlock()
+	if cfgErr != nil {
+		// Store committed but config persistence failed. We do NOT
+		// roll back the store — its audit row reflects truth and the
+		// next probe tick will retry the persister via the same
+		// reconciler entry point (store call short-circuits at that
+		// point, so retry cost is bounded to the persister).
+		return fmt.Errorf("rename: persist config: %w", cfgErr)
+	}
+
+	// 3. Drop the old worktree. Non-fatal — repoctx clones fresh on
+	//    the next acquire of the new slug, so a failure here at
+	//    most leaves an orphan dir for the operator to mop up.
+	purgeErr := r.deps.Purger.Purge(ctx, oldRepo, r.deps.CloneDir)
+	if purgeErr != nil {
+		slog.Warn("rename: worktree purge failed (non-fatal)",
+			"old_repo", oldRepo, "err", purgeErr)
+	}
+
+	// 4. Notify Flutter / TUI subscribers.
+	r.deps.Publisher.Publish(sse.Event{
+		Type: sse.EventRepoRenamed,
+		Data: fmt.Sprintf(
+			`{"old_repo":%q,"new_repo":%q,"worktree_purged":%t}`,
+			oldRepo, newRepo, purgeErr == nil,
+		),
+	})
+	return nil
+}
+
+func validatePair(oldRepo, newRepo string) error {
+	if oldRepo == "" || newRepo == "" {
+		return fmt.Errorf("%w: empty slug", ErrInvalidRepoSlug)
+	}
+	if oldRepo == newRepo {
+		return fmt.Errorf("%w: old and new are identical", ErrInvalidRepoSlug)
+	}
+	if !looksLikeOwnerName(oldRepo) || !looksLikeOwnerName(newRepo) {
+		return fmt.Errorf("%w: expected owner/name shape", ErrInvalidRepoSlug)
+	}
+	return nil
+}
+
+func looksLikeOwnerName(s string) bool {
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 {
+		return false
+	}
+	return parts[0] != "" && parts[1] != ""
+}

--- a/daemon/internal/rename/reconciler.go
+++ b/daemon/internal/rename/reconciler.go
@@ -96,9 +96,19 @@ func NewReconciler(deps Deps) *Reconciler {
 }
 
 // Run reconciles oldRepo→newRepo across every surface. It is safe to
-// call repeatedly with the same pair: the store-level idempotency
-// guard short-circuits the call before any side effects fire, so the
-// detection probe can invoke Run on every tick without consequence.
+// call repeatedly with the same pair: each downstream step
+// (ApplyConfig, Persister.Rename, Purger.Purge) is itself idempotent
+// in the absence of the old slug, so a retry after a partial failure
+// converges.
+//
+// The store's `applied` return value is informational only — it
+// tracks whether THIS invocation moved rows or whether a prior
+// invocation already wrote the audit row. It is NOT a signal to skip
+// downstream work: the downstream surfaces are not audited, so a
+// previous Run could have committed the store and then failed at
+// config persistence or worktree purge, leaving disk and DB out of
+// sync. Re-running the downstream on every successful audit covers
+// the recovery path.
 func (r *Reconciler) Run(ctx context.Context, oldRepo, newRepo string) error {
 	if err := validatePair(oldRepo, newRepo); err != nil {
 		return err
@@ -109,11 +119,16 @@ func (r *Reconciler) Run(ctx context.Context, oldRepo, newRepo string) error {
 	if err != nil {
 		return fmt.Errorf("rename: store: %w", err)
 	}
-	if !applied {
-		// Already on record — every downstream surface should be in
-		// the renamed state already, so we exit silently. This is
-		// the post-restart / probe-loop path.
-		return nil
+	if applied {
+		slog.Info("rename: applying", "old_repo", oldRepo, "new_repo", newRepo)
+	} else {
+		// Audit row already present — could be a duplicate probe
+		// tick after a fully-successful prior Run, or a recovery
+		// attempt after a prior Run committed the store and failed
+		// downstream. Either way we run the downstream; if state is
+		// already settled the steps are cheap no-ops.
+		slog.Info("rename: recovery path (audit row present)",
+			"old_repo", oldRepo, "new_repo", newRepo)
 	}
 
 	// 2. Config mutation + on-disk rewrite under cfgMu so readers
@@ -123,11 +138,11 @@ func (r *Reconciler) Run(ctx context.Context, oldRepo, newRepo string) error {
 	cfgErr := r.deps.Persister.Rename(r.deps.CfgPath, oldRepo, newRepo)
 	r.deps.CfgMu.Unlock()
 	if cfgErr != nil {
-		// Store committed but config persistence failed. We do NOT
-		// roll back the store — its audit row reflects truth and the
-		// next probe tick will retry the persister via the same
-		// reconciler entry point (store call short-circuits at that
-		// point, so retry cost is bounded to the persister).
+		// Store has the audit row but config persistence failed. We
+		// do NOT roll back the store — the next probe tick (or a
+		// manual /admin/repo-rename call) re-enters Run, the store
+		// returns applied=false, and the new flow above re-runs the
+		// downstream until the persister succeeds.
 		return fmt.Errorf("rename: persist config: %w", cfgErr)
 	}
 

--- a/daemon/internal/rename/reconciler.go
+++ b/daemon/internal/rename/reconciler.go
@@ -72,9 +72,21 @@ type Deps struct {
 	// readers never see disk/memory drift.
 	CfgMu sync.Locker
 
+	// TOMLMu serializes read-modify-write operations against the
+	// config TOML file on disk. The HTTP server's PATCH handlers
+	// hold the same mutex (Server.TOMLMu) so the rename pipeline
+	// and operator-driven config edits do not clobber each other.
+	// Lock order is TOMLMu → CfgMu, consistent with the PATCH path
+	// which holds TOMLMu while triggering reloadFn (which takes
+	// CfgMu internally).
+	TOMLMu sync.Locker
+
 	// ApplyConfig mutates the in-memory config in place (rename keys
 	// in Repositories, NonMonitored, AI.Repos, AI.Orgs as applicable).
-	// Invoked under CfgMu between the store commit and the disk write.
+	// Invoked under CfgMu only AFTER Persister.Rename has successfully
+	// rewritten the disk TOML — so a persister failure leaves the
+	// in-memory config untouched and the next probe tick re-detects
+	// the mismatch (because Repos() still reads the old slug).
 	ApplyConfig func(oldRepo, newRepo string)
 
 	CfgPath  string // path to the config TOML to rewrite
@@ -131,17 +143,27 @@ func (r *Reconciler) Run(ctx context.Context, oldRepo, newRepo string) error {
 			"old_repo", oldRepo, "new_repo", newRepo)
 	}
 
-	// 2. Config mutation + on-disk rewrite under cfgMu so readers
-	//    that hold the lock cannot observe a half-applied state.
+	// 2. Config rewrite. Lock order: TOMLMu first (shared with the
+	//    HTTP PATCH handlers' read-modify-write), then CfgMu. Disk
+	//    persister runs FIRST: if it fails, in-memory config stays
+	//    untouched and the probe's next tick will still see the old
+	//    slug in Repos() and re-dispatch this reconciler — which is
+	//    the recovery path. Mutating in-memory first would mask the
+	//    mismatch from the probe and the rename would silently stick
+	//    in a half-state until daemon restart.
+	r.deps.TOMLMu.Lock()
 	r.deps.CfgMu.Lock()
-	r.deps.ApplyConfig(oldRepo, newRepo)
 	cfgErr := r.deps.Persister.Rename(r.deps.CfgPath, oldRepo, newRepo)
+	if cfgErr == nil {
+		r.deps.ApplyConfig(oldRepo, newRepo)
+	}
 	r.deps.CfgMu.Unlock()
+	r.deps.TOMLMu.Unlock()
 	if cfgErr != nil {
 		// Store has the audit row but config persistence failed. We
 		// do NOT roll back the store — the next probe tick (or a
 		// manual /admin/repo-rename call) re-enters Run, the store
-		// returns applied=false, and the new flow above re-runs the
+		// returns applied=false, and the flow above re-runs the
 		// downstream until the persister succeeds.
 		return fmt.Errorf("rename: persist config: %w", cfgErr)
 	}

--- a/daemon/internal/rename/reconciler_test.go
+++ b/daemon/internal/rename/reconciler_test.go
@@ -1,0 +1,217 @@
+package rename_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/rename"
+	"github.com/heimdallm/daemon/internal/sse"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeStore struct {
+	calls    int
+	applied  bool          // value to return from RenameRepo
+	err      error         // error to return
+	gotPairs [][2]string   // (old, new) observed
+}
+
+func (f *fakeStore) RenameRepo(oldRepo, newRepo string) (bool, error) {
+	f.calls++
+	f.gotPairs = append(f.gotPairs, [2]string{oldRepo, newRepo})
+	return f.applied, f.err
+}
+
+type fakePersister struct {
+	calls    int
+	err      error
+	gotPath  string
+	gotPairs [][2]string
+}
+
+func (f *fakePersister) Rename(path, oldRepo, newRepo string) error {
+	f.calls++
+	f.gotPath = path
+	f.gotPairs = append(f.gotPairs, [2]string{oldRepo, newRepo})
+	return f.err
+}
+
+type fakePurger struct {
+	calls    int
+	err      error
+	gotRepo  string
+	gotDir   string
+}
+
+func (f *fakePurger) Purge(ctx context.Context, repo, cloneDir string) error {
+	f.calls++
+	f.gotRepo = repo
+	f.gotDir = cloneDir
+	return f.err
+}
+
+type fakePublisher struct {
+	calls  int
+	events []sse.Event
+}
+
+func (f *fakePublisher) Publish(e sse.Event) {
+	f.calls++
+	f.events = append(f.events, e)
+}
+
+// applyOp tracks invocations of the in-memory config mutator the
+// reconciler runs under cfgMu.
+type applyOp struct {
+	calls    int
+	gotPairs [][2]string
+}
+
+func (a *applyOp) op(oldRepo, newRepo string) {
+	a.calls++
+	a.gotPairs = append(a.gotPairs, [2]string{oldRepo, newRepo})
+}
+
+func newDeps(store *fakeStore, persister *fakePersister, purger *fakePurger,
+	publisher *fakePublisher, op *applyOp,
+) rename.Deps {
+	return rename.Deps{
+		Store:     store,
+		Persister: persister,
+		Purger:    purger,
+		Publisher: publisher,
+		ApplyConfig: op.op,
+		CfgMu:    &sync.Mutex{},
+		CfgPath:  "/tmp/heimdallm/config.toml",
+		CloneDir: "/tmp/heimdallm/clones",
+	}
+}
+
+// --- tests ---------------------------------------------------------------
+
+func TestReconciler_Run_FullPipeline(t *testing.T) {
+	store := &fakeStore{applied: true}
+	persister := &fakePersister{}
+	purger := &fakePurger{}
+	publisher := &fakePublisher{}
+	op := &applyOp{}
+	r := rename.NewReconciler(newDeps(store, persister, purger, publisher, op))
+
+	if err := r.Run(context.Background(), "acme/old", "acme/new"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if store.calls != 1 || store.gotPairs[0] != [2]string{"acme/old", "acme/new"} {
+		t.Errorf("store: %d calls, pairs=%v", store.calls, store.gotPairs)
+	}
+	if op.calls != 1 || op.gotPairs[0] != [2]string{"acme/old", "acme/new"} {
+		t.Errorf("ApplyConfig: %d calls, pairs=%v", op.calls, op.gotPairs)
+	}
+	if persister.calls != 1 || persister.gotPath != "/tmp/heimdallm/config.toml" {
+		t.Errorf("persister: %d calls, path=%q", persister.calls, persister.gotPath)
+	}
+	if purger.calls != 1 || purger.gotRepo != "acme/old" || purger.gotDir != "/tmp/heimdallm/clones" {
+		t.Errorf("purger: %d calls, repo=%q dir=%q", purger.calls, purger.gotRepo, purger.gotDir)
+	}
+	if publisher.calls != 1 || publisher.events[0].Type != sse.EventRepoRenamed {
+		t.Errorf("publisher: %d calls, events=%+v", publisher.calls, publisher.events)
+	}
+	// Payload must carry both slugs and worktree_purged=true.
+	data := publisher.events[0].Data
+	for _, want := range []string{`"old_repo":"acme/old"`, `"new_repo":"acme/new"`, `"worktree_purged":true`} {
+		if !strings.Contains(data, want) {
+			t.Errorf("payload missing %q: %s", want, data)
+		}
+	}
+}
+
+func TestReconciler_Run_Idempotent(t *testing.T) {
+	// Store says "already done" by returning applied=false. The
+	// reconciler must short-circuit BEFORE touching config/persister/
+	// purger/publisher to avoid an SSE storm on every probe tick after
+	// a successful rename.
+	store := &fakeStore{applied: false}
+	persister := &fakePersister{}
+	purger := &fakePurger{}
+	publisher := &fakePublisher{}
+	op := &applyOp{}
+	r := rename.NewReconciler(newDeps(store, persister, purger, publisher, op))
+
+	if err := r.Run(context.Background(), "acme/old", "acme/new"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if op.calls != 0 || persister.calls != 0 || purger.calls != 0 || publisher.calls != 0 {
+		t.Errorf("idempotent path leaked side effects: op=%d persister=%d purger=%d publisher=%d",
+			op.calls, persister.calls, purger.calls, publisher.calls)
+	}
+}
+
+func TestReconciler_Run_ValidationRejectsEmpty(t *testing.T) {
+	store := &fakeStore{}
+	r := rename.NewReconciler(newDeps(store, &fakePersister{}, &fakePurger{}, &fakePublisher{}, &applyOp{}))
+
+	cases := []struct {
+		old, new string
+	}{
+		{"", "acme/new"},
+		{"acme/old", ""},
+		{"acme/old", "acme/old"},
+		{"malformed", "acme/new"},
+		{"acme/old", "no-slash"},
+	}
+	for _, c := range cases {
+		err := r.Run(context.Background(), c.old, c.new)
+		if err == nil {
+			t.Errorf("Run(%q, %q) expected error, got nil", c.old, c.new)
+		}
+	}
+	if store.calls != 0 {
+		t.Errorf("validation leaked into store: calls=%d", store.calls)
+	}
+}
+
+func TestReconciler_Run_StoreErrorAbortsConfig(t *testing.T) {
+	// When the store call fails, the reconciler MUST NOT mutate the
+	// in-memory config or rewrite the TOML file — those would create
+	// disk/DB drift on restart.
+	storeErr := errors.New("simulated SQLite failure")
+	store := &fakeStore{err: storeErr}
+	persister := &fakePersister{}
+	op := &applyOp{}
+	r := rename.NewReconciler(newDeps(store, persister, &fakePurger{}, &fakePublisher{}, op))
+
+	err := r.Run(context.Background(), "acme/old", "acme/new")
+	if !errors.Is(err, storeErr) {
+		t.Fatalf("Run err = %v, want wrapping %v", err, storeErr)
+	}
+	if op.calls != 0 || persister.calls != 0 {
+		t.Errorf("config touched after store error: op=%d persister=%d", op.calls, persister.calls)
+	}
+}
+
+func TestReconciler_Run_WorktreePurgeFailure_NotFatal(t *testing.T) {
+	// A failed worktree purge MUST NOT roll back the store/config
+	// rename — the next acquire of the new slug will clone fresh
+	// anyway. The SSE payload signals the inconsistency to operators.
+	store := &fakeStore{applied: true}
+	persister := &fakePersister{}
+	purger := &fakePurger{err: errors.New("purge failed: device busy")}
+	publisher := &fakePublisher{}
+	op := &applyOp{}
+	r := rename.NewReconciler(newDeps(store, persister, purger, publisher, op))
+
+	if err := r.Run(context.Background(), "acme/old", "acme/new"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if publisher.calls != 1 {
+		t.Fatalf("publisher: %d calls, want 1", publisher.calls)
+	}
+	if !strings.Contains(publisher.events[0].Data, `"worktree_purged":false`) {
+		t.Errorf("payload missing worktree_purged=false: %s", publisher.events[0].Data)
+	}
+}
+

--- a/daemon/internal/rename/reconciler_test.go
+++ b/daemon/internal/rename/reconciler_test.go
@@ -80,14 +80,15 @@ func newDeps(store *fakeStore, persister *fakePersister, purger *fakePurger,
 	publisher *fakePublisher, op *applyOp,
 ) rename.Deps {
 	return rename.Deps{
-		Store:     store,
-		Persister: persister,
-		Purger:    purger,
-		Publisher: publisher,
+		Store:       store,
+		Persister:   persister,
+		Purger:      purger,
+		Publisher:   publisher,
 		ApplyConfig: op.op,
-		CfgMu:    &sync.Mutex{},
-		CfgPath:  "/tmp/heimdallm/config.toml",
-		CloneDir: "/tmp/heimdallm/clones",
+		CfgMu:       &sync.Mutex{},
+		TOMLMu:      &sync.Mutex{},
+		CfgPath:     "/tmp/heimdallm/config.toml",
+		CloneDir:    "/tmp/heimdallm/clones",
 	}
 }
 
@@ -148,14 +149,19 @@ func TestReconciler_Run_RecoversFromPersisterFailureOnRetry(t *testing.T) {
 	op := &applyOp{}
 	r := rename.NewReconciler(newDeps(store, persister, purger, publisher, op))
 
-	// First Run: persister fails after store commit. Reconciler
-	// returns the error; downstream surfaces (purge, SSE) are
-	// skipped because cfgErr aborts the function before them.
+	// First Run: persister fails. Reconciler returns the error;
+	// downstream surfaces (ApplyConfig, purge, SSE) are skipped —
+	// crucially ApplyConfig too, because the in-memory mutation
+	// would mask the mismatch from the probe's next tick and the
+	// recovery path would never re-enter Run.
 	if err := r.Run(context.Background(), "acme/old", "acme/new"); err == nil {
 		t.Fatal("first Run: expected persister failure to surface")
 	}
-	if op.calls != 1 || persister.calls != 1 {
-		t.Errorf("first Run: op=%d persister=%d, want 1/1", op.calls, persister.calls)
+	if persister.calls != 1 {
+		t.Errorf("first Run: persister.calls = %d, want 1", persister.calls)
+	}
+	if op.calls != 0 {
+		t.Errorf("first Run: ApplyConfig was called (%d) even though persister failed — in-memory must stay on the old slug so the probe re-detects the mismatch", op.calls)
 	}
 	if purger.calls != 0 || publisher.calls != 0 {
 		t.Errorf("first Run leaked past persister failure: purger=%d publisher=%d",
@@ -174,8 +180,8 @@ func TestReconciler_Run_RecoversFromPersisterFailureOnRetry(t *testing.T) {
 	if err := r.Run(context.Background(), "acme/old", "acme/new"); err != nil {
 		t.Fatalf("second Run (recovery): %v", err)
 	}
-	if op.calls != 2 {
-		t.Errorf("ApplyConfig calls = %d, want 2 (rerun on retry)", op.calls)
+	if op.calls != 1 {
+		t.Errorf("ApplyConfig calls = %d, want 1 (only after the recovery persister success)", op.calls)
 	}
 	if persister.calls != 2 {
 		t.Errorf("persister.calls = %d, want 2", persister.calls)

--- a/daemon/internal/rename/reconciler_test.go
+++ b/daemon/internal/rename/reconciler_test.go
@@ -129,12 +129,79 @@ func TestReconciler_Run_FullPipeline(t *testing.T) {
 	}
 }
 
-func TestReconciler_Run_Idempotent(t *testing.T) {
-	// Store says "already done" by returning applied=false. The
-	// reconciler must short-circuit BEFORE touching config/persister/
-	// purger/publisher to avoid an SSE storm on every probe tick after
-	// a successful rename.
-	store := &fakeStore{applied: false}
+// TestReconciler_Run_RecoversFromPersisterFailureOnRetry pins the
+// partial-failure recovery contract. When a prior Run committed the
+// store (audit row written) but failed at the persister, the next
+// invocation sees applied=false from the store's idempotency guard
+// — and MUST still complete config + purge + SSE, otherwise the
+// rename is stuck forever with DB on the new slug but config TOML
+// + worktree on the old.
+//
+// This is the bug that motivated removing the applied=false short-
+// circuit at the reconciler entry point: see
+// `daemon/internal/rename/reconciler.go` Run docstring.
+func TestReconciler_Run_RecoversFromPersisterFailureOnRetry(t *testing.T) {
+	store := &fakeStore{applied: true} // first Run: store moves rows
+	persister := &fakePersister{err: errors.New("disk full")}
+	purger := &fakePurger{}
+	publisher := &fakePublisher{}
+	op := &applyOp{}
+	r := rename.NewReconciler(newDeps(store, persister, purger, publisher, op))
+
+	// First Run: persister fails after store commit. Reconciler
+	// returns the error; downstream surfaces (purge, SSE) are
+	// skipped because cfgErr aborts the function before them.
+	if err := r.Run(context.Background(), "acme/old", "acme/new"); err == nil {
+		t.Fatal("first Run: expected persister failure to surface")
+	}
+	if op.calls != 1 || persister.calls != 1 {
+		t.Errorf("first Run: op=%d persister=%d, want 1/1", op.calls, persister.calls)
+	}
+	if purger.calls != 0 || publisher.calls != 0 {
+		t.Errorf("first Run leaked past persister failure: purger=%d publisher=%d",
+			purger.calls, publisher.calls)
+	}
+
+	// Simulate the real store's idempotency guard on the retry: the
+	// audit row is now present, so RenameRepo returns applied=false.
+	// Persister succeeds this time.
+	store.applied = false
+	persister.err = nil
+
+	// Second Run: MUST complete config + purge + SSE despite
+	// applied=false. Pre-fix, the reconciler returned early at this
+	// point and left the system stuck in partial-failure state.
+	if err := r.Run(context.Background(), "acme/old", "acme/new"); err != nil {
+		t.Fatalf("second Run (recovery): %v", err)
+	}
+	if op.calls != 2 {
+		t.Errorf("ApplyConfig calls = %d, want 2 (rerun on retry)", op.calls)
+	}
+	if persister.calls != 2 {
+		t.Errorf("persister.calls = %d, want 2", persister.calls)
+	}
+	if purger.calls != 1 {
+		t.Errorf("purger.calls = %d, want 1 (only the recovery attempt)", purger.calls)
+	}
+	if publisher.calls != 1 {
+		t.Errorf("publisher.calls = %d, want 1 (only the recovery attempt)", publisher.calls)
+	}
+	if !strings.Contains(publisher.events[0].Data, `"old_repo":"acme/old"`) {
+		t.Errorf("recovery SSE payload missing old_repo: %s", publisher.events[0].Data)
+	}
+}
+
+// TestReconciler_Run_NoSSEStormOnRepeatedSuccessfulRuns pins the
+// other side of the contract: in a healthy steady state where the
+// store / config / worktree all agree, the probe should not actually
+// dispatch Run at all (canonical name matches configured slug, no
+// mismatch). But if a buggy caller drives Run repeatedly with the
+// same pair after a successful rename, the downstream re-runs are
+// bounded by their own idempotency — the test asserts no error and
+// a single SSE per call (idempotency at the TOML / Purge layer is
+// already covered in their own packages).
+func TestReconciler_Run_RepeatedRunsConverge(t *testing.T) {
+	store := &fakeStore{applied: true}
 	persister := &fakePersister{}
 	purger := &fakePurger{}
 	publisher := &fakePublisher{}
@@ -142,11 +209,19 @@ func TestReconciler_Run_Idempotent(t *testing.T) {
 	r := rename.NewReconciler(newDeps(store, persister, purger, publisher, op))
 
 	if err := r.Run(context.Background(), "acme/old", "acme/new"); err != nil {
-		t.Fatalf("Run: %v", err)
+		t.Fatalf("first Run: %v", err)
 	}
-	if op.calls != 0 || persister.calls != 0 || purger.calls != 0 || publisher.calls != 0 {
-		t.Errorf("idempotent path leaked side effects: op=%d persister=%d purger=%d publisher=%d",
-			op.calls, persister.calls, purger.calls, publisher.calls)
+	// Second Run with the store now returning applied=false (audit
+	// row present) — still runs the downstream and emits SSE. That
+	// is the documented behaviour; callers that don't want this
+	// should rely on the probe's canonical-name compare to avoid
+	// re-dispatching when state is settled.
+	store.applied = false
+	if err := r.Run(context.Background(), "acme/old", "acme/new"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if publisher.calls != 2 {
+		t.Errorf("publisher.calls = %d, want 2 (one per Run)", publisher.calls)
 	}
 }
 

--- a/daemon/internal/rename/reconciler_test.go
+++ b/daemon/internal/rename/reconciler_test.go
@@ -295,4 +295,3 @@ func TestReconciler_Run_WorktreePurgeFailure_NotFatal(t *testing.T) {
 		t.Errorf("payload missing worktree_purged=false: %s", publisher.events[0].Data)
 	}
 }
-

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -204,6 +204,14 @@ func (srv *Server) SetRepoRenameFn(fn func(ctx context.Context, oldRepo, newRepo
 	srv.repoRenameFn = fn
 }
 
+// TOMLMu returns the mutex serialising read-modify-write operations
+// on the config TOML file. The rename reconciler (#489) shares this
+// mutex with the HTTP PATCH/DELETE handlers so concurrent operator
+// edits and rename reconciliations cannot clobber each other on disk.
+func (srv *Server) TOMLMu() *sync.Mutex {
+	return &srv.tomlMu
+}
+
 // SetCleanCloneFn wires the manual single-repo managed-clone cleanup callback.
 func (srv *Server) SetCleanCloneFn(fn func(ctx context.Context, repo string) error) {
 	srv.cleanCloneFn = fn

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -237,11 +237,37 @@ func (srv *Server) SetRepoMetaFns(labels func(string) ([]string, error), collabs
 // SetConfigPath sets the path to config.toml for PATCH/DELETE handlers.
 func (srv *Server) SetConfigPath(path string) { srv.configPath = path }
 
-// patchTOML is the shared read-merge-write pipeline for all TOML-mutating
-// endpoints. mutateFn receives the current TOML as a map and must apply
-// its changes in-place. On success, returns the full live config for the
-// response body.
+// patchTOML is the shared read-merge-write pipeline for all
+// TOML-mutating endpoints. mutateFn receives the current TOML as a
+// map and must apply its changes in-place. On success, returns the
+// full live config for the response body.
+//
+// tomlMu is held ONLY through the read-mutate-write half. reloadFn
+// runs AFTER the unlock because it can wait on goroutines (the
+// rename probe in particular) that themselves need to acquire
+// tomlMu — keeping the mutex held across reloadFn deadlocks the
+// daemon (#489 review feedback).
 func (srv *Server) patchTOML(mutateFn func(m map[string]any) error) (map[string]any, error) {
+	m, err := srv.writeTOMLUnderLock(mutateFn)
+	if err != nil {
+		return nil, err
+	}
+	if srv.reloadFn != nil {
+		if err := srv.reloadFn(); err != nil {
+			return nil, fmt.Errorf("config reload after write: %w", err)
+		}
+	}
+	if srv.configFn != nil {
+		return srv.configFn(), nil
+	}
+	return m, nil
+}
+
+// writeTOMLUnderLock executes the read-mutate-validate-write half of
+// patchTOML while holding tomlMu, releasing the lock on every exit
+// path (including errors). Split out from patchTOML so the unlock
+// happens before reloadFn — see the comment on patchTOML.
+func (srv *Server) writeTOMLUnderLock(mutateFn func(m map[string]any) error) (map[string]any, error) {
 	srv.tomlMu.Lock()
 	defer srv.tomlMu.Unlock()
 
@@ -269,14 +295,6 @@ func (srv *Server) patchTOML(mutateFn func(m map[string]any) error) (map[string]
 	}
 	if err := config.AtomicWriteTOML(srv.configPath, m); err != nil {
 		return nil, err
-	}
-	if srv.reloadFn != nil {
-		if err := srv.reloadFn(); err != nil {
-			return nil, fmt.Errorf("config reload after write: %w", err)
-		}
-	}
-	if srv.configFn != nil {
-		return srv.configFn(), nil
 	}
 	return m, nil
 }

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -48,6 +48,11 @@ type Server struct {
 	triggerPromoteFn     func(issueID int64) error
 	cleanCloneFn         func(ctx context.Context, repo string) error
 	cleanClonesFn        func(ctx context.Context) (int, error)
+	// repoRenameFn drives the manual rename trigger at
+	// POST /admin/repo-rename (#489). Wired by main; nil when the
+	// daemon was constructed without the rename reconciler (e.g. in
+	// tests that don't need it).
+	repoRenameFn func(ctx context.Context, oldRepo, newRepo string) error
 	meFn                 func() (string, error)
 	// configFn returns the current running config as a JSON-serializable map.
 	configFn func() map[string]any
@@ -191,6 +196,14 @@ func (srv *Server) SetTriggerPromoteFn(fn func(issueID int64) error) {
 	srv.triggerPromoteFn = fn
 }
 
+// SetRepoRenameFn wires the manual rename trigger called by
+// POST /admin/repo-rename (#489). The callback runs the same
+// reconciler the rename probe uses, so a manual rename is fully
+// idempotent against subsequent probe ticks.
+func (srv *Server) SetRepoRenameFn(fn func(ctx context.Context, oldRepo, newRepo string) error) {
+	srv.repoRenameFn = fn
+}
+
 // SetCleanCloneFn wires the manual single-repo managed-clone cleanup callback.
 func (srv *Server) SetCleanCloneFn(fn func(ctx context.Context, repo string) error) {
 	srv.cleanCloneFn = fn
@@ -321,6 +334,7 @@ func (srv *Server) buildRouter() chi.Router {
 	r.Delete("/config/clones/{repo}", srv.handleDeleteManagedClone)
 	r.Post("/reload", srv.handleReload)
 	r.Post("/shutdown", srv.handleShutdown)
+	r.Post("/admin/repo-rename", srv.handleAdminRepoRename)
 	r.Get("/events", srv.handleSSE)
 	r.Get("/logs/stream", srv.handleLogsStream)
 	return r

--- a/daemon/internal/server/handlers_patch_deadlock_test.go
+++ b/daemon/internal/server/handlers_patch_deadlock_test.go
@@ -1,0 +1,143 @@
+package server_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPatchTOML_DoesNotHoldTOMLMuDuringReloadFn pins the no-deadlock
+// invariant called out in the #489 review. Real-world scenario:
+//
+//	1. Operator hits PATCH /config (or any TOML-mutating endpoint).
+//	2. patchTOML acquires tomlMu, writes the file.
+//	3. patchTOML calls reloadFn — which cancels the pollers and waits
+//	   for the WaitGroup containing the rename probe goroutine.
+//	4. The probe goroutine is mid-Reconciler.Run, blocked acquiring
+//	   tomlMu (shared with the server since the #489 race fix).
+//	5. Without the fix, PATCH holds tomlMu while reloadFn blocks
+//	   waiting for the probe, the probe waits for tomlMu — deadlock.
+//
+// The fix releases tomlMu *before* invoking reloadFn. This test
+// models the deadlock by having reloadFn attempt to acquire tomlMu
+// itself; with the fix, the inner acquisition succeeds and PATCH
+// returns. Without the fix, the inner acquisition blocks forever,
+// PATCH never returns, and the test fails via the timeout.
+func TestPatchTOML_DoesNotHoldTOMLMuDuringReloadFn(t *testing.T) {
+	tomlContent := "[ai]\nprimary = \"claude\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	reloadAcquired := make(chan struct{}, 1)
+	srv.SetReloadFn(func() error {
+		// In production, reloadFn cancels pollers and waits on
+		// oldWg.Wait(); the rename probe in that wait group holds
+		// (or is acquiring) tomlMu. We simulate the wait-on-probe
+		// edge with the probe's actual blocking primitive: an
+		// attempt to acquire tomlMu. Pre-fix this blocked forever
+		// because patchTOML still owned the mutex.
+		acquired := make(chan struct{})
+		go func() {
+			srv.TOMLMu().Lock()
+			srv.TOMLMu().Unlock()
+			close(acquired)
+		}()
+		select {
+		case <-acquired:
+			reloadAcquired <- struct{}{}
+			return nil
+		case <-time.After(2 * time.Second):
+			return errors.New("reloadFn: tomlMu still held by patchTOML (deadlock)")
+		}
+	})
+
+	req := httptest.NewRequest("PATCH", "/config",
+		strings.NewReader(`{"ai":{"primary":"openai"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		srv.Router().ServeHTTP(w, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("PATCH /config never returned — patchTOML deadlocked against reloadFn")
+	}
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, body = %s", w.Code, w.Body.String())
+	}
+	select {
+	case <-reloadAcquired:
+	default:
+		t.Fatal("reloadFn never confirmed it could acquire tomlMu — fix not applied")
+	}
+}
+
+// TestPatchTOML_NoDeadlockWithPollerWaitingOnTOMLMu models the full
+// production deadlock: a poller goroutine (modelling the rename
+// probe) wants to acquire tomlMu, and reloadFn waits on that poller
+// to finish (modelling oldWg.Wait). Pre-fix this is a strict 2-way
+// deadlock; post-fix patchTOML's unlock breaks the chain.
+func TestPatchTOML_NoDeadlockWithPollerWaitingOnTOMLMu(t *testing.T) {
+	tomlContent := "[ai]\nprimary = \"claude\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	pollerStart := make(chan struct{})
+	pollerDone := make(chan struct{})
+	go func() {
+		<-pollerStart
+		// Probe-side acquire (mirror of Reconciler.Run's TOMLMu.Lock).
+		srv.TOMLMu().Lock()
+		srv.TOMLMu().Unlock()
+		close(pollerDone)
+	}()
+
+	srv.SetReloadFn(func() error {
+		// reloadFn signals the poller to start (the real reloadFn
+		// cancels its context, which lets the next tick run; here
+		// we just kick the goroutine off) and waits for it to exit
+		// (mirroring oldWg.Wait).
+		close(pollerStart)
+		select {
+		case <-pollerDone:
+			return nil
+		case <-time.After(2 * time.Second):
+			return errors.New("reloadFn: poller did not finish — deadlock")
+		}
+	})
+
+	req := httptest.NewRequest("PATCH", "/config",
+		strings.NewReader(`{"ai":{"primary":"openai"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		srv.Router().ServeHTTP(w, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if w.Code != http.StatusOK {
+			t.Errorf("PATCH status = %d, body = %s", w.Code, w.Body.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("3-way deadlock: PATCH holds tomlMu → reloadFn waits for poller → poller waits for tomlMu")
+	}
+}

--- a/daemon/internal/server/handlers_rename.go
+++ b/daemon/internal/server/handlers_rename.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// renameRequestTimeout caps the reconciler call so a stuck SQLite
+// writer or slow GitHub probe in the same daemon can't make the admin
+// endpoint hang indefinitely.
+const renameRequestTimeout = 30 * time.Second
+
+type repoRenameRequest struct {
+	OldRepo string `json:"old_repo"`
+	NewRepo string `json:"new_repo"`
+}
+
+// handleAdminRepoRename manually triggers the rename reconciler for an
+// (old_repo, new_repo) pair. Mirror of the path the rename probe takes
+// on a canonical-name mismatch — intended for emergencies (operator
+// has just renamed a repo on GitHub and does not want to wait for the
+// next probe tick) and for tests/integration. Idempotent: re-running
+// with the same pair after the reconciler has already committed is a
+// no-op at the store layer and silently returns 200.
+func (srv *Server) handleAdminRepoRename(w http.ResponseWriter, r *http.Request) {
+	if srv.repoRenameFn == nil {
+		http.Error(w, `{"error":"rename trigger not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+	var req repoRenameRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+		return
+	}
+	req.OldRepo = strings.TrimSpace(req.OldRepo)
+	req.NewRepo = strings.TrimSpace(req.NewRepo)
+	if req.OldRepo == "" || req.NewRepo == "" {
+		http.Error(w, `{"error":"old_repo and new_repo are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), renameRequestTimeout)
+	defer cancel()
+	if err := srv.repoRenameFn(ctx, req.OldRepo, req.NewRepo); err != nil {
+		slog.Error("POST /admin/repo-rename failed",
+			"old_repo", req.OldRepo, "new_repo", req.NewRepo, "err", err)
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			http.Error(w, `{"error":"rename timed out"}`, http.StatusGatewayTimeout)
+			return
+		}
+		// Validation errors (empty/identical/malformed slugs) surface
+		// as 400 so an operator typo doesn't trip a 500. The reconciler
+		// wraps its own ErrInvalidRepoSlug into the returned error, so
+		// we use a simple substring match — no need to import the
+		// rename package here for one sentinel check.
+		if strings.Contains(err.Error(), "invalid repo slug") {
+			http.Error(w, `{"error":"`+err.Error()+`"}`, http.StatusBadRequest)
+			return
+		}
+		http.Error(w, `{"error":"rename failed"}`, http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{
+		"status":   "ok",
+		"old_repo": req.OldRepo,
+		"new_repo": req.NewRepo,
+	})
+}

--- a/daemon/internal/server/handlers_rename_test.go
+++ b/daemon/internal/server/handlers_rename_test.go
@@ -1,0 +1,101 @@
+package server_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleAdminRepoRename_RequiresAuth(t *testing.T) {
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetRepoRenameFn(func(ctx context.Context, oldRepo, newRepo string) error {
+		return nil
+	})
+
+	req := httptest.NewRequest("POST", "/admin/repo-rename",
+		strings.NewReader(`{"old_repo":"acme/old","new_repo":"acme/new"}`))
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("POST without token = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleAdminRepoRename_DispatchesReconciler(t *testing.T) {
+	srv := setupServerWithToken(t, "test-token")
+	var got [2]string
+	srv.SetRepoRenameFn(func(ctx context.Context, oldRepo, newRepo string) error {
+		got = [2]string{oldRepo, newRepo}
+		return nil
+	})
+
+	req := httptest.NewRequest("POST", "/admin/repo-rename",
+		strings.NewReader(`{"old_repo":"acme/old","new_repo":"acme/new"}`))
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if got != [2]string{"acme/old", "acme/new"} {
+		t.Errorf("dispatched pair = %v, want (acme/old, acme/new)", got)
+	}
+	if !strings.Contains(w.Body.String(), `"status":"ok"`) {
+		t.Errorf("body = %s, want status ok", w.Body.String())
+	}
+}
+
+func TestHandleAdminRepoRename_RejectsEmptySlugs(t *testing.T) {
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetRepoRenameFn(func(ctx context.Context, oldRepo, newRepo string) error {
+		t.Fatal("reconciler must not be called with empty slugs")
+		return nil
+	})
+
+	for _, body := range []string{
+		`{"old_repo":"","new_repo":"acme/new"}`,
+		`{"old_repo":"acme/old","new_repo":""}`,
+		`{"old_repo":"   ","new_repo":"acme/new"}`,
+	} {
+		req := httptest.NewRequest("POST", "/admin/repo-rename", strings.NewReader(body))
+		req.Header.Set("X-Heimdallm-Token", "test-token")
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("body %q -> status %d, want 400", body, w.Code)
+		}
+	}
+}
+
+func TestHandleAdminRepoRename_SurfacesValidationErrorAs400(t *testing.T) {
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetRepoRenameFn(func(ctx context.Context, oldRepo, newRepo string) error {
+		return errors.New("rename: invalid repo slug: expected owner/name shape")
+	})
+
+	req := httptest.NewRequest("POST", "/admin/repo-rename",
+		strings.NewReader(`{"old_repo":"malformed","new_repo":"acme/new"}`))
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleAdminRepoRename_503WhenNotWired(t *testing.T) {
+	srv := setupServerWithToken(t, "test-token")
+	// Intentionally do NOT call SetRepoRenameFn; admin endpoint must
+	// surface the wiring gap as 503, not 500 or 404.
+	req := httptest.NewRequest("POST", "/admin/repo-rename",
+		strings.NewReader(`{"old_repo":"acme/old","new_repo":"acme/new"}`))
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}

--- a/daemon/internal/sse/broker.go
+++ b/daemon/internal/sse/broker.go
@@ -44,6 +44,13 @@ const (
 	// prev_state. Only fires for PRs whose `auto_implement_issue_id`
 	// column is non-zero — standard PRs never publish this event.
 	EventPRReviewStateChanged = "pr_review_state_changed"
+
+	// EventRepoRenamed fires when the rename reconciler propagates a
+	// GitHub repo/org rename across daemon state (#489). Payload:
+	// {"old_repo": "...", "new_repo": "...", "worktree_purged": bool}.
+	// Flutter consumers refresh the repo / PR / issue lists and dismiss
+	// cached entries keyed on `old_repo`.
+	EventRepoRenamed = "repo_renamed"
 )
 
 // maxSubscribers limits the number of concurrent SSE connections to prevent

--- a/daemon/internal/store/rename.go
+++ b/daemon/internal/store/rename.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -28,14 +29,21 @@ var ErrInvalidRepoSlug = errors.New("store: invalid repo slug")
 // In-flight tables (`reviews_in_flight`, `issue_triage_in_flight`)
 // are keyed on numeric IDs and do not need renaming.
 //
-// Idempotency is derived from the data, not the audit table: each
-// UPDATE matches `WHERE repo = oldRepo`, so on a second call after
-// a successful rename the WHERE matches zero rows and the UPDATE is
-// a natural no-op. This correctly handles rename chains like
-// A→B→A→B: every step inspects the current state of the tables and
-// moves whatever is there. The audit row is inserted ONLY when at
-// least one row actually moved, so the audit log reflects real
-// state transitions instead of accumulating attempts.
+// Idempotency for the UPDATEs is derived from the data, not the
+// audit table: each UPDATE matches `WHERE repo = oldRepo`, so on a
+// second call after a successful rename the WHERE matches zero rows
+// and the UPDATE is a natural no-op. This correctly handles rename
+// chains like A→B→A→B: every step inspects the current state of the
+// tables and moves whatever is there.
+//
+// The audit row in `repo_renames` is inserted whenever this call
+// records a NEW mapping for oldRepo — including the "configured
+// repo renamed before any SQLite state existed" edge case, where
+// the UPDATEs match zero rows but the rename still happened from
+// the reconciler's perspective and the issue/PR contract requires
+// it to be persisted. Duplicate retries (probe re-detection or
+// rerun where the most recent audit row for oldRepo already maps
+// to newRepo) skip the insert to keep the log free of churn.
 //
 // IMPORTANT: `applied` is INFORMATIONAL telemetry only — callers MUST
 // NOT use it to skip downstream reconciliation work (config rewrite,
@@ -97,11 +105,31 @@ func (s *Store) RenameRepo(oldRepo, newRepo string) (applied bool, err error) {
 	}
 	totalMoved += n
 
-	// Audit row only when something actually moved. Reflecting "no
-	// rows for oldRepo" as a no-op in the audit table keeps the log
-	// usable as a real-state-transitions history rather than a
-	// retry/probe-tick log.
-	if totalMoved > 0 {
+	// Audit policy: insert when this call records a NEW mapping.
+	// `rowsMoved` is the common case (rows actually transitioned).
+	// When zero rows moved, we still insert if the most recent audit
+	// row for oldRepo does NOT already map to newRepo — this covers
+	// the edge case of a repo renamed before it had any SQLite state
+	// yet, so the historical mapping survives in repo_renames per
+	// the #489 contract. Duplicate probe re-detections of the same
+	// rename hit the suppression branch and leave the log clean.
+	rowsMoved := totalMoved > 0
+	insertAudit := rowsMoved
+	if !rowsMoved {
+		var lastNew sql.NullString
+		if err := tx.QueryRow(
+			`SELECT new_repo FROM repo_renames WHERE old_repo = ? ORDER BY id DESC LIMIT 1`,
+			oldRepo,
+		).Scan(&lastNew); err != nil && err != sql.ErrNoRows {
+			return false, fmt.Errorf("store: rename audit lookup: %w", err)
+		}
+		// New mapping (no prior audit, or last audit pointed somewhere
+		// else): record this rename.
+		if !lastNew.Valid || lastNew.String != newRepo {
+			insertAudit = true
+		}
+	}
+	if insertAudit {
 		if _, err := tx.Exec(
 			`INSERT INTO repo_renames (old_repo, new_repo, renamed_at) VALUES (?, ?, ?)`,
 			oldRepo, newRepo, time.Now().UTC().Format(sqliteTimeFormat),
@@ -114,7 +142,11 @@ func (s *Store) RenameRepo(oldRepo, newRepo string) (applied bool, err error) {
 		return false, fmt.Errorf("store: rename commit: %w", err)
 	}
 	committed = true
-	return totalMoved > 0, nil
+	// `applied` tracks whether this call produced any state change:
+	// either SQLite rows moved or a new audit row recorded the
+	// rename. Reconciler uses this for log telemetry only — it does
+	// NOT gate downstream work (see the docstring above).
+	return insertAudit, nil
 }
 
 func validateRenamePair(oldRepo, newRepo string) error {

--- a/daemon/internal/store/rename.go
+++ b/daemon/internal/store/rename.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -17,26 +16,32 @@ var ErrInvalidRepoSlug = errors.New("store: invalid repo slug")
 
 // RenameRepo moves every row keyed on `oldRepo` over to `newRepo`
 // in a single SQLite transaction, and writes an audit row to
-// `repo_renames`. The four tables touched are prs, issues,
-// activity_log, watch_state — these are the surfaces that store the
-// `owner/name` string directly. In-flight tables (`reviews_in_flight`,
-// `issue_triage_in_flight`) are keyed on numeric IDs and do not need
-// renaming. activity_log's `org` column is left untouched because the
-// repoOrg helper deriving it is recomputed from `repo` at read time
-// elsewhere; backfilling it here would silently obscure the org
-// rename in audit history.
+// `repo_renames`. Tables touched:
 //
-// Idempotency: if a `repo_renames` row already maps `oldRepo`→`newRepo`,
-// the method returns (false, nil) without writing further state. This
-// keeps daemon restarts from re-applying a successful rename, and lets
-// the detection probe call RenameRepo on every probe tick without
-// double-writing the audit trail.
+//   - prs.repo, issues.repo, watch_state.repo: straight UPDATE.
+//   - activity_log: UPDATEs both repo AND org (when the org
+//     component differs between oldRepo and newRepo) so the
+//     ListActivity org-filter keeps surfacing historical entries
+//     under the new org name after an org-rename. The invariant
+//     org == repoOrg(repo) is preserved.
+//
+// In-flight tables (`reviews_in_flight`, `issue_triage_in_flight`)
+// are keyed on numeric IDs and do not need renaming.
+//
+// Idempotency is derived from the data, not the audit table: each
+// UPDATE matches `WHERE repo = oldRepo`, so on a second call after
+// a successful rename the WHERE matches zero rows and the UPDATE is
+// a natural no-op. This correctly handles rename chains like
+// A→B→A→B: every step inspects the current state of the tables and
+// moves whatever is there. The audit row is inserted ONLY when at
+// least one row actually moved, so the audit log reflects real
+// state transitions instead of accumulating attempts.
 //
 // IMPORTANT: `applied` is INFORMATIONAL telemetry only — callers MUST
 // NOT use it to skip downstream reconciliation work (config rewrite,
 // worktree purge, SSE emission). The downstream surfaces are not
 // audited at the store level, so a prior invocation could have
-// committed this audit row and then failed at the persister or
+// committed the store work and then failed at the persister or
 // purger; the recovery retry sees applied=false and must still
 // complete those steps. See rename.Reconciler.Run for the full
 // rationale.
@@ -45,28 +50,10 @@ func (s *Store) RenameRepo(oldRepo, newRepo string) (applied bool, err error) {
 		return false, err
 	}
 
-	// Idempotency guard: if the most recent audit row for oldRepo
-	// already points at newRepo, the rename was applied previously
-	// and the call is a no-op. A different newRepo would indicate a
-	// rename chain (old→intermediate→new); the caller is expected to
-	// reconcile in order, so we treat that as a fresh rename.
-	var lastNew sql.NullString
-	if err := s.db.QueryRow(
-		`SELECT new_repo FROM repo_renames WHERE old_repo = ? ORDER BY id DESC LIMIT 1`,
-		oldRepo,
-	).Scan(&lastNew); err != nil && err != sql.ErrNoRows {
-		return false, fmt.Errorf("store: rename idempotency check: %w", err)
-	}
-	if lastNew.Valid && lastNew.String == newRepo {
-		return false, nil
-	}
-
 	tx, err := s.db.Begin()
 	if err != nil {
 		return false, fmt.Errorf("store: rename begin tx: %w", err)
 	}
-	// Roll back unconditionally; the Commit path nils err so the deferred
-	// rollback becomes a no-op (sql.ErrTxDone is expected and ignored).
 	committed := false
 	defer func() {
 		if !committed {
@@ -74,27 +61,60 @@ func (s *Store) RenameRepo(oldRepo, newRepo string) (applied bool, err error) {
 		}
 	}()
 
-	for _, table := range []string{"prs", "issues", "activity_log", "watch_state"} {
-		if _, err := tx.Exec(
+	var totalMoved int64
+	for _, table := range []string{"prs", "issues", "watch_state"} {
+		res, err := tx.Exec(
 			`UPDATE `+table+` SET repo = ? WHERE repo = ?`,
 			newRepo, oldRepo,
-		); err != nil {
+		)
+		if err != nil {
 			return false, fmt.Errorf("store: rename %s: %w", table, err)
 		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return false, fmt.Errorf("store: rename %s: rows affected: %w", table, err)
+		}
+		totalMoved += n
 	}
 
-	if _, err := tx.Exec(
-		`INSERT INTO repo_renames (old_repo, new_repo, renamed_at) VALUES (?, ?, ?)`,
-		oldRepo, newRepo, time.Now().UTC().Format(sqliteTimeFormat),
-	); err != nil {
-		return false, fmt.Errorf("store: rename insert audit: %w", err)
+	// activity_log has both `repo` and `org` columns. The org column
+	// drives the ListActivity Orgs filter and is rendered to the UI,
+	// so we keep it in sync with the new repo's org component. For a
+	// same-org rename newOrg == oldOrg and this is a no-op for that
+	// column; for an org rename it's the load-bearing UPDATE that
+	// keeps activity history visible under the new org filter.
+	newOrg := orgOfSlug(newRepo)
+	res, err := tx.Exec(
+		`UPDATE activity_log SET repo = ?, org = ? WHERE repo = ?`,
+		newRepo, newOrg, oldRepo,
+	)
+	if err != nil {
+		return false, fmt.Errorf("store: rename activity_log: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("store: rename activity_log: rows affected: %w", err)
+	}
+	totalMoved += n
+
+	// Audit row only when something actually moved. Reflecting "no
+	// rows for oldRepo" as a no-op in the audit table keeps the log
+	// usable as a real-state-transitions history rather than a
+	// retry/probe-tick log.
+	if totalMoved > 0 {
+		if _, err := tx.Exec(
+			`INSERT INTO repo_renames (old_repo, new_repo, renamed_at) VALUES (?, ?, ?)`,
+			oldRepo, newRepo, time.Now().UTC().Format(sqliteTimeFormat),
+		); err != nil {
+			return false, fmt.Errorf("store: rename insert audit: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
 		return false, fmt.Errorf("store: rename commit: %w", err)
 	}
 	committed = true
-	return true, nil
+	return totalMoved > 0, nil
 }
 
 func validateRenamePair(oldRepo, newRepo string) error {
@@ -121,4 +141,15 @@ func looksLikeOwnerName(s string) bool {
 		return false
 	}
 	return parts[0] != "" && parts[1] != ""
+}
+
+// orgOfSlug returns the owner segment of a `owner/name` slug, or "" when
+// the input is malformed. validateRenamePair has already enforced the
+// shape by the time this is called from RenameRepo, but we keep the
+// defensive empty return for any future direct caller.
+func orgOfSlug(repo string) string {
+	if i := strings.Index(repo, "/"); i > 0 {
+		return repo[:i]
+	}
+	return ""
 }

--- a/daemon/internal/store/rename.go
+++ b/daemon/internal/store/rename.go
@@ -30,8 +30,16 @@ var ErrInvalidRepoSlug = errors.New("store: invalid repo slug")
 // the method returns (false, nil) without writing further state. This
 // keeps daemon restarts from re-applying a successful rename, and lets
 // the detection probe call RenameRepo on every probe tick without
-// worry. On a real rename, returns (true, nil); callers fan that out
-// to SSE / log only when applied=true.
+// double-writing the audit trail.
+//
+// IMPORTANT: `applied` is INFORMATIONAL telemetry only — callers MUST
+// NOT use it to skip downstream reconciliation work (config rewrite,
+// worktree purge, SSE emission). The downstream surfaces are not
+// audited at the store level, so a prior invocation could have
+// committed this audit row and then failed at the persister or
+// purger; the recovery retry sees applied=false and must still
+// complete those steps. See rename.Reconciler.Run for the full
+// rationale.
 func (s *Store) RenameRepo(oldRepo, newRepo string) (applied bool, err error) {
 	if err := validateRenamePair(oldRepo, newRepo); err != nil {
 		return false, err

--- a/daemon/internal/store/rename.go
+++ b/daemon/internal/store/rename.go
@@ -1,0 +1,114 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ErrInvalidRepoSlug is returned by RenameRepo when either slug is
+// empty, equal to the other, or not shaped as "owner/name". Detection
+// callers pre-validate against the GitHub response, so reaching this
+// error in production usually indicates a programming bug or a manual
+// admin endpoint invocation with malformed input.
+var ErrInvalidRepoSlug = errors.New("store: invalid repo slug")
+
+// RenameRepo moves every row keyed on `oldRepo` over to `newRepo`
+// in a single SQLite transaction, and writes an audit row to
+// `repo_renames`. The four tables touched are prs, issues,
+// activity_log, watch_state — these are the surfaces that store the
+// `owner/name` string directly. In-flight tables (`reviews_in_flight`,
+// `issue_triage_in_flight`) are keyed on numeric IDs and do not need
+// renaming. activity_log's `org` column is left untouched because the
+// repoOrg helper deriving it is recomputed from `repo` at read time
+// elsewhere; backfilling it here would silently obscure the org
+// rename in audit history.
+//
+// Idempotency: if a `repo_renames` row already maps `oldRepo`→`newRepo`,
+// the method returns nil without writing further state. This keeps
+// daemon restarts from re-applying a successful rename, and lets the
+// detection probe call RenameRepo on every probe tick without worry.
+func (s *Store) RenameRepo(oldRepo, newRepo string) error {
+	if err := validateRenamePair(oldRepo, newRepo); err != nil {
+		return err
+	}
+
+	// Idempotency guard: if the most recent audit row for oldRepo
+	// already points at newRepo, the rename was applied previously
+	// and the call is a no-op. A different newRepo would indicate a
+	// rename chain (old→intermediate→new); the caller is expected to
+	// reconcile in order, so we treat that as a fresh rename.
+	var lastNew sql.NullString
+	if err := s.db.QueryRow(
+		`SELECT new_repo FROM repo_renames WHERE old_repo = ? ORDER BY id DESC LIMIT 1`,
+		oldRepo,
+	).Scan(&lastNew); err != nil && err != sql.ErrNoRows {
+		return fmt.Errorf("store: rename idempotency check: %w", err)
+	}
+	if lastNew.Valid && lastNew.String == newRepo {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("store: rename begin tx: %w", err)
+	}
+	// Roll back unconditionally; the Commit path nils err so the deferred
+	// rollback becomes a no-op (sql.ErrTxDone is expected and ignored).
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	for _, table := range []string{"prs", "issues", "activity_log", "watch_state"} {
+		if _, err := tx.Exec(
+			`UPDATE `+table+` SET repo = ? WHERE repo = ?`,
+			newRepo, oldRepo,
+		); err != nil {
+			return fmt.Errorf("store: rename %s: %w", table, err)
+		}
+	}
+
+	if _, err := tx.Exec(
+		`INSERT INTO repo_renames (old_repo, new_repo, renamed_at) VALUES (?, ?, ?)`,
+		oldRepo, newRepo, time.Now().UTC().Format(sqliteTimeFormat),
+	); err != nil {
+		return fmt.Errorf("store: rename insert audit: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("store: rename commit: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func validateRenamePair(oldRepo, newRepo string) error {
+	if oldRepo == "" || newRepo == "" {
+		return fmt.Errorf("%w: empty slug", ErrInvalidRepoSlug)
+	}
+	if oldRepo == newRepo {
+		return fmt.Errorf("%w: old and new are identical", ErrInvalidRepoSlug)
+	}
+	if !looksLikeOwnerName(oldRepo) || !looksLikeOwnerName(newRepo) {
+		return fmt.Errorf("%w: expected owner/name shape", ErrInvalidRepoSlug)
+	}
+	return nil
+}
+
+// looksLikeOwnerName checks the minimum well-formedness of a GitHub
+// slug: exactly one '/' separator with non-empty owner and name. GitHub
+// itself enforces stricter character rules; we do not duplicate the
+// regex here because the detection probe only ever passes us values it
+// just read from the GitHub API.
+func looksLikeOwnerName(s string) bool {
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 {
+		return false
+	}
+	return parts[0] != "" && parts[1] != ""
+}

--- a/daemon/internal/store/rename.go
+++ b/daemon/internal/store/rename.go
@@ -27,12 +27,14 @@ var ErrInvalidRepoSlug = errors.New("store: invalid repo slug")
 // rename in audit history.
 //
 // Idempotency: if a `repo_renames` row already maps `oldRepo`→`newRepo`,
-// the method returns nil without writing further state. This keeps
-// daemon restarts from re-applying a successful rename, and lets the
-// detection probe call RenameRepo on every probe tick without worry.
-func (s *Store) RenameRepo(oldRepo, newRepo string) error {
+// the method returns (false, nil) without writing further state. This
+// keeps daemon restarts from re-applying a successful rename, and lets
+// the detection probe call RenameRepo on every probe tick without
+// worry. On a real rename, returns (true, nil); callers fan that out
+// to SSE / log only when applied=true.
+func (s *Store) RenameRepo(oldRepo, newRepo string) (applied bool, err error) {
 	if err := validateRenamePair(oldRepo, newRepo); err != nil {
-		return err
+		return false, err
 	}
 
 	// Idempotency guard: if the most recent audit row for oldRepo
@@ -45,15 +47,15 @@ func (s *Store) RenameRepo(oldRepo, newRepo string) error {
 		`SELECT new_repo FROM repo_renames WHERE old_repo = ? ORDER BY id DESC LIMIT 1`,
 		oldRepo,
 	).Scan(&lastNew); err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("store: rename idempotency check: %w", err)
+		return false, fmt.Errorf("store: rename idempotency check: %w", err)
 	}
 	if lastNew.Valid && lastNew.String == newRepo {
-		return nil
+		return false, nil
 	}
 
 	tx, err := s.db.Begin()
 	if err != nil {
-		return fmt.Errorf("store: rename begin tx: %w", err)
+		return false, fmt.Errorf("store: rename begin tx: %w", err)
 	}
 	// Roll back unconditionally; the Commit path nils err so the deferred
 	// rollback becomes a no-op (sql.ErrTxDone is expected and ignored).
@@ -69,7 +71,7 @@ func (s *Store) RenameRepo(oldRepo, newRepo string) error {
 			`UPDATE `+table+` SET repo = ? WHERE repo = ?`,
 			newRepo, oldRepo,
 		); err != nil {
-			return fmt.Errorf("store: rename %s: %w", table, err)
+			return false, fmt.Errorf("store: rename %s: %w", table, err)
 		}
 	}
 
@@ -77,14 +79,14 @@ func (s *Store) RenameRepo(oldRepo, newRepo string) error {
 		`INSERT INTO repo_renames (old_repo, new_repo, renamed_at) VALUES (?, ?, ?)`,
 		oldRepo, newRepo, time.Now().UTC().Format(sqliteTimeFormat),
 	); err != nil {
-		return fmt.Errorf("store: rename insert audit: %w", err)
+		return false, fmt.Errorf("store: rename insert audit: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("store: rename commit: %w", err)
+		return false, fmt.Errorf("store: rename commit: %w", err)
 	}
 	committed = true
-	return nil
+	return true, nil
 }
 
 func validateRenamePair(oldRepo, newRepo string) error {

--- a/daemon/internal/store/rename_test.go
+++ b/daemon/internal/store/rename_test.go
@@ -346,6 +346,59 @@ func TestStore_RenameRepo_PreservesActivityOrgOnSameOrgRename(t *testing.T) {
 	}
 }
 
+// TestStore_RenameRepo_AuditsRenameOnEmptyState pins the edge case
+// flagged in review: a repo configured on the daemon may be renamed
+// on GitHub BEFORE any PRs/issues/activity rows have accumulated
+// under it. The UPDATEs match zero rows in that case, but the
+// rename still happened from the reconciler's point of view and the
+// issue/PR contract requires the mapping to land in repo_renames so
+// the historical record survives restarts.
+func TestStore_RenameRepo_AuditsRenameOnEmptyState(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	// First call on empty state: no SQLite rows for either slug.
+	applied, err := s.RenameRepo("acme/empty", "acme/renamed")
+	if err != nil {
+		t.Fatalf("RenameRepo on empty state: %v", err)
+	}
+	if !applied {
+		t.Error("applied=false on first rename of an empty-state repo — caller treats this as a recovery path, but it is a fresh rename that just lacks SQLite rows")
+	}
+
+	count := func() int {
+		t.Helper()
+		var n int
+		if err := s.DB().QueryRow(
+			"SELECT COUNT(*) FROM repo_renames WHERE old_repo = ? AND new_repo = ?",
+			"acme/empty", "acme/renamed",
+		).Scan(&n); err != nil {
+			t.Fatalf("count audit: %v", err)
+		}
+		return n
+	}
+	if got := count(); got != 1 {
+		t.Errorf("repo_renames row count = %d, want 1 — empty-state rename must persist the mapping per #489", got)
+	}
+
+	// Retry with the same pair: audit row already records the
+	// mapping, so this is a true no-op. applied=false, no duplicate
+	// audit row.
+	applied, err = s.RenameRepo("acme/empty", "acme/renamed")
+	if err != nil {
+		t.Fatalf("RenameRepo retry: %v", err)
+	}
+	if applied {
+		t.Error("applied=true on duplicate retry — the mapping is already audited and there is no new state to record")
+	}
+	if got := count(); got != 1 {
+		t.Errorf("retry duplicated audit row: count = %d, want 1", got)
+	}
+}
+
 func TestStore_RenameRepo_Idempotent(t *testing.T) {
 	s := seedForRename(t, "acme/old", 1000)
 

--- a/daemon/internal/store/rename_test.go
+++ b/daemon/internal/store/rename_test.go
@@ -97,7 +97,7 @@ func countWithRepo(t *testing.T, s *store.Store, table, repo string) int {
 func TestStore_RenameRepo_UpdatesAllTables(t *testing.T) {
 	s := seedForRename(t, "acme/old", 1000)
 
-	if err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+	if _, err := s.RenameRepo("acme/old", "acme/new"); err != nil {
 		t.Fatalf("rename: %v", err)
 	}
 
@@ -136,7 +136,7 @@ func TestStore_RenameRepo_LeavesUnrelatedRowsUntouched(t *testing.T) {
 		t.Fatalf("seed unrelated activity: %v", err)
 	}
 
-	if err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+	if _, err := s.RenameRepo("acme/old", "acme/new"); err != nil {
 		t.Fatalf("rename: %v", err)
 	}
 
@@ -151,7 +151,7 @@ func TestStore_RenameRepo_LeavesUnrelatedRowsUntouched(t *testing.T) {
 func TestStore_RenameRepo_InsertsAuditRow(t *testing.T) {
 	s := seedForRename(t, "acme/old", 1000)
 
-	if err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+	if _, err := s.RenameRepo("acme/old", "acme/new"); err != nil {
 		t.Fatalf("rename: %v", err)
 	}
 
@@ -185,7 +185,7 @@ func TestStore_RenameRepo_IsAtomic_OnError(t *testing.T) {
 		t.Fatalf("drop activity_log: %v", err)
 	}
 
-	err := s.RenameRepo("acme/old", "acme/new")
+	_, err := s.RenameRepo("acme/old", "acme/new")
 	if err == nil {
 		t.Fatal("expected error from RenameRepo when activity_log is missing")
 	}
@@ -213,11 +213,19 @@ func TestStore_RenameRepo_IsAtomic_OnError(t *testing.T) {
 func TestStore_RenameRepo_Idempotent(t *testing.T) {
 	s := seedForRename(t, "acme/old", 1000)
 
-	if err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+	applied1, err := s.RenameRepo("acme/old", "acme/new")
+	if err != nil {
 		t.Fatalf("rename #1: %v", err)
 	}
-	if err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+	if !applied1 {
+		t.Error("first rename: applied=false, want true")
+	}
+	applied2, err := s.RenameRepo("acme/old", "acme/new")
+	if err != nil {
 		t.Fatalf("rename #2 (should be no-op): %v", err)
+	}
+	if applied2 {
+		t.Error("second rename: applied=true, want false (idempotent no-op)")
 	}
 
 	var n int

--- a/daemon/internal/store/rename_test.go
+++ b/daemon/internal/store/rename_test.go
@@ -210,6 +210,142 @@ func TestStore_RenameRepo_IsAtomic_OnError(t *testing.T) {
 	}
 }
 
+// TestStore_RenameRepo_HandlesRenameBackChain pins the chain-convergence
+// requirement from issue #489 ("A rename followed by a rename-back ...
+// must converge correctly"). The previous audit-table-only idempotency
+// check returned applied=false on the third leg (A→B after a B→A round
+// trip), leaving DB rows on A while the reconciler advanced the config
+// to B — silent drift.
+func TestStore_RenameRepo_HandlesRenameBackChain(t *testing.T) {
+	s := seedForRename(t, "acme/old", 1000)
+
+	step := func(oldR, newR string, wantApplied bool) {
+		t.Helper()
+		applied, err := s.RenameRepo(oldR, newR)
+		if err != nil {
+			t.Fatalf("RenameRepo(%s, %s): %v", oldR, newR, err)
+		}
+		if applied != wantApplied {
+			t.Errorf("RenameRepo(%s, %s) applied = %v, want %v", oldR, newR, applied, wantApplied)
+		}
+	}
+	stateAt := func(repo string) int {
+		t.Helper()
+		return countWithRepo(t, s, "prs", repo) +
+			countWithRepo(t, s, "issues", repo) +
+			countWithRepo(t, s, "activity_log", repo) +
+			countWithRepo(t, s, "watch_state", repo)
+	}
+
+	// Forward: rows move to acme/new.
+	step("acme/old", "acme/new", true)
+	if got := stateAt("acme/old"); got != 0 {
+		t.Errorf("after A→B: %d rows still at acme/old, want 0", got)
+	}
+	if got := stateAt("acme/new"); got == 0 {
+		t.Errorf("after A→B: 0 rows at acme/new, want > 0")
+	}
+
+	// Back: rows return to acme/old.
+	step("acme/new", "acme/old", true)
+	if got := stateAt("acme/new"); got != 0 {
+		t.Errorf("after B→A: %d rows still at acme/new, want 0", got)
+	}
+	if got := stateAt("acme/old"); got == 0 {
+		t.Errorf("after B→A: 0 rows at acme/old, want > 0")
+	}
+
+	// Forward again: this is the leg the old guard mishandled.
+	// MUST return applied=true and actually move the rows.
+	step("acme/old", "acme/new", true)
+	if got := stateAt("acme/old"); got != 0 {
+		t.Errorf("after A→B (round 2): %d rows still at acme/old — rename-back chain broken", got)
+	}
+	if got := stateAt("acme/new"); got == 0 {
+		t.Errorf("after A→B (round 2): 0 rows at acme/new, want > 0")
+	}
+
+	// A fourth A→B with no rows to move is the natural no-op.
+	step("acme/old", "acme/new", false)
+}
+
+// TestStore_RenameRepo_UpdatesActivityLogOrgOnOrgRename pins the org
+// column maintenance for org-level renames (old-org/repo →
+// new-org/repo). The ListActivity org filter (activity.go) keys on
+// the org column, so leaving it stale silently hides historical
+// rows from the post-rename org's view.
+func TestStore_RenameRepo_UpdatesActivityLogOrgOnOrgRename(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	ts := time.Now().UTC().Truncate(time.Second)
+	if _, err := s.InsertActivity(ts, "old-org", "old-org/api", "pr", 1, "x", "review", "", nil); err != nil {
+		t.Fatalf("seed activity: %v", err)
+	}
+
+	if _, err := s.RenameRepo("old-org/api", "new-org/api"); err != nil {
+		t.Fatalf("RenameRepo: %v", err)
+	}
+
+	// repo column must reflect the new slug.
+	if got := countWithRepo(t, s, "activity_log", "new-org/api"); got != 1 {
+		t.Errorf("activity_log row not renamed: %d rows at new-org/api, want 1", got)
+	}
+	// org column must also reflect the new org — otherwise the
+	// ListActivity Orgs filter loses this row.
+	var org string
+	if err := s.DB().QueryRow(
+		"SELECT org FROM activity_log WHERE repo = ?", "new-org/api",
+	).Scan(&org); err != nil {
+		t.Fatalf("scan org: %v", err)
+	}
+	if org != "new-org" {
+		t.Errorf("activity_log.org = %q, want new-org — UI filter by new-org would lose this row", org)
+	}
+}
+
+// TestStore_RenameRepo_PreservesActivityOrgOnSameOrgRename pins the
+// other half: a within-org rename keeps the org column untouched
+// (newOrg == oldOrg), and other rows under that org are unaffected.
+func TestStore_RenameRepo_PreservesActivityOrgOnSameOrgRename(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	ts := time.Now().UTC().Truncate(time.Second)
+	for _, row := range []struct{ repo string }{
+		{"acme/old"},
+		{"acme/sibling"}, // must NOT be touched
+	} {
+		if _, err := s.InsertActivity(ts, "acme", row.repo, "pr", 1, "x", "review", "", nil); err != nil {
+			t.Fatalf("seed activity for %s: %v", row.repo, err)
+		}
+	}
+
+	if _, err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+		t.Fatalf("RenameRepo: %v", err)
+	}
+
+	var org string
+	if err := s.DB().QueryRow(
+		"SELECT org FROM activity_log WHERE repo = ?", "acme/new",
+	).Scan(&org); err != nil {
+		t.Fatalf("scan org for renamed row: %v", err)
+	}
+	if org != "acme" {
+		t.Errorf("renamed row org = %q, want acme", org)
+	}
+	// Sibling row in the same org must remain untouched.
+	if got := countWithRepo(t, s, "activity_log", "acme/sibling"); got != 1 {
+		t.Errorf("sibling row was touched: count = %d, want 1", got)
+	}
+}
+
 func TestStore_RenameRepo_Idempotent(t *testing.T) {
 	s := seedForRename(t, "acme/old", 1000)
 

--- a/daemon/internal/store/rename_test.go
+++ b/daemon/internal/store/rename_test.go
@@ -1,0 +1,233 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// seedForRename inserts one PR, one issue, one activity row, and one
+// watch_state row under `repo`. Returns the store ready for a rename
+// invocation. Used by every test in this file.
+func seedForRename(t *testing.T, repo string, githubBase int64) *store.Store {
+	t.Helper()
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	if _, err := s.UpsertPR(&store.PR{
+		GithubID:  githubBase,
+		Repo:      repo,
+		Number:    1,
+		Title:     "pr",
+		Author:    "alice",
+		URL:       "https://x/" + repo + "/pull/1",
+		State:     "open",
+		UpdatedAt: time.Now().UTC(),
+		FetchedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed pr: %v", err)
+	}
+
+	if _, err := s.UpsertIssue(&store.Issue{
+		GithubID:  githubBase + 100,
+		Repo:      repo,
+		Number:    7,
+		Title:     "issue",
+		Author:    "bob",
+		State:     "open",
+		CreatedAt: time.Now().UTC(),
+		FetchedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+
+	if _, err := s.InsertActivity(
+		time.Now().UTC().Truncate(time.Second),
+		"acme", repo, "pr", 1, "pr", "review", "", nil,
+	); err != nil {
+		t.Fatalf("seed activity: %v", err)
+	}
+
+	// watch_state row. Insert directly via DB() — RenameRepo's contract
+	// is to update existing rows, not to know how callers created them.
+	if _, err := s.DB().Exec(`
+		INSERT INTO watch_state (key, type, repo, number, github_id, next_check, backoff_ns, last_seen)
+		VALUES (?, 'pr', ?, 1, ?, ?, 0, ?)`,
+		"pr."+itoa(githubBase), repo, githubBase,
+		time.Now().Format(time.RFC3339Nano),
+		time.Now().Format(time.RFC3339Nano),
+	); err != nil {
+		t.Fatalf("seed watch_state: %v", err)
+	}
+
+	return s
+}
+
+func itoa(n int64) string {
+	// strconv.FormatInt would pull in another import for one call; the
+	// seeded values are small positives so a hand-rolled formatter keeps
+	// the test self-contained.
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+func countWithRepo(t *testing.T, s *store.Store, table, repo string) int {
+	t.Helper()
+	var n int
+	q := "SELECT COUNT(*) FROM " + table + " WHERE repo = ?"
+	if err := s.DB().QueryRow(q, repo).Scan(&n); err != nil {
+		t.Fatalf("count %s where repo=%s: %v", table, repo, err)
+	}
+	return n
+}
+
+func TestStore_RenameRepo_UpdatesAllTables(t *testing.T) {
+	s := seedForRename(t, "acme/old", 1000)
+
+	if err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	for _, table := range []string{"prs", "issues", "activity_log", "watch_state"} {
+		if got := countWithRepo(t, s, table, "acme/new"); got != 1 {
+			t.Errorf("%s: want 1 row with new slug, got %d", table, got)
+		}
+		if got := countWithRepo(t, s, table, "acme/old"); got != 0 {
+			t.Errorf("%s: want 0 rows with old slug, got %d", table, got)
+		}
+	}
+}
+
+func TestStore_RenameRepo_LeavesUnrelatedRowsUntouched(t *testing.T) {
+	s := seedForRename(t, "acme/old", 1000)
+
+	// Add a second PR + activity row in a different repo. These must
+	// stay put regardless of what RenameRepo does to the acme/old rows.
+	if _, err := s.UpsertPR(&store.PR{
+		GithubID:  2000,
+		Repo:      "globex/other",
+		Number:    99,
+		Title:     "pr",
+		Author:    "x",
+		URL:       "https://x",
+		State:     "open",
+		UpdatedAt: time.Now().UTC(),
+		FetchedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed unrelated pr: %v", err)
+	}
+	if _, err := s.InsertActivity(
+		time.Now().UTC().Truncate(time.Second),
+		"globex", "globex/other", "pr", 99, "x", "review", "", nil,
+	); err != nil {
+		t.Fatalf("seed unrelated activity: %v", err)
+	}
+
+	if err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	if got := countWithRepo(t, s, "prs", "globex/other"); got != 1 {
+		t.Errorf("unrelated PR was touched: want 1 row for globex/other, got %d", got)
+	}
+	if got := countWithRepo(t, s, "activity_log", "globex/other"); got != 1 {
+		t.Errorf("unrelated activity was touched: want 1, got %d", got)
+	}
+}
+
+func TestStore_RenameRepo_InsertsAuditRow(t *testing.T) {
+	s := seedForRename(t, "acme/old", 1000)
+
+	if err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	var (
+		oldRepo, newRepo string
+		ts               string
+	)
+	row := s.DB().QueryRow(
+		"SELECT old_repo, new_repo, renamed_at FROM repo_renames ORDER BY id DESC LIMIT 1",
+	)
+	if err := row.Scan(&oldRepo, &newRepo, &ts); err != nil {
+		t.Fatalf("scan audit: %v", err)
+	}
+	if oldRepo != "acme/old" || newRepo != "acme/new" {
+		t.Errorf("audit pair = (%q, %q); want (acme/old, acme/new)", oldRepo, newRepo)
+	}
+	if ts == "" {
+		t.Error("audit timestamp empty")
+	}
+}
+
+func TestStore_RenameRepo_IsAtomic_OnError(t *testing.T) {
+	s := seedForRename(t, "acme/old", 1000)
+
+	// Force the UPDATE on activity_log to fail mid-TX by dropping the
+	// table before the call. With RenameRepo running everything inside
+	// a single SQLite transaction, the prs / issues UPDATEs that come
+	// before activity_log must roll back when the missing-table error
+	// fires.
+	if _, err := s.DB().Exec("DROP TABLE activity_log"); err != nil {
+		t.Fatalf("drop activity_log: %v", err)
+	}
+
+	err := s.RenameRepo("acme/old", "acme/new")
+	if err == nil {
+		t.Fatal("expected error from RenameRepo when activity_log is missing")
+	}
+
+	// prs and issues must NOT have been advanced to acme/new.
+	for _, table := range []string{"prs", "issues", "watch_state"} {
+		if got := countWithRepo(t, s, table, "acme/new"); got != 0 {
+			t.Errorf("%s: TX leaked — want 0 new-slug rows after rollback, got %d", table, got)
+		}
+		if got := countWithRepo(t, s, table, "acme/old"); got != 1 {
+			t.Errorf("%s: TX leaked — want 1 old-slug row preserved after rollback, got %d", table, got)
+		}
+	}
+
+	// Audit row must also have rolled back.
+	var n int
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM repo_renames").Scan(&n); err != nil {
+		t.Fatalf("count audit: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("audit row leaked — want 0, got %d", n)
+	}
+}
+
+func TestStore_RenameRepo_Idempotent(t *testing.T) {
+	s := seedForRename(t, "acme/old", 1000)
+
+	if err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+		t.Fatalf("rename #1: %v", err)
+	}
+	if err := s.RenameRepo("acme/old", "acme/new"); err != nil {
+		t.Fatalf("rename #2 (should be no-op): %v", err)
+	}
+
+	var n int
+	if err := s.DB().QueryRow(
+		"SELECT COUNT(*) FROM repo_renames WHERE old_repo = ? AND new_repo = ?",
+		"acme/old", "acme/new",
+	).Scan(&n); err != nil {
+		t.Fatalf("count audit: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("idempotency broken: want 1 audit row, got %d", n)
+	}
+}

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -246,10 +246,15 @@ func Open(dsn string) (*Store, error) {
 		started_at  DATETIME NOT NULL,
 		PRIMARY KEY (issue_id, updated_at)
 	)`)
-	// Repo rename audit table (#489). RenameRepo writes an audit row in
-	// the same TX that bulk-renames prs/issues/activity_log/watch_state,
-	// and consults the latest row per old_repo to short-circuit idempotent
-	// re-invocations on daemon restart.
+	// Repo rename audit table (#489). RenameRepo writes a row here
+	// in the same TX that bulk-renames prs/issues/activity_log/
+	// watch_state. The audit table is informational — it is NOT
+	// consulted to short-circuit idempotency of the UPDATEs (those
+	// are naturally idempotent via `WHERE repo = oldRepo`), so the
+	// log is safe across rename-back chains like A→B→A→B. The most
+	// recent row per old_repo is read only on the empty-state edge
+	// path to decide whether to insert a fresh audit row when the
+	// UPDATEs matched zero rows.
 	db.Exec(`CREATE TABLE IF NOT EXISTS repo_renames (
 		id          INTEGER PRIMARY KEY AUTOINCREMENT,
 		old_repo    TEXT NOT NULL,

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -246,6 +246,31 @@ func Open(dsn string) (*Store, error) {
 		started_at  DATETIME NOT NULL,
 		PRIMARY KEY (issue_id, updated_at)
 	)`)
+	// Repo rename audit table (#489). RenameRepo writes an audit row in
+	// the same TX that bulk-renames prs/issues/activity_log/watch_state,
+	// and consults the latest row per old_repo to short-circuit idempotent
+	// re-invocations on daemon restart.
+	db.Exec(`CREATE TABLE IF NOT EXISTS repo_renames (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		old_repo    TEXT NOT NULL,
+		new_repo    TEXT NOT NULL,
+		renamed_at  DATETIME NOT NULL
+	)`)
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_repo_renames_old ON repo_renames(old_repo)")
+	// watch_state is owned by bus.NewWatchStore at runtime, but RenameRepo
+	// needs to UPDATE rows here in the same TX as the prs/issues moves.
+	// Mirror the schema with IF NOT EXISTS so the rename can run from
+	// tests and migration paths that have not yet constructed a WatchStore.
+	db.Exec(`CREATE TABLE IF NOT EXISTS watch_state (
+		key        TEXT PRIMARY KEY,
+		type       TEXT NOT NULL,
+		repo       TEXT NOT NULL,
+		number     INTEGER NOT NULL,
+		github_id  INTEGER NOT NULL,
+		next_check TEXT NOT NULL,
+		backoff_ns INTEGER NOT NULL,
+		last_seen  TEXT NOT NULL
+	)`)
 	// Enforce single-flight per issue at the schema level (#458). The
 	// claim SQL already uses INSERT ... WHERE NOT EXISTS, but a UNIQUE
 	// index lifts the invariant from a query convention to a DB

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -140,6 +140,31 @@ HEIMDALLM_POLL_INTERVAL=5m   # valid: 1m, 5m, 30m, 1h
 poll_interval = "5m"
 ```
 
+### Repo / org rename propagation
+
+When a repository or its parent organisation is renamed on GitHub, Heimdallm needs to flip every record keyed on the old slug — otherwise rows for the OLD slug keep accumulating in the store while new poll data lands under the NEW slug, per-repo `[ai.repos."old/name"]` overrides stop applying, and stale working dirs linger on disk.
+
+A low-frequency probe queries GitHub for each monitored repo's canonical `full_name` and dispatches a reconciler when it differs. The reconciler runs the rename through a single SQLite transaction (`prs`, `issues`, `activity_log`, `watch_state`, plus an audit row in `repo_renames`), rewrites the config TOML (including `[ai.repos."<old>"]` and `[ai.orgs."<old-org>"]` when the org changed), purges the old worktree so the next acquire clones fresh, and emits an `repo_renamed` SSE event for the dashboard.
+
+```toml
+[ai]
+# Default 1h. "0" disables the probe entirely; operators can still
+# trigger renames manually via POST /admin/repo-rename.
+repo_rename_check_interval = "1h"
+```
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `ai.repo_rename_check_interval` | `1h` | Probe cadence (`0` disables) |
+
+Manual trigger for emergencies (idempotent against the probe — re-running with the same pair after the audit row is in place is a no-op):
+
+```bash
+curl -X POST http://localhost:23456/admin/repo-rename \
+  -H "X-Heimdallm-Token: $HEIMDALLM_API_TOKEN" \
+  -d '{"old_repo": "acme/legacy", "new_repo": "acme/modern"}'
+```
+
 ---
 
 ## 4. Local Directory Resolution

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -165,6 +165,14 @@ curl -X POST http://localhost:23456/admin/repo-rename \
   -d '{"old_repo": "acme/legacy", "new_repo": "acme/modern"}'
 ```
 
+**Caveat — the TOML rewrite is lossy for surface details.** Just like the existing `PATCH /config` endpoints, the rename pipeline round-trips `config.toml` through a generic decoder/encoder, which means:
+
+- Comments anywhere in the file are dropped.
+- Key order inside a table follows the encoder, not the original file.
+- Blank lines between sections are not preserved.
+
+If you maintain `config.toml` by hand and care about comments or layout, keep a separate annotated copy as your source of truth — the daemon's view of `config.toml` is its parsed structure, not its bytes on disk.
+
 ---
 
 ## 4. Local Directory Resolution

--- a/docs/superpowers/plans/2026-05-14-issue-489-repo-org-rename.md
+++ b/docs/superpowers/plans/2026-05-14-issue-489-repo-org-rename.md
@@ -1,0 +1,296 @@
+# Plan — Issue #489: handle GitHub repo / org renames
+
+Closes `theburrowhub/heimdallm#489` (URGENT). Detect a repo or org
+rename on GitHub and propagate the slug change atomically through
+every piece of daemon state keyed on the old `org/repo` string.
+
+## Problem statement (verbatim from the issue)
+
+When a repository or its parent org is renamed on GitHub, Heimdallm
+continues to operate against the **old slug**. GitHub silently 301s
+the API for a grace period which masks the problem, but symptoms
+accumulate over time:
+
+- Polling silently 404s when the redirect expires.
+- `prs.repo` / `issues.repo` rows retain the old slug → duplicate
+  rows once the new slug is discovered.
+- `[ai.repos."old/name"]` overrides stop applying because
+  `AIForRepo()` looks up by the current slug.
+- Working dirs under `local_dir_base/old-org/old-repo` go stale.
+- `watch_state` KV entries keep the old `repo` field.
+- The `repositories` / `non_monitored` lists in config retain the
+  old name forever — no reconciliation path renames an entry.
+
+Both repo renames (`org/old-name` → `org/new-name`) AND org renames
+(`old-org/repo` → `new-org/repo`) are in scope. Org renames are
+the worst case (every repo under the org flips at once).
+
+## Current state — evidence
+
+| Concern | Location | Snippet / fact |
+|---|---|---|
+| Schema columns keyed on `repo` | `store/store.go:26-130` | `prs.repo`, `issues.repo`, `activity_log.repo`, watch_state.repo (via `bus/watch.go`). In-flight tables (`reviews_in_flight`, `issue_triage_in_flight`) are keyed on numeric IDs — safe. |
+| AIForRepo lookup | `config.AIForRepo(repo)` | Per-repo overrides keyed on the current slug; a renamed repo silently loses its override. |
+| Config TOML writer | `config/writer.go:157` | `AtomicWriteTOML(path, map[string]any)` rewrites via tmp + rename. No key-rename helper today. |
+| Discovery insert | `cmd/heimdallm/main.go:2378` (`upsertDiscoveredRepos`) | When a PR appears under the new slug, it's added as a NEW repo. Old entry never removed. |
+| GH client redirect handling | `github/client.go` | `http.Client` follows 301/302 automatically but the response struct we expose doesn't surface the final URL. `GetPR` returns `Head.Repo.FullName` which is canonical — useful incidentally but not as a detector. |
+| Working dirs | `repoctx/manager.go:716` (`cloneTarget`) | Path is `base/owner/name/`. No `Rename(old, new)` method today. `Purge` and `PurgeAll` exist. |
+| Watch KV value shape | `bus/watch.go:18-29` (`WatchEntry`) | Carries `Repo`, `Number`, `GithubID`. Keyed in SQLite on `type.<id>` — not on the slug — so the slug is updateable in place. |
+| SSE event constants | `sse/broker.go` | `EventRepoDiscovered` exists; no `EventRepoRenamed` yet. |
+| Concurrency primitives | `cfgMu`, `repoctx.locks`, `store.db (SetMaxOpenConns=1)` | All available to wrap the reconciliation in a single critical section. |
+
+## Design
+
+### A. Detection (`github/client.go` + a per-repo poller)
+
+Reactive detection alone is not enough — many of our calls go through
+the Pulls API and never surface the parent repo's canonical name. We
+need a dedicated lightweight probe:
+
+```go
+// GetCanonicalFullName returns the current canonical `full_name` for
+// the repo at `owner/name`. Returns the SAME value when the repo
+// has not been renamed; the caller compares. A 404 (`*APIError`,
+// StatusCode=404) means the repo no longer exists (deleted, not
+// just renamed); callers treat that as a separate "unreachable"
+// state and emit EventRepoUnreachable rather than EventRepoRenamed.
+func (c *Client) GetCanonicalFullName(repo string) (string, error)
+```
+
+Implementation: `GET /repos/{owner}/{repo}` already returns the
+canonical `full_name` even when called with the old slug (GitHub
+issues a 301 → 200 with the new name). Single network call per
+repo, cheap.
+
+**Where the probe runs.** A new low-frequency goroutine inside
+`runTier2` (or a dedicated Tier 4) — once per `repo_rename_check_interval`
+(default 1h, configurable). Iterates `cfg.Repositories`, calls the
+probe, dispatches to the reconciler when the canonical name differs.
+Bot-discovered repos are also covered because they're appended to
+the same list.
+
+### B. Reconciler (`internal/rename/reconciler.go`, new package)
+
+Single entry point that wraps every side-effect under the right lock:
+
+```go
+type Reconciler struct {
+    store    renameStore
+    cfgMu    *sync.Mutex
+    cfg      **config.Config
+    cfgPath  string
+    repoCtx  *repoctx.Manager
+    broker   eventPublisher
+}
+
+// Run renames `oldRepo` → `newRepo` across the daemon. Idempotent:
+// a second call with the same pair, or a call where oldRepo no
+// longer exists in any store row + config list, is a no-op.
+func (r *Reconciler) Run(ctx context.Context, oldRepo, newRepo string) error
+```
+
+Steps inside `Run`, in order:
+
+1. Validate inputs (non-empty, different, `owner/name` shape).
+2. `cfgMu.Lock()`. Make a defensive copy of the in-memory config.
+3. Open a SQLite transaction; run bulk UPDATEs against `prs`,
+   `issues`, `activity_log`, `watch_state` setting `repo = ? WHERE repo = ?`.
+   Same TX inserts an audit row into the new `repo_renames` table
+   (`old_repo TEXT, new_repo TEXT, renamed_at DATETIME`).
+4. Commit. On error, abort and return — config + filesystem stay
+   untouched.
+5. Mutate the in-memory config: rename keys in `Repositories`,
+   `NonMonitored`, `AI.Repos[<old>]` → `AI.Repos[<new>]`.
+   **For ORG renames** (`old-org/*` → `new-org/*`), also move
+   `AI.Orgs[<old-org>]` → `AI.Orgs[<new-org>]` once per reconcile
+   batch — the org-level overrides are keyed on the bare org name,
+   not `owner/name`, so a repo-level reconcile must check whether
+   the org component changed and rename the org map entry too.
+   Persist via `AtomicWriteTOML` (new helper `RenameRepoInTOML`
+   that reads the existing file as a `map[string]any`, renames the
+   nested key, writes back atomically so we do not lose unrelated
+   keys the daemon does not model).
+6. **Working-dir reset, not move.** `os.Rename(oldClonePath,
+   newClonePath)` is fragile across filesystem boundaries, hits
+   permission edge cases, and races with in-flight worktree
+   acquires under `repoctx`. Instead: under the repoctx
+   critical-section lock for the OLD repo, call
+   `repoctx.Manager.Purge(oldRepo)` (drops the on-disk tree).
+   The next acquire of the NEW slug will clone fresh from the
+   canonical GitHub URL — that path already exists and is well
+   tested. Trade-off: one extra clone after a rename, which is
+   bounded and cheap compared to the failure modes of `os.Rename`.
+   Purge failure is non-fatal (logged + SSE
+   `worktree_purged: false`).
+7. `cfgMu.Unlock()`.
+8. Emit `EventRepoRenamed{old_repo, new_repo, worktree_purged}`.
+
+Locking order is `cfgMu` → repoctx lock → store transaction; the
+existing codebase already uses cfgMu as the outermost lock, so this
+matches the established discipline.
+
+### C. Idempotency + audit
+
+A new table:
+
+```sql
+CREATE TABLE repo_renames (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  old_repo    TEXT NOT NULL,
+  new_repo    TEXT NOT NULL,
+  renamed_at  DATETIME NOT NULL
+);
+CREATE INDEX idx_repo_renames_old ON repo_renames(old_repo);
+```
+
+`Run` checks at step 1: if the most recent `repo_renames` row for
+`old_repo` is `new_repo`, return nil (already done). This keeps a
+restarted daemon from re-emitting events for an already-completed
+rename.
+
+### D. New SSE event
+
+```go
+const EventRepoRenamed = "repo_renamed"
+// payload: {"old_repo": "...", "new_repo": "...", "worktree_renamed": true}
+```
+
+Flutter side: `dashboard_providers.dart` bumps the repo + issue +
+PR list refreshes and dismisses any cached entries keyed on
+`old_repo`.
+
+### E. Config knob
+
+```toml
+[ai]
+repo_rename_check_interval = "1h"  # default; "0" disables the probe entirely
+```
+
+The flag does NOT gate the reconciler — operators can trigger a
+manual rename via a new `POST /admin/repo-rename` endpoint (also
+in scope, behind the existing API token) for emergencies.
+
+## Tests (TDD order)
+
+**Store layer (`store/rename_test.go`):**
+
+| Test | What it pins |
+|---|---|
+| `TestStore_RenameRepo_UpdatesAllTables` | After RenameRepo, every `repo` column on prs / issues / activity_log / watch_state moves to the new slug. |
+| `TestStore_RenameRepo_LeavesUnrelatedRowsUntouched` | Rows for a different repo are not modified. |
+| `TestStore_RenameRepo_InsertsAuditRow` | `repo_renames` carries the pair + timestamp. |
+| `TestStore_RenameRepo_IsAtomic_OnError` | An injected error during the issues UPDATE rolls back every prior UPDATE in the same TX. |
+| `TestStore_RenameRepo_Idempotent` | Calling twice produces one audit row, second call is a no-op. |
+
+**Config writer (`config/writer_rename_test.go`):**
+
+| Test | What it pins |
+|---|---|
+| `TestRenameRepoInTOML_RenamesAIRepoKey` | `[ai.repos."old/name"]` becomes `[ai.repos."new/name"]` with identical values. |
+| `TestRenameRepoInTOML_UpdatesRepositoriesList` | `repositories = [..., "old/name", ...]` becomes `[..., "new/name", ...]` preserving order and dedup. |
+| `TestRenameRepoInTOML_UpdatesNonMonitoredList` | Same for `non_monitored`. |
+| `TestRenameRepoInTOML_PreservesUnrelatedTopLevelKeys` | Operator-only keys we don't model (custom sections) survive the rewrite. |
+| `TestRenameRepoInTOML_NoOpWhenOldAbsent` | Returns nil + no rewrite when the old slug isn't present. |
+| `TestRenameRepoInTOML_RenamesAIOrgKeyWhenOrgChanged` | When `oldOrg != newOrg`, the `[ai.orgs."old-org"]` block moves to `[ai.orgs."new-org"]` preserving values. |
+
+**GitHub client (`github/canonical_test.go`):**
+
+| Test | What it pins |
+|---|---|
+| `TestGetCanonicalFullName_ReturnsNewSlug` | Stubbed `/repos/old/name` returns `{"full_name":"new/name", ...}`; the wrapper returns `"new/name"`. |
+| `TestGetCanonicalFullName_404_PropagatesAPIError` | 404 yields an `*APIError` with StatusCode=404 (the caller treats it as repo-deleted, NOT a rename). |
+
+**Reconciler (`internal/rename/reconciler_test.go`):**
+
+| Test | What it pins |
+|---|---|
+| `TestReconciler_Run_FullPipeline` | Store + config + (skipped) worktree + SSE all flip in one call; payload has expected fields. |
+| `TestReconciler_Run_Idempotent` | A second invocation with the same pair returns nil and emits no second SSE. |
+| `TestReconciler_Run_ValidationRejectsEmpty` | Empty / equal / malformed slugs return error before any side effect. |
+| `TestReconciler_Run_StoreErrorAbortsConfig` | Injected store error leaves config TOML untouched on disk. |
+| `TestReconciler_Run_WorktreePurgeFailure_NotFatal` | A `Purge` failure is logged + SSE field `worktree_purged=false`; store + config still committed. |
+
+**Detector (`cmd/heimdallm/main_rename_probe_test.go`):**
+
+| Test | What it pins |
+|---|---|
+| `TestRenameProbe_DispatchesReconcilerOnMismatch` | Stub GH returns a new full_name; probe calls reconciler with `(old, new)`. |
+| `TestRenameProbe_NoOpWhenCanonicalMatches` | Same name in == out — reconciler not invoked. |
+| `TestRenameProbe_404FromGH_EmitsUnreachableEvent` | 404 emits a separate event, does NOT dispatch the reconciler. |
+
+## Implementation order (TDD)
+
+1. **Store + audit table.** RED+GREEN per the 5 store tests. Schema
+   migration is the idempotent `CREATE TABLE IF NOT EXISTS` block
+   in `store.go`.
+2. **GH client probe.** RED+GREEN per the 2 client tests.
+3. **Config rename helper.** RED+GREEN per the 5 writer tests.
+   Includes the TOML-map rename so unrelated keys round-trip.
+4. **Reconciler.** RED+GREEN per the 5 reconciler tests; uses
+   fakes for store / config-writer / repoctx / broker.
+5. **Probe goroutine.** RED+GREEN per the 3 probe tests.
+6. **Wire into main.go.** Construct the reconciler with real deps,
+   start the probe inside `runTier2` (or sibling goroutine).
+7. **SSE event constant + Flutter case.** New
+   `EventRepoRenamed` + `dashboard_providers.dart` case that
+   bumps repo / issue / PR list refresh.
+8. **Manual trigger endpoint** `POST /admin/repo-rename` with API
+   token check (mirrors existing admin surface).
+9. **Docs.** New section in `configuration-guide.md` near the
+   discovery/monitoring block.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Concurrent poll writes a row under the OLD slug while the rename is in flight | The transaction holds the SQLite writer lock (`SetMaxOpenConns=1`); the reconciler holds `cfgMu` so the config-driven write paths block until the rename commits. |
+| Config TOML round-trip drops unrelated keys we do not model | The writer reads via `map[string]any`, mutates only the keys it knows about, writes back. Pinned by `TestRenameRepoInTOML_PreservesUnrelatedTopLevelKeys`. |
+| Working-dir purge fails (permission, in-use worktree, FS error) | Non-fatal; SSE carries `worktree_purged=false`; the next acquire of the NEW slug clones fresh anyway. Operator may run a manual purge if old dir lingers as orphan. |
+| Daemon crashes mid-reconcile (store committed, config not yet written) | On restart, the store's `repo_renames` audit row is present but config still has the old slug → the probe runs again, the reconciler's idempotency guard sees the audit and re-applies only the config + worktree steps. |
+| GitHub returns a 301 chain (old → intermediate → new) on rename + re-rename | `http.Client` follows the chain; `GetCanonicalFullName` returns the terminal `full_name`. Audit logs every step. |
+| Cross-fork PRs whose `head.repo.full_name` differs from the base | Out of scope; we only reconcile the BASE repo slug, never the head. |
+| Cap on probe API calls | One call per repo per `repo_rename_check_interval`; bounded by `len(cfg.Repositories)` per cycle. Same rate-limit budget as the discovery poll. |
+
+## Out of scope (follow-ups)
+
+- Webhook-driven detection (would eliminate the 1h probe but
+  requires operator infra).
+- Cross-fork base-repo renames mid-PR review.
+- Backfill `repo_renames` for renames that happened before this
+  PR landed.
+- GUI toggle for `repo_rename_check_interval`.
+- **`upsertDiscoveredRepos` rename race** — after the canonical
+  probe finishes but before the reconciler commits, the discovery
+  poll can observe a PR/issue under the NEW slug and insert it as
+  a brand new repo, leaving a transient duplicate in
+  `cfg.Repositories`. Mitigation requires teaching
+  `upsertDiscoveredRepos` to consult the in-flight rename set or
+  to dedupe against the audit table. Tracked as a follow-up;
+  current PR documents the window and accepts it because:
+  (a) the discovery poll cadence (15m default) is much slower
+  than the rename critical section (sub-second), and
+  (b) duplicates dedupe naturally on the next reconciler tick
+  once the audit row is in place.
+
+## Re-entry checklist (post-compact)
+
+1. `cd /Users/imunoz/Projects/ai-platform/heimdallm && git checkout main && git pull --ff-only`
+2. `git checkout -b fix/issue-489-repo-org-rename`
+3. Read this plan top to bottom.
+4. Hot-context files to re-read:
+   - `daemon/internal/store/store.go` (schema)
+   - `daemon/internal/store/prs.go`, `issues.go` (UPDATE patterns)
+   - `daemon/internal/config/writer.go` (AtomicWriteTOML + ReadTOMLMap)
+   - `daemon/internal/config/config.go` (AIConfig / Repos map / Repositories / NonMonitored)
+   - `daemon/internal/bus/watch.go` (WatchEntry / Enroll / ForceUpdate)
+   - `daemon/internal/github/client.go` (response shape + APIError)
+   - `daemon/internal/repoctx/manager.go` (`cloneTarget`, marker writer)
+   - `daemon/cmd/heimdallm/main.go` `upsertDiscoveredRepos` + tier2 runner
+5. Start with TDD step 1 (store + audit). Use `make test-docker`
+   between every change. Branch: `fix/issue-489-repo-org-rename`,
+   PR opens **draft**.
+
+## Branch + PR
+
+Branch: `fix/issue-489-repo-org-rename`. Issue #489 is self-assigned.
+PR opens as draft, references `Closes #489` in the body.

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -230,6 +230,17 @@ void _handleSseEvent(Ref ref, SseEvent event) {
       case 'pr_review_state_changed':
         ref.read(issueListRefreshProvider.notifier).update((s) => s + 1);
 
+      // repo_renamed fires when the rename reconciler propagates a
+      // GitHub repo/org rename through daemon state (#489). Every
+      // cached list keyed on the OLD slug is now stale: PRs, issues,
+      // activity, stats. Bump every refresh counter so the next
+      // render pulls the post-rename data. Payload also carries
+      // worktree_purged so a follow-up surface could badge a
+      // dashboard warning when false; for now we just refresh.
+      case 'repo_renamed':
+        ref.read(prListRefreshProvider.notifier).update((s) => s + 1);
+        ref.read(issueListRefreshProvider.notifier).update((s) => s + 1);
+
       // ── Circuit breaker ────────────────────────────────────────────────
       case 'circuit_breaker_tripped':
         final repo = data['repo'] as String? ?? 'unknown';


### PR DESCRIPTION
## Summary

Closes #489. Detects a GitHub repo or org rename and propagates the slug change atomically through every piece of daemon state keyed on the old `owner/name` string.

Full plan in `docs/superpowers/plans/2026-05-14-issue-489-repo-org-rename.md`. Built in 9 TDD steps; **all 9 landed in this PR**.

## What changed

1. **Store + `repo_renames` audit table** (`daemon/internal/store/rename.go`). `RenameRepo(old, new) (applied bool, err error)` bulk-updates `prs`/`issues`/`activity_log`/`watch_state` in one TX, writes audit row, idempotent. 5 tests.
2. **`Client.GetCanonicalFullName(repo)`** (`daemon/internal/github/canonical.go`). Single-call rename detector via `GET /repos/{owner}/{repo}`; 404 surfaces as `*APIError`. 2 tests.
3. **Config TOML rename helper** (`daemon/internal/config/writer_rename.go`). Substitutes the slug in `[github] repositories` + `non_monitored` lists, moves `[ai.repos."<old>"]`, and moves `[ai.orgs."<old-org>"]` when the org component changed. Operator-only TOML sections survive via `map[string]any` round-trip. 6 tests. Plus `Config.ApplyRename(old, new)` for the in-memory mirror, 2 tests.
4. **Reconciler** (`daemon/internal/rename/reconciler.go`). New package; orchestrates Store → in-memory config → on-disk TOML → worktree purge → SSE publish, under `cfgMu` for the config half. 5 tests.
5. **Probe goroutine** (`daemon/internal/rename/probe.go`). Iterates monitored repos at `ai.repo_rename_check_interval` (default `1h`, `"0"` disables), dispatches the reconciler on a mismatch. 4 tests.
6. **`main.go` wiring** + new SSE event `repo_renamed`. Probe runs in its own goroutine alongside Tier 2; independent cadence so a Tier-2 stall can't suppress rename detection.
7. **Flutter** consumes `repo_renamed` in `dashboard_providers.dart` to bump both the PR list and issue list refresh counters.
8. **Admin endpoint** `POST /admin/repo-rename` behind the existing API token. Runs the same reconciler the probe does; idempotent against subsequent probe ticks. 5 handler tests.
9. **Docs** in `docs/configuration-guide.md` — new section under Repository Monitoring.

## Worktree strategy

Delete-and-reclone via `repoctx.Manager.Purge`, **not** `os.Rename`. `os.Rename` is fragile across filesystem boundaries, hits permission edge cases on macOS bundles, and races with in-flight worktree acquires. The next acquire of the new slug clones fresh — a bounded, well-tested path. Purge failure is non-fatal: the SSE payload carries `worktree_purged: false` so the dashboard can badge the inconsistency.

## Out of scope (follow-ups documented in the plan)

- Webhook-driven detection (would eliminate the 1h probe but requires operator infra).
- Cross-fork base-repo renames mid-PR review.
- Backfill `repo_renames` for renames that happened before this PR landed.
- GUI toggle for `repo_rename_check_interval`.
- `upsertDiscoveredRepos` race window where the discovery poll could observe a PR under the new slug before the reconciler commits (mitigated naturally by the next reconciler tick + the discovery poll cadence being orders of magnitude slower than the rename critical section).

## Test plan

- [x] `make test-docker ./...` clean across the daemon
- [x] `flutter test` clean (176 tests)
- [ ] Manual smoke: rename a sandbox repo on GitHub, wait one probe tick, confirm: SSE `repo_renamed` fires, dashboard refreshes, `repo_renames` audit row written, config TOML rewritten, old worktree dir gone, store rows for old slug = 0
- [ ] Manual smoke: trigger `POST /admin/repo-rename` directly with curl, confirm the same end state without waiting for the probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)