### PR TITLE
feat: add liveness heartbeat watchdog

### DIFF
--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestStreamEventsReturnsWhenContextCanceledWithBlockedSend(t *testing.T) {
+	eventFlushed := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("response writer does not support flushing")
+		}
+		fmt.Fprint(w, "event: heartbeat\ndata: {}\n\n")
+		flusher.Flush()
+		close(eventFlushed)
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	client := New(srv.URL, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan SSEEvent)
+	done := make(chan error, 1)
+	go func() {
+		done <- client.StreamEvents(ctx, events)
+	}()
+
+	select {
+	case <-eventFlushed:
+	case <-time.After(time.Second):
+		t.Fatal("server did not flush SSE event")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected context cancellation error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StreamEvents did not return after context cancellation")
+	}
+}

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -46,21 +46,23 @@ type Dashboard struct {
 	logOffset int
 	logSeeded bool
 
-	err              error
-	connected        bool
-	sseStale         bool
-	refreshing       bool
-	confirmShutdown  bool
-	shutdownInFlight bool
-	shutdownMessage  string
-	startTime        time.Time
-	lastUpdate       time.Time
-	lastSSEEvent     time.Time
-	version          string
+	err               error
+	connected         bool
+	sseStale          bool
+	sseHealthChecking bool
+	refreshing        bool
+	confirmShutdown   bool
+	shutdownInFlight  bool
+	shutdownMessage   string
+	startTime         time.Time
+	lastUpdate        time.Time
+	lastSSEEvent      time.Time
+	version           string
 
-	sseEvents chan api.SSEEvent
-	sseCtx    context.Context
-	sseCancel context.CancelFunc
+	sseEvents    chan api.SSEEvent
+	sseCtx       context.Context
+	sseCancel    context.CancelFunc
+	sseSessionID int64
 
 	showDetail   bool
 	detailScroll int
@@ -83,11 +85,20 @@ type dataMsg struct {
 	activity *api.ActivityResponse
 	err      error
 }
-type sseMsg api.SSEEvent
-type sseDisconnectMsg struct{ err error }
+type sseMsg struct {
+	sessionID int64
+	event     api.SSEEvent
+}
+type sseDisconnectMsg struct {
+	sessionID int64
+	err       error
+}
 type sseReconnectMsg struct{}
 type sseWatchdogMsg time.Time
-type healthCheckMsg struct{ err error }
+type healthCheckMsg struct {
+	err         error
+	lastEventAt time.Time
+}
 type shutdownMsg struct{ err error }
 type promoteIssueMsg struct {
 	id  int64
@@ -105,14 +116,16 @@ func NewDashboard(host, token, version string) *Dashboard {
 		logFollow:    true,
 		sseCtx:       ctx,
 		sseCancel:    cancel,
+		sseSessionID: 1,
 	}
 }
 
 func (d *Dashboard) Init() tea.Cmd {
+	connect, listen := d.sseCommands()
 	return tea.Batch(
 		d.fetchData,
-		d.connectSSE,
-		d.listenSSE(),
+		connect,
+		listen,
 		tickCmd(),
 		sseWatchdogCmd(),
 	)
@@ -171,23 +184,30 @@ func (d *Dashboard) fetchData() tea.Msg {
 	return msg
 }
 
-func (d *Dashboard) connectSSE() tea.Msg {
-	err := d.client.StreamEvents(d.sseCtx, d.sseEvents)
-	if d.sseCtx.Err() != nil {
-		return nil
-	}
-	return sseDisconnectMsg{err: err}
+func (d *Dashboard) sseCommands() (tea.Cmd, tea.Cmd) {
+	return d.connectSSE(d.sseSessionID, d.sseCtx, d.sseEvents),
+		d.listenSSE(d.sseSessionID, d.sseCtx, d.sseEvents)
 }
 
-func (d *Dashboard) listenSSE() tea.Cmd {
+func (d *Dashboard) connectSSE(sessionID int64, ctx context.Context, events chan<- api.SSEEvent) tea.Cmd {
+	return func() tea.Msg {
+		err := d.client.StreamEvents(ctx, events)
+		if ctx.Err() != nil {
+			return nil
+		}
+		return sseDisconnectMsg{sessionID: sessionID, err: err}
+	}
+}
+
+func (d *Dashboard) listenSSE(sessionID int64, ctx context.Context, events <-chan api.SSEEvent) tea.Cmd {
 	return func() tea.Msg {
 		select {
-		case event, ok := <-d.sseEvents:
+		case event, ok := <-events:
 			if !ok {
 				return nil
 			}
-			return sseMsg(event)
-		case <-d.sseCtx.Done():
+			return sseMsg{sessionID: sessionID, event: event}
+		case <-ctx.Done():
 			return nil
 		}
 	}
@@ -201,6 +221,7 @@ func (d *Dashboard) resetSSE() {
 	d.sseCtx = ctx
 	d.sseCancel = cancel
 	d.sseEvents = make(chan api.SSEEvent, 32)
+	d.sseSessionID++
 	d.lastSSEEvent = time.Now()
 }
 
@@ -216,9 +237,9 @@ func (d *Dashboard) promoteIssue(id int64) tea.Cmd {
 	}
 }
 
-func (d *Dashboard) checkHealth() tea.Cmd {
+func (d *Dashboard) checkHealth(lastEventAt time.Time) tea.Cmd {
 	return func() tea.Msg {
-		return healthCheckMsg{err: d.client.Health()}
+		return healthCheckMsg{err: d.client.Health(), lastEventAt: lastEventAt}
 	}
 }
 
@@ -267,10 +288,11 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sseWatchdogMsg:
 		cmds := []tea.Cmd{sseWatchdogCmd()}
-		if !d.shutdownInFlight && !d.lastSSEEvent.IsZero() && time.Since(d.lastSSEEvent) > time.Minute {
+		if !d.shutdownInFlight && !d.sseHealthChecking && !d.lastSSEEvent.IsZero() && time.Since(d.lastSSEEvent) > time.Minute {
 			d.sseStale = true
+			d.sseHealthChecking = true
 			d.shutdownMessage = "SSE stream stale; checking daemon health..."
-			cmds = append(cmds, d.checkHealth())
+			cmds = append(cmds, d.checkHealth(d.lastSSEEvent))
 		}
 		return d, tea.Batch(cmds...)
 
@@ -320,18 +342,24 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return d, nil
 
 	case sseMsg:
+		if msg.sessionID != d.sseSessionID {
+			return d, nil
+		}
+		event := msg.event
 		d.lastSSEEvent = time.Now()
 		d.sseStale = false
-		d.shutdownMessage = ""
-		d.connected = true
-		d.err = nil
-		if msg.Type == "heartbeat" {
-			return d, d.listenSSE()
+		if !d.sseHealthChecking {
+			d.shutdownMessage = ""
+			d.connected = true
+			d.err = nil
 		}
-		itemType, info := formatSSEData(msg.Type, msg.Data)
+		if event.Type == "heartbeat" {
+			return d, d.listenSSE(d.sseSessionID, d.sseCtx, d.sseEvents)
+		}
+		itemType, info := formatSSEData(event.Type, event.Data)
 		line := activityLine{
 			Time:     time.Now().Format("15:04"),
-			Event:    msg.Type,
+			Event:    event.Type,
 			Info:     info,
 			ItemType: itemType,
 		}
@@ -339,7 +367,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(d.activity) > 100 {
 			d.activity = d.activity[:100]
 		}
-		d.logLines = append(d.logLines, sseToLogLine(api.SSEEvent(msg)))
+		d.logLines = append(d.logLines, sseToLogLine(event))
 		if len(d.logLines) > 1000 {
 			excess := len(d.logLines) - 1000
 			d.logLines = d.logLines[excess:]
@@ -350,9 +378,12 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
-		return d, d.listenSSE()
+		return d, d.listenSSE(d.sseSessionID, d.sseCtx, d.sseEvents)
 
 	case sseDisconnectMsg:
+		if msg.sessionID != d.sseSessionID {
+			return d, nil
+		}
 		d.connected = false
 		d.err = msg.err
 		d.sseStale = false
@@ -361,9 +392,14 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		})
 
 	case sseReconnectMsg:
-		return d, d.connectSSE
+		connect, _ := d.sseCommands()
+		return d, connect
 
 	case healthCheckMsg:
+		d.sseHealthChecking = false
+		if !d.sseStale || !msg.lastEventAt.Equal(d.lastSSEEvent) {
+			return d, nil
+		}
 		if msg.err != nil {
 			d.connected = false
 			d.err = msg.err
@@ -372,11 +408,12 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if d.sseStale {
 			d.resetSSE()
+			connect, listen := d.sseCommands()
 			d.connected = false
 			d.err = nil
 			d.sseStale = false
 			d.shutdownMessage = "Reconnecting SSE stream..."
-			return d, tea.Batch(d.connectSSE, d.listenSSE())
+			return d, tea.Batch(connect, listen)
 		}
 		return d, nil
 

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -94,7 +94,7 @@ type sseDisconnectMsg struct {
 	sessionID int64
 	err       error
 }
-type sseReconnectMsg struct{}
+type sseReconnectMsg struct{ sessionID int64 }
 type sseWatchdogMsg time.Time
 type healthCheckMsg struct {
 	err         error
@@ -391,11 +391,15 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		d.connected = false
 		d.err = msg.err
 		d.sseStale = false
+		sessionID := msg.sessionID
 		return d, tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
-			return sseReconnectMsg{}
+			return sseReconnectMsg{sessionID: sessionID}
 		})
 
 	case sseReconnectMsg:
+		if msg.sessionID != d.sseSessionID {
+			return d, nil
+		}
 		connect, _ := d.sseCommands()
 		return d, connect
 
@@ -410,16 +414,13 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d.sseStatusMessage = "Daemon health check failed"
 			return d, nil
 		}
-		if d.sseStale {
-			d.resetSSE()
-			connect, listen := d.sseCommands()
-			d.connected = false
-			d.err = nil
-			d.sseStale = false
-			d.sseStatusMessage = "Reconnecting SSE stream..."
-			return d, tea.Batch(connect, listen)
-		}
-		return d, nil
+		d.resetSSE()
+		connect, listen := d.sseCommands()
+		d.connected = false
+		d.err = nil
+		d.sseStale = false
+		d.sseStatusMessage = "Reconnecting SSE stream..."
+		return d, tea.Batch(connect, listen)
 
 	case shutdownMsg:
 		d.shutdownInFlight = false

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -48,12 +48,14 @@ type Dashboard struct {
 
 	err              error
 	connected        bool
+	sseStale         bool
 	refreshing       bool
 	confirmShutdown  bool
 	shutdownInFlight bool
 	shutdownMessage  string
 	startTime        time.Time
 	lastUpdate       time.Time
+	lastSSEEvent     time.Time
 	version          string
 
 	sseEvents chan api.SSEEvent
@@ -84,6 +86,8 @@ type dataMsg struct {
 type sseMsg api.SSEEvent
 type sseDisconnectMsg struct{ err error }
 type sseReconnectMsg struct{}
+type sseWatchdogMsg time.Time
+type healthCheckMsg struct{ err error }
 type shutdownMsg struct{ err error }
 type promoteIssueMsg struct {
 	id  int64
@@ -93,13 +97,14 @@ type promoteIssueMsg struct {
 func NewDashboard(host, token, version string) *Dashboard {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Dashboard{
-		client:    api.New(host, token),
-		version:   version,
-		startTime: time.Now(),
-		sseEvents: make(chan api.SSEEvent, 32),
-		logFollow: true,
-		sseCtx:    ctx,
-		sseCancel: cancel,
+		client:       api.New(host, token),
+		version:      version,
+		startTime:    time.Now(),
+		lastSSEEvent: time.Now(),
+		sseEvents:    make(chan api.SSEEvent, 32),
+		logFollow:    true,
+		sseCtx:       ctx,
+		sseCancel:    cancel,
 	}
 }
 
@@ -109,12 +114,19 @@ func (d *Dashboard) Init() tea.Cmd {
 		d.connectSSE,
 		d.listenSSE(),
 		tickCmd(),
+		sseWatchdogCmd(),
 	)
 }
 
 func tickCmd() tea.Cmd {
 	return tea.Tick(10*time.Second, func(t time.Time) tea.Msg {
 		return tickMsg(t)
+	})
+}
+
+func sseWatchdogCmd() tea.Cmd {
+	return tea.Tick(10*time.Second, func(t time.Time) tea.Msg {
+		return sseWatchdogMsg(t)
 	})
 }
 
@@ -181,6 +193,17 @@ func (d *Dashboard) listenSSE() tea.Cmd {
 	}
 }
 
+func (d *Dashboard) resetSSE() {
+	if d.sseCancel != nil {
+		d.sseCancel()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	d.sseCtx = ctx
+	d.sseCancel = cancel
+	d.sseEvents = make(chan api.SSEEvent, 32)
+	d.lastSSEEvent = time.Now()
+}
+
 func (d *Dashboard) shutdownDaemon() tea.Cmd {
 	return func() tea.Msg {
 		return shutdownMsg{err: d.client.Shutdown()}
@@ -190,6 +213,12 @@ func (d *Dashboard) shutdownDaemon() tea.Cmd {
 func (d *Dashboard) promoteIssue(id int64) tea.Cmd {
 	return func() tea.Msg {
 		return promoteIssueMsg{id: id, err: d.client.PromoteIssue(id)}
+	}
+}
+
+func (d *Dashboard) checkHealth() tea.Cmd {
+	return func() tea.Msg {
+		return healthCheckMsg{err: d.client.Health()}
 	}
 }
 
@@ -235,6 +264,15 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		return d, tea.Batch(d.fetchData, tickCmd())
+
+	case sseWatchdogMsg:
+		cmds := []tea.Cmd{sseWatchdogCmd()}
+		if !d.shutdownInFlight && !d.lastSSEEvent.IsZero() && time.Since(d.lastSSEEvent) > time.Minute {
+			d.sseStale = true
+			d.shutdownMessage = "SSE stream stale; checking daemon health..."
+			cmds = append(cmds, d.checkHealth())
+		}
+		return d, tea.Batch(cmds...)
 
 	case dataMsg:
 		d.refreshing = false
@@ -282,6 +320,14 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return d, nil
 
 	case sseMsg:
+		d.lastSSEEvent = time.Now()
+		d.sseStale = false
+		d.shutdownMessage = ""
+		d.connected = true
+		d.err = nil
+		if msg.Type == "heartbeat" {
+			return d, d.listenSSE()
+		}
 		itemType, info := formatSSEData(msg.Type, msg.Data)
 		line := activityLine{
 			Time:     time.Now().Format("15:04"),
@@ -304,16 +350,35 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
-		d.connected = true
 		return d, d.listenSSE()
 
 	case sseDisconnectMsg:
+		d.connected = false
+		d.err = msg.err
+		d.sseStale = false
 		return d, tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
 			return sseReconnectMsg{}
 		})
 
 	case sseReconnectMsg:
 		return d, d.connectSSE
+
+	case healthCheckMsg:
+		if msg.err != nil {
+			d.connected = false
+			d.err = msg.err
+			d.shutdownMessage = "Daemon health check failed"
+			return d, nil
+		}
+		if d.sseStale {
+			d.resetSSE()
+			d.connected = false
+			d.err = nil
+			d.sseStale = false
+			d.shutdownMessage = "Reconnecting SSE stream..."
+			return d, tea.Batch(d.connectSSE, d.listenSSE())
+		}
+		return d, nil
 
 	case shutdownMsg:
 		d.shutdownInFlight = false
@@ -665,6 +730,9 @@ func (d *Dashboard) renderStatus() string {
 	if d.refreshing {
 		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).Render("● refreshing...")
 	}
+	if d.sseStale {
+		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).Render("● unresponsive...")
+	}
 	if d.connected {
 		return statusOnline.Render("● online")
 	}
@@ -920,6 +988,9 @@ func (d *Dashboard) renderConfig(height int) string {
 func (d *Dashboard) serverStatusBadge() string {
 	if d.shutdownInFlight {
 		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).Render("● stopping...")
+	}
+	if d.sseStale {
+		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).Render("● unresponsive")
 	}
 	if !d.connected {
 		return lipgloss.NewStyle().Foreground(colorMuted).Render("● stopped")

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -218,6 +218,8 @@ func (d *Dashboard) resetSSE() {
 	if d.sseCancel != nil {
 		d.sseCancel()
 	}
+	// The StreamEvents producer owns the send side and exits through ctx.Done().
+	// Closing the channel here would race with a send and can panic.
 	ctx, cancel := context.WithCancel(context.Background())
 	d.sseCtx = ctx
 	d.sseCancel = cancel

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -54,6 +54,7 @@ type Dashboard struct {
 	confirmShutdown   bool
 	shutdownInFlight  bool
 	shutdownMessage   string
+	sseStatusMessage  string
 	startTime         time.Time
 	lastUpdate        time.Time
 	lastSSEEvent      time.Time
@@ -291,7 +292,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !d.shutdownInFlight && !d.sseHealthChecking && !d.lastSSEEvent.IsZero() && time.Since(d.lastSSEEvent) > time.Minute {
 			d.sseStale = true
 			d.sseHealthChecking = true
-			d.shutdownMessage = "SSE stream stale; checking daemon health..."
+			d.sseStatusMessage = "SSE stream stale; checking daemon health..."
 			cmds = append(cmds, d.checkHealth(d.lastSSEEvent))
 		}
 		return d, tea.Batch(cmds...)
@@ -349,11 +350,12 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		d.lastSSEEvent = time.Now()
 		d.sseStale = false
 		if !d.sseHealthChecking {
-			d.shutdownMessage = ""
+			d.sseStatusMessage = ""
 			d.connected = true
 			d.err = nil
 		}
 		if event.Type == "heartbeat" {
+			// Heartbeats are liveness-only and intentionally skipped in Activity/Logs.
 			return d, d.listenSSE(d.sseSessionID, d.sseCtx, d.sseEvents)
 		}
 		itemType, info := formatSSEData(event.Type, event.Data)
@@ -403,7 +405,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			d.connected = false
 			d.err = msg.err
-			d.shutdownMessage = "Daemon health check failed"
+			d.sseStatusMessage = "Daemon health check failed"
 			return d, nil
 		}
 		if d.sseStale {
@@ -412,7 +414,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d.connected = false
 			d.err = nil
 			d.sseStale = false
-			d.shutdownMessage = "Reconnecting SSE stream..."
+			d.sseStatusMessage = "Reconnecting SSE stream..."
 			return d, tea.Batch(connect, listen)
 		}
 		return d, nil
@@ -824,6 +826,9 @@ func (d *Dashboard) renderStatusBar() string {
 		parts = append(parts, "Confirm stop: y/n")
 	} else if d.shutdownMessage != "" {
 		parts = append(parts, truncateRunes(d.shutdownMessage, 80))
+	}
+	if d.sseStatusMessage != "" {
+		parts = append(parts, truncateRunes(d.sseStatusMessage, 80))
 	}
 
 	return headerStyle.Render(strings.Join(parts, "  │  "))

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -77,3 +77,25 @@ func TestDashboardDropsStaleHealthProbeAfterHeartbeat(t *testing.T) {
 		t.Fatal("health check flag was not cleared")
 	}
 }
+
+func TestDashboardDropsStaleReconnectAfterWatchdogReset(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	oldSessionID := d.sseSessionID
+
+	model, cmd := d.Update(sseDisconnectMsg{sessionID: oldSessionID, err: errors.New("stream closed")})
+	d = model.(*Dashboard)
+	if cmd == nil {
+		t.Fatal("disconnect should schedule delayed reconnect")
+	}
+
+	d.resetSSE()
+	if d.sseSessionID == oldSessionID {
+		t.Fatal("reset did not bump SSE session")
+	}
+
+	model, cmd = d.Update(sseReconnectMsg{sessionID: oldSessionID})
+	d = model.(*Dashboard)
+	if cmd != nil {
+		t.Fatal("stale reconnect tick should be ignored")
+	}
+}

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/theburrowhub/heimdallm/cli/internal/api"
+)
+
+func TestDashboardWatchdogHealthyReset(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	oldCtx := d.sseCtx
+	oldEvents := d.sseEvents
+	oldSessionID := d.sseSessionID
+	lastEventAt := time.Now().Add(-61 * time.Second)
+	d.lastSSEEvent = lastEventAt
+
+	model, cmd := d.Update(sseWatchdogMsg(time.Now()))
+	d = model.(*Dashboard)
+	if cmd == nil {
+		t.Fatal("watchdog should schedule a health check")
+	}
+	if !d.sseStale || !d.sseHealthChecking {
+		t.Fatalf("watchdog state: stale=%v healthChecking=%v", d.sseStale, d.sseHealthChecking)
+	}
+
+	model, cmd = d.Update(healthCheckMsg{lastEventAt: lastEventAt})
+	d = model.(*Dashboard)
+	if cmd == nil {
+		t.Fatal("healthy stale stream should schedule SSE reconnect")
+	}
+	if oldCtx.Err() == nil {
+		t.Fatal("old SSE context was not cancelled")
+	}
+	if d.sseEvents == oldEvents {
+		t.Fatal("SSE channel was not replaced")
+	}
+	if d.sseSessionID != oldSessionID+1 {
+		t.Fatalf("session id: got %d want %d", d.sseSessionID, oldSessionID+1)
+	}
+	if d.sseStale || d.sseHealthChecking {
+		t.Fatalf("reset state: stale=%v healthChecking=%v", d.sseStale, d.sseHealthChecking)
+	}
+}
+
+func TestDashboardDropsStaleHealthProbeAfterHeartbeat(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.connected = true
+	lastEventAt := time.Now().Add(-61 * time.Second)
+	d.lastSSEEvent = lastEventAt
+
+	model, _ := d.Update(sseWatchdogMsg(time.Now()))
+	d = model.(*Dashboard)
+	if !d.sseHealthChecking {
+		t.Fatal("watchdog did not start health check")
+	}
+
+	model, _ = d.Update(sseMsg{
+		sessionID: d.sseSessionID,
+		event:     api.SSEEvent{Type: "heartbeat", Data: "{}"},
+	})
+	d = model.(*Dashboard)
+	if d.sseStale {
+		t.Fatal("heartbeat did not clear stale state")
+	}
+
+	model, _ = d.Update(healthCheckMsg{err: errors.New("health failed"), lastEventAt: lastEventAt})
+	d = model.(*Dashboard)
+	if d.err != nil {
+		t.Fatalf("stale health result should be ignored, got err %v", d.err)
+	}
+	if !d.connected {
+		t.Fatal("stale health result should not mark dashboard disconnected")
+	}
+	if d.sseHealthChecking {
+		t.Fatal("health check flag was not cleared")
+	}
+}

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -305,6 +305,10 @@ func main() {
 	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
 	var reloadMu sync.Mutex // serialises config reloads to prevent duplicate pipelines
+	var lastPollUnixNano int64
+	recordPollCompleted := func(_ string, at time.Time) {
+		atomic.StoreInt64(&lastPollUnixNano, at.UTC().UnixNano())
+	}
 
 	srv := server.NewWithOptions(s, broker, p, apiToken, server.Options{
 		Version:   versionString(),
@@ -312,6 +316,19 @@ func main() {
 	})
 	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)
+	srv.SetHealthSnapshotFn(func() server.HealthSnapshot {
+		cfgMu.Lock()
+		interval := parsePollInterval(cfg.GitHub.PollInterval)
+		cfgMu.Unlock()
+		var lastPoll time.Time
+		if n := atomic.LoadInt64(&lastPollUnixNano); n > 0 {
+			lastPoll = time.Unix(0, n).UTC()
+		}
+		return server.HealthSnapshot{
+			LastPollAt:   lastPoll,
+			PollInterval: interval,
+		}
+	})
 	shutdownReq := make(chan struct{}, 1)
 
 	// discoverySvc holds the discovered repo cache.
@@ -721,7 +738,7 @@ func main() {
 				defer cfgMu.Unlock()
 				return cfg.AI.Tier2RepoConcurrency
 			}
-			runTier2(ctx, adapter, limiter, prReviewPublisher, broker, tier2ConfigFn, tier2RepoConcurrencyFn, reposChan, pollInterval, coldStart)
+			runTier2(ctx, adapter, limiter, prReviewPublisher, broker, tier2ConfigFn, tier2RepoConcurrencyFn, reposChan, pollInterval, coldStart, recordPollCompleted)
 		}()
 
 		// Repo/org rename probe (#489). Detects when GitHub has
@@ -2284,6 +2301,7 @@ func runTier2(
 	reposChan <-chan []string,
 	interval time.Duration,
 	coldStart bool,
+	pollCompletedFn func(kind string, at time.Time),
 ) {
 	var (
 		mu    sync.Mutex
@@ -2326,7 +2344,11 @@ func runTier2(
 		prStart := time.Now()
 		prCount := 0
 		defer func() {
-			sse.EmitPollingCompleted(ssePub, "prs", prCount, time.Since(prStart))
+			completedAt := time.Now()
+			if pollCompletedFn != nil {
+				pollCompletedFn("prs", completedAt)
+			}
+			sse.EmitPollingCompleted(ssePub, "prs", prCount, completedAt.Sub(prStart))
 		}()
 		if err := limiter.Acquire(ctx, scheduler.TierRepo); err != nil {
 			return
@@ -2372,7 +2394,11 @@ func runTier2(
 		// would silently emit 0.
 		issueCount := 0
 		defer func() {
-			sse.EmitPollingCompleted(ssePub, "issues", issueCount, time.Since(issueStart))
+			completedAt := time.Now()
+			if pollCompletedFn != nil {
+				pollCompletedFn("issues", completedAt)
+			}
+			sse.EmitPollingCompleted(ssePub, "issues", issueCount, completedAt.Sub(issueStart))
 		}()
 		if err := limiter.Acquire(ctx, scheduler.TierRepo); err != nil {
 			return

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -306,6 +306,11 @@ func main() {
 	var cfgMu sync.Mutex
 	var reloadMu sync.Mutex // serialises config reloads to prevent duplicate pipelines
 	var lastPollUnixNano int64
+	var pollIntervalNano int64
+	storePollInterval := func(interval time.Duration) {
+		atomic.StoreInt64(&pollIntervalNano, int64(interval))
+	}
+	storePollInterval(parsePollInterval(cfg.GitHub.PollInterval))
 	recordPollCompleted := func(_ string, at time.Time) {
 		atomic.StoreInt64(&lastPollUnixNano, at.UTC().UnixNano())
 	}
@@ -317,9 +322,7 @@ func main() {
 	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)
 	srv.SetHealthSnapshotFn(func() server.HealthSnapshot {
-		cfgMu.Lock()
-		interval := parsePollInterval(cfg.GitHub.PollInterval)
-		cfgMu.Unlock()
+		interval := time.Duration(atomic.LoadInt64(&pollIntervalNano))
 		var lastPoll time.Time
 		if n := atomic.LoadInt64(&lastPollUnixNano); n > 0 {
 			lastPoll = time.Unix(0, n).UTC()
@@ -721,6 +724,7 @@ func main() {
 		cfgMu.Lock()
 		pollInterval := parsePollInterval(cfg.GitHub.PollInterval)
 		cfgMu.Unlock()
+		storePollInterval(pollInterval)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -53,9 +53,11 @@ type Server struct {
 	// daemon was constructed without the rename reconciler (e.g. in
 	// tests that don't need it).
 	repoRenameFn func(ctx context.Context, oldRepo, newRepo string) error
-	meFn                 func() (string, error)
+	meFn         func() (string, error)
 	// configFn returns the current running config as a JSON-serializable map.
 	configFn func() map[string]any
+	// healthSnapshotFn returns live daemon liveness metadata for /health and SSE heartbeat.
+	healthSnapshotFn func() HealthSnapshot
 	// repoMetaFns fetch repo metadata from GitHub for autocomplete.
 	fetchLabelsFn        func(repo string) ([]string, error)
 	fetchCollaboratorsFn func(repo string) ([]string, error)
@@ -85,6 +87,13 @@ type Options struct {
 
 const defaultMaxConcurrentReviews = 5
 const cloneCleanupTimeout = 30 * time.Second
+const heartbeatInterval = 20 * time.Second
+
+// HealthSnapshot is supplied by the daemon to enrich /health and SSE heartbeats.
+type HealthSnapshot struct {
+	LastPollAt   time.Time
+	PollInterval time.Duration
+}
 
 // New creates a new Server. p may be nil if the pipeline is not yet configured.
 // apiToken must be the value returned by LoadOrCreateAPIToken — it is required
@@ -227,6 +236,9 @@ func (srv *Server) SetMeFn(fn func() (string, error)) { srv.meFn = fn }
 
 // SetConfigFn wires the callback that returns the live config for GET /config.
 func (srv *Server) SetConfigFn(fn func() map[string]any) { srv.configFn = fn }
+
+// SetHealthSnapshotFn wires live liveness metadata for GET /health and heartbeat SSE.
+func (srv *Server) SetHealthSnapshotFn(fn func() HealthSnapshot) { srv.healthSnapshotFn = fn }
 
 // SetRepoMetaFns wires GitHub metadata fetchers for autocomplete endpoints.
 func (srv *Server) SetRepoMetaFns(labels func(string) ([]string, error), collabs func(string) ([]string, error)) {
@@ -373,14 +385,95 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 }
 
 func (srv *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	resp := map[string]any{"status": "ok"}
+	now := time.Now().UTC()
+	resp := map[string]any{
+		"status": "ok",
+		"checks": map[string]any{
+			"nats":       srv.natsHealthCheck(),
+			"sqlite":     srv.sqliteHealthCheck(r.Context()),
+			"last_poll":  srv.lastPollHealthCheck(now),
+			"goroutines": map[string]any{"count": runtime.NumGoroutine()},
+		},
+	}
 	if srv.version != "" {
 		resp["version"] = srv.version
 	}
 	if !srv.startedAt.IsZero() {
 		resp["started_at"] = srv.startedAt.UTC().Format(time.RFC3339)
+		resp["uptime_seconds"] = int64(now.Sub(srv.startedAt.UTC()).Seconds())
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func (srv *Server) natsHealthCheck() map[string]any {
+	if srv.natsConn == nil {
+		return map[string]any{
+			"ok":         false,
+			"configured": false,
+			"connected":  false,
+		}
+	}
+	connected := srv.natsConn.IsConnected()
+	return map[string]any{
+		"ok":         connected,
+		"configured": true,
+		"connected":  connected,
+		"status":     fmt.Sprint(srv.natsConn.Status()),
+	}
+}
+
+func (srv *Server) sqliteHealthCheck(ctx context.Context) map[string]any {
+	out := map[string]any{
+		"ok": false,
+	}
+	if srv.store == nil || srv.store.DB() == nil {
+		out["error"] = "store unavailable"
+		return out
+	}
+	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	if err := srv.store.DB().PingContext(ctx); err != nil {
+		out["error"] = err.Error()
+		return out
+	}
+	var result string
+	if err := srv.store.DB().QueryRowContext(ctx, "PRAGMA quick_check").Scan(&result); err != nil {
+		out["error"] = err.Error()
+		return out
+	}
+	out["quick_check"] = result
+	out["ok"] = result == "ok"
+	return out
+}
+
+func (srv *Server) lastPollHealthCheck(now time.Time) map[string]any {
+	snap := srv.healthSnapshot()
+	out := map[string]any{
+		"ok": false,
+	}
+	if snap.LastPollAt.IsZero() {
+		out["at"] = nil
+		out["age_seconds"] = nil
+		return out
+	}
+	lastPoll := snap.LastPollAt.UTC()
+	age := now.Sub(lastPoll)
+	out["at"] = lastPoll.Format(time.RFC3339)
+	out["age_seconds"] = int64(age.Seconds())
+	if snap.PollInterval > 0 {
+		out["max_age_seconds"] = int64((2 * snap.PollInterval).Seconds())
+		out["ok"] = age <= 2*snap.PollInterval
+	} else {
+		out["ok"] = true
+	}
+	return out
+}
+
+func (srv *Server) healthSnapshot() HealthSnapshot {
+	if srv.healthSnapshotFn == nil {
+		return HealthSnapshot{}
+	}
+	return srv.healthSnapshotFn()
 }
 
 func (srv *Server) handleListPRs(w http.ResponseWriter, r *http.Request) {
@@ -1044,7 +1137,11 @@ func (srv *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	defer srv.broker.Unsubscribe(ch)
 
 	fmt.Fprintf(w, ": connected\n\n")
+	fmt.Fprint(w, srv.heartbeatEvent(time.Now()).Format())
 	flusher.Flush()
+
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
 
 	for {
 		select {
@@ -1053,6 +1150,9 @@ func (srv *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			fmt.Fprint(w, event.Format())
+			flusher.Flush()
+		case <-heartbeat.C:
+			fmt.Fprint(w, srv.heartbeatEvent(time.Now()).Format())
 			flusher.Flush()
 		case <-r.Context().Done():
 			return
@@ -1072,11 +1172,12 @@ func (srv *Server) handleSSEViaNATS(w http.ResponseWriter, r *http.Request, flus
 	defer sub.Unsubscribe()
 
 	fmt.Fprintf(w, ": connected\n\n")
+	fmt.Fprint(w, srv.heartbeatEvent(time.Now()).Format())
 	flusher.Flush()
 
-	// Keep-alive ticker prevents proxies/load balancers from closing idle connections.
-	keepAlive := time.NewTicker(20 * time.Second)
-	defer keepAlive.Stop()
+	// Heartbeat prevents idle connection drops and gives clients observable liveness.
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
 
 	for {
 		select {
@@ -1084,13 +1185,38 @@ func (srv *Server) handleSSEViaNATS(w http.ResponseWriter, r *http.Request, flus
 			eventType := strings.TrimPrefix(msg.Subject, "heimdallm.events.")
 			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, string(msg.Data))
 			flusher.Flush()
-		case <-keepAlive.C:
-			fmt.Fprintf(w, ": ping\n\n")
+		case <-heartbeat.C:
+			fmt.Fprint(w, srv.heartbeatEvent(time.Now()).Format())
 			flusher.Flush()
 		case <-r.Context().Done():
 			return
 		}
 	}
+}
+
+func (srv *Server) heartbeatEvent(now time.Time) sse.Event {
+	now = now.UTC()
+	data := map[string]any{
+		"ts":         now.Format(time.RFC3339),
+		"goroutines": runtime.NumGoroutine(),
+	}
+	snap := srv.healthSnapshot()
+	if snap.LastPollAt.IsZero() {
+		data["last_poll_at"] = nil
+		data["last_poll_age_seconds"] = nil
+	} else {
+		lastPoll := snap.LastPollAt.UTC()
+		data["last_poll_at"] = lastPoll.Format(time.RFC3339)
+		data["last_poll_age_seconds"] = int64(now.Sub(lastPoll).Seconds())
+	}
+	if srv.natsConn != nil {
+		data["nats_connected"] = srv.natsConn.IsConnected()
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		b = []byte(`{"ts":"` + now.Format(time.RFC3339) + `"}`)
+	}
+	return sse.Event{Type: sse.EventHeartbeat, Data: string(b)}
 }
 
 func (srv *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -386,13 +386,20 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func (srv *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
+	checks := map[string]any{
+		"nats":      srv.natsHealthCheck(),
+		"sqlite":    srv.sqliteHealthCheck(r.Context()),
+		"last_poll": srv.lastPollHealthCheck(now),
+	}
+	statusCode := http.StatusOK
+	status := "ok"
+	if !healthCheckOK(checks["nats"]) || !healthCheckOK(checks["sqlite"]) || !healthCheckOK(checks["last_poll"]) {
+		statusCode = http.StatusServiceUnavailable
+		status = "degraded"
+	}
 	resp := map[string]any{
-		"status": "ok",
-		"checks": map[string]any{
-			"nats":      srv.natsHealthCheck(),
-			"sqlite":    srv.sqliteHealthCheck(r.Context()),
-			"last_poll": srv.lastPollHealthCheck(now),
-		},
+		"status": status,
+		"checks": checks,
 	}
 	if srv.version != "" {
 		resp["version"] = srv.version
@@ -401,13 +408,22 @@ func (srv *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		resp["started_at"] = srv.startedAt.UTC().Format(time.RFC3339)
 		resp["uptime_seconds"] = int64(now.Sub(srv.startedAt.UTC()).Seconds())
 	}
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, statusCode, resp)
+}
+
+func healthCheckOK(check any) bool {
+	m, ok := check.(map[string]any)
+	if !ok {
+		return false
+	}
+	okValue, ok := m["ok"].(bool)
+	return ok && okValue
 }
 
 func (srv *Server) natsHealthCheck() map[string]any {
 	if srv.natsConn == nil {
 		return map[string]any{
-			"ok":         false,
+			"ok":         true,
 			"configured": false,
 			"connected":  false,
 		}
@@ -451,6 +467,8 @@ func (srv *Server) lastPollHealthCheck(now time.Time) map[string]any {
 		"ok": false,
 	}
 	if snap.LastPollAt.IsZero() {
+		out["ok"] = true
+		out["status"] = "unknown"
 		out["at"] = nil
 		out["age_seconds"] = nil
 		return out

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -389,10 +389,9 @@ func (srv *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]any{
 		"status": "ok",
 		"checks": map[string]any{
-			"nats":       srv.natsHealthCheck(),
-			"sqlite":     srv.sqliteHealthCheck(r.Context()),
-			"last_poll":  srv.lastPollHealthCheck(now),
-			"goroutines": map[string]any{"count": runtime.NumGoroutine()},
+			"nats":      srv.natsHealthCheck(),
+			"sqlite":    srv.sqliteHealthCheck(r.Context()),
+			"last_poll": srv.lastPollHealthCheck(now),
 		},
 	}
 	if srv.version != "" {
@@ -436,13 +435,13 @@ func (srv *Server) sqliteHealthCheck(ctx context.Context) map[string]any {
 		out["error"] = err.Error()
 		return out
 	}
-	var result string
-	if err := srv.store.DB().QueryRowContext(ctx, "PRAGMA quick_check").Scan(&result); err != nil {
+	var result int
+	if err := srv.store.DB().QueryRowContext(ctx, "SELECT 1").Scan(&result); err != nil {
 		out["error"] = err.Error()
 		return out
 	}
-	out["quick_check"] = result
-	out["ok"] = result == "ok"
+	out["query"] = "ok"
+	out["ok"] = result == 1
 	return out
 }
 
@@ -1197,8 +1196,7 @@ func (srv *Server) handleSSEViaNATS(w http.ResponseWriter, r *http.Request, flus
 func (srv *Server) heartbeatEvent(now time.Time) sse.Event {
 	now = now.UTC()
 	data := map[string]any{
-		"ts":         now.Format(time.RFC3339),
-		"goroutines": runtime.NumGoroutine(),
+		"ts": now.Format(time.RFC3339),
 	}
 	snap := srv.healthSnapshot()
 	if snap.LastPollAt.IsZero() {
@@ -1214,6 +1212,7 @@ func (srv *Server) heartbeatEvent(now time.Time) sse.Event {
 	}
 	b, err := json.Marshal(data)
 	if err != nil {
+		slog.Warn("marshal heartbeat payload", "err", err)
 		b = []byte(`{"ts":"` + now.Format(time.RFC3339) + `"}`)
 	}
 	return sse.Event{Type: sse.EventHeartbeat, Data: string(b)}

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -81,9 +81,6 @@ func TestHealth_ReturnsDeepChecks(t *testing.T) {
 	if last, ok := checks["last_poll"].(map[string]any); !ok || last["ok"] != true || last["at"] == nil {
 		t.Fatalf("last_poll check not ok: %v", checks["last_poll"])
 	}
-	if goroutines, ok := checks["goroutines"].(map[string]any); !ok || goroutines["count"] == nil {
-		t.Fatalf("goroutines check missing: %v", checks["goroutines"])
-	}
 }
 
 func TestHealth_ReturnsVersionAndStartedAt(t *testing.T) {
@@ -172,7 +169,7 @@ func TestEventsEmitsObservableHeartbeat(t *testing.T) {
 	if err := json.Unmarshal([]byte(heartbeatData), &payload); err != nil {
 		t.Fatalf("decode heartbeat: %v", err)
 	}
-	if payload["ts"] == "" || payload["goroutines"] == nil {
+	if payload["ts"] == "" {
 		t.Fatalf("heartbeat payload missing liveness fields: %v", payload)
 	}
 	if payload["last_poll_at"] != "2026-01-02T03:04:05Z" {

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -83,6 +83,30 @@ func TestHealth_ReturnsDeepChecks(t *testing.T) {
 	}
 }
 
+func TestHealth_ReturnsServiceUnavailableForStalePoll(t *testing.T) {
+	srv, _ := setupServer(t)
+	srv.SetHealthSnapshotFn(func() server.HealthSnapshot {
+		return server.HealthSnapshot{
+			LastPollAt:   time.Now().UTC().Add(-3 * time.Minute),
+			PollInterval: time.Minute,
+		}
+	})
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("health status: got %d want %d", w.Code, http.StatusServiceUnavailable)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if body["status"] != "degraded" {
+		t.Fatalf("health status body: %v", body)
+	}
+}
+
 func TestHealth_ReturnsVersionAndStartedAt(t *testing.T) {
 	s, err := store.Open(":memory:")
 	if err != nil {

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -41,10 +42,47 @@ func TestHandlerHealth(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("health: status %d", w.Code)
 	}
-	var body map[string]string
-	json.NewDecoder(w.Body).Decode(&body)
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
 	if body["status"] != "ok" {
 		t.Errorf("health body: %v", body)
+	}
+}
+
+func TestHealth_ReturnsDeepChecks(t *testing.T) {
+	srv, _ := setupServer(t)
+	lastPoll := time.Now().UTC().Add(-5 * time.Second)
+	srv.SetHealthSnapshotFn(func() server.HealthSnapshot {
+		return server.HealthSnapshot{
+			LastPollAt:   lastPoll,
+			PollInterval: time.Minute,
+		}
+	})
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("health: status %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	checks, ok := body["checks"].(map[string]any)
+	if !ok {
+		t.Fatalf("checks missing: %v", body)
+	}
+	if sqlite, ok := checks["sqlite"].(map[string]any); !ok || sqlite["ok"] != true {
+		t.Fatalf("sqlite check not ok: %v", checks["sqlite"])
+	}
+	if last, ok := checks["last_poll"].(map[string]any); !ok || last["ok"] != true || last["at"] == nil {
+		t.Fatalf("last_poll check not ok: %v", checks["last_poll"])
+	}
+	if goroutines, ok := checks["goroutines"].(map[string]any); !ok || goroutines["count"] == nil {
+		t.Fatalf("goroutines check missing: %v", checks["goroutines"])
 	}
 }
 
@@ -81,6 +119,64 @@ func TestHealth_ReturnsVersionAndStartedAt(t *testing.T) {
 	}
 	if got["started_at"] != "2026-01-02T03:04:05Z" {
 		t.Errorf("started_at: got %v", got["started_at"])
+	}
+}
+
+func TestEventsEmitsObservableHeartbeat(t *testing.T) {
+	srv, _ := setupServer(t)
+	srv.SetHealthSnapshotFn(func() server.HealthSnapshot {
+		return server.HealthSnapshot{
+			LastPollAt:   time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+			PollInterval: time.Minute,
+		}
+	})
+	ts := httptest.NewServer(srv.Router())
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/events", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	seenHeartbeat := false
+	var heartbeatData string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "event: heartbeat" {
+			seenHeartbeat = true
+			continue
+		}
+		if seenHeartbeat && strings.HasPrefix(line, "data: ") {
+			heartbeatData = strings.TrimPrefix(line, "data: ")
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan SSE: %v", err)
+	}
+	if heartbeatData == "" {
+		t.Fatal("heartbeat event not received")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(heartbeatData), &payload); err != nil {
+		t.Fatalf("decode heartbeat: %v", err)
+	}
+	if payload["ts"] == "" || payload["goroutines"] == nil {
+		t.Fatalf("heartbeat payload missing liveness fields: %v", payload)
+	}
+	if payload["last_poll_at"] != "2026-01-02T03:04:05Z" {
+		t.Fatalf("last_poll_at: got %v", payload["last_poll_at"])
 	}
 }
 

--- a/daemon/internal/sse/broker.go
+++ b/daemon/internal/sse/broker.go
@@ -4,6 +4,7 @@ import "fmt"
 
 // Event type constants
 const (
+	EventHeartbeat             = "heartbeat"
 	EventPRDetected            = "pr_detected"
 	EventReviewStarted         = "review_started"
 	EventReviewCompleted       = "review_completed"

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -71,18 +71,6 @@ class DaemonConnectionStatus {
 
   const DaemonConnectionStatus.connecting()
     : this(phase: DaemonConnectionPhase.connecting);
-
-  DaemonConnectionStatus copyWith({
-    DaemonConnectionPhase? phase,
-    DateTime? lastEventAt,
-    String? message,
-  }) {
-    return DaemonConnectionStatus(
-      phase: phase ?? this.phase,
-      lastEventAt: lastEventAt ?? this.lastEventAt,
-      message: message,
-    );
-  }
 }
 
 class DaemonConnectionNotifier extends Notifier<DaemonConnectionStatus> {
@@ -137,6 +125,7 @@ class DaemonConnectionNotifier extends Notifier<DaemonConnectionStatus> {
       final healthy = await ref.read(apiClientProvider).checkHealth();
       if (!ref.mounted) return;
       if (healthy) {
+        state = const DaemonConnectionStatus.connecting();
         ref.invalidate(sseStreamProvider);
       } else {
         state = DaemonConnectionStatus(

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -51,9 +52,108 @@ final nonMonitoredStaleProvider =
     >(() => LocalStateNotifier<Map<String, String>>(const <String, String>{}));
 
 /// Tracks whether the desktop app is trying to spawn the daemon.
-final daemonStartingProvider =
-    NotifierProvider<LocalStateNotifier<bool>, bool>(
-      () => LocalStateNotifier<bool>(false),
+final daemonStartingProvider = NotifierProvider<LocalStateNotifier<bool>, bool>(
+  () => LocalStateNotifier<bool>(false),
+);
+
+enum DaemonConnectionPhase { connecting, connected, stale, offline }
+
+class DaemonConnectionStatus {
+  final DaemonConnectionPhase phase;
+  final DateTime? lastEventAt;
+  final String? message;
+
+  const DaemonConnectionStatus({
+    required this.phase,
+    this.lastEventAt,
+    this.message,
+  });
+
+  const DaemonConnectionStatus.connecting()
+    : this(phase: DaemonConnectionPhase.connecting);
+
+  DaemonConnectionStatus copyWith({
+    DaemonConnectionPhase? phase,
+    DateTime? lastEventAt,
+    String? message,
+  }) {
+    return DaemonConnectionStatus(
+      phase: phase ?? this.phase,
+      lastEventAt: lastEventAt ?? this.lastEventAt,
+      message: message,
+    );
+  }
+}
+
+class DaemonConnectionNotifier extends Notifier<DaemonConnectionStatus> {
+  static const staleAfter = Duration(seconds: 60);
+  static const checkEvery = Duration(seconds: 5);
+
+  Timer? _watchdog;
+  bool _checkingHealth = false;
+
+  @override
+  DaemonConnectionStatus build() {
+    ref.listen<AsyncValue<SseEvent>>(sseStreamProvider, (prev, next) {
+      if (next.isLoading && !(prev?.hasValue ?? false)) {
+        state = const DaemonConnectionStatus.connecting();
+      }
+      if (next.hasError) {
+        state = DaemonConnectionStatus(
+          phase: DaemonConnectionPhase.offline,
+          lastEventAt: state.lastEventAt,
+          message: next.error.toString(),
+        );
+      }
+      next.whenData((_) {
+        state = DaemonConnectionStatus(
+          phase: DaemonConnectionPhase.connected,
+          lastEventAt: DateTime.now(),
+        );
+      });
+    });
+    _watchdog = Timer.periodic(checkEvery, (_) => _checkForStaleStream());
+    ref.onDispose(() => _watchdog?.cancel());
+    return const DaemonConnectionStatus.connecting();
+  }
+
+  void _checkForStaleStream() {
+    final lastEventAt = state.lastEventAt;
+    if (lastEventAt == null) return;
+    if (DateTime.now().difference(lastEventAt) < staleAfter) return;
+    if (state.phase == DaemonConnectionPhase.offline) return;
+    state = DaemonConnectionStatus(
+      phase: DaemonConnectionPhase.stale,
+      lastEventAt: lastEventAt,
+      message: 'No events received for ${staleAfter.inSeconds}s',
+    );
+    unawaited(_verifyAndReconnect());
+  }
+
+  Future<void> _verifyAndReconnect() async {
+    if (_checkingHealth) return;
+    _checkingHealth = true;
+    try {
+      final healthy = await ref.read(apiClientProvider).checkHealth();
+      if (!ref.mounted) return;
+      if (healthy) {
+        ref.invalidate(sseStreamProvider);
+      } else {
+        state = DaemonConnectionStatus(
+          phase: DaemonConnectionPhase.offline,
+          lastEventAt: state.lastEventAt,
+          message: 'Health check failed',
+        );
+      }
+    } finally {
+      _checkingHealth = false;
+    }
+  }
+}
+
+final daemonConnectionProvider =
+    NotifierProvider<DaemonConnectionNotifier, DaemonConnectionStatus>(
+      DaemonConnectionNotifier.new,
     );
 
 /// Tracks PRs currently being reviewed, keyed by "repo:prNumber". Used to
@@ -95,8 +195,9 @@ class PrListRefreshNotifier extends Notifier<int> {
   void update(int Function(int) updater) => state = updater(state);
 }
 
-final prListRefreshProvider =
-    NotifierProvider<PrListRefreshNotifier, int>(PrListRefreshNotifier.new);
+final prListRefreshProvider = NotifierProvider<PrListRefreshNotifier, int>(
+  PrListRefreshNotifier.new,
+);
 
 void _handleSseEvent(Ref ref, SseEvent event) {
   try {
@@ -278,8 +379,9 @@ void _handleSseEvent(Ref ref, SseEvent event) {
         final repo = data['repo'] as String? ?? 'unknown';
         final prNumber = (data['pr_number'] as num?)?.toInt() ?? 0;
         final reason = data['reason'] as String? ?? '';
-        ref.read(circuitBreakerProvider.notifier).set(
-            '$repo #$prNumber — $reason');
+        ref
+            .read(circuitBreakerProvider.notifier)
+            .set('$repo #$prNumber — $reason');
     }
   } catch (_) {}
 }

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -76,9 +76,11 @@ class DaemonConnectionStatus {
 class DaemonConnectionNotifier extends Notifier<DaemonConnectionStatus> {
   static const staleAfter = Duration(seconds: 60);
   static const checkEvery = Duration(seconds: 5);
+  static const maxReconnectDelay = Duration(minutes: 5);
 
   Timer? _watchdog;
   bool _checkingHealth = false;
+  int _reconnectAttempts = 0;
 
   @override
   DaemonConnectionStatus build() {
@@ -94,6 +96,7 @@ class DaemonConnectionNotifier extends Notifier<DaemonConnectionStatus> {
         );
       }
       next.whenData((_) {
+        _reconnectAttempts = 0;
         state = DaemonConnectionStatus(
           phase: DaemonConnectionPhase.connected,
           lastEventAt: DateTime.now(),
@@ -108,7 +111,7 @@ class DaemonConnectionNotifier extends Notifier<DaemonConnectionStatus> {
   void _checkForStaleStream() {
     final lastEventAt = state.lastEventAt;
     if (lastEventAt == null) return;
-    if (DateTime.now().difference(lastEventAt) < staleAfter) return;
+    if (DateTime.now().difference(lastEventAt) < _currentStaleAfter()) return;
     if (state.phase == DaemonConnectionPhase.offline) return;
     state = DaemonConnectionStatus(
       phase: DaemonConnectionPhase.stale,
@@ -118,6 +121,12 @@ class DaemonConnectionNotifier extends Notifier<DaemonConnectionStatus> {
     unawaited(_verifyAndReconnect());
   }
 
+  Duration _currentStaleAfter() {
+    final shift = _reconnectAttempts > 3 ? 3 : _reconnectAttempts;
+    final delay = Duration(seconds: staleAfter.inSeconds * (1 << shift));
+    return delay.compareTo(maxReconnectDelay) > 0 ? maxReconnectDelay : delay;
+  }
+
   Future<void> _verifyAndReconnect() async {
     if (_checkingHealth) return;
     _checkingHealth = true;
@@ -125,7 +134,11 @@ class DaemonConnectionNotifier extends Notifier<DaemonConnectionStatus> {
       final healthy = await ref.read(apiClientProvider).checkHealth();
       if (!ref.mounted) return;
       if (healthy) {
-        state = const DaemonConnectionStatus.connecting();
+        _reconnectAttempts++;
+        state = DaemonConnectionStatus(
+          phase: DaemonConnectionPhase.connecting,
+          lastEventAt: DateTime.now(),
+        );
         ref.invalidate(sseStreamProvider);
       } else {
         state = DaemonConnectionStatus(

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -33,6 +33,9 @@ class DashboardScreen extends ConsumerWidget {
     final cbMessage = ref.watch(circuitBreakerProvider);
     final daemonRunning = ref.watch(daemonHealthProvider).value ?? false;
     final daemonStarting = ref.watch(daemonStartingProvider);
+    final connection = daemonRunning
+        ? ref.watch(daemonConnectionProvider)
+        : null;
     return DefaultTabController(
       length: 6,
       child: Scaffold(
@@ -97,6 +100,11 @@ class DashboardScreen extends ConsumerWidget {
                 onDismiss: () =>
                     ref.read(circuitBreakerProvider.notifier).set(null),
               ),
+            if (connection != null)
+              _ConnectionBanner(
+                status: connection,
+                onRestart: () => server_actions.restartDaemon(context, ref),
+              ),
             const Expanded(
               child: TabBarView(
                 children: [
@@ -110,6 +118,72 @@ class DashboardScreen extends ConsumerWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ConnectionBanner extends StatelessWidget {
+  const _ConnectionBanner({required this.status, required this.onRestart});
+
+  final DaemonConnectionStatus status;
+  final VoidCallback onRestart;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (color, icon, label) = switch (status.phase) {
+      DaemonConnectionPhase.connected => (
+        Colors.green,
+        Icons.check_circle_outline,
+        'Connected',
+      ),
+      DaemonConnectionPhase.stale => (
+        Colors.amber,
+        Icons.sync_problem,
+        'No events received — reconnecting',
+      ),
+      DaemonConnectionPhase.offline => (
+        theme.colorScheme.error,
+        Icons.error_outline,
+        'Server unavailable',
+      ),
+      DaemonConnectionPhase.connecting => (
+        Colors.blueGrey,
+        Icons.sync,
+        'Connecting',
+      ),
+    };
+    return Material(
+      color: color.withValues(alpha: 0.10),
+      child: SafeArea(
+        bottom: false,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 36),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+            child: Row(
+              children: [
+                Icon(icon, size: 18, color: color),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    label,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: color,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                if (status.phase == DaemonConnectionPhase.offline)
+                  TextButton(
+                    onPressed: onRestart,
+                    child: const Text('Restart'),
+                  ),
+              ],
+            ),
+          ),
         ),
       ),
     );
@@ -672,8 +746,7 @@ class _IssueActivityTile extends ConsumerStatefulWidget {
   const _IssueActivityTile({required this.issue});
 
   @override
-  ConsumerState<_IssueActivityTile> createState() =>
-      _IssueActivityTileState();
+  ConsumerState<_IssueActivityTile> createState() => _IssueActivityTileState();
 }
 
 class _IssueActivityTileState extends ConsumerState<_IssueActivityTile> {

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -100,7 +100,8 @@ class DashboardScreen extends ConsumerWidget {
                 onDismiss: () =>
                     ref.read(circuitBreakerProvider.notifier).set(null),
               ),
-            if (connection != null)
+            if (connection != null &&
+                connection.phase != DaemonConnectionPhase.connected)
               _ConnectionBanner(
                 status: connection,
                 onRestart: () => server_actions.restartDaemon(context, ref),


### PR DESCRIPTION
## Summary
- Add observable SSE `heartbeat` events and lightweight `/health` checks for NATS, SQLite reachability, last poll freshness, version, and uptime.
- Track daemon poll completion snapshots without taking the config mutex from heartbeat paths.
- Add CLI and Flutter watchdogs that detect stale SSE streams, verify daemon health, reconnect safely when healthy, and surface stale/offline states with backoff.
- Harden TUI reconnect state with per-session SSE commands and tests for stale-stream recovery.

## Tests
- `make test-docker`
- `docker run ... sh -c "go vet ./... && go test -timeout 60s ./..."` for `cli/`
- `cd flutter_app && flutter test test/core/sse_client_test.dart test/features/dashboard_test.dart`
- `cd flutter_app && flutter analyze`
- `cd flutter_app && flutter test`
- `make build-web`

Closes #469