### PR TITLE
fix: run codex through non-interactive exec

### DIFF
--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -326,7 +326,7 @@ func labelSetIntersects(set map[string]struct{}, list []string) bool {
 type CLIAgentConfig struct {
 	Model        string `toml:"model" json:"model,omitempty"`                 // e.g. "claude-opus-4-6"
 	MaxTurns     int    `toml:"max_turns" json:"max_turns,omitempty"`         // claude: --max-turns (0 = not set)
-	ApprovalMode string `toml:"approval_mode" json:"approval_mode,omitempty"` // codex: --approval-mode
+	ApprovalMode string `toml:"approval_mode" json:"approval_mode,omitempty"` // codex: --ask-for-approval
 	ExtraFlags   string `toml:"extra_flags" json:"extra_flags,omitempty"`     // free-form additional CLI flags
 	PromptID     string `toml:"prompt" json:"prompt,omitempty"`               // agent-level prompt override
 
@@ -448,9 +448,9 @@ type ReviewResponseConfig struct {
 // The lifetime cap is intentionally low: an operator who wants more
 // rounds must opt-in explicitly so we never silently amplify cost.
 type ReviewFixConfig struct {
-	Enabled         bool `toml:"enabled"`
-	PerPRLifetime   int  `toml:"per_pr_lifetime"`
-	CooldownSecs    int  `toml:"cooldown_secs"`
+	Enabled       bool `toml:"enabled"`
+	PerPRLifetime int  `toml:"per_pr_lifetime"`
+	CooldownSecs  int  `toml:"cooldown_secs"`
 }
 
 // Defaults for the review-response and review-fix paths (#482).

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -39,7 +39,8 @@ type ExecOptions struct {
 	Model string
 	// MaxTurns sets --max-turns <n> for Claude (0 = not set).
 	MaxTurns int
-	// ApprovalMode sets --approval-mode <value> for Codex.
+	// ApprovalMode sets Codex --ask-for-approval <value>.
+	// Legacy values from older Codex CLIs are still accepted and normalized.
 	ApprovalMode string
 	// ExtraFlags is a free-form string of additional CLI flags (split on spaces).
 	ExtraFlags string
@@ -114,11 +115,18 @@ var allowedPermissionModes = map[string]struct{}{
 	"dontAsk":     {},
 }
 
-// allowedApprovalModes is the allowlist for the codex --approval-mode flag.
+// allowedApprovalModes is the allowlist for the Codex approval mode config.
+// The first group is the current Codex --ask-for-approval vocabulary; the
+// second group is kept for existing config.toml files created before Codex
+// switched from --approval-mode to --ask-for-approval.
 var allowedApprovalModes = map[string]struct{}{
-	"auto-edit": {},
-	"full-auto": {},
-	"suggest":   {},
+	"untrusted":  {},
+	"on-failure": {},
+	"on-request": {},
+	"never":      {},
+	"auto-edit":  {},
+	"full-auto":  {},
+	"suggest":    {},
 }
 
 // ValidatePermissionMode returns an error if mode is not in the allowlist.
@@ -136,13 +144,27 @@ func ValidatePermissionMode(mode string) error {
 // ValidateApprovalMode returns an error if mode is not in the allowlist.
 // An empty string is accepted (means "not set").
 func ValidateApprovalMode(mode string) error {
+	mode = strings.TrimSpace(mode)
 	if mode == "" {
 		return nil
 	}
 	if _, ok := allowedApprovalModes[mode]; !ok {
-		return fmt.Errorf("executor: approval_mode %q is not allowed — valid values: auto-edit, full-auto, suggest", mode)
+		return fmt.Errorf("executor: approval_mode %q is not allowed — valid values: untrusted, on-failure, on-request, never, auto-edit, full-auto, suggest", mode)
 	}
 	return nil
+}
+
+func normalizeCodexApprovalMode(mode string) string {
+	switch strings.TrimSpace(mode) {
+	case "full-auto":
+		return "never"
+	case "auto-edit":
+		return "on-request"
+	case "suggest":
+		return "untrusted"
+	default:
+		return strings.TrimSpace(mode)
+	}
 }
 
 // dangerousFlagPrefixes is the denylist for ValidateExtraFlags.
@@ -442,15 +464,19 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
 			args = append(args, "-m", opts.Model)
 		}
 	case "codex":
+		// Codex's top-level command is interactive and requires a TTY. The
+		// daemon must use the non-interactive subcommand and feed the prompt on
+		// stdin, otherwise Codex exits with "stdin is not a terminal".
+		if mode := strings.TrimSpace(opts.ApprovalMode); mode != "" {
+			if err := ValidateApprovalMode(mode); err != nil {
+				slog.Warn("buildArgs: ApprovalMode rejected, ignoring", "mode", mode, "err", err)
+			} else {
+				args = append(args, "--ask-for-approval", normalizeCodexApprovalMode(mode))
+			}
+		}
+		args = append(args, "exec")
 		if opts.Model != "" {
 			args = append(args, "--model", opts.Model)
-		}
-		if opts.ApprovalMode != "" {
-			if err := ValidateApprovalMode(opts.ApprovalMode); err != nil {
-				slog.Warn("buildArgs: ApprovalMode rejected, ignoring", "mode", opts.ApprovalMode, "err", err)
-			} else {
-				args = append(args, "--approval-mode", opts.ApprovalMode)
-			}
 		}
 	default:
 		// claude, gemini: stdin mode
@@ -495,6 +521,9 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
 		args = append(args, strings.Fields(opts.ExtraFlags)...)
 	}
 	if cli == "claude" && len(workDirFlags) > 0 {
+		args = append(args, "-")
+	}
+	if cli == "codex" {
 		args = append(args, "-")
 	}
 

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -152,6 +152,84 @@ func TestExecuteRawFallsBackToCWDWhenWorkDirFlagUnsupported(t *testing.T) {
 	requireSameDir(t, strings.TrimSpace(string(cwdBytes)), workDir)
 }
 
+func TestExecuteRawCodexUsesExecAndReadsPromptFromStdin(t *testing.T) {
+	binDir := t.TempDir()
+	captureArgs := filepath.Join(t.TempDir(), "args.txt")
+	capturePrompt := filepath.Join(t.TempDir(), "prompt.txt")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  printf 'Usage: codex\\n  -C, --cd <DIR>\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"last=''\n" +
+		"saw_exec=0\n" +
+		"for arg in \"$@\"; do last=\"$arg\"; done\n" +
+		"for arg in \"$@\"; do if [ \"$arg\" = \"exec\" ]; then saw_exec=1; fi; done\n" +
+		"if [ \"$saw_exec\" != \"1\" ]; then\n" +
+		"  printf 'exec subcommand missing\\n' >&2\n" +
+		"  exit 2\n" +
+		"fi\n" +
+		"if [ \"$last\" != \"-\" ]; then\n" +
+		"  printf 'stdin prompt marker missing\\n' >&2\n" +
+		"  exit 2\n" +
+		"fi\n" +
+		"cat > " + shellQuote(capturePrompt) + "\n" +
+		"printf '%s\\n' \"$*\" > " + shellQuote(captureArgs) + "\n" +
+		"printf 'ok\\n'\n"
+	path := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	prompt := "review this PR"
+	e := executor.New()
+	if _, err := e.ExecuteRaw("codex", prompt, executor.ExecOptions{ApprovalMode: "full-auto"}); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+
+	argsBytes, err := os.ReadFile(captureArgs)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	args := strings.Fields(string(argsBytes))
+	execIdx := indexOf(args, "exec")
+	if execIdx < 0 {
+		t.Fatalf("args = %v, want codex exec subcommand", args)
+	}
+	if got := args[len(args)-1]; got != "-" {
+		t.Fatalf("args = %v, want stdin marker '-' as final arg", args)
+	}
+	approvalIdx := indexOf(args, "--ask-for-approval")
+	if approvalIdx < 0 || approvalIdx > execIdx || !containsInOrder(args, "--ask-for-approval", "never") {
+		t.Fatalf("args = %v, want legacy full-auto mapped to --ask-for-approval never", args)
+	}
+	if strings.Contains(string(argsBytes), "--approval-mode") {
+		t.Fatalf("args = %v, must not use removed --approval-mode flag", args)
+	}
+	promptBytes, err := os.ReadFile(capturePrompt)
+	if err != nil {
+		t.Fatalf("read captured prompt: %v", err)
+	}
+	if string(promptBytes) != prompt {
+		t.Fatalf("prompt = %q, want %q", string(promptBytes), prompt)
+	}
+}
+
+func TestValidateApprovalModeAcceptsCurrentAndLegacyCodexValues(t *testing.T) {
+	for _, mode := range []string{"", "untrusted", "on-failure", "on-request", "never", "auto-edit", "full-auto", "suggest"} {
+		t.Run(mode, func(t *testing.T) {
+			if err := executor.ValidateApprovalMode(mode); err != nil {
+				t.Fatalf("ValidateApprovalMode(%q): %v", mode, err)
+			}
+		})
+	}
+
+	if err := executor.ValidateApprovalMode("danger-full-access"); err == nil {
+		t.Fatal("ValidateApprovalMode accepted an unsupported value")
+	}
+}
+
 func containsInOrder(args []string, first, second string) bool {
 	for i := 0; i+1 < len(args); i++ {
 		if args[i] == first && args[i+1] == second {
@@ -159,6 +237,15 @@ func containsInOrder(args []string, first, second string) bool {
 		}
 	}
 	return false
+}
+
+func indexOf(args []string, target string) int {
+	for i, arg := range args {
+		if arg == target {
+			return i
+		}
+	}
+	return -1
 }
 
 func fakeCLIScript(help, captureArgs, captureCWD string) string {

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -1007,8 +1007,8 @@ func ensureAutoImplementWritePerms(cli string, opts executor.ExecOptions) execut
 		}
 	case "codex":
 		if strings.TrimSpace(opts.ApprovalMode) == "" {
-			opts.ApprovalMode = "full-auto"
-			slog.Info("issues pipeline: defaulting codex approval_mode to full-auto for auto_implement",
+			opts.ApprovalMode = "never"
+			slog.Info("issues pipeline: defaulting codex approval_mode to never for auto_implement",
 				"cli", cli)
 		}
 	case "gemini":

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -22,14 +22,14 @@ import (
 // ── fakes ────────────────────────────────────────────────────────────────────
 
 type fakeStore struct {
-	upserts      []*store.Issue
-	reviews      []*store.IssueReview
-	prs          []*store.PR
-	nextIssueID  int64
-	nextReviewID int64
-	nextPRID     int64
-	upsertErr    error
-	insertErr    error
+	upserts       []*store.Issue
+	reviews       []*store.IssueReview
+	prs           []*store.PR
+	nextIssueID   int64
+	nextReviewID  int64
+	nextPRID      int64
+	upsertErr     error
+	insertErr     error
 	upsertPRErr   error
 	markOriginErr error
 
@@ -1003,8 +1003,8 @@ func TestPipeline_AutoImplementDefaultsCodexApprovalMode(t *testing.T) {
 	if _, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions()); err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if exec.lastOpts.ApprovalMode != "full-auto" {
-		t.Errorf("ApprovalMode = %q, want full-auto (default for codex auto_implement)", exec.lastOpts.ApprovalMode)
+	if exec.lastOpts.ApprovalMode != "never" {
+		t.Errorf("ApprovalMode = %q, want never (default for codex auto_implement)", exec.lastOpts.ApprovalMode)
 	}
 }
 

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -76,7 +76,7 @@ review_mode = "single"   # "single" or "multi"
 
 # [ai.agents.codex]
 # model = "codex-mini"
-# approval_mode = "full-auto"
+# approval_mode = "never"
 
 # [ai.agents.opencode]
 # model = "anthropic/claude-sonnet-4"

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -548,7 +548,7 @@ model = "gemini-2.5-pro"
 
 [ai.agents.codex]
 model         = "codex-mini"
-approval_mode = "full-auto"
+approval_mode = "never"       # Codex --ask-for-approval value. Legacy full-auto maps to never.
 
 [ai.agents.opencode]
 model = "anthropic/claude-sonnet-4"
@@ -1106,7 +1106,7 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 
 # [ai.agents.codex]
 # model         = "codex-mini"
-# approval_mode = "full-auto"
+# approval_mode = "never"
 
 # [ai.agents.opencode]
 # model = "anthropic/claude-sonnet-4"

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -3,7 +3,7 @@
 class CLIAgentConfig {
   final String model; // --model value ('' = use CLI default)
   final int maxTurns; // claude: --max-turns (0 = not set)
-  final String approvalMode; // codex: --approval-mode ('' = not set)
+  final String approvalMode; // codex: --ask-for-approval ('' = not set)
   final String extraFlags; // free-form additional CLI flags (space-separated)
   final String?
   promptId; // agent-level prompt override (null = use global default)
@@ -88,7 +88,15 @@ class CLIAgentConfig {
     'codex': ['o4-mini', 'o3', 'gpt-4o'],
   };
 
-  static const approvalModeOptions = ['full-auto', 'auto-edit', 'suggest'];
+  static const approvalModeOptions = [
+    'never',
+    'on-request',
+    'on-failure',
+    'untrusted',
+    'full-auto',
+    'auto-edit',
+    'suggest',
+  ];
   static const effortOptions = ['low', 'medium', 'high', 'max'];
   static const permissionModeOptions = [
     'default',

--- a/flutter_app/lib/features/cli_agents/cli_agents_screen.dart
+++ b/flutter_app/lib/features/cli_agents/cli_agents_screen.dart
@@ -388,7 +388,7 @@ class _AgentSectionState extends State<_AgentSection> {
                 // ignore: deprecated_member_use
                 value: s.approvalMode.isEmpty ? null : s.approvalMode,
                 decoration: const InputDecoration(
-                    labelText: '--approval-mode', border: OutlineInputBorder()),
+                    labelText: '--ask-for-approval', border: OutlineInputBorder()),
                 items: [
                   const DropdownMenuItem<String>(value: null, child: Text('CLI default')),
                   ...CLIAgentConfig.approvalModeOptions.map(
@@ -659,7 +659,7 @@ class _AgentSectionState extends State<_AgentSection> {
     switch (name) {
       case 'claude': return '--allowedTools Bash,Read';
       case 'gemini': return '--all-files';
-      case 'codex':  return '--full-auto';
+      case 'codex':  return '--sandbox workspace-write';
       default:       return '--flag value';
     }
   }


### PR DESCRIPTION
## Summary
- Run Codex through the non-interactive `codex exec` path and feed prompts via stdin to avoid `stdin is not a terminal` failures.
- Map legacy Codex approval modes to the current `--ask-for-approval` values while keeping existing configs valid.
- Update auto-implement defaults, UI labels/options, config examples, and docs for the current Codex CLI contract.

## Validation
- `make test-docker GO_TEST_ARGS="./internal/executor/... ./internal/issues/... ./internal/config/... ./internal/server/..."`
- `make test-docker`
- `flutter test`
- `flutter analyze`
- `make build-web`
- Local CLI syntax check: `codex --ask-for-approval never exec --help`
