### PR TITLE
feat(rename): warn on stale non_monitored slugs (#493)

### DIFF
--- a/daemon/cmd/heimdallm/main_rename.go
+++ b/daemon/cmd/heimdallm/main_rename.go
@@ -75,6 +75,21 @@ func renameRepoListFn(cfg *config.Config, cfgMu *sync.Mutex) func() []string {
 	}
 }
 
+// renameNonMonitoredListFn returns the operator-disabled repo set
+// (#493). The probe scans this list separately from the monitored
+// one and emits stale-slug warnings without dispatching the
+// reconciler — non_monitored entries reflect explicit operator
+// choice and must not be auto-rewritten.
+func renameNonMonitoredListFn(cfg *config.Config, cfgMu *sync.Mutex) func() []string {
+	return func() []string {
+		cfgMu.Lock()
+		defer cfgMu.Unlock()
+		out := make([]string, 0, len(cfg.GitHub.NonMonitored))
+		out = append(out, cfg.GitHub.NonMonitored...)
+		return out
+	}
+}
+
 // newRenameProbe constructs the Reconciler + Probe with their real
 // daemon deps. It is invoked once per pollers cycle (re-construction
 // is safe; the probe is goroutine-local), but called from a single
@@ -94,10 +109,12 @@ func newRenameProbe(
 ) *rename.Probe {
 	reconciler := newRenameReconciler(cfg, cfgMu, tomlMu, s, repoCtx, broker, cfgPath)
 	return rename.NewProbe(rename.ProbeDeps{
-		Probe:      ghClient,
-		Dispatcher: reconciler,
-		Repos:      renameRepoListFn(cfg, cfgMu),
-		Interval:   interval,
+		Probe:        ghClient,
+		Dispatcher:   reconciler,
+		Repos:        renameRepoListFn(cfg, cfgMu),
+		NonMonitored: renameNonMonitoredListFn(cfg, cfgMu),
+		Publisher:    broker,
+		Interval:     interval,
 	})
 }
 

--- a/daemon/internal/rename/probe.go
+++ b/daemon/internal/rename/probe.go
@@ -2,8 +2,8 @@ package rename
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -190,12 +190,18 @@ func (p *Probe) tickNonMonitored(ctx context.Context) {
 		slog.Warn("rename probe: non-monitored repo has been renamed; entry is stale",
 			"old_repo", repo, "new_repo", canonical)
 		if p.deps.Publisher != nil {
+			// json.Marshal of a map[string]string is infallible and
+			// produces a deterministic key-sorted payload, which
+			// matches the SSE consumer expectations on the Flutter
+			// side. Preferred over fmt.Sprintf %q on the same shape
+			// because the encoder owns the escaping rules.
+			payload, _ := json.Marshal(map[string]string{
+				"old_repo": repo,
+				"new_repo": canonical,
+			})
 			p.deps.Publisher.Publish(sse.Event{
 				Type: sse.EventRepoNonMonitoredStale,
-				Data: fmt.Sprintf(
-					`{"old_repo":%q,"new_repo":%q}`,
-					repo, canonical,
-				),
+				Data: string(payload),
 			})
 		}
 	}

--- a/daemon/internal/rename/probe.go
+++ b/daemon/internal/rename/probe.go
@@ -3,10 +3,13 @@ package rename
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/sse"
 )
 
 // DefaultProbeInterval is the cadence the rename probe uses when the
@@ -29,13 +32,27 @@ type Dispatcher interface {
 	Run(ctx context.Context, oldRepo, newRepo string) error
 }
 
