### PR TITLE
fix: speed up dynamic config saves

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1548,6 +1549,16 @@ func main() {
 			return fmt.Errorf("reload: %w", err)
 		}
 
+		cfgMu.Lock()
+		restartPollers := configReloadRequiresPollerRestart(cfg, newCfg)
+		if !restartPollers {
+			cfg = newCfg
+			cfgMu.Unlock()
+			slog.Info("config reload: applied without poller restart")
+			return nil
+		}
+		cfgMu.Unlock()
+
 		// Read the current cancel/wg under cfgMu, then stop OUTSIDE the lock.
 		// Holding cfgMu across Wait() risks deadlock: if Wait() blocks
 		// waiting for in-flight goroutines that also acquire cfgMu (e.g.
@@ -2022,6 +2033,66 @@ func parseDiscoveryInterval(discoveryInterval, pollInterval string) time.Duratio
 		return parsePollInterval(pollInterval)
 	}
 	return d
+}
+
+// configReloadRequiresPollerRestart returns true unless the diff is limited to
+// fields known to be read dynamically through cfg under cfgMu. This keeps new
+// config fields conservative by default: if a future field is not scrubbed in
+// configReloadRestartSnapshot, reloads restart pollers until the field is
+// explicitly classified as dynamic.
+func configReloadRequiresPollerRestart(oldCfg, newCfg *config.Config) bool {
+	if oldCfg == nil || newCfg == nil {
+		return true
+	}
+	return !reflect.DeepEqual(configReloadRestartSnapshot(oldCfg), configReloadRestartSnapshot(newCfg))
+}
+
+func configReloadRestartSnapshot(c *config.Config) config.Config {
+	snap := *c
+	snap.GitHub.Repositories = normalizeReloadStringSlice(snap.GitHub.Repositories)
+	snap.GitHub.NonMonitored = normalizeReloadStringSlice(snap.GitHub.NonMonitored)
+	snap.GitHub.DiscoveryOrgs = normalizeReloadStringSlice(snap.GitHub.DiscoveryOrgs)
+	snap.GitHub.LocalDirBase = nil
+	snap.GitHub.AutoEnablePROnDiscovery = nil
+	snap.GitHub.WatchInterval = ""
+	snap.GitHub.IssueTracking = config.IssueTrackingConfig{}
+	snap.GitHub.ReviewGuards = config.ReviewGuardsConfig{}
+
+	snap.AI.Primary = ""
+	snap.AI.Fallback = ""
+	snap.AI.ReviewMode = ""
+	snap.AI.ExecutionTimeout = ""
+	snap.AI.Agents = nil
+	snap.AI.Repos = nil
+	snap.AI.Orgs = nil
+	snap.AI.PRMetadata = config.PRMetadataConfig{}
+	snap.AI.PRReviewers = nil
+	snap.AI.PRLabels = nil
+	snap.AI.PRAssignee = ""
+	snap.AI.PRDraft = nil
+	snap.AI.IssuePrompt = ""
+	snap.AI.ImplementPrompt = ""
+	snap.AI.RefinementTimeout = ""
+	snap.AI.TriageOwner = ""
+	snap.AI.CloneDir = ""
+	snap.AI.AutoPromoteTriage = nil
+	snap.AI.AutoPromoteRefinement = nil
+	snap.AI.Tier2RepoConcurrency = 0
+	snap.AI.GeneratePRDescription = false
+	snap.AI.ReviewResponse = config.ReviewResponseConfig{}
+	snap.AI.ReviewFix = config.ReviewFixConfig{}
+
+	snap.Retention = config.RetentionConfig{}
+	snap.ActivityLog = config.ActivityLogConfig{}
+	snap.CircuitBreaker = config.CircuitBreakerConfig{}
+	return snap
+}
+
+func normalizeReloadStringSlice(v []string) []string {
+	if len(v) == 0 {
+		return nil
+	}
+	return append([]string(nil), v...)
 }
 
 // resolveExecutionTimeout returns the effective execution timeout for the CLI

