### PR TITLE
feat(pipeline): factor PR comments into review approve/request_changes decision

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -910,7 +910,7 @@ func main() {
 		ghID, ghState, err := ghClient.SubmitReview(
 			pr.Repo, pr.Number,
 			pipeline.BuildGitHubBody(result),
-			pipeline.SeverityToEvent(rev.Severity, pipeline.CommentSignals{}),
+			pipeline.SeverityToEvent(rev.Severity),
 		)
 		if err != nil {
 			errStr := err.Error()

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -910,7 +910,7 @@ func main() {
 		ghID, ghState, err := ghClient.SubmitReview(
 			pr.Repo, pr.Number,
 			pipeline.BuildGitHubBody(result),
-			pipeline.SeverityToEvent(rev.Severity, len(issues)),
+			pipeline.SeverityToEvent(rev.Severity, pipeline.CommentSignals{}),
 		)
 		if err != nil {
 			errStr := err.Error()

--- a/daemon/internal/executor/prompt.go
+++ b/daemon/internal/executor/prompt.go
@@ -55,7 +55,11 @@ Review the above diff and respond with ONLY valid JSON in this exact format (no 
   "severity": "low|medium|high"
 }
 
-The top-level "severity" is the highest severity found. If no issues, return empty arrays and severity "low".`
+Rules for severity determination:
+- The top-level "severity" MUST be at least the highest severity of any individual issue.
+- If the PR discussion contains unresolved concerns from reviewers (especially about correctness, security, or design), factor them into your severity assessment. An unresolved reviewer concern about a real defect warrants at least "medium".
+- If reviewers have explicitly flagged something as a blocker or requested changes that were not addressed in the current diff, this is "high" severity.
+- If no issues exist and no unresolved concerns remain, return empty arrays and severity "low".`
 
 // DefaultTemplate returns the built-in prompt template.
 func DefaultTemplate() string { return defaultTemplate }
@@ -93,7 +97,11 @@ Review the diff according to the focus above and respond with ONLY valid JSON (n
   "severity": "low|medium|high"
 }
 
-The top-level "severity" is the highest severity found. If no issues, return empty arrays and severity "low".`
+Rules for severity determination:
+- The top-level "severity" MUST be at least the highest severity of any individual issue.
+- If the PR discussion contains unresolved concerns from reviewers (especially about correctness, security, or design), factor them into your severity assessment. An unresolved reviewer concern about a real defect warrants at least "medium".
+- If reviewers have explicitly flagged something as a blocker or requested changes that were not addressed in the current diff, this is "high" severity.
+- If no issues exist and no unresolved concerns remain, return empty arrays and severity "low".`
 }
 
 // BuildPrompt builds a prompt from the default template.

--- a/daemon/internal/pipeline/comment_signals.go
+++ b/daemon/internal/pipeline/comment_signals.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/heimdallm/daemon/internal/github"
@@ -10,8 +11,9 @@ import (
 // These signals complement the AI's severity assessment by detecting explicit
 // blocking intent or unresolved concerns that the AI might overlook.
 type CommentSignals struct {
-	// HasBlockerKeywords indicates comments contain explicit blocking language
-	// ("blocker", "must fix", "do not merge", etc.).
+	// HasBlockerKeywords indicates that UNRESOLVED reviewer comments contain
+	// explicit blocking language ("blocker", "must fix", "do not merge", etc.).
+	// Resolved concerns (followed by an author reply) clear this flag.
 	HasBlockerKeywords bool
 	// UnresolvedConcerns counts comments by non-author reviewers that appear
 	// to raise issues without a subsequent acknowledgement by the PR author.
@@ -20,26 +22,73 @@ type CommentSignals struct {
 	//   0 = no concerning signals
 	//   1 = minor unresolved discussion (1-2 reviewer comments)
 	//   2 = moderate unresolved discussion (3+ reviewer comments)
-	//   3 = explicit blocking language detected
+	//   3 = explicit blocking language in unresolved comments
+	// Note: Urgency 1-2 currently only enriches prompt context (re-review
+	// NOTE injection). Only Urgency >= 3 escalates the stored severity via
+	// ApplySignalEscalation.
 	Urgency int
 }
 
-// blockerKeywords are phrases that indicate a reviewer explicitly wants to
-// block the PR from merging. These are intentionally conservative to avoid
-// false positives from casual language.
-var blockerKeywords = []string{
-	"blocker",
-	"must fix",
-	"do not merge",
-	"don't merge",
-	"security issue",
-	"critical bug",
-	"blocking",
-	"nack",
-	"must be fixed",
-	"cannot merge",
-	"should not merge",
-	"needs to be fixed before",
+// blockerPatterns are word-boundary-aware regexes that indicate a reviewer
+// explicitly wants to block the PR from merging.
+//
+// Design:
+//   - Each pattern uses \b (word boundary) to avoid substring false positives
+//     (e.g. "non-blocking" won't match the "blocking" pattern).
+//   - Negation prefixes ("not a", "non-", "no ") are excluded via negative
+//     lookbehind approximation (checked separately in containsBlockerKeyword).
+//
+// Precondition: input to matching is already lowercased.
+var blockerPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\bblocker\b`),
+	regexp.MustCompile(`\bmust fix\b`),
+	regexp.MustCompile(`\bdo not merge\b`),
+	regexp.MustCompile(`\bdon'?t merge\b`),
+	regexp.MustCompile(`\bsecurity issue\b`),
+	regexp.MustCompile(`\bcritical bug\b`),
+	regexp.MustCompile(`\bblocking\b`),
+	regexp.MustCompile(`\bnack\b`),
+	regexp.MustCompile(`\bmust be fixed\b`),
+	regexp.MustCompile(`\bcannot merge\b`),
+	regexp.MustCompile(`\bshould not merge\b`),
+	regexp.MustCompile(`\bneeds to be fixed before\b`),
+}
+
+// negationPrefixes are phrases that negate a blocker keyword when they
+// immediately precede the match (e.g. "not a blocker", "non-blocking").
+var negationPrefixes = []string{
+	"not a ",
+	"not ",
+	"non-",
+	"non ",
+	"no ",
+	"isn't a ",
+	"isnt a ",
+}
+
+// containsBlockerKeyword checks whether a lowercased comment body contains
+// a blocker keyword that is NOT negated by a preceding phrase.
+func containsBlockerKeyword(body string) bool {
+	for _, pat := range blockerPatterns {
+		loc := pat.FindStringIndex(body)
+		if loc == nil {
+			continue
+		}
+		// Check if the match is preceded by a negation prefix.
+		matchStart := loc[0]
+		negated := false
+		for _, neg := range negationPrefixes {
+			prefixStart := matchStart - len(neg)
+			if prefixStart >= 0 && body[prefixStart:matchStart] == neg {
+				negated = true
+				break
+			}
+		}
+		if !negated {
+			return true
+		}
+	}
+	return false
 }
 
 // ExtractCommentSignals analyzes PR comments for signals that should
@@ -47,50 +96,54 @@ var blockerKeywords = []string{
 // Only comments from non-author reviewers are considered — the PR author's
 // own comments are excluded since they represent responses, not concerns.
 //
+// Precondition: comments must be in chronological order. The acknowledgement
+// heuristic relies on temporal ordering to determine which concerns have been
+// addressed by the author.
+//
 // The function is designed to be conservative: it only elevates the decision,
-// never lowers it. A PR with blocker keywords in reviewer comments will
-// trigger Urgency 3, which can escalate a "medium" severity to REQUEST_CHANGES.
+// never lowers it. A PR with blocker keywords in UNRESOLVED reviewer comments
+// will trigger Urgency 3, which can escalate a "medium" severity via
+// ApplySignalEscalation.
 func ExtractCommentSignals(comments []github.Comment, prAuthor string) CommentSignals {
 	if len(comments) == 0 {
 		return CommentSignals{}
 	}
 
-	var signals CommentSignals
-
-	// Track which reviewer concerns have been acknowledged by the author.
-	// A reviewer comment followed by an author reply (later in time) is
-	// considered acknowledged.
+	// Track reviewer concerns and whether they contain blocker keywords.
+	// Both are cleared when the PR author replies, ensuring that resolved
+	// blockers don't persist in the final signal.
 	type concern struct {
-		index  int
-		author string
+		hasBlocker bool
 	}
-	var reviewerConcerns []concern
+	var unresolvedConcerns []concern
 
-	for i, c := range comments {
+	for _, c := range comments {
 		if strings.EqualFold(c.Author, prAuthor) {
-			// Author comment: marks prior reviewer concerns as acknowledged
-			// (simple heuristic — any author reply after a concern counts).
-			reviewerConcerns = nil
+			// Author comment: marks ALL prior reviewer concerns as acknowledged.
+			// This is intentionally broad — any author reply signals engagement.
+			unresolvedConcerns = nil
 			continue
 		}
 
-		// Reviewer comment: check for blocker keywords
+		// Reviewer comment: check for blocker keywords with word-boundary
+		// matching and negation handling.
 		body := strings.ToLower(c.Body)
-		for _, kw := range blockerKeywords {
-			if strings.Contains(body, kw) {
-				signals.HasBlockerKeywords = true
-				break
-			}
-		}
+		hasBlocker := containsBlockerKeyword(body)
 
-		reviewerConcerns = append(reviewerConcerns, concern{index: i, author: c.Author})
+		unresolvedConcerns = append(unresolvedConcerns, concern{hasBlocker: hasBlocker})
 	}
 
-	// Unresolved concerns are reviewer comments that were never followed by
-	// an author acknowledgement (i.e., remain at the end of the thread).
-	signals.UnresolvedConcerns = len(reviewerConcerns)
+	// Build final signals from unresolved concerns only.
+	var signals CommentSignals
+	signals.UnresolvedConcerns = len(unresolvedConcerns)
+	for _, c := range unresolvedConcerns {
+		if c.hasBlocker {
+			signals.HasBlockerKeywords = true
+			break
+		}
+	}
 
-	// Compute urgency score
+	// Compute urgency score.
 	switch {
 	case signals.HasBlockerKeywords:
 		signals.Urgency = 3

--- a/daemon/internal/pipeline/comment_signals.go
+++ b/daemon/internal/pipeline/comment_signals.go
@@ -1,0 +1,106 @@
+package pipeline
+
+import (
+	"strings"
+
+	"github.com/heimdallm/daemon/internal/github"
+)
+
+// CommentSignals represents extracted review-relevant signals from PR discussion.
+// These signals complement the AI's severity assessment by detecting explicit
+// blocking intent or unresolved concerns that the AI might overlook.
+type CommentSignals struct {
+	// HasBlockerKeywords indicates comments contain explicit blocking language
+	// ("blocker", "must fix", "do not merge", etc.).
+	HasBlockerKeywords bool
+	// UnresolvedConcerns counts comments by non-author reviewers that appear
+	// to raise issues without a subsequent acknowledgement by the PR author.
+	UnresolvedConcerns int
+	// Urgency is a computed 0-3 score summarizing signal strength:
+	//   0 = no concerning signals
+	//   1 = minor unresolved discussion (1-2 reviewer comments)
+	//   2 = moderate unresolved discussion (3+ reviewer comments)
+	//   3 = explicit blocking language detected
+	Urgency int
+}
+
+// blockerKeywords are phrases that indicate a reviewer explicitly wants to
+// block the PR from merging. These are intentionally conservative to avoid
+// false positives from casual language.
+var blockerKeywords = []string{
+	"blocker",
+	"must fix",
+	"do not merge",
+	"don't merge",
+	"security issue",
+	"critical bug",
+	"blocking",
+	"nack",
+	"must be fixed",
+	"cannot merge",
+	"should not merge",
+	"needs to be fixed before",
+}
+
+// ExtractCommentSignals analyzes PR comments for signals that should
+// influence the review decision beyond what the AI alone determines.
+// Only comments from non-author reviewers are considered — the PR author's
+// own comments are excluded since they represent responses, not concerns.
+//
+// The function is designed to be conservative: it only elevates the decision,
+// never lowers it. A PR with blocker keywords in reviewer comments will
+// trigger Urgency 3, which can escalate a "medium" severity to REQUEST_CHANGES.
+func ExtractCommentSignals(comments []github.Comment, prAuthor string) CommentSignals {
+	if len(comments) == 0 {
+		return CommentSignals{}
+	}
+
+	var signals CommentSignals
+
+	// Track which reviewer concerns have been acknowledged by the author.
+	// A reviewer comment followed by an author reply (later in time) is
+	// considered acknowledged.
+	type concern struct {
+		index  int
+		author string
+	}
+	var reviewerConcerns []concern
+
+	for i, c := range comments {
+		if strings.EqualFold(c.Author, prAuthor) {
+			// Author comment: marks prior reviewer concerns as acknowledged
+			// (simple heuristic — any author reply after a concern counts).
+			reviewerConcerns = nil
+			continue
+		}
+
+		// Reviewer comment: check for blocker keywords
+		body := strings.ToLower(c.Body)
+		for _, kw := range blockerKeywords {
+			if strings.Contains(body, kw) {
+				signals.HasBlockerKeywords = true
+				break
+			}
+		}
+
+		reviewerConcerns = append(reviewerConcerns, concern{index: i, author: c.Author})
+	}
+
+	// Unresolved concerns are reviewer comments that were never followed by
+	// an author acknowledgement (i.e., remain at the end of the thread).
+	signals.UnresolvedConcerns = len(reviewerConcerns)
+
+	// Compute urgency score
+	switch {
+	case signals.HasBlockerKeywords:
+		signals.Urgency = 3
+	case signals.UnresolvedConcerns >= 3:
+		signals.Urgency = 2
+	case signals.UnresolvedConcerns >= 1:
+		signals.Urgency = 1
+	default:
+		signals.Urgency = 0
+	}
+
+	return signals
+}

--- a/daemon/internal/pipeline/comment_signals_test.go
+++ b/daemon/internal/pipeline/comment_signals_test.go
@@ -1,0 +1,270 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/github"
+)
+
+func TestExtractCommentSignals_Empty(t *testing.T) {
+	signals := ExtractCommentSignals(nil, "author")
+	if signals.HasBlockerKeywords || signals.UnresolvedConcerns != 0 || signals.Urgency != 0 {
+		t.Errorf("expected zero signals for nil input, got %+v", signals)
+	}
+}
+
+func TestExtractCommentSignals_AuthorOnlyComments(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "author", Body: "I'll fix this"},
+		{Author: "author", Body: "Done, pushed changes"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.UnresolvedConcerns != 0 {
+		t.Errorf("author-only comments should produce 0 unresolved, got %d", signals.UnresolvedConcerns)
+	}
+	if signals.Urgency != 0 {
+		t.Errorf("expected urgency 0, got %d", signals.Urgency)
+	}
+}
+
+func TestExtractCommentSignals_BlockerKeyword(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "This is a blocker — the API key is exposed"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if !signals.HasBlockerKeywords {
+		t.Error("expected HasBlockerKeywords=true for 'blocker'")
+	}
+	if signals.Urgency != 3 {
+		t.Errorf("expected urgency 3 for blocker keyword, got %d", signals.Urgency)
+	}
+}
+
+func TestExtractCommentSignals_DoNotMerge(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "lead", Body: "Do not merge this until the migration is ready"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if !signals.HasBlockerKeywords {
+		t.Error("expected HasBlockerKeywords=true for 'do not merge'")
+	}
+	if signals.Urgency != 3 {
+		t.Errorf("expected urgency 3, got %d", signals.Urgency)
+	}
+}
+
+func TestExtractCommentSignals_MustFix(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "You must fix the null pointer dereference"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if !signals.HasBlockerKeywords {
+		t.Error("expected HasBlockerKeywords=true for 'must fix'")
+	}
+}
+
+func TestExtractCommentSignals_UnresolvedConcerns(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer1", Body: "This function is too complex"},
+		{Author: "reviewer2", Body: "Missing error handling here"},
+		{Author: "reviewer1", Body: "Also the naming is confusing"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.UnresolvedConcerns != 3 {
+		t.Errorf("expected 3 unresolved concerns, got %d", signals.UnresolvedConcerns)
+	}
+	if signals.Urgency != 2 {
+		t.Errorf("expected urgency 2 for 3+ unresolved, got %d", signals.Urgency)
+	}
+}
+
+func TestExtractCommentSignals_ConcernsResolvedByAuthor(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "This function is too complex"},
+		{Author: "reviewer", Body: "Missing error handling here"},
+		{Author: "author", Body: "Fixed both issues in latest push"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.UnresolvedConcerns != 0 {
+		t.Errorf("expected 0 unresolved after author reply, got %d", signals.UnresolvedConcerns)
+	}
+	if signals.Urgency != 0 {
+		t.Errorf("expected urgency 0 after resolution, got %d", signals.Urgency)
+	}
+}
+
+func TestExtractCommentSignals_PartialResolution(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "Issue A"},
+		{Author: "author", Body: "Fixed A"},
+		{Author: "reviewer", Body: "Issue B"},
+		{Author: "reviewer", Body: "Issue C"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.UnresolvedConcerns != 2 {
+		t.Errorf("expected 2 unresolved (B and C after author reply), got %d", signals.UnresolvedConcerns)
+	}
+	if signals.Urgency != 1 {
+		// 2 concerns → urgency 1 (need 3+ for urgency 2)
+		t.Errorf("expected urgency 1, got %d", signals.Urgency)
+	}
+}
+
+func TestExtractCommentSignals_CaseInsensitiveAuthor(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "Needs work"},
+		{Author: "Author", Body: "Done"}, // different case
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.UnresolvedConcerns != 0 {
+		t.Errorf("expected case-insensitive author match, got %d unresolved", signals.UnresolvedConcerns)
+	}
+}
+
+func TestExtractCommentSignals_BlockerOverridesCount(t *testing.T) {
+	// Even with only 1 comment, blocker keyword → urgency 3
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "This is a security issue"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.Urgency != 3 {
+		t.Errorf("blocker keyword should set urgency 3 regardless of count, got %d", signals.Urgency)
+	}
+}
+
+func TestExtractCommentSignals_NoCasualFalsePositive(t *testing.T) {
+	// Normal discussion should not trigger blockers
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "Nice work, looks good overall"},
+		{Author: "reviewer", Body: "Minor nit: rename this variable"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.HasBlockerKeywords {
+		t.Error("casual comments should not trigger blocker keywords")
+	}
+}
+
+// --- Tests for ReconcileSeverity ---
+
+func TestReconcileSeverity_Consistent(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity string
+		issues   []Issue
+		want     string
+	}{
+		{"high matches", "high", []Issue{{Severity: "high"}}, "high"},
+		{"medium matches", "medium", []Issue{{Severity: "medium"}}, "medium"},
+		{"low matches", "low", []Issue{{Severity: "low"}}, "low"},
+		{"no issues low", "low", nil, "low"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert pipeline.Issue to executor.Issue for the function
+			result := makeResult(tt.severity, tt.issues)
+			got := ReconcileSeverity(result)
+			if got != tt.want {
+				t.Errorf("ReconcileSeverity() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconcileSeverity_EscalatesFromLowToHigh(t *testing.T) {
+	result := makeResult("low", []Issue{
+		{Severity: "low"},
+		{Severity: "high"},
+	})
+	got := ReconcileSeverity(result)
+	if got != "high" {
+		t.Errorf("expected reconciled severity 'high', got %q", got)
+	}
+}
+
+func TestReconcileSeverity_EscalatesFromLowToMedium(t *testing.T) {
+	result := makeResult("low", []Issue{
+		{Severity: "medium"},
+	})
+	got := ReconcileSeverity(result)
+	if got != "medium" {
+		t.Errorf("expected reconciled severity 'medium', got %q", got)
+	}
+}
+
+func TestReconcileSeverity_NeverLowers(t *testing.T) {
+	// AI says "high" but all issues are "low" — we trust the AI's higher assessment
+	result := makeResult("high", []Issue{
+		{Severity: "low"},
+		{Severity: "low"},
+	})
+	got := ReconcileSeverity(result)
+	if got != "high" {
+		t.Errorf("reconcile should never lower severity, got %q", got)
+	}
+}
+
+// --- Tests for SeverityToEvent with CommentSignals ---
+
+func TestSeverityToEvent_HighAlwaysRequestsChanges(t *testing.T) {
+	got := SeverityToEvent("high", CommentSignals{})
+	if got != "REQUEST_CHANGES" {
+		t.Errorf("high severity should always REQUEST_CHANGES, got %q", got)
+	}
+}
+
+func TestSeverityToEvent_LowApproves(t *testing.T) {
+	got := SeverityToEvent("low", CommentSignals{})
+	if got != "APPROVE" {
+		t.Errorf("low severity without signals should APPROVE, got %q", got)
+	}
+}
+
+func TestSeverityToEvent_MediumApprovesNormally(t *testing.T) {
+	got := SeverityToEvent("medium", CommentSignals{Urgency: 1})
+	if got != "APPROVE" {
+		t.Errorf("medium with low urgency should APPROVE, got %q", got)
+	}
+}
+
+func TestSeverityToEvent_MediumEscalatesWithBlocker(t *testing.T) {
+	signals := CommentSignals{
+		HasBlockerKeywords: true,
+		Urgency:            3,
+	}
+	got := SeverityToEvent("medium", signals)
+	if got != "REQUEST_CHANGES" {
+		t.Errorf("medium + blocker signals should REQUEST_CHANGES, got %q", got)
+	}
+}
+
+func TestSeverityToEvent_LowDoesNotEscalateWithBlocker(t *testing.T) {
+	// Design choice: "low" severity is not elevated even with blocker keywords.
+	// Only "medium" can be escalated — keeps Heimdallm non-aggressive.
+	signals := CommentSignals{
+		HasBlockerKeywords: true,
+		Urgency:            3,
+	}
+	got := SeverityToEvent("low", signals)
+	if got != "APPROVE" {
+		t.Errorf("low severity should not escalate even with blockers, got %q", got)
+	}
+}
+
+// --- Helper ---
+
+// Issue mirrors executor.Issue for test readability.
+type Issue struct {
+	Severity string
+}
+
+func makeResult(severity string, issues []Issue) *executor.ReviewResult {
+	var execIssues []executor.Issue
+	for _, iss := range issues {
+		execIssues = append(execIssues, executor.Issue{Severity: iss.Severity})
+	}
+	return &executor.ReviewResult{
+		Severity: severity,
+		Issues:   execIssues,
+	}
+}

--- a/daemon/internal/pipeline/comment_signals_test.go
+++ b/daemon/internal/pipeline/comment_signals_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/heimdallm/daemon/internal/github"
 )
 
+// --- Tests for ExtractCommentSignals ---
+
 func TestExtractCommentSignals_Empty(t *testing.T) {
 	signals := ExtractCommentSignals(nil, "author")
 	if signals.HasBlockerKeywords || signals.UnresolvedConcerns != 0 || signals.Urgency != 0 {
@@ -145,23 +147,141 @@ func TestExtractCommentSignals_NoCasualFalsePositive(t *testing.T) {
 	}
 }
 
+// --- Fix 2: Word-boundary matching prevents substring false positives ---
+
+func TestExtractCommentSignals_NonBlockingNotFalsePositive(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "This is non-blocking, just a nit"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.HasBlockerKeywords {
+		t.Error("'non-blocking' should NOT trigger blocker detection")
+	}
+	if signals.Urgency == 3 {
+		t.Error("'non-blocking' should not produce urgency 3")
+	}
+}
+
+func TestExtractCommentSignals_NotABlockerNotFalsePositive(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "Not a blocker, but consider refactoring"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.HasBlockerKeywords {
+		t.Error("'not a blocker' should NOT trigger blocker detection")
+	}
+}
+
+func TestExtractCommentSignals_NegatedMustFixNotFalsePositive(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "This is not a must fix, just a suggestion"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.HasBlockerKeywords {
+		t.Error("'not a must fix' should NOT trigger blocker detection")
+	}
+}
+
+func TestExtractCommentSignals_KnackNotFalsePositive(t *testing.T) {
+	// "nack" as a pattern should not match inside other words
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "You have a knack for clean code"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.HasBlockerKeywords {
+		t.Error("'knack' should NOT trigger 'nack' blocker detection")
+	}
+}
+
+func TestExtractCommentSignals_RealBlockerStillDetected(t *testing.T) {
+	// After adding negation handling, real blockers must still work
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "This is definitely a blocker for the release"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if !signals.HasBlockerKeywords {
+		t.Error("real 'blocker' keyword should still be detected")
+	}
+}
+
+func TestExtractCommentSignals_RealBlockingStillDetected(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "This bug is blocking the deploy pipeline"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if !signals.HasBlockerKeywords {
+		t.Error("real 'blocking' keyword should still be detected")
+	}
+}
+
+// --- Fix 3: HasBlockerKeywords resets when author resolves ---
+
+func TestExtractCommentSignals_BlockerResolvedByAuthor(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "This is a blocker — exposed credentials"},
+		{Author: "author", Body: "Fixed, removed the credentials"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.HasBlockerKeywords {
+		t.Error("blocker resolved by author reply should clear HasBlockerKeywords")
+	}
+	if signals.UnresolvedConcerns != 0 {
+		t.Errorf("expected 0 unresolved after author addresses blocker, got %d", signals.UnresolvedConcerns)
+	}
+	if signals.Urgency != 0 {
+		t.Errorf("resolved blocker should produce urgency 0, got %d", signals.Urgency)
+	}
+}
+
+func TestExtractCommentSignals_BlockerResolvedThenNewConcern(t *testing.T) {
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "This is a blocker"},
+		{Author: "author", Body: "Fixed"},
+		{Author: "reviewer", Body: "New minor concern, not a big deal"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if signals.HasBlockerKeywords {
+		t.Error("old blocker was resolved; new comment has no blocker keyword")
+	}
+	if signals.UnresolvedConcerns != 1 {
+		t.Errorf("expected 1 unresolved concern (new one), got %d", signals.UnresolvedConcerns)
+	}
+	if signals.Urgency != 1 {
+		t.Errorf("expected urgency 1 (1 unresolved, no blocker), got %d", signals.Urgency)
+	}
+}
+
+func TestExtractCommentSignals_UnresolvedBlockerPersists(t *testing.T) {
+	// If the author never replies to a blocker, it persists
+	comments := []github.Comment{
+		{Author: "reviewer", Body: "This is a blocker"},
+		{Author: "other-reviewer", Body: "I agree, must fix this"},
+	}
+	signals := ExtractCommentSignals(comments, "author")
+	if !signals.HasBlockerKeywords {
+		t.Error("unresolved blocker should persist HasBlockerKeywords")
+	}
+	if signals.Urgency != 3 {
+		t.Errorf("expected urgency 3 for unresolved blocker, got %d", signals.Urgency)
+	}
+}
+
 // --- Tests for ReconcileSeverity ---
 
 func TestReconcileSeverity_Consistent(t *testing.T) {
 	tests := []struct {
 		name     string
 		severity string
-		issues   []Issue
+		issues   []testIssue
 		want     string
 	}{
-		{"high matches", "high", []Issue{{Severity: "high"}}, "high"},
-		{"medium matches", "medium", []Issue{{Severity: "medium"}}, "medium"},
-		{"low matches", "low", []Issue{{Severity: "low"}}, "low"},
+		{"high matches", "high", []testIssue{{Severity: "high"}}, "high"},
+		{"medium matches", "medium", []testIssue{{Severity: "medium"}}, "medium"},
+		{"low matches", "low", []testIssue{{Severity: "low"}}, "low"},
 		{"no issues low", "low", nil, "low"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Convert pipeline.Issue to executor.Issue for the function
 			result := makeResult(tt.severity, tt.issues)
 			got := ReconcileSeverity(result)
 			if got != tt.want {
@@ -172,7 +292,7 @@ func TestReconcileSeverity_Consistent(t *testing.T) {
 }
 
 func TestReconcileSeverity_EscalatesFromLowToHigh(t *testing.T) {
-	result := makeResult("low", []Issue{
+	result := makeResult("low", []testIssue{
 		{Severity: "low"},
 		{Severity: "high"},
 	})
@@ -183,7 +303,7 @@ func TestReconcileSeverity_EscalatesFromLowToHigh(t *testing.T) {
 }
 
 func TestReconcileSeverity_EscalatesFromLowToMedium(t *testing.T) {
-	result := makeResult("low", []Issue{
+	result := makeResult("low", []testIssue{
 		{Severity: "medium"},
 	})
 	got := ReconcileSeverity(result)
@@ -194,7 +314,7 @@ func TestReconcileSeverity_EscalatesFromLowToMedium(t *testing.T) {
 
 func TestReconcileSeverity_NeverLowers(t *testing.T) {
 	// AI says "high" but all issues are "low" — we trust the AI's higher assessment
-	result := makeResult("high", []Issue{
+	result := makeResult("high", []testIssue{
 		{Severity: "low"},
 		{Severity: "low"},
 	})
@@ -204,61 +324,89 @@ func TestReconcileSeverity_NeverLowers(t *testing.T) {
 	}
 }
 
-// --- Tests for SeverityToEvent with CommentSignals ---
+// --- Tests for ApplySignalEscalation ---
 
-func TestSeverityToEvent_HighAlwaysRequestsChanges(t *testing.T) {
-	got := SeverityToEvent("high", CommentSignals{})
+func TestApplySignalEscalation_MediumWithBlocker(t *testing.T) {
+	got := ApplySignalEscalation("medium", CommentSignals{HasBlockerKeywords: true, Urgency: 3})
+	if got != "high" {
+		t.Errorf("medium + blocker should escalate to high, got %q", got)
+	}
+}
+
+func TestApplySignalEscalation_MediumWithoutBlocker(t *testing.T) {
+	got := ApplySignalEscalation("medium", CommentSignals{Urgency: 2})
+	if got != "medium" {
+		t.Errorf("medium + urgency 2 should stay medium, got %q", got)
+	}
+}
+
+func TestApplySignalEscalation_LowWithBlocker(t *testing.T) {
+	// Low is never escalated by signals — conservative design
+	got := ApplySignalEscalation("low", CommentSignals{HasBlockerKeywords: true, Urgency: 3})
+	if got != "low" {
+		t.Errorf("low should never be escalated by signals, got %q", got)
+	}
+}
+
+func TestApplySignalEscalation_HighUnchanged(t *testing.T) {
+	got := ApplySignalEscalation("high", CommentSignals{})
+	if got != "high" {
+		t.Errorf("high should stay high, got %q", got)
+	}
+}
+
+// --- Tests for SeverityToEvent ---
+
+func TestSeverityToEvent_HighRequestsChanges(t *testing.T) {
+	got := SeverityToEvent("high")
 	if got != "REQUEST_CHANGES" {
-		t.Errorf("high severity should always REQUEST_CHANGES, got %q", got)
+		t.Errorf("high severity should REQUEST_CHANGES, got %q", got)
+	}
+}
+
+func TestSeverityToEvent_MediumApproves(t *testing.T) {
+	got := SeverityToEvent("medium")
+	if got != "APPROVE" {
+		t.Errorf("medium severity should APPROVE, got %q", got)
 	}
 }
 
 func TestSeverityToEvent_LowApproves(t *testing.T) {
-	got := SeverityToEvent("low", CommentSignals{})
+	got := SeverityToEvent("low")
 	if got != "APPROVE" {
-		t.Errorf("low severity without signals should APPROVE, got %q", got)
+		t.Errorf("low severity should APPROVE, got %q", got)
 	}
 }
 
-func TestSeverityToEvent_MediumApprovesNormally(t *testing.T) {
-	got := SeverityToEvent("medium", CommentSignals{Urgency: 1})
-	if got != "APPROVE" {
-		t.Errorf("medium with low urgency should APPROVE, got %q", got)
-	}
-}
+// --- Fix 1: Verify escalation is persisted correctly (integration scenario) ---
 
-func TestSeverityToEvent_MediumEscalatesWithBlocker(t *testing.T) {
-	signals := CommentSignals{
-		HasBlockerKeywords: true,
-		Urgency:            3,
-	}
-	got := SeverityToEvent("medium", signals)
-	if got != "REQUEST_CHANGES" {
-		t.Errorf("medium + blocker signals should REQUEST_CHANGES, got %q", got)
-	}
-}
+func TestEscalationPersistenceScenario(t *testing.T) {
+	// Simulate the pipeline flow: medium severity + blocker signals → stored as high
+	signals := ExtractCommentSignals([]github.Comment{
+		{Author: "reviewer", Body: "This is a blocker for release"},
+	}, "author")
+	reconciled := "medium" // AI said medium
+	finalSeverity := ApplySignalEscalation(reconciled, signals)
 
-func TestSeverityToEvent_LowDoesNotEscalateWithBlocker(t *testing.T) {
-	// Design choice: "low" severity is not elevated even with blocker keywords.
-	// Only "medium" can be escalated — keeps Heimdallm non-aggressive.
-	signals := CommentSignals{
-		HasBlockerKeywords: true,
-		Urgency:            3,
+	// This is what gets stored in the DB
+	if finalSeverity != "high" {
+		t.Fatalf("expected stored severity 'high', got %q", finalSeverity)
 	}
-	got := SeverityToEvent("low", signals)
-	if got != "APPROVE" {
-		t.Errorf("low severity should not escalate even with blockers, got %q", got)
+
+	// On retry, PublishPending uses stored severity with no signals
+	event := SeverityToEvent(finalSeverity)
+	if event != "REQUEST_CHANGES" {
+		t.Errorf("retry should reproduce REQUEST_CHANGES from stored severity, got %q", event)
 	}
 }
 
 // --- Helper ---
 
-// Issue mirrors executor.Issue for test readability.
-type Issue struct {
+type testIssue struct {
 	Severity string
 }
 
-func makeResult(severity string, issues []Issue) *executor.ReviewResult {
+func makeResult(severity string, issues []testIssue) *executor.ReviewResult {
 	var execIssues []executor.Issue
 	for _, iss := range issues {
 		execIssues = append(execIssues, executor.Issue{Severity: iss.Severity})

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -591,7 +591,12 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	// will be persisted. By folding signal-driven escalation into the stored
 	// severity, retry paths (PublishPending, NATS worker) reproduce the same
 	// APPROVE/REQUEST_CHANGES decision without needing to re-extract signals.
-	commentSignals := ExtractCommentSignals(prComments, pr.User.Login)
+	//
+	// Filter out the bot's own comments before extraction — Heimdallm's prior
+	// review bodies often contain blocker keywords ("security issue",
+	// "must fix", etc.) that would otherwise self-trigger escalation.
+	signalComments := filterBotComments(prComments, p.botLogin)
+	commentSignals := ExtractCommentSignals(signalComments, pr.User.Login)
 	finalSeverity := ApplySignalEscalation(reconciledSeverity, commentSignals)
 
 	// 6. Marshal issues and suggestions to JSON for storage
@@ -943,6 +948,22 @@ func SeverityToEvent(severity string) string {
 
 // maxCommentsBytes limits the total formatted PR comments included in the prompt.
 const maxCommentsBytes = 16 * 1024 // 16KB
+
+// filterBotComments returns a new slice excluding comments authored by the bot.
+// This prevents Heimdallm's own prior review bodies (which contain keywords like
+// "security issue", "must fix", etc.) from self-triggering blocker detection.
+func filterBotComments(comments []github.Comment, botLogin string) []github.Comment {
+	if botLogin == "" {
+		return comments
+	}
+	filtered := make([]github.Comment, 0, len(comments))
+	for _, c := range comments {
+		if !strings.EqualFold(c.Author, botLogin) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
 
 // formatComments formats a slice of GitHub comments into a prompt section string.
 // Returns empty string if comments is nil or empty.

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -490,6 +490,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 			prevReview.CreatedAt,
 			prComments,
 			p.botLogin,
+			pr.User.Login,
 		)
 	}
 
@@ -582,6 +583,13 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		return nil, fmt.Errorf("pipeline: execute %s: %w", cli, err)
 	}
 
+	// 5b. Reconcile severity: ensure top-level severity >= max(issues[].severity).
+	// Guards against LLM inconsistencies (prompt injection, model errors).
+	reconciledSeverity := ReconcileSeverity(result)
+
+	// 5c. Extract comment signals for the review decision.
+	commentSignals := ExtractCommentSignals(prComments, pr.User.Login)
+
 	// 6. Marshal issues and suggestions to JSON for storage
 	issuesJSON, err := json.Marshal(result.Issues)
 	if err != nil {
@@ -599,7 +607,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		Summary:        result.Summary,
 		Issues:         string(issuesJSON),
 		Suggestions:    string(suggestionsJSON),
-		Severity:       result.Severity,
+		Severity:       reconciledSeverity,
 		CreatedAt:      time.Now().UTC(),
 		GitHubReviewID: 0, // will be set after GitHub publish
 		HeadSHA:        pr.Head.SHA,
@@ -627,7 +635,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
 		pr.Repo, pr.Number,
 		reviewBody,
-		SeverityToEvent(result.Severity, len(result.Issues)),
+		SeverityToEvent(reconciledSeverity, commentSignals),
 	)
 	if publishErr != nil {
 		// Permanent submit failure (PR locked etc.): mark the freshly
@@ -736,10 +744,12 @@ func (p *Pipeline) PublishPending() {
 		}
 		// PublishPending always uses single-mode body (individual comments were
 		// already posted when the review first ran; we only retry the formal review).
+		// Note: comment signals were already factored into the stored severity
+		// at initial review time; retry uses stored severity as-is.
 		ghID, ghState, err := p.gh.SubmitReview(
 			pr.Repo, pr.Number,
 			BuildGitHubBody(result),
-			SeverityToEvent(rev.Severity, len(issues)),
+			SeverityToEvent(rev.Severity, CommentSignals{}),
 		)
 		if err != nil {
 			// Permanent submit failures (currently HTTP 422 "lock
@@ -856,11 +866,61 @@ func BuildGitHubBody(r *executor.ReviewResult) string {
 	return sb.String()
 }
 
-// SeverityToEvent maps severity to a GitHub review event type.
+// severityRank maps a severity string to a numeric rank for comparison.
+func severityRank(s string) int {
+	switch strings.ToLower(s) {
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	default:
+		return 1
+	}
+}
+
+// rankToSeverity converts a numeric rank back to a severity string.
+func rankToSeverity(r int) string {
+	switch r {
+	case 3:
+		return "high"
+	case 2:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+// ReconcileSeverity ensures the top-level severity is at least as high as
+// the maximum severity found in individual issues. This guards against LLM
+// inconsistencies where issues are flagged high but the global field is set
+// low (prompt injection, model error, hallucination).
+func ReconcileSeverity(result *executor.ReviewResult) string {
+	maxRank := severityRank(result.Severity)
+	for _, iss := range result.Issues {
+		if r := severityRank(iss.Severity); r > maxRank {
+			maxRank = r
+		}
+	}
+	reconciled := rankToSeverity(maxRank)
+	if reconciled != result.Severity {
+		slog.Warn("pipeline: severity reconciled (AI inconsistency)",
+			"ai_severity", result.Severity,
+			"reconciled", reconciled,
+			"issue_count", len(result.Issues))
+	}
+	return reconciled
+}
+
+// SeverityToEvent maps severity + comment signals to a GitHub review event type.
 // Only high-severity issues block a PR — Heimdallm must not be a blocker
-// for medium/low issues. Those are left as informational comments with an APPROVE.
-func SeverityToEvent(severity string, _ int) string {
+// for medium/low issues unless comment signals indicate blocking concerns.
+func SeverityToEvent(severity string, signals CommentSignals) string {
 	if severity == "high" {
+		return "REQUEST_CHANGES"
+	}
+	// Elevate to REQUEST_CHANGES if comment signals indicate blocking concerns
+	// even when AI assessed medium severity.
+	if severity == "medium" && signals.Urgency >= 3 {
 		return "REQUEST_CHANGES"
 	}
 	return "APPROVE"

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -587,8 +587,12 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	// Guards against LLM inconsistencies (prompt injection, model errors).
 	reconciledSeverity := ReconcileSeverity(result)
 
-	// 5c. Extract comment signals for the review decision.
+	// 5c. Extract comment signals and apply escalation to the severity that
+	// will be persisted. By folding signal-driven escalation into the stored
+	// severity, retry paths (PublishPending, NATS worker) reproduce the same
+	// APPROVE/REQUEST_CHANGES decision without needing to re-extract signals.
 	commentSignals := ExtractCommentSignals(prComments, pr.User.Login)
+	finalSeverity := ApplySignalEscalation(reconciledSeverity, commentSignals)
 
 	// 6. Marshal issues and suggestions to JSON for storage
 	issuesJSON, err := json.Marshal(result.Issues)
@@ -607,7 +611,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		Summary:        result.Summary,
 		Issues:         string(issuesJSON),
 		Suggestions:    string(suggestionsJSON),
-		Severity:       reconciledSeverity,
+		Severity:       finalSeverity,
 		CreatedAt:      time.Now().UTC(),
 		GitHubReviewID: 0, // will be set after GitHub publish
 		HeadSHA:        pr.Head.SHA,
@@ -635,7 +639,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
 		pr.Repo, pr.Number,
 		reviewBody,
-		SeverityToEvent(reconciledSeverity, commentSignals),
+		SeverityToEvent(finalSeverity),
 	)
 	if publishErr != nil {
 		// Permanent submit failure (PR locked etc.): mark the freshly
@@ -744,12 +748,12 @@ func (p *Pipeline) PublishPending() {
 		}
 		// PublishPending always uses single-mode body (individual comments were
 		// already posted when the review first ran; we only retry the formal review).
-		// Note: comment signals were already factored into the stored severity
-		// at initial review time; retry uses stored severity as-is.
+		// The stored severity already incorporates signal escalation from the
+		// initial review, so SeverityToEvent reproduces the original decision.
 		ghID, ghState, err := p.gh.SubmitReview(
 			pr.Repo, pr.Number,
 			BuildGitHubBody(result),
-			SeverityToEvent(rev.Severity, CommentSignals{}),
+			SeverityToEvent(rev.Severity),
 		)
 		if err != nil {
 			// Permanent submit failures (currently HTTP 422 "lock
@@ -911,16 +915,27 @@ func ReconcileSeverity(result *executor.ReviewResult) string {
 	return reconciled
 }
 
-// SeverityToEvent maps severity + comment signals to a GitHub review event type.
-// Only high-severity issues block a PR — Heimdallm must not be a blocker
-// for medium/low issues unless comment signals indicate blocking concerns.
-func SeverityToEvent(severity string, signals CommentSignals) string {
-	if severity == "high" {
-		return "REQUEST_CHANGES"
-	}
-	// Elevate to REQUEST_CHANGES if comment signals indicate blocking concerns
-	// even when AI assessed medium severity.
+// ApplySignalEscalation elevates severity based on comment signals.
+// A "medium" severity is escalated to "high" when blocker signals are detected.
+// This ensures the escalated severity is persisted, so retry paths reproduce
+// the same decision without re-extracting signals.
+func ApplySignalEscalation(severity string, signals CommentSignals) string {
 	if severity == "medium" && signals.Urgency >= 3 {
+		slog.Info("pipeline: severity escalated by comment signals",
+			"original", severity, "escalated", "high",
+			"has_blocker_keywords", signals.HasBlockerKeywords,
+			"unresolved_concerns", signals.UnresolvedConcerns)
+		return "high"
+	}
+	return severity
+}
+
+// SeverityToEvent maps severity to a GitHub review event type.
+// Only high-severity issues block a PR — Heimdallm must not be a blocker
+// for medium/low issues. Signal-driven escalation is applied upstream via
+// ApplySignalEscalation before the severity reaches this function.
+func SeverityToEvent(severity string) string {
+	if severity == "high" {
 		return "REQUEST_CHANGES"
 	}
 	return "APPROVE"

--- a/daemon/internal/pipeline/review_context.go
+++ b/daemon/internal/pipeline/review_context.go
@@ -31,7 +31,7 @@ type reviewIssue struct {
 
 // buildReviewContext creates a structured prompt section for re-reviews.
 // Returns empty string for first-time reviews (no previous review exists).
-func buildReviewContext(prevIssuesJSON, prevSeverity string, lastReviewAt time.Time, comments []github.Comment, botLogin string) string {
+func buildReviewContext(prevIssuesJSON, prevSeverity string, lastReviewAt time.Time, comments []github.Comment, botLogin, prAuthor string) string {
 	if prevIssuesJSON == "" && lastReviewAt.IsZero() {
 		return ""
 	}
@@ -77,6 +77,16 @@ func buildReviewContext(prevIssuesJSON, prevSeverity string, lastReviewAt time.T
 			}
 		}
 		b.WriteString("\n")
+
+		// Inject unresolved concern signal so the AI explicitly considers it.
+		signals := ExtractCommentSignals(newDiscussion, prAuthor)
+		if signals.UnresolvedConcerns > 0 {
+			b.WriteString(fmt.Sprintf(
+				"NOTE: There are %d unresolved reviewer concern(s) in the discussion above. "+
+					"Verify whether the current diff addresses them. If a concern about a real defect "+
+					"remains unaddressed, reflect this in your severity assessment.\n\n",
+				signals.UnresolvedConcerns))
+		}
 	}
 
 	return b.String()

--- a/daemon/internal/pipeline/review_context_test.go
+++ b/daemon/internal/pipeline/review_context_test.go
@@ -65,7 +65,7 @@ func TestBuildReviewContext_WithPreviousReview(t *testing.T) {
 		{Author: "other-reviewer", Body: "Looks good now", CreatedAt: lastReviewAt.Add(2 * time.Hour)},
 	}
 
-	ctx := buildReviewContext(prevIssues, "high", lastReviewAt, comments, "heimdallm-bot")
+	ctx := buildReviewContext(prevIssues, "high", lastReviewAt, comments, "heimdallm-bot", "author")
 
 	if ctx == "" {
 		t.Fatal("expected non-empty review context")
@@ -86,7 +86,7 @@ func TestBuildReviewContext_WithPreviousReview(t *testing.T) {
 }
 
 func TestBuildReviewContext_NoPreviousReview(t *testing.T) {
-	ctx := buildReviewContext("", "", time.Time{}, nil, "bot")
+	ctx := buildReviewContext("", "", time.Time{}, nil, "bot", "")
 	if ctx != "" {
 		t.Errorf("expected empty context for first review, got: %q", ctx)
 	}
@@ -96,7 +96,7 @@ func TestBuildReviewContext_PreviousReviewNoNewComments(t *testing.T) {
 	prevIssues := `[{"file":"main.go","line":10,"description":"Unused import","severity":"low"}]`
 	lastReviewAt := time.Now()
 
-	ctx := buildReviewContext(prevIssues, "low", lastReviewAt, nil, "bot")
+	ctx := buildReviewContext(prevIssues, "low", lastReviewAt, nil, "bot", "")
 
 	if !strings.Contains(ctx, "RE-REVIEW") {
 		t.Error("missing RE-REVIEW instruction")


### PR DESCRIPTION
## Summary

- **ReconcileSeverity**: guards against AI inconsistency by ensuring the stored severity is at least as high as the max severity among individual issues (prevents prompt injection or model errors from incorrectly approving a PR with high-severity issues).
- **CommentSignals**: extracts blocker keywords ("must fix", "do not merge", "blocker", etc.) and counts unresolved reviewer concerns from PR discussion. A `medium`-severity review is escalated to `REQUEST_CHANGES` when explicit blocking language is detected (urgency >= 3).
- **Prompt improvement**: instructs the AI to factor unresolved reviewer feedback into its severity assessment, and injects a structured NOTE in re-review context when unresolved concerns exist.

## Motivation

Previously, the `SeverityToEvent()` function was purely deterministic based on a single `severity` field from the AI, with no validation against the AI's own issues or the PR discussion. Comments were injected into the prompt as context but had no programmatic weight in the approve/request_changes gate. This meant:

1. An inconsistent AI response (issues flagged high, global severity set low) would approve the PR
2. Reviewer comments saying "do not merge" or "blocker" had zero effect on the decision
3. Multiple unresolved concerns from reviewers were invisible to the decision logic

## Design choices

- **Conservative escalation**: only `medium` + blocker signals → `REQUEST_CHANGES`. A `low` severity is never escalated by comment signals alone, keeping Heimdallm non-aggressive.
- **Never lowers severity**: reconciliation only raises, never lowers the AI's assessment.
- **Retry paths use empty signals**: `PublishPending` and NATS worker retries use `CommentSignals{}` because the severity was already reconciled at initial review time.

## Tests

22 new tests covering `ExtractCommentSignals`, `ReconcileSeverity`, and the updated `SeverityToEvent`. All existing tests updated and passing (`make test-docker` green).