### PR TITLE
feat(config): accept arbitrary poll_interval in [1m, 24h], drop fixed whitelist (closes #538)

### DIFF
--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -14,8 +14,32 @@ import (
 	"github.com/heimdallm/daemon/internal/executor"
 )
 
-var validIntervals = map[string]bool{
-	"1m": true, "5m": true, "30m": true, "1h": true,
+// Poll interval bounds. Any time.ParseDuration value within this range is
+// accepted; the discrete whitelist {1m,5m,30m,1h} was removed in favour of a
+// continuous range so values like 3m or 10m are valid everywhere (TOML, GUI,
+// TUI). 1m keeps the GitHub rate-limit floor; 24h is a generous ceiling that
+// still rejects pathological values like 1s or 0.
+const (
+	minPollInterval = time.Minute
+	maxPollInterval = 24 * time.Hour
+)
+
+// ValidatePollInterval reports whether raw is an acceptable poll_interval: a
+// time.ParseDuration value within [minPollInterval, maxPollInterval]. An empty
+// string is allowed (callers apply the default). Exported so the HTTP config
+// handler enforces the same rule as config load.
+func ValidatePollInterval(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return fmt.Errorf("invalid poll_interval %q: %w", raw, err)
+	}
+	if d < minPollInterval || d > maxPollInterval {
+		return fmt.Errorf("poll_interval %q out of range (must be between %s and %s)", raw, minPollInterval, maxPollInterval)
+	}
+	return nil
 }
 
 // githubTopicPattern enforces GitHub's topic rules: lowercase letters, digits
@@ -1206,8 +1230,8 @@ func (c *Config) Validate() error {
 	if c.AI.Primary == "" {
 		return fmt.Errorf("config: ai.primary is required")
 	}
-	if c.GitHub.PollInterval != "" && !validIntervals[c.GitHub.PollInterval] {
-		return fmt.Errorf("config: invalid poll_interval %q (valid: 1m, 5m, 30m, 1h)", c.GitHub.PollInterval)
+	if err := ValidatePollInterval(c.GitHub.PollInterval); err != nil {
+		return fmt.Errorf("config: %w", err)
 	}
 	// Validate per-CLI agent configs: permission_mode and approval_mode must be in their allowlists.
 	for name, a := range c.AI.Agents {

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -277,18 +277,28 @@ func TestValidate_ValidConfig(t *testing.T) {
 }
 
 func TestValidate_InvalidPollInterval(t *testing.T) {
-	cfg := &Config{}
-	cfg.applyDefaults()
-	cfg.AI.Primary = "claude"
-	cfg.GitHub.PollInterval = "2m"
+	for _, interval := range []string{
+		"nonsense", // unparseable
+		"30s",      // below the 1m floor
+		"0",        // zero
+		"-5m",      // negative
+		"48h",      // above the 24h ceiling
+	} {
+		cfg := &Config{}
+		cfg.applyDefaults()
+		cfg.AI.Primary = "claude"
+		cfg.GitHub.PollInterval = interval
 
-	if err := cfg.Validate(); err == nil {
-		t.Error("Validate() = nil, want error for invalid poll_interval")
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("Validate() with interval %q = nil, want error", interval)
+		}
 	}
 }
 
 func TestValidate_AllValidIntervals(t *testing.T) {
-	for _, interval := range []string{"1m", "5m", "30m", "1h"} {
+	// Any time.ParseDuration value within [1m, 24h] is accepted, including
+	// arbitrary values like 3m that the old discrete whitelist rejected.
+	for _, interval := range []string{"1m", "3m", "5m", "10m", "30m", "90m", "1h", "12h", "24h"} {
 		cfg := &Config{AI: AIConfig{Primary: "claude"}, GitHub: GitHubConfig{PollInterval: interval}}
 		if err := cfg.Validate(); err != nil {
 			t.Errorf("Validate() with interval %q = %v", interval, err)

--- a/daemon/internal/config/store_test.go
+++ b/daemon/internal/config/store_test.go
@@ -359,14 +359,14 @@ func TestMergeStoreLayer_InvalidStoreValue_ReturnsError(t *testing.T) {
 
 func TestMergeStoreLayer_FailsValidationOnBadMergedCfg(t *testing.T) {
 	// If the store row passes JSON decoding but the merged Config fails
-	// Validate (e.g. poll_interval not in allowlist), MergeStoreLayer must
-	// surface the error so reload can abort cleanly.
+	// Validate (e.g. poll_interval out of the accepted [1m,24h] range),
+	// MergeStoreLayer must surface the error so reload can abort cleanly.
 	cfg := &Config{}
 	cfg.applyDefaults()
 	cfg.AI.Primary = "claude"
 
 	store := &fakeStoreLister{rows: map[string]string{
-		"poll_interval": "42m", // valid as string, invalid per validIntervals
+		"poll_interval": "48h", // parseable string, but above the 24h ceiling
 	}}
 
 	if err := cfg.MergeStoreLayer(store); err == nil {

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -685,14 +685,6 @@ var allowedAgentConfigSubkeys = map[string]struct{}{
 	"execution_timeout":      {},
 }
 
-// validPollIntervals is the allowlist of permitted poll_interval values.
-var validPollIntervals = map[string]struct{}{
-	"1m":  {},
-	"5m":  {},
-	"30m": {},
-	"1h":  {},
-}
-
 // validReviewModes is the allowlist of permitted review_mode values.
 var validReviewModes = map[string]struct{}{
 	"single": {},
@@ -722,8 +714,8 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "poll_interval must be a string", http.StatusBadRequest)
 			return
 		}
-		if _, valid := validPollIntervals[s]; !valid {
-			http.Error(w, "poll_interval must be one of: 1m, 5m, 30m, 1h", http.StatusBadRequest)
+		if err := config.ValidatePollInterval(s); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1436,8 +1436,23 @@ func TestHandlerPutConfigValueValidation(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
-			name:       "invalid poll_interval 2m",
-			body:       `{"poll_interval":"2m"}`,
+			name:       "valid arbitrary poll_interval 3m",
+			body:       `{"poll_interval":"3m"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid poll_interval below floor 30s",
+			body:       `{"poll_interval":"30s"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid poll_interval above ceiling 48h",
+			body:       `{"poll_interval":"48h"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid poll_interval unparseable",
+			body:       `{"poll_interval":"nonsense"}`,
 			wantStatus: http.StatusBadRequest,
 		},
 		{

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -111,7 +111,7 @@ GEMINI_API_KEY=
 # Fallback AI CLI if primary is unavailable
 # HEIMDALLM_AI_FALLBACK=gemini
 
-# Poll interval for checking GitHub PRs (valid: 1m, 5m, 30m, 1h)
+# Poll interval for checking GitHub PRs (any time.ParseDuration value in [1m, 24h], e.g. 3m, 10m)
 HEIMDALLM_POLL_INTERVAL=5m
 
 # Review mode: "single" (one review body) or "multi" (one comment per issue + summary)

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -134,7 +134,7 @@ non_monitored = ["myorg/archived-repo", "myorg/internal-mirror"]
 ### Poll interval
 
 ```bash
-HEIMDALLM_POLL_INTERVAL=5m   # valid: 1m, 5m, 30m, 1h
+HEIMDALLM_POLL_INTERVAL=5m   # any time.ParseDuration value in [1m, 24h], e.g. 3m, 10m
 ```
 
 ```toml
@@ -1183,7 +1183,7 @@ bind_addr = "0.0.0.0"  # env: HEIMDALLM_BIND_ADDR
 # ── GitHub ───────────────────────────────────────────────────────────────────
 
 [github]
-# Poll interval for PR/issue checks. Valid: 1m, 5m, 30m, 1h.
+# Poll interval for PR/issue checks. Any time.ParseDuration value in [1m, 24h], e.g. 3m, 10m.
 poll_interval = "5m"   # env: HEIMDALLM_POLL_INTERVAL
 
 # Static list of repos to monitor.

--- a/project-spec.md
+++ b/project-spec.md
@@ -23,7 +23,7 @@ Language: Prefer Go (fallback: Python if necessary)
 
 ### 1.1 GitHub Integration
 
--   Poll GitHub API at configurable intervals (1m, 5m, 30m, 1h)
+-   Poll GitHub API at configurable intervals (any duration in [1m, 24h], e.g. 3m, 10m)
 -   Fetch PRs assigned or requesting review
 -   Filter by configured repositories
 


### PR DESCRIPTION
## Summary

`poll_interval` was validated against a hard-coded whitelist `{1m, 5m, 30m, 1h}`. Any other value — e.g. a sensible `3m` — was rejected, and on the daemon load path this **crash-looped the bundled daemon** (config never loads → nothing listens on `:7842`). This replaces the discrete whitelist with a continuous range: any `time.ParseDuration` value within **[1m, 24h]** is accepted. Closes the legacy validation gap described in #538 (independent of the still-open #537).

## How it works

- New exported helper `config.ValidatePollInterval(raw string) error` — parses with `time.ParseDuration` and bounds the result to `[minPollInterval=1m, maxPollInterval=24h]`. Empty string is allowed (callers apply the default).
- Both enforcement points now call it, so the rule is identical everywhere (TOML, GUI, TUI):
  - `daemon/internal/config/config.go` — `Validate()` (config-load path), replacing the `validIntervals` map.
  - `daemon/internal/server/handlers.go` — `PUT/PATCH /config` handler, replacing the local `validPollIntervals` allowlist.
- `1m` keeps the GitHub rate-limit floor; `24h` is a generous ceiling that still rejects pathological values (`1s`, `0`, negatives).
- Docs (`configuration-guide.md`, `docker/.env.example`, `project-spec.md`) updated to describe the range.

## Scope

**In scope:** relaxing the legacy `[github].poll_interval` validation in the two enforcement points + tests + docs.

**Out of scope:** PR #537's new `[polling]` section (`ResolvedPollInterval`/`min`/`max`) — that PR is still open and does not touch this legacy validation; the two are independent.

## Production impact & what to watch

- **Runtime behavior change:** a config that previously crash-looped the daemon (e.g. `3m`) now loads and the daemon stays up. No new scheduler code path — the interval string was already consumed as-is. Users can now pick intervals near the 1m floor → more frequent GitHub API calls.
- **Rollout failure modes:** removes a crashloop, doesn't add one. No new secret/config/permission. Whitelisted values validate identically. Sub-minute (`30s`) / oversized (`48h`) still rejected. Minor widening: empty `poll_interval` on the HTTP path is now accepted (falls back to default). The `400` **error message changed** ("out of range / invalid …" vs "must be one of: 1m, 5m, 30m, 1h").
- **Blast radius:** single bundled/self-hosted daemon per user; config load + `PUT/PATCH /config`. No multi-replica concern.
- **What to watch:** daemon startup (`config load failed` ERRORs should disappear; listening on `:7842`); `PUT /config` 400s only for genuinely invalid values; GitHub `403` secondary-rate-limit if users pick aggressive intervals.
- **Rollback & sequencing:** fully revertible, no migration. Caveat: a config persisted with a newly-valid value (e.g. `3m`) would crash-loop again if this is reverted (manual edit back to a whitelisted value needed). No flag/ordering required.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/config/... ./internal/server/...`
- [x] `go test ./internal/config/... ./internal/server/...` — pass
- [x] Updated tests: `TestValidate_InvalidPollInterval` (now covers `30s`/`0`/`-5m`/`48h`/unparseable), `TestValidate_AllValidIntervals` (now includes `3m`/`10m`/`90m`/`12h`/`24h`), `store_test.go` bad-row case (`42m`→`48h`), `handlers_test.go` PUT table (valid `3m`, invalid `30s`/`48h`/`nonsense`)
- [ ] Reviewer: confirm bounds `[1m, 24h]` match intended operational policy
- [ ] Note: pre-existing, unrelated failure `internal/executor TestDetect_Fallback` (environment-dependent — a real `codex` binary on PATH defeats the fallback assertion; fails on clean `main` too)

Closes #538