-// ProbeDeps configures the Probe. Repos is a function (not a slice)
-// because the monitored repository set can change at runtime — the
-// probe must observe the current list on every tick.
+// ProbeDeps configures the Probe. Repos / NonMonitored are functions
+// (not slices) because both sets can change at runtime — the probe
+// must observe the current lists on every tick.
 type ProbeDeps struct {
 	Probe      CanonicalProbe
 	Dispatcher Dispatcher
 	Repos      func() []string
+
+	// NonMonitored is the operator's disabled-repo list. When set,
+	// the probe also scans these slugs for renames on every tick,
+	// but does NOT dispatch the reconciler — instead it emits a
+	// best-effort EventRepoNonMonitoredStale via Publisher so the
+	// operator can take manual action. Nil disables this axis
+	// entirely (backward compat for callers that pre-date #493).
+	NonMonitored func() []string
+
+	// Publisher receives EventRepoNonMonitoredStale events. May be
+	// nil when NonMonitored is nil or when callers do not care
+	// about the stale-slug surface; the probe then only logs via
+	// slog.Warn.
+	Publisher Publisher
 
 	// Interval defaults to DefaultProbeInterval when zero.
 	Interval time.Duration
@@ -43,8 +60,18 @@ type ProbeDeps struct {
 
 // Probe periodically asks GitHub for the canonical full_name of each
 // monitored repo and dispatches the rename reconciler on a mismatch.
+// Optionally also scans non-monitored entries for the stale-slug
+// warning surface (#493).
 type Probe struct {
 	deps ProbeDeps
+
+	// nmWarned remembers (old → last-warned-new) pairs across ticks
+	// so the non-monitored scan emits at most one SSE per detected
+	// drift, instead of one per probe interval. Reset on daemon
+	// restart, which is the right trade-off: a restart is the
+	// natural prompt to re-surface known stale entries.
+	nmMu     sync.Mutex
+	nmWarned map[string]string
 }
 
 // NewProbe constructs a Probe ready to Tick or Run.
@@ -52,15 +79,24 @@ func NewProbe(deps ProbeDeps) *Probe {
 	if deps.Interval <= 0 {
 		deps.Interval = DefaultProbeInterval
 	}
-	return &Probe{deps: deps}
+	return &Probe{
+		deps:     deps,
+		nmWarned: make(map[string]string),
+	}
 }
 
-// Tick performs one iteration: probe every repo currently in the
-// monitored set, dispatch the reconciler for each mismatch. Errors
-// from GitHub (404, transport) skip the repo for this tick without
-// failing the whole iteration — the probe is best-effort and the
-// next tick retries naturally.
+// Tick performs one iteration: probes the monitored set and
+// dispatches the reconciler for each mismatch, then optionally
+// scans the non-monitored set and emits stale-slug warnings (no
+// reconciler dispatch — operator-disabled entries are not
+// auto-rewritten).
 func (p *Probe) Tick(ctx context.Context) {
+	p.tickMonitored(ctx)
+	p.tickNonMonitored(ctx)
+}
+
+// tickMonitored is the original probe path: detect-and-dispatch.
+func (p *Probe) tickMonitored(ctx context.Context) {
 	repos := p.deps.Repos()
 	for _, repo := range repos {
 		if ctx.Err() != nil {
@@ -85,6 +121,82 @@ func (p *Probe) Tick(ctx context.Context) {
 		if err := p.deps.Dispatcher.Run(ctx, repo, canonical); err != nil {
 			slog.Error("rename probe: dispatcher failed",
 				"old_repo", repo, "new_repo", canonical, "err", err)
+		}
+	}
+}
+
+// tickNonMonitored scans the operator-disabled repo list (#493) and
+// surfaces stale slugs without auto-renaming them. The non-monitored
+// list reflects deliberate operator choice — auto-rewriting an entry
+// the operator explicitly disabled would be a surprise, so we only
+// observe and report. Per-(old,new) dedup across ticks keeps the
+// signal at one event per detected drift per daemon lifetime.
+func (p *Probe) tickNonMonitored(ctx context.Context) {
+	if p.deps.NonMonitored == nil {
+		return
+	}
+	current := p.deps.NonMonitored()
+
+	// Garbage-collect warned entries that are no longer in the
+	// current non-monitored set. If the operator removes and later
+	// re-adds the same stale slug, the re-add must re-warn.
+	currentSet := make(map[string]struct{}, len(current))
+	for _, repo := range current {
+		currentSet[repo] = struct{}{}
+	}
+	p.nmMu.Lock()
+	for old := range p.nmWarned {
+		if _, ok := currentSet[old]; !ok {
+			delete(p.nmWarned, old)
+		}
+	}
+	p.nmMu.Unlock()
+
+	for _, repo := range current {
+		if ctx.Err() != nil {
+			return
+		}
+		canonical, err := p.deps.Probe.GetCanonicalFullName(repo)
+		if err != nil {
+			var apiErr *gh.APIError
+			if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+				slog.Info("rename probe: non-monitored repo unreachable (404)",
+					"repo", repo)
+				continue
+			}
+			slog.Debug("rename probe: non-monitored canonical lookup failed",
+				"repo", repo, "err", err)
+			continue
+		}
+		if canonical == "" || canonical == repo {
+			// Healthy: drop any stale warning state so a future
+			// rename re-warns from a clean baseline.
+			p.nmMu.Lock()
+			delete(p.nmWarned, repo)
+			p.nmMu.Unlock()
+			continue
+		}
+
+		// Mismatch — dedup against the most-recently-warned
+		// canonical for this slug.
+		p.nmMu.Lock()
+		if p.nmWarned[repo] == canonical {
+			p.nmMu.Unlock()
+			continue
+		}
+		p.nmWarned[repo] = canonical
+		p.nmMu.Unlock()
+
+		slog.Warn("rename probe: non-monitored repo has been renamed; entry is stale",
+			"old_repo", repo, "new_repo", canonical)
+		if p.deps.Publisher != nil {
+			p.deps.Publisher.Publish(sse.Event{
+				Type: sse.EventRepoNonMonitoredStale,
+				Data: fmt.Sprintf(
+					`{"old_repo":%q,"new_repo":%q}`,
+					repo, canonical,
+				),
+			})
 		}
 	}
 }

--- a/daemon/internal/rename/probe_nonmonitored_test.go
+++ b/daemon/internal/rename/probe_nonmonitored_test.go
@@ -1,0 +1,214 @@
+package rename_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/rename"
+	"github.com/heimdallm/daemon/internal/sse"
+)
+
+// newNonMonitoredProbe is a thin wrapper around rename.NewProbe that
+// supplies the non-monitored axis (NonMonitored + Publisher). Tests
+// pass nil for Repos because the non-monitored path runs in addition
+// to the monitored one and can be exercised in isolation by leaving
+// the monitored slug list empty.
+func newNonMonitoredProbe(t *testing.T, canonical *fakeCanonical,
+	publisher *fakePublisher, nonMonitored []string,
+) *rename.Probe {
+	t.Helper()
+	return rename.NewProbe(rename.ProbeDeps{
+		Probe:        canonical,
+		Dispatcher:   &fakeDispatcher{}, // unused on this axis
+		Repos:        func() []string { return nil },
+		NonMonitored: func() []string { return nonMonitored },
+		Publisher:    publisher,
+	})
+}
+
+func TestProbe_NonMonitored_EmitsSSEAndWarnsOnStale(t *testing.T) {
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/parked": {canonical: "acme/parked-v2"},
+		},
+	}
+	publisher := &fakePublisher{}
+	p := newNonMonitoredProbe(t, canonical, publisher, []string{"acme/parked"})
+
+	p.Tick(context.Background())
+
+	if publisher.calls != 1 {
+		t.Fatalf("publisher.calls = %d, want 1", publisher.calls)
+	}
+	if publisher.events[0].Type != sse.EventRepoNonMonitoredStale {
+		t.Errorf("event type = %q, want %q", publisher.events[0].Type, sse.EventRepoNonMonitoredStale)
+	}
+	for _, want := range []string{`"old_repo":"acme/parked"`, `"new_repo":"acme/parked-v2"`} {
+		if !strings.Contains(publisher.events[0].Data, want) {
+			t.Errorf("payload missing %q: %s", want, publisher.events[0].Data)
+		}
+	}
+}
+
+func TestProbe_NonMonitored_NoOpWhenCanonicalMatches(t *testing.T) {
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/parked": {canonical: "acme/parked"},
+		},
+	}
+	publisher := &fakePublisher{}
+	p := newNonMonitoredProbe(t, canonical, publisher, []string{"acme/parked"})
+
+	p.Tick(context.Background())
+
+	if publisher.calls != 0 {
+		t.Errorf("publisher.calls = %d, want 0 when canonical matches", publisher.calls)
+	}
+}
+
+// TestProbe_NonMonitored_DedupesWarningsAcrossTicks pins the cost
+// guard: a non-monitored stale slug must not emit one SSE event per
+// probe tick forever. The probe remembers warned (old, new) pairs in
+// memory and only re-emits if the canonical changes (chained rename)
+// or the entry is removed and re-added.
+func TestProbe_NonMonitored_DedupesWarningsAcrossTicks(t *testing.T) {
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/parked": {canonical: "acme/parked-v2"},
+		},
+	}
+	publisher := &fakePublisher{}
+	p := newNonMonitoredProbe(t, canonical, publisher, []string{"acme/parked"})
+
+	p.Tick(context.Background())
+	p.Tick(context.Background())
+	p.Tick(context.Background())
+
+	if publisher.calls != 1 {
+		t.Errorf("publisher.calls = %d, want 1 (deduped across 3 ticks)", publisher.calls)
+	}
+}
+
+// TestProbe_NonMonitored_ReWarnsWhenCanonicalChanges pins the chained
+// rename path: if GitHub now reports a NEW canonical name for the
+// same stale slug, we want to warn again so the operator sees the
+// fresh suggestion instead of acting on a stale hint.
+func TestProbe_NonMonitored_ReWarnsWhenCanonicalChanges(t *testing.T) {
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/parked": {canonical: "acme/parked-v2"},
+		},
+	}
+	publisher := &fakePublisher{}
+	p := newNonMonitoredProbe(t, canonical, publisher, []string{"acme/parked"})
+
+	p.Tick(context.Background())
+	if publisher.calls != 1 {
+		t.Fatalf("after tick 1: publisher.calls = %d, want 1", publisher.calls)
+	}
+
+	// Simulate a second upstream rename: parked-v2 → final. GitHub
+	// follows the chain, so the canonical for `acme/parked` becomes
+	// the new tip.
+	canonical.results["acme/parked"] = canonicalResult{canonical: "acme/final"}
+
+	p.Tick(context.Background())
+	if publisher.calls != 2 {
+		t.Errorf("after tick 2 with new canonical: publisher.calls = %d, want 2", publisher.calls)
+	}
+	if !strings.Contains(publisher.events[1].Data, `"new_repo":"acme/final"`) {
+		t.Errorf("re-warn payload should carry the new canonical: %s", publisher.events[1].Data)
+	}
+}
+
+// TestProbe_NonMonitored_ReWarnsAfterEntryRemovedAndReAdded pins the
+// dedup-set cleanup invariant: if the operator removes the slug from
+// non_monitored and later re-adds it (with the rename still pending),
+// the probe must emit a fresh warning instead of treating it as
+// already-warned. Achieved by garbage-collecting nmWarned entries
+// that are no longer in the current non_monitored snapshot.
+func TestProbe_NonMonitored_ReWarnsAfterEntryRemovedAndReAdded(t *testing.T) {
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/parked": {canonical: "acme/parked-v2"},
+		},
+	}
+	publisher := &fakePublisher{}
+
+	// Closure-controlled list so the test can simulate operator edits.
+	var list []string
+	p := rename.NewProbe(rename.ProbeDeps{
+		Probe:        canonical,
+		Dispatcher:   &fakeDispatcher{},
+		Repos:        func() []string { return nil },
+		NonMonitored: func() []string { return append([]string(nil), list...) },
+		Publisher:    publisher,
+	})
+
+	list = []string{"acme/parked"}
+	p.Tick(context.Background())
+	if publisher.calls != 1 {
+		t.Fatalf("after first tick: publisher.calls = %d, want 1", publisher.calls)
+	}
+
+	// Operator removes the entry: probe must drop it from the warned
+	// set so a re-add re-warns.
+	list = nil
+	p.Tick(context.Background())
+	if publisher.calls != 1 {
+		t.Errorf("after removal tick: publisher.calls = %d, want still 1 (no entry to probe)", publisher.calls)
+	}
+
+	// Operator re-adds the same entry — must re-warn.
+	list = []string{"acme/parked"}
+	p.Tick(context.Background())
+	if publisher.calls != 2 {
+		t.Errorf("after re-add tick: publisher.calls = %d, want 2 (fresh warning)", publisher.calls)
+	}
+}
+
+func TestProbe_NonMonitored_404DoesNotEmit(t *testing.T) {
+	// A 404 means the non-monitored repo was deleted upstream, not
+	// renamed. We log and move on — no rename-suggestion SSE.
+	apiErr := &gh.APIError{StatusCode: http.StatusNotFound, Body: "Not Found"}
+	canonical := &fakeCanonical{
+		results: map[string]canonicalResult{
+			"acme/deleted": {err: apiErr},
+		},
+	}
+	publisher := &fakePublisher{}
+	p := newNonMonitoredProbe(t, canonical, publisher, []string{"acme/deleted"})
+
+	p.Tick(context.Background())
+
+	if publisher.calls != 0 {
+		t.Errorf("publisher.calls = %d, want 0 on 404 (deleted, not renamed)", publisher.calls)
+	}
+}
+
+// TestProbe_NonMonitored_NilFunc_NoCalls pins backward-compat for
+// callers that wire the probe without the non-monitored axis (e.g.,
+// existing tests). When NonMonitored is nil, the probe must skip
+// the scan entirely without panicking.
+func TestProbe_NonMonitored_NilFunc_NoCalls(t *testing.T) {
+	canonical := &fakeCanonical{}
+	publisher := &fakePublisher{}
+	p := rename.NewProbe(rename.ProbeDeps{
+		Probe:      canonical,
+		Dispatcher: &fakeDispatcher{},
+		Repos:      func() []string { return nil },
+		// NonMonitored intentionally nil
+		Publisher: publisher,
+	})
+
+	p.Tick(context.Background())
+	if canonical.calls != 0 {
+		t.Errorf("canonical.calls = %d, want 0 (no monitored or non-monitored repos)", canonical.calls)
+	}
+	if publisher.calls != 0 {
+		t.Errorf("publisher.calls = %d, want 0", publisher.calls)
+	}
+}

