### PR TITLE
fix(github): return error on timeline pagination cap instead of partial results (closes #519)

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -744,15 +744,17 @@ type TimelineEvent struct {
 // regardless of the user's explicit intent.
 //
 // Returns an empty slice (not nil) when no relevant events exist —
-// callers can range over the result without a nil guard.
+// callers can range over the result without a nil guard. Returns an
+// error (never a partial slice) when the pagination cap is hit, so
+// callers can fail closed instead of acting on a truncated timeline
+// (#519).
 func (c *Client) GetPRTimelineEventsForReviewer(repo string, number int, login string) ([]TimelineEvent, error) {
 	if login == "" {
 		return nil, fmt.Errorf("github: GetPRTimelineEventsForReviewer: empty login")
 	}
 	out := []TimelineEvent{}
-	page := 1
-	for {
-		path := fmt.Sprintf("/repos/%s/issues/%d/timeline?per_page=100&page=%d", repo, number, page)
+	for page := 1; page <= maxPaginationPages; page++ {
+		path := fmt.Sprintf("/repos/%s/issues/%d/timeline?per_page=%d&page=%d", repo, number, perPage, page)
 		resp, err := c.do("GET", path, "application/vnd.github+json")
 		if err != nil {
 			return nil, fmt.Errorf("github: fetch timeline: %w", err)
@@ -801,42 +803,46 @@ func (c *Client) GetPRTimelineEventsForReviewer(repo string, number int, login s
 				}
 			}
 		}
-		// Stop paging when we get a short page (under per_page=100).
-		if len(raw) < 100 {
-			break
-		}
-		page++
-		// Hard cap so a misbehaving server can't make us iterate forever.
-		if page > 50 {
-			slog.Warn("github: timeline pagination cap hit, returning partial results",
-				"repo", repo, "pr", number, "pages", page)
-			break
+		// Stop paging when we get a short page (under per_page).
+		if len(raw) < perPage {
+			// Defensive re-sort: GitHub's timeline API documents ascending
+			// chronological order, but the contract is not load-bearing for us
+			// — pipeline.shouldBypassSHASkipForReReview relies on the slice
+			// being sorted to walk it backward in O(1) for the common case.
+			// A single sort here is cheap (events is filtered down to just
+			// review_requested / review_dismissed for one login) and immunises
+			// the caller against an undocumented re-ordering on GitHub's side.
+			sort.Slice(out, func(i, j int) bool {
+				return out[i].CreatedAt.Before(out[j].CreatedAt)
+			})
+			return out, nil
 		}
 	}
-	// Defensive re-sort: GitHub's timeline API documents ascending
-	// chronological order, but the contract is not load-bearing for us
-	// — pipeline.shouldBypassSHASkipForReReview relies on the slice
-	// being sorted to walk it backward in O(1) for the common case.
-	// A single sort here is cheap (events is filtered down to just
-	// review_requested / review_dismissed for one login) and immunises
-	// the caller against an undocumented re-ordering on GitHub's side.
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].CreatedAt.Before(out[j].CreatedAt)
-	})
-	return out, nil
+	// Hitting the cap with every page full is suspicious: either GitHub is
+	// misbehaving or this PR has >5,000 timeline events. Silently returning
+	// a truncated slice would drop exactly the tail events that
+	// pipeline.shouldBypassSHASkipForReReview walks backward to detect
+	// re-review intent (#322 Bug 5), so surface a hard error and let the
+	// caller fail closed — matching the cap-hit contract of
+	// fetchReviewComments / fetchIssueComments post-#516 (see #519).
+	slog.Warn("github: timeline pagination cap hit",
+		"repo", repo, "pr", number, "pages", maxPaginationPages)
+	return nil, fmt.Errorf("github: timeline pagination exceeded %d pages for %s#%d (per_page=%d, possible runaway)",
+		maxPaginationPages, repo, number, perPage)
 }
 
-// maxCommentPages bounds the number of pages fetchReviewComments and
-// fetchIssueComments will walk. GitHub returns 30 items per page by default
-// and 100 max; with per_page=100 this caps each fetcher at 5,000 comments,
-// well above the largest real PRs we've seen. The cap exists only to keep a
-// misbehaving server from making us iterate forever.
-const maxCommentPages = 50
+// maxPaginationPages bounds the number of pages the paginated endpoints
+// (fetchReviewComments, fetchIssueComments, GetPRTimelineEventsForReviewer)
+// will walk. GitHub returns 30 items per page by default and 100 max; with
+// per_page=100 this caps each fetcher at 5,000 items, well above the
+// largest real PRs we've seen. The cap exists only to keep a misbehaving
+// server from making us iterate forever.
+const maxPaginationPages = 50
 
