### PR TITLE
fix: hide self-authored PRs from review queue

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -133,8 +133,39 @@ func (c *Client) FetchPRsToReview() ([]*PullRequest, error) {
 	if err != nil {
 		return nil, err
 	}
+	prs, skipped := filterSelfAuthoredPRs(prs, username)
+	if skipped > 0 {
+		slog.Info("github: self-authored PRs skipped by review scope", "count", skipped, "user", username)
+	}
 	slog.Info("github: PRs to review (all repos)", "count", len(prs))
 	return prs, nil
+}
+
+func filterSelfAuthoredPRs(prs []*PullRequest, username string) ([]*PullRequest, int) {
+	username = normalizeGitHubLoginForCompare(username)
+	if username == "" || len(prs) == 0 {
+		return prs, 0
+	}
+	filtered := make([]*PullRequest, 0, len(prs))
+	skipped := 0
+	for _, pr := range prs {
+		if pr != nil && githubLoginsEqual(pr.User.Login, username) {
+			skipped++
+			continue
+		}
+		filtered = append(filtered, pr)
+	}
+	return filtered, skipped
+}
+
+func githubLoginsEqual(a, b string) bool {
+	a = normalizeGitHubLoginForCompare(a)
+	b = normalizeGitHubLoginForCompare(b)
+	return a != "" && b != "" && strings.EqualFold(a, b)
+}
+
+func normalizeGitHubLoginForCompare(login string) string {
+	return strings.TrimSpace(strings.TrimLeft(login, "@"))
 }
 
 // FetchPRs fetches all open PRs where the user is reviewer, assignee, or author.

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -47,6 +47,50 @@ func TestFetchPRs(t *testing.T) {
 	}
 }
 
+func TestFetchPRsToReviewFiltersSelfAuthored(t *testing.T) {
+	prs := []gh.PullRequest{
+		{ID: 1, Number: 41, Title: "Own PR", HTMLURL: "https://github.com/org/repo/pull/41",
+			User: gh.User{Login: "alice"}, State: "open",
+			Head: gh.Branch{Repo: gh.Repo{FullName: "org/repo"}},
+		},
+		{ID: 2, Number: 42, Title: "Team PR", HTMLURL: "https://github.com/org/repo/pull/42",
+			User: gh.User{Login: "bob"}, State: "open",
+			Head: gh.Branch{Repo: gh.Repo{FullName: "org/repo"}},
+		},
+	}
+	var searchQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/user":
+			json.NewEncoder(w).Encode(map[string]string{"login": "alice"})
+		case "/search/issues":
+			searchQuery = r.URL.Query().Get("q")
+			result := struct {
+				Items []gh.PullRequest `json:"items"`
+			}{Items: prs}
+			json.NewEncoder(w).Encode(result)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchPRsToReview()
+	if err != nil {
+		t.Fatalf("FetchPRsToReview: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 PR after self-author filter, got %d", len(got))
+	}
+	if got[0].User.Login != "bob" {
+		t.Fatalf("remaining author = %q, want bob", got[0].User.Login)
+	}
+	if !strings.Contains(searchQuery, "review-requested:alice") {
+		t.Fatalf("search query = %q, want review-requested:alice", searchQuery)
+	}
+}
+
 func TestFetchDiff(t *testing.T) {
 	diff := "diff --git a/main.go b/main.go\n+added line\n"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -877,6 +877,7 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 	// a metadata failure does not roll back the PR, which is already public.
 	metadataOpts := opts
 	metadataOpts.PRAssignee = resolveAutoImplementPRAssignee(issue, opts)
+	metadataOpts.PRReviewers = filterSelfPRReviewers(metadataOpts.PRReviewers, firstNonEmpty(p.botLogin, opts.AuthUser))
 	applyPRMetadata(p.gh, issue.Repo, prNumber, metadataOpts)
 
 	// Post a done-marker comment on the issue so watchers see the PR land
@@ -1148,6 +1149,26 @@ func applyPRMetadata(gh PRMetadataApplier, repo string, prNumber int, opts RunOp
 				"repo", repo, "pr", prNumber, "err", err)
 		}
 	}
+}
+
+func filterSelfPRReviewers(reviewers []string, authUser string) []string {
+	authUser = normalizeGitHubLogin(authUser)
+	if authUser == "" || len(reviewers) == 0 {
+		return reviewers
+	}
+	filtered := make([]string, 0, len(reviewers))
+	skipped := 0
+	for _, reviewer := range reviewers {
+		if strings.EqualFold(normalizeGitHubLogin(reviewer), authUser) {
+			skipped++
+			continue
+		}
+		filtered = append(filtered, reviewer)
+	}
+	if skipped > 0 {
+		slog.Info("issues pipeline: self reviewer skipped on auto-created PR", "count", skipped, "user", authUser)
+	}
+	return filtered
 }
 
 func resolveAutoImplementPRAssignee(issue *github.Issue, opts RunOptions) string {

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -1921,6 +1921,28 @@ func TestAutoImplement_AppliesPRMetadata(t *testing.T) {
 	}
 }
 