--- a/daemon/internal/sse/broker.go
+++ b/daemon/internal/sse/broker.go
@@ -51,6 +51,18 @@ const (
 	// Flutter consumers refresh the repo / PR / issue lists and dismiss
 	// cached entries keyed on `old_repo`.
 	EventRepoRenamed = "repo_renamed"
+
+	// EventRepoNonMonitoredStale fires when the rename probe detects
+	// that an entry in `github.non_monitored` has been renamed on
+	// GitHub (#493 follow-up to #489). The daemon deliberately does
+	// NOT auto-rewrite non_monitored entries — they reflect an
+	// explicit operator-disabled state — so this event surfaces the
+	// stale slug for human action. Payload:
+	// {"old_repo": "...", "new_repo": "..."}.
+	// The probe dedupes warnings per (old, new) pair across its
+	// in-memory lifetime, so this event fires at most once per
+	// detected drift per daemon start.
+	EventRepoNonMonitoredStale = "repo_non_monitored_stale"
 )
 
 // maxSubscribers limits the number of concurrent SSE connections to prevent

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -35,6 +35,21 @@ final circuitBreakerProvider =
       () => LocalStateNotifier<String?>(null),
     );
 
+/// Stale non_monitored entries the daemon's rename probe has flagged
+/// (#493). Keys are the configured `old_repo` slug, values are the
+/// canonical `new_repo` GitHub reported. The map accumulates entries
+/// across the session so a future UI surface (banner, settings hint)
+/// can list every stale slug the operator should clean up manually.
+///
+/// The daemon dedupes per (old, new) pair across its lifetime, so this
+/// map grows only when a NEW drift is detected — not on every probe
+/// tick. Cleared on app restart (matches the daemon-side dedup reset).
+final nonMonitoredStaleProvider =
+    NotifierProvider<
+      LocalStateNotifier<Map<String, String>>,
+      Map<String, String>
+    >(() => LocalStateNotifier<Map<String, String>>(const <String, String>{}));
+
 /// Tracks whether the desktop app is trying to spawn the daemon.
 final daemonStartingProvider =
     NotifierProvider<LocalStateNotifier<bool>, bool>(
@@ -240,6 +255,23 @@ void _handleSseEvent(Ref ref, SseEvent event) {
       case 'repo_renamed':
         ref.read(prListRefreshProvider.notifier).update((s) => s + 1);
         ref.read(issueListRefreshProvider.notifier).update((s) => s + 1);
+
+      // repo_non_monitored_stale fires when the rename probe detects
+      // that an entry in github.non_monitored has been renamed
+      // upstream (#493). The daemon does NOT auto-rewrite those
+      // entries — they reflect explicit operator-disabled state — so
+      // we accumulate the (old, new) pairs in a provider that a
+      // future settings/banner surface can list. No list refresh
+      // bump: the disabled entries don't drive any daemon polling
+      // so cached views are unaffected.
+      case 'repo_non_monitored_stale':
+        final oldRepo = data['old_repo'] as String? ?? '';
+        final newRepo = data['new_repo'] as String? ?? '';
+        if (oldRepo.isNotEmpty && newRepo.isNotEmpty) {
+          ref
+              .read(nonMonitoredStaleProvider.notifier)
+              .update((s) => {...s, oldRepo: newRepo});
+        }
 
       // ── Circuit breaker ────────────────────────────────────────────────
       case 'circuit_breaker_tripped':

--- a/flutter_app/test/features/dashboard/non_monitored_stale_test.dart
+++ b/flutter_app/test/features/dashboard/non_monitored_stale_test.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:heimdallm/core/api/sse_client.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
+
+// Tests for the repo_non_monitored_stale SSE handler added in #493.
+// The handler accumulates (old → new) pairs into nonMonitoredStaleProvider
+// so any future UI surface (banner, settings hint) can list every stale
+// non_monitored entry the daemon's rename probe has flagged.
+//
+// Pattern: override sseStreamProvider with a StreamController, attach a
+// listener to prListRefreshProvider so the SSE subscription stays awake
+// (the handler runs inside that notifier's build per Riverpod 3 pause
+// semantics), then inject events and inspect the target provider.
+void main() {
+  group('repo_non_monitored_stale SSE handler', () {
+    test('adds (old, new) pair to nonMonitoredStaleProvider', () async {
+      final events = StreamController<SseEvent>.broadcast();
+      final c = ProviderContainer(
+        overrides: [sseStreamProvider.overrideWith((_) => events.stream)],
+      );
+      addTearDown(() async {
+        await events.close();
+        c.dispose();
+      });
+
+      // Keep the SSE handler chain alive: the handler lives inside
+      // PrListRefreshNotifier.build, so we need at least one listener.
+      c.listen(prListRefreshProvider, (_, _) {});
+
+      events.add(
+        const SseEvent(
+          type: 'repo_non_monitored_stale',
+          data: '{"old_repo":"acme/parked","new_repo":"acme/parked-v2"}',
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(c.read(nonMonitoredStaleProvider), {
+        'acme/parked': 'acme/parked-v2',
+      });
+    });
+
+    test('overwrites previous mapping when canonical changes', () async {
+      final events = StreamController<SseEvent>.broadcast();
+      final c = ProviderContainer(
+        overrides: [sseStreamProvider.overrideWith((_) => events.stream)],
+      );
+      addTearDown(() async {
+        await events.close();
+        c.dispose();
+      });
+      c.listen(prListRefreshProvider, (_, _) {});
+
+      // First event: parked → v2.
+      events.add(
+        const SseEvent(
+          type: 'repo_non_monitored_stale',
+          data: '{"old_repo":"acme/parked","new_repo":"acme/parked-v2"}',
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      // Second event: chained rename, daemon re-warns with the new tip.
+      events.add(
+        const SseEvent(
+          type: 'repo_non_monitored_stale',
+          data: '{"old_repo":"acme/parked","new_repo":"acme/final"}',
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(c.read(nonMonitoredStaleProvider), {'acme/parked': 'acme/final'});
+    });
+
+    test('accumulates entries from independent slugs', () async {
+      final events = StreamController<SseEvent>.broadcast();
+      final c = ProviderContainer(
+        overrides: [sseStreamProvider.overrideWith((_) => events.stream)],
+      );
+      addTearDown(() async {
+        await events.close();
+        c.dispose();
+      });
+      c.listen(prListRefreshProvider, (_, _) {});
+
+      events.add(
+        const SseEvent(
+          type: 'repo_non_monitored_stale',
+          data: '{"old_repo":"acme/foo","new_repo":"acme/foo-v2"}',
+        ),
+      );
+      events.add(
+        const SseEvent(
+          type: 'repo_non_monitored_stale',
+          data: '{"old_repo":"acme/bar","new_repo":"widget/bar"}',
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(c.read(nonMonitoredStaleProvider), {
+        'acme/foo': 'acme/foo-v2',
+        'acme/bar': 'widget/bar',
+      });
+    });
+
+    test('ignores payload with empty slugs', () async {
+      final events = StreamController<SseEvent>.broadcast();
+      final c = ProviderContainer(
+        overrides: [sseStreamProvider.overrideWith((_) => events.stream)],
+      );
+      addTearDown(() async {
+        await events.close();
+        c.dispose();
+      });
+      c.listen(prListRefreshProvider, (_, _) {});
+
+      // Defensive guard against malformed daemon payloads — the
+      // handler must not insert empty-key entries that would clutter
+      // any UI surface backed by this provider.
+      events.add(
+        const SseEvent(
+          type: 'repo_non_monitored_stale',
+          data: '{"old_repo":"","new_repo":"acme/v2"}',
+        ),
+      );
+      events.add(
+        const SseEvent(
+          type: 'repo_non_monitored_stale',
+          data: '{"old_repo":"acme/old","new_repo":""}',
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(c.read(nonMonitoredStaleProvider), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #493 (follow-up to #489). The rename probe deliberately does **not** auto-rewrite entries in `github.non_monitored` — those reflect explicit operator-disabled state. But leaving them stale silently is its own surprise once GitHub's 301 grace period expires.

This PR adds a parallel non-monitored scan axis to the existing probe.

## What changed

- **`rename.Probe`** gains two optional `ProbeDeps` fields: `NonMonitored func() []string` and `Publisher rename.Publisher`. Backward-compat — nil keeps prior behaviour.
- **`Tick()`** now runs `tickMonitored` (existing) and `tickNonMonitored` (new). The new axis logs via `slog.Warn` and emits `EventRepoNonMonitoredStale` SSE with `{old_repo, new_repo}`.
- **In-memory dedup** on `(old → last-warned-new)` so a daemon living through 24h of probe ticks emits at most one event per detected drift. GC of entries no longer in the current non_monitored snapshot, so a remove+re-add re-warns.
- **Wiring** in `main_rename.go`: new `renameNonMonitoredListFn` accessor, plus `Publisher: broker` so the probe can fan stale-slug events out to Flutter.
- **Flutter**: `nonMonitoredStaleProvider` accumulates the pairs the daemon reports. No banner widget in this PR — that's UI design for a separate issue; the provider gives a stable hook.

## Out of scope (intentional)

- Banner/toast surface in the dashboard for the new event. The provider is in place so any future widget can subscribe.
- Auto-rewriting non_monitored entries (the whole reason this issue exists is to NOT do that).

## Test plan

- [x] `make test-docker ./...` clean — 7 new probe tests pin happy path, dedup, GC, chained renames, 404, nil-func backward compat.
- [x] `flutter test` clean (176 tests).
- [ ] Manual smoke: rename a sandbox repo that's in `non_monitored`, wait one probe tick, confirm: SSE `repo_non_monitored_stale` fires, daemon logs warning, no config rewrite, no SQLite changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)