### PR TITLE
ci(release): remove legacy docker-build-push job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,69 +185,6 @@ jobs:
           push-to-registry: true
 
   # ═══════════════════════════════════════════════════════════════════════════
-  # Docker image — legacy build-push-action (remove after GoReleaser verified)
-  # TODO(#269): Remove this job once goreleaser-daemon is verified in production
-  # ═══════════════════════════════════════════════════════════════════════════
-  docker-build-push:
-    name: Docker image (legacy — verify then remove)
-    needs: [release-please, tests]
-    if: always() && needs.tests.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-    env:
-      TAG: ${{ inputs.tag || needs.release-please.outputs.tag_name }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag || needs.release-please.outputs.tag_name }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            ${{ github.event_name != 'workflow_dispatch' && 'type=raw,value=latest' || '' }}
-            type=semver,pattern={{version}},value=${{ env.TAG }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ env.TAG }}
-            type=semver,pattern={{major}},value=${{ env.TAG }}
-            type=sha,prefix=
-
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-
-  # ═══════════════════════════════════════════════════════════════════════════
   # Linux packages — .deb, .rpm (GoReleaser nfpms) + .AppImage
   #
   # .deb/.rpm are built by GoReleaser's nfpms integration.


### PR DESCRIPTION
## Summary
- Removes the `docker-build-push` legacy job from `.github/workflows/release.yml` (was lines 187-249).
- Docker image is now published exclusively by `goreleaser-daemon`, which has been running successfully in parallel since #269.

## Why now
`goreleaser-daemon` matches the legacy job 1:1 on the parts that matter:
- Same registry/image (`ghcr.io/theburrowhub/heimdallm`).
- Same tag pattern (`latest`, `x.y.z`, `x.y`, `x`, `sha`).
- Same SLSA build-provenance attestation via `actions/attest-build-provenance@v2`.
- Verified on releases v0.6.22 → v0.6.24 (both jobs succeeded; same artifacts produced).

Keeping the legacy job longer just adds a parallel writer to the same tags — occasional race, no upside.

## What is NOT removed
- `docker/Dockerfile` stays. It is still consumed by `.github/workflows/docker-publish.yml` (PR validation build, `push: false`). Only the legacy publishing job in `release.yml` is gone.

## Test plan
- [x] `release.yml` still parses as valid YAML.
- [x] No remaining references to `docker-build-push` or `docker/Dockerfile` in `release.yml`.
- [x] No job in `release.yml` has `needs: docker-build-push`.
- [ ] Next release runs cleanly with only `goreleaser-daemon` publishing the image.

Closes #271 (epic #265 step 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)