### PR TITLE
feat(pipeline): persistent per-repo review instructions via PR comment directives (refs ai-platform-workspace#383)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -414,10 +414,10 @@ func main() {
 			}
 		}
 		return pipeline.RunOptions{
-			Primary:        aiCfg.Primary,
-			Fallback:       aiCfg.Fallback,
-			PromptOverride: aiCfg.Prompt,
-			AgentPromptID:  agentCfg.PromptID,
+			Primary:            aiCfg.Primary,
+			Fallback:           aiCfg.Fallback,
+			PromptOverride:     aiCfg.Prompt,
+			AgentPromptID:      agentCfg.PromptID,
 			ReviewMode:         aiCfg.ReviewMode,
 			InstructionAuthors: aiCfg.InstructionAuthors,
 			ExecOpts: executor.ExecOptions{

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -418,7 +418,8 @@ func main() {
 			Fallback:       aiCfg.Fallback,
 			PromptOverride: aiCfg.Prompt,
 			AgentPromptID:  agentCfg.PromptID,
-			ReviewMode:     aiCfg.ReviewMode,
+			ReviewMode:         aiCfg.ReviewMode,
+			InstructionAuthors: aiCfg.InstructionAuthors,
 			ExecOpts: executor.ExecOptions{
 				Model:                agentCfg.Model,
 				MaxTurns:             agentCfg.MaxTurns,

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -264,6 +264,23 @@ func (c IssueTrackingConfig) MatchesAssignees(assignees []string) bool {
 	return ok
 }
 
+// MatchesInstructionAuthors reports whether login is permitted to issue
+// persistent review-instruction directives for this repo. Case-insensitive and
+// tolerant of a leading "@". An empty allowlist denies everyone — comment-driven
+// instructions are opt-in and must be explicitly granted (issue #383).
+func (r RepoAI) MatchesInstructionAuthors(login string) bool {
+	login = strings.ToLower(strings.TrimSpace(strings.TrimLeft(login, "@")))
+	if login == "" {
+		return false
+	}
+	for _, a := range r.InstructionAuthors {
+		if strings.ToLower(strings.TrimSpace(strings.TrimLeft(a, "@"))) == login {
+			return true
+		}
+	}
+	return false
+}
+
 // Classify returns the processing mode for an issue given its labels.
 // Matching is case-insensitive to match the way GitHub displays labels; the
 // underlying labels API is case-preserving but the UI is not, so users
@@ -360,6 +377,12 @@ type AIConfig struct {
 	PRLabels    []string `toml:"pr_labels"`
 	PRAssignee  string   `toml:"pr_assignee"`
 	PRDraft     *bool    `toml:"pr_draft,omitempty"`
+
+	// InstructionAuthors are GitHub logins permitted to set persistent,
+	// per-repo review instructions via PR comment directives (#383). Resolved
+	// through the repo > org > global hierarchy like PRReviewers. Empty means
+	// nobody is authorized — the comment-driven feature is opt-in.
+	InstructionAuthors []string `toml:"instruction_authors"`
 
 	// IssuePrompt is the global default agent profile ID for issue triage.
 	// Per-repo overrides in [ai.repos.<name>] take precedence.
@@ -492,6 +515,8 @@ type RepoAI struct {
 	PRLabels    []string `toml:"pr_labels"`          // labels to add to the PR
 	PRDraft     *bool    `toml:"pr_draft,omitempty"` // create as draft PR
 
+	InstructionAuthors []string `toml:"instruction_authors"` // GitHub logins allowed to set standing instructions (#383)
+
 	// GeneratePRDescription overrides the global ai.generate_pr_description
 	// for this repo. nil = inherit from global.
 	GeneratePRDescription *bool `toml:"generate_pr_description,omitempty"`
@@ -547,10 +572,11 @@ type OrgAI struct {
 
 	// Nil slices inherit from global; non-nil empty slices explicitly clear
 	// inherited values for every repo in this org.
-	PRReviewers []string `toml:"pr_reviewers"`
-	PRAssignee  string   `toml:"pr_assignee"`
-	PRLabels    []string `toml:"pr_labels"`
-	PRDraft     *bool    `toml:"pr_draft,omitempty"`
+	PRReviewers        []string `toml:"pr_reviewers"`
+	PRAssignee         string   `toml:"pr_assignee"`
+	PRLabels           []string `toml:"pr_labels"`
+	PRDraft            *bool    `toml:"pr_draft,omitempty"`
+	InstructionAuthors []string `toml:"instruction_authors"` // see RepoAI.InstructionAuthors (#383)
 
 	GeneratePRDescription *bool                  `toml:"generate_pr_description,omitempty"`
 	IssueTracking         *IssueTrackingOverride `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
@@ -697,6 +723,7 @@ func (c *Config) AIForRepo(repo string) RepoAI {
 		CloneDir:              c.AI.CloneDir,
 		AutoPromoteTriage:     c.AI.AutoPromoteTriage,
 		AutoPromoteRefinement: c.AI.AutoPromoteRefinement,
+		InstructionAuthors:    c.AI.InstructionAuthors,
 	}
 	if org := repoOrg(repo); org != "" && c.AI.Orgs != nil {
 		if o, ok := c.AI.Orgs[org]; ok {
@@ -730,6 +757,7 @@ func applyOrgAI(out *RepoAI, o OrgAI) {
 		PRAssignee:            o.PRAssignee,
 		PRDraft:               o.PRDraft,
 		GeneratePRDescription: o.GeneratePRDescription,
+		InstructionAuthors:    o.InstructionAuthors,
 	})
 }
 
@@ -752,6 +780,7 @@ func applyRepoAI(out *RepoAI, r RepoAI) {
 		PRAssignee:            r.PRAssignee,
 		PRDraft:               r.PRDraft,
 		GeneratePRDescription: r.GeneratePRDescription,
+		InstructionAuthors:    r.InstructionAuthors,
 	})
 }
 
@@ -773,6 +802,7 @@ type scopedAIFields struct {
 	PRAssignee            string
 	PRDraft               *bool
 	GeneratePRDescription *bool
+	InstructionAuthors    []string
 }
 
 func applyScopedAI(out *RepoAI, fields scopedAIFields) {
@@ -826,6 +856,9 @@ func applyScopedAI(out *RepoAI, fields scopedAIFields) {
 	}
 	if fields.GeneratePRDescription != nil {
 		out.GeneratePRDescription = fields.GeneratePRDescription
+	}
+	if fields.InstructionAuthors != nil {
+		out.InstructionAuthors = fields.InstructionAuthors
 	}
 }
 

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -2686,3 +2686,43 @@ func TestReviewGuards_ExplicitFalse(t *testing.T) {
 		t.Errorf("SkipSelfAuthor: explicit false not honoured")
 	}
 }
+
+func TestMatchesInstructionAuthors(t *testing.T) {
+	r := RepoAI{InstructionAuthors: []string{"Alice", "@bob"}}
+	if !r.MatchesInstructionAuthors("alice") {
+		t.Error("alice should match (case-insensitive)")
+	}
+	if !r.MatchesInstructionAuthors("@BOB") {
+		t.Error("@BOB should match (leading @ + case-insensitive)")
+	}
+	if r.MatchesInstructionAuthors("mallory") {
+		t.Error("mallory must not match")
+	}
+	if r.MatchesInstructionAuthors("") {
+		t.Error("empty login must not match")
+	}
+	if (RepoAI{}).MatchesInstructionAuthors("alice") {
+		t.Error("empty allowlist must deny everyone")
+	}
+}
+
+func TestAIForRepo_InstructionAuthorsResolution(t *testing.T) {
+	c := &Config{}
+	c.AI.InstructionAuthors = []string{"global-user"}
+	c.AI.Orgs = map[string]OrgAI{
+		"org": {InstructionAuthors: []string{"org-user"}},
+	}
+	c.AI.Repos = map[string]RepoAI{
+		"org/repo":  {InstructionAuthors: []string{"repo-user"}},
+		"org/inhrt": {}, // nil → inherits org
+	}
+	if got := c.AIForRepo("org/repo").InstructionAuthors; len(got) != 1 || got[0] != "repo-user" {
+		t.Errorf("repo override: got %v", got)
+	}
+	if got := c.AIForRepo("org/inhrt").InstructionAuthors; len(got) != 1 || got[0] != "org-user" {
+		t.Errorf("org inherit: got %v", got)
+	}
+	if got := c.AIForRepo("other/x").InstructionAuthors; len(got) != 1 || got[0] != "global-user" {
+		t.Errorf("global fallback: got %v", got)
+	}
+}

--- a/daemon/internal/executor/prompt.go
+++ b/daemon/internal/executor/prompt.go
@@ -15,8 +15,9 @@ type PRContext struct {
 	Author        string
 	Link          string
 	Diff          string
-	Comments      string // pre-formatted discussion section; empty string if no comments
-	ReviewContext string // structured re-review context; empty on first review
+	Comments             string // pre-formatted discussion section; empty string if no comments
+	ReviewContext        string // structured re-review context; empty on first review
+	StandingInstructions string // persistent per-repo instructions; empty when none
 }
 
 // defaultTemplate is used when no custom agent template is configured.
@@ -35,6 +36,7 @@ Repo: {repo}
 Author: {author}
 Link: {link}
 
+{standing_instructions}
 <user_content>
 Diff:
 {diff}
@@ -69,6 +71,7 @@ Repo: {repo}
 Author: {author}
 Link: {link}
 
+{standing_instructions}
 REVIEW FOCUS:
 ` + instructions + `
 
@@ -118,6 +121,7 @@ func BuildPromptFromTemplate(tmpl string, ctx PRContext) string {
 
 	hasPlaceholder := strings.Contains(tmpl, "{comments}")
 	hasReviewCtx := strings.Contains(tmpl, "{review_context}")
+	hasStanding := strings.Contains(tmpl, "{standing_instructions}")
 
 	r := strings.NewReplacer(
 		"{title}", ctx.Title,
@@ -128,6 +132,7 @@ func BuildPromptFromTemplate(tmpl string, ctx PRContext) string {
 		"{diff}", ctx.Diff,
 		"{comments}", ctx.Comments,
 		"{review_context}", ctx.ReviewContext,
+		"{standing_instructions}", ctx.StandingInstructions,
 	)
 	result := r.Replace(tmpl)
 
@@ -144,6 +149,11 @@ func BuildPromptFromTemplate(tmpl string, ctx PRContext) string {
 	// Prepend review context if template had no {review_context} placeholder
 	if !hasReviewCtx && ctx.ReviewContext != "" {
 		result = ctx.ReviewContext + "\n" + result
+	}
+
+	// Prepend standing instructions if the template had no placeholder.
+	if !hasStanding && ctx.StandingInstructions != "" {
+		result = ctx.StandingInstructions + "\n" + result
 	}
 
 	return result

--- a/daemon/internal/executor/prompt.go
+++ b/daemon/internal/executor/prompt.go
@@ -9,12 +9,12 @@ const maxDiffBytes = 32 * 1024 // 32KB ~ 8k tokens
 
 // PRContext holds all substitutable data for a prompt template.
 type PRContext struct {
-	Title         string
-	Number        int
-	Repo          string
-	Author        string
-	Link          string
-	Diff          string
+	Title                string
+	Number               int
+	Repo                 string
+	Author               string
+	Link                 string
+	Diff                 string
 	Comments             string // pre-formatted discussion section; empty string if no comments
 	ReviewContext        string // structured re-review context; empty on first review
 	StandingInstructions string // persistent per-repo instructions; empty when none
@@ -107,7 +107,7 @@ func BuildPrompt(title, author, diff string) string {
 }
 
 // BuildPromptFromTemplate substitutes placeholders in a template.
-// Supported placeholders: {title} {number} {repo} {author} {link} {diff} {comments} {review_context}
+// Supported placeholders: {title} {number} {repo} {author} {link} {diff} {comments} {review_context} {standing_instructions}
 //
 // Behavior for {comments}:
 //

--- a/daemon/internal/executor/prompt_test.go
+++ b/daemon/internal/executor/prompt_test.go
@@ -87,3 +87,29 @@ func TestBuildPromptFromTemplate_EmptyComments_NoExtraBlankLines(t *testing.T) {
 		t.Errorf("expected no triple newlines with empty Comments, got: %q", result)
 	}
 }
+
+func TestBuildPromptFromTemplate_StandingInstructions(t *testing.T) {
+	// Built-in template carries the placeholder: substituted in place.
+	out := executor.BuildPromptFromTemplate(executor.DefaultTemplate(), executor.PRContext{
+		Diff:                 "diff",
+		StandingInstructions: "PROJECT STANDING INSTRUCTIONS (set by repo maintainers — authoritative):\n- no auth needed\n",
+	})
+	if !strings.Contains(out, "no auth needed") {
+		t.Fatalf("standing instructions missing from prompt:\n%s", out)
+	}
+
+	// Custom template without the placeholder: section is prepended.
+	out = executor.BuildPromptFromTemplate("Review this:\n{diff}", executor.PRContext{
+		Diff:                 "diff",
+		StandingInstructions: "PROJECT STANDING INSTRUCTIONS:\n- rule\n",
+	})
+	if !strings.HasPrefix(out, "PROJECT STANDING INSTRUCTIONS") {
+		t.Fatalf("expected standing instructions prepended:\n%s", out)
+	}
+
+	// Empty standing instructions: nothing injected, no dangling header.
+	out = executor.BuildPromptFromTemplate(executor.DefaultTemplate(), executor.PRContext{Diff: "diff"})
+	if strings.Contains(out, "PROJECT STANDING INSTRUCTIONS") {
+		t.Fatalf("did not expect standing-instructions header:\n%s", out)
+	}
+}

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -863,6 +863,7 @@ func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error)
 			return nil, fmt.Errorf("github: fetch review comments: status %d: %s", resp.StatusCode, errBody)
 		}
 		var raw []struct {
+			ID   int64 `json:"id"`
 			User struct {
 				Login string `json:"login"`
 			} `json:"user"`
@@ -881,6 +882,7 @@ func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error)
 				line = *r.Line
 			}
 			comments = append(comments, Comment{
+				ID:        r.ID,
 				Author:    r.User.Login,
 				Body:      r.Body,
 				CreatedAt: r.CreatedAt,
@@ -924,6 +926,7 @@ func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) 
 			return nil, fmt.Errorf("github: fetch issue comments: status %d: %s", resp.StatusCode, errBody)
 		}
 		var raw []struct {
+			ID   int64 `json:"id"`
 			User struct {
 				Login string `json:"login"`
 			} `json:"user"`
@@ -935,6 +938,7 @@ func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) 
 		}
 		for _, r := range raw {
 			comments = append(comments, Comment{
+				ID:        r.ID,
 				Author:    r.User.Login,
 				Body:      r.Body,
 				CreatedAt: r.CreatedAt,

--- a/daemon/internal/github/models.go
+++ b/daemon/internal/github/models.go
@@ -115,6 +115,7 @@ type PullRequest struct {
 // Comment represents a single comment on a PR — either an inline review comment
 // (File and Line are set) or a general issue comment (File and Line are zero values).
 type Comment struct {
+	ID        int64 // GitHub comment id; 0 if unknown
 	Author    string
 	Body      string
 	CreatedAt time.Time

--- a/daemon/internal/pipeline/directives.go
+++ b/daemon/internal/pipeline/directives.go
@@ -2,8 +2,11 @@ package pipeline
 
 import (
 	"fmt"
+	"log/slog"
+	"strconv"
 	"strings"
 
+	"github.com/heimdallm/daemon/internal/github"
 	"github.com/heimdallm/daemon/internal/store"
 )
 
@@ -98,6 +101,99 @@ func formatStandingInstructions(items []store.RepoInstruction) string {
 	b.WriteString("PROJECT STANDING INSTRUCTIONS (set by repo maintainers — authoritative):\n")
 	for _, it := range items {
 		fmt.Fprintf(&b, "- %s\n", it.Instruction)
+	}
+	return b.String()
+}
+
+// processDirectives scans comments for heimdallm instruction directives (#383).
+// Authorized directives mutate the repo's persistent instruction set and are
+// acknowledged with a reply; every processed directive comment is marked so it
+// is applied at most once across poll cycles. All failures are logged and never
+// abort the surrounding review.
+func (p *Pipeline) processDirectives(pr *github.PullRequest, comments []github.Comment, allowlist []string) {
+	for _, c := range comments {
+		if c.ID == 0 {
+			continue // cannot dedup without a stable id
+		}
+		verb, scope, payload, ok := parseDirective(c.Body, p.botLogin)
+		if !ok {
+			continue
+		}
+		done, err := p.store.DirectiveProcessed(c.ID)
+		if err != nil {
+			slog.Warn("pipeline: directive dedup check failed", "err", err, "comment_id", c.ID)
+			continue
+		}
+		if done {
+			continue
+		}
+		switch {
+		case scope != "repo":
+			slog.Info("pipeline: ignoring directive with unsupported scope", "scope", scope, "repo", pr.Repo)
+		case !authorAllowed(allowlist, c.Author):
+			slog.Info("pipeline: ignoring directive from unauthorized author", "author", c.Author, "repo", pr.Repo)
+		default:
+			p.applyDirective(pr, verb, payload, c)
+		}
+		p.markDirective(c.ID, verb)
+	}
+}
+
+func (p *Pipeline) applyDirective(pr *github.PullRequest, verb, payload string, c github.Comment) {
+	switch verb {
+	case directiveRemember:
+		id, err := p.store.AddRepoInstruction(pr.Repo, payload, c.Author, c.ID)
+		if err != nil {
+			slog.Warn("pipeline: add repo instruction failed", "err", err, "repo", pr.Repo)
+			return
+		}
+		p.reply(pr, fmt.Sprintf("✅ Remembered for %s (#%d): %s", pr.Repo, id, payload))
+	case directiveForget:
+		id, perr := strconv.ParseInt(strings.TrimSpace(payload), 10, 64)
+		if perr != nil {
+			p.reply(pr, fmt.Sprintf("⚠️ `forget` expects a numeric instruction id; got %q. Use `@%s list` to see ids.", payload, p.botLogin))
+			return
+		}
+		removed, err := p.store.DeleteRepoInstruction(pr.Repo, id)
+		if err != nil {
+			slog.Warn("pipeline: delete repo instruction failed", "err", err, "repo", pr.Repo)
+			return
+		}
+		if !removed {
+			p.reply(pr, fmt.Sprintf("⚠️ No standing instruction #%d for %s.", id, pr.Repo))
+			return
+		}
+		p.reply(pr, fmt.Sprintf("🗑️ Forgot #%d for %s.", id, pr.Repo))
+	case directiveList:
+		p.reply(pr, p.formatInstructionList(pr.Repo))
+	}
+}
+
+func (p *Pipeline) reply(pr *github.PullRequest, body string) {
+	if _, err := p.gh.PostComment(pr.Repo, pr.Number, body); err != nil {
+		slog.Warn("pipeline: post directive reply failed", "err", err, "repo", pr.Repo, "pr", pr.Number)
+	}
+}
+
+func (p *Pipeline) markDirective(commentID int64, verb string) {
+	if err := p.store.MarkDirectiveProcessed(commentID, verb); err != nil {
+		slog.Warn("pipeline: mark directive processed failed", "err", err, "comment_id", commentID)
+	}
+}
+
+func (p *Pipeline) formatInstructionList(repo string) string {
+	items, err := p.store.ListRepoInstructions(repo)
+	if err != nil {
+		slog.Warn("pipeline: list repo instructions failed", "err", err, "repo", repo)
+		return "⚠️ Could not read standing instructions."
+	}
+	if len(items) == 0 {
+		return fmt.Sprintf("No standing instructions for %s.", repo)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Standing instructions for %s:\n", repo)
+	for _, it := range items {
+		fmt.Fprintf(&b, "- #%d: %s\n", it.ID, it.Instruction)
 	}
 	return b.String()
 }

--- a/daemon/internal/pipeline/directives.go
+++ b/daemon/internal/pipeline/directives.go
@@ -1,0 +1,95 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+const (
+	directiveRemember = "remember"
+	directiveForget   = "forget"
+	directiveList     = "list"
+)
+
+// parseDirective extracts a heimdallm instruction directive addressed to
+// botLogin from a comment body. Returns ok=false when the comment is not a
+// recognized directive. Grammar (case-insensitive, leading whitespace allowed):
+//
+//	@<botLogin> <verb>[(<scope>)][: <payload>]
+//
+// verb ∈ {remember, forget, list}; scope defaults to "repo". remember and
+// forget require a non-empty payload; list takes none.
+func parseDirective(body, botLogin string) (verb, scope, payload string, ok bool) {
+	if botLogin == "" {
+		return "", "", "", false
+	}
+	line := strings.TrimSpace(body)
+	mention := "@" + botLogin
+	if !strings.HasPrefix(strings.ToLower(line), strings.ToLower(mention)) {
+		return "", "", "", false
+	}
+	rest := strings.TrimSpace(line[len(mention):])
+
+	head := rest
+	if i := strings.Index(rest, ":"); i >= 0 {
+		head = strings.TrimSpace(rest[:i])
+		payload = strings.TrimSpace(rest[i+1:])
+	}
+
+	scope = "repo"
+	if i := strings.Index(head, "("); i >= 0 && strings.HasSuffix(head, ")") {
+		scope = strings.ToLower(strings.TrimSpace(head[i+1 : len(head)-1]))
+		head = strings.TrimSpace(head[:i])
+	}
+	if scope == "" {
+		scope = "repo"
+	}
+
+	verb = strings.ToLower(strings.TrimSpace(head))
+	switch verb {
+	case directiveRemember, directiveForget:
+		if payload == "" {
+			return "", "", "", false
+		}
+	case directiveList:
+		// no payload
+	default:
+		return "", "", "", false
+	}
+	return verb, scope, payload, true
+}
+
+// authorAllowed mirrors config.RepoAI.MatchesInstructionAuthors but operates on
+// the resolved allowlist slice threaded through RunOptions. It is duplicated
+// here deliberately: the pipeline package does not import config (the codebase
+// already shadows config<->pipeline types to avoid an import cycle — see
+// config.ResolvedReviewGuards). Empty allowlist denies everyone.
+func authorAllowed(allowlist []string, login string) bool {
+	login = strings.ToLower(strings.TrimSpace(strings.TrimLeft(login, "@")))
+	if login == "" {
+		return false
+	}
+	for _, a := range allowlist {
+		if strings.ToLower(strings.TrimSpace(strings.TrimLeft(a, "@"))) == login {
+			return true
+		}
+	}
+	return false
+}
+
+// formatStandingInstructions renders the persistent instruction set as a
+// high-salience prompt section. Returns "" when there are none (the section is
+// then omitted from the prompt entirely).
+func formatStandingInstructions(items []store.RepoInstruction) string {
+	if len(items) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("PROJECT STANDING INSTRUCTIONS (set by repo maintainers — authoritative):\n")
+	for _, it := range items {
+		fmt.Fprintf(&b, "- %s\n", it.Instruction)
+	}
+	return b.String()
+}

--- a/daemon/internal/pipeline/directives.go
+++ b/daemon/internal/pipeline/directives.go
@@ -30,7 +30,13 @@ func parseDirective(body, botLogin string) (verb, scope, payload string, ok bool
 	if !strings.HasPrefix(strings.ToLower(line), strings.ToLower(mention)) {
 		return "", "", "", false
 	}
-	rest := strings.TrimSpace(line[len(mention):])
+	raw := line[len(mention):]
+	// Require a word boundary after the mention so a login that is a strict
+	// prefix of the next token (e.g. "@heimdallmremember") does not match.
+	if raw != "" && raw[0] != ' ' && raw[0] != '\t' && raw[0] != '(' {
+		return "", "", "", false
+	}
+	rest := strings.TrimSpace(raw)
 
 	head := rest
 	if i := strings.Index(rest, ":"); i >= 0 {
@@ -54,7 +60,9 @@ func parseDirective(body, botLogin string) (verb, scope, payload string, ok bool
 			return "", "", "", false
 		}
 	case directiveList:
-		// no payload
+		if payload != "" {
+			return "", "", "", false
+		}
 	default:
 		return "", "", "", false
 	}

--- a/daemon/internal/pipeline/directives.go
+++ b/daemon/internal/pipeline/directives.go
@@ -112,6 +112,12 @@ func formatStandingInstructions(items []store.RepoInstruction) string {
 // abort the surrounding review.
 func (p *Pipeline) processDirectives(pr *github.PullRequest, comments []github.Comment, allowlist []string) {
 	for _, c := range comments {
+		// Dedup is keyed on the GitHub comment ID. Directives are normally
+		// top-level issue comments; review-comment and issue-comment IDs are
+		// separate GitHub sequences, so a cross-space ID collision could in
+		// theory mark one directive as already-seen. The blast radius is a
+		// single missed directive (recoverable by re-commenting), so we accept
+		// the bare-ID key rather than a (kind, id) composite.
 		if c.ID == 0 {
 			continue // cannot dedup without a stable id
 		}
@@ -128,10 +134,16 @@ func (p *Pipeline) processDirectives(pr *github.PullRequest, comments []github.C
 			continue
 		}
 		switch {
-		case scope != "repo":
-			slog.Info("pipeline: ignoring directive with unsupported scope", "scope", scope, "repo", pr.Repo)
 		case !authorAllowed(allowlist, c.Author):
+			// Silent for unauthorized users — no reply, so the bot does not
+			// advertise the directive feature to non-maintainers. Marked
+			// processed below so it is not re-evaluated every poll cycle.
 			slog.Info("pipeline: ignoring directive from unauthorized author", "author", c.Author, "repo", pr.Repo)
+		case scope != "repo":
+			// Authorized user, but only repo scope is implemented. Reply so the
+			// maintainer knows why nothing happened, then burn the comment.
+			slog.Info("pipeline: ignoring directive with unsupported scope", "scope", scope, "repo", pr.Repo)
+			p.reply(pr, fmt.Sprintf("⚠️ Only repo-scoped instructions are supported. Drop the scope (e.g. `@%s %s: …`) to apply it to %s.", p.botLogin, verb, pr.Repo))
 		default:
 			p.applyDirective(pr, verb, payload, c)
 		}

--- a/daemon/internal/pipeline/directives_test.go
+++ b/daemon/internal/pipeline/directives_test.go
@@ -5,30 +5,34 @@ import "testing"
 func TestParseDirective(t *testing.T) {
 	const bot = "heimdallm"
 	cases := []struct {
-		name              string
-		body              string
-		wantOK            bool
-		wantVerb, wantPay string
+		name                        string
+		body                        string
+		wantOK                      bool
+		wantVerb, wantScope, wantPay string
 	}{
-		{"remember", "@heimdallm remember: unauth endpoints are fine", true, "remember", "unauth endpoints are fine"},
-		{"remember scoped", "@heimdallm remember(repo): rule X", true, "remember", "rule X"},
-		{"forget", "@heimdallm forget: 12", true, "forget", "12"},
-		{"list", "@heimdallm list", true, "list", ""},
-		{"case-insensitive mention+verb", "@HeimdallM REMEMBER: y", true, "remember", "y"},
-		{"leading whitespace", "   @heimdallm list", true, "list", ""},
-		{"not a directive", "looks good to me", false, "", ""},
-		{"mention without verb", "@heimdallm hello there", false, "", ""},
-		{"remember without payload", "@heimdallm remember:", false, "", ""},
-		{"unknown verb", "@heimdallm frobnicate: x", false, "", ""},
+		{"remember", "@heimdallm remember: unauth endpoints are fine", true, "remember", "repo", "unauth endpoints are fine"},
+		{"remember scoped", "@heimdallm remember(repo): rule X", true, "remember", "repo", "rule X"},
+		{"forget", "@heimdallm forget: 12", true, "forget", "repo", "12"},
+		{"list", "@heimdallm list", true, "list", "repo", ""},
+		{"case-insensitive mention+verb", "@HeimdallM REMEMBER: y", true, "remember", "repo", "y"},
+		{"leading whitespace", "   @heimdallm list", true, "list", "repo", ""},
+		{"not a directive", "looks good to me", false, "", "", ""},
+		{"mention without verb", "@heimdallm hello there", false, "", "", ""},
+		{"remember without payload", "@heimdallm remember:", false, "", "", ""},
+		{"unknown verb", "@heimdallm frobnicate: x", false, "", "", ""},
+		{"remember scoped non-default", "@heimdallm remember(global): rule X", true, "remember", "global", "rule X"},
+		{"list scoped", "@heimdallm list(global)", true, "list", "global", ""},
+		{"no word boundary", "@heimdallmremember: x", false, "", "", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			verb, _, payload, ok := parseDirective(tc.body, bot)
+			verb, scope, payload, ok := parseDirective(tc.body, bot)
 			if ok != tc.wantOK {
 				t.Fatalf("ok=%v want %v", ok, tc.wantOK)
 			}
-			if ok && (verb != tc.wantVerb || payload != tc.wantPay) {
-				t.Fatalf("got verb=%q payload=%q; want verb=%q payload=%q", verb, payload, tc.wantVerb, tc.wantPay)
+			if ok && (verb != tc.wantVerb || scope != tc.wantScope || payload != tc.wantPay) {
+				t.Fatalf("got verb=%q scope=%q payload=%q; want verb=%q scope=%q payload=%q",
+					verb, scope, payload, tc.wantVerb, tc.wantScope, tc.wantPay)
 			}
 		})
 	}

--- a/daemon/internal/pipeline/directives_test.go
+++ b/daemon/internal/pipeline/directives_test.go
@@ -1,0 +1,45 @@
+package pipeline
+
+import "testing"
+
+func TestParseDirective(t *testing.T) {
+	const bot = "heimdallm"
+	cases := []struct {
+		name              string
+		body              string
+		wantOK            bool
+		wantVerb, wantPay string
+	}{
+		{"remember", "@heimdallm remember: unauth endpoints are fine", true, "remember", "unauth endpoints are fine"},
+		{"remember scoped", "@heimdallm remember(repo): rule X", true, "remember", "rule X"},
+		{"forget", "@heimdallm forget: 12", true, "forget", "12"},
+		{"list", "@heimdallm list", true, "list", ""},
+		{"case-insensitive mention+verb", "@HeimdallM REMEMBER: y", true, "remember", "y"},
+		{"leading whitespace", "   @heimdallm list", true, "list", ""},
+		{"not a directive", "looks good to me", false, "", ""},
+		{"mention without verb", "@heimdallm hello there", false, "", ""},
+		{"remember without payload", "@heimdallm remember:", false, "", ""},
+		{"unknown verb", "@heimdallm frobnicate: x", false, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			verb, _, payload, ok := parseDirective(tc.body, bot)
+			if ok != tc.wantOK {
+				t.Fatalf("ok=%v want %v", ok, tc.wantOK)
+			}
+			if ok && (verb != tc.wantVerb || payload != tc.wantPay) {
+				t.Fatalf("got verb=%q payload=%q; want verb=%q payload=%q", verb, payload, tc.wantVerb, tc.wantPay)
+			}
+		})
+	}
+}
+
+func TestAuthorAllowed(t *testing.T) {
+	allow := []string{"Alice", "@bob"}
+	if !authorAllowed(allow, "alice") || !authorAllowed(allow, "@BOB") {
+		t.Error("alice/bob should be allowed")
+	}
+	if authorAllowed(allow, "mallory") || authorAllowed(allow, "") || authorAllowed(nil, "alice") {
+		t.Error("unexpected allow")
+	}
+}

--- a/daemon/internal/pipeline/directives_test.go
+++ b/daemon/internal/pipeline/directives_test.go
@@ -122,3 +122,45 @@ func TestProcessDirectives_RememberForgetDedup(t *testing.T) {
 }
 
 func itoa(n int64) string { return fmt.Sprintf("%d", n) }
+
+func TestProcessDirectives_UnsupportedScopeRepliesNoStore(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	gh := &fakeGH{}
+	p := New(s, gh, nil, nopNotifier{})
+	p.SetBotLogin("heimdallm")
+	pr := &github.PullRequest{Repo: "org/repo", Number: 9}
+
+	p.processDirectives(pr, []github.Comment{
+		{ID: 50, Author: "alice", Body: "@heimdallm remember(global): everywhere"},
+	}, []string{"alice"})
+
+	if items, _ := s.ListRepoInstructions("org/repo"); len(items) != 0 {
+		t.Fatalf("unsupported scope must not store an instruction, got %d", len(items))
+	}
+	if len(gh.posted) != 1 {
+		t.Fatalf("want 1 reply explaining unsupported scope, got %d", len(gh.posted))
+	}
+}
+
+func TestProcessDirectives_UnauthorizedIsSilent(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	gh := &fakeGH{}
+	p := New(s, gh, nil, nopNotifier{})
+	p.SetBotLogin("heimdallm")
+	pr := &github.PullRequest{Repo: "org/repo", Number: 9}
+
+	// Unauthorized user, even with bad scope, gets NO reply (no info leak).
+	p.processDirectives(pr, []github.Comment{
+		{ID: 51, Author: "mallory", Body: "@heimdallm remember(global): everywhere"},
+	}, []string{"alice"})
+
+	if len(gh.posted) != 0 {
+		t.Fatalf("unauthorized directive must get no reply, got %d", len(gh.posted))
+	}
+}

--- a/daemon/internal/pipeline/directives_test.go
+++ b/daemon/internal/pipeline/directives_test.go
@@ -12,9 +12,9 @@ import (
 func TestParseDirective(t *testing.T) {
 	const bot = "heimdallm"
 	cases := []struct {
-		name                        string
-		body                        string
-		wantOK                      bool
+		name                         string
+		body                         string
+		wantOK                       bool
 		wantVerb, wantScope, wantPay string
 	}{
 		{"remember", "@heimdallm remember: unauth endpoints are fine", true, "remember", "repo", "unauth endpoints are fine"},

--- a/daemon/internal/pipeline/directives_test.go
+++ b/daemon/internal/pipeline/directives_test.go
@@ -1,6 +1,13 @@
 package pipeline
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/store"
+)
 
 func TestParseDirective(t *testing.T) {
 	const bot = "heimdallm"
@@ -47,3 +54,71 @@ func TestAuthorAllowed(t *testing.T) {
 		t.Error("unexpected allow")
 	}
 }
+
+// fakeGH satisfies the pipeline's gh interface; only the methods used by
+// processDirectives do real work.
+type fakeGH struct {
+	posted []string
+}
+
+func (f *fakeGH) FetchDiff(string, int) (string, error)               { return "", nil }
+func (f *fakeGH) GetPRHeadSHA(string, int) (string, error)            { return "", nil }
+func (f *fakeGH) FetchComments(string, int) ([]github.Comment, error) { return nil, nil }
+func (f *fakeGH) SubmitReview(string, int, string, string) (int64, string, error) {
+	return 0, "", nil
+}
+func (f *fakeGH) PostComment(_ string, _ int, body string) (time.Time, error) {
+	f.posted = append(f.posted, body)
+	return time.Time{}, nil
+}
+
+type nopNotifier struct{}
+
+func (nopNotifier) Notify(string, string) {}
+
+func TestProcessDirectives_RememberForgetDedup(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	gh := &fakeGH{}
+	p := New(s, gh, nil, nopNotifier{})
+	p.SetBotLogin("heimdallm")
+
+	pr := &github.PullRequest{Repo: "org/repo", Number: 7}
+	allow := []string{"alice"}
+
+	comments := []github.Comment{
+		{ID: 1, Author: "mallory", Body: "@heimdallm remember: evil"},
+		{ID: 2, Author: "alice", Body: "@heimdallm remember: unauth endpoints are fine"},
+	}
+	p.processDirectives(pr, comments, allow)
+
+	items, _ := s.ListRepoInstructions("org/repo")
+	if len(items) != 1 || items[0].Instruction != "unauth endpoints are fine" {
+		t.Fatalf("want 1 authorized instruction, got %+v", items)
+	}
+	if len(gh.posted) != 1 {
+		t.Fatalf("want 1 ack, got %d: %v", len(gh.posted), gh.posted)
+	}
+
+	// Re-processing the same comments is a no-op (dedup via directive_marks).
+	p.processDirectives(pr, comments, allow)
+	items, _ = s.ListRepoInstructions("org/repo")
+	if len(items) != 1 {
+		t.Fatalf("dedup failed: got %d instructions", len(items))
+	}
+	if len(gh.posted) != 1 {
+		t.Fatalf("dedup failed: got %d acks", len(gh.posted))
+	}
+
+	// forget removes it.
+	forget := []github.Comment{{ID: 3, Author: "alice", Body: "@heimdallm forget: " + itoa(items[0].ID)}}
+	p.processDirectives(pr, forget, allow)
+	items, _ = s.ListRepoInstructions("org/repo")
+	if len(items) != 0 {
+		t.Fatalf("forget failed: %d remain", len(items))
+	}
+}
+
+func itoa(n int64) string { return fmt.Sprintf("%d", n) }

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -293,6 +293,10 @@ type RunOptions struct {
 	// before pushing PRs into the pipeline; this layer prevents regressions
 	// if a new caller forgets.
 	Guards GateConfig
+	// InstructionAuthors is the resolved allowlist of GitHub logins permitted
+	// to set persistent per-repo instructions via comment directives (#383).
+	// Empty disables the comment-driven path for this repo.
+	InstructionAuthors []string
 }
 
 // Run executes the full review pipeline for one PR and publishes the review to GitHub.
@@ -409,6 +413,21 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		p.publishSkipped(pr, SkipReasonLegacyBackfill)
 		return nil, nil
 	}
+
+	// 2a.5 Process persistent-instruction directives (#383) BEFORE the
+	// re-review skip gate so a remember/forget takes effect even on cycles
+	// that will not produce a review. Opt-in: only when the repo configures an
+	// instruction-author allowlist, so unconfigured repos pay no extra fetch.
+	var prComments []github.Comment
+	if len(opts.InstructionAuthors) > 0 {
+		if cs, err := p.gh.FetchComments(pr.Repo, pr.Number); err != nil {
+			slog.Warn("pipeline: fetch comments for directives failed", "err", err, "repo", pr.Repo, "pr", pr.Number)
+		} else {
+			prComments = cs
+			p.processDirectives(pr, prComments, opts.InstructionAuthors)
+		}
+	}
+
 	if prevReview != nil && pr.Head.SHA != "" {
 		// Regardless of whether the HEAD SHA changed, the bot must not
 		// re-review unless the operator explicitly re-requested it. The
@@ -449,11 +468,16 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 			"prev_head_sha", prevReview.HeadSHA, "head_sha", pr.Head.SHA)
 	}
 
-	// 2b. Fetch PR comments for context (non-fatal: proceed without if unavailable)
-	prComments, err := p.gh.FetchComments(pr.Repo, pr.Number)
-	if err != nil {
-		slog.Warn("pipeline: failed to fetch PR comments, proceeding without", "err", err)
-		prComments = nil
+	// 2b. Fetch PR comments for context (non-fatal: proceed without if unavailable).
+	// prComments may already be populated by the directive-fetch above; reuse it
+	// to avoid a duplicate API call.
+	if prComments == nil {
+		cs, err := p.gh.FetchComments(pr.Repo, pr.Number)
+		if err != nil {
+			slog.Warn("pipeline: failed to fetch PR comments, proceeding without", "err", err)
+			cs = nil
+		}
+		prComments = cs
 	}
 	commentsSection := formatComments(prComments, pr.User.Login)
 
@@ -474,15 +498,22 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	promptTemplate := executor.DefaultTemplate()
 	var cliFlags string
 	p.applyPrompt(promptOverride, opts.AgentPromptID, &promptTemplate, &cliFlags)
+	var standing string
+	if instr, err := p.store.ListRepoInstructions(pr.Repo); err != nil {
+		slog.Warn("pipeline: list repo instructions for prompt failed", "err", err, "repo", pr.Repo)
+	} else {
+		standing = formatStandingInstructions(instr)
+	}
 	prompt := executor.BuildPromptFromTemplate(promptTemplate, executor.PRContext{
-		Title:         pr.Title,
-		Number:        pr.Number,
-		Repo:          pr.Repo,
-		Author:        pr.User.Login,
-		Link:          pr.HTMLURL,
-		Diff:          diff,
-		Comments:      commentsSection,
-		ReviewContext: reviewCtx,
+		Title:                pr.Title,
+		Number:               pr.Number,
+		Repo:                 pr.Repo,
+		Author:               pr.User.Login,
+		Link:                 pr.HTMLURL,
+		Diff:                 diff,
+		Comments:             commentsSection,
+		ReviewContext:        reviewCtx,
+		StandingInstructions: standing,
 	})
 
 	// 4. Select CLI (profile can override the global primary/fallback)

--- a/daemon/internal/store/repo_instructions.go
+++ b/daemon/internal/store/repo_instructions.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// RepoInstruction is a persistent, project-scoped review instruction captured
+// from an authorized PR comment directive. It is injected into every future
+// review of the repo. See issue #383.
+type RepoInstruction struct {
+	ID          int64
+	Repo        string
+	Instruction string
+	Author      string
+	CommentID   int64
+	CreatedAt   time.Time
+}
+
+// ListRepoInstructions returns all standing instructions for a repo, oldest first.
+func (s *Store) ListRepoInstructions(repo string) ([]RepoInstruction, error) {
+	rows, err := s.db.Query(
+		"SELECT id, repo, instruction, author, comment_id, created_at FROM repo_instructions WHERE repo = ? ORDER BY id ASC",
+		repo,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list repo instructions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []RepoInstruction
+	for rows.Next() {
+		var ri RepoInstruction
+		var createdAt string
+		if err := rows.Scan(&ri.ID, &ri.Repo, &ri.Instruction, &ri.Author, &ri.CommentID, &createdAt); err != nil {
+			return nil, fmt.Errorf("store: scan repo instruction: %w", err)
+		}
+		ri.CreatedAt, _ = time.Parse(sqliteTimeFormat, createdAt)
+		out = append(out, ri)
+	}
+	return out, rows.Err()
+}
+
+// AddRepoInstruction inserts a new standing instruction and returns its id.
+func (s *Store) AddRepoInstruction(repo, instruction, author string, commentID int64) (int64, error) {
+	res, err := s.db.Exec(
+		"INSERT INTO repo_instructions (repo, instruction, author, comment_id, created_at) VALUES (?, ?, ?, ?, ?)",
+		repo, instruction, author, commentID, time.Now().UTC().Format(sqliteTimeFormat),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("store: add repo instruction: %w", err)
+	}
+	return res.LastInsertId()
+}
+
+// DeleteRepoInstruction removes a standing instruction by id, scoped to repo so
+// a directive on one repo cannot delete another repo's instruction. Returns
+// (false, nil) when no row matched.
+func (s *Store) DeleteRepoInstruction(repo string, id int64) (bool, error) {
+	res, err := s.db.Exec("DELETE FROM repo_instructions WHERE repo = ? AND id = ?", repo, id)
+	if err != nil {
+		return false, fmt.Errorf("store: delete repo instruction: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// DirectiveProcessed reports whether a directive comment has already been handled.
+func (s *Store) DirectiveProcessed(commentID int64) (bool, error) {
+	var one int
+	err := s.db.QueryRow("SELECT 1 FROM directive_marks WHERE comment_id = ?", commentID).Scan(&one)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("store: directive processed: %w", err)
+	}
+	return true, nil
+}
+
+// MarkDirectiveProcessed records that a directive comment has been handled so it
+// is never re-applied or re-acked across poll cycles. Idempotent.
+func (s *Store) MarkDirectiveProcessed(commentID int64, verb string) error {
+	if _, err := s.db.Exec(
+		"INSERT INTO directive_marks (comment_id, verb, processed_at) VALUES (?, ?, ?) ON CONFLICT(comment_id) DO NOTHING",
+		commentID, verb, time.Now().UTC().Format(sqliteTimeFormat),
+	); err != nil {
+		return fmt.Errorf("store: mark directive processed: %w", err)
+	}
+	return nil
+}

--- a/daemon/internal/store/repo_instructions.go
+++ b/daemon/internal/store/repo_instructions.go
@@ -36,7 +36,9 @@ func (s *Store) ListRepoInstructions(repo string) ([]RepoInstruction, error) {
 		if err := rows.Scan(&ri.ID, &ri.Repo, &ri.Instruction, &ri.Author, &ri.CommentID, &createdAt); err != nil {
 			return nil, fmt.Errorf("store: scan repo instruction: %w", err)
 		}
-		ri.CreatedAt, _ = time.Parse(sqliteTimeFormat, createdAt)
+		if ri.CreatedAt, err = time.Parse(sqliteTimeFormat, createdAt); err != nil {
+			return nil, fmt.Errorf("store: parse created_at %q: %w", createdAt, err)
+		}
 		out = append(out, ri)
 	}
 	return out, rows.Err()

--- a/daemon/internal/store/repo_instructions_test.go
+++ b/daemon/internal/store/repo_instructions_test.go
@@ -1,0 +1,70 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+func TestRepoInstructions_AddListDelete(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	id1, err := s.AddRepoInstruction("org/repo", "unauthenticated endpoints are intentional", "alice", 1001)
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := s.AddRepoInstruction("org/repo", "ignore TODO comments", "alice", 1002); err != nil {
+		t.Fatalf("add2: %v", err)
+	}
+	if _, err := s.AddRepoInstruction("org/other", "other repo rule", "bob", 1003); err != nil {
+		t.Fatalf("add3: %v", err)
+	}
+
+	items, err := s.ListRepoInstructions("org/repo")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(items))
+	}
+	if items[0].ID != id1 || items[0].Instruction != "unauthenticated endpoints are intentional" || items[0].Author != "alice" || items[0].CommentID != 1001 {
+		t.Fatalf("unexpected first item: %+v", items[0])
+	}
+
+	ok, err := s.DeleteRepoInstruction("org/repo", id1)
+	if err != nil || !ok {
+		t.Fatalf("delete: ok=%v err=%v", ok, err)
+	}
+	ok, err = s.DeleteRepoInstruction("org/repo", id1)
+	if err != nil || ok {
+		t.Fatalf("re-delete: want ok=false err=nil, got ok=%v err=%v", ok, err)
+	}
+	items, _ = s.ListRepoInstructions("org/repo")
+	if len(items) != 1 {
+		t.Fatalf("want 1 after delete, got %d", len(items))
+	}
+}
+
+func TestDirectiveMarks_Idempotent(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	done, err := s.DirectiveProcessed(42)
+	if err != nil || done {
+		t.Fatalf("want not processed: done=%v err=%v", done, err)
+	}
+	if err := s.MarkDirectiveProcessed(42, "remember"); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	if err := s.MarkDirectiveProcessed(42, "remember"); err != nil {
+		t.Fatalf("re-mark: %v", err)
+	}
+	done, err = s.DirectiveProcessed(42)
+	if err != nil || !done {
+		t.Fatalf("want processed: done=%v err=%v", done, err)
+	}
+}

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -156,6 +156,26 @@ CREATE TABLE IF NOT EXISTS issue_triage_in_flight (
   started_at  DATETIME NOT NULL,
   PRIMARY KEY (issue_id, updated_at)
 );
+
+-- Persistent per-repo review instructions captured from authorized PR
+-- comment directives (#383). Injected into every future review of the repo.
+CREATE TABLE IF NOT EXISTS repo_instructions (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  repo        TEXT NOT NULL,
+  instruction TEXT NOT NULL,
+  author      TEXT NOT NULL,
+  comment_id  INTEGER NOT NULL,
+  created_at  DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_repo_instructions_repo ON repo_instructions(repo);
+
+-- Dedup/audit guard so each directive comment is applied/acked exactly once
+-- across poll cycles. GitHub comment ids are stable and effectively unique.
+CREATE TABLE IF NOT EXISTS directive_marks (
+  comment_id   INTEGER PRIMARY KEY,
+  verb         TEXT NOT NULL,
+  processed_at DATETIME NOT NULL
+);
 `
 
 // Open opens (or creates) a SQLite database at dsn and applies the schema.
@@ -262,6 +282,20 @@ func Open(dsn string) (*Store, error) {
 		renamed_at  DATETIME NOT NULL
 	)`)
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_repo_renames_old ON repo_renames(old_repo)")
+	db.Exec(`CREATE TABLE IF NOT EXISTS repo_instructions (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		repo        TEXT NOT NULL,
+		instruction TEXT NOT NULL,
+		author      TEXT NOT NULL,
+		comment_id  INTEGER NOT NULL,
+		created_at  DATETIME NOT NULL
+	)`)
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_repo_instructions_repo ON repo_instructions(repo)")
+	db.Exec(`CREATE TABLE IF NOT EXISTS directive_marks (
+		comment_id   INTEGER PRIMARY KEY,
+		verb         TEXT NOT NULL,
+		processed_at DATETIME NOT NULL
+	)`)
 	// watch_state is owned by bus.NewWatchStore at runtime, but RenameRepo
 	// needs to UPDATE rows here in the same TX as the prs/issues moves.
 	// Mirror the schema with IF NOT EXISTS so the rename can run from

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -168,6 +168,7 @@ CREATE TABLE IF NOT EXISTS repo_instructions (
   created_at  DATETIME NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_repo_instructions_repo ON repo_instructions(repo);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_repo_instructions_comment ON repo_instructions(comment_id);
 
 -- Dedup/audit guard so each directive comment is applied/acked exactly once
 -- across poll cycles. GitHub comment ids are stable and effectively unique.
@@ -291,6 +292,7 @@ func Open(dsn string) (*Store, error) {
 		created_at  DATETIME NOT NULL
 	)`)
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_repo_instructions_repo ON repo_instructions(repo)")
+	db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_repo_instructions_comment ON repo_instructions(comment_id)")
 	db.Exec(`CREATE TABLE IF NOT EXISTS directive_marks (
 		comment_id   INTEGER PRIMARY KEY,
 		verb         TEXT NOT NULL,


### PR DESCRIPTION
## Summary

Adds comment-driven, persistent per-repo review instructions to Heimdallm. An allowlisted maintainer can teach the bot a project-specific rule directly from a PR comment (e.g. *"unauthenticated endpoints here are intentional, don't flag them"*), and that instruction persists across PRs — it is injected into every future review of the repo. This addresses freepik-company/ai-platform-workspace#383: today, corrections made in a PR comment only live within that PR's context and are forgotten once it closes, forcing maintainers to re-justify the same decisions repeatedly. The pre-existing agent-profile mechanism required editing config/UI; this is the low-friction, in-PR path.

## How it works

A maintainer comments a directive addressed to the bot:

- `@heimdallm remember: <text>` — persist a standing instruction for the repo
- `@heimdallm forget: <id>` — remove one by id
- `@heimdallm list` — reply with the repo's current instructions + ids

Flow:

1. **Authorization** — `config.RepoAI.InstructionAuthors` (new `instruction_authors` allowlist) is resolved through the existing repo > org > global hierarchy, exactly like `pr_reviewers`. An **empty allowlist denies everyone** — the feature is opt-in. Unauthorized directives get no reply (no info leak) and are marked processed so they aren't re-evaluated.
2. **Capture (Approach B)** — directives are processed in `pipeline.Run` **before** the SHA/re-request skip gate, so a `remember`/`forget` takes effect even on poll cycles that produce no review. The comment fetch is reused (single API call), and the whole path is skipped when no allowlist is configured (zero cost for repos not using it).
3. **Persistence** — two new SQLite tables following the per-domain store convention: `repo_instructions` (the live set) and `directive_marks` (a dedup guard so each directive comment is applied/acked exactly once). A `UNIQUE(comment_id)` index makes dedup self-healing if a mark write fails mid-flight.
4. **Injection** — on every review, active instructions render into a dedicated, high-salience **"PROJECT STANDING INSTRUCTIONS (set by repo maintainers — authoritative)"** prompt section via a new `{standing_instructions}` placeholder, fenced separately from untrusted PR/diff content.

Key files: `config.go` (allowlist + `MatchesInstructionAuthors`), `store/repo_instructions.go` (+ schema/migration in `store.go`), `pipeline/directives.go` (parser + processing), `pipeline/pipeline.go` (wiring), `executor/prompt.go` (placeholder), `cmd/heimdallm/main.go` (threads the resolved allowlist into `RunOptions`).

## Scope

**In scope**
- Repo-scoped standing instructions; `remember` / `forget` / `list`.
- Allowlist authorization (global/org/repo, inherit-override; empty = inert).
- Prompt injection; confirmation replies; persistence + idempotent migration; tests at every layer.

**Out of scope (deliberate, possible follow-ups)**
- Global/org-wide instruction scope (an authorized `remember(global): …` gets a polite "only repo scope supported" reply).
- Web-UI CRUD for instructions (DB + directives only).
- Inferring instructions from dismissed-finding justifications.
- GitHub permission/role-based auth (allowlist only).

## Security

- PR comments are untrusted input; only allowlisted logins can mutate instructions.
- Standing instructions are fenced as their own authoritative section, separate from the untrusted `<user_content>`/`{comments}` blocks.
- Bot replies never begin with `@heimdallm <verb>`, so they cannot re-trigger the parser.

## Test plan

- [x] `go test ./...` green across store/config/pipeline/executor/github/cmd (one pre-existing, unrelated `TestDetect_Fallback` failure — a local CLI-detection test that picks up a real `codex` binary on `PATH`; fails identically on `origin/main`).
- [x] `go build ./...` and `go vet ./...` clean; changed files gofmt-clean.
- [x] `make verify-linux` passes (Docker Linux build gate).
- [x] Unit tests: directive grammar (incl. word-boundary + scoped forms), allowlist resolution (inherit/override/global, empty=deny), store CRUD + idempotent dedup, processDirectives (authorized apply, unauthorized silent, unsupported-scope reply, dedup no-op, forget), prompt substitution/prepend/empty.
- [ ] Reviewers: manual smoke on a real repo — set `[ai.repos."org/repo"] instruction_authors = ["yourlogin"]`, comment `@heimdallm remember: …`, confirm the ack + that the next review prompt includes the standing-instructions section, then `@heimdallm forget: <id>`.

Refs freepik-company/ai-platform-workspace#383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
