### PR TITLE
fix(github): reconstruct diff via List PR Files API for PRs over 300 files (closes #506)

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -665,7 +665,10 @@ func (c *Client) GetPR(repo string, number int) (*PullRequest, error) {
 	return &pr, nil
 }
 
-// FetchDiff returns the unified diff for a PR.
+// FetchDiff returns the unified diff for a PR. PRs over GitHub's 300-file
+// diff limit make the diff endpoint return 406; those fall back to a
+// reconstruction from the List Pull Request Files API (#506) instead of
+// aborting the review.
 func (c *Client) FetchDiff(repo string, number int) (string, error) {
 	path := fmt.Sprintf("/repos/%s/pulls/%d", repo, number)
 	resp, err := c.do("GET", path, "application/vnd.github.v3.diff")
@@ -673,6 +676,14 @@ func (c *Client) FetchDiff(repo string, number int) (string, error) {
 		return "", fmt.Errorf("github: fetch diff: %w", err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotAcceptable {
+		// GitHub's "diff exceeded the maximum number of files (300)"
+		// response. Only 406 triggers the fallback; every other non-200
+		// keeps the hard-error contract below.
+		slog.Info("github: diff endpoint returned 406, reconstructing via files API",
+			"repo", repo, "pr", number)
+		return c.fetchDiffViaFilesAPI(repo, number)
+	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 		errBody := safeTruncate(string(body), maxErrBodyLen)
@@ -686,6 +697,146 @@ func (c *Client) FetchDiff(repo string, number int) (string, error) {
 		slog.Warn("github: diff truncated at size limit", "repo", repo, "pr", number, "limit_bytes", maxDiffBodyBytes)
 	}
 	return string(data), nil
+}
+
+// maxFilesPageBytes is the body ceiling for List Pull Request Files pages.
+// Deliberately NOT maxPaginatedPageBytes (5 MiB): files pages embed per-file
+// `patch` strings, so a per_page=100 page can plausibly exceed 5 MiB even
+// when the final reconstruction would truncate safely at maxDiffBodyBytes —
+// a truncated JSON page fails to decode and would abort the review, the
+// exact failure mode #506 removes. 2× maxDiffBodyBytes (20 MiB) is generous
+// because GitHub omits the `patch` field entirely for very large file
+// diffs, which bounds realistic page sizes.
+const maxFilesPageBytes = 2 * maxDiffBodyBytes
+
+// githubPRFilesCap is GitHub's documented hard cap on the List Pull Request
+// Files endpoint: at most 3,000 files are ever returned, regardless of
+// pagination.
+const githubPRFilesCap = 3000
+
+// prDiffFile is the subset of a List Pull Request Files item needed to
+// reconstruct a unified-diff entry.
+type prDiffFile struct {
+	Filename         string `json:"filename"`
+	PreviousFilename string `json:"previous_filename"`
+	Status           string `json:"status"`
+	Additions        int    `json:"additions"`
+	Deletions        int    `json:"deletions"`
+	Patch            string `json:"patch"`
+}
+
+// fetchDiffViaFilesAPI reconstructs a unified diff from the List Pull
+// Request Files API, for PRs whose diff endpoint 406s (>300 files, #506).
+//
+// Unlike the comment/timeline fetchers (#516/#519), every degradation path
+// here returns a PARTIAL diff with a note instead of an error: the diff is
+// advisory review context that the prompt layer already truncates to 32 KB,
+// whereas comments and timeline events feed dedup/re-review correctness
+// decisions. Erroring on truncation would re-create the aborted-review
+// failure mode this fallback exists to remove. The reconstructed diff makes
+// no claim about a local checkout: the review path runs with or without one
+// (repoctx is best-effort) and this client cannot tell which.
+func (c *Client) fetchDiffViaFilesAPI(repo string, number int) (string, error) {
+	var b strings.Builder
+	b.WriteString("# NOTE: diff reconstructed via GitHub's List Pull Request Files API because this PR exceeds GitHub's 300-file diff limit; it may be incomplete.\n")
+
+	listed := 0       // files received from the API, appended or not
+	truncated := false // any lossy stop: size ceiling, page ceiling, pagination cap
+	complete := false  // saw a short page (no more files upstream)
+pages:
+	for page := 1; page <= maxPaginationPages; page++ {
+		path := fmt.Sprintf("/repos/%s/pulls/%d/files?per_page=%d&page=%d", repo, number, perPage, page)
+		resp, err := c.do("GET", path, "application/vnd.github+json")
+		if err != nil {
+			return "", fmt.Errorf("github: list pr files: %w", err)
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxFilesPageBytes))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			errBody := safeTruncate(string(body), maxErrBodyLen)
+			return "", fmt.Errorf("github: list pr files: status %d: %s", resp.StatusCode, errBody)
+		}
+		var raw []prDiffFile
+		if err := json.Unmarshal(body, &raw); err != nil {
+			if int64(len(body)) >= maxFilesPageBytes {
+				// Self-inflicted truncation: the page ceiling cut the JSON.
+				// Degrade to what we have rather than abort the review.
+				slog.Warn("github: pr files page truncated at byte ceiling, returning partial reconstructed diff",
+					"repo", repo, "pr", number, "page", page, "bytes_read", len(body))
+				truncated = true
+				break
+			}
+			// Below the ceiling this is genuine upstream corruption.
+			return "", fmt.Errorf("github: decode pr files (%d bytes read): %w", len(body), err)
+		}
+		for i := range raw {
+			if b.Len() >= maxDiffBodyBytes {
+				// Same ceiling as the direct diff path. Stop paginating too:
+				// the remaining pages would only be fetched to be dropped,
+				// which is why the truncation note is generic (no exact
+				// omitted count).
+				slog.Warn("github: reconstructed diff truncated at size limit",
+					"repo", repo, "pr", number, "limit_bytes", maxDiffBodyBytes, "files_appended", listed)
+				truncated = true
+				break pages
+			}
+			appendFileDiff(&b, &raw[i])
+			listed++
+		}
+		if len(raw) < perPage {
+			complete = true
+			break
+		}
+	}
+	if !complete && !truncated {
+		// Pagination cap with every page full. Unreachable in practice
+		// (GitHub caps the endpoint at 3,000 files = 30 pages, the cap is
+		// 50) but handled for symmetry with the other fetchers.
+		slog.Warn("github: pr files pagination cap hit, returning partial reconstructed diff",
+			"repo", repo, "pr", number, "pages", maxPaginationPages)
+		truncated = true
+	}
+	if truncated {
+		b.WriteString("\n... (diff truncated: size limit reached, remaining files omitted)\n")
+	}
+	if listed >= githubPRFilesCap {
+		// Conservative: a PR with exactly 3,000 files gets the note too —
+		// distinguishing "at cap" from "capped" would need extra API calls
+		// and a spurious note is harmless.
+		slog.Warn("github: pr files listing reached GitHub's 3,000-file cap, diff may omit files",
+			"repo", repo, "pr", number, "files", listed)
+		b.WriteString("\n# NOTE: GitHub caps file listings at 3,000 files; some files may be missing from this diff.\n")
+	}
+	return b.String(), nil
+}
+
+// appendFileDiff writes one file's unified-diff-shaped entry: the
+// `diff --git` header, `---`/`+++` markers (with /dev/null for added and
+// removed files, and previous_filename on the a/ side for renames), then
+// the patch body — or a stub when GitHub omitted the patch (binary or
+// oversized per-file diff).
+func appendFileDiff(b *strings.Builder, f *prDiffFile) {
+	oldName := f.Filename
+	if f.PreviousFilename != "" {
+		oldName = f.PreviousFilename
+	}
+	fmt.Fprintf(b, "diff --git a/%s b/%s\n", oldName, f.Filename)
+	switch f.Status {
+	case "added":
+		fmt.Fprintf(b, "--- /dev/null\n+++ b/%s\n", f.Filename)
+	case "removed":
+		fmt.Fprintf(b, "--- a/%s\n+++ /dev/null\n", oldName)
+	default:
+		fmt.Fprintf(b, "--- a/%s\n+++ b/%s\n", oldName, f.Filename)
+	}
+	if f.Patch == "" {
+		fmt.Fprintf(b, "(patch unavailable — +%d/-%d)\n", f.Additions, f.Deletions)
+		return
+	}
+	b.WriteString(f.Patch)
+	if !strings.HasSuffix(f.Patch, "\n") {
+		b.WriteByte('\n')
+	}
 }
 
 // FetchComments retrieves both inline review comments and general issue comments

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -770,7 +770,15 @@ pages:
 			return "", fmt.Errorf("github: decode pr files (%d bytes read): %w", len(body), err)
 		}
 		for i := range raw {
-			if b.Len() >= maxDiffBodyBytes {
+			// Render the entry separately and check the PROJECTED size, not
+			// the accumulated size before append — a single oversized patch
+			// (under maxFilesPageBytes, over maxDiffBodyBytes) on a short
+			// page would otherwise be appended whole and returned without a
+			// truncation note, breaking the "same ceiling as the direct
+			// diff path" contract.
+			var entry strings.Builder
+			appendFileDiff(&entry, &raw[i])
+			if b.Len()+entry.Len() > maxDiffBodyBytes {
 				// Same ceiling as the direct diff path. Stop paginating too:
 				// the remaining pages would only be fetched to be dropped,
 				// which is why the truncation note is generic (no exact
@@ -780,7 +788,7 @@ pages:
 				truncated = true
 				break pages
 			}
-			appendFileDiff(&b, &raw[i])
+			b.WriteString(entry.String())
 			listed++
 		}
 		if len(raw) < perPage {

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -295,6 +295,43 @@ func TestFetchDiff_FilesAPITruncatesAtMaxDiffBodyBytes(t *testing.T) {
 	}
 }
 
+// TestFetchDiff_FilesAPISingleOversizedPatchRespectsCeiling: the size
+// check must be on the PROJECTED size, not the accumulated size before
+// append — otherwise a single patch under maxFilesPageBytes but over
+// maxDiffBodyBytes lands on a short page with complete=true and FetchDiff
+// returns a >10 MiB diff with no truncation note, breaking the "same
+// ceiling as the direct diff path" contract.
+func TestFetchDiff_FilesAPISingleOversizedPatchRespectsCeiling(t *testing.T) {
+	// One file, ~12 MiB patch: under the 20 MiB page ceiling, over the
+	// 10 MiB reconstruction ceiling, on a single short page.
+	patch := "@@ -1 +1 @@\n+" + strings.Repeat("w", 12*1024*1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/42":
+			http.Error(w, `{"message":"diff too big"}`, http.StatusNotAcceptable)
+		case "/repos/org/repo/pulls/42/files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"filename": "pkg/huge.go", "status": "modified", "additions": 1, "deletions": 1, "patch": patch},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	diff, err := client.FetchDiff("org/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(diff) > 10*1024*1024 {
+		t.Errorf("reconstructed diff exceeds maxDiffBodyBytes: %d bytes", len(diff))
+	}
+	if !strings.Contains(diff, "diff truncated") {
+		t.Errorf("expected truncation note when a single patch exceeds the ceiling")
+	}
+}
+
 // TestFetchDiff_FilesAPIWarnsAtGitHubFileCap: GitHub hard-caps this
 // endpoint at 3,000 files. Reading that many must append a note that
 // files may be missing — conservatively, even a PR with exactly 3,000

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -111,6 +111,300 @@ func TestFetchDiff(t *testing.T) {
 	}
 }
 
+// emitFilesPage writes a JSON page of /pulls/:n/files shaped items. Each
+// file is "pkg/file<page>_<i>.go", modified, with the given patch body.
+func emitFilesPage(w http.ResponseWriter, page, n int, patch string) {
+	files := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		files = append(files, map[string]any{
+			"filename":  fmt.Sprintf("pkg/file%d_%d.go", page, i),
+			"status":    "modified",
+			"additions": 1,
+			"deletions": 1,
+			"patch":     patch,
+		})
+	}
+	_ = json.NewEncoder(w).Encode(files)
+}
+
+// TestFetchDiff_FallsBackToFilesAPIOn406 locks in the core fix for #506:
+// when the diff endpoint returns 406 (PR exceeds GitHub's 300-file diff
+// limit), FetchDiff must fall back to the List Pull Request Files API and
+// return a reconstructed unified diff instead of aborting the review.
+// Exercises pagination (full + short page), rename handling, added and
+// removed files, and the leading agent note.
+func TestFetchDiff_FallsBackToFilesAPIOn406(t *testing.T) {
+	var filesPages int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/42":
+			http.Error(w, `{"message":"Sorry, the diff exceeded the maximum number of files (300)."}`, http.StatusNotAcceptable)
+		case "/repos/org/repo/pulls/42/files":
+			atomic.AddInt32(&filesPages, 1)
+			page := parsePageParam(t, r)
+			if page > 1 {
+				// Short page terminates pagination; includes a removed file
+				// so the assertion below proves page-2 content survived.
+				_ = json.NewEncoder(w).Encode([]map[string]any{
+					{"filename": "pkg/gone.go", "status": "removed", "additions": 0, "deletions": 3,
+						"patch": "@@ -1,3 +0,0 @@\n-bye\n-bye\n-bye"},
+				})
+				return
+			}
+			files := make([]map[string]any, 0, 100)
+			for i := 0; i < 100; i++ {
+				files = append(files, map[string]any{
+					"filename":  fmt.Sprintf("pkg/file%d.go", i),
+					"status":    "modified",
+					"additions": 1,
+					"deletions": 1,
+					"patch":     fmt.Sprintf("@@ -1 +1 @@\n-old%d\n+new%d", i, i),
+				})
+			}
+			files[1] = map[string]any{"filename": "pkg/renamed.go", "previous_filename": "pkg/old.go",
+				"status": "renamed", "additions": 1, "deletions": 1, "patch": "@@ -1 +1 @@\n-a\n+b"}
+			files[2] = map[string]any{"filename": "pkg/new.go", "status": "added",
+				"additions": 1, "deletions": 0, "patch": "@@ -0,0 +1 @@\n+x"}
+			_ = json.NewEncoder(w).Encode(files)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	diff, err := client.FetchDiff("org/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(diff, "reconstructed via") {
+		t.Errorf("expected leading agent note mentioning 'reconstructed via', got start: %.200s", diff)
+	}
+	if !strings.Contains(diff, "diff --git a/pkg/file0.go b/pkg/file0.go") {
+		t.Errorf("expected per-file diff header for pkg/file0.go")
+	}
+	if !strings.Contains(diff, "diff --git a/pkg/old.go b/pkg/renamed.go") {
+		t.Errorf("expected rename to use previous_filename on the a/ side")
+	}
+	if !strings.Contains(diff, "--- /dev/null\n+++ b/pkg/new.go") {
+		t.Errorf("expected added file to use /dev/null on the old side")
+	}
+	if !strings.Contains(diff, "--- a/pkg/gone.go\n+++ /dev/null") {
+		t.Errorf("expected removed file (from page 2) to use /dev/null on the new side")
+	}
+	if !strings.Contains(diff, "-old5\n+new5") {
+		t.Errorf("expected patch body content to survive reconstruction")
+	}
+	if got := atomic.LoadInt32(&filesPages); got != 2 {
+		t.Errorf("files endpoint hit count: got %d, want 2", got)
+	}
+}
+
+// TestFetchDiff_FilesAPIStubsMissingPatch: files without a patch field
+// (binary or oversized per-file diffs) must yield a stub line instead of
+// being dropped silently.
+func TestFetchDiff_FilesAPIStubsMissingPatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/42":
+			http.Error(w, `{"message":"diff too big"}`, http.StatusNotAcceptable)
+		case "/repos/org/repo/pulls/42/files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"filename": "assets/logo.png", "status": "modified", "additions": 3, "deletions": 1},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	diff, err := client.FetchDiff("org/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(diff, "diff --git a/assets/logo.png b/assets/logo.png") {
+		t.Errorf("expected diff header for patch-less file")
+	}
+	if !strings.Contains(diff, "(patch unavailable — +3/-1)") {
+		t.Errorf("expected stub line for patch-less file, got: %s", diff)
+	}
+}
+
+// TestFetchDiff_NonDiffErrorsStillPropagate guards the fallback trigger:
+// only 406 falls back to the files API. Genuine errors (404, 500) keep the
+// existing contract and must NOT touch the files endpoint. Note: this test
+// passes before the #506 change by construction — it exists to pin the
+// contract so the fallback cannot widen to non-406 statuses unnoticed.
+func TestFetchDiff_NonDiffErrorsStillPropagate(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusInternalServerError} {
+		filesHit := false
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/repos/org/repo/pulls/42/files" {
+				filesHit = true
+			}
+			http.Error(w, `{"message":"nope"}`, status)
+		}))
+
+		client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+		_, err := client.FetchDiff("org/repo", 42)
+		if err == nil {
+			t.Errorf("status %d: expected error, got nil", status)
+		}
+		if filesHit {
+			t.Errorf("status %d: files endpoint must not be hit for non-406 errors", status)
+		}
+		srv.Close()
+	}
+}
+
+// TestFetchDiff_FilesAPITruncatesAtMaxDiffBodyBytes: the reconstruction
+// must stop appending once it crosses the same 10 MiB ceiling the direct
+// diff path uses, carry a generic truncation note (no exact omitted count
+// — we stop paginating rather than walk the rest just to count), and not
+// fetch further pages.
+func TestFetchDiff_FilesAPITruncatesAtMaxDiffBodyBytes(t *testing.T) {
+	var filesPages int32
+	// 100 files × ~120 KB patch ≈ 12 MB on one page: crosses the 10 MiB
+	// reconstruction ceiling mid-page while staying under the 20 MiB page
+	// ceiling.
+	bigPatch := "@@ -1 +1 @@\n+" + strings.Repeat("x", 120*1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/42":
+			http.Error(w, `{"message":"diff too big"}`, http.StatusNotAcceptable)
+		case "/repos/org/repo/pulls/42/files":
+			atomic.AddInt32(&filesPages, 1)
+			emitFilesPage(w, parsePageParam(t, r), 100, bigPatch)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	diff, err := client.FetchDiff("org/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(diff, "diff truncated") {
+		t.Errorf("expected truncation note in reconstructed diff")
+	}
+	if got := atomic.LoadInt32(&filesPages); got != 1 {
+		t.Errorf("files endpoint hit count: got %d, want 1 (must stop paginating after truncation)", got)
+	}
+}
+
+// TestFetchDiff_FilesAPIWarnsAtGitHubFileCap: GitHub hard-caps this
+// endpoint at 3,000 files. Reading that many must append a note that
+// files may be missing — conservatively, even a PR with exactly 3,000
+// files gets the note (we cannot distinguish the two without extra API
+// calls).
+func TestFetchDiff_FilesAPIWarnsAtGitHubFileCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/42":
+			http.Error(w, `{"message":"diff too big"}`, http.StatusNotAcceptable)
+		case "/repos/org/repo/pulls/42/files":
+			page := parsePageParam(t, r)
+			if page > 30 {
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
+			emitFilesPage(w, page, 100, "@@ -1 +1 @@\n-a\n+b")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	diff, err := client.FetchDiff("org/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(diff, "3,000 files") {
+		t.Errorf("expected GitHub file-cap note after reading 3,000 files")
+	}
+}
+
+// TestFetchDiff_FilesAPIHandlesLargePages: a single files page over the
+// generic 5 MiB paginated ceiling (but under the dedicated 20 MiB files
+// ceiling) must decode and reconstruct successfully — files pages embed
+// patch strings, which is why they get their own ceiling (#506 review).
+func TestFetchDiff_FilesAPIHandlesLargePages(t *testing.T) {
+	// 100 files × ~80 KB ≈ 8 MB page.
+	patch := "@@ -1 +1 @@\n+" + strings.Repeat("y", 80*1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/42":
+			http.Error(w, `{"message":"diff too big"}`, http.StatusNotAcceptable)
+		case "/repos/org/repo/pulls/42/files":
+			if parsePageParam(t, r) > 1 {
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
+			emitFilesPage(w, 1, 100, patch)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	diff, err := client.FetchDiff("org/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error on >5MiB files page: %v", err)
+	}
+	if !strings.Contains(diff, "diff --git a/pkg/file1_0.go b/pkg/file1_0.go") {
+		t.Errorf("expected reconstructed content from the large page")
+	}
+}
+
+// TestFetchDiff_FilesAPIPageAtCeilingDegradesGracefully: when a files page
+// is cut by the 20 MiB page ceiling itself (decode fails with the body
+// read exactly at the limit), the fallback must return the diff
+// accumulated so far with a truncation note — NOT an error. Erroring here
+// would re-create the aborted-review failure mode #506 removes.
+func TestFetchDiff_FilesAPIPageAtCeilingDegradesGracefully(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/repo/pulls/42":
+			http.Error(w, `{"message":"diff too big"}`, http.StatusNotAcceptable)
+		case "/repos/org/repo/pulls/42/files":
+			if parsePageParam(t, r) == 1 {
+				emitFilesPage(w, 1, 100, "@@ -1 +1 @@\n-a\n+b")
+				return
+			}
+			// Page 2: valid JSON prefix far larger than the 20 MiB page
+			// ceiling, so the client reads exactly the ceiling and the
+			// decode fails on the truncated body.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"filename":"`))
+			chunk := strings.Repeat("z", 1024*1024)
+			for i := 0; i < 21; i++ {
+				_, _ = w.Write([]byte(chunk))
+			}
+			_, _ = w.Write([]byte(`"}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	diff, err := client.FetchDiff("org/repo", 42)
+	if err != nil {
+		t.Fatalf("expected graceful partial diff on at-ceiling decode failure, got error: %v", err)
+	}
+	if !strings.Contains(diff, "diff --git a/pkg/file1_0.go b/pkg/file1_0.go") {
+		t.Errorf("expected page-1 content to survive")
+	}
+	if !strings.Contains(diff, "diff truncated") {
+		t.Errorf("expected truncation note on at-ceiling degradation")
+	}
+}
+
 func TestFetchComments_MergesAndSorts(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/docs/superpowers/specs/2026-06-05-large-pr-diff-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-05-large-pr-diff-fallback-design.md
@@ -88,7 +88,7 @@ endpoint); there is no message sniffing.
 
 | Condition | Behavior |
 |---|---|
-| Accumulated diff exceeds `maxDiffBodyBytes` (10 MB) | stop appending, add `... (diff truncated, N files omitted)`, `slog.Warn` — mirrors the direct path's truncation behavior |
+| Appending a file would push the reconstruction over `maxDiffBodyBytes` (10 MB) | skip it, stop appending and paginating, add a generic truncation note (no exact omitted count — we stop paginating rather than walk the rest just to count), `slog.Warn`. Checked on the projected size so the result never exceeds the ceiling, even for a single oversized patch |
 | ≥3,000 files read (GitHub's documented hard cap on this endpoint) | append a note that GitHub caps file listings at 3,000 files and some files may be missing, `slog.Warn`. Conservative: a PR with exactly 3,000 files gets the note too — the client cannot distinguish "exactly at cap" from "capped" without extra API calls (`changed_files` is not parsed in our `PullRequest` model), and a spurious note on an at-cap PR is harmless |
 | Pagination cap hit (50 pages) | return the partial diff with a truncation note, `slog.Warn` — deliberately NOT an error (see below) |
 | HTTP error mid-pagination | propagate as error |

--- a/docs/superpowers/specs/2026-06-05-large-pr-diff-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-05-large-pr-diff-fallback-design.md
@@ -62,8 +62,16 @@ endpoint); there is no message sniffing.
 ### fetchDiffViaFilesAPI
 
 - Paginates `GET /repos/{repo}/pulls/{n}/files?per_page=100&page=K` reusing
-  the shared pagination constants (`perPage`, `maxPaginationPages`) and the
-  paginated body ceiling (`maxPaginatedPageBytes`) from #519/#518.
+  the shared pagination constants (`perPage`, `maxPaginationPages`) from
+  #519/#518.
+- **Dedicated page-body ceiling** `maxFilesPageBytes = 2 × maxDiffBodyBytes`
+  (20 MiB). The generic `maxPaginatedPageBytes` (5 MiB) is NOT reused: files
+  pages embed per-file `patch` strings, so a 100-file page can plausibly
+  exceed 5 MiB even when the final reconstruction would truncate safely at
+  10 MiB — a truncated JSON page would fail to decode and abort the review,
+  the exact failure mode this design removes. 20 MiB is generous because
+  GitHub omits the `patch` field entirely for very large file diffs, which
+  bounds realistic page sizes.
 - Emits, per file, unified-diff-shaped headers followed by the `patch` field:
   - `diff --git a/<previous_filename|filename> b/<filename>`
   - `--- a/<old>` / `+++ b/<new>`, with `/dev/null` for added/removed files
@@ -84,7 +92,8 @@ endpoint); there is no message sniffing.
 | ≥3,000 files read (GitHub's documented hard cap on this endpoint) | append a note that GitHub caps file listings at 3,000 files and some files may be missing, `slog.Warn`. Conservative: a PR with exactly 3,000 files gets the note too — the client cannot distinguish "exactly at cap" from "capped" without extra API calls (`changed_files` is not parsed in our `PullRequest` model), and a spurious note on an at-cap PR is harmless |
 | Pagination cap hit (50 pages) | return the partial diff with a truncation note, `slog.Warn` — deliberately NOT an error (see below) |
 | HTTP error mid-pagination | propagate as error |
-| JSON decode error | propagate as error, including `N bytes read` (pattern from #518) |
+| Decode error with the page read at the `maxFilesPageBytes` ceiling | self-inflicted truncation: return the diff accumulated so far with a truncation note, `slog.Warn` with bytes read — NOT an error (same advisory-context rationale as the cap) |
+| Decode error below the ceiling | genuine upstream corruption: propagate as error, including `N bytes read` (pattern from #518) |
 
 **Why cap-hit ≠ error here (unlike #519):** the diff is advisory context that
 the prompt truncates to 32 KB anyway; failing hard would re-create the exact
@@ -110,7 +119,13 @@ GitHub also hard-caps this endpoint at 3,000 files (30 pages), so the
    `diff truncated, N files omitted` note.
 5. `TestFetchDiff_FilesAPIWarnsAtGitHubFileCap` — reading 3,000 files
    appends the GitHub-cap note.
-6. Existing `TestFetchDiff*` tests pass unchanged (200 path untouched).
+6. `TestFetchDiff_FilesAPIHandlesLargePages` — a single files page >5 MiB
+   (over the generic paginated ceiling, under `maxFilesPageBytes`) decodes
+   and reconstructs successfully.
+7. `TestFetchDiff_FilesAPIPageAtCeilingDegradesGracefully` — a page
+   truncated at `maxFilesPageBytes` returns the diff accumulated so far
+   with a truncation note instead of an error.
+8. Existing `TestFetchDiff*` tests pass unchanged (200 path untouched).
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-05-large-pr-diff-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-05-large-pr-diff-fallback-design.md
@@ -1,0 +1,110 @@
+# Large-PR diff fallback via List Pull Request Files (#506)
+
+**Date:** 2026-06-05
+**Issue:** [#506 — Gestionar PRs mastodónticas](https://github.com/theburrowhub/heimdallm/issues/506)
+**Status:** Approved
+
+## Problem
+
+When a PR touches more than 300 files, GitHub's diff endpoint
+(`GET /repos/{repo}/pulls/{n}` with `Accept: application/vnd.github.v3.diff`)
+returns `406 Not Acceptable`:
+
+```
+Review failed: pipeline: fetch diff: github: fetch diff: status 406:
+{"message":"Sorry, the diff exceeded the maximum number of files (300).
+Consider using 'List pull requests files' API or locally cloning the repository instead."}
+```
+
+`pipeline.Run` aborts at the fetch-diff step (`pipeline.go`), so Heimdallm
+never reviews these PRs at all. Example: freepik-company/ai-bumblebee-proxy#1147.
+
+## Context that shapes the design
+
+- The diff has exactly one consumer: `PRContext.Diff`, embedded in the review
+  prompt. Nothing else parses it.
+- `executor.BuildPromptFromTemplate` already truncates the diff at 32 KB
+  (`maxDiffBytes`), so the prompt never sees more than that regardless of
+  how complete the fetched diff is.
+- The review agent already runs with `WorkDir` set to a local worktree of the
+  repo (acquired via `repoctx`, `ModeRead`), so it can inspect any file
+  locally; the 406 simply aborted the pipeline before reaching that point.
+
+These three facts make the diff *advisory, lossy-by-design context* — unlike
+PR comments (#516/#518) or timeline events (#519), which feed correctness
+decisions and therefore fail hard on truncation.
+
+## Decision
+
+**Option A from the issue: fall back to the List Pull Request Files API.**
+Rejected alternatives: local `git diff` in the worktree (more plumbing across
+layers; the review worktree is a shallow `ModeRead` clone without guaranteed
+full history) and prompt-note-only (review quality would depend entirely on
+the agent exploring on its own).
+
+## Design
+
+All changes live in `daemon/internal/github/client.go`. `FetchDiff` keeps its
+signature; the `pipeline.DiffFetcher` interface and all callers are untouched.
+
+```
+FetchDiff(repo, number)
+  ├─ GET /pulls/N (Accept: diff) → 200: return diff      (existing path, unchanged)
+  ├─ 406                          → fetchDiffViaFilesAPI (new fallback)
+  └─ any other non-200            → error                (existing path, unchanged)
+```
+
+Any 406 triggers the fallback (GitHub uses it for "diff too large" on this
+endpoint); there is no message sniffing.
+
+### fetchDiffViaFilesAPI
+
+- Paginates `GET /repos/{repo}/pulls/{n}/files?per_page=100&page=K` reusing
+  the shared pagination constants (`perPage`, `maxPaginationPages`) and the
+  paginated body ceiling (`maxPaginatedPageBytes`) from #519/#518.
+- Emits, per file, unified-diff-shaped headers followed by the `patch` field:
+  - `diff --git a/<previous_filename|filename> b/<filename>`
+  - `--- a/<old>` / `+++ b/<new>`, with `/dev/null` for added/removed files
+  - renames use `previous_filename` on the `a/` side
+- Files without `patch` (binary or oversized): a stub line
+  `(patch unavailable — +<additions>/-<deletions>)`.
+- The reconstructed diff starts with a comment line telling the agent that
+  the diff was rebuilt because the PR exceeds GitHub's 300-file limit and
+  that the full checkout is available in its working directory.
+
+### Limits and error handling
+
+| Condition | Behavior |
+|---|---|
+| Accumulated diff exceeds `maxDiffBodyBytes` (10 MB) | stop appending, add `... (diff truncated, N files omitted)`, `slog.Warn` — mirrors the direct path's truncation behavior |
+| Pagination cap hit (50 pages) | return the partial diff with a truncation note, `slog.Warn` — deliberately NOT an error (see below) |
+| HTTP error mid-pagination | propagate as error |
+| JSON decode error | propagate as error, including `N bytes read` (pattern from #518) |
+
+**Why cap-hit ≠ error here (unlike #519):** the diff is advisory context that
+the prompt truncates to 32 KB anyway; failing hard would re-create the exact
+problem this issue fixes (review aborts on big PRs). Comments and timeline
+events drive dedup/re-review correctness decisions, which is why those
+fetchers fail closed. This rationale is documented inline in the code.
+GitHub also hard-caps this endpoint at 3,000 files (30 pages), so the
+50-page cap is unreachable in practice.
+
+## Testing (TDD)
+
+1. `TestFetchDiff_FallsBackToFilesAPIOn406` — diff endpoint returns 406; files
+   endpoint serves 2 pages (full + short). Asserts: reconstructed diff
+   contains per-file headers, patch bodies, rename handling, and the leading
+   agent note; files endpoint hit exactly twice.
+2. `TestFetchDiff_FilesAPIStubsMissingPatch` — a file without `patch` yields
+   the stub line instead of dropping the file silently.
+3. `TestFetchDiff_NonDiffErrorsStillPropagate` — 404/500 from the diff
+   endpoint do NOT trigger the fallback and surface as errors (existing
+   contract).
+4. Existing `TestFetchDiff*` tests pass unchanged (200 path untouched).
+
+## Out of scope
+
+- PRs beyond GitHub's 3,000-file files-API cap (partial diff + note).
+- Local `git diff` computation (rejected alternative; can be revisited if
+  the files API proves insufficient).
+- Changes to the prompt template or the 32 KB prompt truncation.

--- a/docs/superpowers/specs/2026-06-05-large-pr-diff-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-05-large-pr-diff-fallback-design.md
@@ -26,9 +26,11 @@ never reviews these PRs at all. Example: freepik-company/ai-bumblebee-proxy#1147
 - `executor.BuildPromptFromTemplate` already truncates the diff at 32 KB
   (`maxDiffBytes`), so the prompt never sees more than that regardless of
   how complete the fetched diff is.
-- The review agent already runs with `WorkDir` set to a local worktree of the
-  repo (acquired via `repoctx`, `ModeRead`), so it can inspect any file
-  locally; the 406 simply aborted the pipeline before reaching that point.
+- The review agent *usually* runs with `WorkDir` set to a local worktree of
+  the repo (acquired via `repoctx`, `ModeRead`) — but repoctx is best-effort:
+  on acquire failure `main.go` clears `aiCfg.LocalDir` and the review still
+  runs without a checkout. `FetchDiff(repo, number)` cannot know which case
+  applies, so the reconstructed diff must NOT claim a checkout exists.
 
 These three facts make the diff *advisory, lossy-by-design context* — unlike
 PR comments (#516/#518) or timeline events (#519), which feed correctness
@@ -68,15 +70,18 @@ endpoint); there is no message sniffing.
   - renames use `previous_filename` on the `a/` side
 - Files without `patch` (binary or oversized): a stub line
   `(patch unavailable — +<additions>/-<deletions>)`.
-- The reconstructed diff starts with a comment line telling the agent that
-  the diff was rebuilt because the PR exceeds GitHub's 300-file limit and
-  that the full checkout is available in its working directory.
+- The reconstructed diff starts with a neutral comment line: the diff was
+  rebuilt via the List Pull Request Files API because the PR exceeds
+  GitHub's 300-file diff limit, and may be incomplete. It makes no claim
+  about a local checkout (the review path runs with or without one, and
+  the client cannot tell which).
 
 ### Limits and error handling
 
 | Condition | Behavior |
 |---|---|
 | Accumulated diff exceeds `maxDiffBodyBytes` (10 MB) | stop appending, add `... (diff truncated, N files omitted)`, `slog.Warn` — mirrors the direct path's truncation behavior |
+| ≥3,000 files read (GitHub's documented hard cap on this endpoint) | append a note that GitHub caps file listings at 3,000 files and some files may be missing, `slog.Warn`. Conservative: a PR with exactly 3,000 files gets the note too — the client cannot distinguish "exactly at cap" from "capped" without extra API calls (`changed_files` is not parsed in our `PullRequest` model), and a spurious note on an at-cap PR is harmless |
 | Pagination cap hit (50 pages) | return the partial diff with a truncation note, `slog.Warn` — deliberately NOT an error (see below) |
 | HTTP error mid-pagination | propagate as error |
 | JSON decode error | propagate as error, including `N bytes read` (pattern from #518) |
@@ -100,11 +105,18 @@ GitHub also hard-caps this endpoint at 3,000 files (30 pages), so the
 3. `TestFetchDiff_NonDiffErrorsStillPropagate` — 404/500 from the diff
    endpoint do NOT trigger the fallback and surface as errors (existing
    contract).
-4. Existing `TestFetchDiff*` tests pass unchanged (200 path untouched).
+4. `TestFetchDiff_FilesAPITruncatesAtMaxDiffBodyBytes` — accumulated
+   reconstruction crossing 10 MB stops appending and carries the
+   `diff truncated, N files omitted` note.
+5. `TestFetchDiff_FilesAPIWarnsAtGitHubFileCap` — reading 3,000 files
+   appends the GitHub-cap note.
+6. Existing `TestFetchDiff*` tests pass unchanged (200 path untouched).
 
 ## Out of scope
 
-- PRs beyond GitHub's 3,000-file files-API cap (partial diff + note).
+- Recovering file content beyond GitHub's 3,000-file files-API cap (the
+  fallback returns the capped diff plus the warning note defined above;
+  fetching the remainder would require cloning, the rejected alternative).
 - Local `git diff` computation (rejected alternative; can be revisited if
   the files API proves insufficient).
 - Changes to the prompt template or the 32 KB prompt truncation.


### PR DESCRIPTION
## Summary

PRs touching more than 300 files make GitHub's diff endpoint return `406 Not Acceptable`, which aborted `pipeline.Run` at the fetch-diff step — Heimdallm never reviewed those PRs at all (e.g. `freepik-company/ai-bumblebee-proxy#1147`).

`FetchDiff` now falls back on 406 to the **List Pull Request Files API** (option 1 from the issue) and rebuilds a unified-diff-shaped text. The `DiffFetcher` interface and all callers are untouched.

Closes #506.

Design spec (reviewed in 3 rounds, included in this PR): `docs/superpowers/specs/2026-06-05-large-pr-diff-fallback-design.md`

## Key design points

- **Only 406 triggers the fallback** — 404/500 keep the existing hard-error contract (pinned by test).
- **Reconstruction**: per-file `diff --git` headers, `/dev/null` for added/removed, `previous_filename` for renames, per-file `patch` bodies, stub line `(patch unavailable — +A/-D)` for binary/oversized files, and a leading note telling the agent the diff was reconstructed and may be incomplete (no claim about a local checkout — repoctx is best-effort).
- **Every degradation path returns a partial diff + note, never an error**: the diff is advisory context the prompt layer already truncates to 32 KB. This deliberately differs from the comments/timeline fetchers (#516/#519), which feed correctness decisions and fail hard — rationale documented inline.
- **Dedicated 20 MiB page ceiling** (`maxFilesPageBytes = 2 × maxDiffBodyBytes`): files pages embed patch strings, so reusing the generic 5 MiB paginated ceiling could cut a page mid-JSON and abort the review (caught in spec review). Decode failure *at* the ceiling degrades gracefully; *below* it, it errors (upstream corruption, #518 pattern).
- **10 MiB reconstruction ceiling** (same as the direct diff path) with a generic truncation note, and a conservative note when GitHub's 3,000-file endpoint cap is reached.

## Test plan

- [x] TDD: 6 new tests written first and watched fail with the original 406; 1 contract guard (non-406 errors don't trigger the fallback) passes by construction before and after
- [x] `TestFetchDiff_FallsBackToFilesAPIOn406` — pagination, renames, added/removed, agent note
- [x] `TestFetchDiff_FilesAPIStubsMissingPatch`
- [x] `TestFetchDiff_NonDiffErrorsStillPropagate` — 404/500, files endpoint never hit
- [x] `TestFetchDiff_FilesAPITruncatesAtMaxDiffBodyBytes` — stops paginating, generic note
- [x] `TestFetchDiff_FilesAPIWarnsAtGitHubFileCap` — 3,000-file note
- [x] `TestFetchDiff_FilesAPIHandlesLargePages` — 8 MB page (>5 MiB generic ceiling) decodes fine
- [x] `TestFetchDiff_FilesAPIPageAtCeilingDegradesGracefully` — 20 MiB-truncated page → partial diff, no error
- [x] `make test-docker` full suite green (`go vet` + all packages, `-count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)