### PR TITLE
fix(github): paginate PR comments to capture newest entries (closes #512)

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -826,78 +826,108 @@ func (c *Client) GetPRTimelineEventsForReviewer(repo string, number int, login s
 	return out, nil
 }
 
+// maxCommentPages bounds the number of pages fetchReviewComments and
+// fetchIssueComments will walk. GitHub returns 30 items per page by default
+// and 100 max; with per_page=100 this caps each fetcher at 5,000 comments,
+// well above the largest real PRs we've seen. The cap exists only to keep a
+// misbehaving server from making us iterate forever.
+const maxCommentPages = 50
+
 func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error) {
-	path := fmt.Sprintf("/repos/%s/pulls/%d/comments", repo, number)
-	resp, err := c.do("GET", path, "application/vnd.github+json")
-	if err != nil {
-		return nil, fmt.Errorf("github: fetch review comments: %w", err)
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
-	if resp.StatusCode != http.StatusOK {
-		errBody := safeTruncate(string(body), maxErrBodyLen)
-		return nil, fmt.Errorf("github: fetch review comments: status %d: %s", resp.StatusCode, errBody)
-	}
-	var raw []struct {
-		User struct {
-			Login string `json:"login"`
-		} `json:"user"`
-		Body         string    `json:"body"`
-		CreatedAt    time.Time `json:"created_at"`
-		Path         string    `json:"path"`
-		Line         *int      `json:"line"`
-		OriginalLine int       `json:"original_line"`
-	}
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, fmt.Errorf("github: decode review comments: %w", err)
-	}
-	comments := make([]Comment, len(raw))
-	for i, r := range raw {
-		line := r.OriginalLine
-		if r.Line != nil {
-			line = *r.Line
+	// GitHub's default page size is 30 and the API sorts ascending by
+	// created_at, so without explicit pagination any PR with >30 review
+	// comments silently drops the newest entries — exactly the ones a
+	// re-review depends on. Walk every page with per_page=100, matching
+	// the pattern used by GetPRTimelineEventsForReviewer.
+	comments := []Comment{}
+	for page := 1; page <= maxCommentPages; page++ {
+		path := fmt.Sprintf("/repos/%s/pulls/%d/comments?per_page=100&page=%d", repo, number, page)
+		resp, err := c.do("GET", path, "application/vnd.github+json")
+		if err != nil {
+			return nil, fmt.Errorf("github: fetch review comments: %w", err)
 		}
-		comments[i] = Comment{
-			Author:    r.User.Login,
-			Body:      r.Body,
-			CreatedAt: r.CreatedAt,
-			File:      r.Path,
-			Line:      line,
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			errBody := safeTruncate(string(body), maxErrBodyLen)
+			return nil, fmt.Errorf("github: fetch review comments: status %d: %s", resp.StatusCode, errBody)
+		}
+		var raw []struct {
+			User struct {
+				Login string `json:"login"`
+			} `json:"user"`
+			Body         string    `json:"body"`
+			CreatedAt    time.Time `json:"created_at"`
+			Path         string    `json:"path"`
+			Line         *int      `json:"line"`
+			OriginalLine int       `json:"original_line"`
+		}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, fmt.Errorf("github: decode review comments: %w", err)
+		}
+		for _, r := range raw {
+			line := r.OriginalLine
+			if r.Line != nil {
+				line = *r.Line
+			}
+			comments = append(comments, Comment{
+				Author:    r.User.Login,
+				Body:      r.Body,
+				CreatedAt: r.CreatedAt,
+				File:      r.Path,
+				Line:      line,
+			})
+		}
+		// Short page means GitHub has no more entries upstream.
+		if len(raw) < 100 {
+			return comments, nil
 		}
 	}
+	slog.Warn("github: fetch review comments pagination cap hit, returning partial results",
+		"repo", repo, "pr", number, "pages", maxCommentPages)
 	return comments, nil
 }
 
 func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) {
-	path := fmt.Sprintf("/repos/%s/issues/%d/comments", repo, number)
-	resp, err := c.do("GET", path, "application/vnd.github+json")
-	if err != nil {
-		return nil, fmt.Errorf("github: fetch issue comments: %w", err)
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
-	if resp.StatusCode != http.StatusOK {
-		errBody := safeTruncate(string(body), maxErrBodyLen)
-		return nil, fmt.Errorf("github: fetch issue comments: status %d: %s", resp.StatusCode, errBody)
-	}
-	var raw []struct {
-		User struct {
-			Login string `json:"login"`
-		} `json:"user"`
-		Body      string    `json:"body"`
-		CreatedAt time.Time `json:"created_at"`
-	}
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, fmt.Errorf("github: decode issue comments: %w", err)
-	}
-	comments := make([]Comment, len(raw))
-	for i, r := range raw {
-		comments[i] = Comment{
-			Author:    r.User.Login,
-			Body:      r.Body,
-			CreatedAt: r.CreatedAt,
+	// Same rationale as fetchReviewComments: paginate with per_page=100
+	// so we don't lose the newest issue comments on long-running PRs or
+	// busy issues.
+	comments := []Comment{}
+	for page := 1; page <= maxCommentPages; page++ {
+		path := fmt.Sprintf("/repos/%s/issues/%d/comments?per_page=100&page=%d", repo, number, page)
+		resp, err := c.do("GET", path, "application/vnd.github+json")
+		if err != nil {
+			return nil, fmt.Errorf("github: fetch issue comments: %w", err)
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			errBody := safeTruncate(string(body), maxErrBodyLen)
+			return nil, fmt.Errorf("github: fetch issue comments: status %d: %s", resp.StatusCode, errBody)
+		}
+		var raw []struct {
+			User struct {
+				Login string `json:"login"`
+			} `json:"user"`
+			Body      string    `json:"body"`
+			CreatedAt time.Time `json:"created_at"`
+		}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, fmt.Errorf("github: decode issue comments: %w", err)
+		}
+		for _, r := range raw {
+			comments = append(comments, Comment{
+				Author:    r.User.Login,
+				Body:      r.Body,
+				CreatedAt: r.CreatedAt,
+			})
+		}
+		if len(raw) < 100 {
+			return comments, nil
 		}
 	}
+	slog.Warn("github: fetch issue comments pagination cap hit, returning partial results",
+		"repo", repo, "issue", number, "pages", maxCommentPages)
 	return comments, nil
 }
 

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -833,15 +833,25 @@ func (c *Client) GetPRTimelineEventsForReviewer(repo string, number int, login s
 // misbehaving server from making us iterate forever.
 const maxCommentPages = 50
 
+// perPage is the page size used for paginated comment endpoints. Kept
+// alongside maxCommentPages so changing either is an explicit decision,
+// and so the per_page query parameter and the short-page termination
+// check can't drift apart.
+const perPage = 100
+
 func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error) {
 	// GitHub's default page size is 30 and the API sorts ascending by
 	// created_at, so without explicit pagination any PR with >30 review
 	// comments silently drops the newest entries — exactly the ones a
 	// re-review depends on. Walk every page with per_page=100, matching
-	// the pattern used by GetPRTimelineEventsForReviewer.
+	// the pattern used by GetPRTimelineEventsForReviewer. Pin
+	// sort=created&direction=asc explicitly as defense-in-depth against
+	// server-side default changes; callers downstream rely on ascending
+	// order.
 	comments := []Comment{}
 	for page := 1; page <= maxCommentPages; page++ {
-		path := fmt.Sprintf("/repos/%s/pulls/%d/comments?per_page=100&page=%d", repo, number, page)
+		path := fmt.Sprintf("/repos/%s/pulls/%d/comments?per_page=%d&page=%d&sort=created&direction=asc",
+			repo, number, perPage, page)
 		resp, err := c.do("GET", path, "application/vnd.github+json")
 		if err != nil {
 			return nil, fmt.Errorf("github: fetch review comments: %w", err)
@@ -879,22 +889,30 @@ func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error)
 			})
 		}
 		// Short page means GitHub has no more entries upstream.
