### PR TITLE
docs(landing): auto-version the hero badge via release-please extra-files (closes #514)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -334,7 +334,7 @@
 
 <!-- Hero -->
 <section class="hero">
-  <div class="hero-badge">⚡ macOS · Linux · Docker · Free · Open Source</div>
+  <div class="hero-badge">⚡ v0.6.23 · macOS · Linux · Docker · Free · Open Source</div><!-- x-release-please-version -->
   <h1>Your GitHub, on <em>autopilot</em>.<br>Reviews, triage, and PRs.</h1>
   <p>
     Heimdallm is a background daemon that reviews your pull requests, triages and refines your issues,

--- a/docs/superpowers/specs/2026-06-05-auto-version-hero-badge-design.md
+++ b/docs/superpowers/specs/2026-06-05-auto-version-hero-badge-design.md
@@ -1,0 +1,82 @@
+# Auto-versioned hero badge via release-please extra-files (#514)
+
+**Date:** 2026-06-05
+**Issue:** [#514 — docs(landing): auto-version the hero badge from release pipeline](https://github.com/theburrowhub/heimdallm/issues/514)
+**Status:** Approved
+
+## Problem
+
+PR #513 (landing refresh for 0.6.23) hardcoded a version string in the
+`hero-badge` of `docs/index.html`; reviewers flagged that it goes silently
+stale on every release, so the version was removed as a stopgap. This issue
+restores the version on the landing page without manual edits per release.
+
+## Decision
+
+Use release-please's **`extra-files` generic updater**
+([docs](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files)):
+files listed in `extra-files` get any semver on lines annotated with
+`x-release-please-version` replaced with the new version, **inside the
+release PR release-please already opens**.
+
+Rejected alternatives:
+
+- **Step in `release.yml` that commits the bump to main** — a direct
+  workflow push to main conflicts with branch protection (everything lands
+  via reviewed PRs in this repo); `extra-files` rides the normal release PR
+  instead, with zero workflow changes.
+- **Client-side JS fetching `releases/latest`** — depends on the GitHub API
+  on every visit (rate limits, version flash, failure fallback).
+- **Build-time injection** — GitHub Pages serves `main:/docs` statically;
+  there is no build step to hook.
+
+The updating commit is the same one that creates the tag, so badge and
+release can never drift.
+
+## Changes (2 files)
+
+1. **`release-please-config.json`** — add inside `packages["."]` (tied to
+   the single versioned component, not floating at the root):
+
+   ```json
+   "extra-files": [
+     { "type": "generic", "path": "docs/index.html" }
+   ]
+   ```
+
+2. **`docs/index.html`** — re-seed the badge with the current manifest
+   version (`0.6.23`) and annotate the line:
+
+   ```html
+   <div class="hero-badge">⚡ v0.6.23 · macOS · Linux · Docker · Free · Open Source</div><!-- x-release-please-version -->
+   ```
+
+   The `v` stays as a visual prefix; release-please replaces only the
+   semver `0.6.23`. The annotated line contains exactly one semver, so the
+   generic updater cannot match anything unintended. No other file is
+   annotated.
+
+## Acceptance criteria (from the issue)
+
+| Criterion | How it is met |
+|---|---|
+| Releasing a new tag updates the badge automatically | The release-please release PR carries the `docs/index.html` bump |
+| No manual `docs/index.html` edit per release | The generic updater rewrites the annotated line every release |
+| Identical behavior on GitHub Pages (static from `main:/docs`) | Only HTML content changes; no build step, no JS |
+
+## Verification
+
+Config + HTML have no unit-test surface; verification is:
+
+1. `jq . release-please-config.json` — valid JSON.
+2. **Key check — dry-run with a real token**:
+   `release-please release-pr --dry-run` against the repo. Since 0.6.23
+   there are `fix` commits (#521/#522/#523), so it must propose 0.6.24 and
+   list `docs/index.html` in the changeset with the badge bumped to the
+   proposed version.
+3. Definitive confirmation on the next real release PR.
+
+## Out of scope
+
+- Versioning anything else on the landing page.
+- Changes to `release.yml` or the release pipeline.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,9 @@
       "initial-version": "0.1.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        { "type": "generic", "path": "docs/index.html" }
+      ],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Restores the version on the landing hero badge (removed as a stopgap in #513) in a way that can never go stale: `docs/index.html` is registered as a release-please **generic extra-file**, so every release PR bumps the badge to the new version automatically.

Closes #514.

Design spec (included): `docs/superpowers/specs/2026-06-05-auto-version-hero-badge-design.md`

## Changes (2 files)

- **`release-please-config.json`** — `extra-files: [{type: "generic", path: "docs/index.html"}]` inside `packages["."]` (tied to the single versioned component).
- **`docs/index.html`** — badge re-seeded with the current manifest version and annotated:
  ```html
  <div class="hero-badge">⚡ v0.6.23 · macOS · Linux · Docker · Free · Open Source</div><!-- x-release-please-version -->
  ```
  The `v` is a visual prefix; release-please replaces only the semver. The annotated line contains exactly one semver, so nothing unintended can match.

## Why this approach

- **vs. a step in `release.yml`**: a direct workflow push to main conflicts with branch protection; this rides the normal reviewed release PR with zero workflow changes.
- **vs. client-side JS**: no GitHub API dependency per visit, no rate limits, no version flash.
- Badge bump and tag creation are the same commit — they cannot drift.

[Official docs for `extra-files` + `x-release-please-version`](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files)

## Verification

- [x] `jq . release-please-config.json` — valid JSON
- [x] **Dry-run with real token against this branch**: `release-please release-pr --dry-run --target-branch=fix/514-auto-version-hero-badge` proposes `0.6.24` and reports `updates: 4` including `docs/index.html: [class Generic]` (baseline against main: `updates: 3`, no index.html — proving the config change is what wires it)
- [ ] Definitive confirmation on the next real release PR (will carry the badge bump to 0.6.24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)