### PR TITLE
fix(github): scale body ceiling for paginated comment endpoints (closes #518)

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -25,6 +25,18 @@ const maxBodyBytes = 1 * 1024 * 1024 // 1 MB for most API responses
 // maxDiffBodyBytes allows a larger limit for PR diffs, which can be legitimately large.
 const maxDiffBodyBytes = 10 * 1024 * 1024 // 10 MB for diffs
 
+// maxPaginatedPageBytes is the body ceiling for the paginated endpoints
+// (fetchReviewComments, fetchIssueComments, GetPRTimelineEventsForReviewer).
+// These request per_page=100 items per call, and a single comment can
+// legitimately carry 30 KB+ (long stack traces, big code blocks,
+// multi-paragraph review bodies), so a full page can exceed the generic
+// 1 MiB maxBodyBytes — truncating mid-JSON and aborting pagination with a
+// decode error, which drops the newest comments (#518, the failure mode
+// #512 exists to prevent). 5 MiB gives ~50 KB per item at a full page,
+// comfortably above anything observed, while still bounding exposure to a
+// misbehaving server.
+const maxPaginatedPageBytes = 5 * 1024 * 1024 // 5 MB for per_page=100 endpoints
+
 // maxErrBodyLen limits the number of bytes included in error messages to avoid
 // leaking sensitive GitHub diagnostic information (e.g. token details).
 const maxErrBodyLen = 200
@@ -759,7 +771,7 @@ func (c *Client) GetPRTimelineEventsForReviewer(repo string, number int, login s
 		if err != nil {
 			return nil, fmt.Errorf("github: fetch timeline: %w", err)
 		}
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxPaginatedPageBytes))
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			errBody := safeTruncate(string(body), maxErrBodyLen)
@@ -781,7 +793,9 @@ func (c *Client) GetPRTimelineEventsForReviewer(repo string, number int, login s
 			} `json:"dismissed_review,omitempty"`
 		}
 		if err := json.Unmarshal(body, &raw); err != nil {
-			return nil, fmt.Errorf("github: decode timeline: %w", err)
+			// Include the payload size: a decode failure right at the byte
+			// ceiling is the signature of a truncated page (#518).
+			return nil, fmt.Errorf("github: decode timeline (%d bytes read): %w", len(body), err)
 		}
 		for _, ev := range raw {
 			switch ev.Event {
@@ -862,7 +876,7 @@ func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error)
 		if err != nil {
 			return nil, fmt.Errorf("github: fetch review comments: %w", err)
 		}
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxPaginatedPageBytes))
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			errBody := safeTruncate(string(body), maxErrBodyLen)
@@ -880,7 +894,9 @@ func (c *Client) fetchReviewComments(repo string, number int) ([]Comment, error)
 			OriginalLine int       `json:"original_line"`
 		}
 		if err := json.Unmarshal(body, &raw); err != nil {
-			return nil, fmt.Errorf("github: decode review comments: %w", err)
+			// Include the payload size: a decode failure right at the byte
+			// ceiling is the signature of a truncated page (#518).
+			return nil, fmt.Errorf("github: decode review comments (%d bytes read): %w", len(body), err)
 		}
 		for _, r := range raw {
 			line := r.OriginalLine
@@ -925,7 +941,7 @@ func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) 
 		if err != nil {
 			return nil, fmt.Errorf("github: fetch issue comments: %w", err)
 		}
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxPaginatedPageBytes))
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			errBody := safeTruncate(string(body), maxErrBodyLen)
@@ -940,7 +956,9 @@ func (c *Client) fetchIssueComments(repo string, number int) ([]Comment, error) 
 			CreatedAt time.Time `json:"created_at"`
 		}
 		if err := json.Unmarshal(body, &raw); err != nil {
-			return nil, fmt.Errorf("github: decode issue comments: %w", err)
+			// Include the payload size: a decode failure right at the byte
+			// ceiling is the signature of a truncated page (#518).
+			return nil, fmt.Errorf("github: decode issue comments (%d bytes read): %w", len(body), err)
 		}
 		for _, r := range raw {
 			comments = append(comments, Comment{

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -718,6 +718,89 @@ func TestGetPRTimelineEventsForReviewer_PaginationCapReturnsError(t *testing.T) 
 	}
 }
 
+// TestFetchComments_LargeCommentPagesFetchSuccessfully locks in the fix
+// for #518: with per_page=100, a page of comments with large bodies
+// (long stack traces, big code blocks) can exceed the generic 1 MiB
+// maxBodyBytes ceiling. The old io.LimitReader truncated the response
+// mid-JSON, json.Unmarshal failed on the partial body, and pagination
+// aborted — dropping the newest comments yet again (the failure mode
+// #512 was opened to fix). Acceptance criterion from the issue: a PR
+// with 100 comments of 30 KB each fetches successfully.
+func TestFetchComments_LargeCommentPagesFetchSuccessfully(t *testing.T) {
+	// 100 × ~30 KB ≈ 3 MB per page — over 1 MiB, under the paginated ceiling.
+	bigBody := strings.Repeat("x", 30*1024)
+	emitLargePage := func(w http.ResponseWriter, page, n int) {
+		if page > 1 {
+			n = 0 // short page terminates pagination
+		}
+		raw := make([]map[string]any, 0, n)
+		for i := 0; i < n; i++ {
+			raw = append(raw, map[string]any{
+				"user":       map[string]string{"login": fmt.Sprintf("u%d", i)},
+				"body":       bigBody,
+				"created_at": "2024-01-01T00:00:00Z",
+			})
+		}
+		_ = json.NewEncoder(w).Encode(raw)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := parsePageParam(t, r)
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/1/comments":
+			emitLargePage(w, page, 100)
+		case "/repos/org/repo/issues/1/comments":
+			emitLargePage(w, page, 100)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	comments, err := client.FetchComments("org/repo", 1)
+	if err != nil {
+		t.Fatalf("unexpected error fetching large comment pages: %v", err)
+	}
+	if got, want := len(comments), 200; got != want {
+		t.Fatalf("expected %d comments (100 review + 100 issue), got %d", want, got)
+	}
+	for i, c := range comments {
+		if len(c.Body) != len(bigBody) {
+			t.Fatalf("comment %d body truncated: got %d bytes, want %d", i, len(c.Body), len(bigBody))
+		}
+	}
+}
+
+// TestFetchComments_DecodeErrorReportsPayloadSize is the defensive bonus
+// from #518: when a comment page fails to decode after a non-empty body
+// read, the error must report how many bytes were read so a
+// ceiling-truncation (or upstream corruption) is diagnosable from
+// production logs before users complain.
+func TestFetchComments_DecodeErrorReportsPayloadSize(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/1/comments":
+			// Invalid JSON: looks like a truncated array, as produced by a
+			// byte-ceiling cut mid-payload.
+			_, _ = w.Write([]byte(`[{"user":{"login":"alice"},"body":"trunc`))
+		case "/repos/org/repo/issues/1/comments":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	_, err := client.FetchComments("org/repo", 1)
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+	if !strings.Contains(err.Error(), "bytes read") {
+		t.Errorf("expected decode error to report payload size ('bytes read'), got: %v", err)
+	}
+}
+
 // emitTimelinePage writes a JSON page of /issues/:n/timeline shaped items:
 // n review_requested events targeting the given reviewer login, so the
 // production filter keeps them and the raw page length drives the


### PR DESCRIPTION
## Summary

`fetchReviewComments`, `fetchIssueComments` and `GetPRTimelineEventsForReviewer` request `per_page=100` items but read each page through `io.LimitReader(resp.Body, maxBodyBytes)` with the generic 1 MiB ceiling. A page of comments with large embedded payloads (long stack traces, big code blocks, multi-paragraph review bodies — 30 KB+ each) crosses 1 MiB: the body is truncated mid-JSON, `json.Unmarshal` fails on the partial body, and pagination aborts with a decode error — silently dropping the newest comments yet again (the failure mode #512 was opened to fix).

Closes #518. Builds on the constants shared in #521 (#519).

## Changes

- **`maxPaginatedPageBytes = 5 MiB`** — new ceiling for the three `per_page=100` endpoints, with the rationale documented inline (~50 KB per item at a full page, comfortably above anything observed while still bounding exposure to a misbehaving server). This is the "cheap" option from the issue; the streaming-decoder ("robust") variant can be a follow-up if 5 MiB pages ever show up in production.
- **Defensive bonus** (also from the issue): decode errors on paginated pages now report the payload size (`N bytes read`), so a ceiling truncation is diagnosable from production logs before users complain.

## Test plan

- [x] TDD: both tests written first and watched fail (`unexpected end of JSON input` on the pre-fix code — the exact truncation signature)
- [x] `TestFetchComments_LargeCommentPagesFetchSuccessfully`: 100 comments × 30 KB per page on both legs (issue acceptance criterion), asserts no body truncation
- [x] `TestFetchComments_DecodeErrorReportsPayloadSize`: decode failures carry the byte count
- [x] No regression in existing `TestFetchComments_*` tests (issue acceptance criterion)
- [x] `make test-docker` full suite green (`go vet` + all packages, `-count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)