### PR TITLE
feat(daemon): GitHub API efficiency — ETag, aggregated search, GH-aware throttle, adaptive polling, GraphQL

### DIFF
--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -1554,6 +1554,41 @@ func (d *Dashboard) buildConfigLines() []string {
 		blank()
 	}
 
+	// ── Polling / Rate Limit ──
+	if pRaw, ok := d.config["polling"]; ok {
+		if p, ok := pRaw.(map[string]any); ok {
+			section("Polling / Rate Limit")
+			if v, ok := p["adaptive"].(bool); ok {
+				kv("Adaptive", fmt.Sprintf("%v", v))
+			}
+			if v, ok := p["poll_interval"].(string); ok && v != "" {
+				kv("Poll interval", v)
+			}
+			if v, ok := p["min_interval"].(string); ok && v != "" {
+				kv("Min interval", v)
+			}
+			if v, ok := p["max_interval"].(string); ok && v != "" {
+				kv("Max interval", v)
+			}
+			if v, ok := p["discovery_interval"].(string); ok && v != "" {
+				kv("Discovery interval", v)
+			}
+			if v, ok := p["tier3_interval"].(string); ok && v != "" {
+				kv("Tier3 interval", v)
+			}
+			if v, ok := p["rate_limit_safety_threshold"].(float64); ok {
+				kv("Rate-limit safety threshold", fmt.Sprintf("%d", int(v)))
+			}
+			if v, ok := p["use_etag"].(bool); ok {
+				kv("ETag/304 caching", fmt.Sprintf("%v", v))
+			}
+			if v, ok := p["use_graphql"].(bool); ok {
+				kv("GraphQL batching", fmt.Sprintf("%v", v))
+			}
+			blank()
+		}
+	}
+
 	return lines
 }
 

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -401,6 +402,69 @@ func TestCycleIssueRepoFilter(t *testing.T) {
 	d.cycleIssueRepoFilter()
 	if d.issueRepoFilter != "" {
 		t.Fatalf("third cycle: got %q, want empty (all)", d.issueRepoFilter)
+	}
+}
+
+func TestBuildConfigLinesPollingSection(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.config = map[string]any{
+		"polling": map[string]any{
+			"adaptive":                    true,
+			"poll_interval":               "30s",
+			"min_interval":                "10s",
+			"max_interval":                "5m",
+			"discovery_interval":          "15m",
+			"tier3_interval":              "1h",
+			"rate_limit_safety_threshold": float64(20),
+			"use_etag":                    true,
+			"use_graphql":                 false,
+		},
+	}
+
+	lines := d.buildConfigLines()
+
+	// Collect all lines into a single string for easy substring checks.
+	combined := ""
+	for _, l := range lines {
+		combined += l + "\n"
+	}
+
+	expectations := []string{
+		"Polling / Rate Limit",
+		"Adaptive",
+		"true",
+		"Poll interval",
+		"30s",
+		"Min interval",
+		"10s",
+		"Max interval",
+		"5m",
+		"Discovery interval",
+		"15m",
+		"Tier3 interval",
+		"1h",
+		"Rate-limit safety threshold",
+		"20",
+		"ETag/304 caching",
+		"GraphQL batching",
+		"false",
+	}
+	for _, want := range expectations {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("buildConfigLines() missing %q in Polling section.\nGot:\n%s", want, combined)
+		}
+	}
+}
+
+func TestBuildConfigLinesPollingAbsentWhenMissing(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.config = map[string]any{} // no "polling" key
+
+	lines := d.buildConfigLines()
+	for _, l := range lines {
+		if strings.Contains(l, "Polling / Rate Limit") {
+			t.Fatal("Polling section should not appear when polling key is absent from config")
+		}
 	}
 }
 

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -104,9 +104,9 @@ func TestDashboardDropsStaleReconnectAfterWatchdogReset(t *testing.T) {
 
 func TestClampScrollOffset(t *testing.T) {
 	cases := []struct {
-		name                    string
-		offset, total, visible  int
-		want                    int
+		name                   string
+		offset, total, visible int
+		want                   int
 	}{
 		{"viewport larger than content keeps offset at 0", 0, 5, 20, 0},
 		{"viewport larger than content clamps non-zero offset to 0", 7, 5, 20, 0},

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -614,6 +614,10 @@ func main() {
 	// Apply [polling] kill-switches and safety knobs from config.
 	// ETag cache (C1): enabled by default; operator can disable via use_etag=false.
 	ghClient.SetCacheEnabled(cfg.ETagEnabled())
+	// GraphQL issue search (C4): disabled by default; operator enables via use_graphql=true.
+	// When enabled, SearchIssues dispatches to the GraphQL API first and falls
+	// back to REST /search/issues on any error — zero behaviour change when false.
+	ghClient.SetGraphQLEnabled(cfg.GraphQLEnabled())
 	// Rate-limit safety threshold: drives how eagerly each tier backs off.
 	// Default 100 matches the current hardcoded tierSafetyThreshold[TierDiscovery].
 	limiter.SetDiscoverySafetyThreshold(cfg.Polling.RateLimitSafetyThreshold)

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1752,6 +1752,12 @@ func main() {
 		adaptiveSched.UpdateBounds(newCfg.ResolvedMinInterval(), newCfg.ResolvedMaxInterval())
 
 		cfgMu.Lock()
+		// tier3_interval is restart-only (the state poller is not managed by
+		// startPollers). Warn so operators aren't surprised by the silent no-op.
+		if cfg.ResolvedTier3Interval() != newCfg.ResolvedTier3Interval() {
+			slog.Warn("config reload: tier3_interval change is restart-only; it will not take effect until the daemon is restarted",
+				"old", cfg.ResolvedTier3Interval(), "new", newCfg.ResolvedTier3Interval())
+		}
 		restartPollers := configReloadRequiresPollerRestart(cfg, newCfg)
 		if !restartPollers {
 			cfg = newCfg
@@ -3485,15 +3491,9 @@ func (a *tier2Adapter) PrefetchIssuesForCycle(repos []string) {
 	a.cfgMu.Unlock()
 	authUser := a.resolveAuthenticatedUser()
 
-	// eligibleFn resolves, per repo, the effective IssueTrackingConfig and the
-	// autonomous flag. The third return is "resolved ok" — always true here
-	// because resolution can't fail (it reads in-memory config); it exists so
-	// the EligibleFn signature can support resolvers that may fail. The actual
-	// gating (skip repos with issue_tracking disabled or autonomous enabled)
-	// happens inside PrefetchIssues, which checks `!ok || autonomous || !it.Enabled`
-	// — see fetcher.go. PrefetchIssues then groups eligible repos by their
-	// resolved assignee set (one search query per group) so per-repo assignee
-	// overrides use their own scope, preventing silent issue drops.
+	// The third return is "resolved ok" — always true here because resolving
+	// from in-memory config can't fail. The actual gating (disabled/autonomous)
+	// and assignee-set grouping happen in PrefetchIssues (see fetcher.go).
 	eligibleFn := func(repo string) (config.IssueTrackingConfig, bool, bool) {
 		repoIT := c.IssueTrackingForRepo(repo)
 		autonomousEnabled := c.AutonomousForRepo(repo).Enabled

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -605,6 +605,11 @@ func main() {
 	// Shared rate limiter (was Pipeline.limiter).
 	limiter := scheduler.NewRateLimiter(4500)
 
+	// Wire the GitHub client → rate limiter so every API response updates the
+	// live budget, enabling proactive throttle before a 403 and correct backoff
+	// on secondary limits (Retry-After).
+	ghClient.SetRateObserver(&rateLimitAdapter{limiter: limiter})
+
 	// tier2Adapter bridges main.go's concrete types to the polling logic.
 	adapter := &tier2Adapter{
 		ghClient:             ghClient,
@@ -2822,6 +2827,29 @@ func (a *tier2Adapter) upsertDiscoveredFromTopics(repos []string) {
 	if len(added) > 0 {
 		slog.Info("tier2: persisting topic-discovered repos", "added", len(added), "repos", added)
 		processDiscoveredRepos(added, reposSnap, nonMonSnap, a.store, a.broker, time.Now())
+	}
+}
+
+// ── rateLimitAdapter bridges the GitHub client observer → scheduler limiter ──
+
+// rateLimitAdapter implements gh.RateLimitObserver. After every GitHub API
+// response it parses the X-RateLimit-* headers and forwards the live budget
+// to the scheduler limiter, enabling proactive throttle before hitting 403
+// and honoring Retry-After on secondary limits.
+type rateLimitAdapter struct {
+	limiter *scheduler.RateLimiter
+}
+
+func (a *rateLimitAdapter) ObserveResponse(resp *http.Response) {
+	parsed, ok := gh.ParseRateLimitHeaders(resp)
+	if !ok {
+		return
+	}
+	if parsed.Resource != "" {
+		a.limiter.Observe(parsed.Resource, parsed.Remaining, parsed.Reset)
+	}
+	if parsed.RetryAfter > 0 {
+		a.limiter.ObserveRetryAfter(parsed.RetryAfter)
 	}
 }
 

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2248,14 +2248,10 @@ func parseDiscoveryInterval(discoveryInterval, pollInterval string) time.Duratio
 // config fields conservative by default: if a future field is not scrubbed in
 // configReloadRestartSnapshot, reloads restart pollers until the field is
 // explicitly classified as dynamic.
-// applyClientRuntimeConfig (re)applies the [polling] kill-switches and safety
-// knobs that live on the long-lived ghClient / limiter objects rather than
-// being re-read each tick. Called at startup and on every config reload so the
-// GUI/TUI toggles (use_etag, use_graphql, rate_limit_safety_threshold) take
-// effect hot — without these re-applications a reload would update intervals
-// but leave the client-side feature flags frozen at their startup values until
-// the daemon restarts. All three setters are concurrency-safe (atomic.Bool /
-// mutex), so this is safe to call while pollers are running.
+// applyClientRuntimeConfig (re)applies the [polling] kill-switches/knobs that
+// live on the long-lived ghClient/limiter (not re-read per tick). Called at
+// startup AND on every reload so GUI/TUI toggles take effect hot. All three
+// setters are concurrency-safe, so it is safe to call while pollers run.
 func applyClientRuntimeConfig(ghClient *gh.Client, limiter *scheduler.RateLimiter, cfg *config.Config) {
 	// ETag cache (C1): enabled by default; operator can disable via use_etag=false.
 	ghClient.SetCacheEnabled(cfg.ETagEnabled())

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -692,6 +692,16 @@ func main() {
 	// consumes from NATS and forwards repo lists through this channel.
 	reposChan := make(chan []string, 1)
 
+	// adaptiveSched is the per-repo adaptive interval engine (C5). It is
+	// constructed once at daemon start and intentionally outlives config
+	// reloads — accumulated backoff state must not be lost when the operator
+	// tweaks an unrelated setting. It is passed to runTier2 which uses it
+	// when cfg.Polling.Adaptive is true; when Adaptive is false the scheduler
+	// is allocated but never consulted, so the overhead is negligible.
+	cfgMu.Lock()
+	adaptiveSched := scheduler.NewAdaptiveScheduler(cfg.ResolvedMinInterval(), cfg.ResolvedMaxInterval())
+	cfgMu.Unlock()
+
 	// startPollers launches all polling goroutines under the given context.
 	// Returns a cancel function and a WaitGroup that completes when all
 	// goroutines have exited.
@@ -820,7 +830,12 @@ func main() {
 				defer cfgMu.Unlock()
 				return cfg.AI.Tier2RepoConcurrency
 			}
-			runTier2(ctx, adapter, limiter, prReviewPublisher, broker, tier2ConfigFn, tier2RepoConcurrencyFn, reposChan, pollInterval, coldStart, recordPollCompleted)
+			tier2AdaptiveFn := func() bool {
+				cfgMu.Lock()
+				defer cfgMu.Unlock()
+				return cfg.Polling.Adaptive
+			}
+			runTier2(ctx, adapter, limiter, prReviewPublisher, broker, tier2ConfigFn, tier2RepoConcurrencyFn, tier2AdaptiveFn, adaptiveSched, reposChan, pollInterval, coldStart, recordPollCompleted)
 		}()
 
 		// Repo/org rename probe (#489). Detects when GitHub has
@@ -2445,6 +2460,8 @@ func runTier2(
 	ssePub sse.Publisher,
 	configFn func() []string,
 	repoConcurrencyFn func() int,
+	adaptiveFn func() bool,
+	adaptiveSched *scheduler.AdaptiveScheduler,
 	reposChan <-chan []string,
 	interval time.Duration,
 	coldStart bool,
@@ -2531,6 +2548,21 @@ func runTier2(
 	// runIssueTier promotes ready issues and processes every repo's
 	// issue list in parallel, bounded by ai.tier2_repo_concurrency.
 	//
+	// When polling.adaptive is true (opt-in), only repos whose next
+	// scheduled poll is due are processed this tick. After each repo
+	// finishes, MarkActive (count>0) or MarkIdle (count==0) adjusts
+	// its interval so active repos stay at min_interval while idle
+	// repos back off toward max_interval.
+	//
+	// The Search API prefetch always covers ALL currentRepos regardless
+	// of the adaptive filter. This keeps the C2 prefetch intact (one
+	// cheap search query per cycle) while the actual processing fan-out
+	// is limited to due repos. On search error the per-repo REST fallback
+	// inside ProcessRepo is unaffected.
+	//
+	// When polling.adaptive is false (default) the behaviour is EXACTLY
+	// unchanged: all currentRepos are processed every tick.
+	//
 	// NOTE: if NATS publishes are ever added to this tier, also call
 	// adapter.PublishPending() at the end — it is intentionally bound
 	// to the PR tick today (see prTick) because pending publishes
@@ -2571,10 +2603,28 @@ func runTier2(
 		// using the separate search rate budget (30/min) instead of the core
 		// REST budget (5000/hr). On search error the per-repo REST fallback is
 		// still active inside ProcessRepo — no repos are skipped.
+		// The prefetch always covers ALL currentRepos even in adaptive mode so
+		// the search result cache is warm for whichever repos are due.
 		adapter.PrefetchIssuesForCycle(currentRepos)
 		defer adapter.ClearIssuePrefetch()
 
-		issueCount = processReposInParallel(ctx, currentRepos, concurrency, func(ctx context.Context, repo string) (int, error) {
+		// Adaptive gating: narrow the work list to only repos that are due
+		// this tick. Falls back to all repos when adaptive is disabled.
+		adaptive := adaptiveFn != nil && adaptiveFn()
+		reposToProcess := currentRepos
+		now := time.Now()
+		if adaptive {
+			reposToProcess = adaptiveSched.Due(now, currentRepos)
+			if len(reposToProcess) < len(currentRepos) {
+				slog.Debug("tier2: adaptive mode — skipping idle repos",
+					"total", len(currentRepos), "due", len(reposToProcess))
+			}
+			// Prune repos that have been removed from monitoring so the
+			// scheduler's memory stays bounded.
+			adaptiveSched.PruneAbsent(currentRepos)
+		}
+
+		issueCount = processReposInParallel(ctx, reposToProcess, concurrency, func(ctx context.Context, repo string) (int, error) {
 			if err := limiter.Acquire(ctx, scheduler.TierRepo); err != nil {
 				return 0, err
 			}
@@ -2588,10 +2638,22 @@ func runTier2(
 				} else {
 					slog.Error("tier2: issue processing", "repo", repo, "err", err)
 				}
+				// On error we don't advance the adaptive schedule for
+				// this repo; it will be re-evaluated as due on the next
+				// tick (nextDue is not updated because MarkActive/MarkIdle
+				// are not called).
 				return 0, err
 			}
 			if n > 0 {
 				slog.Info("tier2: processed issues", "repo", repo, "count", n)
+			}
+			// Update adaptive cadence based on observed activity.
+			if adaptive {
+				if n > 0 {
+					adaptiveSched.MarkActive(repo, now)
+				} else {
+					adaptiveSched.MarkIdle(repo, now)
+				}
 			}
 			return n, nil
 		})

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1672,6 +1672,17 @@ func main() {
 		if len(pm) > 0 {
 			result["pr_metadata"] = pm
 		}
+		result["polling"] = map[string]any{
+			"poll_interval":              c.Polling.PollInterval,
+			"min_interval":               c.Polling.MinInterval,
+			"max_interval":               c.Polling.MaxInterval,
+			"adaptive":                   c.Polling.Adaptive,
+			"discovery_interval":         c.Polling.DiscoveryInterval,
+			"tier3_interval":             c.Polling.Tier3Interval,
+			"rate_limit_safety_threshold": c.Polling.RateLimitSafetyThreshold,
+			"use_etag":                   c.ETagEnabled(),
+			"use_graphql":                c.GraphQLEnabled(),
+		}
 		return result
 	})
 

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -330,8 +330,8 @@ func main() {
 		slog.Warn("could not resolve bot login for re-review context", "err", err)
 	}
 	issueFetcher := issuepipeline.NewFetcher(ghClient, ghClient, s, issuePipe)
-	issueFetcher.SetBotLogin(resolvedBotLogin)   // break re-triage loop (#362)
-	issueFetcher.SetSearcher(ghClient)            // enable aggregated Search API prefetch (separate rate budget)
+	issueFetcher.SetBotLogin(resolvedBotLogin) // break re-triage loop (#362)
+	issueFetcher.SetSearcher(ghClient)         // enable aggregated Search API prefetch (separate rate budget)
 	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
 	var reloadMu sync.Mutex // serialises config reloads to prevent duplicate pipelines
@@ -1677,15 +1677,15 @@ func main() {
 			result["pr_metadata"] = pm
 		}
 		result["polling"] = map[string]any{
-			"poll_interval":              c.Polling.PollInterval,
-			"min_interval":               c.Polling.MinInterval,
-			"max_interval":               c.Polling.MaxInterval,
-			"adaptive":                   c.Polling.Adaptive,
-			"discovery_interval":         c.Polling.DiscoveryInterval,
-			"tier3_interval":             c.Polling.Tier3Interval,
+			"poll_interval":               c.Polling.PollInterval,
+			"min_interval":                c.Polling.MinInterval,
+			"max_interval":                c.Polling.MaxInterval,
+			"adaptive":                    c.Polling.Adaptive,
+			"discovery_interval":          c.Polling.DiscoveryInterval,
+			"tier3_interval":              c.Polling.Tier3Interval,
 			"rate_limit_safety_threshold": c.Polling.RateLimitSafetyThreshold,
-			"use_etag":                   c.ETagEnabled(),
-			"use_graphql":                c.GraphQLEnabled(),
+			"use_etag":                    c.ETagEnabled(),
+			"use_graphql":                 c.GraphQLEnabled(),
 		}
 		return result
 	})

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -615,6 +615,7 @@ func main() {
 	// every reload (see SetReloadFn) so GUI/TUI toggles take effect hot, without
 	// a daemon restart.
 	applyClientRuntimeConfig(ghClient, limiter, cfg)
+	warnInvalidPollingDurations(cfg.Polling)
 
 	// tier2Adapter bridges main.go's concrete types to the polling logic.
 	adapter := &tier2Adapter{
@@ -1744,6 +1745,7 @@ func main() {
 		// are not re-read by the pollers, so they must be set explicitly here —
 		// independent of the poller-restart decision below.
 		applyClientRuntimeConfig(ghClient, limiter, newCfg)
+		warnInvalidPollingDurations(newCfg.Polling)
 
 		// Refresh adaptive-scheduler bounds in place so min_interval/max_interval
 		// changes take effect on reload while per-repo backoff state is preserved.
@@ -2262,6 +2264,29 @@ func applyClientRuntimeConfig(ghClient *gh.Client, limiter *scheduler.RateLimite
 	// Rate-limit safety threshold: drives how eagerly each tier backs off.
 	// Default 100 matches the hardcoded tierSafetyThreshold[TierDiscovery].
 	limiter.SetDiscoverySafetyThreshold(cfg.ResolvedRateLimitSafetyThreshold())
+}
+
+// warnInvalidPollingDurations logs a warning for any non-empty [polling]
+// duration string that fails to parse, so a typo (e.g. poll_interval = "bogus")
+// is surfaced to the operator instead of silently falling back to the default.
+// Called once per config load (startup + reload) — NOT inside the Resolved*
+// hot path, which would spam a warning on every tick.
+func warnInvalidPollingDurations(p config.PollingConfig) {
+	for _, f := range []struct{ name, val string }{
+		{"poll_interval", p.PollInterval},
+		{"min_interval", p.MinInterval},
+		{"max_interval", p.MaxInterval},
+		{"discovery_interval", p.DiscoveryInterval},
+		{"tier3_interval", p.Tier3Interval},
+	} {
+		if f.val == "" {
+			continue // empty = inherit / use default, not a typo
+		}
+		if _, err := time.ParseDuration(f.val); err != nil {
+			slog.Warn("[polling] invalid duration string; falling back to default",
+				"field", f.name, "value", f.val, "err", err)
+		}
+	}
 }
 
 func configReloadRequiresPollerRestart(oldCfg, newCfg *config.Config) bool {

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -696,9 +696,10 @@ func main() {
 	// tweaks an unrelated setting. It is passed to runTier2 which uses it
 	// when cfg.Polling.Adaptive is true; when Adaptive is false the scheduler
 	// is allocated but never consulted, so the overhead is negligible.
-	cfgMu.Lock()
+	// No cfgMu needed here: this runs at daemon startup before startPollers, so
+	// no other goroutine reads cfg yet. On reload the bounds are refreshed via
+	// adaptiveSched.UpdateBounds while per-repo backoff state is preserved.
 	adaptiveSched := scheduler.NewAdaptiveScheduler(cfg.ResolvedMinInterval(), cfg.ResolvedMaxInterval())
-	cfgMu.Unlock()
 
 	// startPollers launches all polling goroutines under the given context.
 	// Returns a cancel function and a WaitGroup that completes when all
@@ -923,7 +924,7 @@ func main() {
 			"discovery", discoveryInterval,
 			"poll", pollInterval,
 			"etag_cache", cfg.ETagEnabled(),
-			"rate_limit_threshold", cfg.Polling.RateLimitSafetyThreshold)
+			"rate_limit_threshold", cfg.ResolvedRateLimitSafetyThreshold())
 
 		return cancel, &wg
 	}
@@ -1677,7 +1678,7 @@ func main() {
 			"adaptive":                    c.Polling.Adaptive,
 			"discovery_interval":          c.Polling.DiscoveryInterval,
 			"tier3_interval":              c.Polling.Tier3Interval,
-			"rate_limit_safety_threshold": c.Polling.RateLimitSafetyThreshold,
+			"rate_limit_safety_threshold": c.ResolvedRateLimitSafetyThreshold(),
 			"use_etag":                    c.ETagEnabled(),
 			"use_graphql":                 c.GraphQLEnabled(),
 		}
@@ -1743,6 +1744,12 @@ func main() {
 		// are not re-read by the pollers, so they must be set explicitly here —
 		// independent of the poller-restart decision below.
 		applyClientRuntimeConfig(ghClient, limiter, newCfg)
+
+		// Refresh adaptive-scheduler bounds in place so min_interval/max_interval
+		// changes take effect on reload while per-repo backoff state is preserved.
+		// The scheduler lives outside startPollers, so the poller restart below
+		// would not pick these up otherwise.
+		adaptiveSched.UpdateBounds(newCfg.ResolvedMinInterval(), newCfg.ResolvedMaxInterval())
 
 		cfgMu.Lock()
 		restartPollers := configReloadRequiresPollerRestart(cfg, newCfg)
@@ -2252,7 +2259,7 @@ func applyClientRuntimeConfig(ghClient *gh.Client, limiter *scheduler.RateLimite
 	ghClient.SetGraphQLEnabled(cfg.GraphQLEnabled())
 	// Rate-limit safety threshold: drives how eagerly each tier backs off.
 	// Default 100 matches the hardcoded tierSafetyThreshold[TierDiscovery].
-	limiter.SetDiscoverySafetyThreshold(cfg.Polling.RateLimitSafetyThreshold)
+	limiter.SetDiscoverySafetyThreshold(cfg.ResolvedRateLimitSafetyThreshold())
 }
 
 func configReloadRequiresPollerRestart(oldCfg, newCfg *config.Config) bool {
@@ -2300,6 +2307,25 @@ func configReloadRestartSnapshot(c *config.Config) config.Config {
 	snap.Retention = config.RetentionConfig{}
 	snap.ActivityLog = config.ActivityLogConfig{}
 	snap.CircuitBreaker = config.CircuitBreakerConfig{}
+
+	// [polling]: zero the fields that already take effect on reload WITHOUT a
+	// poller restart, so changing them doesn't trigger a spurious restart:
+	//   - Adaptive            — read dynamically via adaptiveFn closures
+	//   - Min/MaxInterval     — applied via adaptiveSched.UpdateBounds on reload
+	//   - RateLimitSafetyThreshold/UseETag/UseGraphQL — applied via
+	//     applyClientRuntimeConfig on reload
+	//   - Tier3Interval       — restart-only (documented on PollingConfig); a
+	//     poller restart wouldn't re-create the state poller anyway, so don't
+	//     trigger one.
+	// PollInterval and DiscoveryInterval are intentionally KEPT: the pollers
+	// re-read them only on restart, so a change there must still restart pollers.
+	snap.Polling.Adaptive = false
+	snap.Polling.MinInterval = ""
+	snap.Polling.MaxInterval = ""
+	snap.Polling.Tier3Interval = ""
+	snap.Polling.RateLimitSafetyThreshold = nil
+	snap.Polling.UseETag = nil
+	snap.Polling.UseGraphQL = nil
 	return snap
 }
 
@@ -2581,28 +2607,15 @@ func runTier2(
 		}
 	}
 
-	// runIssueTier promotes ready issues and processes every repo's
-	// issue list in parallel, bounded by ai.tier2_repo_concurrency.
-	//
-	// When polling.adaptive is true (opt-in), only repos whose next
-	// scheduled poll is due are processed this tick. After each repo
-	// finishes, MarkActive (count>0) or MarkIdle (count==0) adjusts
-	// its interval so active repos stay at min_interval while idle
-	// repos back off toward max_interval.
-	//
-	// The Search API prefetch always covers ALL currentRepos regardless
-	// of the adaptive filter. This keeps the C2 prefetch intact (one
-	// cheap search query per cycle) while the actual processing fan-out
-	// is limited to due repos. On search error the per-repo REST fallback
-	// inside ProcessRepo is unaffected.
-	//
-	// When polling.adaptive is false (default) the behaviour is EXACTLY
-	// unchanged: all currentRepos are processed every tick.
+	// runIssueTier promotes ready issues and processes each repo's issue list in
+	// parallel (bounded by ai.tier2_repo_concurrency). Non-obvious invariant:
+	// the Search API prefetch always covers ALL currentRepos, even when
+	// polling.adaptive limits the processing fan-out to due repos — keeping the
+	// per-cycle prefetch a single cheap query.
 	//
 	// NOTE: if NATS publishes are ever added to this tier, also call
-	// adapter.PublishPending() at the end — it is intentionally bound
-	// to the PR tick today (see prTick) because pending publishes
-	// originate exclusively from runPRTier.
+	// adapter.PublishPending() at the end — today it is intentionally bound to
+	// the PR tick (see prTick) since pending publishes originate only there.
 	runIssueTier := func(currentRepos []string) {
 		sse.EmitPollingStarted(ssePub, "issues", currentRepos)
 		issueStart := time.Now()
@@ -3472,11 +3485,15 @@ func (a *tier2Adapter) PrefetchIssuesForCycle(repos []string) {
 	a.cfgMu.Unlock()
 	authUser := a.resolveAuthenticatedUser()
 
-	// eligibleFn resolves the effective IssueTrackingConfig and autonomous flag
-	// for each repo. PrefetchIssues uses this to group repos by their resolved
-	// assignee set, running one search query per group. This ensures repos with
-	// per-repo assignee overrides are fetched with their own assignee scope
-	// rather than the global one, preventing silent issue drops.
+	// eligibleFn resolves, per repo, the effective IssueTrackingConfig and the
+	// autonomous flag. The third return is "resolved ok" — always true here
+	// because resolution can't fail (it reads in-memory config); it exists so
+	// the EligibleFn signature can support resolvers that may fail. The actual
+	// gating (skip repos with issue_tracking disabled or autonomous enabled)
+	// happens inside PrefetchIssues, which checks `!ok || autonomous || !it.Enabled`
+	// — see fetcher.go. PrefetchIssues then groups eligible repos by their
+	// resolved assignee set (one search query per group) so per-repo assignee
+	// overrides use their own scope, preventing silent issue drops.
 	eligibleFn := func(repo string) (config.IssueTrackingConfig, bool, bool) {
 		repoIT := c.IssueTrackingForRepo(repo)
 		autonomousEnabled := c.AutonomousForRepo(repo).Enabled

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -330,7 +330,8 @@ func main() {
 		slog.Warn("could not resolve bot login for re-review context", "err", err)
 	}
 	issueFetcher := issuepipeline.NewFetcher(ghClient, ghClient, s, issuePipe)
-	issueFetcher.SetBotLogin(resolvedBotLogin) // break re-triage loop (#362)
+	issueFetcher.SetBotLogin(resolvedBotLogin)   // break re-triage loop (#362)
+	issueFetcher.SetSearcher(ghClient)            // enable aggregated Search API prefetch (separate rate budget)
 	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
 	var reloadMu sync.Mutex // serialises config reloads to prevent duplicate pipelines
@@ -2552,6 +2553,14 @@ func runTier2(
 				concurrency = v
 			}
 		}
+
+		// Aggregated Search API prefetch: one query covers all eligible repos,
+		// using the separate search rate budget (30/min) instead of the core
+		// REST budget (5000/hr). On search error the per-repo REST fallback is
+		// still active inside ProcessRepo — no repos are skipped.
+		adapter.PrefetchIssuesForCycle(currentRepos)
+		defer adapter.ClearIssuePrefetch()
+
 		issueCount = processReposInParallel(ctx, currentRepos, concurrency, func(ctx context.Context, repo string) (int, error) {
 			if err := limiter.Acquire(ctx, scheduler.TierRepo); err != nil {
 				return 0, err
@@ -3332,6 +3341,55 @@ func (a *tier2Adapter) reviewReadyForPublishRetry(rev *store.Review) (bool, erro
 		return false, err
 	}
 	return !inFlight, nil
+}
+
+// PrefetchIssuesForCycle runs the aggregated Search API query for all eligible
+// repos, populating the Fetcher's per-cycle prefetch map. Must be called BEFORE
+// the parallel ProcessRepo fan-out. On search error it logs and returns so
+// per-repo FetchIssues fallback still applies inside ProcessRepo.
+//
+// The method iterates repos to build the eligible list (skipping repos with
+// issue_tracking disabled or autonomous mode enabled — the same gating
+// ProcessRepo applies — so the search scope matches what would actually be
+// processed).
+func (a *tier2Adapter) PrefetchIssuesForCycle(repos []string) {
+	if a.fetcher == nil {
+		return
+	}
+	a.cfgMu.Lock()
+	c := *a.cfg
+	a.cfgMu.Unlock()
+	authUser := a.resolveAuthenticatedUser()
+
+	// Collect repos that are eligible for issue processing this cycle.
+	eligible := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		repoIT := c.IssueTrackingForRepo(repo)
+		autonomousEnabled := c.AutonomousForRepo(repo).Enabled
+		if !repoIT.Enabled || autonomousEnabled {
+			continue
+		}
+		eligible = append(eligible, repo)
+	}
+	if len(eligible) == 0 {
+		return
+	}
+
+	// Use the global issue tracking config as the query base; per-repo
+	// overrides are applied after in ProcessRepo (classification + filter).
+	globalIT := c.GitHub.IssueTracking
+	if _, err := a.fetcher.PrefetchIssues(globalIT, authUser, eligible); err != nil {
+		// Error already logged by PrefetchIssues; fallback is automatic.
+		return
+	}
+}
+
+// ClearIssuePrefetch discards the cycle-scoped prefetch map so stale results
+// cannot leak into the next cycle.
+func (a *tier2Adapter) ClearIssuePrefetch() {
+	if a.fetcher != nil {
+		a.fetcher.ClearPrefetch()
+	}
 }
 
 // ProcessRepo implements scheduler.Tier2IssueProcessor.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -340,7 +340,7 @@ func main() {
 	storePollInterval := func(interval time.Duration) {
 		atomic.StoreInt64(&pollIntervalNano, int64(interval))
 	}
-	storePollInterval(parsePollInterval(cfg.GitHub.PollInterval))
+	storePollInterval(cfg.ResolvedPollInterval())
 	recordPollCompleted := func(_ string, at time.Time) {
 		atomic.StoreInt64(&lastPollUnixNano, at.UTC().UnixNano())
 	}
@@ -611,6 +611,13 @@ func main() {
 	// on secondary limits (Retry-After).
 	ghClient.SetRateObserver(&rateLimitAdapter{limiter: limiter})
 
+	// Apply [polling] kill-switches and safety knobs from config.
+	// ETag cache (C1): enabled by default; operator can disable via use_etag=false.
+	ghClient.SetCacheEnabled(cfg.ETagEnabled())
+	// Rate-limit safety threshold: drives how eagerly each tier backs off.
+	// Default 100 matches the current hardcoded tierSafetyThreshold[TierDiscovery].
+	limiter.SetDiscoverySafetyThreshold(cfg.Polling.RateLimitSafetyThreshold)
+
 	// tier2Adapter bridges main.go's concrete types to the polling logic.
 	adapter := &tier2Adapter{
 		ghClient:             ghClient,
@@ -744,11 +751,10 @@ func main() {
 		}()
 
 		// Tier 1: Discovery — publishes to NATS
+		// [polling].discovery_interval takes precedence over [github].discovery_interval;
+		// both fall back to 5m (ResolvedDiscoveryInterval handles the full cascade).
 		cfgMu.Lock()
-		discoveryInterval := parseDiscoveryInterval(
-			cfg.GitHub.DiscoveryInterval,
-			cfg.GitHub.PollInterval,
-		)
+		discoveryInterval := cfg.ResolvedDiscoveryInterval()
 		cfgMu.Unlock()
 		wg.Add(1)
 		go func() {
@@ -791,9 +797,10 @@ func main() {
 			bridgeDiscovery(ctx, conn, reposChan)
 		}()
 
-		// Tier 2: PR / issue polling
+		// Tier 2: PR / issue polling — use the resolved interval which honours
+		// [polling].poll_interval > [github].poll_interval > 5m default.
 		cfgMu.Lock()
-		pollInterval := parsePollInterval(cfg.GitHub.PollInterval)
+		pollInterval := cfg.ResolvedPollInterval()
 		cfgMu.Unlock()
 		storePollInterval(pollInterval)
 		wg.Add(1)
@@ -901,7 +908,9 @@ func main() {
 
 		slog.Info("pollers: started",
 			"discovery", discoveryInterval,
-			"poll", pollInterval)
+			"poll", pollInterval,
+			"etag_cache", cfg.ETagEnabled(),
+			"rate_limit_threshold", cfg.Polling.RateLimitSafetyThreshold)
 
 		return cancel, &wg
 	}
@@ -1382,13 +1391,17 @@ func main() {
 	}()
 
 	// ── State check poller ──────────────────────────────────────────────
-	// Scans the NATS KV watch bucket every 30s and publishes StateCheckMsg
-	// for items due for a state check. Replaces the in-memory WatchQueue.
+	// Scans the NATS KV watch bucket on the configured Tier 3 interval and
+	// publishes StateCheckMsg for items due for a state check. Replaces the
+	// in-memory WatchQueue. Default: 30s (matches previous hardcoded value).
 	stateCheckPub := bus.NewStateCheckPublisher(conn)
 	statePollerCtx, statePollerCancel := context.WithCancel(context.Background())
 	defer statePollerCancel()
 	go func() {
-		ticker := time.NewTicker(30 * time.Second)
+		cfgMu.Lock()
+		tier3Interval := cfg.ResolvedTier3Interval()
+		cfgMu.Unlock()
+		ticker := time.NewTicker(tier3Interval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -611,16 +611,10 @@ func main() {
 	// on secondary limits (Retry-After).
 	ghClient.SetRateObserver(&rateLimitAdapter{limiter: limiter})
 
-	// Apply [polling] kill-switches and safety knobs from config.
-	// ETag cache (C1): enabled by default; operator can disable via use_etag=false.
-	ghClient.SetCacheEnabled(cfg.ETagEnabled())
-	// GraphQL issue search (C4): disabled by default; operator enables via use_graphql=true.
-	// When enabled, SearchIssues dispatches to the GraphQL API first and falls
-	// back to REST /search/issues on any error — zero behaviour change when false.
-	ghClient.SetGraphQLEnabled(cfg.GraphQLEnabled())
-	// Rate-limit safety threshold: drives how eagerly each tier backs off.
-	// Default 100 matches the current hardcoded tierSafetyThreshold[TierDiscovery].
-	limiter.SetDiscoverySafetyThreshold(cfg.Polling.RateLimitSafetyThreshold)
+	// Apply [polling] kill-switches and safety knobs from config. Re-applied on
+	// every reload (see SetReloadFn) so GUI/TUI toggles take effect hot, without
+	// a daemon restart.
+	applyClientRuntimeConfig(ghClient, limiter, cfg)
 
 	// tier2Adapter bridges main.go's concrete types to the polling logic.
 	adapter := &tier2Adapter{
@@ -1743,6 +1737,13 @@ func main() {
 			return fmt.Errorf("reload: %w", err)
 		}
 
+		// Re-apply client-side kill-switches (use_etag / use_graphql /
+		// rate_limit_safety_threshold) so a GUI/TUI toggle takes effect on this
+		// reload without a daemon restart. These live on ghClient/limiter and
+		// are not re-read by the pollers, so they must be set explicitly here —
+		// independent of the poller-restart decision below.
+		applyClientRuntimeConfig(ghClient, limiter, newCfg)
+
 		cfgMu.Lock()
 		restartPollers := configReloadRequiresPollerRestart(cfg, newCfg)
 		if !restartPollers {
@@ -2234,6 +2235,26 @@ func parseDiscoveryInterval(discoveryInterval, pollInterval string) time.Duratio
 // config fields conservative by default: if a future field is not scrubbed in
 // configReloadRestartSnapshot, reloads restart pollers until the field is
 // explicitly classified as dynamic.
+// applyClientRuntimeConfig (re)applies the [polling] kill-switches and safety
+// knobs that live on the long-lived ghClient / limiter objects rather than
+// being re-read each tick. Called at startup and on every config reload so the
+// GUI/TUI toggles (use_etag, use_graphql, rate_limit_safety_threshold) take
+// effect hot — without these re-applications a reload would update intervals
+// but leave the client-side feature flags frozen at their startup values until
+// the daemon restarts. All three setters are concurrency-safe (atomic.Bool /
+// mutex), so this is safe to call while pollers are running.
+func applyClientRuntimeConfig(ghClient *gh.Client, limiter *scheduler.RateLimiter, cfg *config.Config) {
+	// ETag cache (C1): enabled by default; operator can disable via use_etag=false.
+	ghClient.SetCacheEnabled(cfg.ETagEnabled())
+	// GraphQL (C4): disabled by default; operator enables via use_graphql=true.
+	// When enabled, SearchIssues and the discovery archive-check dispatch to the
+	// GraphQL API first and fall back to REST on any error.
+	ghClient.SetGraphQLEnabled(cfg.GraphQLEnabled())
+	// Rate-limit safety threshold: drives how eagerly each tier backs off.
+	// Default 100 matches the hardcoded tierSafetyThreshold[TierDiscovery].
+	limiter.SetDiscoverySafetyThreshold(cfg.Polling.RateLimitSafetyThreshold)
+}
+
 func configReloadRequiresPollerRestart(oldCfg, newCfg *config.Config) bool {
 	if oldCfg == nil || newCfg == nil {
 		return true

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -3361,24 +3361,17 @@ func (a *tier2Adapter) PrefetchIssuesForCycle(repos []string) {
 	a.cfgMu.Unlock()
 	authUser := a.resolveAuthenticatedUser()
 
-	// Collect repos that are eligible for issue processing this cycle.
-	eligible := make([]string, 0, len(repos))
-	for _, repo := range repos {
+	// eligibleFn resolves the effective IssueTrackingConfig and autonomous flag
+	// for each repo. PrefetchIssues uses this to group repos by their resolved
+	// assignee set, running one search query per group. This ensures repos with
+	// per-repo assignee overrides are fetched with their own assignee scope
+	// rather than the global one, preventing silent issue drops.
+	eligibleFn := func(repo string) (config.IssueTrackingConfig, bool, bool) {
 		repoIT := c.IssueTrackingForRepo(repo)
 		autonomousEnabled := c.AutonomousForRepo(repo).Enabled
-		if !repoIT.Enabled || autonomousEnabled {
-			continue
-		}
-		eligible = append(eligible, repo)
+		return repoIT, autonomousEnabled, true
 	}
-	if len(eligible) == 0 {
-		return
-	}
-
-	// Use the global issue tracking config as the query base; per-repo
-	// overrides are applied after in ProcessRepo (classification + filter).
-	globalIT := c.GitHub.IssueTracking
-	if _, err := a.fetcher.PrefetchIssues(globalIT, authUser, eligible); err != nil {
+	if _, err := a.fetcher.PrefetchIssues(eligibleFn, authUser, repos); err != nil {
 		// Error already logged by PrefetchIssues; fallback is automatic.
 		return
 	}

--- a/daemon/cmd/heimdallm/runtime_config_test.go
+++ b/daemon/cmd/heimdallm/runtime_config_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/config"
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/scheduler"
+)
+
+// TestApplyClientRuntimeConfig_HotTogglesGraphQL proves a use_graphql change
+// applied via applyClientRuntimeConfig (the reload path) takes effect on the
+// live client without recreating it — guarding against the regression where a
+// GUI/TUI toggle was persisted but never re-applied until a daemon restart.
+func TestApplyClientRuntimeConfig_HotTogglesGraphQL(t *testing.T) {
+	data := map[string]any{"r0": map[string]any{"isArchived": true}}
+	envelope, _ := json.Marshal(map[string]any{"data": data})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(envelope)
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	limiter := scheduler.NewRateLimiter(100)
+
+	// GraphQL disabled by default → batch archive-check short-circuits with an
+	// error so callers fall back to per-repo REST.
+	if _, err := ghClient.BatchReposArchived([]string{"org/repo"}); err == nil {
+		t.Fatal("expected disabled error before enabling GraphQL")
+	}
+
+	// Enable use_graphql via config and re-apply (mirrors the reload path).
+	enabled := true
+	applyClientRuntimeConfig(ghClient, limiter, &config.Config{
+		Polling: config.PollingConfig{UseGraphQL: &enabled},
+	})
+
+	got, err := ghClient.BatchReposArchived([]string{"org/repo"})
+	if err != nil {
+		t.Fatalf("expected GraphQL batch to succeed after enabling, got %v", err)
+	}
+	if !got["org/repo"] {
+		t.Errorf("want org/repo archived=true via GraphQL, got %v", got)
+	}
+
+	// Toggle back off → reverts to the disabled (fall-back) behaviour.
+	disabled := false
+	applyClientRuntimeConfig(ghClient, limiter, &config.Config{
+		Polling: config.PollingConfig{UseGraphQL: &disabled},
+	})
+	if _, err := ghClient.BatchReposArchived([]string{"org/repo"}); err == nil {
+		t.Fatal("expected disabled error after toggling GraphQL back off")
+	}
+}

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	ActivityLog    ActivityLogConfig    `toml:"activity_log"`
 	CircuitBreaker CircuitBreakerConfig `toml:"circuit_breaker"`
 	Autonomous     AutonomousConfig     `toml:"autonomous"`
+	Polling        PollingConfig        `toml:"polling"`
 }
 
 type ServerConfig struct {
@@ -1054,6 +1055,7 @@ func (c *Config) applyDefaults() {
 		c.CircuitBreaker.PerImplRepoHr = 5
 	}
 	c.applyAutonomousDefaults()
+	c.applyPollingDefaults()
 }
 
 // applyEnvOverrides applies HEIMDALLM_* environment variable overrides.

--- a/daemon/internal/config/polling.go
+++ b/daemon/internal/config/polling.go
@@ -34,6 +34,9 @@ type PollingConfig struct {
 
 	// Tier3Interval controls the state-check (watch) scanner tick. Default
 	// "30s" — matches the current hardcoded value in the state-poller goroutine.
+	// RESTART-ONLY: the state poller reads this once at startup and is not
+	// managed by startPollers, so a change only takes effect after a full daemon
+	// restart (not on config reload). Unlike poll_interval/discovery_interval.
 	Tier3Interval string `toml:"tier3_interval"`
 
 	// RateLimitSafetyThreshold is the minimum X-RateLimit-Remaining for the
@@ -41,7 +44,9 @@ type PollingConfig struct {
 	// The scheduler already uses per-tier offsets (TierRepo = base-25,
 	// TierWatch = base-75). Default 100, matching the current hardcoded value
 	// of tierSafetyThreshold[TierDiscovery].
-	RateLimitSafetyThreshold int `toml:"rate_limit_safety_threshold"`
+	// Pointer so an explicit rate_limit_safety_threshold = 0 is distinguishable
+	// from "unset" (nil → default). Resolve via ResolvedRateLimitSafetyThreshold.
+	RateLimitSafetyThreshold *int `toml:"rate_limit_safety_threshold,omitempty"`
 
 	// UseETag is a kill-switch for the conditional ETag cache (C1). Defaults
 	// to true (cache enabled). Set to false to disable If-None-Match and force
@@ -80,8 +85,9 @@ func (c *Config) applyPollingDefaults() {
 	if p.Tier3Interval == "" {
 		p.Tier3Interval = DefaultPollingTier3Interval
 	}
-	if p.RateLimitSafetyThreshold == 0 {
-		p.RateLimitSafetyThreshold = DefaultPollingRateLimitSafetyThreshold
+	if p.RateLimitSafetyThreshold == nil {
+		v := DefaultPollingRateLimitSafetyThreshold
+		p.RateLimitSafetyThreshold = &v
 	}
 	if p.UseETag == nil {
 		v := true
@@ -158,4 +164,14 @@ func (c *Config) GraphQLEnabled() bool {
 		return false
 	}
 	return *c.Polling.UseGraphQL
+}
+
+// ResolvedRateLimitSafetyThreshold returns the effective threshold: the
+// explicitly-configured value (including a deliberate 0), or the default when
+// unset. Safe to call before applyDefaults (nil → default).
+func (c *Config) ResolvedRateLimitSafetyThreshold() int {
+	if c.Polling.RateLimitSafetyThreshold == nil {
+		return DefaultPollingRateLimitSafetyThreshold
+	}
+	return *c.Polling.RateLimitSafetyThreshold
 }

--- a/daemon/internal/config/polling.go
+++ b/daemon/internal/config/polling.go
@@ -57,10 +57,10 @@ type PollingConfig struct {
 // Default values for [polling] — centralised so applyPollingDefaults and the
 // Resolved* helpers can't drift.
 const (
-	DefaultPollingMinInterval             = "1m"
-	DefaultPollingMaxInterval             = "15m"
-	DefaultPollingDiscoveryInterval       = "5m"
-	DefaultPollingTier3Interval           = "30s"
+	DefaultPollingMinInterval              = "1m"
+	DefaultPollingMaxInterval              = "15m"
+	DefaultPollingDiscoveryInterval        = "5m"
+	DefaultPollingTier3Interval            = "30s"
 	DefaultPollingRateLimitSafetyThreshold = 100
 )
 

--- a/daemon/internal/config/polling.go
+++ b/daemon/internal/config/polling.go
@@ -8,24 +8,25 @@ import "time"
 // that reproduce the existing daemon behaviour when the section is absent.
 //
 // Adaptive scheduling (PollInterval → MinInterval / MaxInterval backoff) is
-// reserved for a separate task; the fields exist here so the config schema is
-// stable before the engine lands.
+// implemented by the AdaptiveScheduler and gated behind the Adaptive flag
+// (opt-in). When Adaptive is false the daemon polls every repo every cycle at
+// PollInterval, reproducing the prior behaviour.
 type PollingConfig struct {
 	// PollInterval is the base Tier 2 (per-repo PR/issue) poll cadence.
 	// Empty string inherits from [github].poll_interval. Accepts any
 	// Go time.ParseDuration value (e.g. "5m", "1m30s").
 	PollInterval string `toml:"poll_interval"`
 
-	// MinInterval is the adaptive lower bound. The adaptive engine (separate
-	// task) will never schedule a tick faster than this. Default "1m".
+	// MinInterval is the adaptive lower bound. The adaptive engine never
+	// schedules a tick faster than this. Default "1m".
 	MinInterval string `toml:"min_interval"`
 
 	// MaxInterval is the adaptive upper bound. The adaptive engine will never
 	// back off slower than this. Default "15m".
 	MaxInterval string `toml:"max_interval"`
 
-	// Adaptive enables the adaptive back-off engine (separate task). Default
-	// false — opt-in only. When false, MinInterval/MaxInterval are ignored.
+	// Adaptive enables the adaptive back-off engine. Default false — opt-in
+	// only. When false, MinInterval/MaxInterval are ignored.
 	Adaptive bool `toml:"adaptive"`
 
 	// DiscoveryInterval controls Tier 1 (topic-based repo discovery) cadence.

--- a/daemon/internal/config/polling.go
+++ b/daemon/internal/config/polling.go
@@ -1,0 +1,161 @@
+package config
+
+import "time"
+
+// PollingConfig is the [polling] TOML section that controls polling cadence,
+// rate-limit safety, and feature kill-switches for the GitHub API efficiency
+// feature (C5). Fields are all optional; applyPollingDefaults fills safe values
+// that reproduce the existing daemon behaviour when the section is absent.
+//
+// Adaptive scheduling (PollInterval → MinInterval / MaxInterval backoff) is
+// reserved for a separate task; the fields exist here so the config schema is
+// stable before the engine lands.
+type PollingConfig struct {
+	// PollInterval is the base Tier 2 (per-repo PR/issue) poll cadence.
+	// Empty string inherits from [github].poll_interval. Accepts any
+	// Go time.ParseDuration value (e.g. "5m", "1m30s").
+	PollInterval string `toml:"poll_interval"`
+
+	// MinInterval is the adaptive lower bound. The adaptive engine (separate
+	// task) will never schedule a tick faster than this. Default "1m".
+	MinInterval string `toml:"min_interval"`
+
+	// MaxInterval is the adaptive upper bound. The adaptive engine will never
+	// back off slower than this. Default "15m".
+	MaxInterval string `toml:"max_interval"`
+
+	// Adaptive enables the adaptive back-off engine (separate task). Default
+	// false — opt-in only. When false, MinInterval/MaxInterval are ignored.
+	Adaptive bool `toml:"adaptive"`
+
+	// DiscoveryInterval controls Tier 1 (topic-based repo discovery) cadence.
+	// Default "5m" — matches the current hardcoded value in startPollers.
+	DiscoveryInterval string `toml:"discovery_interval"`
+
+	// Tier3Interval controls the state-check (watch) scanner tick. Default
+	// "30s" — matches the current hardcoded value in the state-poller goroutine.
+	Tier3Interval string `toml:"tier3_interval"`
+
+	// RateLimitSafetyThreshold is the minimum X-RateLimit-Remaining for the
+	// "core" resource below which the TierDiscovery tier starts throttling.
+	// The scheduler already uses per-tier offsets (TierRepo = base-25,
+	// TierWatch = base-75). Default 100, matching the current hardcoded value
+	// of tierSafetyThreshold[TierDiscovery].
+	RateLimitSafetyThreshold int `toml:"rate_limit_safety_threshold"`
+
+	// UseETag is a kill-switch for the conditional ETag cache (C1). Defaults
+	// to true (cache enabled). Set to false to disable If-None-Match and force
+	// full 200 responses on every GET — useful when debugging or when the
+	// upstream server doesn't honour ETags correctly.
+	UseETag *bool `toml:"use_etag,omitempty"`
+
+	// UseGraphQL is reserved for Phase 3 (GraphQL-based polling). Defaults to
+	// false. Set to true once the GraphQL engine is ready to enable it.
+	UseGraphQL *bool `toml:"use_graphql,omitempty"`
+}
+
+// Default values for [polling] — centralised so applyPollingDefaults and the
+// Resolved* helpers can't drift.
+const (
+	DefaultPollingMinInterval             = "1m"
+	DefaultPollingMaxInterval             = "15m"
+	DefaultPollingDiscoveryInterval       = "5m"
+	DefaultPollingTier3Interval           = "30s"
+	DefaultPollingRateLimitSafetyThreshold = 100
+)
+
+// applyPollingDefaults fills zero-value scalars with safe defaults. Called from
+// applyDefaults so the section is always fully populated after Load/LoadOrCreate.
+func (c *Config) applyPollingDefaults() {
+	p := &c.Polling
+	if p.MinInterval == "" {
+		p.MinInterval = DefaultPollingMinInterval
+	}
+	if p.MaxInterval == "" {
+		p.MaxInterval = DefaultPollingMaxInterval
+	}
+	if p.DiscoveryInterval == "" {
+		p.DiscoveryInterval = DefaultPollingDiscoveryInterval
+	}
+	if p.Tier3Interval == "" {
+		p.Tier3Interval = DefaultPollingTier3Interval
+	}
+	if p.RateLimitSafetyThreshold == 0 {
+		p.RateLimitSafetyThreshold = DefaultPollingRateLimitSafetyThreshold
+	}
+	if p.UseETag == nil {
+		v := true
+		p.UseETag = &v
+	}
+	if p.UseGraphQL == nil {
+		v := false
+		p.UseGraphQL = &v
+	}
+	// PollInterval: left as-is (empty = inherit from [github].poll_interval).
+	// Adaptive: left as-is (false = opt-in).
+}
+
+// parseDurationWithFallback parses s as a Go duration. Returns fallback when s
+// is empty or invalid, or when the parsed value is non-positive.
+func parseDurationWithFallback(s string, fallback time.Duration) time.Duration {
+	if s == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return d
+}
+
+// ResolvedPollInterval returns the effective Tier 2 base poll interval.
+// Resolution order:
+//  1. [polling].poll_interval when set and valid.
+//  2. [github].poll_interval (may also be empty or invalid — falls back to 5m).
+func (c *Config) ResolvedPollInterval() time.Duration {
+	if c.Polling.PollInterval != "" {
+		if d := parseDurationWithFallback(c.Polling.PollInterval, 0); d > 0 {
+			return d
+		}
+	}
+	// Fall back to [github].poll_interval → 5 min default.
+	return parseDurationWithFallback(c.GitHub.PollInterval, 5*time.Minute)
+}
+
+// ResolvedMinInterval returns the adaptive lower bound for the poll interval.
+func (c *Config) ResolvedMinInterval() time.Duration {
+	return parseDurationWithFallback(c.Polling.MinInterval, time.Minute)
+}
+
+// ResolvedMaxInterval returns the adaptive upper bound for the poll interval.
+func (c *Config) ResolvedMaxInterval() time.Duration {
+	return parseDurationWithFallback(c.Polling.MaxInterval, 15*time.Minute)
+}
+
+// ResolvedDiscoveryInterval returns the Tier 1 discovery cadence.
+func (c *Config) ResolvedDiscoveryInterval() time.Duration {
+	return parseDurationWithFallback(c.Polling.DiscoveryInterval, 5*time.Minute)
+}
+
+// ResolvedTier3Interval returns the Tier 3 state-check scanner tick.
+func (c *Config) ResolvedTier3Interval() time.Duration {
+	return parseDurationWithFallback(c.Polling.Tier3Interval, 30*time.Second)
+}
+
+// ETagEnabled reports whether the conditional ETag cache is active.
+// Returns true unless UseETag is explicitly set to false.
+func (c *Config) ETagEnabled() bool {
+	if c.Polling.UseETag == nil {
+		return true
+	}
+	return *c.Polling.UseETag
+}
+
+// GraphQLEnabled reports whether GraphQL-based polling is active.
+// Returns false unless UseGraphQL is explicitly set to true.
+func (c *Config) GraphQLEnabled() bool {
+	if c.Polling.UseGraphQL == nil {
+		return false
+	}
+	return *c.Polling.UseGraphQL
+}

--- a/daemon/internal/config/polling_test.go
+++ b/daemon/internal/config/polling_test.go
@@ -29,9 +29,12 @@ func TestApplyPollingDefaults_FillsDocumentedDefaults(t *testing.T) {
 	if p.Tier3Interval != DefaultPollingTier3Interval {
 		t.Errorf("Tier3Interval: got %q, want %q", p.Tier3Interval, DefaultPollingTier3Interval)
 	}
-	if p.RateLimitSafetyThreshold != DefaultPollingRateLimitSafetyThreshold {
+	if p.RateLimitSafetyThreshold == nil {
+		t.Fatal("RateLimitSafetyThreshold: got nil, want non-nil")
+	}
+	if *p.RateLimitSafetyThreshold != DefaultPollingRateLimitSafetyThreshold {
 		t.Errorf("RateLimitSafetyThreshold: got %d, want %d",
-			p.RateLimitSafetyThreshold, DefaultPollingRateLimitSafetyThreshold)
+			*p.RateLimitSafetyThreshold, DefaultPollingRateLimitSafetyThreshold)
 	}
 	if p.UseETag == nil {
 		t.Fatal("UseETag: got nil, want non-nil")
@@ -58,6 +61,7 @@ func TestApplyPollingDefaults_FillsDocumentedDefaults(t *testing.T) {
 func TestApplyPollingDefaults_DoesNotOverwriteExplicitValues(t *testing.T) {
 	useETag := false
 	useGraphQL := true
+	threshold := 200
 	c := Config{
 		Polling: PollingConfig{
 			PollInterval:             "2m",
@@ -66,7 +70,7 @@ func TestApplyPollingDefaults_DoesNotOverwriteExplicitValues(t *testing.T) {
 			Adaptive:                 true,
 			DiscoveryInterval:        "3m",
 			Tier3Interval:            "1m",
-			RateLimitSafetyThreshold: 200,
+			RateLimitSafetyThreshold: &threshold,
 			UseETag:                  &useETag,
 			UseGraphQL:               &useGraphQL,
 		},
@@ -92,8 +96,8 @@ func TestApplyPollingDefaults_DoesNotOverwriteExplicitValues(t *testing.T) {
 	if p.Tier3Interval != "1m" {
 		t.Errorf("Tier3Interval overwritten: got %q", p.Tier3Interval)
 	}
-	if p.RateLimitSafetyThreshold != 200 {
-		t.Errorf("RateLimitSafetyThreshold overwritten: got %d", p.RateLimitSafetyThreshold)
+	if p.RateLimitSafetyThreshold == nil || *p.RateLimitSafetyThreshold != 200 {
+		t.Errorf("RateLimitSafetyThreshold overwritten: got %v", p.RateLimitSafetyThreshold)
 	}
 	if p.UseETag == nil || *p.UseETag {
 		t.Errorf("UseETag overwritten: got %v", p.UseETag)
@@ -305,9 +309,9 @@ func TestPollingDefaultsMatchCurrentBehaviour(t *testing.T) {
 	}
 
 	// Rate-limit safety: previously tierSafetyThreshold[TierDiscovery] = 100.
-	if c.Polling.RateLimitSafetyThreshold != 100 {
+	if c.ResolvedRateLimitSafetyThreshold() != 100 {
 		t.Errorf("RateLimitSafetyThreshold default changed from 100 to %d — behaviour regression",
-			c.Polling.RateLimitSafetyThreshold)
+			c.ResolvedRateLimitSafetyThreshold())
 	}
 
 	// ETag: previously always enabled.
@@ -335,5 +339,20 @@ func TestApplyDefaultsCallsPollingDefaults(t *testing.T) {
 	}
 	if c.Polling.UseETag == nil {
 		t.Error("applyDefaults did not populate Polling.UseETag")
+	}
+}
+
+// TestApplyPollingDefaults_PreservesExplicitZeroThreshold guards the *int
+// change: an operator-set rate_limit_safety_threshold = 0 must survive the
+// defaults pass (not be silently rewritten to the default 100).
+func TestApplyPollingDefaults_PreservesExplicitZeroThreshold(t *testing.T) {
+	zero := 0
+	c := Config{Polling: PollingConfig{RateLimitSafetyThreshold: &zero}}
+	c.applyPollingDefaults()
+	if c.Polling.RateLimitSafetyThreshold == nil || *c.Polling.RateLimitSafetyThreshold != 0 {
+		t.Errorf("explicit 0 must survive defaults, got %v", c.Polling.RateLimitSafetyThreshold)
+	}
+	if got := c.ResolvedRateLimitSafetyThreshold(); got != 0 {
+		t.Errorf("ResolvedRateLimitSafetyThreshold() = %d, want 0 (explicit)", got)
 	}
 }

--- a/daemon/internal/config/polling_test.go
+++ b/daemon/internal/config/polling_test.go
@@ -106,10 +106,10 @@ func TestApplyPollingDefaults_DoesNotOverwriteExplicitValues(t *testing.T) {
 // TestResolvedPollInterval covers all resolution branches.
 func TestResolvedPollInterval(t *testing.T) {
 	tests := []struct {
-		name           string
-		pollingPoll    string
-		githubPoll     string
-		wantDuration   time.Duration
+		name         string
+		pollingPoll  string
+		githubPoll   string
+		wantDuration time.Duration
 	}{
 		{
 			name:         "polling.poll_interval takes precedence over github.poll_interval",

--- a/daemon/internal/config/polling_test.go
+++ b/daemon/internal/config/polling_test.go
@@ -1,0 +1,339 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+// boolPtr returns a pointer to b, used to set *bool fields in tests without a
+// named variable.
+func boolPtr(b bool) *bool { return &b }
+
+// TestApplyPollingDefaults_FillsDocumentedDefaults verifies that calling
+// applyPollingDefaults on a zero-value PollingConfig produces exactly the
+// documented defaults.
+func TestApplyPollingDefaults_FillsDocumentedDefaults(t *testing.T) {
+	var c Config
+	c.applyPollingDefaults()
+
+	p := c.Polling
+	if p.MinInterval != DefaultPollingMinInterval {
+		t.Errorf("MinInterval: got %q, want %q", p.MinInterval, DefaultPollingMinInterval)
+	}
+	if p.MaxInterval != DefaultPollingMaxInterval {
+		t.Errorf("MaxInterval: got %q, want %q", p.MaxInterval, DefaultPollingMaxInterval)
+	}
+	if p.DiscoveryInterval != DefaultPollingDiscoveryInterval {
+		t.Errorf("DiscoveryInterval: got %q, want %q", p.DiscoveryInterval, DefaultPollingDiscoveryInterval)
+	}
+	if p.Tier3Interval != DefaultPollingTier3Interval {
+		t.Errorf("Tier3Interval: got %q, want %q", p.Tier3Interval, DefaultPollingTier3Interval)
+	}
+	if p.RateLimitSafetyThreshold != DefaultPollingRateLimitSafetyThreshold {
+		t.Errorf("RateLimitSafetyThreshold: got %d, want %d",
+			p.RateLimitSafetyThreshold, DefaultPollingRateLimitSafetyThreshold)
+	}
+	if p.UseETag == nil {
+		t.Fatal("UseETag: got nil, want non-nil")
+	}
+	if !*p.UseETag {
+		t.Errorf("UseETag: got false, want true (default enabled)")
+	}
+	if p.UseGraphQL == nil {
+		t.Fatal("UseGraphQL: got nil, want non-nil")
+	}
+	if *p.UseGraphQL {
+		t.Errorf("UseGraphQL: got true, want false (default disabled)")
+	}
+	if p.PollInterval != "" {
+		t.Errorf("PollInterval: got %q, want empty string (inherits from [github])", p.PollInterval)
+	}
+	if p.Adaptive {
+		t.Errorf("Adaptive: got true, want false (opt-in)")
+	}
+}
+
+// TestApplyPollingDefaults_DoesNotOverwriteExplicitValues verifies that
+// explicitly-set values survive the defaults pass untouched.
+func TestApplyPollingDefaults_DoesNotOverwriteExplicitValues(t *testing.T) {
+	useETag := false
+	useGraphQL := true
+	c := Config{
+		Polling: PollingConfig{
+			PollInterval:             "2m",
+			MinInterval:              "30s",
+			MaxInterval:              "10m",
+			Adaptive:                 true,
+			DiscoveryInterval:        "3m",
+			Tier3Interval:            "1m",
+			RateLimitSafetyThreshold: 200,
+			UseETag:                  &useETag,
+			UseGraphQL:               &useGraphQL,
+		},
+	}
+	c.applyPollingDefaults()
+
+	p := c.Polling
+	if p.PollInterval != "2m" {
+		t.Errorf("PollInterval overwritten: got %q", p.PollInterval)
+	}
+	if p.MinInterval != "30s" {
+		t.Errorf("MinInterval overwritten: got %q", p.MinInterval)
+	}
+	if p.MaxInterval != "10m" {
+		t.Errorf("MaxInterval overwritten: got %q", p.MaxInterval)
+	}
+	if !p.Adaptive {
+		t.Errorf("Adaptive overwritten")
+	}
+	if p.DiscoveryInterval != "3m" {
+		t.Errorf("DiscoveryInterval overwritten: got %q", p.DiscoveryInterval)
+	}
+	if p.Tier3Interval != "1m" {
+		t.Errorf("Tier3Interval overwritten: got %q", p.Tier3Interval)
+	}
+	if p.RateLimitSafetyThreshold != 200 {
+		t.Errorf("RateLimitSafetyThreshold overwritten: got %d", p.RateLimitSafetyThreshold)
+	}
+	if p.UseETag == nil || *p.UseETag {
+		t.Errorf("UseETag overwritten: got %v", p.UseETag)
+	}
+	if p.UseGraphQL == nil || !*p.UseGraphQL {
+		t.Errorf("UseGraphQL overwritten: got %v", p.UseGraphQL)
+	}
+}
+
+// TestResolvedPollInterval covers all resolution branches.
+func TestResolvedPollInterval(t *testing.T) {
+	tests := []struct {
+		name           string
+		pollingPoll    string
+		githubPoll     string
+		wantDuration   time.Duration
+	}{
+		{
+			name:         "polling.poll_interval takes precedence over github.poll_interval",
+			pollingPoll:  "2m",
+			githubPoll:   "5m",
+			wantDuration: 2 * time.Minute,
+		},
+		{
+			name:         "falls back to github.poll_interval when polling empty",
+			pollingPoll:  "",
+			githubPoll:   "1m",
+			wantDuration: time.Minute,
+		},
+		{
+			name:         "falls back to 5m when both empty",
+			pollingPoll:  "",
+			githubPoll:   "",
+			wantDuration: 5 * time.Minute,
+		},
+		{
+			name:         "invalid polling string falls back to github.poll_interval",
+			pollingPoll:  "not-a-duration",
+			githubPoll:   "10m",
+			wantDuration: 10 * time.Minute,
+		},
+		{
+			name:         "invalid polling AND invalid github falls back to 5m",
+			pollingPoll:  "bad",
+			githubPoll:   "also-bad",
+			wantDuration: 5 * time.Minute,
+		},
+		{
+			name:         "non-positive polling value falls back",
+			pollingPoll:  "-1m",
+			githubPoll:   "3m",
+			wantDuration: 3 * time.Minute,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			c := Config{
+				GitHub:  GitHubConfig{PollInterval: tc.githubPoll},
+				Polling: PollingConfig{PollInterval: tc.pollingPoll},
+			}
+			got := c.ResolvedPollInterval()
+			if got != tc.wantDuration {
+				t.Errorf("ResolvedPollInterval() = %v, want %v", got, tc.wantDuration)
+			}
+		})
+	}
+}
+
+// TestResolvedMinMaxIntervals verifies parse-with-fallback behaviour.
+func TestResolvedMinMaxIntervals(t *testing.T) {
+	t.Run("valid values parse correctly", func(t *testing.T) {
+		c := Config{Polling: PollingConfig{MinInterval: "30s", MaxInterval: "20m"}}
+		if got := c.ResolvedMinInterval(); got != 30*time.Second {
+			t.Errorf("ResolvedMinInterval() = %v, want 30s", got)
+		}
+		if got := c.ResolvedMaxInterval(); got != 20*time.Minute {
+			t.Errorf("ResolvedMaxInterval() = %v, want 20m", got)
+		}
+	})
+	t.Run("empty falls back to defaults", func(t *testing.T) {
+		var c Config
+		if got := c.ResolvedMinInterval(); got != time.Minute {
+			t.Errorf("ResolvedMinInterval() empty = %v, want 1m", got)
+		}
+		if got := c.ResolvedMaxInterval(); got != 15*time.Minute {
+			t.Errorf("ResolvedMaxInterval() empty = %v, want 15m", got)
+		}
+	})
+	t.Run("invalid falls back to defaults", func(t *testing.T) {
+		c := Config{Polling: PollingConfig{MinInterval: "xyz", MaxInterval: "abc"}}
+		if got := c.ResolvedMinInterval(); got != time.Minute {
+			t.Errorf("ResolvedMinInterval() invalid = %v, want 1m", got)
+		}
+		if got := c.ResolvedMaxInterval(); got != 15*time.Minute {
+			t.Errorf("ResolvedMaxInterval() invalid = %v, want 15m", got)
+		}
+	})
+}
+
+// TestResolvedDiscoveryInterval confirms the discovery interval fallback and
+// that the default matches the current hardcoded value in startPollers (5m).
+func TestResolvedDiscoveryInterval(t *testing.T) {
+	t.Run("explicit value", func(t *testing.T) {
+		c := Config{Polling: PollingConfig{DiscoveryInterval: "3m"}}
+		if got := c.ResolvedDiscoveryInterval(); got != 3*time.Minute {
+			t.Errorf("got %v, want 3m", got)
+		}
+	})
+	t.Run("empty falls back to 5m (matches current hardcoded default)", func(t *testing.T) {
+		var c Config
+		want := 5 * time.Minute
+		if got := c.ResolvedDiscoveryInterval(); got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+	t.Run("invalid falls back to 5m", func(t *testing.T) {
+		c := Config{Polling: PollingConfig{DiscoveryInterval: "garbage"}}
+		if got := c.ResolvedDiscoveryInterval(); got != 5*time.Minute {
+			t.Errorf("got %v, want 5m", got)
+		}
+	})
+}
+
+// TestResolvedTier3Interval confirms the Tier 3 tick fallback and that the
+// default matches the current hardcoded value in the state-poller (30s).
+func TestResolvedTier3Interval(t *testing.T) {
+	t.Run("explicit value", func(t *testing.T) {
+		c := Config{Polling: PollingConfig{Tier3Interval: "1m"}}
+		if got := c.ResolvedTier3Interval(); got != time.Minute {
+			t.Errorf("got %v, want 1m", got)
+		}
+	})
+	t.Run("empty falls back to 30s (matches current hardcoded default)", func(t *testing.T) {
+		var c Config
+		want := 30 * time.Second
+		if got := c.ResolvedTier3Interval(); got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+	t.Run("invalid falls back to 30s", func(t *testing.T) {
+		c := Config{Polling: PollingConfig{Tier3Interval: "not-valid"}}
+		if got := c.ResolvedTier3Interval(); got != 30*time.Second {
+			t.Errorf("got %v, want 30s", got)
+		}
+	})
+}
+
+// TestETagEnabled verifies kill-switch semantics (default true).
+func TestETagEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		useETag *bool
+		want    bool
+	}{
+		{"nil (default) → true", nil, true},
+		{"explicit true → true", boolPtr(true), true},
+		{"explicit false → false (kill-switch)", boolPtr(false), false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			c := Config{Polling: PollingConfig{UseETag: tc.useETag}}
+			if got := c.ETagEnabled(); got != tc.want {
+				t.Errorf("ETagEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGraphQLEnabled verifies reserved-feature semantics (default false).
+func TestGraphQLEnabled(t *testing.T) {
+	tests := []struct {
+		name       string
+		useGraphQL *bool
+		want       bool
+	}{
+		{"nil (default) → false", nil, false},
+		{"explicit false → false", boolPtr(false), false},
+		{"explicit true → true", boolPtr(true), true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			c := Config{Polling: PollingConfig{UseGraphQL: tc.useGraphQL}}
+			if got := c.GraphQLEnabled(); got != tc.want {
+				t.Errorf("GraphQLEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPollingDefaultsMatchCurrentBehaviour is a regression test that confirms
+// the defaults reproduce the behaviour existing BEFORE this config section was
+// introduced. If this test breaks, we've changed a default that could affect
+// operators running with no [polling] section.
+func TestPollingDefaultsMatchCurrentBehaviour(t *testing.T) {
+	var c Config
+	c.applyPollingDefaults()
+
+	// Discovery: previously parseDiscoveryInterval("", "5m") = 5m.
+	if got := c.ResolvedDiscoveryInterval(); got != 5*time.Minute {
+		t.Errorf("DiscoveryInterval default changed from 5m to %v — behaviour regression", got)
+	}
+
+	// Tier 3 scan: previously time.NewTicker(30 * time.Second).
+	if got := c.ResolvedTier3Interval(); got != 30*time.Second {
+		t.Errorf("Tier3Interval default changed from 30s to %v — behaviour regression", got)
+	}
+
+	// Rate-limit safety: previously tierSafetyThreshold[TierDiscovery] = 100.
+	if c.Polling.RateLimitSafetyThreshold != 100 {
+		t.Errorf("RateLimitSafetyThreshold default changed from 100 to %d — behaviour regression",
+			c.Polling.RateLimitSafetyThreshold)
+	}
+
+	// ETag: previously always enabled.
+	if !c.ETagEnabled() {
+		t.Errorf("ETag default changed to disabled — behaviour regression")
+	}
+
+	// GraphQL: previously not implemented, effectively false.
+	if c.GraphQLEnabled() {
+		t.Errorf("GraphQL default changed to enabled — behaviour regression")
+	}
+}
+
+// TestApplyDefaultsCallsPollingDefaults verifies the top-level applyDefaults
+// calls applyPollingDefaults so callers don't need to invoke it separately.
+func TestApplyDefaultsCallsPollingDefaults(t *testing.T) {
+	c := Config{AI: AIConfig{Primary: "claude"}}
+	c.applyDefaults()
+
+	if c.Polling.Tier3Interval == "" {
+		t.Error("applyDefaults did not populate Polling.Tier3Interval")
+	}
+	if c.Polling.DiscoveryInterval == "" {
+		t.Error("applyDefaults did not populate Polling.DiscoveryInterval")
+	}
+	if c.Polling.UseETag == nil {
+		t.Error("applyDefaults did not populate Polling.UseETag")
+	}
+}

--- a/daemon/internal/discovery/discovery.go
+++ b/daemon/internal/discovery/discovery.go
@@ -187,6 +187,14 @@ type ArchivedChecker interface {
 	IsRepoArchived(repo string) (bool, error)
 }
 
+// BatchArchivedChecker resolves archived status for many repos at once (e.g.
+// via a single GraphQL query). Returns a map keyed by "owner/repo". A checker
+// that also implements this lets FilterArchived collapse N per-repo REST calls
+// into one batched call, falling back to per-repo IsRepoArchived on error.
+type BatchArchivedChecker interface {
+	BatchReposArchived(repos []string) (map[string]bool, error)
+}
+
 // FilterArchived separates repos into active and archived/deleted sets.
 // Repos listed in skipCheck (e.g. those freshly returned by topic-based
 // discovery, which already filters archived:false) are assumed active and
@@ -198,11 +206,38 @@ func FilterArchived(repos []string, checker ArchivedChecker, skipCheck []string)
 	for _, r := range skipCheck {
 		skip[r] = struct{}{}
 	}
+	var toCheck []string
 	for _, r := range repos {
 		if _, ok := skip[r]; ok {
 			active = append(active, r)
 			continue
 		}
+		toCheck = append(toCheck, r)
+	}
+	if len(toCheck) == 0 {
+		return
+	}
+
+	// Fast path: a single batched call (GraphQL) instead of one REST request
+	// per repo. On any error we fall through to the per-repo loop below, which
+	// is fail-open, so the batch path never risks purging repos.
+	if bc, ok := checker.(BatchArchivedChecker); ok {
+		if results, err := bc.BatchReposArchived(toCheck); err == nil {
+			for _, r := range toCheck {
+				if results[r] {
+					archived = append(archived, r)
+				} else {
+					active = append(active, r)
+				}
+			}
+			return
+		} else {
+			slog.Warn("discovery: batch archive check failed, falling back to per-repo", "repos", len(toCheck), "err", err)
+		}
+	}
+
+	// Slow path: per-repo REST checks, fail-open on error.
+	for _, r := range toCheck {
 		isArchived, err := checker.IsRepoArchived(r)
 		if err != nil {
 			slog.Warn("discovery: archive check failed, keeping repo", "repo", r, "err", err)

--- a/daemon/internal/discovery/discovery_test.go
+++ b/daemon/internal/discovery/discovery_test.go
@@ -261,6 +261,67 @@ func TestFilterArchived_EmptyInput(t *testing.T) {
 	}
 }
 
+// fakeBatchChecker also implements discovery.BatchArchivedChecker. batchErr,
+// when set, makes the batch path fail so FilterArchived falls back to per-repo.
+// perRepoCalls counts IsRepoArchived calls so tests can assert the batch path
+// avoided them.
+type fakeBatchChecker struct {
+	archived     map[string]bool
+	batchErr     error
+	perRepoCalls int
+}
+
+func (f *fakeBatchChecker) IsRepoArchived(repo string) (bool, error) {
+	f.perRepoCalls++
+	return f.archived[repo], nil
+}
+
+func (f *fakeBatchChecker) BatchReposArchived(repos []string) (map[string]bool, error) {
+	if f.batchErr != nil {
+		return nil, f.batchErr
+	}
+	out := make(map[string]bool, len(repos))
+	for _, r := range repos {
+		out[r] = f.archived[r]
+	}
+	return out, nil
+}
+
+func TestFilterArchived_UsesBatchPath(t *testing.T) {
+	checker := &fakeBatchChecker{
+		archived: map[string]bool{"org/old": true},
+	}
+	repos := []string{"org/active", "org/old", "org/other"}
+	active, archived := discovery.FilterArchived(repos, checker, nil)
+	if len(active) != 2 || active[0] != "org/active" || active[1] != "org/other" {
+		t.Errorf("active = %v, want [org/active org/other]", active)
+	}
+	if len(archived) != 1 || archived[0] != "org/old" {
+		t.Errorf("archived = %v, want [org/old]", archived)
+	}
+	if checker.perRepoCalls != 0 {
+		t.Errorf("batch path should avoid per-repo calls, got %d", checker.perRepoCalls)
+	}
+}
+
+func TestFilterArchived_FallsBackWhenBatchFails(t *testing.T) {
+	checker := &fakeBatchChecker{
+		archived: map[string]bool{"org/old": true},
+		batchErr: errors.New("graphql exploded"),
+	}
+	repos := []string{"org/active", "org/old"}
+	active, archived := discovery.FilterArchived(repos, checker, nil)
+	if len(active) != 1 || active[0] != "org/active" {
+		t.Errorf("active = %v, want [org/active]", active)
+	}
+	if len(archived) != 1 || archived[0] != "org/old" {
+		t.Errorf("archived = %v, want [org/old]", archived)
+	}
+	if checker.perRepoCalls != 2 {
+		t.Errorf("fallback should hit per-repo for each checked repo, got %d", checker.perRepoCalls)
+	}
+}
+
 // ── InferOrgs ───────────────────────────────────────────────────────────────
 
 func TestInferOrgs(t *testing.T) {

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 )
@@ -67,11 +68,12 @@ func safeTruncate(s string, max int) string {
 }
 
 type Client struct {
-	token   string
-	baseURL string
-	http    *http.Client
-	cache   *ConditionalCache
-	rateObs RateLimitObserver
+	token         string
+	baseURL       string
+	http          *http.Client
+	cache         *ConditionalCache
+	rateObs       RateLimitObserver
+	cacheDisabled atomic.Bool // when true, ETag conditional-request layer is bypassed
 }
 
 type Option func(*Client)
@@ -98,6 +100,14 @@ func NewClient(token string, opts ...Option) *Client {
 // Intended for observability / metrics; callers must not depend on exact values.
 func (c *Client) CacheStats() (hits, misses int64) {
 	return c.cache.CacheHits(), c.cache.CacheMisses()
+}
+
+// SetCacheEnabled enables or disables the conditional ETag cache. When
+// disabled every GET request is made without an If-None-Match header, forcing
+// a full 200 response from GitHub. Thread-safe; takes effect on the next
+// request. Defaults to enabled (true).
+func (c *Client) SetCacheEnabled(enabled bool) {
+	c.cacheDisabled.Store(!enabled)
 }
 
 // SetRateObserver registers an observer that will be called after every HTTP
@@ -145,6 +155,12 @@ func (c *Client) do(method, path string, accept string) (*http.Response, error) 
 	}
 
 	// ── ETag conditional-request layer (GET only) ────────────────────────────
+	// When the cache is disabled via SetCacheEnabled(false), bypass the ETag
+	// layer entirely and make a plain unconditional GET. doWithBody already
+	// calls notifyRateObserver so all rate-limit accounting still applies.
+	if c.cacheDisabled.Load() {
+		return c.doWithBody(method, path, accept, "", nil)
+	}
 	// If we have a cached ETag for this path, send If-None-Match so GitHub can
 	// return 304 Not Modified (which does NOT count against the rate limit).
 	// On 304: swap the empty body for the cached bytes and re-report 200 so

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -38,6 +38,13 @@ const maxDiffBodyBytes = 10 * 1024 * 1024 // 10 MB for diffs
 // misbehaving server.
 const maxPaginatedPageBytes = 5 * 1024 * 1024 // 5 MB for per_page=100 endpoints
 
+// maxCacheBodyBytes is the maximum body size that will be stored in the ETag
+// cache. Bodies larger than this limit are still served in full to the caller
+// (read up to maxDiffBodyBytes) but are not kept in memory across requests.
+// Set to maxBodyBytes (1 MiB) so the cached-entry memory budget is bounded
+// regardless of which Accept type was used to fetch the resource.
+const maxCacheBodyBytes = maxBodyBytes // 1 MB
+
 // maxErrBodyLen limits the number of bytes included in error messages to avoid
 // leaking sensitive GitHub diagnostic information (e.g. token details).
 const maxErrBodyLen = 200
@@ -145,7 +152,12 @@ func (c *Client) do(method, path string, accept string) (*http.Response, error) 
 	// On 200 with a new ETag: read+buffer the body, store it, hand the caller
 	// a fresh reader so it can decode normally.
 	// Any other status: passthrough without touching the cache.
-	key := cacheKey(method, path)
+	//
+	// The key includes the Accept value because the same path can be requested
+	// with different Accept headers (e.g. application/vnd.github+json vs
+	// application/vnd.github.v3.diff for the pulls endpoint) and must produce
+	// separate cache entries. See cacheKey for details.
+	key := cacheKey(method, accept, path)
 	cachedETag, cachedBody, hasCached := c.cache.Get(key)
 
 	req, err := http.NewRequest(method, c.baseURL+path, nil)
@@ -197,8 +209,20 @@ func (c *Client) do(method, path string, accept string) (*http.Response, error) 
 			// No ETag — pass through without caching.
 			return resp, nil
 		}
-		// Buffer the body so we can (a) cache it and (b) give the caller a fresh reader.
-		data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		// Do not cache paginated responses: a 304 re-serve would lose the
+		// Link header and break the caller's cursor-based pagination
+		// (e.g. FetchCollaborators). Serve the body normally without storing.
+		if resp.Header.Get("Link") != "" {
+			return resp, nil
+		}
+		// Buffer the full body up to maxDiffBodyBytes so that large diffs
+		// (up to 10 MiB) are never silently truncated by the cache layer.
+		// We read with the larger limit here; callers that need only a
+		// smaller bound (most JSON endpoints) apply their own LimitReader
+		// after receiving the response. The body is served in full regardless
+		// of size, but is only stored in the cache when it is small enough
+		// not to blow the per-entry memory budget (maxCacheBodyBytes).
+		data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxDiffBodyBytes))
 		resp.Body.Close()
 		if readErr != nil {
 			// Return an error-wrapping response with a body so callers that
@@ -206,8 +230,10 @@ func (c *Client) do(method, path string, accept string) (*http.Response, error) 
 			resp.Body = http.NoBody
 			return resp, fmt.Errorf("github: etag cache: read body: %w", readErr)
 		}
-		c.cache.Put(key, newETag, data)
-		c.cache.cacheMisses.Add(1)
+		if len(data) <= maxCacheBodyBytes {
+			c.cache.Put(key, newETag, data)
+			c.cache.cacheMisses.Add(1)
+		}
 		resp.Body = io.NopCloser(bytes.NewReader(data))
 		return resp, nil
 

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -62,6 +63,7 @@ type Client struct {
 	token   string
 	baseURL string
 	http    *http.Client
+	cache   *ConditionalCache
 }
 
 type Option func(*Client)
@@ -75,11 +77,19 @@ func NewClient(token string, opts ...Option) *Client {
 		token:   token,
 		baseURL: defaultBaseURL,
 		http:    &http.Client{Timeout: 30 * time.Second},
+		cache:   NewConditionalCache(),
 	}
 	for _, o := range opts {
 		o(c)
 	}
 	return c
+}
+
+// CacheStats returns the number of ETag cache hits (304→200 transparently
+// converted) and misses (200 responses stored) since this client was created.
+// Intended for observability / metrics; callers must not depend on exact values.
+func (c *Client) CacheStats() (hits, misses int64) {
+	return c.cache.CacheHits(), c.cache.CacheMisses()
 }
 
 // AuthenticatedUser returns the GitHub login of the token owner.
@@ -105,7 +115,81 @@ func (c *Client) AuthenticatedUser() (string, error) {
 }
 
 func (c *Client) do(method, path string, accept string) (*http.Response, error) {
-	return c.doWithBody(method, path, accept, "", nil)
+	if method != "GET" {
+		return c.doWithBody(method, path, accept, "", nil)
+	}
+
+	// ── ETag conditional-request layer (GET only) ────────────────────────────
+	// If we have a cached ETag for this path, send If-None-Match so GitHub can
+	// return 304 Not Modified (which does NOT count against the rate limit).
+	// On 304: swap the empty body for the cached bytes and re-report 200 so
+	// every caller transparently gets the data it already decoded once.
+	// On 200 with a new ETag: read+buffer the body, store it, hand the caller
+	// a fresh reader so it can decode normally.
+	// Any other status: passthrough without touching the cache.
+	key := cacheKey(method, path)
+	cachedETag, cachedBody, hasCached := c.cache.Get(key)
+
+	req, err := http.NewRequest(method, c.baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", accept)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if hasCached && cachedETag != "" {
+		req.Header.Set("If-None-Match", cachedETag)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNotModified: // 304
+		// Must drain and close the (empty) server body.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if !hasCached || cachedBody == nil {
+			// Defensive: 304 with nothing cached — this shouldn't happen with a
+			// well-behaved server, but we must not return a nil body to callers.
+			// Treat it as a passthrough empty 304 that callers will handle as an
+			// error (non-200 status).
+			resp.Body = http.NoBody
+			return resp, nil
+		}
+
+		c.cache.cacheHits.Add(1)
+		resp.StatusCode = http.StatusOK
+		resp.Body = io.NopCloser(bytes.NewReader(cachedBody))
+		return resp, nil
+
+	case http.StatusOK:
+		newETag := resp.Header.Get("ETag")
+		if newETag == "" {
+			// No ETag — pass through without caching.
+			return resp, nil
+		}
+		// Buffer the body so we can (a) cache it and (b) give the caller a fresh reader.
+		data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		resp.Body.Close()
+		if readErr != nil {
+			// Return an error-wrapping response with a body so callers that
+			// do resp.Body.Close() don't panic.
+			resp.Body = http.NoBody
+			return resp, fmt.Errorf("github: etag cache: read body: %w", readErr)
+		}
+		c.cache.Put(key, newETag, data)
+		c.cache.cacheMisses.Add(1)
+		resp.Body = io.NopCloser(bytes.NewReader(data))
+		return resp, nil
+
+	default:
+		// Non-200/304 status — pass through unchanged; do not cache.
+		return resp, nil
+	}
 }
 
 // doWithBody is the POST/PUT/PATCH counterpart to do(). It accepts an

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -74,6 +74,7 @@ type Client struct {
 	cache         *ConditionalCache
 	rateObs       RateLimitObserver
 	cacheDisabled atomic.Bool // when true, ETag conditional-request layer is bypassed
+	useGraphQL    atomic.Bool // when true, SearchIssues dispatches to GraphQL with REST fallback
 }
 
 type Option func(*Client)

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -64,6 +64,7 @@ type Client struct {
 	baseURL string
 	http    *http.Client
 	cache   *ConditionalCache
+	rateObs RateLimitObserver
 }
 
 type Option func(*Client)
@@ -90,6 +91,23 @@ func NewClient(token string, opts ...Option) *Client {
 // Intended for observability / metrics; callers must not depend on exact values.
 func (c *Client) CacheStats() (hits, misses int64) {
 	return c.cache.CacheHits(), c.cache.CacheMisses()
+}
+
+// SetRateObserver registers an observer that will be called after every HTTP
+// response (success or error status) made through do() or doWithBody().
+// The observer receives the raw *http.Response to inspect headers.
+// Replaces any previously registered observer. Pass nil to disable.
+func (c *Client) SetRateObserver(o RateLimitObserver) {
+	c.rateObs = o
+}
+
+// notifyRateObserver calls the registered observer if one is set.
+// Must be called AFTER the response is ready but BEFORE the body is consumed
+// by this layer (headers are what the observer needs).
+func (c *Client) notifyRateObserver(resp *http.Response) {
+	if c.rateObs != nil && resp != nil {
+		c.rateObs.ObserveResponse(resp)
+	}
 }
 
 // AuthenticatedUser returns the GitHub login of the token owner.
@@ -145,6 +163,13 @@ func (c *Client) do(method, path string, accept string) (*http.Response, error) 
 	if err != nil {
 		return nil, err
 	}
+
+	// Notify the rate-limit observer with the raw response (headers only —
+	// the observer must not consume the body). Called before the ETag cache
+	// layer modifies the response so the observer sees the real status code
+	// and headers GitHub sent (including 304, which does not count against
+	// the budget and carries up-to-date X-RateLimit-* values).
+	c.notifyRateObserver(resp)
 
 	switch resp.StatusCode {
 	case http.StatusNotModified: // 304
@@ -211,7 +236,14 @@ func (c *Client) doWithBody(method, path, accept, contentType string, body io.Re
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
-	return c.http.Do(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return resp, err
+	}
+	// Notify the rate-limit observer so POST/PUT/PATCH responses also update
+	// the live budget. The observer inspects headers only; the body is untouched.
+	c.notifyRateObserver(resp)
+	return resp, nil
 }
 
 // FetchPRsToReview returns all open PRs where the authenticated user is explicitly

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -248,9 +248,6 @@ func (c *Client) do(method, path string, accept string) (*http.Response, error) 
 // set when a body is present. Every authenticated call should go through
 // this helper so auth, Accept headers, and the pinned API version stay in
 // one place.
-//
-// TODO: migrate SubmitReview and PostComment to doWithBody as well — they
-// still build their request inline, duplicating the header setup.
 func (c *Client) doWithBody(method, path, accept, contentType string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest(method, c.baseURL+path, body)
 	if err != nil {
@@ -456,16 +453,7 @@ func (c *Client) SubmitReview(repo string, number int, body, event string) (int6
 	}
 
 	data, _ := json.Marshal(payload)
-	req, err := http.NewRequest("POST", c.baseURL+path, strings.NewReader(string(data)))
-	if err != nil {
-		return 0, "", fmt.Errorf("github: submit review: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-
-	resp, err := c.http.Do(req)
+	resp, err := c.doWithBody("POST", path, "application/vnd.github+json", "application/json", strings.NewReader(string(data)))
 	if err != nil {
 		return 0, "", fmt.Errorf("github: submit review: %w", err)
 	}
@@ -505,15 +493,7 @@ func (c *Client) PostComment(repo string, number int, body string) (time.Time, e
 	path := fmt.Sprintf("/repos/%s/issues/%d/comments", repo, number)
 	payload := map[string]any{"body": body}
 	data, _ := json.Marshal(payload)
-	req, err := http.NewRequest("POST", c.baseURL+path, strings.NewReader(string(data)))
-	if err != nil {
-		return time.Time{}, fmt.Errorf("github: post comment: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	resp, err := c.http.Do(req)
+	resp, err := c.doWithBody("POST", path, "application/vnd.github+json", "application/json", strings.NewReader(string(data)))
 	if err != nil {
 		return time.Time{}, fmt.Errorf("github: post comment: %w", err)
 	}

--- a/daemon/internal/github/conditional_cache.go
+++ b/daemon/internal/github/conditional_cache.go
@@ -87,10 +87,15 @@ func (c *ConditionalCache) CacheHits() int64 { return c.cacheHits.Load() }
 // CacheMisses returns the number of 200 responses that were stored since creation.
 func (c *ConditionalCache) CacheMisses() int64 { return c.cacheMisses.Load() }
 
-// cacheKey builds the lookup key for a given path (which already includes
-// any query string). The method parameter is retained in the signature for
-// clarity but the cache is only used for GET; the key itself is just the path
-// because the method is always "GET" at call sites.
-func cacheKey(_ string, path string) string {
-	return path
+// cacheKey builds the lookup key for a given GET request. The cache is keyed
+// by both the Accept header and the path (including any query string) because
+// the same path can legitimately be requested with different Accept values that
+// produce different response bodies — for example, /repos/{}/pulls/{n} is
+// fetched as application/vnd.github+json by getPR/GetPRSnapshot and as
+// application/vnd.github.v3.diff by FetchDiff. Path-only keying caused cache
+// collisions between those two callers (the diff body was served for the JSON
+// request or vice-versa). The method parameter is retained in the signature for
+// symmetry with its callers but is always "GET" at every call site.
+func cacheKey(_ string, accept, path string) string {
+	return accept + "\n" + path
 }

--- a/daemon/internal/github/conditional_cache.go
+++ b/daemon/internal/github/conditional_cache.go
@@ -1,0 +1,96 @@
+package github
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// maxCacheEntries is the maximum number of entries the ConditionalCache will
+// hold before evicting the oldest entries. This bounds memory usage to
+// roughly maxCacheEntries × average-body-size (≤1 MiB each in practice).
+const maxCacheEntries = 2000
+
+// condEntry stores the ETag and response body for one cached GET response.
+type condEntry struct {
+	etag     string
+	body     []byte
+	storedAt time.Time
+}
+
+// ConditionalCache stores ETag/body pairs keyed by request path so that
+// repeated GET requests can be made conditional (If-None-Match). Thread-safe.
+type ConditionalCache struct {
+	mu      sync.RWMutex
+	entries map[string]condEntry
+
+	// Observability counters — incremented atomically from doWithBody.
+	cacheHits   atomic.Int64
+	cacheMisses atomic.Int64
+}
+
+// NewConditionalCache returns an initialised, empty ConditionalCache.
+func NewConditionalCache() *ConditionalCache {
+	return &ConditionalCache{
+		entries: make(map[string]condEntry),
+	}
+}
+
+// Get retrieves the stored etag and body for key.
+// Returns ok=false when no entry exists.
+func (c *ConditionalCache) Get(key string) (etag string, body []byte, ok bool) {
+	c.mu.RLock()
+	e, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return "", nil, false
+	}
+	return e.etag, e.body, true
+}
+
+// Put stores or updates the etag and body for key.
+// When the cache is at capacity it evicts the single oldest entry first.
+func (c *ConditionalCache) Put(key, etag string, body []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Evict the oldest entry if we're at the cap and this is a new key.
+	if _, exists := c.entries[key]; !exists && len(c.entries) >= maxCacheEntries {
+		c.evictOldestLocked()
+	}
+	c.entries[key] = condEntry{
+		etag:     etag,
+		body:     body,
+		storedAt: time.Now(),
+	}
+}
+
+// evictOldestLocked removes the entry with the earliest storedAt timestamp.
+// Caller must hold c.mu.Lock().
+func (c *ConditionalCache) evictOldestLocked() {
+	var oldestKey string
+	var oldestTime time.Time
+	for k, e := range c.entries {
+		if oldestKey == "" || e.storedAt.Before(oldestTime) {
+			oldestKey = k
+			oldestTime = e.storedAt
+		}
+	}
+	if oldestKey != "" {
+		delete(c.entries, oldestKey)
+	}
+}
+
+// CacheHits returns the number of 304-converted responses since the cache was created.
+func (c *ConditionalCache) CacheHits() int64 { return c.cacheHits.Load() }
+
+// CacheMisses returns the number of 200 responses that were stored since creation.
+func (c *ConditionalCache) CacheMisses() int64 { return c.cacheMisses.Load() }
+
+// cacheKey builds the lookup key for a given path (which already includes
+// any query string). The method parameter is retained in the signature for
+// clarity but the cache is only used for GET; the key itself is just the path
+// because the method is always "GET" at call sites.
+func cacheKey(_ string, path string) string {
+	return path
+}

--- a/daemon/internal/github/conditional_cache_test.go
+++ b/daemon/internal/github/conditional_cache_test.go
@@ -317,6 +317,237 @@ func TestETagCaching_NoETagResponseIsNotCached(t *testing.T) {
 	}
 }
 
+// TestETagCaching_DifferentAcceptHeadersKeepSeparateEntries verifies that two
+// GETs to the SAME path with DIFFERENT Accept headers maintain independent
+// cache entries. This is the regression test for the FetchDiff vs getPR
+// cache-key collision: both hit /repos/{}/pulls/{n} but with Accept values
+// application/vnd.github.v3.diff and application/vnd.github+json respectively,
+// and must never serve one body in place of the other.
+func TestETagCaching_DifferentAcceptHeadersKeepSeparateEntries(t *testing.T) {
+	const jsonBody = `{"state":"open"}`
+	const diffBody = `diff --git a/foo.go b/foo.go\n--- a/foo.go\n+++ b/foo.go\n@@ -1 +1 @@\n-old\n+new`
+	const acceptJSON = "application/vnd.github+json"
+	const acceptDiff = "application/vnd.github.v3.diff"
+	path := "/repos/org/repo/pulls/7"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != path {
+			http.NotFound(w, r)
+			return
+		}
+		switch r.Header.Get("Accept") {
+		case acceptJSON:
+			inm := r.Header.Get("If-None-Match")
+			if inm == `"json-v1"` {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("ETag", `"json-v1"`)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, jsonBody)
+		case acceptDiff:
+			inm := r.Header.Get("If-None-Match")
+			if inm == `"diff-v1"` {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("ETag", `"diff-v1"`)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, diffBody)
+		default:
+			http.Error(w, "unexpected Accept", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	// First JSON GET — populates the json-keyed cache entry.
+	r1, err := client.DoGETForTest(path, acceptJSON)
+	if err != nil {
+		t.Fatalf("json call 1: %v", err)
+	}
+	d1, _ := io.ReadAll(r1.Body)
+	r1.Body.Close()
+	if string(d1) != jsonBody {
+		t.Errorf("json call 1 body = %q, want %q", d1, jsonBody)
+	}
+
+	// First Diff GET — populates the diff-keyed cache entry (different key).
+	r2, err := client.DoGETForTest(path, acceptDiff)
+	if err != nil {
+		t.Fatalf("diff call 1: %v", err)
+	}
+	d2, _ := io.ReadAll(r2.Body)
+	r2.Body.Close()
+	if string(d2) != diffBody {
+		t.Errorf("diff call 1 body = %q, want %q", d2, diffBody)
+	}
+
+	// Second JSON GET — must return the JSON body (not the diff body).
+	r3, err := client.DoGETForTest(path, acceptJSON)
+	if err != nil {
+		t.Fatalf("json call 2: %v", err)
+	}
+	d3, _ := io.ReadAll(r3.Body)
+	r3.Body.Close()
+	if r3.StatusCode != http.StatusOK {
+		t.Errorf("json call 2 status = %d, want 200", r3.StatusCode)
+	}
+	if string(d3) != jsonBody {
+		t.Errorf("json call 2 body = %q, want %q (must NOT serve diff body)", d3, jsonBody)
+	}
+
+	// Second Diff GET — must return the diff body (not the JSON body).
+	r4, err := client.DoGETForTest(path, acceptDiff)
+	if err != nil {
+		t.Fatalf("diff call 2: %v", err)
+	}
+	d4, _ := io.ReadAll(r4.Body)
+	r4.Body.Close()
+	if r4.StatusCode != http.StatusOK {
+		t.Errorf("diff call 2 status = %d, want 200", r4.StatusCode)
+	}
+	if string(d4) != diffBody {
+		t.Errorf("diff call 2 body = %q, want %q (must NOT serve json body)", d4, diffBody)
+	}
+
+	// We stored 2 entries (one per Accept) and got 2 hits (one per Accept on
+	// the second round). Assert on the aggregated counters.
+	hits, misses := client.CacheStats()
+	if hits != 2 {
+		t.Errorf("cache hits = %d, want 2", hits)
+	}
+	if misses != 2 {
+		t.Errorf("cache misses (stores) = %d, want 2", misses)
+	}
+}
+
+// TestETagCaching_LargeBodyServedFullButNotCached verifies that a response
+// body larger than maxCacheBodyBytes (1 MiB) is served to the caller in full
+// (no truncation) and is NOT stored in the cache. A subsequent GET must NOT
+// send If-None-Match (because nothing was cached), and the server delivers a
+// fresh response — confirming that large bodies do not poison the cache.
+func TestETagCaching_LargeBodyServedFullButNotCached(t *testing.T) {
+	// Build a body that is strictly larger than 1 MiB (maxCacheBodyBytes).
+	const oneMiB = 1 * 1024 * 1024
+	largeBody := make([]byte, oneMiB+1)
+	for i := range largeBody {
+		largeBody[i] = 'x'
+	}
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		// If the client sent If-None-Match the large body was incorrectly
+		// cached — fail immediately.
+		if r.Header.Get("If-None-Match") != "" {
+			http.Error(w, "unexpected If-None-Match for large body", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("ETag", `"big-v1"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(largeBody)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	path := "/repos/org/repo/pulls/99"
+
+	// First call — body is large; must be served in full.
+	r1, err := client.DoGETForTest(path, "application/vnd.github.v3.diff")
+	if err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+	d1, _ := io.ReadAll(r1.Body)
+	r1.Body.Close()
+	if r1.StatusCode != http.StatusOK {
+		t.Fatalf("call 1 status = %d, want 200", r1.StatusCode)
+	}
+	if len(d1) != len(largeBody) {
+		t.Errorf("call 1 body length = %d, want %d (must not be truncated)", len(d1), len(largeBody))
+	}
+
+	// Second call — must NOT send If-None-Match (server handler above would
+	// fail if it did). Server returns a fresh 200.
+	r2, err := client.DoGETForTest(path, "application/vnd.github.v3.diff")
+	if err != nil {
+		t.Fatalf("call 2: %v", err)
+	}
+	r2.Body.Close()
+	if r2.StatusCode != http.StatusOK {
+		t.Fatalf("call 2 status = %d, want 200", r2.StatusCode)
+	}
+	if callCount != 2 {
+		t.Errorf("server call count = %d, want 2 (large body must not be cached)", callCount)
+	}
+
+	// Misses counter must remain 0 because the entry was never stored.
+	_, misses := client.CacheStats()
+	if misses != 0 {
+		t.Errorf("cache misses (stores) = %d, want 0 (large body not stored)", misses)
+	}
+}
+
+// TestETagCaching_LinkHeaderSkipsCaching verifies that a 200 response that
+// carries a Link header (cursor/offset pagination) is NOT stored in the cache.
+// Caching paginated responses would cause a later 304 re-serve to lose the
+// Link header, breaking the caller's pagination cursor. This covers endpoints
+// like FetchCollaborators that use Link: rel="next" style pagination.
+func TestETagCaching_LinkHeaderSkipsCaching(t *testing.T) {
+	const body1 = `[{"login":"alice"},{"login":"bob"}]`
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		// If the client sent If-None-Match the paginated response was
+		// incorrectly cached — fail the test immediately.
+		if r.Header.Get("If-None-Match") != "" {
+			http.Error(w, "unexpected If-None-Match for paginated response", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("ETag", `"page-v1"`)
+		w.Header().Set("Link", `<https://api.github.com/repos/org/repo/collaborators?page=2>; rel="next"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body1)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	path := "/repos/org/repo/collaborators?per_page=100"
+
+	// Two calls: both must reach the server (no caching) and both must receive
+	// the full body including the Link header.
+	for i := 1; i <= 2; i++ {
+		resp, err := client.DoGETForTest(path, "application/vnd.github+json")
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		data, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("call %d status = %d, want 200", i, resp.StatusCode)
+		}
+		if string(data) != body1 {
+			t.Errorf("call %d body = %q, want %q", i, data, body1)
+		}
+		// The Link header must survive in the response the caller sees.
+		if resp.Header.Get("Link") == "" {
+			t.Errorf("call %d: Link header missing from response (pagination broken)", i)
+		}
+	}
+
+	if callCount != 2 {
+		t.Errorf("server call count = %d, want 2 (paginated response must not be cached)", callCount)
+	}
+
+	// Nothing was stored — misses counter must remain 0.
+	_, misses := client.CacheStats()
+	if misses != 0 {
+		t.Errorf("cache misses (stores) = %d, want 0 (Link header → no caching)", misses)
+	}
+}
+
 // TestETagCaching_NonGETNotCached confirms that DELETE (and other non-GET
 // methods) are never intercepted by the cache layer.
 func TestETagCaching_NonGETNotCached(t *testing.T) {

--- a/daemon/internal/github/conditional_cache_test.go
+++ b/daemon/internal/github/conditional_cache_test.go
@@ -1,0 +1,354 @@
+package github_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+// ── ConditionalCache unit tests ───────────────────────────────────────────────
+
+func TestConditionalCache_GetPutRoundTrip(t *testing.T) {
+	c := gh.NewConditionalCache()
+
+	// Empty cache returns ok=false.
+	if _, _, ok := c.Get("key1"); ok {
+		t.Fatal("expected ok=false on empty cache")
+	}
+
+	c.Put("key1", `"v1"`, []byte("hello"))
+	etag, body, ok := c.Get("key1")
+	if !ok {
+		t.Fatal("expected ok=true after Put")
+	}
+	if etag != `"v1"` {
+		t.Errorf("etag = %q, want %q", etag, `"v1"`)
+	}
+	if string(body) != "hello" {
+		t.Errorf("body = %q, want %q", body, "hello")
+	}
+}
+
+func TestConditionalCache_PutUpdatesExistingEntry(t *testing.T) {
+	c := gh.NewConditionalCache()
+	c.Put("key1", `"v1"`, []byte("old"))
+	c.Put("key1", `"v2"`, []byte("new"))
+
+	etag, body, ok := c.Get("key1")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if etag != `"v2"` || string(body) != "new" {
+		t.Errorf("got etag=%q body=%q, want v2/new", etag, body)
+	}
+}
+
+func TestConditionalCache_EvictsOldestWhenAtCap(t *testing.T) {
+	c := gh.NewConditionalCache()
+
+	// Fill the cache to capacity with keys key-0000 … key-1999.
+	for i := 0; i < 2000; i++ {
+		k := fmt.Sprintf("key-%04d", i)
+		c.Put(k, `"etag"`, []byte(k))
+	}
+
+	// Verify all entries exist.
+	for i := 0; i < 2000; i++ {
+		k := fmt.Sprintf("key-%04d", i)
+		if _, _, ok := c.Get(k); !ok {
+			t.Fatalf("expected entry %s before eviction", k)
+		}
+	}
+
+	// Adding a 2001st key should evict exactly one entry.
+	c.Put("new-key", `"etag"`, []byte("data"))
+
+	// The new key must be present.
+	if _, _, ok := c.Get("new-key"); !ok {
+		t.Fatal("new-key missing after insert")
+	}
+
+	// Total entries in cache must be exactly 2000 (one was evicted).
+	// We verify by counting how many of the original keys are still present.
+	present := 0
+	for i := 0; i < 2000; i++ {
+		k := fmt.Sprintf("key-%04d", i)
+		if _, _, ok := c.Get(k); ok {
+			present++
+		}
+	}
+	// 1999 original keys + 1 new key = 2000 total.
+	if present != 1999 {
+		t.Errorf("expected 1999 original keys after eviction, got %d", present)
+	}
+}
+
+func TestConditionalCache_ConcurrencyNoPanic(t *testing.T) {
+	c := gh.NewConditionalCache()
+	var wg sync.WaitGroup
+	const goroutines = 50
+	const opsPerGoroutine = 200
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < opsPerGoroutine; j++ {
+				k := fmt.Sprintf("key-%d-%d", id, j%10)
+				c.Put(k, `"etag"`, []byte("data"))
+				c.Get(k)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// ── Integration tests via httptest ────────────────────────────────────────────
+
+// serverCallCount keeps a per-path counter so tests can assert the server was
+// only hit a specific number of times.
+type callCounter struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func newCallCounter() *callCounter { return &callCounter{counts: map[string]int{}} }
+func (cc *callCounter) inc(path string) {
+	cc.mu.Lock()
+	cc.counts[path]++
+	cc.mu.Unlock()
+}
+func (cc *callCounter) get(path string) int {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	return cc.counts[path]
+}
+
+// TestETagCaching_SecondCallSendsIfNoneMatch verifies that:
+//  1. First GET → 200 + ETag "v1" + body B1.
+//  2. Client stores the ETag and body.
+//  3. Second GET → server receives If-None-Match "v1" → replies 304 (empty body).
+//  4. Caller still observes status 200 and can read B1 — transparent swap.
+func TestETagCaching_SecondCallSendsIfNoneMatch(t *testing.T) {
+	const body1 = `{"state":"open"}`
+	cc := newCallCounter()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/org/repo/issues/1" {
+			http.NotFound(w, r)
+			return
+		}
+		cc.inc(r.URL.Path)
+		inm := r.Header.Get("If-None-Match")
+		if inm == `"v1"` {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", `"v1"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, body1)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+
+	// First call — should hit the server and cache the response.
+	resp1, err := client.DoGETForTest("/repos/org/repo/issues/1", "application/vnd.github+json")
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	data1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Errorf("first call status = %d, want 200", resp1.StatusCode)
+	}
+	if string(data1) != body1 {
+		t.Errorf("first call body = %q, want %q", data1, body1)
+	}
+	if cc.get("/repos/org/repo/issues/1") != 1 {
+		t.Errorf("server call count after first request = %d, want 1", cc.get("/repos/org/repo/issues/1"))
+	}
+
+	// Second call — server receives If-None-Match "v1" and replies 304.
+	// Client must transparently return 200 + cached body.
+	resp2, err := client.DoGETForTest("/repos/org/repo/issues/1", "application/vnd.github+json")
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	data2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Errorf("second call status = %d, want 200", resp2.StatusCode)
+	}
+	if string(data2) != body1 {
+		t.Errorf("second call body = %q, want %q", data2, body1)
+	}
+	if cc.get("/repos/org/repo/issues/1") != 2 {
+		t.Errorf("server call count after second request = %d, want 2", cc.get("/repos/org/repo/issues/1"))
+	}
+
+	hits, _ := client.CacheStats()
+	if hits != 1 {
+		t.Errorf("cache hits = %d, want 1", hits)
+	}
+}
+
+// TestETagCaching_UpdatedETagReplacesCachedBody verifies that when the server
+// returns a new ETag (v2) + new body (B2), the cache is updated and the caller
+// sees B2 transparently.
+func TestETagCaching_UpdatedETagReplacesCachedBody(t *testing.T) {
+	const body1 = `{"state":"open"}`
+	const body2 = `{"state":"closed"}`
+	call := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call++
+		switch call {
+		case 1:
+			w.Header().Set("ETag", `"v1"`)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, body1)
+		case 2:
+			// New ETag — resource changed.
+			w.Header().Set("ETag", `"v2"`)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, body2)
+		default:
+			// Third call: If-None-Match "v2" → 304.
+			if r.Header.Get("If-None-Match") != `"v2"` {
+				http.Error(w, "unexpected If-None-Match", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNotModified)
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	path := "/repos/org/repo/issues/42"
+	accept := "application/vnd.github+json"
+
+	// Call 1 → 200 + ETag v1 + body1.
+	r1, err := client.DoGETForTest(path, accept)
+	if err != nil {
+		t.Fatalf("call1: %v", err)
+	}
+	d1, _ := io.ReadAll(r1.Body)
+	r1.Body.Close()
+	if string(d1) != body1 {
+		t.Errorf("call1 body = %q, want %q", d1, body1)
+	}
+
+	// Call 2 → server replies with new ETag v2 + body2.
+	r2, err := client.DoGETForTest(path, accept)
+	if err != nil {
+		t.Fatalf("call2: %v", err)
+	}
+	d2, _ := io.ReadAll(r2.Body)
+	r2.Body.Close()
+	if r2.StatusCode != http.StatusOK {
+		t.Errorf("call2 status = %d, want 200", r2.StatusCode)
+	}
+	if string(d2) != body2 {
+		t.Errorf("call2 body = %q, want %q", d2, body2)
+	}
+
+	// Call 3 → 304 served from cache (v2 body).
+	r3, err := client.DoGETForTest(path, accept)
+	if err != nil {
+		t.Fatalf("call3: %v", err)
+	}
+	d3, _ := io.ReadAll(r3.Body)
+	r3.Body.Close()
+	if r3.StatusCode != http.StatusOK {
+		t.Errorf("call3 status = %d, want 200", r3.StatusCode)
+	}
+	if string(d3) != body2 {
+		t.Errorf("call3 body = %q, want %q (expected v2 body from cache)", d3, body2)
+	}
+
+	hits, misses := client.CacheStats()
+	if hits != 1 {
+		t.Errorf("cache hits = %d, want 1", hits)
+	}
+	if misses != 2 {
+		t.Errorf("cache misses (stores) = %d, want 2", misses)
+	}
+}
+
+// TestETagCaching_NoETagResponseIsNotCached verifies that responses without an
+// ETag header are not cached: no If-None-Match is sent on the next request.
+func TestETagCaching_NoETagResponseIsNotCached(t *testing.T) {
+	cc := newCallCounter()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cc.inc(r.URL.Path)
+		// Deliberately no ETag header.
+		if r.Header.Get("If-None-Match") != "" {
+			http.Error(w, "unexpected If-None-Match", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"id":1}`)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	path := "/repos/org/repo/issues/99"
+
+	for i := 0; i < 3; i++ {
+		resp, err := client.DoGETForTest(path, "application/vnd.github+json")
+		if err != nil {
+			t.Fatalf("call %d: %v", i+1, err)
+		}
+		resp.Body.Close()
+	}
+	if cc.get(path) != 3 {
+		t.Errorf("server call count = %d, want 3 (no caching without ETag)", cc.get(path))
+	}
+	_, misses := client.CacheStats()
+	if misses != 0 {
+		t.Errorf("cache misses (stores) = %d, want 0 (no ETag → nothing stored)", misses)
+	}
+}
+
+// TestETagCaching_NonGETNotCached confirms that DELETE (and other non-GET
+// methods) are never intercepted by the cache layer.
+func TestETagCaching_NonGETNotCached(t *testing.T) {
+	cc := newCallCounter()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cc.inc(r.Method)
+		if r.Header.Get("If-None-Match") != "" {
+			http.Error(w, "unexpected If-None-Match on DELETE", http.StatusInternalServerError)
+			return
+		}
+		// ETag on the response should also be ignored for non-GETs.
+		w.Header().Set("ETag", `"v1"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	// Issue two DELETE calls; the cache must not interfere.
+	for i := 0; i < 2; i++ {
+		resp, err := client.DoDELETEForTest("/repos/org/repo/issues/1/labels/foo",
+			"application/vnd.github+json")
+		if err != nil {
+			t.Fatalf("DELETE call %d: %v", i+1, err)
+		}
+		resp.Body.Close()
+	}
+	if cc.get("DELETE") != 2 {
+		t.Errorf("server DELETE count = %d, want 2", cc.get("DELETE"))
+	}
+	hits, misses := client.CacheStats()
+	if hits != 0 || misses != 0 {
+		t.Errorf("cache hits=%d misses=%d, want 0/0 for non-GET requests", hits, misses)
+	}
+}

--- a/daemon/internal/github/export_test.go
+++ b/daemon/internal/github/export_test.go
@@ -17,3 +17,4 @@ func (c *Client) DoGETForTest(path, accept string) (*http.Response, error) {
 func (c *Client) DoDELETEForTest(path, accept string) (*http.Response, error) {
 	return c.do("DELETE", path, accept)
 }
+

--- a/daemon/internal/github/export_test.go
+++ b/daemon/internal/github/export_test.go
@@ -1,0 +1,19 @@
+// export_test.go exposes internal helpers for use in _test.go files in the
+// external test package (package github_test). These symbols are only compiled
+// when running tests — they are not part of the package's public API.
+package github
+
+import "net/http"
+
+// DoGETForTest calls the internal do() helper with method GET so integration
+// tests can exercise the ETag cache layer directly without going through a
+// higher-level method that may add its own body-reading.
+func (c *Client) DoGETForTest(path, accept string) (*http.Response, error) {
+	return c.do("GET", path, accept)
+}
+
+// DoDELETEForTest calls the internal do() helper with method DELETE so tests
+// can verify that non-GET requests bypass the cache layer entirely.
+func (c *Client) DoDELETEForTest(path, accept string) (*http.Response, error) {
+	return c.do("DELETE", path, accept)
+}

--- a/daemon/internal/github/export_test.go
+++ b/daemon/internal/github/export_test.go
@@ -17,4 +17,3 @@ func (c *Client) DoGETForTest(path, accept string) (*http.Response, error) {
 func (c *Client) DoDELETEForTest(path, accept string) (*http.Response, error) {
 	return c.do("DELETE", path, accept)
 }
-

--- a/daemon/internal/github/fetch_issues.go
+++ b/daemon/internal/github/fetch_issues.go
@@ -157,6 +157,35 @@ func (c *Client) fetchIssuesPage(repo string, page int) ([]*Issue, error) {
 	return batch, nil
 }
 
+// ClassifyAndFilterIssues applies the same classification + filter pipeline
+// that FetchIssues applies to a page, producing a sorted slice ready for the
+// issue processing pipeline. It is intended for the Search API prefetch path
+// where issues are already in memory and need only the client-side processing.
+//
+// The returned slice is sorted by sortIssuesByPriority with the given
+// authenticatedUser.
+func ClassifyAndFilterIssues(issues []*Issue, repo string, cfg config.IssueTrackingConfig, authenticatedUser string) []*Issue {
+	kept := issues[:0:0]
+	kept = make([]*Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue == nil || issue.IsPullRequest() {
+			continue
+		}
+		issue.Repo = repo
+		mode := cfg.Classify(issue.LabelNames())
+		if mode == config.IssueModeIgnore || mode == config.IssueModeBlocked {
+			continue
+		}
+		if !issueMatchesFilters(issue, repo, cfg) {
+			continue
+		}
+		issue.Mode = mode
+		kept = append(kept, issue)
+	}
+	sortIssuesByPriority(kept, authenticatedUser)
+	return kept
+}
+
 // issueMatchesFilters applies organizations + assignees + filter_mode.
 // The label dimension is handled up-stream (cfg.Classify + ignore short-
 // circuit), so by the time we get here the issue is known to be

--- a/daemon/internal/github/graphql.go
+++ b/daemon/internal/github/graphql.go
@@ -3,6 +3,7 @@ package github
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -27,19 +28,25 @@ func (c *Client) graphqlURL() string {
 // reported to the observer (mirrors doWithBody behaviour). If the response
 // contains a top-level "errors" array, an error is returned containing all
 // error messages joined with "; ". The body is limited to maxBodyBytes.
-func (c *Client) graphQL(query string, variables map[string]any, out any) error {
+// graphQLExec runs a GraphQL query and returns the raw data node plus any
+// GraphQL-level error messages. data and gqlErrs can coexist: a batched query
+// where some aliases resolve and others fail (e.g. a deleted repo →
+// "Could not resolve to a Repository") returns partial data alongside errors.
+// transportErr is non-nil only for HTTP/transport/decode failures, never for
+// GraphQL-level errors — callers decide which gqlErrs are tolerable.
+func (c *Client) graphQLExec(query string, variables map[string]any) (data json.RawMessage, gqlErrs []string, transportErr error) {
 	payload, err := json.Marshal(map[string]any{
 		"query":     query,
 		"variables": variables,
 	})
 	if err != nil {
-		return fmt.Errorf("github: graphql: marshal request: %w", err)
+		return nil, nil, fmt.Errorf("github: graphql: marshal request: %w", err)
 	}
 
 	gqlURL := c.graphqlURL()
 	req, err := http.NewRequest("POST", gqlURL, bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("github: graphql: build request: %w", err)
+		return nil, nil, fmt.Errorf("github: graphql: build request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Accept", "application/vnd.github+json")
@@ -48,7 +55,7 @@ func (c *Client) graphQL(query string, variables map[string]any, out any) error 
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return fmt.Errorf("github: graphql: request: %w", err)
+		return nil, nil, fmt.Errorf("github: graphql: request: %w", err)
 	}
 	// Notify the rate-limit observer — mirrors doWithBody so GraphQL
 	// responses also update the live budget.
@@ -57,11 +64,11 @@ func (c *Client) graphQL(query string, variables map[string]any, out any) error 
 
 	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if readErr != nil {
-		return fmt.Errorf("github: graphql: read body: %w", readErr)
+		return nil, nil, fmt.Errorf("github: graphql: read body: %w", readErr)
 	}
 	if resp.StatusCode != http.StatusOK {
 		errBody := safeTruncate(string(body), maxErrBodyLen)
-		return fmt.Errorf("github: graphql: status %d: %s", resp.StatusCode, errBody)
+		return nil, nil, fmt.Errorf("github: graphql: status %d: %s", resp.StatusCode, errBody)
 	}
 
 	// Parse the GraphQL envelope: {"data":..., "errors":[...]}.
@@ -72,17 +79,24 @@ func (c *Client) graphQL(query string, variables map[string]any, out any) error 
 		} `json:"errors"`
 	}
 	if err := json.Unmarshal(body, &envelope); err != nil {
-		return fmt.Errorf("github: graphql: decode envelope: %w", err)
+		return nil, nil, fmt.Errorf("github: graphql: decode envelope: %w", err)
 	}
-	if len(envelope.Errors) > 0 {
-		msgs := make([]string, len(envelope.Errors))
-		for i, e := range envelope.Errors {
-			msgs[i] = e.Message
-		}
-		return fmt.Errorf("github: graphql: errors: %s", strings.Join(msgs, "; "))
+	for _, e := range envelope.Errors {
+		gqlErrs = append(gqlErrs, e.Message)
 	}
-	if out != nil && envelope.Data != nil {
-		if err := json.Unmarshal(envelope.Data, out); err != nil {
+	return envelope.Data, gqlErrs, nil
+}
+
+func (c *Client) graphQL(query string, variables map[string]any, out any) error {
+	data, gqlErrs, err := c.graphQLExec(query, variables)
+	if err != nil {
+		return err
+	}
+	if len(gqlErrs) > 0 {
+		return fmt.Errorf("github: graphql: errors: %s", strings.Join(gqlErrs, "; "))
+	}
+	if out != nil && data != nil {
+		if err := json.Unmarshal(data, out); err != nil {
 			return fmt.Errorf("github: graphql: decode data: %w", err)
 		}
 	}
@@ -259,4 +273,104 @@ func (c *Client) SearchIssuesGraphQL(searchQuery string) ([]*Issue, error) {
 // the next call. Defaults to disabled (false = zero-value atomic.Bool).
 func (c *Client) SetGraphQLEnabled(enabled bool) {
 	c.useGraphQL.Store(enabled)
+}
+
+// maxBatchArchivedRepos caps how many repos go into a single batched archive
+// query. GraphQL bills one point per query regardless of alias count, but the
+// node/complexity limits and request size make unbounded batches unwise; the
+// caller chunks larger sets across multiple queries.
+const maxBatchArchivedRepos = 100
+
+// BatchReposArchived resolves isArchived for many repos in as few API calls as
+// possible. With GraphQL enabled it batches via BatchReposArchivedGraphQL (one
+// call per up-to-100 repos); otherwise it returns errGraphQLDisabled so the
+// caller falls back to per-repo REST IsRepoArchived.
+func (c *Client) BatchReposArchived(repos []string) (map[string]bool, error) {
+	if !c.useGraphQL.Load() {
+		return nil, errGraphQLDisabled
+	}
+	out := make(map[string]bool, len(repos))
+	for start := 0; start < len(repos); start += maxBatchArchivedRepos {
+		end := start + maxBatchArchivedRepos
+		if end > len(repos) {
+			end = len(repos)
+		}
+		chunk, err := c.BatchReposArchivedGraphQL(repos[start:end])
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range chunk {
+			out[k] = v
+		}
+	}
+	return out, nil
+}
+
+// errGraphQLDisabled signals that GraphQL batching is off so callers fall back
+// to the per-repo REST path.
+var errGraphQLDisabled = errors.New("github: graphql disabled")
+
+// BatchReposArchivedGraphQL checks isArchived for many repos in a single
+// GraphQL query using per-repo aliases (r0, r1, ...). A repo GraphQL cannot
+// resolve (deleted/transferred → "Could not resolve to a Repository") is
+// reported as archived=true, mirroring IsRepoArchived's 404 handling. Returns a
+// map keyed by the input "owner/name". On transport errors or unexpected
+// GraphQL errors returns (nil, err) so the caller can fall back to REST.
+func (c *Client) BatchReposArchivedGraphQL(repos []string) (map[string]bool, error) {
+	if len(repos) == 0 {
+		return map[string]bool{}, nil
+	}
+	var decls, fields []string
+	vars := make(map[string]any, len(repos)*2)
+	aliasToRepo := make(map[string]string, len(repos))
+	i := 0
+	for _, repo := range repos {
+		owner, name, ok := strings.Cut(repo, "/")
+		if !ok || owner == "" || name == "" {
+			continue
+		}
+		alias := fmt.Sprintf("r%d", i)
+		ov, nv := fmt.Sprintf("o%d", i), fmt.Sprintf("n%d", i)
+		decls = append(decls, fmt.Sprintf("$%s: String!, $%s: String!", ov, nv))
+		fields = append(fields, fmt.Sprintf("  %s: repository(owner: $%s, name: $%s) { isArchived }", alias, ov, nv))
+		vars[ov] = owner
+		vars[nv] = name
+		aliasToRepo[alias] = repo
+		i++
+	}
+	if i == 0 {
+		return map[string]bool{}, nil
+	}
+	query := fmt.Sprintf("query(%s) {\n%s\n}", strings.Join(decls, ", "), strings.Join(fields, "\n"))
+
+	data, gqlErrs, err := c.graphQLExec(query, vars)
+	if err != nil {
+		return nil, err
+	}
+	// Only NOT_FOUND-style errors are expected (deleted/transferred repos →
+	// node resolves to null). Any other GraphQL error is unexpected → bubble up
+	// so the caller falls back to REST rather than silently mis-classifying.
+	for _, m := range gqlErrs {
+		if !strings.Contains(m, "Could not resolve to a Repository") {
+			return nil, fmt.Errorf("github: graphql: batch archived: %s", m)
+		}
+	}
+
+	var raw map[string]*struct {
+		IsArchived bool `json:"isArchived"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("github: graphql: decode batch archived: %w", err)
+	}
+	out := make(map[string]bool, len(aliasToRepo))
+	for alias, repo := range aliasToRepo {
+		// A null node (unresolved repo) means deleted/transferred → treat as
+		// archived, exactly like IsRepoArchived's 404 → true.
+		if node := raw[alias]; node != nil {
+			out[repo] = node.IsArchived
+		} else {
+			out[repo] = true
+		}
+	}
+	return out, nil
 }

--- a/daemon/internal/github/graphql.go
+++ b/daemon/internal/github/graphql.go
@@ -109,6 +109,9 @@ query($q: String!, $cursor: String) {
         url
         createdAt
         updatedAt
+        author {
+          login
+        }
         repository {
           nameWithOwner
         }
@@ -152,6 +155,9 @@ type graphQLIssueNode struct {
 	URL        string `json:"url"` // HTMLURL
 	CreatedAt  string `json:"createdAt"`
 	UpdatedAt  string `json:"updatedAt"`
+	Author     struct {
+		Login string `json:"login"`
+	} `json:"author"`
 	Repository struct {
 		NameWithOwner string `json:"nameWithOwner"`
 	} `json:"repository"`
@@ -201,8 +207,9 @@ func (c *Client) SearchIssuesGraphQL(searchQuery string) ([]*Issue, error) {
 				Number:  node.Number,
 				Title:   node.Title,
 				Body:    node.Body,
-				State:   node.State,
+				State:   strings.ToLower(node.State),
 				HTMLURL: node.URL,
+				User:    User{Login: node.Author.Login},
 				Repo:    node.Repository.NameWithOwner,
 			}
 

--- a/daemon/internal/github/graphql.go
+++ b/daemon/internal/github/graphql.go
@@ -1,0 +1,255 @@
+package github
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// graphqlURL returns the GraphQL endpoint URL. The REST base URL
+// (e.g. https://api.github.com or an httptest server) is transformed to the
+// /graphql path: api.github.com/graphql for production, <base>/graphql for
+// tests. This allows httptest servers to serve both REST and GraphQL on the
+// same mux.
+func (c *Client) graphqlURL() string {
+	base := strings.TrimRight(c.baseURL, "/")
+	return base + "/graphql"
+}
+
+// graphQL executes a GraphQL request against the GitHub GraphQL endpoint.
+// It marshals the query+variables into a JSON body, POSTs to <base>/graphql,
+// and unmarshals the response envelope into out. Rate-limit headers are
+// reported to the observer (mirrors doWithBody behaviour). If the response
+// contains a top-level "errors" array, an error is returned containing all
+// error messages joined with "; ". The body is limited to maxBodyBytes.
+func (c *Client) graphQL(query string, variables map[string]any, out any) error {
+	payload, err := json.Marshal(map[string]any{
+		"query":     query,
+		"variables": variables,
+	})
+	if err != nil {
+		return fmt.Errorf("github: graphql: marshal request: %w", err)
+	}
+
+	gqlURL := c.graphqlURL()
+	req, err := http.NewRequest("POST", gqlURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("github: graphql: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("github: graphql: request: %w", err)
+	}
+	// Notify the rate-limit observer — mirrors doWithBody so GraphQL
+	// responses also update the live budget.
+	c.notifyRateObserver(resp)
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if readErr != nil {
+		return fmt.Errorf("github: graphql: read body: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		errBody := safeTruncate(string(body), maxErrBodyLen)
+		return fmt.Errorf("github: graphql: status %d: %s", resp.StatusCode, errBody)
+	}
+
+	// Parse the GraphQL envelope: {"data":..., "errors":[...]}.
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("github: graphql: decode envelope: %w", err)
+	}
+	if len(envelope.Errors) > 0 {
+		msgs := make([]string, len(envelope.Errors))
+		for i, e := range envelope.Errors {
+			msgs[i] = e.Message
+		}
+		return fmt.Errorf("github: graphql: errors: %s", strings.Join(msgs, "; "))
+	}
+	if out != nil && envelope.Data != nil {
+		if err := json.Unmarshal(envelope.Data, out); err != nil {
+			return fmt.Errorf("github: graphql: decode data: %w", err)
+		}
+	}
+	return nil
+}
+
+// graphQLSearchQuery is the GraphQL query used by SearchIssuesGraphQL.
+// It paginates via the cursor/pageInfo mechanism and selects exactly the
+// fields that SearchIssues (REST) populates on *Issue.
+const graphQLSearchQuery = `
+query($q: String!, $cursor: String) {
+  search(query: $q, type: ISSUE, first: 100, after: $cursor) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      ... on Issue {
+        databaseId
+        number
+        title
+        body
+        state
+        url
+        createdAt
+        updatedAt
+        repository {
+          nameWithOwner
+        }
+        assignees(first: 20) {
+          nodes {
+            login
+          }
+        }
+        labels(first: 50) {
+          nodes {
+            name
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+// graphQLSearchResult is the JSON shape of the data.search node returned
+// by the GraphQL search query.
+type graphQLSearchResult struct {
+	Search struct {
+		PageInfo struct {
+			HasNextPage bool   `json:"hasNextPage"`
+			EndCursor   string `json:"endCursor"`
+		} `json:"pageInfo"`
+		Nodes []graphQLIssueNode `json:"nodes"`
+	} `json:"search"`
+}
+
+// graphQLIssueNode is a single node in the search result. Non-Issue nodes
+// (e.g. PRs returned in a search) will have a zero-value databaseId and are
+// silently dropped by SearchIssuesGraphQL.
+type graphQLIssueNode struct {
+	DatabaseID int64  `json:"databaseId"`
+	Number     int    `json:"number"`
+	Title      string `json:"title"`
+	Body       string `json:"body"`
+	State      string `json:"state"`
+	URL        string `json:"url"` // HTMLURL
+	CreatedAt  string `json:"createdAt"`
+	UpdatedAt  string `json:"updatedAt"`
+	Repository struct {
+		NameWithOwner string `json:"nameWithOwner"`
+	} `json:"repository"`
+	Assignees struct {
+		Nodes []struct {
+			Login string `json:"login"`
+		} `json:"nodes"`
+	} `json:"assignees"`
+	Labels struct {
+		Nodes []struct {
+			Name string `json:"name"`
+		} `json:"nodes"`
+	} `json:"labels"`
+}
+
+// SearchIssuesGraphQL fetches open issues matching searchQuery via the GitHub
+// GraphQL API, using the search(type:ISSUE) connection. It paginates via
+// cursor/pageInfo up to the same 1000-item cap as SearchIssues (REST).
+//
+// Returns []*Issue with the same field layout as SearchIssues so it is a
+// drop-in for the dispatch layer. Non-Issue nodes (PRs) are silently dropped.
+//
+// On any error, returns (nil, err) — the caller should fall back to REST.
+func (c *Client) SearchIssuesGraphQL(searchQuery string) ([]*Issue, error) {
+	var all []*Issue
+	var cursor *string // nil on first page
+
+	for page := 1; page <= maxSearchIssuePages; page++ {
+		vars := map[string]any{"q": searchQuery}
+		if cursor != nil {
+			vars["cursor"] = *cursor
+		}
+
+		var result graphQLSearchResult
+		if err := c.graphQL(graphQLSearchQuery, vars, &result); err != nil {
+			return nil, fmt.Errorf("github: SearchIssuesGraphQL (page %d): %w", page, err)
+		}
+
+		for _, node := range result.Search.Nodes {
+			// Non-Issue nodes have a zero databaseId (and no number/title). Drop them.
+			if node.DatabaseID == 0 {
+				continue
+			}
+
+			issue := &Issue{
+				ID:      node.DatabaseID,
+				Number:  node.Number,
+				Title:   node.Title,
+				Body:    node.Body,
+				State:   node.State,
+				HTMLURL: node.URL,
+				Repo:    node.Repository.NameWithOwner,
+			}
+
+			// Parse timestamps.
+			if t, err := time.Parse(time.RFC3339, node.CreatedAt); err == nil {
+				issue.CreatedAt = t
+			}
+			if t, err := time.Parse(time.RFC3339, node.UpdatedAt); err == nil {
+				issue.UpdatedAt = t
+			}
+
+			// Assignees.
+			issue.Assignees = make([]User, 0, len(node.Assignees.Nodes))
+			for _, a := range node.Assignees.Nodes {
+				if a.Login != "" {
+					issue.Assignees = append(issue.Assignees, User{Login: a.Login})
+				}
+			}
+
+			// Labels.
+			issue.Labels = make([]Label, 0, len(node.Labels.Nodes))
+			for _, l := range node.Labels.Nodes {
+				if l.Name != "" {
+					issue.Labels = append(issue.Labels, Label{Name: l.Name})
+				}
+			}
+
+			all = append(all, issue)
+		}
+
+		if !result.Search.PageInfo.HasNextPage {
+			break
+		}
+		if page == maxSearchIssuePages {
+			slog.Warn("github: SearchIssuesGraphQL reached result cap", "cap", maxSearchIssuePages*100)
+			break
+		}
+		end := result.Search.PageInfo.EndCursor
+		cursor = &end
+	}
+	return all, nil
+}
+
+// SetGraphQLEnabled enables or disables GraphQL-based issue search. When
+// enabled, SearchIssues dispatches to SearchIssuesGraphQL first and falls back
+// to the REST /search/issues path on any error. Thread-safe; takes effect on
+// the next call. Defaults to disabled (false = zero-value atomic.Bool).
+func (c *Client) SetGraphQLEnabled(enabled bool) {
+	c.useGraphQL.Store(enabled)
+}

--- a/daemon/internal/github/graphql_test.go
+++ b/daemon/internal/github/graphql_test.go
@@ -478,3 +478,86 @@ func TestSearchIssues_GraphQLHTTPErrorFallsBackToREST(t *testing.T) {
 		t.Errorf("expected 1 issue from REST fallback, got %d", len(issues))
 	}
 }
+
+// ── BatchReposArchivedGraphQL tests ───────────────────────────────────────────
+
+func TestBatchReposArchivedGraphQL_MapsAliasesAndNullNodes(t *testing.T) {
+	// r0 active, r1 archived, r2 deleted (null node + NOT_FOUND error). The
+	// alias→repo order follows the input slice order (r0, r1, r2).
+	data := map[string]any{
+		"r0": map[string]any{"isArchived": false},
+		"r1": map[string]any{"isArchived": true},
+		"r2": nil,
+	}
+	envelope, _ := json.Marshal(map[string]any{
+		"data": data,
+		"errors": []map[string]string{
+			{"message": "Could not resolve to a Repository with the name 'org/gone'."},
+		},
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" || r.Method != "POST" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(envelope)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	got, err := client.BatchReposArchivedGraphQL([]string{"org/active", "org/old", "org/gone"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]bool{"org/active": false, "org/old": true, "org/gone": true}
+	for repo, w := range want {
+		if got[repo] != w {
+			t.Errorf("%s: want archived=%v, got %v", repo, w, got[repo])
+		}
+	}
+}
+
+func TestBatchReposArchivedGraphQL_UnexpectedErrorBubblesUp(t *testing.T) {
+	envelope := gqlErrorEnvelope("Something went very wrong")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(envelope)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	if _, err := client.BatchReposArchivedGraphQL([]string{"org/a"}); err == nil {
+		t.Fatal("expected error to bubble up for non-NOT_FOUND GraphQL errors")
+	}
+}
+
+func TestBatchReposArchived_DisabledReturnsError(t *testing.T) {
+	// GraphQL off (default): BatchReposArchived must signal an error so the
+	// caller falls back to per-repo REST.
+	client := gh.NewClient("fake", gh.WithBaseURL("http://127.0.0.1:0"))
+	if _, err := client.BatchReposArchived([]string{"org/a"}); err == nil {
+		t.Fatal("expected error when GraphQL disabled")
+	}
+}
+
+func TestBatchReposArchived_EnabledUsesGraphQL(t *testing.T) {
+	data := map[string]any{"r0": map[string]any{"isArchived": true}}
+	envelope, _ := json.Marshal(map[string]any{"data": data})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(envelope)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	client.SetGraphQLEnabled(true)
+	got, err := client.BatchReposArchived([]string{"org/old"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got["org/old"] {
+		t.Errorf("want org/old archived=true, got %v", got)
+	}
+}

--- a/daemon/internal/github/graphql_test.go
+++ b/daemon/internal/github/graphql_test.go
@@ -1,0 +1,470 @@
+package github_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+// ── GraphQL test helpers ──────────────────────────────────────────────────────
+
+// gqlIssueNode builds a GraphQL Issue node matching the search query fields.
+func gqlIssueNode(id int64, number int, repo, title, state string, labels, assignees []string) map[string]any {
+	labelNodes := make([]map[string]string, len(labels))
+	for i, l := range labels {
+		labelNodes[i] = map[string]string{"name": l}
+	}
+	assigneeNodes := make([]map[string]string, len(assignees))
+	for i, a := range assignees {
+		assigneeNodes[i] = map[string]string{"login": a}
+	}
+	return map[string]any{
+		"databaseId": id,
+		"number":     number,
+		"title":      title,
+		"body":       "issue body",
+		"state":      state,
+		"url":        fmt.Sprintf("https://github.com/%s/issues/%d", repo, number),
+		"createdAt":  time.Now().UTC().Format(time.RFC3339),
+		"updatedAt":  time.Now().UTC().Format(time.RFC3339),
+		"repository": map[string]string{"nameWithOwner": repo},
+		"assignees":  map[string]any{"nodes": assigneeNodes},
+		"labels":     map[string]any{"nodes": labelNodes},
+	}
+}
+
+// gqlSearchEnvelope builds the full GraphQL response envelope for a search result.
+// hasNextPage and endCursor control pagination metadata.
+func gqlSearchEnvelope(nodes []map[string]any, hasNextPage bool, endCursor string) []byte {
+	pageInfo := map[string]any{
+		"hasNextPage": hasNextPage,
+		"endCursor":   endCursor,
+	}
+	data := map[string]any{
+		"search": map[string]any{
+			"pageInfo": pageInfo,
+			"nodes":    nodes,
+		},
+	}
+	b, _ := json.Marshal(map[string]any{"data": data})
+	return b
+}
+
+// gqlErrorEnvelope builds a GraphQL response with top-level errors.
+func gqlErrorEnvelope(messages ...string) []byte {
+	errs := make([]map[string]string, len(messages))
+	for i, m := range messages {
+		errs[i] = map[string]string{"message": m}
+	}
+	b, _ := json.Marshal(map[string]any{"errors": errs})
+	return b
+}
+
+// ── SearchIssuesGraphQL tests ─────────────────────────────────────────────────
+
+func TestSearchIssuesGraphQL_ParsesPayloadAndMapsFields(t *testing.T) {
+	node := gqlIssueNode(42, 7, "org/repo", "GraphQL issue", "OPEN", []string{"bug"}, []string{"alice"})
+	body := gqlSearchEnvelope([]map[string]any{node}, false, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != "POST" {
+			http.Error(w, "expected POST", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	issues, err := client.SearchIssuesGraphQL("is:issue is:open assignee:alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	got := issues[0]
+	if got.ID != 42 {
+		t.Errorf("ID: want 42, got %d", got.ID)
+	}
+	if got.Number != 7 {
+		t.Errorf("Number: want 7, got %d", got.Number)
+	}
+	if got.Title != "GraphQL issue" {
+		t.Errorf("Title: want %q, got %q", "GraphQL issue", got.Title)
+	}
+	if got.Repo != "org/repo" {
+		t.Errorf("Repo: want %q, got %q", "org/repo", got.Repo)
+	}
+	if got.State != "OPEN" {
+		t.Errorf("State: want %q, got %q", "OPEN", got.State)
+	}
+	if got.HTMLURL != "https://github.com/org/repo/issues/7" {
+		t.Errorf("HTMLURL: want %q, got %q", "https://github.com/org/repo/issues/7", got.HTMLURL)
+	}
+	if len(got.Labels) != 1 || got.Labels[0].Name != "bug" {
+		t.Errorf("Labels: want [{bug}], got %v", got.Labels)
+	}
+	if len(got.Assignees) != 1 || got.Assignees[0].Login != "alice" {
+		t.Errorf("Assignees: want [{alice}], got %v", got.Assignees)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be set")
+	}
+	if got.UpdatedAt.IsZero() {
+		t.Error("UpdatedAt should be set")
+	}
+}
+
+func TestSearchIssuesGraphQL_PaginatesTwoPages(t *testing.T) {
+	// Page 1: 100 nodes, hasNextPage=true, endCursor="cursor1"
+	page1Nodes := make([]map[string]any, 100)
+	for i := range page1Nodes {
+		page1Nodes[i] = gqlIssueNode(int64(i+1), i+1, "org/repo", fmt.Sprintf("issue %d", i+1), "OPEN", nil, nil)
+	}
+	page1Body := gqlSearchEnvelope(page1Nodes, true, "cursor1")
+
+	// Page 2: 3 nodes, hasNextPage=false
+	page2Nodes := []map[string]any{
+		gqlIssueNode(101, 101, "org/repo", "issue 101", "OPEN", nil, nil),
+		gqlIssueNode(102, 102, "org/repo", "issue 102", "OPEN", nil, nil),
+		gqlIssueNode(103, 103, "org/repo", "issue 103", "OPEN", nil, nil),
+	}
+	page2Body := gqlSearchEnvelope(page2Nodes, false, "")
+
+	pageCount := 0
+	var receivedCursors []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			http.NotFound(w, r)
+			return
+		}
+		pageCount++
+		// Extract the cursor variable from the request body.
+		var reqBody struct {
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&reqBody)
+		if c, ok := reqBody.Variables["cursor"]; ok && c != nil {
+			receivedCursors = append(receivedCursors, fmt.Sprintf("%v", c))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch pageCount {
+		case 1:
+			w.Write(page1Body)
+		case 2:
+			w.Write(page2Body)
+		default:
+			w.Write(gqlSearchEnvelope(nil, false, ""))
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	issues, err := client.SearchIssuesGraphQL("is:issue is:open")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 103 {
+		t.Errorf("expected 103 issues, got %d", len(issues))
+	}
+	if pageCount != 2 {
+		t.Errorf("expected 2 page requests, got %d", pageCount)
+	}
+	// The second request should carry cursor="cursor1".
+	if len(receivedCursors) != 1 || receivedCursors[0] != "cursor1" {
+		t.Errorf("expected cursor1 on page 2, got %v", receivedCursors)
+	}
+}
+
+func TestSearchIssuesGraphQL_StopsAtPageCap(t *testing.T) {
+	// Always return 100 nodes and hasNextPage=true so the paginator would loop
+	// forever without the cap.
+	pageCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			http.NotFound(w, r)
+			return
+		}
+		pageCount++
+		nodes := make([]map[string]any, 100)
+		for i := range nodes {
+			id := int64(pageCount*100 + i + 1)
+			nodes[i] = gqlIssueNode(id, int(id), "org/repo", "issue", "OPEN", nil, nil)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(gqlSearchEnvelope(nodes, true, fmt.Sprintf("cursor%d", pageCount)))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	issues, err := client.SearchIssuesGraphQL("is:issue is:open")
+	if err != nil {
+		t.Fatalf("cap should not surface an error, got: %v", err)
+	}
+	// Should stop at maxSearchIssuePages (10) × 100 = 1000 issues.
+	if len(issues) != 1000 {
+		t.Errorf("expected 1000 issues at cap, got %d", len(issues))
+	}
+	if pageCount != 10 {
+		t.Errorf("expected exactly 10 page requests (cap), got %d", pageCount)
+	}
+}
+
+func TestSearchIssuesGraphQL_ErrorsEnvelopeReturnsError(t *testing.T) {
+	body := gqlErrorEnvelope("NOT_FOUND: resource not found", "FORBIDDEN: insufficient scope")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	_, err := client.SearchIssuesGraphQL("is:issue is:open")
+	if err == nil {
+		t.Fatal("expected error from GraphQL errors envelope, got nil")
+	}
+	if !strings.Contains(err.Error(), "NOT_FOUND") {
+		t.Errorf("error should contain first error message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "FORBIDDEN") {
+		t.Errorf("error should contain second error message, got: %v", err)
+	}
+}
+
+func TestSearchIssuesGraphQL_DropsNonIssueNodes(t *testing.T) {
+	// A non-Issue node (e.g. a PR) has databaseId=0 in the GraphQL union type
+	// when the ... on Issue fragment doesn't match.
+	issueNode := gqlIssueNode(10, 1, "org/repo", "real issue", "OPEN", nil, nil)
+	// PR node: zero databaseId (fragment doesn't apply).
+	prNode := map[string]any{
+		"databaseId": 0,
+	}
+	body := gqlSearchEnvelope([]map[string]any{issueNode, prNode}, false, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	issues, err := client.SearchIssuesGraphQL("is:issue is:open")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue (PR node dropped), got %d", len(issues))
+	}
+	if issues[0].ID != 10 {
+		t.Errorf("wrong issue kept: ID=%d", issues[0].ID)
+	}
+}
+
+// ── graphQL() low-level tests ─────────────────────────────────────────────────
+
+func TestGraphQLLowLevel_HTTPErrorReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"bad credentials"}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("bad-token", gh.WithBaseURL(srv.URL))
+	// Call SearchIssuesGraphQL which internally calls graphQL().
+	_, err := client.SearchIssuesGraphQL("is:issue")
+	if err == nil {
+		t.Fatal("expected error on 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should contain status 401, got: %v", err)
+	}
+}
+
+func TestGraphQLLowLevel_RateObserverNotified(t *testing.T) {
+	// Assert that the rate observer is called on GraphQL responses.
+	body := gqlSearchEnvelope(nil, false, "")
+
+	observedCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "4500")
+		w.Header().Set("X-RateLimit-Resource", "graphql")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	client.SetRateObserver(gh.RateLimitObserverFunc(func(resp *http.Response) {
+		observedCount++
+	}))
+
+	_, err := client.SearchIssuesGraphQL("is:issue is:open")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if observedCount != 1 {
+		t.Errorf("rate observer should have been called once, got %d", observedCount)
+	}
+}
+
+// ── Dispatch / fallback tests ─────────────────────────────────────────────────
+
+// TestSearchIssues_GraphQLDisabledNeverCallsGraphQLEndpoint asserts that when
+// useGraphQL is false (the default), /graphql is never hit.
+func TestSearchIssues_GraphQLDisabledNeverCallsGraphQLEndpoint(t *testing.T) {
+	restItem := searchIssueItem(1, 42, "org/repo", "rest issue", []string{}, []string{}, false)
+
+	graphqlHit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/graphql") {
+			graphqlHit = true
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+			return
+		}
+		// REST search path.
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(searchEnvelope(1, []map[string]any{restItem}))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	// GraphQL is off by default — do not call SetGraphQLEnabled.
+	issues, err := client.SearchIssues("is:issue is:open")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Errorf("expected 1 issue from REST, got %d", len(issues))
+	}
+	if graphqlHit {
+		t.Error("/graphql should never be called when GraphQL is disabled")
+	}
+}
+
+// TestSearchIssues_GraphQLEnabledUsesGraphQLPath asserts that when GraphQL is
+// enabled, SearchIssues calls the GraphQL endpoint (not REST search).
+func TestSearchIssues_GraphQLEnabledUsesGraphQLPath(t *testing.T) {
+	gqlNode := gqlIssueNode(77, 3, "org/repo", "graphql issue", "OPEN", nil, nil)
+	gqlBody := gqlSearchEnvelope([]map[string]any{gqlNode}, false, "")
+
+	restHit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/graphql") {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(gqlBody)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/search/issues") {
+			restHit = true
+			http.Error(w, "should not call REST", http.StatusInternalServerError)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	client.SetGraphQLEnabled(true)
+
+	issues, err := client.SearchIssues("is:issue is:open")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue from GraphQL, got %d", len(issues))
+	}
+	if issues[0].ID != 77 {
+		t.Errorf("Issue ID: want 77, got %d", issues[0].ID)
+	}
+	if restHit {
+		t.Error("REST /search/issues should not be called when GraphQL succeeds")
+	}
+}
+
+// TestSearchIssues_GraphQLEnabledFallsBackOnError asserts that when GraphQL
+// errors, SearchIssues falls back to the REST search path transparently.
+func TestSearchIssues_GraphQLEnabledFallsBackOnError(t *testing.T) {
+	restItem := searchIssueItem(99, 55, "org/repo", "fallback rest issue", []string{}, []string{}, false)
+
+	fallbackHit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/graphql") {
+			// Return a GraphQL errors envelope to trigger fallback.
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(gqlErrorEnvelope("internal server error"))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/search/issues") {
+			fallbackHit = true
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(searchEnvelope(1, []map[string]any{restItem}))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	client.SetGraphQLEnabled(true)
+
+	issues, err := client.SearchIssues("is:issue is:open")
+	if err != nil {
+		t.Fatalf("fallback should succeed, got error: %v", err)
+	}
+	if !fallbackHit {
+		t.Error("REST fallback path should have been called when GraphQL errors")
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue from REST fallback, got %d", len(issues))
+	}
+	if issues[0].Number != 55 {
+		t.Errorf("Issue.Number: want 55, got %d", issues[0].Number)
+	}
+}
+
+// TestSearchIssues_GraphQLHTTPErrorFallsBackToREST asserts that an HTTP-level
+// error (non-200 from /graphql) also triggers the REST fallback.
+func TestSearchIssues_GraphQLHTTPErrorFallsBackToREST(t *testing.T) {
+	restItem := searchIssueItem(1, 1, "org/repo", "rest fallback", []string{}, []string{}, false)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/graphql") {
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/search/issues") {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(searchEnvelope(1, []map[string]any{restItem}))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	client.SetGraphQLEnabled(true)
+
+	issues, err := client.SearchIssues("is:issue is:open")
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Errorf("expected 1 issue from REST fallback, got %d", len(issues))
+	}
+}

--- a/daemon/internal/github/graphql_test.go
+++ b/daemon/internal/github/graphql_test.go
@@ -15,7 +15,13 @@ import (
 // ── GraphQL test helpers ──────────────────────────────────────────────────────
 
 // gqlIssueNode builds a GraphQL Issue node matching the search query fields.
+// author is the login of the issue author (maps to Issue.User).
 func gqlIssueNode(id int64, number int, repo, title, state string, labels, assignees []string) map[string]any {
+	return gqlIssueNodeWithAuthor(id, number, repo, title, state, "", labels, assignees)
+}
+
+// gqlIssueNodeWithAuthor is like gqlIssueNode but also sets the author login.
+func gqlIssueNodeWithAuthor(id int64, number int, repo, title, state, author string, labels, assignees []string) map[string]any {
 	labelNodes := make([]map[string]string, len(labels))
 	for i, l := range labels {
 		labelNodes[i] = map[string]string{"name": l}
@@ -33,6 +39,7 @@ func gqlIssueNode(id int64, number int, repo, title, state string, labels, assig
 		"url":        fmt.Sprintf("https://github.com/%s/issues/%d", repo, number),
 		"createdAt":  time.Now().UTC().Format(time.RFC3339),
 		"updatedAt":  time.Now().UTC().Format(time.RFC3339),
+		"author":     map[string]string{"login": author},
 		"repository": map[string]string{"nameWithOwner": repo},
 		"assignees":  map[string]any{"nodes": assigneeNodes},
 		"labels":     map[string]any{"nodes": labelNodes},
@@ -69,7 +76,7 @@ func gqlErrorEnvelope(messages ...string) []byte {
 // ── SearchIssuesGraphQL tests ─────────────────────────────────────────────────
 
 func TestSearchIssuesGraphQL_ParsesPayloadAndMapsFields(t *testing.T) {
-	node := gqlIssueNode(42, 7, "org/repo", "GraphQL issue", "OPEN", []string{"bug"}, []string{"alice"})
+	node := gqlIssueNodeWithAuthor(42, 7, "org/repo", "GraphQL issue", "OPEN", "bob", []string{"bug"}, []string{"alice"})
 	body := gqlSearchEnvelope([]map[string]any{node}, false, "")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -107,8 +114,11 @@ func TestSearchIssuesGraphQL_ParsesPayloadAndMapsFields(t *testing.T) {
 	if got.Repo != "org/repo" {
 		t.Errorf("Repo: want %q, got %q", "org/repo", got.Repo)
 	}
-	if got.State != "OPEN" {
-		t.Errorf("State: want %q, got %q", "OPEN", got.State)
+	if got.State != "open" {
+		t.Errorf("State: want %q, got %q", "open", got.State)
+	}
+	if got.User.Login != "bob" {
+		t.Errorf("User.Login: want %q, got %q", "bob", got.User.Login)
 	}
 	if got.HTMLURL != "https://github.com/org/repo/issues/7" {
 		t.Errorf("HTMLURL: want %q, got %q", "https://github.com/org/repo/issues/7", got.HTMLURL)

--- a/daemon/internal/github/ratelimit.go
+++ b/daemon/internal/github/ratelimit.go
@@ -1,0 +1,90 @@
+package github
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RateLimitObserver is implemented by callers that want to receive parsed
+// rate-limit signals after every GitHub API response.
+type RateLimitObserver interface {
+	// ObserveResponse is called with the raw HTTP response after every call
+	// made through do() or doWithBody(). The response body is NOT consumed
+	// by ObserveResponse; only headers are inspected.
+	ObserveResponse(resp *http.Response)
+}
+
+// RateLimitObserverFunc is a function type that implements RateLimitObserver.
+// It lets callers register a plain function as an observer without defining
+// a new named type.
+type RateLimitObserverFunc func(resp *http.Response)
+
+// ObserveResponse implements RateLimitObserver.
+func (f RateLimitObserverFunc) ObserveResponse(resp *http.Response) { f(resp) }
+
+// ParsedRateLimit holds the result of parseRateLimitHeaders.
+// ok is false when the response carries no X-RateLimit-* headers.
+type ParsedRateLimit struct {
+	Resource   string        // e.g. "core", "search"
+	Remaining  int           // X-RateLimit-Remaining
+	Reset      time.Time     // X-RateLimit-Reset (unix epoch → time.Time)
+	RetryAfter time.Duration // Retry-After if present (0 when absent)
+}
+
+// ParseRateLimitHeaders extracts GitHub rate-limit signals from a response.
+// It is a pure function with no side effects, placed here for easy testing.
+//
+// Returns (result, true) when at least X-RateLimit-Remaining is present.
+// Returns (ParsedRateLimit{}, false) when the headers are absent.
+//
+// Secondary rate limit detection:
+//   - 403 or 429 with a Retry-After header → RetryAfter is set.
+//   - 403 with body containing "secondary rate limit" is handled upstream by
+//     callers that read the body; the header-only path here uses Retry-After.
+func ParseRateLimitHeaders(resp *http.Response) (ParsedRateLimit, bool) {
+	if resp == nil {
+		return ParsedRateLimit{}, false
+	}
+
+	remainingStr := resp.Header.Get("X-RateLimit-Remaining")
+	if remainingStr == "" {
+		// No rate-limit headers at all.
+		return ParsedRateLimit{}, false
+	}
+
+	remaining, err := strconv.Atoi(strings.TrimSpace(remainingStr))
+	if err != nil {
+		return ParsedRateLimit{}, false
+	}
+
+	resource := strings.TrimSpace(resp.Header.Get("X-RateLimit-Resource"))
+	if resource == "" {
+		resource = "core" // default to "core" when resource header is absent
+	}
+
+	var reset time.Time
+	if resetStr := resp.Header.Get("X-RateLimit-Reset"); resetStr != "" {
+		if epoch, err := strconv.ParseInt(strings.TrimSpace(resetStr), 10, 64); err == nil {
+			reset = time.Unix(epoch, 0)
+		}
+	}
+
+	var retryAfter time.Duration
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+		if raStr := resp.Header.Get("Retry-After"); raStr != "" {
+			raStr = strings.TrimSpace(raStr)
+			if secs, err := strconv.ParseInt(raStr, 10, 64); err == nil {
+				retryAfter = time.Duration(secs) * time.Second
+			}
+		}
+	}
+
+	return ParsedRateLimit{
+		Resource:   resource,
+		Remaining:  remaining,
+		Reset:      reset,
+		RetryAfter: retryAfter,
+	}, true
+}

--- a/daemon/internal/github/ratelimit_test.go
+++ b/daemon/internal/github/ratelimit_test.go
@@ -155,13 +155,13 @@ func TestParseRateLimitHeaders_NilResponseReturnsFalse(t *testing.T) {
 func TestParseRateLimitHeaders_TableDriven(t *testing.T) {
 	epoch := int64(1700000000)
 	cases := []struct {
-		name       string
-		status     int
-		headers    map[string]string
-		wantOK     bool
-		wantRes    string
-		wantRem    int
-		wantRetry  time.Duration
+		name      string
+		status    int
+		headers   map[string]string
+		wantOK    bool
+		wantRes   string
+		wantRem   int
+		wantRetry time.Duration
 	}{
 		{
 			name:   "core 200",

--- a/daemon/internal/github/ratelimit_test.go
+++ b/daemon/internal/github/ratelimit_test.go
@@ -1,0 +1,418 @@
+package github_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+// ── ParseRateLimitHeaders unit tests ─────────────────────────────────────────
+
+func makeResp(status int, headers map[string]string) *http.Response {
+	resp := &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       http.NoBody,
+	}
+	for k, v := range headers {
+		resp.Header.Set(k, v)
+	}
+	return resp
+}
+
+func TestParseRateLimitHeaders_CoreResource(t *testing.T) {
+	resp := makeResp(http.StatusOK, map[string]string{
+		"X-RateLimit-Remaining": "4321",
+		"X-RateLimit-Reset":     "1700000000",
+		"X-RateLimit-Resource":  "core",
+	})
+
+	parsed, ok := gh.ParseRateLimitHeaders(resp)
+	if !ok {
+		t.Fatal("expected ok=true for core resource response")
+	}
+	if parsed.Resource != "core" {
+		t.Errorf("Resource = %q, want %q", parsed.Resource, "core")
+	}
+	if parsed.Remaining != 4321 {
+		t.Errorf("Remaining = %d, want 4321", parsed.Remaining)
+	}
+	want := time.Unix(1700000000, 0)
+	if !parsed.Reset.Equal(want) {
+		t.Errorf("Reset = %v, want %v", parsed.Reset, want)
+	}
+	if parsed.RetryAfter != 0 {
+		t.Errorf("RetryAfter = %v, want 0 (not a 403/429)", parsed.RetryAfter)
+	}
+}
+
+func TestParseRateLimitHeaders_SearchResource(t *testing.T) {
+	resp := makeResp(http.StatusOK, map[string]string{
+		"X-RateLimit-Remaining": "25",
+		"X-RateLimit-Reset":     "1700001234",
+		"X-RateLimit-Resource":  "search",
+	})
+
+	parsed, ok := gh.ParseRateLimitHeaders(resp)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if parsed.Resource != "search" {
+		t.Errorf("Resource = %q, want %q", parsed.Resource, "search")
+	}
+	if parsed.Remaining != 25 {
+		t.Errorf("Remaining = %d, want 25", parsed.Remaining)
+	}
+}
+
+func TestParseRateLimitHeaders_DefaultsToCore(t *testing.T) {
+	// X-RateLimit-Resource absent → default to "core".
+	resp := makeResp(http.StatusOK, map[string]string{
+		"X-RateLimit-Remaining": "100",
+		"X-RateLimit-Reset":     "1700000000",
+	})
+
+	parsed, ok := gh.ParseRateLimitHeaders(resp)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if parsed.Resource != "core" {
+		t.Errorf("Resource = %q, want %q (default)", parsed.Resource, "core")
+	}
+}
+
+func TestParseRateLimitHeaders_RetryAfterOn403(t *testing.T) {
+	resp := makeResp(http.StatusForbidden, map[string]string{
+		"X-RateLimit-Remaining": "0",
+		"X-RateLimit-Reset":     "1700000000",
+		"X-RateLimit-Resource":  "core",
+		"Retry-After":           "60",
+	})
+
+	parsed, ok := gh.ParseRateLimitHeaders(resp)
+	if !ok {
+		t.Fatal("expected ok=true on 403 with headers")
+	}
+	if parsed.RetryAfter != 60*time.Second {
+		t.Errorf("RetryAfter = %v, want 60s", parsed.RetryAfter)
+	}
+}
+
+func TestParseRateLimitHeaders_RetryAfterOn429(t *testing.T) {
+	resp := makeResp(http.StatusTooManyRequests, map[string]string{
+		"X-RateLimit-Remaining": "0",
+		"X-RateLimit-Reset":     "1700000000",
+		"Retry-After":           "30",
+	})
+
+	parsed, ok := gh.ParseRateLimitHeaders(resp)
+	if !ok {
+		t.Fatal("expected ok=true on 429 with headers")
+	}
+	if parsed.RetryAfter != 30*time.Second {
+		t.Errorf("RetryAfter = %v, want 30s", parsed.RetryAfter)
+	}
+}
+
+func TestParseRateLimitHeaders_No403RetryAfterOn200(t *testing.T) {
+	// Retry-After on a 200 should NOT be set (it's not a rate-limit signal on 200).
+	resp := makeResp(http.StatusOK, map[string]string{
+		"X-RateLimit-Remaining": "4000",
+		"X-RateLimit-Reset":     "1700000000",
+		"Retry-After":           "60", // unusual — should be ignored on non-403/429
+	})
+
+	parsed, ok := gh.ParseRateLimitHeaders(resp)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if parsed.RetryAfter != 0 {
+		t.Errorf("RetryAfter = %v, want 0 on 200", parsed.RetryAfter)
+	}
+}
+
+func TestParseRateLimitHeaders_AbsentHeadersReturnsFalse(t *testing.T) {
+	resp := makeResp(http.StatusOK, map[string]string{})
+	_, ok := gh.ParseRateLimitHeaders(resp)
+	if ok {
+		t.Error("expected ok=false when no X-RateLimit-Remaining header")
+	}
+}
+
+func TestParseRateLimitHeaders_NilResponseReturnsFalse(t *testing.T) {
+	_, ok := gh.ParseRateLimitHeaders(nil)
+	if ok {
+		t.Error("expected ok=false for nil response")
+	}
+}
+
+func TestParseRateLimitHeaders_TableDriven(t *testing.T) {
+	epoch := int64(1700000000)
+	cases := []struct {
+		name       string
+		status     int
+		headers    map[string]string
+		wantOK     bool
+		wantRes    string
+		wantRem    int
+		wantRetry  time.Duration
+	}{
+		{
+			name:   "core 200",
+			status: 200,
+			headers: map[string]string{
+				"X-RateLimit-Remaining": "5000",
+				"X-RateLimit-Reset":     fmt.Sprintf("%d", epoch),
+				"X-RateLimit-Resource":  "core",
+			},
+			wantOK: true, wantRes: "core", wantRem: 5000, wantRetry: 0,
+		},
+		{
+			name:   "search 200",
+			status: 200,
+			headers: map[string]string{
+				"X-RateLimit-Remaining": "10",
+				"X-RateLimit-Reset":     fmt.Sprintf("%d", epoch),
+				"X-RateLimit-Resource":  "search",
+			},
+			wantOK: true, wantRes: "search", wantRem: 10, wantRetry: 0,
+		},
+		{
+			name:   "403 secondary limit",
+			status: 403,
+			headers: map[string]string{
+				"X-RateLimit-Remaining": "0",
+				"X-RateLimit-Reset":     fmt.Sprintf("%d", epoch),
+				"X-RateLimit-Resource":  "core",
+				"Retry-After":           "120",
+			},
+			wantOK: true, wantRes: "core", wantRem: 0, wantRetry: 120 * time.Second,
+		},
+		{
+			name:    "no headers → false",
+			status:  200,
+			headers: map[string]string{},
+			wantOK:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := makeResp(tc.status, tc.headers)
+			parsed, ok := gh.ParseRateLimitHeaders(resp)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if parsed.Resource != tc.wantRes {
+				t.Errorf("Resource = %q, want %q", parsed.Resource, tc.wantRes)
+			}
+			if parsed.Remaining != tc.wantRem {
+				t.Errorf("Remaining = %d, want %d", parsed.Remaining, tc.wantRem)
+			}
+			if parsed.RetryAfter != tc.wantRetry {
+				t.Errorf("RetryAfter = %v, want %v", parsed.RetryAfter, tc.wantRetry)
+			}
+		})
+	}
+}
+
+// ── Observer integration tests via httptest ───────────────────────────────────
+
+// fakeObserver records all calls to ObserveResponse for test assertions.
+type fakeObserver struct {
+	mu    sync.Mutex
+	calls []*http.Response
+}
+
+func (f *fakeObserver) ObserveResponse(resp *http.Response) {
+	f.mu.Lock()
+	f.calls = append(f.calls, resp)
+	f.mu.Unlock()
+}
+
+func (f *fakeObserver) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func (f *fakeObserver) last() *http.Response {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) == 0 {
+		return nil
+	}
+	return f.calls[len(f.calls)-1]
+}
+
+// TestSetRateObserver_CalledAfterGetRequest verifies that a registered observer
+// receives a call with the response after a GET request through do().
+func TestSetRateObserver_CalledAfterGetRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "4999")
+		w.Header().Set("X-RateLimit-Reset", "1700000000")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"login":"bot"}`)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	obs := &fakeObserver{}
+	client.SetRateObserver(obs)
+
+	resp, err := client.DoGETForTest("/user", "application/vnd.github+json")
+	if err != nil {
+		t.Fatalf("DoGETForTest: %v", err)
+	}
+	resp.Body.Close()
+
+	if obs.count() != 1 {
+		t.Errorf("observer called %d times, want 1", obs.count())
+	}
+	last := obs.last()
+	if last == nil {
+		t.Fatal("last observed response is nil")
+	}
+	if last.Header.Get("X-RateLimit-Remaining") != "4999" {
+		t.Errorf("observer saw Remaining=%q, want %q",
+			last.Header.Get("X-RateLimit-Remaining"), "4999")
+	}
+	if last.Header.Get("X-RateLimit-Resource") != "core" {
+		t.Errorf("observer saw Resource=%q, want %q",
+			last.Header.Get("X-RateLimit-Resource"), "core")
+	}
+}
+
+// TestSetRateObserver_CalledAfterNonGetRequest verifies that the observer is
+// also invoked for POST/PUT requests through doWithBody().
+func TestSetRateObserver_CalledAfterNonGetRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "2000")
+		w.Header().Set("X-RateLimit-Reset", "1700000001")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	obs := &fakeObserver{}
+	client.SetRateObserver(obs)
+
+	// Trigger doWithBody via MergePR (PUT).
+	_ = client.MergePR("org/repo", 1, "squash")
+
+	if obs.count() < 1 {
+		t.Errorf("observer called %d times, want >= 1 (from PUT via doWithBody)", obs.count())
+	}
+	last := obs.last()
+	if last == nil {
+		t.Fatal("last observed response is nil")
+	}
+	if last.Header.Get("X-RateLimit-Remaining") != "2000" {
+		t.Errorf("observer saw Remaining=%q, want %q",
+			last.Header.Get("X-RateLimit-Remaining"), "2000")
+	}
+}
+
+// TestSetRateObserver_NotCalledWhenNil verifies that no panic occurs when no
+// observer is registered and a request is made.
+func TestSetRateObserver_NotCalledWhenNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "100")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"login":"bot"}`)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	// No observer registered — must not panic.
+	resp, err := client.DoGETForTest("/user", "application/vnd.github+json")
+	if err != nil {
+		t.Fatalf("DoGETForTest: %v", err)
+	}
+	resp.Body.Close()
+}
+
+// TestSetRateObserver_ObserverSeesRealHeaders verifies end-to-end: the observer
+// sees the headers the httptest server returned, and ParseRateLimitHeaders
+// correctly extracts them.
+func TestSetRateObserver_ObserverSeesRealHeaders(t *testing.T) {
+	resetEpoch := int64(1800000000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "42")
+		w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", resetEpoch))
+		w.Header().Set("X-RateLimit-Resource", "search")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"login":"bot"}`)
+	}))
+	defer srv.Close()
+
+	var gotParsed gh.ParsedRateLimit
+	var gotOK bool
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	client.SetRateObserver(gh.RateLimitObserverFunc(func(resp *http.Response) {
+		gotParsed, gotOK = gh.ParseRateLimitHeaders(resp)
+	}))
+
+	resp, err := client.DoGETForTest("/user", "application/vnd.github+json")
+	if err != nil {
+		t.Fatalf("DoGETForTest: %v", err)
+	}
+	resp.Body.Close()
+
+	if !gotOK {
+		t.Fatal("ParseRateLimitHeaders returned ok=false inside observer")
+	}
+	if gotParsed.Resource != "search" {
+		t.Errorf("Resource = %q, want %q", gotParsed.Resource, "search")
+	}
+	if gotParsed.Remaining != 42 {
+		t.Errorf("Remaining = %d, want 42", gotParsed.Remaining)
+	}
+	if !gotParsed.Reset.Equal(time.Unix(resetEpoch, 0)) {
+		t.Errorf("Reset = %v, want %v", gotParsed.Reset, time.Unix(resetEpoch, 0))
+	}
+}
+
+// TestSetRateObserver_MultipleRequestsCallObserverEachTime verifies the observer
+// is called once per request, not once per client lifetime.
+func TestSetRateObserver_MultipleRequestsCallObserverEachTime(t *testing.T) {
+	call := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call++
+		w.Header().Set("X-RateLimit-Remaining", fmt.Sprintf("%d", 5000-call))
+		w.Header().Set("X-RateLimit-Reset", "1700000000")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"login":"bot"}`)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	obs := &fakeObserver{}
+	client.SetRateObserver(obs)
+
+	const n = 3
+	for i := 0; i < n; i++ {
+		resp, err := client.DoGETForTest("/user", "application/vnd.github+json")
+		if err != nil {
+			t.Fatalf("call %d: %v", i+1, err)
+		}
+		resp.Body.Close()
+	}
+
+	if obs.count() != n {
+		t.Errorf("observer called %d times, want %d", obs.count(), n)
+	}
+}

--- a/daemon/internal/github/ratelimit_test.go
+++ b/daemon/internal/github/ratelimit_test.go
@@ -416,3 +416,146 @@ func TestSetRateObserver_MultipleRequestsCallObserverEachTime(t *testing.T) {
 		t.Errorf("observer called %d times, want %d", obs.count(), n)
 	}
 }
+
+// TestSetRateObserver_CalledAfterSubmitReview verifies that a registered
+// observer is called when SubmitReview is invoked, so 403 secondary-rate-limit
+// responses on the write path update the limiter's cooldown.
+func TestSetRateObserver_CalledAfterSubmitReview(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "3000")
+		w.Header().Set("X-RateLimit-Reset", "1700000000")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"id":42,"state":"APPROVED"}`)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	obs := &fakeObserver{}
+	client.SetRateObserver(obs)
+
+	_, _, err := client.SubmitReview("org/repo", 1, "looks good", "APPROVE")
+	if err != nil {
+		t.Fatalf("SubmitReview: %v", err)
+	}
+
+	if obs.count() != 1 {
+		t.Errorf("observer called %d times after SubmitReview, want 1", obs.count())
+	}
+	last := obs.last()
+	if last == nil {
+		t.Fatal("last observed response is nil")
+	}
+	if last.Header.Get("X-RateLimit-Remaining") != "3000" {
+		t.Errorf("observer saw Remaining=%q, want %q",
+			last.Header.Get("X-RateLimit-Remaining"), "3000")
+	}
+}
+
+// TestSetRateObserver_CalledAfterPostComment verifies that a registered
+// observer is called when PostComment is invoked, so 403 secondary-rate-limit
+// responses on the write path update the limiter's cooldown.
+func TestSetRateObserver_CalledAfterPostComment(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "1500")
+		w.Header().Set("X-RateLimit-Reset", "1700000000")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"created_at":"2024-01-01T00:00:00Z"}`)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	obs := &fakeObserver{}
+	client.SetRateObserver(obs)
+
+	_, err := client.PostComment("org/repo", 1, "hello from bot")
+	if err != nil {
+		t.Fatalf("PostComment: %v", err)
+	}
+
+	if obs.count() != 1 {
+		t.Errorf("observer called %d times after PostComment, want 1", obs.count())
+	}
+	last := obs.last()
+	if last == nil {
+		t.Fatal("last observed response is nil")
+	}
+	if last.Header.Get("X-RateLimit-Remaining") != "1500" {
+		t.Errorf("observer saw Remaining=%q, want %q",
+			last.Header.Get("X-RateLimit-Remaining"), "1500")
+	}
+}
+
+// TestSetRateObserver_SubmitReview403SecondaryRateLimit verifies that a 403
+// with Retry-After (GitHub's secondary rate-limit signal) on SubmitReview
+// reaches the observer so the limiter can enter cooldown.
+func TestSetRateObserver_SubmitReview403SecondaryRateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "1700000000")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"message":"You have exceeded a secondary rate limit."}`)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	obs := &fakeObserver{}
+	client.SetRateObserver(obs)
+
+	// SubmitReview will return an error (403), but the observer must still fire.
+	_, _, _ = client.SubmitReview("org/repo", 1, "body", "APPROVE")
+
+	if obs.count() != 1 {
+		t.Errorf("observer called %d times on 403 from SubmitReview, want 1", obs.count())
+	}
+	last := obs.last()
+	if last == nil {
+		t.Fatal("last observed response is nil")
+	}
+	parsed, ok := gh.ParseRateLimitHeaders(last)
+	if !ok {
+		t.Fatal("ParseRateLimitHeaders returned ok=false on 403 response")
+	}
+	if parsed.RetryAfter != 60*time.Second {
+		t.Errorf("RetryAfter = %v, want 60s", parsed.RetryAfter)
+	}
+}
+
+// TestSetRateObserver_PostComment403SecondaryRateLimit verifies that a 403
+// with Retry-After on PostComment reaches the observer.
+func TestSetRateObserver_PostComment403SecondaryRateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "1700000000")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"message":"You have exceeded a secondary rate limit."}`)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	obs := &fakeObserver{}
+	client.SetRateObserver(obs)
+
+	// PostComment will return an error (403), but the observer must still fire.
+	_, _ = client.PostComment("org/repo", 1, "body")
+
+	if obs.count() != 1 {
+		t.Errorf("observer called %d times on 403 from PostComment, want 1", obs.count())
+	}
+	last := obs.last()
+	if last == nil {
+		t.Fatal("last observed response is nil")
+	}
+	parsed, ok := gh.ParseRateLimitHeaders(last)
+	if !ok {
+		t.Fatal("ParseRateLimitHeaders returned ok=false on 403 response")
+	}
+	if parsed.RetryAfter != 30*time.Second {
+		t.Errorf("RetryAfter = %v, want 30s", parsed.RetryAfter)
+	}
+}

--- a/daemon/internal/github/search_issues.go
+++ b/daemon/internal/github/search_issues.go
@@ -1,0 +1,216 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/heimdallm/daemon/internal/config"
+)
+
+// maxSearchIssuePages is the GitHub Search API's hard cap on paginated results:
+// at most 1000 items (10 pages × per_page=100). Requesting page 11 or beyond
+// returns an error. We stop here to avoid burning the search budget on an
+// empty or error response.
+const maxSearchIssuePages = 10
+
+// SearchIssues fetches open issues matching query from the GitHub Search API
+// (GET /search/issues?q=...) and returns them as a flat []*Issue slice.
+//
+// Each page is capped at 100 items; pagination stops when GitHub returns a
+// partial page, the result set hits the 1000-item cap (maxSearchIssuePages ×
+// 100), or an error occurs. Because this is a GET the existing ETag cache layer
+// and rate-limit observer are applied automatically.
+//
+// The Repo field of each returned issue is derived from the issue's
+// repository_url field ("https://api.github.com/repos/org/repo") using the
+// same extraction logic as PullRequest.ResolveRepo. The PullRequest probe
+// field is checked so PRs that appear in the search results are silently
+// dropped (GitHub's search endpoint returns both issues and PRs when the query
+// targets issues unless `is:issue` is present — this is defense-in-depth for
+// callers that pass a query without that qualifier).
+//
+// On any error SearchIssues returns (nil, err) so callers can decide whether
+// to fall back to per-repo FetchIssues.
+func (c *Client) SearchIssues(query string) ([]*Issue, error) {
+	var all []*Issue
+	for page := 1; page <= maxSearchIssuePages; page++ {
+		params := url.Values{}
+		params.Set("q", query)
+		params.Set("per_page", "100")
+		params.Set("page", strconv.Itoa(page))
+
+		path := "/search/issues?" + params.Encode()
+		resp, err := c.do("GET", path, "application/vnd.github+json")
+		if err != nil {
+			return nil, fmt.Errorf("github: search issues (page %d): %w", page, err)
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("github: search issues: read body (page %d): %w", page, readErr)
+		}
+		if resp.StatusCode != 200 {
+			errBody := safeTruncate(string(body), maxErrBodyLen)
+			return nil, fmt.Errorf("github: search issues (page %d): status %d: %s", page, resp.StatusCode, errBody)
+		}
+
+		var result struct {
+			TotalCount int      `json:"total_count"`
+			Items      []*Issue `json:"items"`
+		}
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, fmt.Errorf("github: search issues: decode (page %d): %w", page, err)
+		}
+
+		for _, issue := range result.Items {
+			if issue == nil {
+				continue
+			}
+			if issue.IsPullRequest() {
+				continue // search returns PRs too; drop them
+			}
+			// Derive Repo from repository_url when Repository is absent.
+			if issue.Repository != nil && issue.Repository.FullName != "" {
+				issue.Repo = issue.Repository.FullName
+			} else {
+				issue.Repo = repoFromURL(issue.HTMLURL)
+			}
+			all = append(all, issue)
+		}
+
+		if len(result.Items) < 100 {
+			break // last (partial) page
+		}
+		if page == maxSearchIssuePages {
+			slog.Warn("github: SearchIssues reached result cap", "cap", maxSearchIssuePages*100)
+		}
+	}
+	return all, nil
+}
+
+// repoFromURL derives "org/repo" from a GitHub html_url
+// ("https://github.com/org/repo/issues/42") or a repository_url
+// ("https://api.github.com/repos/org/repo"). Returns "" on failure.
+func repoFromURL(rawURL string) string {
+	// repository_url form: https://api.github.com/repos/org/repo
+	const apiPrefix = "https://api.github.com/repos/"
+	if strings.HasPrefix(rawURL, apiPrefix) {
+		extracted := rawURL[len(apiPrefix):]
+		if isValidRepo(extracted) {
+			return extracted
+		}
+	}
+	// html_url form: https://github.com/org/repo/issues/42
+	const ghPrefix = "https://github.com/"
+	if strings.HasPrefix(rawURL, ghPrefix) {
+		rest := rawURL[len(ghPrefix):]
+		// rest = "org/repo/issues/42"
+		parts := strings.SplitN(rest, "/", 3)
+		if len(parts) >= 2 && parts[0] != "" && parts[1] != "" {
+			candidate := parts[0] + "/" + parts[1]
+			if isValidRepo(candidate) {
+				return candidate
+			}
+		}
+	}
+	return ""
+}
+
+// isValidRepo checks that s has the form "owner/name" with no path traversal.
+func isValidRepo(s string) bool {
+	return strings.Count(s, "/") == 1 &&
+		!strings.Contains(s, "..") &&
+		!strings.Contains(s, "//")
+}
+
+// BuildIssueSearchQuery constructs the `q=` value for GET /search/issues that
+// mirrors the semantics of FetchIssues:
+//
+//   - always adds `is:issue is:open`
+//   - adds `assignee:<login>` for each configured assignee (or the
+//     authenticatedUser as fallback when Assignees is empty)
+//   - adds `org:<org>` for each configured organization when no explicit repos
+//     are given; otherwise adds `repo:<org/repo>` for each repo in the list
+//   - adds `label:<name>` for each label found in DevelopLabels,
+//     RefinementLabels, or ReviewOnlyLabels (the positive action-mapped labels)
+//
+// The resulting query is intended for SearchIssues, which drops PRs
+// and further applies cfg.Classify + issueMatchesFilters — so the query is a
+// broad net, not an exact replacement for those filters.
+//
+// repos must be pre-filtered to only include repos that have issue tracking
+// enabled (and that are not in autonomous mode) — buildIssueSearchQuery does
+// not perform that filtering.
+func BuildIssueSearchQuery(it config.IssueTrackingConfig, authenticatedUser string, repos []string) string {
+	var parts []string
+	parts = append(parts, "is:issue", "is:open")
+
+	// Assignee scope.
+	assignees := it.Assignees
+	if len(assignees) == 0 && authenticatedUser != "" {
+		assignees = []string{authenticatedUser}
+	}
+	for _, a := range assignees {
+		a = strings.TrimSpace(a)
+		if a != "" {
+			parts = append(parts, "assignee:"+a)
+		}
+	}
+
+	// Repo / org scope.
+	if len(repos) > 0 {
+		for _, r := range repos {
+			r = strings.TrimSpace(r)
+			if r != "" {
+				parts = append(parts, "repo:"+r)
+			}
+		}
+	} else if len(it.Organizations) > 0 {
+		for _, o := range it.Organizations {
+			o = strings.TrimSpace(o)
+			if o != "" {
+				parts = append(parts, "org:"+o)
+			}
+		}
+	}
+
+	// Label filters — include only the positive-action labels (develop,
+	// refinement, review_only). Skip and blocked labels are not included:
+	// the search net is wide; per-issue filtering in FetchIssues / SearchIssues
+	// downstream removes skip/blocked items.
+	allActionLabels := make([]string, 0,
+		len(it.DevelopLabels)+len(it.RefinementLabels)+len(it.ReviewOnlyLabels))
+	allActionLabels = append(allActionLabels, it.DevelopLabels...)
+	allActionLabels = append(allActionLabels, it.RefinementLabels...)
+	allActionLabels = append(allActionLabels, it.ReviewOnlyLabels...)
+
+	// Only add label qualifiers when every action dimension has labels.
+	// If DefaultAction != ignore, unlabelled issues also qualify and a
+	// label filter would incorrectly exclude them.
+	defaultActionIsIgnore := it.DefaultAction == "" || it.DefaultAction == string(config.IssueModeIgnore)
+	if defaultActionIsIgnore && len(allActionLabels) > 0 {
+		seen := make(map[string]struct{}, len(allActionLabels))
+		for _, l := range allActionLabels {
+			l = strings.TrimSpace(l)
+			if l == "" {
+				continue
+			}
+			if _, dup := seen[l]; dup {
+				continue
+			}
+			seen[l] = struct{}{}
+			// GitHub label qualifiers need quoting when the name has spaces.
+			if strings.ContainsAny(l, " \t") {
+				l = `"` + l + `"`
+			}
+			parts = append(parts, "label:"+l)
+		}
+	}
+
+	return strings.Join(parts, " ")
+}

--- a/daemon/internal/github/search_issues.go
+++ b/daemon/internal/github/search_issues.go
@@ -94,17 +94,12 @@ func (c *Client) SearchIssues(query string) ([]*Issue, error) {
 }
 
 // repoFromURL derives "org/repo" from a GitHub html_url
-// ("https://github.com/org/repo/issues/42") or a repository_url
-// ("https://api.github.com/repos/org/repo"). Returns "" on failure.
+// ("https://github.com/org/repo/issues/42"). Returns "" on failure.
+//
+// Note: issue.HTMLURL is always a github.com URL; the api.github.com/repos/
+// form only appears in the repository_url field, which is handled by the
+// Repository.FullName path in SearchIssues before repoFromURL is called.
 func repoFromURL(rawURL string) string {
-	// repository_url form: https://api.github.com/repos/org/repo
-	const apiPrefix = "https://api.github.com/repos/"
-	if strings.HasPrefix(rawURL, apiPrefix) {
-		extracted := rawURL[len(apiPrefix):]
-		if isValidRepo(extracted) {
-			return extracted
-		}
-	}
 	// html_url form: https://github.com/org/repo/issues/42
 	const ghPrefix = "https://github.com/"
 	if strings.HasPrefix(rawURL, ghPrefix) {
@@ -126,6 +121,41 @@ func isValidRepo(s string) bool {
 	return strings.Count(s, "/") == 1 &&
 		!strings.Contains(s, "..") &&
 		!strings.Contains(s, "//")
+}
+
+// BuildAggregatedSearchQuery constructs a minimal `q=` value for the
+// aggregated prefetch path. Unlike BuildIssueSearchQuery it intentionally
+// omits label qualifiers so the search returns a SUPERSET of all issues that
+// the per-repo client-side ClassifyAndFilterIssues would keep. This is correct
+// because:
+//
+//  1. Per-repo label configs differ, so no single label set can scope all repos.
+//  2. ClassifyAndFilterIssues (called in ProcessRepo for prefetched results)
+//     already applies classification + label/filter_mode filtering precisely,
+//     ensuring no unwanted issue survives into the pipeline.
+//
+// The query includes `is:issue is:open`, one `assignee:<login>` qualifier per
+// assignee, and one `repo:<org/repo>` qualifier per repo.
+//
+// assignees must be the resolved set for the group (empty falls back to authUser
+// if provided via the caller; pass the already-resolved list here).
+// repos must be non-empty.
+func BuildAggregatedSearchQuery(assignees []string, repos []string) string {
+	var parts []string
+	parts = append(parts, "is:issue", "is:open")
+	for _, a := range assignees {
+		a = strings.TrimSpace(a)
+		if a != "" {
+			parts = append(parts, "assignee:"+a)
+		}
+	}
+	for _, r := range repos {
+		r = strings.TrimSpace(r)
+		if r != "" {
+			parts = append(parts, "repo:"+r)
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 // BuildIssueSearchQuery constructs the `q=` value for GET /search/issues that

--- a/daemon/internal/github/search_issues.go
+++ b/daemon/internal/github/search_issues.go
@@ -18,8 +18,30 @@ import (
 // empty or error response.
 const maxSearchIssuePages = 10
 
-// SearchIssues fetches open issues matching query from the GitHub Search API
-// (GET /search/issues?q=...) and returns them as a flat []*Issue slice.
+// SearchIssues fetches open issues matching query. When GraphQL is enabled via
+// SetGraphQLEnabled(true), it dispatches to SearchIssuesGraphQL first; on any
+// error it falls back to the REST /search/issues path automatically (the caller
+// never sees the GraphQL error — only the REST result or error).
+//
+// When GraphQL is disabled (the default), only the REST path is used.
+//
+// On any error SearchIssues returns (nil, err) so callers can decide whether
+// to fall back to per-repo FetchIssues.
+func (c *Client) SearchIssues(query string) ([]*Issue, error) {
+	if c.useGraphQL.Load() {
+		issues, err := c.SearchIssuesGraphQL(query)
+		if err != nil {
+			slog.Warn("github: SearchIssuesGraphQL failed, falling back to REST",
+				"err", err)
+			return c.searchIssuesREST(query)
+		}
+		return issues, nil
+	}
+	return c.searchIssuesREST(query)
+}
+
+// searchIssuesREST fetches open issues matching query from the GitHub Search
+// API (GET /search/issues?q=...) and returns them as a flat []*Issue slice.
 //
 // Each page is capped at 100 items; pagination stops when GitHub returns a
 // partial page, the result set hits the 1000-item cap (maxSearchIssuePages ×
@@ -34,9 +56,8 @@ const maxSearchIssuePages = 10
 // targets issues unless `is:issue` is present — this is defense-in-depth for
 // callers that pass a query without that qualifier).
 //
-// On any error SearchIssues returns (nil, err) so callers can decide whether
-// to fall back to per-repo FetchIssues.
-func (c *Client) SearchIssues(query string) ([]*Issue, error) {
+// On any error searchIssuesREST returns (nil, err).
+func (c *Client) searchIssuesREST(query string) ([]*Issue, error) {
 	var all []*Issue
 	for page := 1; page <= maxSearchIssuePages; page++ {
 		params := url.Values{}

--- a/daemon/internal/github/search_issues_test.go
+++ b/daemon/internal/github/search_issues_test.go
@@ -1,0 +1,390 @@
+package github_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// searchIssueItem builds the JSON shape returned by /search/issues for a
+// single issue item. The repository_url is used by SearchIssues to derive Repo.
+func searchIssueItem(id int64, number int, repo, title string, labels, assignees []string, isPR bool) map[string]any {
+	labelItems := make([]map[string]string, len(labels))
+	for i, l := range labels {
+		labelItems[i] = map[string]string{"name": l}
+	}
+	assigneeItems := make([]map[string]string, len(assignees))
+	for i, a := range assignees {
+		assigneeItems[i] = map[string]string{"login": a}
+	}
+	item := map[string]any{
+		"id":               id,
+		"number":           number,
+		"title":            title,
+		"state":            "open",
+		"labels":           labelItems,
+		"assignees":        assigneeItems,
+		"user":             map[string]string{"login": "author"},
+		"html_url":         fmt.Sprintf("https://github.com/%s/issues/%d", repo, number),
+		"repository_url":   fmt.Sprintf("https://api.github.com/repos/%s", repo),
+		"created_at":       time.Now().UTC().Format(time.RFC3339),
+		"updated_at":       time.Now().UTC().Format(time.RFC3339),
+	}
+	if isPR {
+		item["pull_request"] = map[string]string{"url": "…"}
+	}
+	return item
+}
+
+// searchEnvelope builds the JSON envelope returned by GET /search/issues.
+func searchEnvelope(totalCount int, items []map[string]any) []byte {
+	b, _ := json.Marshal(map[string]any{
+		"total_count":        totalCount,
+		"incomplete_results": false,
+		"items":              items,
+	})
+	return b
+}
+
+// ── SearchIssues tests ───────────────────────────────────────────────────────
+
+func TestSearchIssues_ParsesEnvelopeAndDeriveRepo(t *testing.T) {
+	item := searchIssueItem(1, 42, "org/repo", "bug title", []string{"bug"}, []string{"alice"}, false)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/search/issues") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(searchEnvelope(1, []map[string]any{item}))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	issues, err := client.SearchIssues("is:issue is:open assignee:alice repo:org/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	got := issues[0]
+	if got.Number != 42 {
+		t.Errorf("Number: want 42, got %d", got.Number)
+	}
+	if got.Title != "bug title" {
+		t.Errorf("Title: want %q, got %q", "bug title", got.Title)
+	}
+	if got.Repo != "org/repo" {
+		t.Errorf("Repo: want %q, got %q", "org/repo", got.Repo)
+	}
+	if len(got.Labels) != 1 || got.Labels[0].Name != "bug" {
+		t.Errorf("Labels: want [bug], got %v", got.Labels)
+	}
+	if len(got.Assignees) != 1 || got.Assignees[0].Login != "alice" {
+		t.Errorf("Assignees: want [alice], got %v", got.Assignees)
+	}
+}
+
+func TestSearchIssues_DropsEmbeddedPullRequests(t *testing.T) {
+	items := []map[string]any{
+		searchIssueItem(1, 10, "org/repo", "real issue", nil, nil, false),
+		searchIssueItem(2, 11, "org/repo", "this is a PR", nil, nil, true),
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(searchEnvelope(2, items))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	issues, err := client.SearchIssues("is:issue is:open")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue (PR dropped), got %d", len(issues))
+	}
+	if issues[0].Number != 10 {
+		t.Errorf("wrong issue kept: %d", issues[0].Number)
+	}
+}
+
+func TestSearchIssues_PaginatesTwoPages(t *testing.T) {
+	// Build page1 (100 items) and page2 (1 item).
+	page1Items := make([]map[string]any, 100)
+	for i := range page1Items {
+		page1Items[i] = searchIssueItem(int64(i+1), i+1, "org/repo", fmt.Sprintf("issue %d", i+1), nil, nil, false)
+	}
+	page2Items := []map[string]any{
+		searchIssueItem(101, 101, "org/repo", "issue 101", nil, nil, false),
+	}
+
+	var pageRequests []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page == 0 {
+			page = 1
+		}
+		pageRequests = append(pageRequests, page)
+		switch page {
+		case 1:
+			w.Write(searchEnvelope(101, page1Items))
+		case 2:
+			w.Write(searchEnvelope(101, page2Items))
+		default:
+			w.Write(searchEnvelope(101, nil))
+		}
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	issues, err := client.SearchIssues("is:issue is:open")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 101 {
+		t.Errorf("expected 101 issues, got %d", len(issues))
+	}
+	if len(pageRequests) != 2 {
+		t.Errorf("expected 2 page requests, got %d: %v", len(pageRequests), pageRequests)
+	}
+}
+
+func TestSearchIssues_StopsAtPageCap(t *testing.T) {
+	// Always return a full page so the paginator would loop forever without the
+	// cap.
+	pageCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pageCount++
+		items := make([]map[string]any, 100)
+		for i := range items {
+			id := int64(pageCount*100 + i)
+			items[i] = searchIssueItem(id, int(id), "org/repo", "issue", nil, nil, false)
+		}
+		w.Write(searchEnvelope(10000, items))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	issues, err := client.SearchIssues("is:issue is:open")
+	if err != nil {
+		t.Fatalf("cap should not surface an error, got: %v", err)
+	}
+	// Should have exactly 10 pages × 100 = 1000 issues.
+	if len(issues) != 1000 {
+		t.Errorf("expected 1000 issues at cap, got %d", len(issues))
+	}
+	if pageCount != 10 {
+		t.Errorf("expected exactly 10 page requests (cap), got %d", pageCount)
+	}
+}
+
+func TestSearchIssues_HTTPErrorReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"rate limited"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	_, err := client.SearchIssues("is:issue is:open")
+	if err == nil {
+		t.Fatal("expected error on 403, got nil")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error should include status code, got: %v", err)
+	}
+}
+
+func TestSearchIssues_DerivesRepoFromHTMLURL(t *testing.T) {
+	// Build an item without repository_url — Repo must be derived from html_url.
+	item := map[string]any{
+		"id":         int64(99),
+		"number":     99,
+		"title":      "html url fallback",
+		"state":      "open",
+		"labels":     []any{},
+		"assignees":  []any{},
+		"user":       map[string]string{"login": "bob"},
+		"html_url":   "https://github.com/myorg/myrepo/issues/99",
+		"created_at": time.Now().UTC().Format(time.RFC3339),
+		"updated_at": time.Now().UTC().Format(time.RFC3339),
+		// repository_url intentionally absent
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(searchEnvelope(1, []map[string]any{item}))
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	issues, err := client.SearchIssues("is:issue is:open")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].Repo != "myorg/myrepo" {
+		t.Errorf("Repo derived from html_url: want %q, got %q", "myorg/myrepo", issues[0].Repo)
+	}
+}
+
+// ── buildIssueSearchQuery / BuildIssueSearchQuery tests ──────────────────────
+
+func TestBuildIssueSearchQuery_BaseAlways(t *testing.T) {
+	q := gh.BuildIssueSearchQuery(config.IssueTrackingConfig{}, "", nil)
+	if !strings.Contains(q, "is:issue") {
+		t.Errorf("expected is:issue in query, got %q", q)
+	}
+	if !strings.Contains(q, "is:open") {
+		t.Errorf("expected is:open in query, got %q", q)
+	}
+}
+
+func TestBuildIssueSearchQuery_AssigneeFromConfig(t *testing.T) {
+	it := config.IssueTrackingConfig{Assignees: []string{"alice", "bob"}}
+	q := gh.BuildIssueSearchQuery(it, "ignored-user", nil)
+	if !strings.Contains(q, "assignee:alice") {
+		t.Errorf("expected assignee:alice, got %q", q)
+	}
+	if !strings.Contains(q, "assignee:bob") {
+		t.Errorf("expected assignee:bob, got %q", q)
+	}
+}
+
+func TestBuildIssueSearchQuery_AssigneeFallsBackToAuthUser(t *testing.T) {
+	it := config.IssueTrackingConfig{} // no Assignees
+	q := gh.BuildIssueSearchQuery(it, "carol", nil)
+	if !strings.Contains(q, "assignee:carol") {
+		t.Errorf("expected assignee:carol fallback, got %q", q)
+	}
+}
+
+func TestBuildIssueSearchQuery_OrgScoping(t *testing.T) {
+	it := config.IssueTrackingConfig{Organizations: []string{"myorg"}}
+	q := gh.BuildIssueSearchQuery(it, "", nil) // no repos → uses orgs
+	if !strings.Contains(q, "org:myorg") {
+		t.Errorf("expected org:myorg, got %q", q)
+	}
+}
+
+func TestBuildIssueSearchQuery_RepoScopingOverridesOrg(t *testing.T) {
+	it := config.IssueTrackingConfig{Organizations: []string{"myorg"}}
+	q := gh.BuildIssueSearchQuery(it, "", []string{"myorg/repo1", "myorg/repo2"})
+	if strings.Contains(q, "org:myorg") {
+		t.Errorf("org: qualifier should be absent when repos are provided, got %q", q)
+	}
+	if !strings.Contains(q, "repo:myorg/repo1") {
+		t.Errorf("expected repo:myorg/repo1, got %q", q)
+	}
+	if !strings.Contains(q, "repo:myorg/repo2") {
+		t.Errorf("expected repo:myorg/repo2, got %q", q)
+	}
+}
+
+func TestBuildIssueSearchQuery_LabelFiltersAddedWhenDefaultIgnore(t *testing.T) {
+	it := config.IssueTrackingConfig{
+		DefaultAction:    string(config.IssueModeIgnore),
+		DevelopLabels:    []string{"bug"},
+		ReviewOnlyLabels: []string{"question"},
+	}
+	q := gh.BuildIssueSearchQuery(it, "", nil)
+	if !strings.Contains(q, "label:bug") {
+		t.Errorf("expected label:bug, got %q", q)
+	}
+	if !strings.Contains(q, "label:question") {
+		t.Errorf("expected label:question, got %q", q)
+	}
+}
+
+func TestBuildIssueSearchQuery_NoLabelFiltersWhenDefaultIsNotIgnore(t *testing.T) {
+	it := config.IssueTrackingConfig{
+		DefaultAction:    string(config.IssueModeReviewOnly),
+		DevelopLabels:    []string{"bug"},
+		ReviewOnlyLabels: []string{"question"},
+	}
+	q := gh.BuildIssueSearchQuery(it, "", nil)
+	if strings.Contains(q, "label:") {
+		t.Errorf("no label qualifier expected when default_action != ignore, got %q", q)
+	}
+}
+
+func TestBuildIssueSearchQuery_NoLabelFiltersWhenDefaultEmptyAndNoLabels(t *testing.T) {
+	it := config.IssueTrackingConfig{} // DefaultAction="" → treated as ignore but no labels
+	q := gh.BuildIssueSearchQuery(it, "", nil)
+	if strings.Contains(q, "label:") {
+		t.Errorf("no label qualifier expected when no labels configured, got %q", q)
+	}
+}
+
+func TestBuildIssueSearchQuery_FilterModeHasNoEffect(t *testing.T) {
+	// filter_mode is applied client-side post-fetch; query should be the same
+	// regardless of whether it's inclusive or exclusive.
+	base := config.IssueTrackingConfig{
+		DevelopLabels: []string{"bug"},
+		DefaultAction: string(config.IssueModeIgnore),
+	}
+	incl := base
+	incl.FilterMode = config.FilterModeInclusive
+	excl := base
+	excl.FilterMode = config.FilterModeExclusive
+
+	qIncl := gh.BuildIssueSearchQuery(incl, "u", nil)
+	qExcl := gh.BuildIssueSearchQuery(excl, "u", nil)
+	if qIncl != qExcl {
+		t.Errorf("filter_mode should not affect search query:\n  inclusive: %q\n  exclusive: %q", qIncl, qExcl)
+	}
+}
+
+func TestBuildIssueSearchQuery_LabelWithSpacesIsQuoted(t *testing.T) {
+	it := config.IssueTrackingConfig{
+		DefaultAction: string(config.IssueModeIgnore),
+		DevelopLabels: []string{"needs work"},
+	}
+	q := gh.BuildIssueSearchQuery(it, "", nil)
+	if !strings.Contains(q, `label:"needs work"`) {
+		t.Errorf("label with spaces should be quoted, got %q", q)
+	}
+}
+
+func TestBuildIssueSearchQuery_QURLEncodeable(t *testing.T) {
+	// Verify the query can be URL-encoded and decoded without loss, which is
+	// what SearchIssues does internally via url.Values.Set.
+	it := config.IssueTrackingConfig{
+		DefaultAction: string(config.IssueModeIgnore),
+		DevelopLabels: []string{"bug fix"},
+		Assignees:     []string{"alice"},
+	}
+	q := gh.BuildIssueSearchQuery(it, "", []string{"org/repo"})
+	encoded := url.QueryEscape(q)
+	decoded, err := url.QueryUnescape(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded != q {
+		t.Errorf("round-trip mismatch:\n  orig:    %q\n  decoded: %q", q, decoded)
+	}
+}
+
+func TestBuildIssueSearchQuery_DeduplicatesLabels(t *testing.T) {
+	it := config.IssueTrackingConfig{
+		DefaultAction: string(config.IssueModeIgnore),
+		DevelopLabels: []string{"bug", "bug"}, // duplicate
+		ReviewOnlyLabels: []string{"bug"},     // same label in another dimension
+	}
+	q := gh.BuildIssueSearchQuery(it, "", nil)
+	count := strings.Count(q, "label:bug")
+	if count != 1 {
+		t.Errorf("expected label:bug to appear exactly once (deduped), got %d in %q", count, q)
+	}
+}

--- a/daemon/internal/github/search_issues_test.go
+++ b/daemon/internal/github/search_issues_test.go
@@ -29,17 +29,17 @@ func searchIssueItem(id int64, number int, repo, title string, labels, assignees
 		assigneeItems[i] = map[string]string{"login": a}
 	}
 	item := map[string]any{
-		"id":               id,
-		"number":           number,
-		"title":            title,
-		"state":            "open",
-		"labels":           labelItems,
-		"assignees":        assigneeItems,
-		"user":             map[string]string{"login": "author"},
-		"html_url":         fmt.Sprintf("https://github.com/%s/issues/%d", repo, number),
-		"repository_url":   fmt.Sprintf("https://api.github.com/repos/%s", repo),
-		"created_at":       time.Now().UTC().Format(time.RFC3339),
-		"updated_at":       time.Now().UTC().Format(time.RFC3339),
+		"id":             id,
+		"number":         number,
+		"title":          title,
+		"state":          "open",
+		"labels":         labelItems,
+		"assignees":      assigneeItems,
+		"user":           map[string]string{"login": "author"},
+		"html_url":       fmt.Sprintf("https://github.com/%s/issues/%d", repo, number),
+		"repository_url": fmt.Sprintf("https://api.github.com/repos/%s", repo),
+		"created_at":     time.Now().UTC().Format(time.RFC3339),
+		"updated_at":     time.Now().UTC().Format(time.RFC3339),
 	}
 	if isPR {
 		item["pull_request"] = map[string]string{"url": "…"}
@@ -378,9 +378,9 @@ func TestBuildIssueSearchQuery_QURLEncodeable(t *testing.T) {
 
 func TestBuildIssueSearchQuery_DeduplicatesLabels(t *testing.T) {
 	it := config.IssueTrackingConfig{
-		DefaultAction: string(config.IssueModeIgnore),
-		DevelopLabels: []string{"bug", "bug"}, // duplicate
-		ReviewOnlyLabels: []string{"bug"},     // same label in another dimension
+		DefaultAction:    string(config.IssueModeIgnore),
+		DevelopLabels:    []string{"bug", "bug"}, // duplicate
+		ReviewOnlyLabels: []string{"bug"},        // same label in another dimension
 	}
 	q := gh.BuildIssueSearchQuery(it, "", nil)
 	count := strings.Count(q, "label:bug")

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -39,6 +39,13 @@ type IssuesFetcher interface {
 	FetchIssues(repo string, cfg config.IssueTrackingConfig, authenticatedUser string) ([]*github.Issue, error)
 }
 
+// IssueSearcher is the optional Search API back-end used by PrefetchIssues.
+// Keeping it separate from IssuesFetcher lets tests that only need FetchIssues
+// inject a nil searcher without changes.
+type IssueSearcher interface {
+	SearchIssues(query string) ([]*github.Issue, error)
+}
+
 // PipelineRunner is the subset of *Pipeline the fetcher uses. Takes a
 // context so shutdown cancellation propagates through the whole dispatch
 // path down to the git / HTTP calls inside the pipeline.
@@ -97,6 +104,12 @@ type Fetcher struct {
 
 	stageClient StageTransitionClient
 	stageBroker Publisher
+
+	// searcher is optional. When set, PrefetchIssues uses the Search API to
+	// aggregate issue results across repos in a single call, populating
+	// prefetched so ProcessRepo can skip the per-repo REST call.
+	searcher   IssueSearcher
+	prefetched map[string][]*github.Issue // set by PrefetchIssues; read by ProcessRepo
 }
 
 // NewFetcher wires the orchestrator. All dependencies are interfaces so
@@ -128,6 +141,83 @@ func (f *Fetcher) SetStageTransitioner(client StageTransitionClient, broker Publ
 	f.stageBroker = broker
 }
 
+// SetSearcher enables the aggregated Search API prefetch path. When set,
+// PrefetchIssues is available for callers to warm the prefetch map before
+// calling ProcessRepo.
+func (f *Fetcher) SetSearcher(s IssueSearcher) {
+	f.searcher = s
+}
+
+// PrefetchIssues runs ONE aggregated GET /search/issues query covering all
+// eligible repos in repos (those with issue tracking enabled and autonomous
+// mode disabled), builds a per-repo map of raw []*github.Issue, and stores it
+// internally so subsequent ProcessRepo calls for any of those repos can skip
+// the per-repo REST GET.
+//
+// eligibleFn(repo) should return (IssueTrackingConfig, autonomousEnabled, ok).
+// Repos for which autonomousEnabled==true or ok==false are excluded from the
+// search scope (matching the gating in ProcessRepo).
+//
+// On search error PrefetchIssues logs a warning and returns the error; callers
+// should then call ProcessRepo without a prefetched map, which falls back to the
+// per-repo FetchIssues path automatically.
+//
+// PrefetchIssues is NOT goroutine-safe; it must be called BEFORE the parallel
+// ProcessRepo fan-out begins and the prefetched map must not be written again
+// until all ProcessRepo calls for that cycle have returned.
+func (f *Fetcher) PrefetchIssues(
+	it config.IssueTrackingConfig,
+	authUser string,
+	repos []string,
+) (map[string][]*github.Issue, error) {
+	if f.searcher == nil {
+		return nil, nil
+	}
+
+	// Filter repos to those eligible for search.
+	eligible := repos[:0:0] // same backing array cap avoids allocation on empty input
+	eligible = make([]string, 0, len(repos))
+	for _, r := range repos {
+		if r != "" {
+			eligible = append(eligible, r)
+		}
+	}
+	if len(eligible) == 0 {
+		return nil, nil
+	}
+
+	query := github.BuildIssueSearchQuery(it, authUser, eligible)
+	if query == "" {
+		return nil, nil
+	}
+
+	raw, err := f.searcher.SearchIssues(query)
+	if err != nil {
+		slog.Warn("issues fetcher: search prefetch failed, will fall back to per-repo fetch",
+			"err", err, "repos", len(eligible))
+		return nil, err
+	}
+
+	byRepo := make(map[string][]*github.Issue, len(eligible))
+	for _, issue := range raw {
+		if issue.Repo == "" {
+			continue
+		}
+		byRepo[issue.Repo] = append(byRepo[issue.Repo], issue)
+	}
+
+	slog.Info("issues fetcher: search prefetch complete",
+		"repos", len(eligible), "issues", len(raw))
+	f.prefetched = byRepo
+	return byRepo, nil
+}
+
+// ClearPrefetch discards the prefetch map. Call once per cycle after all
+// ProcessRepo calls have completed so stale data cannot leak into the next cycle.
+func (f *Fetcher) ClearPrefetch() {
+	f.prefetched = nil
+}
+
 // ProcessRepo fetches every eligible issue for one repo and dispatches it to
 // the pipeline. Returns the number of issues actually handed off and a
 // non-nil error only when the fetch itself failed — per-issue pipeline
@@ -153,9 +243,25 @@ func (f *Fetcher) ProcessRepo(ctx context.Context, repo string, cfg config.Issue
 		ctx = context.Background()
 	}
 
-	issues, err := f.client.FetchIssues(repo, cfg, authUser)
-	if err != nil {
-		return 0, fmt.Errorf("issues fetcher: fetch %s: %w", repo, err)
+	// Use prefetched search results when available; fall back to per-repo REST.
+	// The prefetch map is populated by PrefetchIssues before the parallel
+	// ProcessRepo fan-out begins and is read-only during that fan-out, so no
+	// locking is needed here.
+	var issues []*github.Issue
+	var fetchErr error
+	if prefetchedSlice, ok := f.prefetched[repo]; ok {
+		slog.Debug("issues fetcher: using prefetched search results",
+			"repo", repo, "count", len(prefetchedSlice))
+		// The raw search results still need to go through the same
+		// classification + filter pipeline that FetchIssues applies.
+		// ClassifyAndFilterIssues is the exported version of that logic.
+		issues = github.ClassifyAndFilterIssues(prefetchedSlice, repo, cfg, authUser)
+	} else {
+		// No prefetch for this repo — use the per-repo REST endpoint.
+		issues, fetchErr = f.client.FetchIssues(repo, cfg, authUser)
+		if fetchErr != nil {
+			return 0, fmt.Errorf("issues fetcher: fetch %s: %w", repo, fetchErr)
+		}
 	}
 
 	processed := 0

--- a/daemon/internal/issues/fetcher.go
+++ b/daemon/internal/issues/fetcher.go
@@ -148,25 +148,60 @@ func (f *Fetcher) SetSearcher(s IssueSearcher) {
 	f.searcher = s
 }
 
-// PrefetchIssues runs ONE aggregated GET /search/issues query covering all
-// eligible repos in repos (those with issue tracking enabled and autonomous
-// mode disabled), builds a per-repo map of raw []*github.Issue, and stores it
-// internally so subsequent ProcessRepo calls for any of those repos can skip
-// the per-repo REST GET.
+// EligibleFn is the per-repo eligibility callback passed to PrefetchIssues.
+// It returns the effective IssueTrackingConfig for repo, whether autonomous
+// mode is enabled (which disables issue processing), and whether the repo
+// should be included at all (ok=false skips the repo silently).
+type EligibleFn func(repo string) (it config.IssueTrackingConfig, autonomousEnabled bool, ok bool)
+
+// assigneeKey builds a canonical string key for a resolved assignee set so
+// repos that share the same effective assignees end up in the same search
+// group. The key is the sorted, joined assignee list (case-preserved to match
+// the GitHub login convention).
+func assigneeKey(assignees []string) string {
+	if len(assignees) == 0 {
+		return ""
+	}
+	sorted := make([]string, len(assignees))
+	copy(sorted, assignees)
+	// simple insertion sort — lists are always tiny (1–5 entries)
+	for i := 1; i < len(sorted); i++ {
+		for j := i; j > 0 && sorted[j] < sorted[j-1]; j-- {
+			sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
+		}
+	}
+	return strings.Join(sorted, "\x00")
+}
+
+// PrefetchIssues runs one aggregated GET /search/issues query PER DISTINCT
+// ASSIGNEE SET covering all eligible repos, builds a per-repo map of raw
+// []*github.Issue, and stores it internally so subsequent ProcessRepo calls for
+// any of those repos can skip the per-repo REST GET.
 //
-// eligibleFn(repo) should return (IssueTrackingConfig, autonomousEnabled, ok).
-// Repos for which autonomousEnabled==true or ok==false are excluded from the
-// search scope (matching the gating in ProcessRepo).
+// eligibleFn(repo) returns (effectiveIssueTrackingConfig, autonomousEnabled,
+// ok). Repos for which autonomousEnabled==true or ok==false are excluded from
+// the search scope (matching the gating in ProcessRepo).
 //
-// On search error PrefetchIssues logs a warning and returns the error; callers
-// should then call ProcessRepo without a prefetched map, which falls back to the
-// per-repo FetchIssues path automatically.
+// Grouping by assignee set is necessary because per-repo IssueTracking
+// overrides can specify different Assignees than the global config. Running a
+// single global-assignee query and storing results under a repo whose effective
+// assignees differ would silently drop issues assigned to the override assignees.
 //
-// PrefetchIssues is NOT goroutine-safe; it must be called BEFORE the parallel
-// ProcessRepo fan-out begins and the prefetched map must not be written again
-// until all ProcessRepo calls for that cycle have returned.
+// Label qualifiers are intentionally omitted from the aggregated queries
+// (BuildAggregatedSearchQuery). The per-repo client-side ClassifyAndFilterIssues
+// step (called in ProcessRepo) already applies classification and label/filter
+// filtering precisely, so the aggregated query only needs to narrow by assignee
+// and repo scope.
+//
+// On search error for any group, PrefetchIssues logs a warning, clears the
+// internal prefetch map for that group's repos (leaving them absent so
+// ProcessRepo falls back to per-repo FetchIssues), and returns the last error.
+//
+// PrefetchIssues is NOT goroutine-safe; call it BEFORE the parallel ProcessRepo
+// fan-out and do not write the prefetch map again until all ProcessRepo calls
+// for that cycle have returned.
 func (f *Fetcher) PrefetchIssues(
-	it config.IssueTrackingConfig,
+	eligibleFn EligibleFn,
 	authUser string,
 	repos []string,
 ) (map[string][]*github.Issue, error) {
@@ -174,42 +209,72 @@ func (f *Fetcher) PrefetchIssues(
 		return nil, nil
 	}
 
-	// Filter repos to those eligible for search.
-	eligible := repos[:0:0] // same backing array cap avoids allocation on empty input
-	eligible = make([]string, 0, len(repos))
+	// Build groups: assigneeKey → (assignees, []repo)
+	type group struct {
+		assignees []string
+		repos     []string
+	}
+	groups := make(map[string]*group)
+	groupOrder := make([]string, 0) // preserve deterministic iteration order
+
 	for _, r := range repos {
-		if r != "" {
-			eligible = append(eligible, r)
-		}
-	}
-	if len(eligible) == 0 {
-		return nil, nil
-	}
-
-	query := github.BuildIssueSearchQuery(it, authUser, eligible)
-	if query == "" {
-		return nil, nil
-	}
-
-	raw, err := f.searcher.SearchIssues(query)
-	if err != nil {
-		slog.Warn("issues fetcher: search prefetch failed, will fall back to per-repo fetch",
-			"err", err, "repos", len(eligible))
-		return nil, err
-	}
-
-	byRepo := make(map[string][]*github.Issue, len(eligible))
-	for _, issue := range raw {
-		if issue.Repo == "" {
+		if r == "" {
 			continue
 		}
-		byRepo[issue.Repo] = append(byRepo[issue.Repo], issue)
+		it, autonomous, ok := eligibleFn(r)
+		if !ok || autonomous || !it.Enabled {
+			continue
+		}
+		// Resolve effective assignees the same way ProcessRepo / FetchIssues does.
+		resolved := it.WithDefaultAssignee(authUser).Assignees
+		key := assigneeKey(resolved)
+		if _, exists := groups[key]; !exists {
+			groups[key] = &group{assignees: resolved}
+			groupOrder = append(groupOrder, key)
+		}
+		groups[key].repos = append(groups[key].repos, r)
+	}
+
+	if len(groups) == 0 {
+		return nil, nil
+	}
+
+	byRepo := make(map[string][]*github.Issue)
+	var lastErr error
+	totalRepos := 0
+	totalIssues := 0
+
+	for _, key := range groupOrder {
+		g := groups[key]
+		query := github.BuildAggregatedSearchQuery(g.assignees, g.repos)
+		if query == "" {
+			continue
+		}
+		raw, err := f.searcher.SearchIssues(query)
+		if err != nil {
+			slog.Warn("issues fetcher: search prefetch failed for assignee group, will fall back to per-repo fetch",
+				"err", err, "repos", len(g.repos))
+			lastErr = err
+			continue
+		}
+		for _, issue := range raw {
+			if issue.Repo == "" {
+				continue
+			}
+			byRepo[issue.Repo] = append(byRepo[issue.Repo], issue)
+		}
+		totalRepos += len(g.repos)
+		totalIssues += len(raw)
+	}
+
+	if len(byRepo) == 0 && lastErr != nil {
+		return nil, lastErr
 	}
 
 	slog.Info("issues fetcher: search prefetch complete",
-		"repos", len(eligible), "issues", len(raw))
+		"groups", len(groups), "repos", totalRepos, "issues", totalIssues)
 	f.prefetched = byRepo
-	return byRepo, nil
+	return byRepo, lastErr
 }
 
 // ClearPrefetch discards the prefetch map. Call once per cycle after all

--- a/daemon/internal/issues/prefetch_test.go
+++ b/daemon/internal/issues/prefetch_test.go
@@ -343,7 +343,7 @@ func TestClearPrefetch_PreventsStaleReuseAcrossCycles(t *testing.T) {
 
 	repos := []string{"org/repo"}
 	// Cycle 1: prefetch active — FetchIssues must NOT be called.
-	fetcher.PrefetchIssues(simpleEligibleFn(cfg, repos), "alice", repos) //nolint:errcheck
+	fetcher.PrefetchIssues(simpleEligibleFn(cfg, repos), "alice", repos)         //nolint:errcheck
 	fetcher.ProcessRepo(context.Background(), "org/repo", cfg, "alice", optsFor) //nolint:errcheck
 	if restClient.calls != 0 {
 		t.Fatalf("cycle 1: FetchIssues should not be called when prefetch warm; got %d", restClient.calls)

--- a/daemon/internal/issues/prefetch_test.go
+++ b/daemon/internal/issues/prefetch_test.go
@@ -1,0 +1,322 @@
+package issues_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/issues"
+)
+
+// ── fakeSearcher ─────────────────────────────────────────────────────────────
+
+type fakeSearcher struct {
+	issues []*github.Issue
+	err    error
+	calls  int
+}
+
+func (s *fakeSearcher) SearchIssues(_ string) ([]*github.Issue, error) {
+	s.calls++
+	return s.issues, s.err
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func makeIssue(id int64, number int, repo string, labels []string, assignees []string) *github.Issue {
+	lbls := make([]github.Label, len(labels))
+	for i, l := range labels {
+		lbls[i] = github.Label{Name: l}
+	}
+	asgs := make([]github.User, len(assignees))
+	for i, a := range assignees {
+		asgs[i] = github.User{Login: a}
+	}
+	return &github.Issue{
+		ID:        id,
+		Number:    number,
+		Title:     "issue",
+		State:     "open",
+		Repo:      repo,
+		Labels:    lbls,
+		Assignees: asgs,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+func searchCfg() config.IssueTrackingConfig {
+	return config.IssueTrackingConfig{
+		Enabled:          true,
+		FilterMode:       config.FilterModeExclusive,
+		DevelopLabels:    []string{"bug"},
+		ReviewOnlyLabels: []string{"question"},
+		SkipLabels:       []string{"wontfix"},
+		DefaultAction:    string(config.IssueModeIgnore),
+	}
+}
+
+// ── PrefetchIssues tests ──────────────────────────────────────────────────────
+
+func TestPrefetchIssues_PopulatesMapByRepo(t *testing.T) {
+	searcher := &fakeSearcher{
+		issues: []*github.Issue{
+			makeIssue(1, 1, "org/repo-a", []string{"bug"}, nil),
+			makeIssue(2, 2, "org/repo-b", []string{"bug"}, nil),
+			makeIssue(3, 3, "org/repo-a", []string{"bug"}, nil),
+		},
+	}
+	client := &fakeClient{}
+	fetcher := issues.NewFetcher(client, nil, &fakeDedup{}, nil)
+	fetcher.SetSearcher(searcher)
+
+	byRepo, err := fetcher.PrefetchIssues(searchCfg(), "alice", []string{"org/repo-a", "org/repo-b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(byRepo["org/repo-a"]) != 2 {
+		t.Errorf("expected 2 issues for org/repo-a, got %d", len(byRepo["org/repo-a"]))
+	}
+	if len(byRepo["org/repo-b"]) != 1 {
+		t.Errorf("expected 1 issue for org/repo-b, got %d", len(byRepo["org/repo-b"]))
+	}
+	if searcher.calls != 1 {
+		t.Errorf("expected exactly 1 SearchIssues call, got %d", searcher.calls)
+	}
+}
+
+func TestPrefetchIssues_NilSearcherReturnsNil(t *testing.T) {
+	fetcher := issues.NewFetcher(&fakeClient{}, nil, &fakeDedup{}, nil)
+	// no SetSearcher call
+
+	byRepo, err := fetcher.PrefetchIssues(searchCfg(), "alice", []string{"org/repo"})
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if byRepo != nil {
+		t.Errorf("expected nil map when no searcher, got %v", byRepo)
+	}
+}
+
+func TestPrefetchIssues_SearchErrorPropagated(t *testing.T) {
+	searchErr := errors.New("search rate limited")
+	searcher := &fakeSearcher{err: searchErr}
+	fetcher := issues.NewFetcher(&fakeClient{}, nil, &fakeDedup{}, nil)
+	fetcher.SetSearcher(searcher)
+
+	_, err := fetcher.PrefetchIssues(searchCfg(), "alice", []string{"org/repo"})
+	if err == nil {
+		t.Fatal("expected error to be propagated, got nil")
+	}
+}
+
+func TestPrefetchIssues_EmptyReposListReturnsNil(t *testing.T) {
+	searcher := &fakeSearcher{} // should not be called
+	fetcher := issues.NewFetcher(&fakeClient{}, nil, &fakeDedup{}, nil)
+	fetcher.SetSearcher(searcher)
+
+	byRepo, err := fetcher.PrefetchIssues(searchCfg(), "alice", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if byRepo != nil {
+		t.Errorf("expected nil for empty repos list, got %v", byRepo)
+	}
+	if searcher.calls != 0 {
+		t.Errorf("expected 0 SearchIssues calls for empty repos, got %d", searcher.calls)
+	}
+}
+
+// ── ProcessRepo prefetch path tests ──────────────────────────────────────────
+
+// TestProcessRepo_UsesPrefetchedResults verifies that when a prefetch map is
+// populated for a repo, ProcessRepo does NOT call FetchIssues for that repo.
+func TestProcessRepo_UsesPrefetchedResults(t *testing.T) {
+	// Searcher returns one issue for org/repo.
+	searcher := &fakeSearcher{
+		issues: []*github.Issue{
+			makeIssue(1, 1, "org/repo", []string{"bug"}, []string{"alice"}),
+		},
+	}
+	// REST client has a different issue — presence of its number in the
+	// dispatched set would mean FetchIssues was incorrectly used.
+	restClient := &fakeClient{
+		issues: []*github.Issue{
+			makeIssue(99, 99, "org/repo", []string{"bug"}, []string{"alice"}),
+		},
+	}
+	pipe := &fakePipeline{}
+
+	fetcher := issues.NewFetcher(restClient, nil, &fakeDedup{}, pipe)
+	fetcher.SetSearcher(searcher)
+
+	cfg := searchCfg()
+	cfg.Assignees = []string{"alice"}
+
+	// Warm the prefetch.
+	if _, err := fetcher.PrefetchIssues(cfg, "alice", []string{"org/repo"}); err != nil {
+		t.Fatalf("PrefetchIssues failed: %v", err)
+	}
+
+	// ProcessRepo should consume from prefetch, NOT call FetchIssues.
+	optsFor := func(_ *github.Issue) (issues.RunOptions, bool) {
+		return issues.RunOptions{}, true
+	}
+	n, err := fetcher.ProcessRepo(context.Background(), "org/repo", cfg, "alice", optsFor)
+	if err != nil {
+		t.Fatalf("ProcessRepo failed: %v", err)
+	}
+
+	if restClient.calls != 0 {
+		t.Errorf("FetchIssues should NOT have been called when prefetch map is warm; got %d calls", restClient.calls)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 dispatched issue from prefetch, got %d", n)
+	}
+	// The pipeline should have been called with the prefetched issue (number 1),
+	// not the REST issue (number 99).
+	if len(pipe.calls) != 1 || pipe.calls[0] != 1 {
+		t.Errorf("pipeline should have received issue #1 from prefetch, got calls %v", pipe.calls)
+	}
+}
+
+// TestProcessRepo_FallsBackToFetchIssuesWhenNoPrefetch verifies that when there
+// is no prefetch entry for a repo, ProcessRepo falls back to FetchIssues.
+func TestProcessRepo_FallsBackToFetchIssuesWhenNoPrefetch(t *testing.T) {
+	restClient := &fakeClient{
+		issues: []*github.Issue{
+			makeIssue(5, 5, "org/repo", []string{"bug"}, nil),
+		},
+	}
+	pipe := &fakePipeline{}
+	fetcher := issues.NewFetcher(restClient, nil, &fakeDedup{}, pipe)
+	// no SetSearcher / no PrefetchIssues — map is nil
+
+	cfg := searchCfg()
+	// ProcessRepo requires at least one assignee; provide the auth user as fallback.
+	optsFor := func(_ *github.Issue) (issues.RunOptions, bool) {
+		return issues.RunOptions{}, true
+	}
+	if _, err := fetcher.ProcessRepo(context.Background(), "org/repo", cfg, "alice", optsFor); err != nil {
+		t.Fatalf("ProcessRepo failed: %v", err)
+	}
+	if restClient.calls != 1 {
+		t.Errorf("FetchIssues should have been called as fallback; got %d calls", restClient.calls)
+	}
+}
+
+// TestProcessRepo_FallsBackWhenSearchErrors verifies that a failed PrefetchIssues
+// leaves the prefetch map nil so ProcessRepo falls back to per-repo FetchIssues.
+func TestProcessRepo_FallsBackWhenSearchErrors(t *testing.T) {
+	searcher := &fakeSearcher{err: errors.New("search unavailable")}
+	restClient := &fakeClient{
+		issues: []*github.Issue{
+			makeIssue(7, 7, "org/repo", []string{"bug"}, nil),
+		},
+	}
+	pipe := &fakePipeline{}
+	fetcher := issues.NewFetcher(restClient, nil, &fakeDedup{}, pipe)
+	fetcher.SetSearcher(searcher)
+
+	cfg := searchCfg()
+
+	// PrefetchIssues returns an error — prefetch map stays nil.
+	if _, err := fetcher.PrefetchIssues(cfg, "alice", []string{"org/repo"}); err == nil {
+		t.Fatal("expected PrefetchIssues to return the search error")
+	}
+
+	optsFor := func(_ *github.Issue) (issues.RunOptions, bool) {
+		return issues.RunOptions{}, true
+	}
+	// Use "alice" so the assignee scope check passes.
+	if _, err := fetcher.ProcessRepo(context.Background(), "org/repo", cfg, "alice", optsFor); err != nil {
+		t.Fatalf("ProcessRepo failed: %v", err)
+	}
+	if restClient.calls != 1 {
+		t.Errorf("FetchIssues fallback should have run; got %d calls", restClient.calls)
+	}
+}
+
+// TestClearPrefetch_PreventsStaleReuseAcrossCycles verifies that ClearPrefetch
+// removes the map so the next cycle's ProcessRepo falls back to FetchIssues.
+func TestClearPrefetch_PreventsStaleReuseAcrossCycles(t *testing.T) {
+	searcher := &fakeSearcher{
+		issues: []*github.Issue{
+			makeIssue(1, 1, "org/repo", []string{"bug"}, []string{"alice"}),
+		},
+	}
+	restClient := &fakeClient{
+		issues: []*github.Issue{
+			makeIssue(2, 2, "org/repo", []string{"bug"}, []string{"alice"}),
+		},
+	}
+	pipe := &fakePipeline{}
+	fetcher := issues.NewFetcher(restClient, nil, &fakeDedup{}, pipe)
+	fetcher.SetSearcher(searcher)
+
+	cfg := searchCfg()
+	cfg.Assignees = []string{"alice"}
+	optsFor := func(_ *github.Issue) (issues.RunOptions, bool) { return issues.RunOptions{}, true }
+
+	// Cycle 1: prefetch active — FetchIssues must NOT be called.
+	fetcher.PrefetchIssues(cfg, "alice", []string{"org/repo"}) //nolint:errcheck
+	fetcher.ProcessRepo(context.Background(), "org/repo", cfg, "alice", optsFor) //nolint:errcheck
+	if restClient.calls != 0 {
+		t.Fatalf("cycle 1: FetchIssues should not be called when prefetch warm; got %d", restClient.calls)
+	}
+
+	// Clear the prefetch.
+	fetcher.ClearPrefetch()
+
+	// Cycle 2: prefetch gone — FetchIssues must be called.
+	fetcher.ProcessRepo(context.Background(), "org/repo", cfg, "alice", optsFor) //nolint:errcheck
+	if restClient.calls != 1 {
+		t.Errorf("cycle 2: FetchIssues should be called after ClearPrefetch; got %d calls", restClient.calls)
+	}
+}
+
+// TestPrefetchIssues_ClassifyAndFilterApplied verifies that search results are
+// classified and filtered before being stored, so ProcessRepo only sees eligible
+// issues from the prefetch map.
+func TestPrefetchIssues_ClassifyAndFilterApplied(t *testing.T) {
+	searcher := &fakeSearcher{
+		issues: []*github.Issue{
+			// Should pass: label=bug, assignee=alice
+			makeIssue(1, 1, "org/repo", []string{"bug"}, []string{"alice"}),
+			// Should be dropped by skip label filter
+			makeIssue(2, 2, "org/repo", []string{"wontfix"}, []string{"alice"}),
+			// Should be dropped: assignee filter (only alice is allowed)
+			makeIssue(3, 3, "org/repo", []string{"bug"}, []string{"bob"}),
+		},
+	}
+
+	restClient := &fakeClient{}
+	pipe := &fakePipeline{}
+
+	fetcher := issues.NewFetcher(restClient, nil, &fakeDedup{}, pipe)
+	fetcher.SetSearcher(searcher)
+
+	cfg := searchCfg()
+	cfg.Assignees = []string{"alice"}
+
+	if _, err := fetcher.PrefetchIssues(cfg, "alice", []string{"org/repo"}); err != nil {
+		t.Fatalf("PrefetchIssues failed: %v", err)
+	}
+
+	optsFor := func(_ *github.Issue) (issues.RunOptions, bool) {
+		return issues.RunOptions{}, true
+	}
+	n, err := fetcher.ProcessRepo(context.Background(), "org/repo", cfg, "alice", optsFor)
+	if err != nil {
+		t.Fatalf("ProcessRepo failed: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 dispatched issue after classify+filter, got %d", n)
+	}
+	if len(pipe.calls) != 1 || pipe.calls[0] != 1 {
+		t.Errorf("expected only issue #1 dispatched, got %v", pipe.calls)
+	}
+}

--- a/daemon/internal/issues/prefetch_test.go
+++ b/daemon/internal/issues/prefetch_test.go
@@ -3,6 +3,7 @@ package issues_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,15 +14,33 @@ import (
 
 // ── fakeSearcher ─────────────────────────────────────────────────────────────
 
+// fakeSearcher records every query it receives so tests can assert the
+// correct number and shape of queries.
 type fakeSearcher struct {
+	// issues is returned for every call unless perQueryIssues is set.
 	issues []*github.Issue
 	err    error
 	calls  int
+	// queries records the raw query strings passed to each SearchIssues call.
+	queries []string
+	// perQueryIssues maps query index (0-based) to a custom result. When set,
+	// the corresponding call returns that slice instead of f.issues.
+	perQueryIssues map[int][]*github.Issue
 }
 
-func (s *fakeSearcher) SearchIssues(_ string) ([]*github.Issue, error) {
+func (s *fakeSearcher) SearchIssues(query string) ([]*github.Issue, error) {
+	idx := s.calls
 	s.calls++
-	return s.issues, s.err
+	s.queries = append(s.queries, query)
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.perQueryIssues != nil {
+		if specific, ok := s.perQueryIssues[idx]; ok {
+			return specific, nil
+		}
+	}
+	return s.issues, nil
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -59,6 +78,22 @@ func searchCfg() config.IssueTrackingConfig {
 	}
 }
 
+// simpleEligibleFn builds an issues.EligibleFn that returns the same cfg for
+// every repo in the allowed set (autonomous=false, ok=true) and ok=false for
+// any repo not in the set. Pass nil to allow all repos.
+func simpleEligibleFn(cfg config.IssueTrackingConfig, allowed []string) issues.EligibleFn {
+	set := make(map[string]bool, len(allowed))
+	for _, r := range allowed {
+		set[r] = true
+	}
+	return func(repo string) (config.IssueTrackingConfig, bool, bool) {
+		if len(set) > 0 && !set[repo] {
+			return config.IssueTrackingConfig{}, false, false
+		}
+		return cfg, false, true
+	}
+}
+
 // ── PrefetchIssues tests ──────────────────────────────────────────────────────
 
 func TestPrefetchIssues_PopulatesMapByRepo(t *testing.T) {
@@ -73,7 +108,8 @@ func TestPrefetchIssues_PopulatesMapByRepo(t *testing.T) {
 	fetcher := issues.NewFetcher(client, nil, &fakeDedup{}, nil)
 	fetcher.SetSearcher(searcher)
 
-	byRepo, err := fetcher.PrefetchIssues(searchCfg(), "alice", []string{"org/repo-a", "org/repo-b"})
+	repos := []string{"org/repo-a", "org/repo-b"}
+	byRepo, err := fetcher.PrefetchIssues(simpleEligibleFn(searchCfg(), repos), "alice", repos)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -92,7 +128,8 @@ func TestPrefetchIssues_NilSearcherReturnsNil(t *testing.T) {
 	fetcher := issues.NewFetcher(&fakeClient{}, nil, &fakeDedup{}, nil)
 	// no SetSearcher call
 
-	byRepo, err := fetcher.PrefetchIssues(searchCfg(), "alice", []string{"org/repo"})
+	repos := []string{"org/repo"}
+	byRepo, err := fetcher.PrefetchIssues(simpleEligibleFn(searchCfg(), repos), "alice", repos)
 	if err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
@@ -107,7 +144,8 @@ func TestPrefetchIssues_SearchErrorPropagated(t *testing.T) {
 	fetcher := issues.NewFetcher(&fakeClient{}, nil, &fakeDedup{}, nil)
 	fetcher.SetSearcher(searcher)
 
-	_, err := fetcher.PrefetchIssues(searchCfg(), "alice", []string{"org/repo"})
+	repos := []string{"org/repo"}
+	_, err := fetcher.PrefetchIssues(simpleEligibleFn(searchCfg(), repos), "alice", repos)
 	if err == nil {
 		t.Fatal("expected error to be propagated, got nil")
 	}
@@ -118,7 +156,7 @@ func TestPrefetchIssues_EmptyReposListReturnsNil(t *testing.T) {
 	fetcher := issues.NewFetcher(&fakeClient{}, nil, &fakeDedup{}, nil)
 	fetcher.SetSearcher(searcher)
 
-	byRepo, err := fetcher.PrefetchIssues(searchCfg(), "alice", nil)
+	byRepo, err := fetcher.PrefetchIssues(simpleEligibleFn(searchCfg(), nil), "alice", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -156,8 +194,9 @@ func TestProcessRepo_UsesPrefetchedResults(t *testing.T) {
 	cfg := searchCfg()
 	cfg.Assignees = []string{"alice"}
 
+	repos := []string{"org/repo"}
 	// Warm the prefetch.
-	if _, err := fetcher.PrefetchIssues(cfg, "alice", []string{"org/repo"}); err != nil {
+	if _, err := fetcher.PrefetchIssues(simpleEligibleFn(cfg, repos), "alice", repos); err != nil {
 		t.Fatalf("PrefetchIssues failed: %v", err)
 	}
 
@@ -208,6 +247,46 @@ func TestProcessRepo_FallsBackToFetchIssuesWhenNoPrefetch(t *testing.T) {
 	}
 }
 
+// TestProcessRepo_FallsBackWhenPrefetchMapNonNilButKeyAbsent verifies that
+// ProcessRepo falls back to per-repo FetchIssues when the prefetch map is
+// non-nil but does not contain the repo. This covers the case where the search
+// API returned 0 results for that repo (e.g., over the 1000-issue cap within
+// its group).
+func TestProcessRepo_FallsBackWhenPrefetchMapNonNilButKeyAbsent(t *testing.T) {
+	// Prefetch is warm for org/other-repo but NOT for org/repo.
+	searcher := &fakeSearcher{
+		issues: []*github.Issue{
+			makeIssue(10, 10, "org/other-repo", []string{"bug"}, []string{"alice"}),
+		},
+	}
+	restClient := &fakeClient{
+		issues: []*github.Issue{
+			makeIssue(7, 7, "org/repo", []string{"bug"}, nil),
+		},
+	}
+	pipe := &fakePipeline{}
+	fetcher := issues.NewFetcher(restClient, nil, &fakeDedup{}, pipe)
+	fetcher.SetSearcher(searcher)
+
+	cfg := searchCfg()
+	cfg.Assignees = []string{"alice"}
+
+	// Prefetch covers org/other-repo, not org/repo.
+	repos := []string{"org/other-repo", "org/repo"}
+	if _, err := fetcher.PrefetchIssues(simpleEligibleFn(cfg, repos), "alice", repos); err != nil {
+		t.Fatalf("PrefetchIssues failed: %v", err)
+	}
+
+	optsFor := func(_ *github.Issue) (issues.RunOptions, bool) { return issues.RunOptions{}, true }
+	// ProcessRepo for org/repo — prefetch map exists but org/repo key is absent.
+	if _, err := fetcher.ProcessRepo(context.Background(), "org/repo", cfg, "alice", optsFor); err != nil {
+		t.Fatalf("ProcessRepo failed: %v", err)
+	}
+	if restClient.calls != 1 {
+		t.Errorf("FetchIssues fallback should have fired for absent key; got %d calls", restClient.calls)
+	}
+}
+
 // TestProcessRepo_FallsBackWhenSearchErrors verifies that a failed PrefetchIssues
 // leaves the prefetch map nil so ProcessRepo falls back to per-repo FetchIssues.
 func TestProcessRepo_FallsBackWhenSearchErrors(t *testing.T) {
@@ -223,8 +302,9 @@ func TestProcessRepo_FallsBackWhenSearchErrors(t *testing.T) {
 
 	cfg := searchCfg()
 
+	repos := []string{"org/repo"}
 	// PrefetchIssues returns an error — prefetch map stays nil.
-	if _, err := fetcher.PrefetchIssues(cfg, "alice", []string{"org/repo"}); err == nil {
+	if _, err := fetcher.PrefetchIssues(simpleEligibleFn(cfg, repos), "alice", repos); err == nil {
 		t.Fatal("expected PrefetchIssues to return the search error")
 	}
 
@@ -261,8 +341,9 @@ func TestClearPrefetch_PreventsStaleReuseAcrossCycles(t *testing.T) {
 	cfg.Assignees = []string{"alice"}
 	optsFor := func(_ *github.Issue) (issues.RunOptions, bool) { return issues.RunOptions{}, true }
 
+	repos := []string{"org/repo"}
 	// Cycle 1: prefetch active — FetchIssues must NOT be called.
-	fetcher.PrefetchIssues(cfg, "alice", []string{"org/repo"}) //nolint:errcheck
+	fetcher.PrefetchIssues(simpleEligibleFn(cfg, repos), "alice", repos) //nolint:errcheck
 	fetcher.ProcessRepo(context.Background(), "org/repo", cfg, "alice", optsFor) //nolint:errcheck
 	if restClient.calls != 0 {
 		t.Fatalf("cycle 1: FetchIssues should not be called when prefetch warm; got %d", restClient.calls)
@@ -302,7 +383,8 @@ func TestPrefetchIssues_ClassifyAndFilterApplied(t *testing.T) {
 	cfg := searchCfg()
 	cfg.Assignees = []string{"alice"}
 
-	if _, err := fetcher.PrefetchIssues(cfg, "alice", []string{"org/repo"}); err != nil {
+	repos := []string{"org/repo"}
+	if _, err := fetcher.PrefetchIssues(simpleEligibleFn(cfg, repos), "alice", repos); err != nil {
 		t.Fatalf("PrefetchIssues failed: %v", err)
 	}
 
@@ -318,5 +400,226 @@ func TestPrefetchIssues_ClassifyAndFilterApplied(t *testing.T) {
 	}
 	if len(pipe.calls) != 1 || pipe.calls[0] != 1 {
 		t.Errorf("expected only issue #1 dispatched, got %v", pipe.calls)
+	}
+}
+
+// ── Group-by-assignee-set tests ───────────────────────────────────────────────
+
+// TestPrefetchIssues_TwoGroupsIssuesTwoSearchCalls verifies that when two repos
+// have different effective assignee sets, PrefetchIssues issues TWO search
+// queries (one per group) and merges both repos' results into the prefetch map.
+func TestPrefetchIssues_TwoGroupsIssuesTwoSearchCalls(t *testing.T) {
+	// Group 1: org/global-repo uses global assignees ["alice"]
+	// Group 2: org/override-repo uses per-repo override assignees ["bob"]
+	globalCfg := config.IssueTrackingConfig{
+		Enabled:       true,
+		Assignees:     []string{"alice"},
+		DefaultAction: string(config.IssueModeIgnore),
+		DevelopLabels: []string{"bug"},
+	}
+	overrideCfg := config.IssueTrackingConfig{
+		Enabled:       true,
+		Assignees:     []string{"bob"},
+		DefaultAction: string(config.IssueModeIgnore),
+		DevelopLabels: []string{"bug"},
+	}
+
+	searcher := &fakeSearcher{
+		perQueryIssues: map[int][]*github.Issue{
+			// First query (group: alice): returns issue for org/global-repo
+			0: {makeIssue(1, 1, "org/global-repo", []string{"bug"}, []string{"alice"})},
+			// Second query (group: bob): returns issue for org/override-repo
+			1: {makeIssue(2, 2, "org/override-repo", []string{"bug"}, []string{"bob"})},
+		},
+	}
+	fetcher := issues.NewFetcher(&fakeClient{}, nil, &fakeDedup{}, nil)
+	fetcher.SetSearcher(searcher)
+
+	repos := []string{"org/global-repo", "org/override-repo"}
+	eligibleFn := func(repo string) (config.IssueTrackingConfig, bool, bool) {
+		switch repo {
+		case "org/global-repo":
+			return globalCfg, false, true
+		case "org/override-repo":
+			return overrideCfg, false, true
+		default:
+			return config.IssueTrackingConfig{}, false, false
+		}
+	}
+
+	byRepo, err := fetcher.PrefetchIssues(eligibleFn, "alice", repos)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Two distinct assignee sets → two search queries.
+	if searcher.calls != 2 {
+		t.Errorf("expected 2 SearchIssues calls (one per assignee group), got %d", searcher.calls)
+	}
+
+	// Both repos' issues must be in the prefetch map.
+	if len(byRepo["org/global-repo"]) != 1 {
+		t.Errorf("expected 1 issue for org/global-repo, got %d", len(byRepo["org/global-repo"]))
+	}
+	if len(byRepo["org/override-repo"]) != 1 {
+		t.Errorf("expected 1 issue for org/override-repo, got %d", len(byRepo["org/override-repo"]))
+	}
+
+	// Each query must use the correct assignee scope.
+	globalQuery := searcher.queries[0]
+	overrideQuery := searcher.queries[1]
+	// Determine which query is for which group (order is deterministic but
+	// depends on group key sort — check both queries collectively).
+	allQueries := globalQuery + " " + overrideQuery
+	if !strings.Contains(allQueries, "assignee:alice") {
+		t.Errorf("expected assignee:alice in one of the queries, got: %v", searcher.queries)
+	}
+	if !strings.Contains(allQueries, "assignee:bob") {
+		t.Errorf("expected assignee:bob in one of the queries, got: %v", searcher.queries)
+	}
+}
+
+// TestPrefetchIssues_PerRepoOverrideAssigneeIssueNotDropped verifies the core
+// correctness fix: an issue assigned to a per-repo-override assignee is present
+// in that repo's prefetched results even when the global assignees are different.
+// Before the fix, the single-query path would miss such issues if the prefetch
+// map already had an entry for that repo (from global-assignee issues), causing
+// silently dropped issues.
+func TestPrefetchIssues_PerRepoOverrideAssigneeIssueNotDropped(t *testing.T) {
+	globalCfg := config.IssueTrackingConfig{
+		Enabled:       true,
+		Assignees:     []string{"alice"},
+		DefaultAction: string(config.IssueModeIgnore),
+		DevelopLabels: []string{"bug"},
+	}
+	overrideCfg := config.IssueTrackingConfig{
+		Enabled:       true,
+		Assignees:     []string{"bob"},
+		DefaultAction: string(config.IssueModeIgnore),
+		DevelopLabels: []string{"bug"},
+	}
+
+	// The searcher returns an issue assigned to "bob" for org/override-repo.
+	searcher := &fakeSearcher{
+		perQueryIssues: map[int][]*github.Issue{
+			0: {makeIssue(1, 1, "org/global-repo", []string{"bug"}, []string{"alice"})},
+			1: {makeIssue(2, 2, "org/override-repo", []string{"bug"}, []string{"bob"})},
+		},
+	}
+	restClient := &fakeClient{}
+	pipe := &fakePipeline{}
+	fetcher := issues.NewFetcher(restClient, nil, &fakeDedup{}, pipe)
+	fetcher.SetSearcher(searcher)
+
+	repos := []string{"org/global-repo", "org/override-repo"}
+	eligibleFn := func(repo string) (config.IssueTrackingConfig, bool, bool) {
+		switch repo {
+		case "org/global-repo":
+			return globalCfg, false, true
+		case "org/override-repo":
+			return overrideCfg, false, true
+		default:
+			return config.IssueTrackingConfig{}, false, false
+		}
+	}
+
+	if _, err := fetcher.PrefetchIssues(eligibleFn, "alice", repos); err != nil {
+		t.Fatalf("PrefetchIssues failed: %v", err)
+	}
+
+	// ProcessRepo for org/override-repo must use prefetched results and
+	// classify/filter them with the override config (assignee=bob).
+	optsFor := func(_ *github.Issue) (issues.RunOptions, bool) { return issues.RunOptions{}, true }
+	n, err := fetcher.ProcessRepo(context.Background(), "org/override-repo", overrideCfg, "alice", optsFor)
+	if err != nil {
+		t.Fatalf("ProcessRepo(org/override-repo) failed: %v", err)
+	}
+	// The bob-assigned issue must have been dispatched.
+	if n != 1 {
+		t.Errorf("expected 1 dispatched issue for org/override-repo (bob-assigned), got %d", n)
+	}
+	if restClient.calls != 0 {
+		t.Errorf("FetchIssues should NOT have been called (prefetch was populated); got %d calls", restClient.calls)
+	}
+}
+
+// TestPrefetchIssues_SharedAssigneeSetRunsOneQuery verifies that repos sharing
+// the same effective assignees are batched into a single search query.
+func TestPrefetchIssues_SharedAssigneeSetRunsOneQuery(t *testing.T) {
+	sharedCfg := config.IssueTrackingConfig{
+		Enabled:       true,
+		Assignees:     []string{"alice"},
+		DefaultAction: string(config.IssueModeIgnore),
+		DevelopLabels: []string{"bug"},
+	}
+
+	searcher := &fakeSearcher{
+		issues: []*github.Issue{
+			makeIssue(1, 1, "org/repo-a", []string{"bug"}, []string{"alice"}),
+			makeIssue(2, 2, "org/repo-b", []string{"bug"}, []string{"alice"}),
+		},
+	}
+	fetcher := issues.NewFetcher(&fakeClient{}, nil, &fakeDedup{}, nil)
+	fetcher.SetSearcher(searcher)
+
+	repos := []string{"org/repo-a", "org/repo-b"}
+	if _, err := fetcher.PrefetchIssues(simpleEligibleFn(sharedCfg, repos), "alice", repos); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Same assignees → one query covering both repos.
+	if searcher.calls != 1 {
+		t.Errorf("expected 1 SearchIssues call for shared assignee set, got %d", searcher.calls)
+	}
+	// Both repos must appear in the single query.
+	if len(searcher.queries) == 0 {
+		t.Fatal("no queries recorded")
+	}
+	q := searcher.queries[0]
+	if !strings.Contains(q, "repo:org/repo-a") {
+		t.Errorf("expected repo:org/repo-a in query, got %q", q)
+	}
+	if !strings.Contains(q, "repo:org/repo-b") {
+		t.Errorf("expected repo:org/repo-b in query, got %q", q)
+	}
+}
+
+// ── BuildAggregatedSearchQuery tests ─────────────────────────────────────────
+
+// TestBuildAggregatedSearchQuery_NoLabelQualifiers verifies that the aggregated
+// search query contains assignee and repo scope but NO label qualifiers.
+func TestBuildAggregatedSearchQuery_NoLabelQualifiers(t *testing.T) {
+	q := github.BuildAggregatedSearchQuery([]string{"alice"}, []string{"org/repo"})
+	if strings.Contains(q, "label:") {
+		t.Errorf("aggregated query must not contain label qualifiers, got %q", q)
+	}
+	if !strings.Contains(q, "is:issue") {
+		t.Errorf("expected is:issue, got %q", q)
+	}
+	if !strings.Contains(q, "is:open") {
+		t.Errorf("expected is:open, got %q", q)
+	}
+	if !strings.Contains(q, "assignee:alice") {
+		t.Errorf("expected assignee:alice, got %q", q)
+	}
+	if !strings.Contains(q, "repo:org/repo") {
+		t.Errorf("expected repo:org/repo, got %q", q)
+	}
+}
+
+// TestBuildAggregatedSearchQuery_MultipleAssigneesAndRepos verifies that
+// multiple assignees and repos are all included in the query.
+func TestBuildAggregatedSearchQuery_MultipleAssigneesAndRepos(t *testing.T) {
+	q := github.BuildAggregatedSearchQuery(
+		[]string{"alice", "bob"},
+		[]string{"org/repo-a", "org/repo-b"},
+	)
+	for _, expected := range []string{"assignee:alice", "assignee:bob", "repo:org/repo-a", "repo:org/repo-b"} {
+		if !strings.Contains(q, expected) {
+			t.Errorf("expected %q in query, got %q", expected, q)
+		}
+	}
+	if strings.Contains(q, "label:") {
+		t.Errorf("no label qualifiers expected, got %q", q)
 	}
 }

--- a/daemon/internal/scheduler/adaptive.go
+++ b/daemon/internal/scheduler/adaptive.go
@@ -1,0 +1,164 @@
+package scheduler
+
+import (
+	"sync"
+	"time"
+)
+
+// repoState tracks the adaptive scheduling state for a single repo.
+type repoState struct {
+	interval time.Duration
+	nextDue  time.Time
+}
+
+// AdaptiveScheduler tracks per-repo polling cadence and adjusts it based on
+// observed activity. Repos with actionable work are polled at the minimum
+// interval; idle repos are backed off exponentially toward the maximum.
+//
+// The zero value is not usable — always construct via NewAdaptiveScheduler.
+//
+// All methods are safe for concurrent use.
+type AdaptiveScheduler struct {
+	min    time.Duration
+	max    time.Duration
+	factor float64
+
+	mu    sync.Mutex
+	state map[string]*repoState
+}
+
+// NewAdaptiveScheduler creates an AdaptiveScheduler with the given min/max
+// bounds and a default growth factor of 2× (interval doubles each idle cycle).
+// min must be positive; if max < min, max is clamped to min.
+func NewAdaptiveScheduler(min, max time.Duration) *AdaptiveScheduler {
+	if min <= 0 {
+		min = time.Minute
+	}
+	if max < min {
+		max = min
+	}
+	return &AdaptiveScheduler{
+		min:    min,
+		max:    max,
+		factor: 2.0,
+		state:  make(map[string]*repoState),
+	}
+}
+
+// Due returns the subset of keys whose next scheduled poll is at or before now.
+// Keys that have never been seen are treated as immediately due and are
+// initialised with the minimum interval; their nextDue is set to now+min so
+// the NEXT call to Due respects the cadence.
+func (a *AdaptiveScheduler) Due(now time.Time, keys []string) []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		st, exists := a.state[k]
+		if !exists {
+			// New key: due immediately, schedule next poll at now+min.
+			a.state[k] = &repoState{
+				interval: a.min,
+				nextDue:  now.Add(a.min),
+			}
+			out = append(out, k)
+			continue
+		}
+		if !now.Before(st.nextDue) {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// MarkActive records that key had actionable work this cycle. The interval is
+// reset to min and nextDue is set to now+min (the repo will be polled again
+// quickly).
+func (a *AdaptiveScheduler) MarkActive(key string, now time.Time) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	st := a.getOrCreate(key, now)
+	st.interval = a.min
+	st.nextDue = now.Add(a.min)
+}
+
+// MarkIdle records that key had no actionable work this cycle. The interval is
+// grown by the growth factor (default 2×) and capped at max; nextDue is set to
+// now+newInterval.
+func (a *AdaptiveScheduler) MarkIdle(key string, now time.Time) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	st := a.getOrCreate(key, now)
+	next := time.Duration(float64(st.interval) * a.factor)
+	if next > a.max {
+		next = a.max
+	}
+	if next < a.min {
+		next = a.min
+	}
+	st.interval = next
+	st.nextDue = now.Add(next)
+}
+
+// Forget removes key from the scheduler. Subsequent calls to Due will treat it
+// as a new, immediately-due key. Use this to keep memory bounded when repos are
+// removed from monitoring.
+func (a *AdaptiveScheduler) Forget(key string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.state, key)
+}
+
+// PruneAbsent removes any key from the scheduler that is NOT in the provided
+// set. This prevents unbounded memory growth when repos are removed from
+// monitoring over time. O(len(state) + len(active)).
+func (a *AdaptiveScheduler) PruneAbsent(active []string) {
+	if len(active) == 0 {
+		a.mu.Lock()
+		a.state = make(map[string]*repoState)
+		a.mu.Unlock()
+		return
+	}
+	set := make(map[string]struct{}, len(active))
+	for _, k := range active {
+		set[k] = struct{}{}
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for k := range a.state {
+		if _, ok := set[k]; !ok {
+			delete(a.state, k)
+		}
+	}
+}
+
+// Interval returns the current scheduled interval for key, or min if unknown.
+// Intended for observability / testing only.
+func (a *AdaptiveScheduler) Interval(key string) time.Duration {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if st, ok := a.state[key]; ok {
+		return st.interval
+	}
+	return a.min
+}
+
+// getOrCreate returns the state for key, creating a fresh entry at min interval
+// if absent. Caller must hold a.mu.
+func (a *AdaptiveScheduler) getOrCreate(key string, now time.Time) *repoState {
+	if st, ok := a.state[key]; ok {
+		return st
+	}
+	st := &repoState{
+		interval: a.min,
+		nextDue:  now.Add(a.min),
+	}
+	a.state[key] = st
+	return st
+}

--- a/daemon/internal/scheduler/adaptive.go
+++ b/daemon/internal/scheduler/adaptive.go
@@ -45,6 +45,24 @@ func NewAdaptiveScheduler(min, max time.Duration) *AdaptiveScheduler {
 	}
 }
 
+// UpdateBounds replaces the min/max interval bounds while preserving the
+// accumulated per-repo backoff state. Called on config reload so changes to
+// [polling].min_interval / max_interval take effect without a daemon restart.
+// Same clamping as the constructor (min positive; max >= min). Existing repo
+// intervals are left as-is and naturally re-clamp on the next MarkActive/MarkIdle.
+func (a *AdaptiveScheduler) UpdateBounds(min, max time.Duration) {
+	if min <= 0 {
+		min = time.Minute
+	}
+	if max < min {
+		max = min
+	}
+	a.mu.Lock()
+	a.min = min
+	a.max = max
+	a.mu.Unlock()
+}
+
 // Due returns the subset of keys whose next scheduled poll is at or before now.
 // Keys that have never been seen are treated as immediately due and are
 // initialised with the minimum interval; their nextDue is set to now+min so

--- a/daemon/internal/scheduler/adaptive_test.go
+++ b/daemon/internal/scheduler/adaptive_test.go
@@ -363,3 +363,27 @@ func TestAdaptive_IssueGating_OnlyDueReposProcessed(t *testing.T) {
 		t.Error("c/3: MarkActive at t0 → due at t0+min")
 	}
 }
+
+// TestAdaptiveScheduler_UpdateBounds verifies that UpdateBounds changes the
+// min/max applied to subsequent MarkActive/MarkIdle while preserving the
+// existing per-repo state map (no reset).
+func TestAdaptiveScheduler_UpdateBounds(t *testing.T) {
+	s := scheduler.NewAdaptiveScheduler(time.Minute, 10*time.Minute)
+	t0 := time.Unix(1_000_000, 0).UTC()
+
+	// Seed a repo (becomes known) and grow it idle.
+	s.Due(t0, []string{"r/1"})
+	s.MarkIdle("r/1", t0)
+
+	// Tighten bounds; existing state must survive (not pruned).
+	s.UpdateBounds(5*time.Second, 20*time.Second)
+
+	// MarkActive now resets to the NEW min (5s), not the old 1m.
+	s.MarkActive("r/1", t0)
+	if due := s.Due(t0.Add(6*time.Second), []string{"r/1"}); len(due) != 1 {
+		t.Errorf("after UpdateBounds(min=5s)+MarkActive, repo should be due at t0+6s, got %v", due)
+	}
+	if due := s.Due(t0.Add(4*time.Second), []string{"r/1"}); len(due) != 0 {
+		t.Errorf("repo should NOT be due at t0+4s (new min=5s), got %v", due)
+	}
+}

--- a/daemon/internal/scheduler/adaptive_test.go
+++ b/daemon/internal/scheduler/adaptive_test.go
@@ -1,0 +1,365 @@
+package scheduler_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/scheduler"
+)
+
+// ── basic construction ────────────────────────────────────────────────────
+
+func TestAdaptive_NewKeyDueImmediately(t *testing.T) {
+	now := time.Now()
+	s := scheduler.NewAdaptiveScheduler(time.Minute, 15*time.Minute)
+
+	due := s.Due(now, []string{"org/repo"})
+	if len(due) != 1 || due[0] != "org/repo" {
+		t.Fatalf("new key: want [org/repo], got %v", due)
+	}
+}
+
+func TestAdaptive_NewKeyDueImmediately_MultipleKeys(t *testing.T) {
+	now := time.Now()
+	s := scheduler.NewAdaptiveScheduler(time.Minute, 15*time.Minute)
+	repos := []string{"a/1", "b/2", "c/3"}
+
+	due := s.Due(now, repos)
+	if len(due) != len(repos) {
+		t.Fatalf("want %d new keys due, got %d: %v", len(repos), len(due), due)
+	}
+}
+
+// ── Due scheduling ─────────────────────────────────────────────────────────
+
+func TestAdaptive_DueReturnsOnlyDueKeys(t *testing.T) {
+	t0 := time.UnixMilli(0) // deterministic base
+	s := scheduler.NewAdaptiveScheduler(time.Minute, 15*time.Minute)
+
+	// First call: both keys are new → both are due.
+	due := s.Due(t0, []string{"a/1", "b/2"})
+	if len(due) != 2 {
+		t.Fatalf("first call: want 2, got %d", len(due))
+	}
+
+	// Second call at the same instant: neither is due yet (nextDue = t0+1m).
+	due = s.Due(t0, []string{"a/1", "b/2"})
+	if len(due) != 0 {
+		t.Fatalf("immediately after: want 0, got %d (%v)", len(due), due)
+	}
+
+	// Call at t0+1m: both are due again.
+	due = s.Due(t0.Add(time.Minute), []string{"a/1", "b/2"})
+	if len(due) != 2 {
+		t.Fatalf("at t0+1m: want 2, got %d (%v)", len(due), due)
+	}
+}
+
+func TestAdaptive_DueAtExactBoundary(t *testing.T) {
+	t0 := time.UnixMilli(0)
+	min := time.Minute
+	s := scheduler.NewAdaptiveScheduler(min, 15*time.Minute)
+
+	// Prime key.
+	s.Due(t0, []string{"r/1"})
+	// At exactly t0+min, the key should be due (nextDue = t0+min → !now.Before means >=).
+	due := s.Due(t0.Add(min), []string{"r/1"})
+	if len(due) != 1 {
+		t.Fatalf("at boundary: want 1 due, got %d", len(due))
+	}
+}
+
+// ── MarkActive ─────────────────────────────────────────────────────────────
+
+func TestAdaptive_MarkActive_ResetsToMin(t *testing.T) {
+	t0 := time.UnixMilli(0)
+	min := time.Minute
+	max := 15 * time.Minute
+	s := scheduler.NewAdaptiveScheduler(min, max)
+
+	// Prime key and let it go idle a few times (grows interval).
+	s.Due(t0, []string{"r/1"})
+	s.MarkIdle("r/1", t0)
+	s.MarkIdle("r/1", t0)
+	s.MarkIdle("r/1", t0)
+
+	if interval := s.Interval("r/1"); interval == min {
+		t.Log("MarkIdle didn't grow interval; test will still verify reset")
+	}
+
+	// Mark active: interval must reset to min.
+	s.MarkActive("r/1", t0)
+	if got := s.Interval("r/1"); got != min {
+		t.Fatalf("after MarkActive: interval = %v, want %v", got, min)
+	}
+}
+
+func TestAdaptive_MarkActive_NextDueIsNowPlusMin(t *testing.T) {
+	t0 := time.UnixMilli(0)
+	min := time.Minute
+	s := scheduler.NewAdaptiveScheduler(min, 15*time.Minute)
+
+	s.Due(t0, []string{"r/1"})
+	// Grow the interval first.
+	s.MarkIdle("r/1", t0)
+	s.MarkIdle("r/1", t0)
+
+	s.MarkActive("r/1", t0)
+
+	// Just before t0+min: not due.
+	due := s.Due(t0.Add(min-time.Millisecond), []string{"r/1"})
+	if len(due) != 0 {
+		t.Fatalf("before min: want 0 due, got %d", len(due))
+	}
+	// At t0+min: due.
+	due = s.Due(t0.Add(min), []string{"r/1"})
+	if len(due) != 1 {
+		t.Fatalf("at t0+min: want 1 due, got %d", len(due))
+	}
+}
+
+// ── MarkIdle ───────────────────────────────────────────────────────────────
+
+func TestAdaptive_MarkIdle_GrowsInterval(t *testing.T) {
+	t0 := time.UnixMilli(0)
+	min := time.Minute
+	s := scheduler.NewAdaptiveScheduler(min, 15*time.Minute)
+
+	// Prime.
+	s.Due(t0, []string{"r/1"})
+
+	s.MarkIdle("r/1", t0)
+	after1 := s.Interval("r/1")
+	if after1 <= min {
+		t.Fatalf("interval should grow after 1 idle: got %v, want > %v", after1, min)
+	}
+
+	s.MarkIdle("r/1", t0)
+	after2 := s.Interval("r/1")
+	if after2 <= after1 {
+		t.Fatalf("interval should grow after 2nd idle: got %v, want > %v", after2, after1)
+	}
+}
+
+func TestAdaptive_MarkIdle_CapsAtMax(t *testing.T) {
+	t0 := time.UnixMilli(0)
+	min := time.Minute
+	max := 4 * time.Minute
+	s := scheduler.NewAdaptiveScheduler(min, max)
+
+	s.Due(t0, []string{"r/1"})
+
+	// Drive idle many times — interval must never exceed max.
+	for i := 0; i < 20; i++ {
+		s.MarkIdle("r/1", t0)
+	}
+	if got := s.Interval("r/1"); got > max {
+		t.Fatalf("interval capped: got %v, want <= %v", got, max)
+	}
+	if got := s.Interval("r/1"); got != max {
+		t.Fatalf("interval at max after many idles: got %v, want %v", got, max)
+	}
+}
+
+func TestAdaptive_MarkIdle_NextDueExcludesBeforeNewInterval(t *testing.T) {
+	t0 := time.UnixMilli(0)
+	min := time.Minute
+	s := scheduler.NewAdaptiveScheduler(min, 15*time.Minute)
+
+	s.Due(t0, []string{"r/1"})
+	s.MarkIdle("r/1", t0) // interval grows to 2m
+
+	got := s.Interval("r/1")
+	// Should not be due before now+interval.
+	due := s.Due(t0.Add(got-time.Millisecond), []string{"r/1"})
+	if len(due) != 0 {
+		t.Fatalf("before nextDue: want 0, got %d", len(due))
+	}
+	// Should be due at now+interval.
+	due = s.Due(t0.Add(got), []string{"r/1"})
+	if len(due) != 1 {
+		t.Fatalf("at nextDue: want 1, got %d", len(due))
+	}
+}
+
+// ── Forget ─────────────────────────────────────────────────────────────────
+
+func TestAdaptive_Forget_ReturnsKeyToDueImmediately(t *testing.T) {
+	t0 := time.UnixMilli(0)
+	s := scheduler.NewAdaptiveScheduler(time.Minute, 15*time.Minute)
+
+	// Prime and advance interval.
+	s.Due(t0, []string{"r/1"})
+	s.MarkIdle("r/1", t0)
+	s.MarkIdle("r/1", t0)
+
+	// Not due at t0 (nextDue is in the future).
+	due := s.Due(t0, []string{"r/1"})
+	if len(due) != 0 {
+		t.Fatal("should not be due before forget")
+	}
+
+	// Forget: the key is now unknown → due immediately.
+	s.Forget("r/1")
+	due = s.Due(t0, []string{"r/1"})
+	if len(due) != 1 {
+		t.Fatalf("after Forget: want 1 due, got %d", len(due))
+	}
+}
+
+// ── PruneAbsent ────────────────────────────────────────────────────────────
+
+func TestAdaptive_PruneAbsent_RemovesGoneKeys(t *testing.T) {
+	t0 := time.UnixMilli(0)
+	s := scheduler.NewAdaptiveScheduler(time.Minute, 15*time.Minute)
+
+	s.Due(t0, []string{"a/1", "b/2", "c/3"})
+	s.PruneAbsent([]string{"a/1"}) // b/2 and c/3 removed
+
+	// a/1 is still tracked (not due yet at t0+tiny).
+	due := s.Due(t0.Add(time.Millisecond), []string{"a/1"})
+	if len(due) != 0 {
+		t.Fatal("a/1 should not be due immediately after prime+prune")
+	}
+
+	// b/2 and c/3 were pruned → new keys → due immediately.
+	due = s.Due(t0, []string{"b/2", "c/3"})
+	if len(due) != 2 {
+		t.Fatalf("pruned keys: want 2 due, got %d", len(due))
+	}
+}
+
+// ── concurrency ────────────────────────────────────────────────────────────
+
+func TestAdaptive_Concurrent_NoRaceOrDeadlock(t *testing.T) {
+	// This test is deliberately run with -race to detect data races.
+	s := scheduler.NewAdaptiveScheduler(time.Millisecond, 10*time.Millisecond)
+	repos := []string{"r/1", "r/2", "r/3", "r/4", "r/5"}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	var ops atomic.Int64
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			now := time.Now()
+			switch id % 4 {
+			case 0:
+				s.Due(now, repos)
+			case 1:
+				s.MarkActive(repos[id%len(repos)], now)
+			case 2:
+				s.MarkIdle(repos[id%len(repos)], now)
+			case 3:
+				s.PruneAbsent(repos[:3])
+			}
+			ops.Add(1)
+		}(i)
+	}
+	wg.Wait()
+	if ops.Load() != goroutines {
+		t.Fatalf("want %d ops, got %d", goroutines, ops.Load())
+	}
+}
+
+// ── edge cases ─────────────────────────────────────────────────────────────
+
+func TestAdaptive_MinEqualsMax_NeverGrows(t *testing.T) {
+	t0 := time.UnixMilli(0)
+	fixed := 5 * time.Minute
+	s := scheduler.NewAdaptiveScheduler(fixed, fixed)
+
+	s.Due(t0, []string{"r/1"})
+	for i := 0; i < 10; i++ {
+		s.MarkIdle("r/1", t0)
+	}
+	if got := s.Interval("r/1"); got != fixed {
+		t.Fatalf("min==max: interval = %v, want %v", got, fixed)
+	}
+}
+
+func TestAdaptive_EmptyKeyList_NoDue(t *testing.T) {
+	s := scheduler.NewAdaptiveScheduler(time.Minute, 15*time.Minute)
+	due := s.Due(time.Now(), nil)
+	if due != nil {
+		t.Fatalf("nil keys: want nil, got %v", due)
+	}
+	due = s.Due(time.Now(), []string{})
+	if due != nil {
+		t.Fatalf("empty keys: want nil, got %v", due)
+	}
+}
+
+func TestAdaptive_MaxLessThanMin_ClampedToMin(t *testing.T) {
+	// max < min should clamp max to min.
+	s := scheduler.NewAdaptiveScheduler(5*time.Minute, time.Minute)
+	t0 := time.UnixMilli(0)
+	s.Due(t0, []string{"r/1"})
+	for i := 0; i < 10; i++ {
+		s.MarkIdle("r/1", t0)
+	}
+	got := s.Interval("r/1")
+	if got < 5*time.Minute {
+		t.Fatalf("clamped max: interval = %v, want >= 5m", got)
+	}
+}
+
+// ── filterDueRepos helper ─────────────────────────────────────────────────
+
+// TestFilterDueRepos_* tests the tier2 gating helper function exported for
+// testability from cmd/heimdallm (or implemented inline here as a pure function
+// for demonstration). The actual gate lives in runIssueTier in main.go and calls
+// adaptiveSched.Due — this test verifies the expected filtering behaviour when
+// integrated at the seam, using AdaptiveScheduler directly.
+func TestAdaptive_IssueGating_OnlyDueReposProcessed(t *testing.T) {
+	// Simulate the tier2 adaptive gating decision:
+	// - 3 repos: a/1 and b/2 are new (due), c/3 was recently active (not yet due).
+	t0 := time.UnixMilli(0)
+	min := time.Minute
+	s := scheduler.NewAdaptiveScheduler(min, 15*time.Minute)
+
+	// c/3 already primed and marked active (nextDue = t0+min).
+	s.Due(t0, []string{"c/3"})
+	s.MarkActive("c/3", t0)
+
+	// Now at t0: a/1 and b/2 are new, c/3 is not due yet.
+	all := []string{"a/1", "b/2", "c/3"}
+	due := s.Due(t0, all)
+
+	// Expected: a/1 and b/2 (new → due), c/3 not due.
+	if len(due) != 2 {
+		t.Fatalf("want 2 due, got %d: %v", len(due), due)
+	}
+	dueSet := map[string]bool{}
+	for _, k := range due {
+		dueSet[k] = true
+	}
+	if dueSet["c/3"] {
+		t.Fatal("c/3 should not be due (MarkActive just set nextDue = t0+min)")
+	}
+
+	// After MarkActive on a/1 and MarkIdle on b/2:
+	s.MarkActive("a/1", t0)
+	s.MarkIdle("b/2", t0)
+
+	// At t0+min: a/1 is due (reset to min), b/2 interval grew to 2m so not due, c/3 due.
+	now2 := t0.Add(min)
+	due2 := s.Due(now2, all)
+	due2Set := map[string]bool{}
+	for _, k := range due2 {
+		due2Set[k] = true
+	}
+	if !due2Set["a/1"] {
+		t.Error("a/1: MarkActive → due at t0+min")
+	}
+	if due2Set["b/2"] {
+		t.Error("b/2: MarkIdle 2x → interval=2m, should not be due at t0+min")
+	}
+	if !due2Set["c/3"] {
+		t.Error("c/3: MarkActive at t0 → due at t0+min")
+	}
+}

--- a/daemon/internal/scheduler/ratelimit.go
+++ b/daemon/internal/scheduler/ratelimit.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"sync"
 	"time"
 )
 
@@ -21,12 +22,43 @@ var tierWait = map[Tier]time.Duration{
 	TierWatch:     50 * time.Millisecond,
 }
 
+// tierSafetyThreshold maps a Tier to the minimum remaining-budget below which
+// that tier must wait until the reset window. Higher-priority tiers (Watch)
+// use a smaller reserve so they can still make calls when budget is scarce,
+// while Discovery/Repo back off earlier to protect critical work.
+//
+//	TierWatch     →  25  (backs off very late — only when nearly exhausted)
+//	TierRepo      →  75  (medium priority)
+//	TierDiscovery → 100  (lowest priority, backs off earliest)
+var tierSafetyThreshold = map[Tier]int{
+	TierDiscovery: 100,
+	TierRepo:      75,
+	TierWatch:     25,
+}
+
+// resourceBudget holds the live rate-limit state for a single GitHub resource
+// category (e.g. "core", "search").
+type resourceBudget struct {
+	remaining int
+	reset     time.Time
+}
+
 // RateLimiter is a shared token pool that governs GitHub API usage across
 // all polling tiers. Higher-priority tiers (Watch) get shorter initial wait
 // times, meaning they acquire tokens faster when the pool is under pressure.
+//
+// In addition to the token-pool burst guard, the limiter tracks GitHub's
+// live X-RateLimit-Remaining budget per resource category. When remaining
+// drops below the tier's safety threshold the limiter blocks until the reset
+// time (respecting ctx cancellation). A secondary-limit cooldown (from
+// Retry-After on 403/429) overrides everything and makes all tiers wait.
 type RateLimiter struct {
 	pool chan struct{}
 	size int
+
+	mu       sync.Mutex
+	budgets  map[string]*resourceBudget // keyed by resource name, e.g. "core", "search"
+	cooldown time.Time                   // secondary-limit cooldown: block until this time
 }
 
 // NewRateLimiter creates a rate limiter with the given number of tokens.
@@ -35,11 +67,68 @@ func NewRateLimiter(tokens int) *RateLimiter {
 	for i := 0; i < tokens; i++ {
 		pool <- struct{}{}
 	}
-	return &RateLimiter{pool: pool, size: tokens}
+	return &RateLimiter{
+		pool:    pool,
+		size:    tokens,
+		budgets: make(map[string]*resourceBudget),
+	}
+}
+
+// Observe records the live rate-limit state for a GitHub resource category.
+// Called by the client-side observer after every API response that carries
+// X-RateLimit-* headers (resource, remaining, reset).
+func (r *RateLimiter) Observe(resource string, remaining int, reset time.Time) {
+	if resource == "" {
+		return
+	}
+	r.mu.Lock()
+	r.budgets[resource] = &resourceBudget{remaining: remaining, reset: reset}
+	r.mu.Unlock()
+}
+
+// ObserveRetryAfter sets a secondary-limit cooldown: all tiers will block
+// until now+d (or ctx cancellation). This is triggered by a 403/429
+// secondary rate limit from GitHub which includes a Retry-After header.
+func (r *RateLimiter) ObserveRetryAfter(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	until := time.Now().Add(d)
+	r.mu.Lock()
+	if until.After(r.cooldown) {
+		r.cooldown = until
+	}
+	r.mu.Unlock()
 }
 
 // Acquire blocks until a token is available or the context is done.
+// Before acquiring a token it also enforces:
+//  1. Any active secondary-limit cooldown (Retry-After).
+//  2. Per-resource budget: if remaining < tier's safety threshold, waits
+//     until the resource's reset time.
+//
+// The resource checked is "core" by default (the most common limit bucket).
+// Tier priority determines the safety threshold: Watch backs off latest,
+// Discovery earliest, so critical polling can proceed while discovery idles.
 func (r *RateLimiter) Acquire(ctx context.Context, tier Tier) error {
+	return r.AcquireResource(ctx, tier, "core")
+}
+
+// AcquireResource is the full form of Acquire: it checks budget for the
+// named resource (e.g. "core", "search") before acquiring a token.
+// Acquire() calls this with "core".
+func (r *RateLimiter) AcquireResource(ctx context.Context, tier Tier, resource string) error {
+	// 1. Honor secondary-limit cooldown first.
+	if err := r.waitForCooldown(ctx); err != nil {
+		return err
+	}
+
+	// 2. Honor proactive budget throttle for the named resource.
+	if err := r.waitForBudget(ctx, tier, resource); err != nil {
+		return err
+	}
+
+	// 3. Existing token-pool burst guard.
 	wait := tierWait[tier]
 	timer := time.NewTimer(wait)
 	defer timer.Stop()
@@ -59,6 +148,60 @@ func (r *RateLimiter) Acquire(ctx context.Context, tier Tier) error {
 	}
 }
 
+// waitForCooldown blocks until any active secondary-limit cooldown elapses or
+// ctx is done.
+func (r *RateLimiter) waitForCooldown(ctx context.Context) error {
+	r.mu.Lock()
+	until := r.cooldown
+	r.mu.Unlock()
+
+	now := time.Now()
+	if !until.After(now) {
+		return nil
+	}
+	delay := until.Sub(now)
+	select {
+	case <-time.After(delay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// waitForBudget blocks until the resource's remaining budget is above the
+// tier's safety threshold, or until the reset time passes, or ctx is done.
+func (r *RateLimiter) waitForBudget(ctx context.Context, tier Tier, resource string) error {
+	threshold := tierSafetyThreshold[tier]
+
+	r.mu.Lock()
+	b, ok := r.budgets[resource]
+	if !ok {
+		r.mu.Unlock()
+		return nil // no budget info yet — proceed optimistically
+	}
+	remaining := b.remaining
+	reset := b.reset
+	r.mu.Unlock()
+
+	if remaining >= threshold {
+		return nil // budget is healthy — proceed immediately
+	}
+
+	// Budget is below threshold: wait until the reset time.
+	now := time.Now()
+	if !reset.After(now) {
+		// Reset time already passed (or wasn't set) — proceed.
+		return nil
+	}
+	delay := reset.Sub(now)
+	select {
+	case <-time.After(delay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // Refill restores the token pool to its original capacity.
 func (r *RateLimiter) Refill() {
 	for {
@@ -73,4 +216,19 @@ func (r *RateLimiter) Refill() {
 // Available returns the number of tokens currently in the pool.
 func (r *RateLimiter) Available() int {
 	return len(r.pool)
+}
+
+// BudgetRemaining returns the last-observed remaining count for the given
+// resource, and whether any budget info has been recorded. Used for testing
+// and observability.
+func (r *RateLimiter) BudgetRemaining(resource string) (remaining int, ok bool) {
+	r.mu.Lock()
+	b, ok := r.budgets[resource]
+	if !ok {
+		r.mu.Unlock()
+		return 0, false
+	}
+	remaining = b.remaining
+	r.mu.Unlock()
+	return remaining, true
 }

--- a/daemon/internal/scheduler/ratelimit.go
+++ b/daemon/internal/scheduler/ratelimit.go
@@ -56,9 +56,10 @@ type RateLimiter struct {
 	pool chan struct{}
 	size int
 
-	mu       sync.Mutex
-	budgets  map[string]*resourceBudget // keyed by resource name, e.g. "core", "search"
-	cooldown time.Time                   // secondary-limit cooldown: block until this time
+	mu               sync.Mutex
+	budgets          map[string]*resourceBudget // keyed by resource name, e.g. "core", "search"
+	cooldown         time.Time                   // secondary-limit cooldown: block until this time
+	baseDiscThreshold int                        // override for TierDiscovery threshold (0 = use package default)
 }
 
 // NewRateLimiter creates a rate limiter with the given number of tokens.
@@ -168,10 +169,57 @@ func (r *RateLimiter) waitForCooldown(ctx context.Context) error {
 	}
 }
 
+// SetDiscoverySafetyThreshold overrides the base safety threshold for
+// TierDiscovery. The per-tier offsets (TierRepo = base-25, TierWatch = base-75)
+// are applied relative to this value when it is set.  A value of 0 or below
+// falls back to the package-level default (100). Thread-safe.
+func (r *RateLimiter) SetDiscoverySafetyThreshold(threshold int) {
+	r.mu.Lock()
+	if threshold > 0 {
+		r.baseDiscThreshold = threshold
+	} else {
+		r.baseDiscThreshold = 0 // revert to package default
+	}
+	r.mu.Unlock()
+}
+
+// effectiveThreshold returns the safety threshold for a given tier, taking
+// into account any SetDiscoverySafetyThreshold override.
+func (r *RateLimiter) effectiveThreshold(tier Tier) int {
+	r.mu.Lock()
+	base := r.baseDiscThreshold
+	r.mu.Unlock()
+	if base <= 0 {
+		return tierSafetyThreshold[tier]
+	}
+	// Scale the tier offsets relative to the configured base:
+	//   TierDiscovery → base
+	//   TierRepo      → base - 25 (same delta as default 100→75)
+	//   TierWatch     → base - 75 (same delta as default 100→25)
+	switch tier {
+	case TierDiscovery:
+		return base
+	case TierRepo:
+		v := base - 25
+		if v < 1 {
+			return 1
+		}
+		return v
+	case TierWatch:
+		v := base - 75
+		if v < 1 {
+			return 1
+		}
+		return v
+	default:
+		return tierSafetyThreshold[tier]
+	}
+}
+
 // waitForBudget blocks until the resource's remaining budget is above the
 // tier's safety threshold, or until the reset time passes, or ctx is done.
 func (r *RateLimiter) waitForBudget(ctx context.Context, tier Tier, resource string) error {
-	threshold := tierSafetyThreshold[tier]
+	threshold := r.effectiveThreshold(tier)
 
 	r.mu.Lock()
 	b, ok := r.budgets[resource]

--- a/daemon/internal/scheduler/ratelimit.go
+++ b/daemon/internal/scheduler/ratelimit.go
@@ -56,9 +56,9 @@ type RateLimiter struct {
 	pool chan struct{}
 	size int
 
-	mu               sync.Mutex
-	budgets          map[string]*resourceBudget // keyed by resource name, e.g. "core", "search"
-	cooldown         time.Time                   // secondary-limit cooldown: block until this time
+	mu                sync.Mutex
+	budgets           map[string]*resourceBudget // keyed by resource name, e.g. "core", "search"
+	cooldown          time.Time                  // secondary-limit cooldown: block until this time
 	baseDiscThreshold int                        // override for TierDiscovery threshold (0 = use package default)
 }
 

--- a/daemon/internal/scheduler/ratelimit_gh_test.go
+++ b/daemon/internal/scheduler/ratelimit_gh_test.go
@@ -262,7 +262,7 @@ func TestRateLimiter_ResetAlreadyPassedProceedsImmediately(t *testing.T) {
 // values so a future change to defaults is a deliberate, visible diff.
 func TestRateLimiter_TierThresholdValues(t *testing.T) {
 	cases := []struct {
-		tier      Tier
+		tier       Tier
 		wantThresh int
 	}{
 		{TierDiscovery, 100},

--- a/daemon/internal/scheduler/ratelimit_gh_test.go
+++ b/daemon/internal/scheduler/ratelimit_gh_test.go
@@ -1,0 +1,318 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestRateLimiter_ObserveHealthyBudgetDoesNotThrottle verifies that when the
+// remaining budget is well above all tier thresholds, Acquire returns
+// immediately without blocking.
+func TestRateLimiter_ObserveHealthyBudgetDoesNotThrottle(t *testing.T) {
+	rl := NewRateLimiter(100)
+	reset := time.Now().Add(1 * time.Hour)
+
+	// Observe a healthy budget (far above all thresholds).
+	rl.Observe("core", 5000, reset)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if err := rl.Acquire(ctx, TierDiscovery); err != nil {
+		t.Fatalf("Acquire failed with healthy budget: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// Should return in well under 50ms — no budget wait, no cooldown.
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("Acquire took %v with healthy budget, expected near-instant", elapsed)
+	}
+}
+
+// TestRateLimiter_ObserveDepletedBudgetThrottlesLowPriority verifies that when
+// remaining drops below the TierDiscovery threshold, Acquire blocks until
+// the reset time elapses.
+func TestRateLimiter_ObserveDepletedBudgetThrottlesLowPriority(t *testing.T) {
+	rl := NewRateLimiter(100)
+
+	// Set reset 80ms in the future.
+	resetDelay := 80 * time.Millisecond
+	reset := time.Now().Add(resetDelay)
+
+	// Observe remaining=50, which is below TierDiscovery threshold (100)
+	// but above TierWatch threshold (25).
+	rl.Observe("core", 50, reset)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	// TierDiscovery has threshold=100, remaining=50 < 100 → must wait for reset.
+	if err := rl.Acquire(ctx, TierDiscovery); err != nil {
+		t.Fatalf("Acquire returned error: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// Must have waited at least resetDelay - small tolerance.
+	if elapsed < resetDelay-10*time.Millisecond {
+		t.Errorf("Acquire returned too early: elapsed=%v, reset delay=%v", elapsed, resetDelay)
+	}
+}
+
+// TestRateLimiter_HighPriorityTierNotThrottledWhenMediumWouldBe verifies tier
+// priority: TierWatch uses a lower threshold (25) than TierDiscovery (100).
+// When remaining=50, Discovery blocks but Watch proceeds immediately.
+func TestRateLimiter_HighPriorityTierNotThrottledWhenMediumWouldBe(t *testing.T) {
+	rl := NewRateLimiter(100)
+	reset := time.Now().Add(2 * time.Second) // long reset, would block
+
+	// remaining=50: above Watch threshold (25) but below Discovery threshold (100)
+	rl.Observe("core", 50, reset)
+
+	// TierWatch should NOT block — remaining(50) >= threshold(25).
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if err := rl.AcquireResource(ctx, TierWatch, "core"); err != nil {
+		t.Fatalf("TierWatch Acquire failed: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("TierWatch took %v, expected near-instant with remaining=50 (threshold=25)", elapsed)
+	}
+
+	// TierDiscovery with a fresh limiter (same conditions) SHOULD block,
+	// but we can't wait 2s in a test. Instead verify that ctx cancellation
+	// interrupts the wait, which proves it would have waited.
+	rl2 := NewRateLimiter(100)
+	rl2.Observe("core", 50, time.Now().Add(2*time.Second))
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel2()
+	if err := rl2.AcquireResource(ctx2, TierDiscovery, "core"); err == nil {
+		t.Error("TierDiscovery should have been throttled (ctx should expire first), got nil error")
+	}
+}
+
+// TestRateLimiter_SecondaryCooldownBlocksAllTiers verifies that ObserveRetryAfter
+// makes Acquire block until the cooldown elapses, regardless of tier.
+func TestRateLimiter_SecondaryCooldownBlocksAllTiers(t *testing.T) {
+	rl := NewRateLimiter(100)
+	cooldown := 80 * time.Millisecond
+	rl.ObserveRetryAfter(cooldown)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	// Even TierWatch (highest priority) must wait for the cooldown.
+	if err := rl.Acquire(ctx, TierWatch); err != nil {
+		t.Fatalf("Acquire returned error during cooldown: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed < cooldown-10*time.Millisecond {
+		t.Errorf("Acquire returned before cooldown elapsed: elapsed=%v, cooldown=%v", elapsed, cooldown)
+	}
+}
+
+// TestRateLimiter_SecondaryCooldownExpiredDoesNotBlock verifies that once the
+// Retry-After window has passed, Acquire returns immediately.
+func TestRateLimiter_SecondaryCooldownExpiredDoesNotBlock(t *testing.T) {
+	rl := NewRateLimiter(100)
+	// Set a cooldown that already expired.
+	rl.ObserveRetryAfter(-100 * time.Millisecond) // negative → treated as 0 → no-op
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if err := rl.Acquire(ctx, TierWatch); err != nil {
+		t.Fatalf("Acquire returned error with expired cooldown: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("Acquire too slow with no active cooldown: %v", elapsed)
+	}
+}
+
+// TestRateLimiter_CtxCancelDuringBudgetWait verifies that context cancellation
+// during a budget-wait returns ctx.Err().
+func TestRateLimiter_CtxCancelDuringBudgetWait(t *testing.T) {
+	rl := NewRateLimiter(100)
+	// Budget depleted, reset far in the future.
+	rl.Observe("core", 10, time.Now().Add(10*time.Second))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := rl.AcquireResource(ctx, TierDiscovery, "core") // threshold=100 > remaining=10
+	if err == nil {
+		t.Fatal("expected ctx error, got nil")
+	}
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+// TestRateLimiter_CtxCancelDuringCooldownWait verifies that context cancellation
+// during a Retry-After cooldown returns ctx.Err().
+func TestRateLimiter_CtxCancelDuringCooldownWait(t *testing.T) {
+	rl := NewRateLimiter(100)
+	rl.ObserveRetryAfter(10 * time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := rl.Acquire(ctx, TierWatch)
+	if err == nil {
+		t.Fatal("expected ctx error, got nil")
+	}
+}
+
+// TestRateLimiter_NoBudgetInfoProceeds verifies that Acquire is unthrottled
+// when no Observe() call has been made (i.e. no budget info yet).
+func TestRateLimiter_NoBudgetInfoProceeds(t *testing.T) {
+	rl := NewRateLimiter(100)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if err := rl.Acquire(ctx, TierDiscovery); err != nil {
+		t.Fatalf("Acquire should succeed with no budget info: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("Acquire too slow with no budget info: %v", elapsed)
+	}
+}
+
+// TestRateLimiter_ObserveUpdatesExistingBudget verifies that a second Observe
+// call replaces the previous budget.
+func TestRateLimiter_ObserveUpdatesExistingBudget(t *testing.T) {
+	rl := NewRateLimiter(100)
+
+	// First observation: healthy budget.
+	rl.Observe("core", 5000, time.Now().Add(1*time.Hour))
+	rem, ok := rl.BudgetRemaining("core")
+	if !ok || rem != 5000 {
+		t.Errorf("BudgetRemaining after first observe: got (%d,%v), want (5000,true)", rem, ok)
+	}
+
+	// Second observation: updated budget.
+	rl.Observe("core", 42, time.Now().Add(1*time.Hour))
+	rem, ok = rl.BudgetRemaining("core")
+	if !ok || rem != 42 {
+		t.Errorf("BudgetRemaining after second observe: got (%d,%v), want (42,true)", rem, ok)
+	}
+}
+
+// TestRateLimiter_SearchResourceIndependentOfCore verifies that "search" and
+// "core" budgets are tracked independently. Depleting "search" does not affect
+// Acquire(ctx, tier) which checks "core".
+func TestRateLimiter_SearchResourceIndependentOfCore(t *testing.T) {
+	rl := NewRateLimiter(100)
+
+	// Core is healthy; search is depleted.
+	rl.Observe("core", 5000, time.Now().Add(1*time.Hour))
+	rl.Observe("search", 0, time.Now().Add(10*time.Second))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// Acquire (which checks "core") should be fast.
+	start := time.Now()
+	if err := rl.Acquire(ctx, TierDiscovery); err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("Acquire took %v, expected near-instant (core is healthy)", elapsed)
+	}
+
+	// AcquireResource on "search" with Discovery should block (remaining=0 < 100).
+	rl2 := NewRateLimiter(100)
+	rl2.Observe("search", 0, time.Now().Add(10*time.Second))
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel2()
+	if err := rl2.AcquireResource(ctx2, TierDiscovery, "search"); err == nil {
+		t.Error("expected throttle on depleted search resource, got nil")
+	}
+}
+
+// TestRateLimiter_ResetAlreadyPassedProceedsImmediately verifies that if the
+// reset time is already in the past, Acquire does NOT wait.
+func TestRateLimiter_ResetAlreadyPassedProceedsImmediately(t *testing.T) {
+	rl := NewRateLimiter(100)
+	// Observe a depleted budget with a reset time in the past.
+	rl.Observe("core", 0, time.Now().Add(-5*time.Second))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	// Should proceed immediately since reset already passed.
+	if err := rl.Acquire(ctx, TierDiscovery); err != nil {
+		t.Fatalf("Acquire returned error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("Acquire took %v with past reset, expected near-instant", elapsed)
+	}
+}
+
+// TestRateLimiter_TierThresholdValues documents and asserts the exact threshold
+// values so a future change to defaults is a deliberate, visible diff.
+func TestRateLimiter_TierThresholdValues(t *testing.T) {
+	cases := []struct {
+		tier      Tier
+		wantThresh int
+	}{
+		{TierDiscovery, 100},
+		{TierRepo, 75},
+		{TierWatch, 25},
+	}
+	for _, tc := range cases {
+		got := tierSafetyThreshold[tc.tier]
+		if got != tc.wantThresh {
+			t.Errorf("tierSafetyThreshold[%v] = %d, want %d", tc.tier, got, tc.wantThresh)
+		}
+	}
+
+	// Verify ordering: Discovery > Repo > Watch (backs off earliest to latest).
+	if tierSafetyThreshold[TierDiscovery] <= tierSafetyThreshold[TierRepo] {
+		t.Error("TierDiscovery threshold should be > TierRepo (back off earlier)")
+	}
+	if tierSafetyThreshold[TierRepo] <= tierSafetyThreshold[TierWatch] {
+		t.Error("TierRepo threshold should be > TierWatch (back off earlier)")
+	}
+}
+
+// TestRateLimiter_ExistingBehaviorPreserved verifies that the original token-pool
+// behavior (Acquire, Refill, Available, context cancellation on empty pool) is
+// unchanged by the GitHub-aware extensions.
+func TestRateLimiter_ExistingBehaviorPreserved(t *testing.T) {
+	rl := NewRateLimiter(5)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		if err := rl.Acquire(ctx, TierRepo); err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+	}
+	if rl.Available() != 0 {
+		t.Errorf("expected 0 tokens, got %d", rl.Available())
+	}
+
+	rl.Refill()
+	if rl.Available() != 5 {
+		t.Errorf("after refill: got %d, want 5", rl.Available())
+	}
+
+	// Context cancellation on empty pool.
+	for i := 0; i < 5; i++ {
+		rl.Acquire(ctx, TierRepo)
+	}
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := rl.Acquire(cancelledCtx, TierWatch); err == nil {
+		t.Error("expected error on cancelled context with empty pool")
+	}
+}

--- a/daemon/internal/scheduler/ratelimit_test.go
+++ b/daemon/internal/scheduler/ratelimit_test.go
@@ -57,3 +57,50 @@ func TestRateLimiter_Refill(t *testing.T) {
 		t.Errorf("after refill = %d, want 10", rl.Available())
 	}
 }
+
+// TestSetDiscoverySafetyThreshold verifies the override and its per-tier scaling.
+func TestSetDiscoverySafetyThreshold(t *testing.T) {
+	t.Run("default thresholds unchanged when override is zero", func(t *testing.T) {
+		rl := NewRateLimiter(100)
+		if got := rl.effectiveThreshold(TierDiscovery); got != 100 {
+			t.Errorf("TierDiscovery default = %d, want 100", got)
+		}
+		if got := rl.effectiveThreshold(TierRepo); got != 75 {
+			t.Errorf("TierRepo default = %d, want 75", got)
+		}
+		if got := rl.effectiveThreshold(TierWatch); got != 25 {
+			t.Errorf("TierWatch default = %d, want 25", got)
+		}
+	})
+
+	t.Run("override scales all tiers proportionally", func(t *testing.T) {
+		rl := NewRateLimiter(100)
+		rl.SetDiscoverySafetyThreshold(200)
+		if got := rl.effectiveThreshold(TierDiscovery); got != 200 {
+			t.Errorf("TierDiscovery with override 200 = %d, want 200", got)
+		}
+		if got := rl.effectiveThreshold(TierRepo); got != 175 {
+			t.Errorf("TierRepo with override 200 = %d, want 175", got)
+		}
+		if got := rl.effectiveThreshold(TierWatch); got != 125 {
+			t.Errorf("TierWatch with override 200 = %d, want 125", got)
+		}
+	})
+
+	t.Run("zero or negative override reverts to package default", func(t *testing.T) {
+		rl := NewRateLimiter(100)
+		rl.SetDiscoverySafetyThreshold(200)
+		rl.SetDiscoverySafetyThreshold(0) // revert
+		if got := rl.effectiveThreshold(TierDiscovery); got != 100 {
+			t.Errorf("TierDiscovery after revert = %d, want 100", got)
+		}
+	})
+
+	t.Run("watch tier clamped to 1 when base is very low", func(t *testing.T) {
+		rl := NewRateLimiter(100)
+		rl.SetDiscoverySafetyThreshold(50) // TierWatch = 50 - 75 = -25, should clamp to 1
+		if got := rl.effectiveThreshold(TierWatch); got < 1 {
+			t.Errorf("TierWatch with low base = %d, want >= 1", got)
+		}
+	})
+}

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -2377,3 +2377,137 @@ func TestHandleListIssues_StateFilter(t *testing.T) {
 		t.Errorf("GET /issues?state=open,closed: expected 2, got %d", len(got))
 	}
 }
+
+// TestHandlerGetConfig_ExposesPolling guards the [polling] section in the GET
+// /config response. The Flutter UI and CLI Config tab read these keys, so a
+// silent rename or re-nesting would break consumers.
+func TestHandlerGetConfig_ExposesPolling(t *testing.T) {
+	srv, _ := setupServer(t)
+	srv.SetConfigFn(func() map[string]any {
+		return map[string]any{
+			"polling": map[string]any{
+				"poll_interval":               "3m",
+				"min_interval":                "1m",
+				"max_interval":                "15m",
+				"adaptive":                    true,
+				"discovery_interval":          "5m",
+				"tier3_interval":              "30s",
+				"rate_limit_safety_threshold": int64(100),
+				"use_etag":                    true,
+				"use_graphql":                 false,
+			},
+		}
+	})
+
+	req := httptest.NewRequest("GET", "/config", nil)
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v (body: %s)", err, w.Body.String())
+	}
+	polling, ok := body["polling"].(map[string]any)
+	if !ok {
+		t.Fatalf("polling missing or wrong type: %T: %v", body["polling"], body["polling"])
+	}
+
+	checks := map[string]any{
+		"poll_interval":               "3m",
+		"min_interval":                "1m",
+		"max_interval":                "15m",
+		"adaptive":                    true,
+		"discovery_interval":          "5m",
+		"tier3_interval":              "30s",
+		"rate_limit_safety_threshold": float64(100), // JSON numbers decode to float64
+		"use_etag":                    true,
+		"use_graphql":                 false,
+	}
+	for key, want := range checks {
+		got := polling[key]
+		if got != want {
+			t.Errorf("polling[%q] = %v (%T), want %v (%T)", key, got, got, want, want)
+		}
+	}
+}
+
+// TestHandlePatchConfig_PollingSectionPersists verifies that PATCH /config
+// with {"polling":{...}} round-trips to TOML correctly. Mirrors the pattern
+// used by TestHandlePatchConfig and its siblings.
+func TestHandlePatchConfig_PollingSectionPersists(t *testing.T) {
+	tomlContent := "[ai]\nprimary = \"claude\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	body := `{"polling":{"adaptive":true,"max_interval":"30m"}}`
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, err := config.ReadTOMLMap(tomlPath)
+	if err != nil {
+		t.Fatalf("read TOML after PATCH: %v", err)
+	}
+	polling, ok := m["polling"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected [polling] section in TOML, got %v", m)
+	}
+	if polling["adaptive"] != true {
+		t.Errorf("adaptive = %v, want true", polling["adaptive"])
+	}
+	if polling["max_interval"] != "30m" {
+		t.Errorf("max_interval = %v, want 30m", polling["max_interval"])
+	}
+}
+
+// TestHandlePatchConfig_PollingIntAndBoolFields verifies that integer
+// (rate_limit_safety_threshold) and pointer-bool (use_etag) fields in the
+// [polling] section persist to TOML via PATCH /config.
+func TestHandlePatchConfig_PollingIntAndBoolFields(t *testing.T) {
+	tomlContent := "[ai]\nprimary = \"claude\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	body := `{"polling":{"rate_limit_safety_threshold":200,"use_etag":false}}`
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, err := config.ReadTOMLMap(tomlPath)
+	if err != nil {
+		t.Fatalf("read TOML after PATCH: %v", err)
+	}
+	polling, ok := m["polling"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected [polling] section in TOML, got %v", m)
+	}
+	// TOML round-trip: JSON integers arrive as float64 after NormalizeNumbers
+	// converts them to int64; TOML writes int64; reads back as int64.
+	threshold := polling["rate_limit_safety_threshold"]
+	if threshold != int64(200) {
+		t.Errorf("rate_limit_safety_threshold = %v (%T), want int64(200)", threshold, threshold)
+	}
+	if polling["use_etag"] != false {
+		t.Errorf("use_etag = %v, want false", polling["use_etag"])
+	}
+}

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -21,7 +21,8 @@ Full reference for all settings, environment variables, and deployment options.
 13. [Distribution Formats](#13-distribution-formats)
 14. [Circuit Breakers](#14-circuit-breakers)
 15. [Autonomous Mode](#15-autonomous-mode)
-16. [Full config.toml Reference](#16-full-configtoml-reference)
+16. [Polling](#16-polling)
+17. [Full config.toml Reference](#17-full-configtoml-reference)
 
 ---
 
@@ -1166,7 +1167,56 @@ With this setup, Heimdallm will autonomously triage issues and implement them in
 
 ---
 
-## 16. Full config.toml Reference
+## 16. Polling
+
+The `[polling]` table tunes how the daemon schedules its fetch cycles. All fields are optional — omitting the section entirely reproduces the prior behaviour with no change in how the daemon polls.
+
+```toml
+[polling]
+poll_interval              = "5m"   # inherits [github].poll_interval when unset
+min_interval               = "1m"
+max_interval               = "15m"
+adaptive                   = false
+discovery_interval         = "5m"
+tier3_interval             = "30s"
+rate_limit_safety_threshold = 100
+use_etag                   = true
+use_graphql                = false
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `poll_interval` | inherits `[github].poll_interval` | Base poll cadence. When unset, the value from `[github].poll_interval` (or its env var `HEIMDALLM_POLL_INTERVAL`) is used. Setting `[polling].poll_interval` overrides the `[github]` field for the polling subsystem. |
+| `min_interval` | `"1m"` | Shortest interval the adaptive scheduler will use for an actively-changing repo. Has no effect when `adaptive = false`. |
+| `max_interval` | `"15m"` | Longest interval the adaptive scheduler will back off to for idle repos. Has no effect when `adaptive = false`. |
+| `adaptive` | `false` | When `true`, repos that have seen no new events for several consecutive cycles gradually back off from `min_interval` toward `max_interval`. Repos that receive new events reset to `min_interval`. This reduces rate-limit consumption when monitoring many quiet repos. |
+| `discovery_interval` | `"5m"` | How often the topic-discovery pass runs to find newly-tagged repos. Independent of `poll_interval`. |
+| `tier3_interval` | `"30s"` | Cadence of the Tier 3 observation loop (review-state polling on `auto_implement` PRs). |
+| `rate_limit_safety_threshold` | `100` | Core-remaining floor. When the GitHub core rate-limit remaining count drops below this number, non-critical polling (discovery, Tier 3 observation, adaptive back-off checks) is throttled until the rate-limit window resets. Critical paths (PR review, issue triage) are not blocked by this threshold. |
+| `use_etag` | `true` | Send `If-None-Match` / `ETag` conditional-request headers on list endpoints. A `304 Not Modified` response reuses the cached body without counting against the rate limit. Disable only if your GitHub proxy strips ETag headers. |
+| `use_graphql` | `false` | Fetch issue lists via the GraphQL `search(type:ISSUE)` API instead of REST `/search/issues`. GraphQL requests consume from the separate GraphQL rate-limit budget (5,000 points/hour), leaving the core REST budget for other operations. Falls back to REST automatically on any GraphQL error. |
+
+> **Reload behaviour:** All fields except `tier3_interval` and the adaptive `min_interval`/`max_interval` bounds take effect on the next `PUT /config` or file reload without a restart. Changes to `tier3_interval` and `min_interval`/`max_interval` are applied at daemon start; a restart is needed for those three to take effect after a live config change.
+
+> **Unconfigured = no change:** A missing `[polling]` section is equivalent to setting every field to its default. There is no opt-in required — existing deployments that do not add this section continue to behave exactly as before.
+
+### Example: adaptive polling with GraphQL enabled (conservative)
+
+```toml
+[polling]
+min_interval               = "2m"
+max_interval               = "20m"
+adaptive                   = true
+rate_limit_safety_threshold = 200   # throttle earlier on rate-constrained installations
+use_etag                   = true
+use_graphql                = true
+```
+
+This setup lets idle repos drift to a 20-minute cycle, saving roughly 80 % of poll calls on dormant repos, while keeping active repos at the 2-minute minimum. GraphQL consumes from the separate 5,000-point budget, and ETags ensure 304s on unchanged endpoints cost zero REST points.
+
+---
+
+## 17. Full config.toml Reference
 
 ```toml
 # Heimdallm configuration

--- a/docs/superpowers/specs/2026-06-15-gh-api-efficiency-design.md
+++ b/docs/superpowers/specs/2026-06-15-gh-api-efficiency-design.md
@@ -1,0 +1,118 @@
+# GitHub API Efficiency for Polling — Diseño
+
+- **Fecha**: 2026-06-15
+- **Estado**: Aprobado para planificación
+- **Ámbito**: `daemon/` (Go: `github`, `scheduler`, `config`, wiring en `cmd/heimdallm`), GUI Flutter, CLI TUI.
+
+## 1. Problema
+
+El daemon agota el límite **core REST de GitHub (5.000/h, por usuario y compartido)** y entra en 403-storm. Causa raíz medida (config real: ~75 repos, `poll_interval=1m`, `discovery=1m`, Tier3 30s):
+
+- **Issues = O(repos)**: una llamada `GET /repos/{repo}/issues` por repo y ciclo → ~75 × 60 ≈ hasta 4.500 req/h solo en issues. Los **PRs ya están optimizados** (1 Search agregada). Asimetría central.
+- **Sin ETag/304**: cada GET cuenta como llamada completa aunque el recurso no haya cambiado (los 304 NO cuentan contra el límite).
+- **Rate-limiter local no GitHub-aware** (`scheduler/ratelimit.go`, 4.500 tokens estáticos): no lee `X-RateLimit-*` ni hace backoff ante 403/secondary → 403-storm.
+- **GraphQL sin usar** (budget 5.000 pts/h casi intacto).
+- **Tier3** cada 30s hace `GetPRSnapshot` (+`GetPRReviews`) por ítem.
+
+## 2. Objetivo y restricciones
+
+- Recortar ~80-90% del consumo core **sin penalizar la latencia donde importa** (DX).
+- **Token personal** (sin GitHub App). **Webhooks fuera de alcance** (requieren GitHub App / endpoint público).
+- Cadencia y umbrales **configurables por el usuario desde `config.toml`, GUI y TUI**.
+
+## 3. Componentes
+
+### C1 — Capa de peticiones condicionales (ETag/304)
+`daemon/internal/github/` (cliente HTTP).
+
+- **`ConditionalCache`**: mapa concurrente keyed por `method+path+rawquery` → `{etag string, body []byte, storedAt time.Time}`. Interfaz pequeña (`Get(key)`, `Put(key, etag, body)`), thread-safe (RWMutex), con límite de entradas (LRU simple o cap + evicción por antigüedad) para no crecer sin control.
+- **Integración en el cliente**: un helper `doConditionalGET(path, accept)` que, si hay ETag cacheado para la key, envía `If-None-Match`. Respuesta:
+  - `304 Not Modified` → devuelve el body cacheado y marca `fromCache=true` (no recomputa, no cuenta como consumo).
+  - `200` con `ETag` → actualiza la caché y devuelve el body nuevo.
+  - `200` sin `ETag` → passthrough sin cachear.
+- **Aplicar a** los GET de polling idempotentes: snapshots de PR (`GetPRSnapshot`), reviews (`GetPRReviews`), repo archived/rename probe, labels, comments, y el fetch de issues/PRs (search) cuando proceda.
+- **Caché en memoria** en v1 (vive en el proceso). Persistencia a SQLite = futuro (nice-to-have, no v1).
+- Métrica: contador de hits 304 vs 200 para observabilidad (log/SSE opcional).
+
+### C2 — Fetch de issues agregado vía Search
+`daemon/internal/github/` + `daemon/internal/issues/fetcher.go`.
+
+- Nuevo `SearchIssues(query string) ([]*Issue, error)` sobre `GET /search/issues?q=...&per_page=100` con paginación hasta el cap de 1000 resultados.
+- Construir la query desde `issue_tracking` (assignees, organizations, filter_mode exclusive, labels): p.ej. `is:issue is:open assignee:<bot> org:<org1> org:<org2>` o `repo:<org/repo>` para repos sueltos. O(orgs) en lugar de O(repos).
+- El fetcher pasa de iterar `FetchIssues` por repo a **una (o pocas) búsquedas agregadas**; mapear resultados a `*Issue` (number, title, labels, assignees, state, repo, updated_at — suficientes para selección/clasificación). Detalle por-issue queda on-demand (con ETag).
+- Usa el **budget de search (30/min)**, separado del core. Tolera el lag de indexado (segundos) — aceptable para la DX.
+- Mantener `FetchIssues` (REST per-repo) como fallback para casos sin search (p.ej. repos sin org) o tras error de search.
+
+### C3 — Rate-limiter GitHub-aware
+`daemon/internal/scheduler/ratelimit.go` (sustituye/extiende el estático).
+
+- **`GitHubLimiter`**: lee de cada respuesta `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `X-RateLimit-Resource`, y `Retry-After`/secondary-limit; mantiene el estado vivo de los budgets (core/search/graphql).
+- **Throttle proactivo**: cuando `remaining < safetyThreshold` para un recurso, frena las llamadas de ese recurso hasta `reset`, **priorizando lo crítico** (publicar reviews, review-loop) sobre discovery/polling de bajo valor (tiers con prioridad).
+- **Backoff ante 403/secondary**: exponencial + honra `Retry-After`; nunca hammering.
+- El cliente HTTP reporta las cabeceras al limiter tras cada respuesta (hook/observer). El limiter expone `Acquire(ctx, tier, resource)` que bloquea/espera según presupuesto.
+- `safetyThreshold` y los pesos por tier son configurables (ver C5).
+
+### C4 — GraphQL batching (steady-state)
+`daemon/internal/github/graphql.go` (nuevo).
+
+- Cliente GraphQL mínimo (`POST /graphql`) con una query que trae, para el set de repos monitorizados: issues abiertos (assignee-scoped) + PRs review-requested, en **una sola petición** (usando `search()` connections o `repository(...)` por nodo con cursores).
+- Usa el **budget graphql ocioso** (5.000 pts/h). Coste por puntos proporcional a nodos; una query para N repos ≪ N REST.
+- Reemplaza el fetch agregado del steady-state (issues+PRs) cuando GraphQL está disponible; REST+ETag (C1) y Search (C2) quedan como fallback y para detalle/on-demand.
+- Manejo de errores GraphQL (errors array, rate-limit en la respuesta), paginación por cursor.
+- **Feature-flag** (`polling.use_graphql`, default según validación) para poder caer a REST/Search si algo falla.
+
+### C5 — Intervalos adaptativos y configurables (3 capas)
+`daemon/internal/scheduler/` + `config` + GUI + TUI.
+
+- **Adaptativo por-repo**: repos con actividad reciente → intervalo mínimo; ociosos → backoff hasta un máximo. Señal de actividad: cambios detectados (200 vs 304) o eventos recientes.
+- **Config nueva** sección `[polling]` (+ `[rate_limit]`): `poll_interval` (base), `min_interval`, `max_interval`, `adaptive` (bool), `discovery_interval`, `tier3_interval`, `rate_limit_safety_threshold`, `use_graphql`, `use_etag` (kill-switches). Resueltos con defaults sanos.
+- **Exposición en las 3 capas** (mismo patrón que la config-UI de autonomous): `GET/PATCH /config` (DTO + handlers), sección editable en GUI Flutter (`config_screen.dart` + modelo + diff provider), display read-only en TUI (`buildConfigLines`).
+
+### C6 — Tier3 condicional + backoff adaptativo
+`daemon/cmd/heimdallm` (wiring Tier3).
+
+- `GetPRSnapshot`/`GetPRReviews` pasan por C1 (ETag) → la mayoría de ticks devuelven 304 (gratis).
+- Backoff adaptativo de los ítems vigilados (C5): ítems sin cambios amplían su intervalo; los activos se mantienen rápidos. `tier3_interval` configurable.
+
+## 4. Fases (orden de construcción)
+
+- **Fase 1 — parón de hemorragia, cero coste DX**: C1 (ETag/304) + C3 (rate-limiter GH-aware) + C2 (issues vía Search). Tests por componente.
+- **Fase 2 — adaptativo + configurable**: C5 (intervalos adaptativos + config `[polling]`/`[rate_limit]` en las 3 capas) + C6 (Tier3). 
+- **Fase 3 — GraphQL**: C4 (batching steady-state) tras feature-flag, con fallback a Fase 1/2.
+
+## 5. Flujo de datos (steady-state objetivo)
+
+```
+ciclo de poll
+  → GitHubLimiter.Acquire (comprueba budget vivo; throttle si bajo)
+  → Fase3: 1 query GraphQL (issues+PRs de N repos)  [o]
+    Fase1/2: 1 Search issues + 1 Search PRs (+ detalle on-demand con ETag)
+  → respuestas → ConditionalCache actualiza ETags; 304 = gratis
+  → limiter actualiza budgets desde X-RateLimit-*
+  → Tier3: snapshots/reviews con ETag (304 mayoritario)
+  → cadencia siguiente = adaptativa por actividad + config del usuario
+```
+
+## 6. Manejo de errores
+
+- 304 → ruta normal (cache hit). 403/secondary → backoff + Retry-After (C3). Search lag/cap → fallback REST (C2). GraphQL error → fallback Search/REST (C4). ETag cache miss → GET normal. Todo degrada con seguridad; nada bloquea el review-loop crítico.
+
+## 7. Testing
+
+- **C1**: tests con `httptest` — segunda petición con ETag → servidor responde 304 → cliente devuelve cuerpo cacheado; 200 con ETag nuevo actualiza caché; sin ETag no cachea. Concurrencia (-race).
+- **C2**: `SearchIssues` parsea/pagina/mapea; construcción de query desde `issue_tracking`; fallback a REST.
+- **C3**: parseo de cabeceras; throttle cuando remaining<threshold; backoff y Retry-After; prioridad por tier. `-race`.
+- **C4**: query GraphQL construida y parseada (httptest con payload GraphQL); fallback ante error; paginación por cursor.
+- **C5**: resolución de config `[polling]`/`[rate_limit]` con defaults + overrides; lógica adaptativa (activo→min, ocioso→max); exposición en GET/PATCH /config; GUI (flutter test) y TUI (display).
+- **C6**: Tier3 usa ETag (304) y backoff adaptativo.
+- Gate por capa: `cd daemon && go build ./... && go vet ./... && go test ./... -race`; `cd flutter_app && flutter analyze && flutter test`; `make -C cli test`.
+
+## 8. Fuera de alcance (YAGNI)
+
+- **GitHub App** (token de instalación) y **webhooks** (push) — descartados por el usuario; north-star futuro.
+- Persistencia de la caché de ETags a disco (v1 = memoria).
+- Overrides per-org/repo de la config `[polling]` por UI (la config global basta para v1; el daemon puede soportar overrides por TOML si hiciera falta).
+
+## 9. Observabilidad
+
+Contadores/SSE opcionales: ratio de 304 vs 200, budget remaining por recurso, throttle activado, fallbacks GraphQL→REST. Para que el usuario vea el ahorro y el estado del rate-limit en GUI/TUI.

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -628,6 +628,79 @@ List<String>? _nullableStringListAllowEmpty(dynamic v) {
       .toList();
 }
 
+/// Adaptive polling / rate-limit configuration (mirrors [polling] TOML section).
+class PollingConfig {
+  final bool adaptive;
+  final String pollInterval;
+  final String minInterval;
+  final String maxInterval;
+  final String discoveryInterval;
+  final String tier3Interval;
+  final int rateLimitSafetyThreshold;
+  final bool useEtag;
+  final bool useGraphql;
+
+  const PollingConfig({
+    this.adaptive = false,
+    this.pollInterval = '',
+    this.minInterval = '1m',
+    this.maxInterval = '15m',
+    this.discoveryInterval = '5m',
+    this.tier3Interval = '30s',
+    this.rateLimitSafetyThreshold = 100,
+    this.useEtag = true,
+    this.useGraphql = false,
+  });
+
+  PollingConfig copyWith({
+    bool? adaptive,
+    String? pollInterval,
+    String? minInterval,
+    String? maxInterval,
+    String? discoveryInterval,
+    String? tier3Interval,
+    int? rateLimitSafetyThreshold,
+    bool? useEtag,
+    bool? useGraphql,
+  }) => PollingConfig(
+    adaptive: adaptive ?? this.adaptive,
+    pollInterval: pollInterval ?? this.pollInterval,
+    minInterval: minInterval ?? this.minInterval,
+    maxInterval: maxInterval ?? this.maxInterval,
+    discoveryInterval: discoveryInterval ?? this.discoveryInterval,
+    tier3Interval: tier3Interval ?? this.tier3Interval,
+    rateLimitSafetyThreshold:
+        rateLimitSafetyThreshold ?? this.rateLimitSafetyThreshold,
+    useEtag: useEtag ?? this.useEtag,
+    useGraphql: useGraphql ?? this.useGraphql,
+  );
+
+  factory PollingConfig.fromJson(Map<String, dynamic> json) => PollingConfig(
+    adaptive: (json['adaptive'] as bool?) ?? false,
+    pollInterval: (json['poll_interval'] as String?) ?? '',
+    minInterval: (json['min_interval'] as String?) ?? '1m',
+    maxInterval: (json['max_interval'] as String?) ?? '15m',
+    discoveryInterval: (json['discovery_interval'] as String?) ?? '5m',
+    tier3Interval: (json['tier3_interval'] as String?) ?? '30s',
+    rateLimitSafetyThreshold:
+        ((json['rate_limit_safety_threshold'] as num?)?.toInt()) ?? 100,
+    useEtag: (json['use_etag'] as bool?) ?? true,
+    useGraphql: (json['use_graphql'] as bool?) ?? false,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'adaptive': adaptive,
+    'poll_interval': pollInterval,
+    'min_interval': minInterval,
+    'max_interval': maxInterval,
+    'discovery_interval': discoveryInterval,
+    'tier3_interval': tier3Interval,
+    'rate_limit_safety_threshold': rateLimitSafetyThreshold,
+    'use_etag': useEtag,
+    'use_graphql': useGraphql,
+  };
+}
+
 /// Issue tracking pipeline configuration.
 class IssueTrackingConfig {
   final bool enabled;
@@ -736,6 +809,7 @@ class AppConfig {
   final bool? globalAutoPromoteTriage;
   final bool? globalAutoPromoteRefinement;
   final bool globalGeneratePRDescription;
+  final PollingConfig polling;
 
   /// Host paths the daemon scans (in order) when a repo has no explicit
   /// `local_dir` set — first match at `{base}/{short-repo-name}` wins.
@@ -773,6 +847,7 @@ class AppConfig {
     this.globalAutoPromoteTriage,
     this.globalAutoPromoteRefinement,
     this.globalGeneratePRDescription = false,
+    this.polling = const PollingConfig(),
     this.localDirBase = const [],
     this.localDirsDetected = const {},
   });
@@ -847,6 +922,7 @@ class AppConfig {
     Object? globalAutoPromoteTriage = _sentinel,
     Object? globalAutoPromoteRefinement = _sentinel,
     bool? globalGeneratePRDescription,
+    PollingConfig? polling,
     List<String>? localDirBase,
     Map<String, String>? localDirsDetected,
   }) {
@@ -879,6 +955,7 @@ class AppConfig {
           : globalAutoPromoteRefinement as bool?,
       globalGeneratePRDescription:
           globalGeneratePRDescription ?? this.globalGeneratePRDescription,
+      polling: polling ?? this.polling,
       localDirBase: localDirBase ?? this.localDirBase,
       localDirsDetected: localDirsDetected ?? this.localDirsDetected,
     );
@@ -1061,6 +1138,9 @@ class AppConfig {
       globalAutoPromoteRefinement: json['auto_promote_refinement'] as bool?,
       globalGeneratePRDescription:
           (json['generate_pr_description'] as bool?) ?? false,
+      polling: json['polling'] != null
+          ? PollingConfig.fromJson(json['polling'] as Map<String, dynamic>)
+          : const PollingConfig(),
       localDirBase: _parseStringList(json['local_dir_base']),
       localDirsDetected: localDirsDetected,
     );

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/config_model.dart';
 import '../../core/platform/platform_services_provider.dart';
@@ -219,6 +220,39 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
     diff['retention'] = retentionDiff;
   }
 
+  // Polling
+  final pollingDiff = <String, dynamic>{};
+  if (old.polling.adaptive != updated.polling.adaptive) {
+    pollingDiff['adaptive'] = updated.polling.adaptive;
+  }
+  if (old.polling.pollInterval != updated.polling.pollInterval) {
+    pollingDiff['poll_interval'] = updated.polling.pollInterval;
+  }
+  if (old.polling.minInterval != updated.polling.minInterval) {
+    pollingDiff['min_interval'] = updated.polling.minInterval;
+  }
+  if (old.polling.maxInterval != updated.polling.maxInterval) {
+    pollingDiff['max_interval'] = updated.polling.maxInterval;
+  }
+  if (old.polling.discoveryInterval != updated.polling.discoveryInterval) {
+    pollingDiff['discovery_interval'] = updated.polling.discoveryInterval;
+  }
+  if (old.polling.tier3Interval != updated.polling.tier3Interval) {
+    pollingDiff['tier3_interval'] = updated.polling.tier3Interval;
+  }
+  if (old.polling.rateLimitSafetyThreshold !=
+      updated.polling.rateLimitSafetyThreshold) {
+    pollingDiff['rate_limit_safety_threshold'] =
+        updated.polling.rateLimitSafetyThreshold;
+  }
+  if (old.polling.useEtag != updated.polling.useEtag) {
+    pollingDiff['use_etag'] = updated.polling.useEtag;
+  }
+  if (old.polling.useGraphql != updated.polling.useGraphql) {
+    pollingDiff['use_graphql'] = updated.polling.useGraphql;
+  }
+  if (pollingDiff.isNotEmpty) diff['polling'] = pollingDiff;
+
   return diff;
 }
 
@@ -264,3 +298,10 @@ bool _listsDiffer(List<String> a, List<String> b) {
   }
   return false;
 }
+
+/// Thin wrapper that exposes [_computeGlobalDiff] to unit tests.
+@visibleForTesting
+Map<String, dynamic> computeGlobalDiffForTest(
+  AppConfig old,
+  AppConfig updated,
+) => _computeGlobalDiff(old, updated);

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -97,6 +97,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   IssueTrackingConfig _issueTracking = const IssueTrackingConfig();
   String? _issuePromptId;
   String? _developPromptId;
+  PollingConfig _polling = const PollingConfig();
 
   // All known repos. Key = "org/repo", Value = per-repo settings.
   Map<String, RepoConfig> _repoConfigs = {};
@@ -148,6 +149,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     _retentionDays = config.retentionDays;
     _repoConfigs = Map.from(config.repoConfigs);
     _issueTracking = config.issueTracking;
+    _polling = config.polling;
     _issuePromptId = config.globalIssuePrompt.isEmpty
         ? null
         : config.globalIssuePrompt;
@@ -247,6 +249,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             _pollSection(),
             const SizedBox(height: 20),
             _retentionSection(),
+            const SizedBox(height: 20),
+            _pollingSection(),
             const SizedBox(height: 20),
             _issueTrackingSection(config),
             const SizedBox(height: 20),
@@ -499,6 +503,165 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         ),
       ],
     );
+  }
+
+  // ── Polling / Rate-limit ─────────────────────────────────────────────────
+
+  Widget _pollingSection() {
+    return _settingsCard('Polling / Rate Limit', [
+      SwitchListTile(
+        title: const Text('Adaptive polling', style: TextStyle(fontSize: 13)),
+        subtitle: const Text(
+          'Dynamically adjust poll interval based on activity',
+          style: TextStyle(fontSize: 11),
+        ),
+        dense: true,
+        contentPadding: EdgeInsets.zero,
+        value: _polling.adaptive,
+        onChanged: (v) => setState(() {
+          _polling = _polling.copyWith(adaptive: v);
+        }),
+      ),
+      const SizedBox(height: 10),
+      TextFormField(
+        initialValue: _polling.pollInterval,
+        decoration: const InputDecoration(
+          labelText: 'Poll interval',
+          helperText: 'Override global poll interval (e.g. 2m, 30s)',
+          border: OutlineInputBorder(),
+        ),
+        onChanged: (v) => setState(() {
+          _polling = _polling.copyWith(pollInterval: v);
+        }),
+      ),
+      if (_polling.adaptive) ...[
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            Expanded(
+              child: TextFormField(
+                initialValue: _polling.minInterval,
+                decoration: const InputDecoration(
+                  labelText: 'Min interval',
+                  helperText: 'Shortest allowed poll cycle',
+                  border: OutlineInputBorder(),
+                ),
+                onChanged: (v) => setState(() {
+                  _polling = _polling.copyWith(minInterval: v);
+                }),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: TextFormField(
+                initialValue: _polling.maxInterval,
+                decoration: const InputDecoration(
+                  labelText: 'Max interval',
+                  helperText: 'Longest allowed poll cycle',
+                  border: OutlineInputBorder(),
+                ),
+                onChanged: (v) => setState(() {
+                  _polling = _polling.copyWith(maxInterval: v);
+                }),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            Expanded(
+              child: TextFormField(
+                initialValue: _polling.discoveryInterval,
+                decoration: const InputDecoration(
+                  labelText: 'Discovery interval',
+                  helperText: 'Repo discovery scan cadence',
+                  border: OutlineInputBorder(),
+                ),
+                onChanged: (v) => setState(() {
+                  _polling = _polling.copyWith(discoveryInterval: v);
+                }),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: TextFormField(
+                initialValue: _polling.tier3Interval,
+                decoration: const InputDecoration(
+                  labelText: 'Tier-3 interval',
+                  helperText: 'Slow-lane repos poll cadence',
+                  border: OutlineInputBorder(),
+                ),
+                onChanged: (v) => setState(() {
+                  _polling = _polling.copyWith(tier3Interval: v);
+                }),
+              ),
+            ),
+          ],
+        ),
+      ],
+      const SizedBox(height: 10),
+      TextFormField(
+        initialValue: _polling.rateLimitSafetyThreshold.toString(),
+        decoration: const InputDecoration(
+          labelText: 'Rate-limit safety threshold',
+          helperText: 'Remaining API requests before backing off',
+          border: OutlineInputBorder(),
+        ),
+        keyboardType: TextInputType.number,
+        onChanged: (v) => setState(() {
+          _polling = _polling.copyWith(
+            rateLimitSafetyThreshold: int.tryParse(v) ?? 100,
+          );
+        }),
+      ),
+      const SizedBox(height: 10),
+      Container(
+        decoration: BoxDecoration(
+          color: Theme.of(
+            context,
+          ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+        child: Column(
+          children: [
+            SwitchListTile(
+              title: const Text(
+                'Use ETag caching',
+                style: TextStyle(fontSize: 11),
+              ),
+              subtitle: Text(
+                'Skip unchanged responses using HTTP ETags',
+                style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+              ),
+              dense: true,
+              contentPadding: EdgeInsets.zero,
+              value: _polling.useEtag,
+              onChanged: (v) => setState(() {
+                _polling = _polling.copyWith(useEtag: v);
+              }),
+            ),
+            SwitchListTile(
+              title: const Text(
+                'Use GraphQL API',
+                style: TextStyle(fontSize: 11),
+              ),
+              subtitle: Text(
+                'Fetch PR/issue data via GraphQL instead of REST',
+                style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+              ),
+              dense: true,
+              contentPadding: EdgeInsets.zero,
+              value: _polling.useGraphql,
+              onChanged: (v) => setState(() {
+                _polling = _polling.copyWith(useGraphql: v);
+              }),
+            ),
+          ],
+        ),
+      ),
+    ]);
   }
 
   // ── Issue tracking ──────────────────────────────────────────────────────
@@ -949,6 +1112,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     retentionDays: _retentionDays,
     repoConfigs: Map.from(_repoConfigs),
     issueTracking: _issueTracking,
+    polling: _polling,
     globalPRReviewers: _globalPRReviewers,
     globalPRLabels: _globalPRLabels,
     globalPRAssignee: _globalPRAssignee,

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -526,7 +526,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       TextFormField(
         initialValue: _polling.pollInterval,
         decoration: const InputDecoration(
-          labelText: 'Poll interval',
+          labelText: 'Poll interval override',
           helperText: 'Override global poll interval (e.g. 2m, 30s)',
           border: OutlineInputBorder(),
         ),

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -461,7 +461,12 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         Wrap(
           spacing: 8,
           children: _pollIntervalSuggestions
-              .map((v) => ActionChip(label: Text(v), onPressed: () => _pickPollInterval(v)))
+              .map(
+                (v) => ActionChip(
+                  label: Text(v),
+                  onPressed: () => _pickPollInterval(v),
+                ),
+              )
               .toList(),
         ),
       ],
@@ -616,49 +621,50 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         }),
       ),
       const SizedBox(height: 10),
-      Container(
-        decoration: BoxDecoration(
-          color: Theme.of(
-            context,
-          ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
-          borderRadius: BorderRadius.circular(6),
-        ),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
-        child: Column(
-          children: [
-            SwitchListTile(
-              title: const Text(
-                'Use ETag caching',
-                style: TextStyle(fontSize: 11),
+      Material(
+        type: MaterialType.canvas,
+        color: Theme.of(
+          context,
+        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(6),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+          child: Column(
+            children: [
+              SwitchListTile(
+                title: const Text(
+                  'Use ETag caching',
+                  style: TextStyle(fontSize: 11),
+                ),
+                subtitle: Text(
+                  'Skip unchanged responses using HTTP ETags',
+                  style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+                ),
+                dense: true,
+                contentPadding: EdgeInsets.zero,
+                value: _polling.useEtag,
+                onChanged: (v) => setState(() {
+                  _polling = _polling.copyWith(useEtag: v);
+                }),
               ),
-              subtitle: Text(
-                'Skip unchanged responses using HTTP ETags',
-                style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+              SwitchListTile(
+                title: const Text(
+                  'Use GraphQL API',
+                  style: TextStyle(fontSize: 11),
+                ),
+                subtitle: Text(
+                  'Fetch PR/issue data via GraphQL instead of REST',
+                  style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+                ),
+                dense: true,
+                contentPadding: EdgeInsets.zero,
+                value: _polling.useGraphql,
+                onChanged: (v) => setState(() {
+                  _polling = _polling.copyWith(useGraphql: v);
+                }),
               ),
-              dense: true,
-              contentPadding: EdgeInsets.zero,
-              value: _polling.useEtag,
-              onChanged: (v) => setState(() {
-                _polling = _polling.copyWith(useEtag: v);
-              }),
-            ),
-            SwitchListTile(
-              title: const Text(
-                'Use GraphQL API',
-                style: TextStyle(fontSize: 11),
-              ),
-              subtitle: Text(
-                'Fetch PR/issue data via GraphQL instead of REST',
-                style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
-              ),
-              dense: true,
-              contentPadding: EdgeInsets.zero,
-              value: _polling.useGraphql,
-              onChanged: (v) => setState(() {
-                _polling = _polling.copyWith(useGraphql: v);
-              }),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     ]);
@@ -878,27 +884,28 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           }),
         ),
         const SizedBox(height: 10),
-        Container(
-          decoration: BoxDecoration(
-            color: Theme.of(
-              context,
-            ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
-            borderRadius: BorderRadius.circular(6),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
-          child: SwitchListTile(
-            title: const Text(
-              'Create as draft',
-              style: TextStyle(fontSize: 11),
+        Material(
+          type: MaterialType.canvas,
+          color: Theme.of(
+            context,
+          ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(6),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+            child: SwitchListTile(
+              title: const Text(
+                'Create as draft',
+                style: TextStyle(fontSize: 11),
+              ),
+              subtitle: Text(
+                'PRs are created as drafts by default',
+                style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+              ),
+              dense: true,
+              contentPadding: EdgeInsets.zero,
+              value: _globalPRDraft,
+              onChanged: (v) => setState(() => _globalPRDraft = v),
             ),
-            subtitle: Text(
-              'PRs are created as drafts by default',
-              style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
-            ),
-            dense: true,
-            contentPadding: EdgeInsets.zero,
-            value: _globalPRDraft,
-            onChanged: (v) => setState(() => _globalPRDraft = v),
           ),
         ),
         const SizedBox(height: 10),

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -444,10 +444,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -833,26 +833,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   timezone:
     dependency: transitive
     description:

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -8,7 +8,8 @@ import 'package:heimdallm/core/api/api_client.dart';
 import 'package:heimdallm/core/models/config_model.dart';
 import 'package:heimdallm/core/platform/platform_services_provider.dart';
 import 'package:heimdallm/core/setup/first_run_setup.dart';
-import 'package:heimdallm/features/config/config_providers.dart';
+import 'package:heimdallm/features/config/config_providers.dart'
+    show ConfigNotifier, configNotifierProvider, computeGlobalDiffForTest;
 import 'package:heimdallm/features/config/config_screen.dart';
 import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
 import '../core/platform/fake_platform_services.dart';
@@ -448,6 +449,132 @@ void main() {
       'repo-reviewer',
     ]);
   });
+
+  // ── PollingConfig tests ────────────────────────────────────────────────────
+
+  test('PollingConfig.fromJson round-trips via toJson', () {
+    final json = {
+      'adaptive': true,
+      'poll_interval': '2m',
+      'min_interval': '30s',
+      'max_interval': '10m',
+      'discovery_interval': '3m',
+      'tier3_interval': '1m',
+      'rate_limit_safety_threshold': 200,
+      'use_etag': false,
+      'use_graphql': true,
+    };
+    final cfg = PollingConfig.fromJson(json);
+    expect(cfg.adaptive, isTrue);
+    expect(cfg.pollInterval, '2m');
+    expect(cfg.minInterval, '30s');
+    expect(cfg.maxInterval, '10m');
+    expect(cfg.discoveryInterval, '3m');
+    expect(cfg.tier3Interval, '1m');
+    expect(cfg.rateLimitSafetyThreshold, 200);
+    expect(cfg.useEtag, isFalse);
+    expect(cfg.useGraphql, isTrue);
+
+    final roundTrip = PollingConfig.fromJson(cfg.toJson());
+    expect(roundTrip.adaptive, cfg.adaptive);
+    expect(roundTrip.pollInterval, cfg.pollInterval);
+    expect(roundTrip.minInterval, cfg.minInterval);
+    expect(roundTrip.maxInterval, cfg.maxInterval);
+    expect(roundTrip.discoveryInterval, cfg.discoveryInterval);
+    expect(roundTrip.tier3Interval, cfg.tier3Interval);
+    expect(roundTrip.rateLimitSafetyThreshold, cfg.rateLimitSafetyThreshold);
+    expect(roundTrip.useEtag, cfg.useEtag);
+    expect(roundTrip.useGraphql, cfg.useGraphql);
+  });
+
+  test('PollingConfig.fromJson applies defaults for missing keys', () {
+    final cfg = PollingConfig.fromJson({});
+    expect(cfg.adaptive, isFalse);
+    expect(cfg.pollInterval, '');
+    expect(cfg.minInterval, '1m');
+    expect(cfg.maxInterval, '15m');
+    expect(cfg.discoveryInterval, '5m');
+    expect(cfg.tier3Interval, '30s');
+    expect(cfg.rateLimitSafetyThreshold, 100);
+    expect(cfg.useEtag, isTrue);
+    expect(cfg.useGraphql, isFalse);
+  });
+
+  test('PollingConfig.fromJson parses rate_limit_safety_threshold as int via num', () {
+    // The daemon may send it as a JSON number (double or int)
+    final cfg = PollingConfig.fromJson({'rate_limit_safety_threshold': 150});
+    expect(cfg.rateLimitSafetyThreshold, 150);
+  });
+
+  test('AppConfig.fromJson parses nested polling object', () {
+    final json = {
+      'repositories': <String>[],
+      'server_port': 7842,
+      'poll_interval': '5m',
+      'retention_days': 90,
+      'ai_primary': 'claude',
+      'ai_fallback': '',
+      'review_mode': 'single',
+      'issue_tracking': {'enabled': false},
+      'polling': {
+        'adaptive': true,
+        'poll_interval': '1m',
+        'min_interval': '30s',
+        'max_interval': '10m',
+        'discovery_interval': '4m',
+        'tier3_interval': '45s',
+        'rate_limit_safety_threshold': 50,
+        'use_etag': true,
+        'use_graphql': false,
+      },
+    };
+    final cfg = AppConfig.fromJson(json);
+    expect(cfg.polling.adaptive, isTrue);
+    expect(cfg.polling.pollInterval, '1m');
+    expect(cfg.polling.minInterval, '30s');
+    expect(cfg.polling.rateLimitSafetyThreshold, 50);
+  });
+
+  test('AppConfig.fromJson uses PollingConfig defaults when polling key absent', () {
+    final json = {
+      'repositories': <String>[],
+      'server_port': 7842,
+      'poll_interval': '5m',
+      'retention_days': 90,
+      'ai_primary': 'claude',
+      'ai_fallback': '',
+      'review_mode': 'single',
+      'issue_tracking': {'enabled': false},
+    };
+    final cfg = AppConfig.fromJson(json);
+    expect(cfg.polling.adaptive, isFalse);
+    expect(cfg.polling.useEtag, isTrue);
+  });
+
+  test('_computeGlobalDiff emits polling diff only for changed fields', () {
+    const old = AppConfig();
+    // Change two fields: adaptive and use_graphql
+    final updated = old.copyWith(
+      polling: const PollingConfig(adaptive: true, useGraphql: true),
+    );
+    final diff = computeGlobalDiffForTest(old, updated);
+    expect(diff.containsKey('polling'), isTrue);
+    final pd = diff['polling'] as Map<String, dynamic>;
+    expect(pd['adaptive'], isTrue);
+    expect(pd['use_graphql'], isTrue);
+    // Unchanged fields must not appear
+    expect(pd.containsKey('use_etag'), isFalse);
+    expect(pd.containsKey('min_interval'), isFalse);
+    expect(pd.containsKey('poll_interval'), isFalse);
+  });
+
+  test('_computeGlobalDiff emits no polling diff when polling unchanged', () {
+    const cfg = AppConfig();
+    final diff = computeGlobalDiffForTest(cfg, cfg);
+    expect(diff.containsKey('polling'), isFalse);
+  });
+
+  // ── saveAndStartDaemon tests ───────────────────────────────────────────────
 
   testWidgets('saveAndStartDaemon calls platform.spawnDaemon', (tester) async {
     final platform = FakePlatformServices(


### PR DESCRIPTION
## Summary

Fixes the daemon **exhausting GitHub's core REST budget (5000/h)** and 403-storming. Root cause: issues were fetched **one REST call per repo per cycle** (~75 repos × 60 cycles/h ≈ 4500/h), with **no ETag caching** and a **non-GitHub-aware** local limiter. Delivered in 3 phases, all knobs **configurable from config.toml, GUI and TUI**, on the **personal token** (no GitHub App / webhooks). Defaults reproduce prior behavior (unconfigured = no change); the DX (detection latency) is preserved.

### Phase 1 — stop the hemorrhage (zero DX cost)
- **ETag/304 conditional caching** (C1): every polling GET sends `If-None-Match`; 304s are served from cache and **don't count against the rate limit**. Keyed by Accept+path; skips large/paginated bodies. Biggest reduction.
- **Aggregated issue Search** (C2): replaces O(repos) per-repo `GET /repos/{repo}/issues` with **one `GET /search/issues`** (assignee-grouped), using the **separate search budget**; per-repo REST fallback preserved; client-side classify/filter keeps behavior equivalent.
- **GitHub-aware rate limiter** (C3): reads `X-RateLimit-*` + `Retry-After`, throttles proactively before 403 (per-tier thresholds keep the review-loop alive), honors secondary-limit cooldowns. Write paths (SubmitReview/PostComment) report headers too.

### Phase 2 — adaptive + configurable (3 layers)
- **`[polling]` config** (C5): poll/min/max/discovery/tier3 intervals, `adaptive`, `rate_limit_safety_threshold`, `use_etag`/`use_graphql` kill-switches. Exposed in `GET/PATCH /config`, an editable **GUI** section, and the **TUI** Config tab.
- **Adaptive interval engine** (C5): idle repos back off (min→max), active repos stay at min. Opt-in (`adaptive=false` default → all repos every cycle).
- **Tier3** (C6): already conditional (ETag) + per-item exponential backoff + configurable tick.

### Phase 3 — GraphQL batching
- **GraphQL issue search** (C4): when `use_graphql=true`, fetch issues via the **idle GraphQL budget** with automatic REST-Search fallback. Default OFF.

## Test Plan
- [x] `cd daemon && go build ./... && go vet ./... && go test ./... -race` — green (pre-existing flaky `internal/executor TestExecuteRawAddsDetectedWorkDirFlags` passes in isolation)
- [x] `cd cli && go test ./...` — green · `cd flutter_app && flutter analyze && flutter test` — 187/187
- [x] `gofmt` clean on all changed Go files
- [x] Unit coverage per component (ETag 304/large/paginated, search assignee-grouping + fallback, limiter throttle/backoff/priority, adaptive engine, GraphQL parse/paginate/fallback, config defaults + 3-layer exposure)
- [ ] Manual: enable `[polling] adaptive=true` / `use_graphql=true` on a test daemon; confirm core budget consumption drops and detection latency for active repos is unchanged

## Notes
- **Safety by defaults**: `use_etag=true` (the one intended change — transparent), `use_graphql=false`, `adaptive=false`, intervals/threshold = prior hardcoded values.
- Out of scope (per decision): GitHub App, webhooks.
- Spec: `docs/superpowers/specs/2026-06-15-gh-api-efficiency-design.md`. Config docs: `docs/configuration-guide.md` §16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)