+func TestAutoImplement_FiltersAuthenticatedUserFromPRReviewers(t *testing.T) {
+	gh := &fakeGH{defaultBranch: "main", createPRNumber: 77}
+	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("implement done")}
+	git := &fakeGit{hasChanges: true}
+	p := issues.New(&fakeStore{}, gh, exec, git, &fakeBroker{}, nil)
+
+	opts := issues.RunOptions{
+		Primary:     "claude",
+		ExecOpts:    executor.ExecOptions{WorkDir: "/tmp/repo"},
+		GitHubToken: "tok",
+		AuthUser:    "ivanmunozruiz",
+		PRReviewers: []string{"alice", "ivanmunozruiz", "@IVANMUNOZRUIZ", "bob"},
+	}
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gh.reviewersCalls) != 1 || !stringsEqual(gh.reviewersCalls[0], []string{"alice", "bob"}) {
+		t.Errorf("reviewers = %v, want [alice bob]", gh.reviewersCalls)
+	}
+}
+
 func TestAutoImplement_DefaultsPRAssigneeToSingleIssueAssignee(t *testing.T) {
 	gh := &fakeGH{defaultBranch: "main", createPRNumber: 77}
 	exec := &fakeExec{detectCLI: "claude", rawOutput: []byte("implement done")}

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -398,12 +398,43 @@ func (srv *Server) handleListPRs(w http.ResponseWriter, r *http.Request) {
 		*store.PR
 		LatestReview *store.Review `json:"latest_review,omitempty"`
 	}
+	authLogin := srv.authenticatedLoginForPRListing()
+	skippedSelf := 0
 	result := make([]prWithReview, 0, len(prs))
 	for _, pr := range prs {
+		if authLogin != "" && githubLoginsEqual(pr.Author, authLogin) {
+			skippedSelf++
+			continue
+		}
 		rev, _ := srv.store.LatestReviewForPR(pr.ID)
 		result = append(result, prWithReview{PR: pr, LatestReview: rev})
 	}
+	if skippedSelf > 0 {
+		slog.Info("handleListPRs: self-authored PRs hidden from review listing", "count", skippedSelf, "user", authLogin)
+	}
 	writeJSON(w, http.StatusOK, result)
+}
+
+func (srv *Server) authenticatedLoginForPRListing() string {
+	if srv.meFn == nil {
+		return ""
+	}
+	login, err := srv.meFn()
+	if err != nil {
+		slog.Warn("handleListPRs: authenticated user unavailable; self-authored PRs remain visible", "err", err)
+		return ""
+	}
+	return normalizeGitHubLoginForCompare(login)
+}
+
+func githubLoginsEqual(a, b string) bool {
+	a = normalizeGitHubLoginForCompare(a)
+	b = normalizeGitHubLoginForCompare(b)
+	return a != "" && b != "" && strings.EqualFold(a, b)
+}
+
+func normalizeGitHubLoginForCompare(login string) string {
+	return strings.TrimSpace(strings.TrimLeft(login, "@"))
 }
 
 func (srv *Server) handleGetPR(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -101,6 +101,31 @@ func TestHandlerListPRs(t *testing.T) {
 	}
 }
 
+func TestHandlerListPRsFiltersSelfAuthored(t *testing.T) {
+	srv, s := setupServer(t)
+	srv.SetMeFn(func() (string, error) { return "ivan", nil })
+	now := time.Now()
+	s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/r", Number: 1, Title: "own", Author: "Ivan", URL: "u1", State: "open", UpdatedAt: now, FetchedAt: now})
+	s.UpsertPR(&store.PR{GithubID: 2, Repo: "org/r", Number: 2, Title: "team", Author: "teammate", URL: "u2", State: "open", UpdatedAt: now, FetchedAt: now})
+
+	req := httptest.NewRequest("GET", "/prs", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list prs: status %d", w.Code)
+	}
+	var prs []map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&prs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 non-self PR, got %d: %#v", len(prs), prs)
+	}
+	if prs[0]["author"] != "teammate" {
+		t.Fatalf("author = %v, want teammate", prs[0]["author"])
+	}
+}
+
 func TestHandlerGetPR(t *testing.T) {
 	srv, s := setupServer(t)
 	id, _ := s.UpsertPR(&store.PR{GithubID: 2, Repo: "org/r", Number: 2, Title: "t", Author: "a", URL: "u", State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now()})


### PR DESCRIPTION
Fixes #499.\n\nSummary:\n- Filter self-authored PRs after GitHub review-requested search.\n- Hide self-authored stored PRs from the /prs review listing.\n- Remove the authenticated user from auto-created PR reviewer metadata.\n\nTests:\n- make test-docker