-		if len(raw) < 100 {
+		if len(raw) < perPage {
 			return comments, nil
 		}
 	}
-	slog.Warn("github: fetch review comments pagination cap hit, returning partial results",
+	// Hitting the cap with every page full is suspicious: either GitHub
+	// is misbehaving or this PR has >5,000 review comments. Either way,
+	// silently returning a truncated slice would re-introduce the exact
+	// bug this function exists to fix (losing the newest entries — the
+	// ones a re-review depends on), so surface a hard error and match
+	// the mid-pagination error contract the other tests already enforce.
+	slog.Warn("github: fetch review comments pagination cap hit",
 		"repo", repo, "pr", number, "pages", maxCommentPages)
-	return comments, nil
+	return nil, fmt.Errorf("github: comment pagination exceeded %d pages for %s#%d (per_page=%d, possible runaway)",
+		maxCommentPages, repo, number, perPage)
 }
 
 func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) {
-	// Same rationale as fetchReviewComments: paginate with per_page=100
+	// Same rationale as fetchReviewComments: paginate with per_page=perPage
 	// so we don't lose the newest issue comments on long-running PRs or
-	// busy issues.
+	// busy issues, and pin sort=created&direction=asc explicitly.
 	comments := []Comment{}
 	for page := 1; page <= maxCommentPages; page++ {
-		path := fmt.Sprintf("/repos/%s/issues/%d/comments?per_page=100&page=%d", repo, number, page)
+		path := fmt.Sprintf("/repos/%s/issues/%d/comments?per_page=%d&page=%d&sort=created&direction=asc",
+			repo, number, perPage, page)
 		resp, err := c.do("GET", path, "application/vnd.github+json")
 		if err != nil {
 			return nil, fmt.Errorf("github: fetch issue comments: %w", err)
@@ -922,13 +940,16 @@ func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) 
 				CreatedAt: r.CreatedAt,
 			})
 		}