-// perPage is the page size used for paginated comment endpoints. Kept
-// alongside maxCommentPages so changing either is an explicit decision,
-// and so the per_page query parameter and the short-page termination
-// check can't drift apart.
+// perPage is the page size used for paginated endpoints. Kept alongside
+// maxPaginationPages so changing either is an explicit decision, and so
+// the per_page query parameter and the short-page termination check
+// can't drift apart.
 const perPage = 100
 
 func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error) {
@@ -849,7 +855,7 @@ func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error)
 	// server-side default changes; callers downstream rely on ascending
 	// order.
 	comments := []Comment{}
-	for page := 1; page <= maxCommentPages; page++ {
+	for page := 1; page <= maxPaginationPages; page++ {
 		path := fmt.Sprintf("/repos/%s/pulls/%d/comments?per_page=%d&page=%d&sort=created&direction=asc",
 			repo, number, perPage, page)
 		resp, err := c.do("GET", path, "application/vnd.github+json")
@@ -902,9 +908,9 @@ func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error)
 	// ones a re-review depends on), so surface a hard error and match
 	// the mid-pagination error contract the other tests already enforce.
 	slog.Warn("github: fetch review comments pagination cap hit",
-		"repo", repo, "pr", number, "pages", maxCommentPages)
+		"repo", repo, "pr", number, "pages", maxPaginationPages)
 	return nil, fmt.Errorf("github: comment pagination exceeded %d pages for %s#%d (per_page=%d, possible runaway)",
-		maxCommentPages, repo, number, perPage)
+		maxPaginationPages, repo, number, perPage)
 }
 
 func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) {
@@ -912,7 +918,7 @@ func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) 
 	// so we don't lose the newest issue comments on long-running PRs or
 	// busy issues, and pin sort=created&direction=asc explicitly.
 	comments := []Comment{}
-	for page := 1; page <= maxCommentPages; page++ {
+	for page := 1; page <= maxPaginationPages; page++ {
 		path := fmt.Sprintf("/repos/%s/issues/%d/comments?per_page=%d&page=%d&sort=created&direction=asc",
 			repo, number, perPage, page)
 		resp, err := c.do("GET", path, "application/vnd.github+json")
@@ -951,9 +957,9 @@ func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) 
 	// See fetchReviewComments for the rationale: silent partial results
 	// at the cap would re-introduce the bug #512 fixes.
 	slog.Warn("github: fetch issue comments pagination cap hit",
-		"repo", repo, "issue", number, "pages", maxCommentPages)
+		"repo", repo, "issue", number, "pages", maxPaginationPages)
 	return nil, fmt.Errorf("github: comment pagination exceeded %d pages for %s#%d (per_page=%d, possible runaway)",
-		maxCommentPages, repo, number, perPage)
+		maxPaginationPages, repo, number, perPage)
 }
 
 // FetchLabels returns the label names for a repository.

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -410,7 +410,7 @@ func TestFetchComments_MidPaginationErrorOnIssuesPropagates(t *testing.T) {
 }
 
 // TestFetchComments_PaginationCapReturnsError locks in the contract that
-// hitting maxCommentPages with every page full surfaces a hard error
+// hitting maxPaginationPages with every page full surfaces a hard error
 // rather than a silently-truncated slice. Silent partial results here
 // would re-introduce the exact failure mode #512 exists to prevent
 // (dropping the newest comments) and would be inconsistent with the