--- a/daemon/cmd/heimdallm/main_interval_test.go
+++ b/daemon/cmd/heimdallm/main_interval_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"testing"
 	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
 )
 
 func TestParseDiscoveryIntervalFallsBackToPollInterval(t *testing.T) {
@@ -51,4 +53,132 @@ func TestResolveRefinementTimeoutFallsBackToAgentThenGlobal(t *testing.T) {
 	if got != 20*time.Minute {
 		t.Fatalf("resolveRefinementTimeout(empty, 20m, empty) = %v, want 20m", got)
 	}
+}
+
+func TestConfigReloadRequiresPollerRestartSkipsDynamicOnlyChanges(t *testing.T) {
+	oldCfg := reloadRestartBaseConfig()
+	newCfg := cloneReloadRestartConfig(oldCfg)
+	newCfg.AI.Primary = "codex"
+	newCfg.AI.ReviewMode = "multi"
+	newCfg.GitHub.IssueTracking.DefaultAction = "review_only"
+
+	if configReloadRequiresPollerRestart(oldCfg, newCfg) {
+		t.Fatal("dynamic AI/issue config changes should not restart pollers")
+	}
+}
+
+func TestConfigReloadRequiresPollerRestartForCadenceAndRepoStream(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*config.Config)
+	}{
+		{
+			name: "poll interval",
+			mutate: func(c *config.Config) {
+				c.GitHub.PollInterval = "2m"
+			},
+		},
+		{
+			name: "discovery interval",
+			mutate: func(c *config.Config) {
+				c.GitHub.DiscoveryInterval = "10m"
+			},
+		},
+		{
+			name: "rename probe interval",
+			mutate: func(c *config.Config) {
+				c.AI.RepoRenameCheckInterval = "2h"
+			},
+		},
+		{
+			name: "repositories",
+			mutate: func(c *config.Config) {
+				c.GitHub.Repositories = append(c.GitHub.Repositories, "org/repo2")
+			},
+		},
+		{
+			name: "non monitored",
+			mutate: func(c *config.Config) {
+				c.GitHub.NonMonitored = append(c.GitHub.NonMonitored, "org/off2")
+			},
+		},
+		{
+			name: "discovery topic",
+			mutate: func(c *config.Config) {
+				c.GitHub.DiscoveryTopic = "new-topic"
+			},
+		},
+		{
+			name: "discovery orgs",
+			mutate: func(c *config.Config) {
+				c.GitHub.DiscoveryOrgs = append(c.GitHub.DiscoveryOrgs, "other-org")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldCfg := reloadRestartBaseConfig()
+			newCfg := cloneReloadRestartConfig(oldCfg)
+			tc.mutate(newCfg)
+			if !configReloadRequiresPollerRestart(oldCfg, newCfg) {
+				t.Fatal("expected poller restart")
+			}
+		})
+	}
+}
+
+func TestConfigReloadRequiresPollerRestartTreatsNilAndEmptySlicesAsSame(t *testing.T) {
+	oldCfg := reloadRestartBaseConfig()
+	oldCfg.GitHub.Repositories = nil
+	oldCfg.GitHub.NonMonitored = nil
+	oldCfg.GitHub.DiscoveryOrgs = nil
+
+	newCfg := cloneReloadRestartConfig(oldCfg)
+	newCfg.GitHub.Repositories = []string{}
+	newCfg.GitHub.NonMonitored = []string{}
+	newCfg.GitHub.DiscoveryOrgs = []string{}
+
+	if configReloadRequiresPollerRestart(oldCfg, newCfg) {
+		t.Fatal("nil and empty repo/discovery slices should not restart pollers")
+	}
+}
+
+func TestConfigReloadRequiresPollerRestartDefaultsUnknownFieldsToRestart(t *testing.T) {
+	oldCfg := reloadRestartBaseConfig()
+	newCfg := cloneReloadRestartConfig(oldCfg)
+	newCfg.Server.MaxConcurrentWorkers = oldCfg.Server.MaxConcurrentWorkers + 1
+
+	if !configReloadRequiresPollerRestart(oldCfg, newCfg) {
+		t.Fatal("non-dynamic fields should restart pollers by default")
+	}
+}
+
+func reloadRestartBaseConfig() *config.Config {
+	return &config.Config{
+		GitHub: config.GitHubConfig{
+			PollInterval:      "1m",
+			Repositories:      []string{"org/repo1"},
+			NonMonitored:      []string{"org/off1"},
+			DiscoveryTopic:    "heimdallm-review",
+			DiscoveryOrgs:     []string{"org"},
+			DiscoveryInterval: "5m",
+			IssueTracking: config.IssueTrackingConfig{
+				DefaultAction: "ignore",
+			},
+		},
+		AI: config.AIConfig{
+			Primary:                 "claude",
+			ReviewMode:              "single",
+			RepoRenameCheckInterval: "1h",
+		},
+	}
+}
+
+func cloneReloadRestartConfig(c *config.Config) *config.Config {
+	clone := *c
+	clone.GitHub.Repositories = append([]string(nil), c.GitHub.Repositories...)
+	clone.GitHub.NonMonitored = append([]string(nil), c.GitHub.NonMonitored...)
+	clone.GitHub.DiscoveryOrgs = append([]string(nil), c.GitHub.DiscoveryOrgs...)
+	return &clone
 }


### PR DESCRIPTION
## Summary
- avoid cancelling/restarting pollers when config reloads only change dynamic fields
- keep full poller restart for cadence, repo stream, and discovery changes
- add unit coverage for restart vs fast-swap reload decisions

## Tests
- make test-docker GO_TEST_ARGS="-run 'TestConfigReloadRequiresPollerRestart|TestParseDiscoveryInterval|TestResolveRefinementTimeout' ./cmd/heimdallm"
- make test-docker

Closes #463