### PR TITLE
chore: integrate CLI dev workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/*.dmg
 dist/*.zip
 daemon/bin/
+cli/bin/
 
 # Local Docker runtime state
 # - docker/.env holds GITHUB_TOKEN + provider credentials; never commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Hardening details are inlined in the Makefile target. Summary:
 If IT/Security asks how we run Go tests on their laptops, point them at
 this section and the `test-docker` target.
 
-## When `go test` on the host is OK
+## When daemon `go test` on the host is OK
 
 Never, on a corporate laptop with an EDR, unless Security has explicitly
 whitelisted `$GOCACHE` and `/var/folders/.../go-build/`. Raising a ticket
@@ -70,12 +70,41 @@ binaries). Run them normally:
 
 ```bash
 cd flutter_app && flutter test
-# or combined with Go tests (note: `make test` runs Go on the host):
+# or combined with daemon + CLI tests (note: `make test` runs daemon Go tests on the host):
 make test
 ```
 
-**Prefer `make test-docker && cd flutter_app && flutter test`** over
-`make test` on EDR-protected endpoints.
+**Prefer `make test-docker && cd flutter_app && flutter test && make test-cli`**
+over `make test` on EDR-protected endpoints.
+
+## CLI / TUI
+
+The CLI/TUI lives in `cli/` and is a separate Go module
+(`github.com/theburrowhub/heimdallm/cli`). It uses Cobra for commands and
+Bubble Tea + Lipgloss for the terminal dashboard. It talks to the daemon only
+over HTTP/SSE through `cli/internal/api/client.go`.
+
+CLI tests are OK to run on the host: unlike the daemon, the CLI is a client
+process with no embedded NATS, SQLite, pollers, worker loops, or daemon
+server. Run:
+
+```bash
+make -C cli test
+make test-cli
+make -C cli lint
+make lint-cli
+```
+
+For TUI UI changes, run a daemon locally and verify the dashboard visually:
+
+```bash
+make dev-daemon
+make dev-cli
+```
+
+Any daemon endpoint consumed by CLI/TUI should get a matching method in
+`cli/internal/api/client.go`; do not let commands or TUI screens make ad hoc
+HTTP calls.
 
 ## Flutter platform abstraction layer
 
@@ -126,7 +155,9 @@ bump.
 
 ## Do not
 
-- Run `go test` / `go build` on the host on a corporate laptop with EDR.
+- Run daemon `go test` / `go build` on the host on a corporate laptop with EDR.
+- Import daemon packages from `cli/`; the CLI is a separate Go module and must
+  use `cli/internal/api/client.go` over HTTP/SSE.
 - Stage `.DS_Store` in commits.
 - Push directly to `main` — always open a PR.
 - Skip hooks (`--no-verify`) without an explicit user instruction.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ else
   APP_BUNDLE       := $(FLUTTER_BUILD)/bundle
 endif
 
-.PHONY: build-daemon build-app build-web test test-docker dev dev-daemon dev-stop \
+.PHONY: build-daemon build-app build-web build-cli test test-cli lint-cli dev-cli test-docker dev dev-daemon dev-stop \
         release-local package-macos install-service verify-linux run-linux \
         install-linux uninstall-linux \
         setup up up-build up-daemon up-build-daemon down logs logs-daemon \
@@ -30,6 +30,9 @@ build-daemon:
 build-app:
 	cd flutter_app && flutter build $(FLUTTER_DEVICE) --release
 
+build-cli:
+	$(MAKE) -C cli build
+
 # Flutter Web bundle, consumed by docker/Dockerfile.web (served via Nginx).
 # --base-href=/ matches the Nginx server block that expects assets at the root.
 build-web:
@@ -40,6 +43,13 @@ build-web:
 test:
 	cd daemon && make test
 	cd flutter_app && flutter test
+	$(MAKE) -C cli test
+
+test-cli:
+	$(MAKE) -C cli test
+
+lint-cli:
+	$(MAKE) -C cli lint
 
 # ── Sandboxed Go tests (EDR-safe) ─────────────────────────────────────────────
 #
@@ -95,6 +105,9 @@ dev: build-daemon dev-stop
 dev-daemon: build-daemon dev-stop
 	@echo "▶  Daemon en http://localhost:7842 (Ctrl-C para parar)"
 	GITHUB_TOKEN="$${GITHUB_TOKEN}" $(DAEMON_BIN)
+
+dev-cli:
+	$(MAKE) -C cli dev
 
 dev-stop:
 	@pkill -f "$(DAEMON_BIN)" 2>/dev/null && echo "↓  Daemon parado" || true

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ make uninstall-linux PURGE=1 # also wipe ~/.config + ~/.local/share state
 
 > **Requires**: Docker running, `gh` CLI authenticated (or `$GITHUB_TOKEN` exported), Ubuntu 22.04 / Debian 12+ / Fedora / Arch or similarly current distro. Same binary-compatibility envelope as the CI-built `.deb`.
 
+### CLI / TUI
+
+The terminal client is distributed as `heimdallm-cli` via Homebrew and GitHub Releases. It connects to a running daemon and supports status checks, PR/issue lists, manual review triggers, live event following, stats, config inspection, and a Bubble Tea dashboard.
+
+```bash
+brew install theburrowhub/tap/heimdallm-cli
+
+# or download a heimdallm-cli_* archive from GitHub Releases
+heimdallm-cli dashboard
+```
+
 ### Docker
 
 For headless/server deployment, Heimdallm runs as a Docker container with all four AI CLIs bundled. The repository ships Make wrappers around `docker compose` so you don't have to remember the compose path.
@@ -363,15 +374,16 @@ On first launch Heimdallm detects your `gh` CLI token automatically and sets its
 
 The **Go daemon** (`heimdalld`, port `7842`) is the engine. It polls GitHub for PRs and issues, dispatches work to the configured AI CLI, posts reviews or opens implementation PRs, and broadcasts state to any connected UI over SSE.
 
-Two first-party UIs talk to it over HTTP:
+Three first-party UIs talk to it over HTTP:
 
 - **Flutter desktop app** — macOS menu-bar + dashboard, system notifications. Ships inside the `.dmg` / Linux packages.
 - **Flutter Web UI** — browser dashboard on port `3000`, served by Nginx, ships as a second Docker container alongside the daemon.
+- **Terminal CLI/TUI** — Cobra commands plus a Bubble Tea + Lipgloss dashboard. Ships as `heimdallm-cli` via Homebrew and GitHub Releases.
 
 ```
 Flutter app ─┐
-             ├──→ HTTP / SSE ──→  heimdalld  ──→  GitHub API
-Web UI     ──┘                       │
+Web UI      ─┼──→ HTTP / SSE ──→  heimdalld  ──→  GitHub API
+CLI / TUI   ─┘                       │
                                      ├──→  PR review pipeline   ──→  POST /reviews
                                      ├──→  Issue triage pipeline
                                      └──→  Auto-implement       ──→  branch + commits + PR
@@ -414,11 +426,24 @@ For iterating on the Flutter Web bundle against a running daemon:
 make build-web    # compile Flutter → web/; then `make up-build` to bake into the Nginx image
 ```
 
+**CLI / TUI** — terminal client against a running daemon:
+```bash
+make build-cli
+make dev-daemon
+make dev-cli
+make test-cli
+```
+`make dev-cli` launches `heimdallm-cli dashboard` against `http://localhost:7842` by default. Set `HEIMDALLM_HOST` and `HEIMDALLM_TOKEN` when targeting another daemon.
+
 ### Other targets
 
 ```bash
-make test          # Run Go + Flutter test suites on the host
+make test          # Run daemon Go + Flutter + CLI tests on the host
 make test-docker   # Run Go tests inside a pinned Docker image (EDR-safe)
+make build-cli     # Build cli/bin/heimdallm-cli
+make test-cli      # Run CLI module tests on the host
+make lint-cli      # Run CLI module vet checks
+make dev-cli       # Run the CLI dashboard against localhost:7842
 make dev-daemon    # Run daemon only (debug API at localhost:7842)
 make dev-stop      # Stop the running daemon
 make up                # Docker: bring up daemon + web UI
@@ -459,6 +484,12 @@ heimdallm/
 │       ├── scheduler/       Poll loop, grace windows
 │       ├── server/          HTTP + SSE API
 │       └── keychain/        Host credential storage
+├── cli/                     Terminal client and TUI (separate Go module)
+│   ├── cmd/heimdallm-cli/   Cobra entrypoint
+│   └── internal/
+│       ├── api/             Daemon HTTP + SSE client
+│       ├── cli/             Commands and config loading
+│       └── tui/             Bubble Tea dashboard
 ├── flutter_app/             macOS / Linux / Web UI
 │   ├── lib/
 │   │   ├── features/

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -8,10 +8,10 @@ build:
 	go build -o $(BINARY) $(CMD)
 
 test:
-	go test ./... -timeout 60s
+	go test -timeout 60s ./...
 
 test-race:
-	go test ./... -race -timeout 60s
+	go test -race -timeout 60s ./...
 
 lint:
 	go vet ./...

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,0 +1,23 @@
+BINARY = bin/heimdallm-cli
+CMD    = ./cmd/heimdallm-cli
+
+.PHONY: build test test-race lint clean dev
+
+build:
+	@mkdir -p $(dir $(BINARY))
+	go build -o $(BINARY) $(CMD)
+
+test:
+	go test ./... -timeout 60s
+
+test-race:
+	go test ./... -race -timeout 60s
+
+lint:
+	go vet ./...
+
+clean:
+	rm -rf bin/
+
+dev:
+	go run $(CMD) dashboard

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -900,6 +900,12 @@ Worst-case disk use: `(HEIMDALLM_LOG_KEEP + 1) × HEIMDALLM_LOG_MAX_MB`.
 
 ### Installation
 
+**Homebrew:**
+
+```bash
+brew install theburrowhub/tap/heimdallm-cli
+```
+
 **Binary download:**
 
 Download the appropriate archive from [GitHub Releases](https://github.com/theburrowhub/heimdallm/releases) (look for `heimdallm-cli_*`):
@@ -940,6 +946,29 @@ make setup   # prints the token and copies it into docker/.env
 docker exec heimdallm cat /data/api_token
 ```
 
+### Local development
+
+The CLI is a separate Go module under `cli/`. It uses Cobra for commands and
+Bubble Tea + Lipgloss for the dashboard, and it talks to the daemon through
+`cli/internal/api/client.go`.
+
+From the repository root:
+
+```bash
+make build-cli    # builds cli/bin/heimdallm-cli
+make test-cli     # host-safe CLI tests
+make lint-cli     # go vet for the CLI module
+make dev-daemon   # run the daemon at http://localhost:7842
+make dev-cli      # run heimdallm-cli dashboard
+```
+
+Set `HEIMDALLM_HOST` and `HEIMDALLM_TOKEN` when testing against a non-local
+daemon:
+
+```bash
+HEIMDALLM_HOST=https://heimdallm.example.com HEIMDALLM_TOKEN=... make dev-cli
+```
+
 ### Commands
 
 | Command | Description |
@@ -953,6 +982,28 @@ docker exec heimdallm cat /data/api_token
 | `heimdallm-cli config` | Print the daemon's running configuration as JSON |
 | `heimdallm-cli stats` | Review statistics: totals, by severity, by CLI, top repos, timing |
 | `heimdallm-cli dashboard` | Live terminal dashboard |
+
+### TUI dashboard keybindings
+
+The dashboard tabs are Activity, PRs, Issues, Config, Stats, Logs, and Server.
+
+| Key | Action |
+|---|---|
+| `tab`, `l`, `right` | Move to the next tab |
+| `h`, `left` | Move to the previous tab |
+| `1`-`7` | Jump directly to a tab |
+| `r` | Refresh data |
+| `s` | Stop the daemon (opens a confirmation prompt) |
+| `q`, `ctrl+c` | Quit |
+| `j`, `down` | Move or scroll down |
+| `k`, `up` | Move or scroll up |
+| `pgdn`, `pgup` | Page through long lists or detail views |
+| `g` | Jump to the top of the current list |
+| `G` | Follow the live Logs tab |
+| `enter` | Open PR or issue details |
+| `esc` | Close an open detail view |
+| `p` | Promote a promotable issue |
+| `y` / `n` | Confirm or cancel daemon shutdown |
 
 ---
 


### PR DESCRIPTION
## Summary
- add cli/Makefile with build/test/lint/dev targets
- expose root CLI targets and include CLI tests in make test
- document CLI/TUI workflow in AGENTS, README, and configuration guide

## Tests
- make -C cli test
- make -C cli lint
- make build-cli
- make test-cli
- make lint-cli
- make test-docker

Closes #472