@@ -447,8 +447,8 @@ func TestFetchComments_PaginationCapReturnsError(t *testing.T) {
 		if got != nil {
 			t.Errorf("expected nil slice on cap-hit error, got %d comments", len(got))
 		}
-		// The loop runs `for page := 1; page <= maxCommentPages; page++`,
-		// so on cap-hit exactly maxCommentPages (50) requests should be
+		// The loop runs `for page := 1; page <= maxPaginationPages; page++`,
+		// so on cap-hit exactly maxPaginationPages (50) requests should be
 		// made and no 51st request should be attempted.
 		if got, want := atomic.LoadInt32(&reviewPages), int32(50); got != want {
 			t.Errorf("review endpoint hit count: got %d, want %d (must not walk past cap)", got, want)
@@ -674,6 +674,65 @@ func TestGetPRTimelineEventsForReviewer_RejectsEmptyLogin(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on empty login, got nil")
 	}
+}
+
+// TestGetPRTimelineEventsForReviewer_PaginationCapReturnsError mirrors
+// TestFetchComments_PaginationCapReturnsError for the timeline endpoint
+// (#519): hitting the pagination cap with every page full must surface a
+// hard error rather than a silently-truncated slice. The tail events are
+// exactly what pipeline.shouldBypassSHASkipForReReview walks backward to
+// detect re-review intent (#322 Bug 5), so silent truncation here could
+// skip a review the operator explicitly asked for. The caller already
+// fails closed on error, so the contract change is safe. Also asserts
+// the production code does NOT walk past the cap (no 51st request).
+func TestGetPRTimelineEventsForReviewer_PaginationCapReturnsError(t *testing.T) {
+	var pages int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/org/repo/issues/7/timeline" {
+			http.NotFound(w, r)
+			return
+		}
+		atomic.AddInt32(&pages, 1)
+		// Always emit a full page so the loop never short-circuits on
+		// len<perPage and is forced to hit the cap.
+		emitTimelinePage(w, 100, "heimdallm-bot")
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	got, err := client.GetPRTimelineEventsForReviewer("org/repo", 7, "heimdallm-bot")
+	if err == nil {
+		t.Fatalf("expected pagination cap error, got nil and %d events", len(got))
+	}
+	if !strings.Contains(err.Error(), "timeline pagination exceeded") {
+		t.Errorf("expected error to mention 'timeline pagination exceeded', got: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil slice on cap-hit error, got %d events", len(got))
+	}
+	// The loop runs `for page := 1; page <= maxPaginationPages; page++`,
+	// so on cap-hit exactly maxPaginationPages (50) requests should be
+	// made and no 51st request should be attempted.
+	if got, want := atomic.LoadInt32(&pages), int32(50); got != want {
+		t.Errorf("timeline endpoint hit count: got %d, want %d (must not walk past cap)", got, want)
+	}
+}
+
+// emitTimelinePage writes a JSON page of /issues/:n/timeline shaped items:
+// n review_requested events targeting the given reviewer login, so the
+// production filter keeps them and the raw page length drives the
+// short-page termination check.
+func emitTimelinePage(w http.ResponseWriter, n int, login string) {
+	raw := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		raw = append(raw, map[string]any{
+			"event":              "review_requested",
+			"created_at":         "2026-04-24T07:00:00Z",
+			"actor":              map[string]string{"login": "alice"},
+			"requested_reviewer": map[string]string{"login": login},
+		})
+	}
+	_ = json.NewEncoder(w).Encode(raw)
 }
 
 func mustTime(s string) time.Time {


### PR DESCRIPTION
## Summary

`GetPRTimelineEventsForReviewer` had the same cap-hit silent-truncation anti-pattern that #516 fixed in `fetchReviewComments`/`fetchIssueComments`: on hitting the 50-page cap it logged `slog.Warn` and returned a partial slice. The tail events are exactly what `pipeline.shouldBypassSHASkipForReReview` walks backward to detect re-review intent (#322 Bug 5), so a silent truncation could miss a re-review request and skip the review entirely.

Closes #519.

## Changes

- **Cap-hit contract**: the timeline fetcher now returns a hard error instead of partial results, matching the post-#516 contract of the comment fetchers. The only caller (`pipeline.shouldBypassSHASkipForReReview`, `pipeline.go:213-218`) already fails closed on error — the SHA skip stays in place — so no caller changes were needed.
- **Shared pagination constants**: `maxCommentPages` → `maxPaginationPages`, reused (together with `perPage`) by the timeline loop. The `per_page` query param and the short-page termination check can no longer drift apart across endpoints.
- **Test**: `TestGetPRTimelineEventsForReviewer_PaginationCapReturnsError` mirrors `TestFetchComments_PaginationCapReturnsError` — asserts the error, the nil slice, and that exactly 50 requests are made (no walk past the cap).

## Test plan

- [x] TDD: new test written first and watched fail (`got nil and 5000 events` on the pre-fix code)
- [x] `make test-docker` full suite green (`go vet` + all packages, `-count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)