### PR TITLE
test(rename): guard fakeDispatcher with mutex to fix -race flake

### DIFF
--- a/daemon/internal/rename/probe_test.go
+++ b/daemon/internal/rename/probe_test.go
@@ -33,6 +33,15 @@ func (f *fakeCanonical) GetCanonicalFullName(repo string) (string, error) {
 	return r.canonical, r.err
 }
 
+// callCount returns f.calls under the mutex. Use from any test goroutine
+// that may run concurrently with GetCanonicalFullName (e.g. Run-based
+// tests) instead of inlining lock/read/unlock at each call site.
+func (f *fakeCanonical) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
 // fakeDispatcher records reconciler invocations so the test can pin
 // which (old, new) pairs the probe dispatched. Concrete *Reconciler
 // is too heavy to construct in a probe test; the Dispatcher interface
@@ -46,11 +55,19 @@ type fakeDispatcher struct {
 
 func (f *fakeDispatcher) Run(_ context.Context, oldRepo, newRepo string) error {
 	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.calls++
 	f.gotPairs = append(f.gotPairs, [2]string{oldRepo, newRepo})
-	err := f.err
-	f.mu.Unlock()
-	return err
+	return f.err
+}
+
+// callCount returns f.calls under the mutex. Use from any test goroutine
+// that may run concurrently with Run (e.g. Run-based tests) instead of
+// inlining lock/read/unlock at each call site.
+func (f *fakeDispatcher) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
 }
 
 func newProbe(t *testing.T, canonical *fakeCanonical, dispatcher *fakeDispatcher,
@@ -166,12 +183,8 @@ func TestRenameProbe_Run_FiresInitialTickBeforeIntervalElapses(t *testing.T) {
 	// the 1h interval that the loop tick would need.
 	deadline := time.After(2 * time.Second)
 	for {
-		canonical.mu.Lock()
-		calls := canonical.calls
-		canonical.mu.Unlock()
-		dispatcher.mu.Lock()
-		dispatched := dispatcher.calls
-		dispatcher.mu.Unlock()
+		calls := canonical.callCount()
+		dispatched := dispatcher.callCount()
 		if calls >= 1 && dispatched >= 1 {
 			break
 		}

--- a/daemon/internal/rename/probe_test.go
+++ b/daemon/internal/rename/probe_test.go
@@ -41,12 +41,16 @@ type fakeDispatcher struct {
 	calls    int
 	gotPairs [][2]string
 	err      error
+	mu       sync.Mutex
 }
 
 func (f *fakeDispatcher) Run(_ context.Context, oldRepo, newRepo string) error {
+	f.mu.Lock()
 	f.calls++
 	f.gotPairs = append(f.gotPairs, [2]string{oldRepo, newRepo})
-	return f.err
+	err := f.err
+	f.mu.Unlock()
+	return err
 }
 
 func newProbe(t *testing.T, canonical *fakeCanonical, dispatcher *fakeDispatcher,
@@ -165,13 +169,16 @@ func TestRenameProbe_Run_FiresInitialTickBeforeIntervalElapses(t *testing.T) {
 		canonical.mu.Lock()
 		calls := canonical.calls
 		canonical.mu.Unlock()
-		if calls >= 1 && dispatcher.calls >= 1 {
+		dispatcher.mu.Lock()
+		dispatched := dispatcher.calls
+		dispatcher.mu.Unlock()
+		if calls >= 1 && dispatched >= 1 {
 			break
 		}
 		select {
 		case <-deadline:
 			t.Fatalf("initial tick did not fire within budget: canonical.calls=%d, dispatcher.calls=%d",
-				calls, dispatcher.calls)
+				calls, dispatched)
 		case <-time.After(10 * time.Millisecond):
 		}
 	}


### PR DESCRIPTION
## Summary

- `fakeDispatcher` in `probe_test.go` had no synchronization, so when `TestRenameProbe_Run_FiresInitialTickBeforeIntervalElapses` polled `dispatcher.calls` from the test goroutine, it raced with the probe-side write inside `(*fakeDispatcher).Run`.
- Added `sync.Mutex` to `fakeDispatcher` and locked both the write in `Run` and the polling read in the test, mirroring the pattern already used by `fakeCanonical` in the same file.

## Why

Without this, `go test ./internal/rename/... -race` flaked roughly 1 in 3 runs on `main@a994086`. The flake masks any future race regressions and noise-fails CI.

```
WARNING: DATA RACE
Read at 0x...  TestRenameProbe_Run_FiresInitialTickBeforeIntervalElapses probe_test.go:168
Previous write at 0x...  (*fakeDispatcher).Run            probe_test.go:47
```

The other dispatcher-reading tests in the file (`Tick`-based) are synchronous, so they don't race and don't need changes.

## Test plan

- [x] `go test ./internal/rename/... -race -count=30 -run TestRenameProbe_Run_FiresInitialTickBeforeIntervalElapses` → all 30 pass (was ~1/3 fail before).
- [x] `go test ./internal/rename/... -race -count=1` → full package PASS.
- [x] `go vet ./...` clean.