-		if len(raw) < 100 {
+		if len(raw) < perPage {
 			return comments, nil
 		}
 	}
-	slog.Warn("github: fetch issue comments pagination cap hit, returning partial results",
+	// See fetchReviewComments for the rationale: silent partial results
+	// at the cap would re-introduce the bug #512 fixes.
+	slog.Warn("github: fetch issue comments pagination cap hit",
 		"repo", repo, "issue", number, "pages", maxCommentPages)
-	return comments, nil
+	return nil, fmt.Errorf("github: comment pagination exceeded %d pages for %s#%d (per_page=%d, possible runaway)",
+		maxCommentPages, repo, number, perPage)
 }
 
 // FetchLabels returns the label names for a repository.

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -3,9 +3,11 @@ package github_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -186,6 +188,277 @@ func TestFetchComments_APIError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 404 response, got nil")
 	}
+}
+
+// TestFetchComments_PaginatesReviewAndIssueComments locks in the fix for
+// theburrowhub/heimdallm#512: GitHub returns 30 comments per page sorted
+// ascending by created_at, so without explicit pagination any PR with >30
+// review or issue comments silently lost the newest entries — exactly the
+// ones a re-review depends on. This test mocks both endpoints to return
+// 100+50 (full + partial page) and asserts FetchComments returns all 300
+// merged entries.
+func TestFetchComments_PaginatesReviewAndIssueComments(t *testing.T) {
+	const fullPage = 100
+	const tailPage = 50
+
+	var reviewPages, issuePages int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			fmt.Sscanf(p, "%d", &page)
+		}
+		if pp := r.URL.Query().Get("per_page"); pp != "100" {
+			t.Errorf("expected per_page=100, got %q on path %s", pp, r.URL.Path)
+		}
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/1/comments":
+			atomic.AddInt32(&reviewPages, 1)
+			emitReviewCommentsPage(w, page, fullPage, tailPage, "review")
+		case "/repos/org/repo/issues/1/comments":
+			atomic.AddInt32(&issuePages, 1)
+			emitIssueCommentsPage(w, page, fullPage, tailPage, "issue")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	comments, err := client.FetchComments("org/repo", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := len(comments), 2*(fullPage+tailPage); got != want {
+		t.Fatalf("expected %d total comments, got %d", want, got)
+	}
+	// Both endpoints fetched 2 pages each (1 full + 1 partial).
+	if got := atomic.LoadInt32(&reviewPages); got != 2 {
+		t.Errorf("review endpoint hit count: got %d, want 2", got)
+	}
+	if got := atomic.LoadInt32(&issuePages); got != 2 {
+		t.Errorf("issue endpoint hit count: got %d, want 2", got)
+	}
+	// Spot-check that comments from the tail page (only available via
+	// pagination) actually made it through.
+	foundTail := false
+	for _, c := range comments {
+		if c.Body == "review-2-49" {
+			foundTail = true
+			break
+		}
+	}
+	if !foundTail {
+		t.Errorf("expected to find a comment from the second review page (body=review-2-49); pagination dropped it")
+	}
+}
+
+// TestFetchComments_ShortFirstPageStopsPaging guards against the inverse
+// regression: a single short page must NOT trigger a redundant second
+// request. Cheap PRs (<100 comments) should still cost exactly one round
+// trip per endpoint.
+func TestFetchComments_ShortFirstPageStopsPaging(t *testing.T) {
+	var reviewPages, issuePages int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/1/comments":
+			atomic.AddInt32(&reviewPages, 1)
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"user":          map[string]string{"login": "bob"},
+					"body":          "inline",
+					"created_at":    "2024-01-02T00:00:00Z",
+					"path":          "main.go",
+					"original_line": 10,
+				},
+			})
+		case "/repos/org/repo/issues/1/comments":
+			atomic.AddInt32(&issuePages, 1)
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"user":       map[string]string{"login": "alice"},
+					"body":       "general",
+					"created_at": "2024-01-01T00:00:00Z",
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	comments, err := client.FetchComments("org/repo", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(comments))
+	}
+	if got := atomic.LoadInt32(&reviewPages); got != 1 {
+		t.Errorf("review endpoint hit %d times, want 1 (short page must not trigger another request)", got)
+	}
+	if got := atomic.LoadInt32(&issuePages); got != 1 {
+		t.Errorf("issue endpoint hit %d times, want 1 (short page must not trigger another request)", got)
+	}
+}
+
+// TestFetchComments_FullPageThenEmptyStopsCleanly covers the edge case
+// where total_count is an exact multiple of per_page=100: the first page
+// is full (so we paginate), the second page is empty, and pagination must
+// terminate cleanly without surfacing an error.
+func TestFetchComments_FullPageThenEmptyStopsCleanly(t *testing.T) {
+	var reviewPages, issuePages int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			fmt.Sscanf(p, "%d", &page)
+		}
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/1/comments":
+			atomic.AddInt32(&reviewPages, 1)
+			if page == 1 {
+				emitReviewCommentsPage(w, page, 100, 0, "review")
+			} else {
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+			}
+		case "/repos/org/repo/issues/1/comments":
+			atomic.AddInt32(&issuePages, 1)
+			if page == 1 {
+				emitIssueCommentsPage(w, page, 100, 0, "issue")
+			} else {
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	comments, err := client.FetchComments("org/repo", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 100 review + 100 issue, all from the first page.
+	if got, want := len(comments), 200; got != want {
+		t.Fatalf("expected %d comments, got %d", want, got)
+	}
+	if got := atomic.LoadInt32(&reviewPages); got != 2 {
+		t.Errorf("review endpoint hits: got %d, want 2 (page 1 full + page 2 empty)", got)
+	}
+	if got := atomic.LoadInt32(&issuePages); got != 2 {
+		t.Errorf("issue endpoint hits: got %d, want 2 (page 1 full + page 2 empty)", got)
+	}
+}
+
+// TestFetchComments_MidPaginationErrorPropagates verifies that an HTTP 500
+// on page 2 of /pulls/:n/comments surfaces as a hard error rather than a
+// silently-truncated slice. Returning partial results would defeat the
+// point of paginating in the first place.
+func TestFetchComments_MidPaginationErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			fmt.Sscanf(p, "%d", &page)
+		}
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/1/comments":
+			if page == 1 {
+				emitReviewCommentsPage(w, page, 100, 0, "review")
+				return
+			}
+			http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+		case "/repos/org/repo/issues/1/comments":
+			// Issue side is well-behaved so the failure is unambiguously the review leg.
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchComments("org/repo", 1)
+	if err == nil {
+		t.Fatalf("expected error from mid-pagination 500, got nil and %d comments", len(got))
+	}
+	if !strings.Contains(err.Error(), "fetch review comments") {
+		t.Errorf("expected error to mention 'fetch review comments', got: %v", err)
+	}
+}
+
+// TestFetchComments_MidPaginationErrorOnIssuesPropagates is the symmetric
+// guard for the issue-comments leg. Same contract: mid-pagination failure
+// must NOT return a partial slice.
+func TestFetchComments_MidPaginationErrorOnIssuesPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			fmt.Sscanf(p, "%d", &page)
+		}
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/1/comments":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case "/repos/org/repo/issues/1/comments":
+			if page == 1 {
+				emitIssueCommentsPage(w, page, 100, 0, "issue")
+				return
+			}
+			http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.FetchIssueCommentsOnly("org/repo", 1)
+	if err == nil {
+		t.Fatalf("expected error from mid-pagination 500, got nil and %d comments", len(got))
+	}
+	if !strings.Contains(err.Error(), "fetch issue comments") {
+		t.Errorf("expected error to mention 'fetch issue comments', got: %v", err)
+	}
+}
+
+// emitReviewCommentsPage writes a JSON page of /pulls/:n/comments shaped
+// items. Page 1 emits fullSize items; subsequent pages emit tailSize and
+// signal end-of-pagination by being short. Each body is tagged "<tag>-<page>-<index>"
+// so tests can assert specific entries survived pagination.
+func emitReviewCommentsPage(w http.ResponseWriter, page, fullSize, tailSize int, tag string) {
+	n := fullSize
+	if page > 1 {
+		n = tailSize
+	}
+	raw := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		raw = append(raw, map[string]any{
+			"user":          map[string]string{"login": fmt.Sprintf("u%d", i)},
+			"body":          fmt.Sprintf("%s-%d-%d", tag, page, i),
+			"created_at":    "2024-01-01T00:00:00Z",
+			"path":          "main.go",
+			"original_line": i,
+		})
+	}
+	_ = json.NewEncoder(w).Encode(raw)
+}
+
+// emitIssueCommentsPage is the issue-comments counterpart: no file/line
+// fields, since /issues/:n/comments doesn't return them.
+func emitIssueCommentsPage(w http.ResponseWriter, page, fullSize, tailSize int, tag string) {
+	n := fullSize
+	if page > 1 {
+		n = tailSize
+	}
+	raw := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		raw = append(raw, map[string]any{
+			"user":       map[string]string{"login": fmt.Sprintf("u%d", i)},
+			"body":       fmt.Sprintf("%s-%d-%d", tag, page, i),
+			"created_at": "2024-01-01T00:00:00Z",
+		})
+	}
+	_ = json.NewEncoder(w).Encode(raw)
 }
 
 // TestFetchIssueCommentsOnly_IgnoresPREndpoint locks in the fix for #292:

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -203,10 +203,7 @@ func TestFetchComments_PaginatesReviewAndIssueComments(t *testing.T) {
 
 	var reviewPages, issuePages int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		page := 1
-		if p := r.URL.Query().Get("page"); p != "" {
-			fmt.Sscanf(p, "%d", &page)
-		}
+		page := parsePageParam(t, r)
 		if pp := r.URL.Query().Get("per_page"); pp != "100" {
 			t.Errorf("expected per_page=100, got %q on path %s", pp, r.URL.Path)
 		}
@@ -309,10 +306,7 @@ func TestFetchComments_ShortFirstPageStopsPaging(t *testing.T) {
 func TestFetchComments_FullPageThenEmptyStopsCleanly(t *testing.T) {
 	var reviewPages, issuePages int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		page := 1
-		if p := r.URL.Query().Get("page"); p != "" {
-			fmt.Sscanf(p, "%d", &page)
-		}
+		page := parsePageParam(t, r)
 		switch r.URL.Path {
 		case "/repos/org/repo/pulls/1/comments":
 			atomic.AddInt32(&reviewPages, 1)
@@ -357,10 +351,7 @@ func TestFetchComments_FullPageThenEmptyStopsCleanly(t *testing.T) {
 // point of paginating in the first place.
 func TestFetchComments_MidPaginationErrorPropagates(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		page := 1
-		if p := r.URL.Query().Get("page"); p != "" {
-			fmt.Sscanf(p, "%d", &page)
-		}
+		page := parsePageParam(t, r)
 		switch r.URL.Path {
 		case "/repos/org/repo/pulls/1/comments":
 			if page == 1 {
@@ -392,10 +383,7 @@ func TestFetchComments_MidPaginationErrorPropagates(t *testing.T) {
 // must NOT return a partial slice.
 func TestFetchComments_MidPaginationErrorOnIssuesPropagates(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		page := 1
-		if p := r.URL.Query().Get("page"); p != "" {
-			fmt.Sscanf(p, "%d", &page)
-		}
+		page := parsePageParam(t, r)
 		switch r.URL.Path {
 		case "/repos/org/repo/pulls/1/comments":
 			_ = json.NewEncoder(w).Encode([]map[string]any{})
@@ -419,6 +407,102 @@ func TestFetchComments_MidPaginationErrorOnIssuesPropagates(t *testing.T) {
 	if !strings.Contains(err.Error(), "fetch issue comments") {
 		t.Errorf("expected error to mention 'fetch issue comments', got: %v", err)
 	}
+}
+
+// TestFetchComments_PaginationCapReturnsError locks in the contract that
+// hitting maxCommentPages with every page full surfaces a hard error
+// rather than a silently-truncated slice. Silent partial results here
+// would re-introduce the exact failure mode #512 exists to prevent
+// (dropping the newest comments) and would be inconsistent with the
+// mid-pagination 500 contract that TestFetchComments_MidPaginationError*
+// already enforce. Also asserts the production code does NOT walk past
+// the cap (no 51st request).
+func TestFetchComments_PaginationCapReturnsError(t *testing.T) {
+	t.Run("review_comments", func(t *testing.T) {
+		var reviewPages int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			page := parsePageParam(t, r)
+			switch r.URL.Path {
+			case "/repos/org/repo/pulls/1/comments":
+				atomic.AddInt32(&reviewPages, 1)
+				// Always emit a full page so the loop never short-circuits
+				// on len<perPage and is forced to hit the cap.
+				emitReviewCommentsPage(w, page, 100, 100, "review")
+			case "/repos/org/repo/issues/1/comments":
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer srv.Close()
+
+		client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+		got, err := client.FetchComments("org/repo", 1)
+		if err == nil {
+			t.Fatalf("expected pagination cap error, got nil and %d comments", len(got))
+		}
+		if !strings.Contains(err.Error(), "comment pagination exceeded") {
+			t.Errorf("expected error to mention 'comment pagination exceeded', got: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil slice on cap-hit error, got %d comments", len(got))
+		}
+		// The loop runs `for page := 1; page <= maxCommentPages; page++`,
+		// so on cap-hit exactly maxCommentPages (50) requests should be
+		// made and no 51st request should be attempted.
+		if got, want := atomic.LoadInt32(&reviewPages), int32(50); got != want {
+			t.Errorf("review endpoint hit count: got %d, want %d (must not walk past cap)", got, want)
+		}
+	})
+
+	t.Run("issue_comments", func(t *testing.T) {
+		var issuePages int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			page := parsePageParam(t, r)
+			switch r.URL.Path {
+			case "/repos/org/repo/pulls/1/comments":
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+			case "/repos/org/repo/issues/1/comments":
+				atomic.AddInt32(&issuePages, 1)
+				emitIssueCommentsPage(w, page, 100, 100, "issue")
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer srv.Close()
+
+		client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+		got, err := client.FetchIssueCommentsOnly("org/repo", 1)
+		if err == nil {
+			t.Fatalf("expected pagination cap error, got nil and %d comments", len(got))
+		}
+		if !strings.Contains(err.Error(), "comment pagination exceeded") {
+			t.Errorf("expected error to mention 'comment pagination exceeded', got: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil slice on cap-hit error, got %d comments", len(got))
+		}
+		if got, want := atomic.LoadInt32(&issuePages), int32(50); got != want {
+			t.Errorf("issue endpoint hit count: got %d, want %d (must not walk past cap)", got, want)
+		}
+	})
+}
+
+// parsePageParam reads ?page=N from r and returns it, defaulting to 1 when
+// the param is absent. A malformed value is a test bug — the production
+// code only ever emits integers — so we fail loudly via t.Fatalf rather
+// than silently coercing to 1 and masking the mistake.
+func parsePageParam(t *testing.T, r *http.Request) int {
+	t.Helper()
+	raw := r.URL.Query().Get("page")
+	if raw == "" {
+		return 1
+	}
+	page := 0
+	if _, err := fmt.Sscanf(raw, "%d", &page); err != nil {
+		t.Fatalf("test bug: malformed page param %q on %s: %v", raw, r.URL.Path, err)
+	}
+	return page
 }
 
 // emitReviewCommentsPage writes a JSON page of /pulls/:n/comments shaped


### PR DESCRIPTION
## Summary

- `fetchReviewComments` and `fetchIssueComments` now paginate `/pulls/:n/comments` and `/issues/:n/comments` with `per_page=100` and follow every page, matching the pattern already used by `GetPRTimelineEventsForReviewer`.
- Pagination terminates on a short page (`<100` items) and is hard-capped at 50 pages so a misbehaving upstream can't make us iterate forever.
- Mid-pagination HTTP errors propagate as hard failures — no silently truncated slices.

## Why

GitHub returns 30 items per page by default for both comment endpoints, sorted **ascending** by `created_at`. The previous implementation called both without `per_page` or `page` parameters, so any PR with >30 review or issue comments silently dropped the newest entries — exactly the comments a re-review depends on (peer reviewer feedback, the latest \`heimdallm:done\` markers, etc.).

This was the root cause of #512.

## Test plan

New tests in `daemon/internal/github/poller_test.go`:

- [x] `TestFetchComments_PaginatesReviewAndIssueComments` — both endpoints return 100+50 across two pages; FetchComments returns all 300 merged entries and we explicitly assert a tail-page body survives the round trip.
- [x] `TestFetchComments_ShortFirstPageStopsPaging` — single short page must NOT trigger a redundant second request (efficiency guard for the common case).
- [x] `TestFetchComments_FullPageThenEmptyStopsCleanly` — total count is an exact multiple of 100; pagination must terminate on the empty second page without erroring.
- [x] `TestFetchComments_MidPaginationErrorPropagates` — 500 on page 2 of `/pulls/:n/comments` surfaces a hard error (no partial slice).
- [x] `TestFetchComments_MidPaginationErrorOnIssuesPropagates` — symmetric guard for the issue-comments leg, exercised via `FetchIssueCommentsOnly`.

Verification:

\`\`\`
$ cd daemon && go test ./internal/github/... ./internal/pipeline/... ./internal/issues/... ./cmd/... -race -count=1
ok  	github.com/heimdallm/daemon/internal/github	1.408s
ok  	github.com/heimdallm/daemon/internal/pipeline	3.661s
ok  	github.com/heimdallm/daemon/internal/issues	3.716s
ok  	github.com/heimdallm/daemon/cmd/heimdallm	4.814s
\`\`\`

A pre-existing race in `internal/rename/probe_test.go` (`TestRenameProbe_Run_FiresInitialTickBeforeIntervalElapses`) fails on `main@a994086` as well — unrelated to this change, no `internal/github` code paths involved.

## Notes

- `maxBodyBytes = 1 MiB` left unchanged. With pagination split into separate HTTP requests, each page is its own 1 MiB budget; a 100-comment page comfortably fits.
- Public API surface is unchanged: `FetchComments`, `FetchIssueCommentsOnly`, and the internal `[]Comment` ascending-by-`CreatedAt` ordering are all preserved.

Closes #512