### PR TITLE
fix: persist topic-discovered repos to config even without open PRs

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2323,6 +2323,11 @@ func runTier2(
 				repos = r
 				mu.Unlock()
 				slog.Info("tier2: received repo list", "count", len(r))
+
+				// Persist topic-discovered repos so they appear in
+				// heimdallm-cli status and GET /config even when they
+				// have no open PRs. Fixes #507.
+				adapter.upsertDiscoveredFromTopics(r)
 			}
 		}
 	}()
@@ -2557,6 +2562,55 @@ func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
 		added = append(added, pr.Repo)
 	}
 	return added
+}
+
+// upsertDiscoveredFromTopics persists repos received from tier1's topic
+// discovery into cfg.GitHub.Repositories (or NonMonitored) and invokes
+// processDiscoveredRepos to write them to the K/V store. This ensures repos
+// discovered by topic appear in heimdallm-cli status and GET /config even
+// when they have no open PRs. Fixes #507.
+func (a *tier2Adapter) upsertDiscoveredFromTopics(repos []string) {
+	if len(repos) == 0 {
+		return
+	}
+
+	a.cfgMu.Lock()
+	cfg := *a.cfg
+
+	known := make(map[string]struct{}, len(cfg.GitHub.Repositories)+len(cfg.GitHub.NonMonitored))
+	for _, r := range cfg.GitHub.Repositories {
+		known[r] = struct{}{}
+	}
+	for _, r := range cfg.GitHub.NonMonitored {
+		known[r] = struct{}{}
+	}
+
+	enable := cfg.GitHub.AutoEnablePRForDiscovery()
+	var added []string
+	for _, repo := range repos {
+		if repo == "" {
+			continue
+		}
+		if _, ok := known[repo]; ok {
+			continue
+		}
+		if enable {
+			cfg.GitHub.Repositories = append(cfg.GitHub.Repositories, repo)
+		} else {
+			cfg.GitHub.NonMonitored = append(cfg.GitHub.NonMonitored, repo)
+		}
+		known[repo] = struct{}{}
+		added = append(added, repo)
+	}
+
+	reposSnap := append([]string(nil), cfg.GitHub.Repositories...)
+	nonMonSnap := append([]string(nil), cfg.GitHub.NonMonitored...)
+	a.cfgMu.Unlock()
+
+	if len(added) > 0 {
+		slog.Info("tier2: persisting topic-discovered repos", "added", len(added), "repos", added)
+		processDiscoveredRepos(added, reposSnap, nonMonSnap, a.store, a.broker, time.Now())
+	}
 }
 
 // ── tier2Adapter bridges main.go's concrete types to Pipeline interfaces ──

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2607,6 +2607,10 @@ func (a *tier2Adapter) upsertDiscoveredFromTopics(repos []string) {
 	nonMonSnap := append([]string(nil), cfg.GitHub.NonMonitored...)
 	a.cfgMu.Unlock()
 
+	// Intentionally release the mutex before persisting to the K/V store:
+	// processDiscoveredRepos performs I/O (SQLite writes, SSE publish) that
+	// should not hold the config lock. The in-memory config is already
+	// mutated above; the snapshots capture the post-mutation state.
 	if len(added) > 0 {
 		slog.Info("tier2: persisting topic-discovered repos", "added", len(added), "repos", added)
 		processDiscoveredRepos(added, reposSnap, nonMonSnap, a.store, a.broker, time.Now())

--- a/daemon/cmd/heimdallm/main_discover_topics_test.go
+++ b/daemon/cmd/heimdallm/main_discover_topics_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/sse"
+)
+
+func TestUpsertDiscoveredFromTopics_AddsNewRepos(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.Repositories = []string{"org/existing"}
+
+	s := newMemStore(t)
+	broker := sse.NewBroker()
+	broker.Start()
+	defer broker.Stop()
+
+	var mu sync.Mutex
+	a := &tier2Adapter{
+		cfgMu:  &mu,
+		cfg:    &cfg,
+		store:  s,
+		broker: broker,
+	}
+
+	a.upsertDiscoveredFromTopics([]string{"org/existing", "org/new1", "org/new2"})
+
+	if len(cfg.GitHub.Repositories) != 3 {
+		t.Fatalf("expected 3 repos, got %v", cfg.GitHub.Repositories)
+	}
+	want := map[string]bool{"org/existing": true, "org/new1": true, "org/new2": true}
+	for _, r := range cfg.GitHub.Repositories {
+		if !want[r] {
+			t.Fatalf("unexpected repo %q in Repositories", r)
+		}
+	}
+}
+
+func TestUpsertDiscoveredFromTopics_SkipsKnownRepos(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.Repositories = []string{"org/a"}
+	cfg.GitHub.NonMonitored = []string{"org/b"}
+
+	s := newMemStore(t)
+	broker := sse.NewBroker()
+	broker.Start()
+	defer broker.Stop()
+
+	var mu sync.Mutex
+	a := &tier2Adapter{
+		cfgMu:  &mu,
+		cfg:    &cfg,
+		store:  s,
+		broker: broker,
+	}
+
+	a.upsertDiscoveredFromTopics([]string{"org/a", "org/b"})
+
+	if len(cfg.GitHub.Repositories) != 1 {
+		t.Fatalf("Repositories should be unchanged, got %v", cfg.GitHub.Repositories)
+	}
+	if len(cfg.GitHub.NonMonitored) != 1 {
+		t.Fatalf("NonMonitored should be unchanged, got %v", cfg.GitHub.NonMonitored)
+	}
+}
+
+func TestUpsertDiscoveredFromTopics_IdempotentOnSecondCall(t *testing.T) {
+	cfg := &config.Config{}
+
+	s := newMemStore(t)
+	broker := sse.NewBroker()
+	broker.Start()
+	defer broker.Stop()
+
+	var mu sync.Mutex
+	a := &tier2Adapter{
+		cfgMu:  &mu,
+		cfg:    &cfg,
+		store:  s,
+		broker: broker,
+	}
+
+	a.upsertDiscoveredFromTopics([]string{"org/repo1", "org/repo2"})
+	a.upsertDiscoveredFromTopics([]string{"org/repo1", "org/repo2"})
+
+	if len(cfg.GitHub.Repositories) != 2 {
+		t.Fatalf("expected 2 repos after idempotent call, got %v", cfg.GitHub.Repositories)
+	}
+}
+
+func TestUpsertDiscoveredFromTopics_RespectsDisabledFlag(t *testing.T) {
+	f := false
+	cfg := &config.Config{}
+	cfg.GitHub.AutoEnablePROnDiscovery = &f
+
+	s := newMemStore(t)
+	broker := sse.NewBroker()
+	broker.Start()
+	defer broker.Stop()
+
+	var mu sync.Mutex
+	a := &tier2Adapter{
+		cfgMu:  &mu,
+		cfg:    &cfg,
+		store:  s,
+		broker: broker,
+	}
+
+	a.upsertDiscoveredFromTopics([]string{"org/new"})
+
+	if len(cfg.GitHub.Repositories) != 0 {
+		t.Fatalf("repo should not be in Repositories when disabled, got %v", cfg.GitHub.Repositories)
+	}
+	if len(cfg.GitHub.NonMonitored) != 1 || cfg.GitHub.NonMonitored[0] != "org/new" {
+		t.Fatalf("repo should be in NonMonitored, got %v", cfg.GitHub.NonMonitored)
+	}
+}
+
+func TestUpsertDiscoveredFromTopics_EmptyInput(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.Repositories = []string{"org/a"}
+
+	s := newMemStore(t)
+
+	var mu sync.Mutex
+	a := &tier2Adapter{
+		cfgMu:  &mu,
+		cfg:    &cfg,
+		store:  s,
+		broker: nil,
+	}
+
+	a.upsertDiscoveredFromTopics(nil)
+	a.upsertDiscoveredFromTopics([]string{})
+
+	if len(cfg.GitHub.Repositories) != 1 {
+		t.Fatalf("empty input should be no-op, got %v", cfg.GitHub.Repositories)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes #507: repos discovered by tier1's topic search now persist to `cfg.GitHub.Repositories` immediately, even when they have no open PRs
- Adds `upsertDiscoveredFromTopics()` method on `tier2Adapter` that runs when tier2 receives the repo list from tier1 via NATS
- Uses the existing `processDiscoveredRepos()` path to write to the K/V store and emit SSE `repo_discovered` events

## Root cause

`upsertDiscoveredRepos()` only iterates over PRs returned by `FetchPRsToReview()`. Repos discovered by tier1's topic search that have no open PRs were never passed through this function and therefore never persisted — invisible to `heimdallm-cli status` and the Flutter UI.

## Testing

- `go vet ./...` passes
- All `cmd/heimdallm` tests pass (`make test-docker`)
- The new method reuses the same `processDiscoveredRepos` helper already covered by existing discovery tests