### PR TITLE
fix: keep triage suggested assignee when unverified

### DIFF
--- a/daemon/internal/issues/triage_assignment.go
+++ b/daemon/internal/issues/triage_assignment.go
@@ -77,18 +77,27 @@ func resolveTriageAssignee(ctx context.Context, workDir, triageOwner string, tri
 		}
 		return fallback, "triage_owner", reason, []string{fmt.Sprintf("@%s configured as triage_owner fallback", fallback)}
 	}
+	unverifiedSuggestedResult := func(reason string, evidence []string) (string, string, string, []string) {
+		if len(evidence) == 0 {
+			evidence = nil
+		}
+		return suggested, "suggested_assignee_unverified", reason, evidence
+	}
 
 	if suggested == "" && fallback == "" {
 		return "", "none", "no suggested_assignee or triage_owner available", nil
+	}
+	if suggested == "" {
+		return fallbackResult("no suggested_assignee available")
 	}
 	if !confidenceAllowsAssignment(confidence) {
 		return fallbackResult("assignee confidence is low or missing")
 	}
 	if strings.TrimSpace(workDir) == "" {
-		return fallbackResult("repo workdir unavailable; cannot verify assignee against git history")
+		return unverifiedSuggestedResult("repo workdir unavailable; cannot verify assignee against git history", nil)
 	}
 	if len(triage.AffectedPaths) == 0 {
-		return fallbackResult("no affected_paths provided for git-history verification")
+		return unverifiedSuggestedResult("no affected_paths provided for git-history verification", nil)
 	}
 	if runner == nil {
 		runner = defaultGitHistoryRunner{}
@@ -96,29 +105,22 @@ func resolveTriageAssignee(ctx context.Context, workDir, triageOwner string, tri
 
 	contributors, err := contributorsForPaths(ctx, runner, workDir, triage.AffectedPaths)
 	if err != nil {
-		return fallbackResult(fmt.Sprintf("git-history verification unavailable: %v", err))
+		return unverifiedSuggestedResult(fmt.Sprintf("git-history verification unavailable: %v", err), nil)
 	}
 	if len(contributors) == 0 {
-		return fallbackResult("no GitHub-login-like contributors found in affected path history")
+		return unverifiedSuggestedResult("no GitHub-login-like contributors found in affected path history", nil)
 	}
 
-	if suggested != "" {
-		for _, c := range contributors {
-			if strings.EqualFold(c.login, suggested) {
-				return c.login, "suggested_assignee_verified", "suggested_assignee appears in affected path history", contributorEvidence(contributors)
-			}
-		}
-		if fallback != "" {
-			return fallbackResult(fmt.Sprintf("model suggested @%s, but that login was not found in affected path history", suggested))
+	for _, c := range contributors {
+		if strings.EqualFold(c.login, suggested) {
+			return c.login, "suggested_assignee_verified", "suggested_assignee appears in affected path history", contributorEvidence(contributors)
 		}
 	}
 
-	top := contributors[0]
-	reason := "assigned top contributor from affected path history"
-	if suggested != "" {
-		reason = fmt.Sprintf("model suggested @%s, but that login was not found in affected path history; assigned top contributor instead", suggested)
-	}
-	return top.login, "history_top_contributor", reason, contributorEvidence(contributors)
+	return unverifiedSuggestedResult(
+		fmt.Sprintf("model suggested @%s, but that login was not found in affected path history; keeping suggested assignee", suggested),
+		contributorEvidence(contributors),
+	)
 }
 
 func contributorsForPaths(ctx context.Context, runner gitHistoryRunner, workDir string, affectedPaths []string) ([]contributorHit, error) {

--- a/daemon/internal/issues/triage_assignment_test.go
+++ b/daemon/internal/issues/triage_assignment_test.go
@@ -47,7 +47,7 @@ func TestResolveTriageAssignee_VerifiesSuggestedAssigneeInHistory(t *testing.T) 
 	}
 }
 
-func TestResolveTriageAssignee_UsesTopContributorWhenNoFallbackOwner(t *testing.T) {
+func TestResolveTriageAssignee_KeepsSuggestedWhenHistoryPointsElsewhereWithoutFallback(t *testing.T) {
 	runner := &fakeHistoryRunner{outByCmd: map[string]string{
 		historyKey("rev-parse", "--is-shallow-repository"):                                                     "false\n",
 		historyKey("log", "--max-count=500", "--no-merges", "--format=%ae%x00%an", "--", "daemon/pipeline.go"): "alice@users.noreply.github.com\x00Alice\nbob@users.noreply.github.com\x00Bob\nalice@users.noreply.github.com\x00Alice\n",
@@ -59,34 +59,57 @@ func TestResolveTriageAssignee_UsesTopContributorWhenNoFallbackOwner(t *testing.
 	}
 
 	assignee, source, diagnostic, _ := resolveTriageAssignee(context.Background(), "/repo", "", triage, runner)
-	if assignee != "alice" || source != "history_top_contributor" {
-		t.Fatalf("assignee/source = %q/%q, want alice/history_top_contributor", assignee, source)
+	if assignee != "ghost" || source != "suggested_assignee_unverified" {
+		t.Fatalf("assignee/source = %q/%q, want ghost/suggested_assignee_unverified", assignee, source)
 	}
-	if !strings.Contains(diagnostic, "ghost") {
-		t.Fatalf("diagnostic should mention rejected suggestion, got %q", diagnostic)
+	if !strings.Contains(diagnostic, "keeping suggested assignee") {
+		t.Fatalf("diagnostic should explain the suggested assignee was kept, got %q", diagnostic)
 	}
 }
 
-func TestResolveTriageAssignee_KeepsFallbackWhenSuggestedMissingFromHistory(t *testing.T) {
+func TestResolveTriageAssignee_KeepsSuggestedWhenOnlyRecognizedHistoryIsAnotherContributor(t *testing.T) {
 	runner := &fakeHistoryRunner{outByCmd: map[string]string{
 		historyKey("rev-parse", "--is-shallow-repository"):                                                 "false\n",
-		historyKey("log", "--max-count=500", "--no-merges", "--format=%ae%x00%an", "--", "docs/config.md"): "vbuenog@users.noreply.github.com\x00V Bueno\n",
+		historyKey("log", "--max-count=500", "--no-merges", "--format=%ae%x00%an", "--", "docs/config.md"): "carol@users.noreply.github.com\x00Carol\n",
 	}}
 	triage := Triage{
 		AffectedPaths:      []string{"docs/config.md"},
-		SuggestedAssignee:  "ivanmunozruiz",
+		SuggestedAssignee:  "alice",
 		AssigneeConfidence: "high",
 	}
 
-	assignee, source, diagnostic, evidence := resolveTriageAssignee(context.Background(), "/repo", "ivanmunozruiz", triage, runner)
-	if assignee != "ivanmunozruiz" || source != "triage_owner" {
-		t.Fatalf("assignee/source = %q/%q, want ivanmunozruiz/triage_owner", assignee, source)
+	assignee, source, diagnostic, evidence := resolveTriageAssignee(context.Background(), "/repo", "owner", triage, runner)
+	if assignee != "alice" || source != "suggested_assignee_unverified" {
+		t.Fatalf("assignee/source = %q/%q, want alice/suggested_assignee_unverified", assignee, source)
 	}
-	if !strings.Contains(diagnostic, "ivanmunozruiz") {
-		t.Fatalf("diagnostic should mention rejected suggestion, got %q", diagnostic)
+	if !strings.Contains(diagnostic, "alice") {
+		t.Fatalf("diagnostic should mention unverified suggestion, got %q", diagnostic)
 	}
-	if len(evidence) == 0 || !strings.Contains(evidence[0], "triage_owner") {
-		t.Fatalf("expected fallback evidence, got %v", evidence)
+	if len(evidence) == 0 || !strings.Contains(evidence[0], "@carol") {
+		t.Fatalf("expected history evidence without assigning carol, got %v", evidence)
+	}
+}
+
+func TestResolveTriageAssignee_KeepsSuggestedWhenHistoryHasNoRecognizedLogins(t *testing.T) {
+	runner := &fakeHistoryRunner{outByCmd: map[string]string{
+		historyKey("rev-parse", "--is-shallow-repository"):                                                     "false\n",
+		historyKey("log", "--max-count=500", "--no-merges", "--format=%ae%x00%an", "--", "daemon/pipeline.go"): "dev@example.com\x00Dev One\nmaintainer@company.test\x00Maintainer\n",
+	}}
+	triage := Triage{
+		AffectedPaths:      []string{"daemon/pipeline.go"},
+		SuggestedAssignee:  "alice",
+		AssigneeConfidence: "high",
+	}
+
+	assignee, source, diagnostic, evidence := resolveTriageAssignee(context.Background(), "/repo", "owner", triage, runner)
+	if assignee != "alice" || source != "suggested_assignee_unverified" {
+		t.Fatalf("assignee/source = %q/%q, want alice/suggested_assignee_unverified", assignee, source)
+	}
+	if !strings.Contains(diagnostic, "no GitHub-login-like contributors") {
+		t.Fatalf("diagnostic should mention unrecognized history, got %q", diagnostic)
+	}
+	if evidence != nil {
+		t.Fatalf("evidence = %v, want nil", evidence)
 	}
 }
 
@@ -128,7 +151,7 @@ func TestEnrichTriageResult_PreservesTentativeAssignee(t *testing.T) {
 	}
 }
 
-func TestResolveTriageAssignee_ShallowHistoryFallsBackToTriageOwner(t *testing.T) {
+func TestResolveTriageAssignee_ShallowHistoryKeepsSuggestedUnverified(t *testing.T) {
 	runner := &fakeHistoryRunner{outByCmd: map[string]string{
 		historyKey("rev-parse", "--is-shallow-repository"): "true\n",
 	}}
@@ -138,11 +161,33 @@ func TestResolveTriageAssignee_ShallowHistoryFallsBackToTriageOwner(t *testing.T
 		AssigneeConfidence: "high",
 	}, runner)
 
-	if assignee != "owner" || source != "triage_owner" {
-		t.Fatalf("assignee/source = %q/%q, want owner/triage_owner", assignee, source)
+	if assignee != "alice" || source != "suggested_assignee_unverified" {
+		t.Fatalf("assignee/source = %q/%q, want alice/suggested_assignee_unverified", assignee, source)
 	}
 	if !strings.Contains(diagnostic, errShallowHistory.Error()) {
 		t.Fatalf("diagnostic should mention shallow history, got %q", diagnostic)
+	}
+}
+
+func TestResolveTriageAssignee_NoSuggestedNoFallbackDoesNotAssignTopContributor(t *testing.T) {
+	runner := &fakeHistoryRunner{outByCmd: map[string]string{
+		historyKey("rev-parse", "--is-shallow-repository"):                                       "false\n",
+		historyKey("log", "--max-count=500", "--no-merges", "--format=%ae%x00%an", "--", "x.go"): "alice@users.noreply.github.com\x00Alice\n",
+	}}
+
+	assignee, source, diagnostic, evidence := resolveTriageAssignee(context.Background(), "/repo", "", Triage{
+		AffectedPaths:      []string{"x.go"},
+		AssigneeConfidence: "high",
+	}, runner)
+
+	if assignee != "" || source != "none" {
+		t.Fatalf("assignee/source = %q/%q, want empty/none", assignee, source)
+	}
+	if !strings.Contains(diagnostic, "no suggested_assignee") {
+		t.Fatalf("diagnostic should mention missing suggestion, got %q", diagnostic)
+	}
+	if evidence != nil {
+		t.Fatalf("evidence = %v, want nil", evidence)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #492.

The triage assignee resolver still asks the model for a suggested owner and still checks git history, but history is no longer allowed to replace a valid model suggestion with an unrelated top contributor.

## What changed

- Keep a valid `suggested_assignee` with `medium` / `high` confidence even when git-history verification is unavailable or points at someone else.
- Mark those assignments as `suggested_assignee_unverified` with a clear diagnostic.
- Preserve the existing `suggested_assignee_verified` path when the suggested login appears in affected-path history.
- Keep `triage_owner` fallback only for missing/invalid suggested assignee or low/missing confidence.
- Stop assigning `history_top_contributor` when there is no suggested assignee and no owner fallback.

## Why

The old behavior treated git history as a hard veto. Because contributor extraction only recognizes GitHub noreply emails, history could be incomplete and biased toward whichever commits had mappable noreply addresses. That could accidentally assign issues to the wrong contributor.

## Test plan

- [x] `make test-docker GO_TEST_ARGS="./internal/issues/..."`
