### PR TITLE
fix(discovery): keep config consistent when promoting explicit [ai.repos.*] repos (closes #527)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2601,12 +2601,13 @@ func aiRepoKeys(c *config.Config) []string {
 // first-seen timestamps. This helper is pure state mutation so it's easy
 // to test in isolation.
 func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
-	known := make(map[string]struct{})
+	inRepositories := make(map[string]struct{}, len(c.GitHub.Repositories))
 	for _, r := range c.GitHub.Repositories {
-		known[r] = struct{}{}
+		inRepositories[r] = struct{}{}
 	}
+	inNonMonitored := make(map[string]struct{}, len(c.GitHub.NonMonitored))
 	for _, r := range c.GitHub.NonMonitored {
-		known[r] = struct{}{}
+		inNonMonitored[r] = struct{}{}
 	}
 
 	// Build an org allowlist from DiscoveryOrgs. When set, repos whose org
@@ -2624,7 +2625,43 @@ func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
 		if pr.Repo == "" {
 			continue
 		}
-		if _, alreadyKnown := known[pr.Repo]; alreadyKnown {
+
+		// Repos with an explicit [ai.repos.*] entry are opted in by the
+		// operator. Explicit config is intent and must win over both guards:
+		//   - It bypasses the discovery_orgs allowlist (theburrowhub/heimdallm#527
+		//     item 2): a configured repo outside the discovery orgs must still
+		//     be monitored, so this check precedes the org filter below.
+		//   - It promotes the repo out of NonMonitored when a stale row from a
+		//     prior tick blacklisted it (#527 item 1). Leaving it in
+		//     NonMonitored keeps config state inconsistent for code that reads
+		//     the list directly, even though MergeRepos already exempts it. So
+		//     we strip the repo from NonMonitored and add it to Repositories.
+		// See also theburrowhub/heimdallm#281 for why a configured repo must
+		// never linger in NonMonitored (MergeRepos would otherwise blacklist it
+		// and silently stop issue polling).
+		if _, hasExplicitAIConfig := c.AI.Repos[pr.Repo]; hasExplicitAIConfig {
+			_, alreadyMonitored := inRepositories[pr.Repo]
+			if _, blacklisted := inNonMonitored[pr.Repo]; blacklisted {
+				c.GitHub.NonMonitored = removeRepo(c.GitHub.NonMonitored, pr.Repo)
+				delete(inNonMonitored, pr.Repo)
+			}
+			if !alreadyMonitored {
+				c.GitHub.Repositories = append(c.GitHub.Repositories, pr.Repo)
+				inRepositories[pr.Repo] = struct{}{}
+				// Reported as added so processDiscoveredRepos persists the
+				// updated lists (it early-returns on an empty added set) — this
+				// is what makes the NonMonitored strip durable across reloads.
+				added = append(added, pr.Repo)
+			}
+			continue
+		}
+
+		// Auto-discovered repos (no explicit config): skip when already tracked
+		// in either list.
+		if _, ok := inRepositories[pr.Repo]; ok {
+			continue
+		}
+		if _, ok := inNonMonitored[pr.Repo]; ok {
 			continue
 		}
 		// Filter by allowed orgs when configured.
@@ -2639,21 +2676,27 @@ func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
 				continue
 			}
 		}
-		// Repos with an explicit [ai.repos.*] entry are opted in by the operator
-		// and must NEVER land in NonMonitored — even when AutoEnablePRForDiscovery
-		// is off. Otherwise the next MergeRepos call would blacklist them and
-		// silently stop issue polling for a repo the user just configured. See
-		// theburrowhub/heimdallm#281.
-		_, hasExplicitAIConfig := c.AI.Repos[pr.Repo]
-		if enable || hasExplicitAIConfig {
+		if enable {
 			c.GitHub.Repositories = append(c.GitHub.Repositories, pr.Repo)
+			inRepositories[pr.Repo] = struct{}{}
 		} else {
 			c.GitHub.NonMonitored = append(c.GitHub.NonMonitored, pr.Repo)
+			inNonMonitored[pr.Repo] = struct{}{}
 		}
-		known[pr.Repo] = struct{}{}
 		added = append(added, pr.Repo)
 	}
 	return added
+}
+
+// removeRepo returns s without the first occurrence of repo, preserving order.
+// Returns s unchanged when repo is absent.
+func removeRepo(s []string, repo string) []string {
+	for i, r := range s {
+		if r == repo {
+			return append(s[:i:i], s[i+1:]...)
+		}
+	}
+	return s
 }
 
 // upsertDiscoveredFromTopics persists repos received from tier1's topic

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2640,17 +2640,28 @@ func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
 		// never linger in NonMonitored (MergeRepos would otherwise blacklist it
 		// and silently stop issue polling).
 		if _, hasExplicitAIConfig := c.AI.Repos[pr.Repo]; hasExplicitAIConfig {
+			// Within-tick duplicate PRs for the same repo are absorbed: after the
+			// first one promotes the repo, inRepositories/inNonMonitored reflect
+			// the new state, so a second PR for the same repo is a no-op here.
 			_, alreadyMonitored := inRepositories[pr.Repo]
-			if _, blacklisted := inNonMonitored[pr.Repo]; blacklisted {
+			_, blacklisted := inNonMonitored[pr.Repo]
+			if blacklisted {
 				c.GitHub.NonMonitored = removeRepo(c.GitHub.NonMonitored, pr.Repo)
 				delete(inNonMonitored, pr.Repo)
 			}
 			if !alreadyMonitored {
 				c.GitHub.Repositories = append(c.GitHub.Repositories, pr.Repo)
 				inRepositories[pr.Repo] = struct{}{}
-				// Reported as added so processDiscoveredRepos persists the
-				// updated lists (it early-returns on an empty added set) — this
-				// is what makes the NonMonitored strip durable across reloads.
+			}
+			// Report the repo as added whenever EITHER list was mutated — not
+			// only on the add-to-Repositories path. processDiscoveredRepos
+			// early-returns on an empty added set, so a strip-only change (repo
+			// already in Repositories but also stale in NonMonitored) must still
+			// land here, or the NonMonitored strip would not be persisted and the
+			// inconsistency would survive across reloads.
+			if blacklisted || !alreadyMonitored {
+				slog.Info("upsertDiscoveredRepos: promoted explicitly-configured repo",
+					"repo", pr.Repo, "added_to_repositories", !alreadyMonitored, "stripped_from_non_monitored", blacklisted)
 				added = append(added, pr.Repo)
 			}
 			continue

--- a/daemon/cmd/heimdallm/main_discover_test.go
+++ b/daemon/cmd/heimdallm/main_discover_test.go
@@ -201,3 +201,95 @@ func TestUpsertDiscoveredRepos_ExplicitAIConfigOverridesAutoEnableOff(t *testing
 		t.Fatalf("a/no-config should be in NonMonitored (no explicit config + auto-enable off), got %v", cfg.GitHub.NonMonitored)
 	}
 }
+
+// theburrowhub/heimdallm#527 item 1: a repo blacklisted in NonMonitored on a
+// prior tick that later gains explicit [ai.repos.*] config must be promoted —
+// stripped from NonMonitored and added to Repositories — so config state stays
+// consistent for code that reads NonMonitored directly (not just MergeRepos,
+// which already exempts it). The promotion is reported in `added` so the
+// updated lists are persisted.
+func TestUpsertDiscoveredRepos_PromotesExplicitConfigOutOfNonMonitored(t *testing.T) {
+	f := false
+	cfg := &config.Config{}
+	cfg.GitHub.AutoEnablePROnDiscovery = &f
+	cfg.GitHub.NonMonitored = []string{"a/keep-blacklisted", "a/wired-up"}
+	cfg.AI.Repos = map[string]config.RepoAI{
+		"a/wired-up": {},
+	}
+
+	prs := []*gh.PullRequest{
+		{RepositoryURL: "https://api.github.com/repos/a/wired-up", Number: 1},
+	}
+	for _, pr := range prs {
+		pr.ResolveRepo()
+	}
+
+	added := upsertDiscoveredRepos(cfg, prs)
+	if len(added) != 1 || added[0] != "a/wired-up" {
+		t.Fatalf("promoted repo must be reported in added (so lists persist), got %v", added)
+	}
+
+	// Must now be in Repositories.
+	foundWired := false
+	for _, r := range cfg.GitHub.Repositories {
+		if r == "a/wired-up" {
+			foundWired = true
+		}
+	}
+	if !foundWired {
+		t.Fatalf("a/wired-up must be promoted to Repositories, got %v", cfg.GitHub.Repositories)
+	}
+
+	// Must be stripped from NonMonitored, while the unrelated blacklist row stays.
+	wantNonMon := []string{"a/keep-blacklisted"}
+	if len(cfg.GitHub.NonMonitored) != len(wantNonMon) || cfg.GitHub.NonMonitored[0] != wantNonMon[0] {
+		t.Fatalf("NonMonitored = %v, want %v (wired-up stripped, other kept)", cfg.GitHub.NonMonitored, wantNonMon)
+	}
+}
+
+// theburrowhub/heimdallm#527 item 2: explicit [ai.repos.*] config is operator
+// intent and must bypass the discovery_orgs allowlist. A configured repo whose
+// org is outside discovery_orgs must still land in Repositories via upsert,
+// while a non-configured repo in the same out-of-list org is still filtered.
+func TestUpsertDiscoveredRepos_ExplicitConfigBypassesOrgFilter(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.DiscoveryOrgs = []string{"allowed-org"}
+	cfg.AI.Repos = map[string]config.RepoAI{
+		"other-org/wired-up": {},
+	}
+
+	prs := []*gh.PullRequest{
+		{RepositoryURL: "https://api.github.com/repos/other-org/wired-up", Number: 1},
+		{RepositoryURL: "https://api.github.com/repos/other-org/not-configured", Number: 2},
+	}
+	for _, pr := range prs {
+		pr.ResolveRepo()
+	}
+
+	added := upsertDiscoveredRepos(cfg, prs)
+	if len(added) != 1 || added[0] != "other-org/wired-up" {
+		t.Fatalf("only the explicitly-configured out-of-org repo should be added, got %v", added)
+	}
+
+	foundWired := false
+	for _, r := range cfg.GitHub.Repositories {
+		if r == "other-org/wired-up" {
+			foundWired = true
+		}
+	}
+	if !foundWired {
+		t.Fatalf("other-org/wired-up must be in Repositories (explicit config bypasses org filter), got %v", cfg.GitHub.Repositories)
+	}
+
+	// The non-configured out-of-org repo must not appear in either list.
+	for _, r := range cfg.GitHub.Repositories {
+		if r == "other-org/not-configured" {
+			t.Fatal("other-org/not-configured must be filtered by discovery_orgs")
+		}
+	}
+	for _, r := range cfg.GitHub.NonMonitored {
+		if r == "other-org/not-configured" {
+			t.Fatal("other-org/not-configured must not be added to NonMonitored either")
+		}
+	}
+}

--- a/daemon/cmd/heimdallm/main_discover_test.go
+++ b/daemon/cmd/heimdallm/main_discover_test.go
@@ -247,6 +247,52 @@ func TestUpsertDiscoveredRepos_PromotesExplicitConfigOutOfNonMonitored(t *testin
 	}
 }
 
+// Edge case (review of #527): a repo that is SIMULTANEOUSLY in Repositories and
+// NonMonitored — the inconsistent prior-tick state this fix targets — must still
+// have its NonMonitored strip reported in `added`, even though it is already
+// monitored. Otherwise, if it is the only change in the tick, the empty `added`
+// set makes processDiscoveredRepos early-return and the strip is never persisted.
+func TestUpsertDiscoveredRepos_PromotionPersistsWhenAlreadyMonitored(t *testing.T) {
+	f := false
+	cfg := &config.Config{}
+	cfg.GitHub.AutoEnablePROnDiscovery = &f
+	cfg.GitHub.Repositories = []string{"a/wired-up"}
+	cfg.GitHub.NonMonitored = []string{"a/wired-up"} // inconsistent: present in both
+	cfg.AI.Repos = map[string]config.RepoAI{
+		"a/wired-up": {},
+	}
+
+	prs := []*gh.PullRequest{
+		{RepositoryURL: "https://api.github.com/repos/a/wired-up", Number: 1},
+	}
+	for _, pr := range prs {
+		pr.ResolveRepo()
+	}
+
+	added := upsertDiscoveredRepos(cfg, prs)
+
+	// The strip MUST be reported so the updated lists get persisted.
+	if len(added) != 1 || added[0] != "a/wired-up" {
+		t.Fatalf("strip-only promotion must be reported in added (else it is not persisted), got %v", added)
+	}
+	// Stripped from NonMonitored.
+	for _, r := range cfg.GitHub.NonMonitored {
+		if r == "a/wired-up" {
+			t.Fatalf("a/wired-up must be stripped from NonMonitored, got %v", cfg.GitHub.NonMonitored)
+		}
+	}
+	// Still present in Repositories exactly once (no duplicate append).
+	count := 0
+	for _, r := range cfg.GitHub.Repositories {
+		if r == "a/wired-up" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("a/wired-up must appear exactly once in Repositories, got %v", cfg.GitHub.Repositories)
+	}
+}
+
 // theburrowhub/heimdallm#527 item 2: explicit [ai.repos.*] config is operator
 // intent and must bypass the discovery_orgs allowlist. A configured repo whose
 // org is outside discovery_orgs must still land in Repositories via upsert,

--- a/daemon/internal/discovery/discovery_test.go
+++ b/daemon/internal/discovery/discovery_test.go
@@ -149,6 +149,28 @@ func TestMergeRepos_ConfiguredOverridesNonMonitored(t *testing.T) {
 	}
 }
 
+// theburrowhub/heimdallm#527 item 4: a repo present in static, configured AND
+// nonMonitored simultaneously must survive — explicit [ai.repos.*] config
+// (exempt) wins over the NonMonitored blacklist across all three sources, and
+// the repo is deduplicated to a single entry.
+func TestMergeRepos_ConfiguredExemptWinsAcrossAllSources(t *testing.T) {
+	got := discovery.MergeRepos(
+		[]string{"org/triple", "org/static-only"},
+		[]string{"org/triple"},
+		[]string{"org/triple"},
+		[]string{"org/triple"},
+	)
+	want := []string{"org/triple", "org/static-only"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v (exempt config must win over non_monitored, deduped)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 // A repo listed in both static and configured is deduplicated; static order wins.
 func TestMergeRepos_ConfiguredDeduplicatesWithStatic(t *testing.T) {
 	got := discovery.MergeRepos(


### PR DESCRIPTION
## Summary

Follow-up to the review of PR #485 (#527). When a repository is wired up via `[ai.repos.*]`, that is explicit operator intent and should win over the auto-discovery guards. `upsertDiscoveredRepos` previously left such a repo in an inconsistent state in two situations, and the merge layer (`MergeRepos`) only papered over it at read time. This makes the persisted config itself consistent.

## How it works

`daemon/cmd/heimdallm/main.go` — `upsertDiscoveredRepos` now handles explicitly-configured repos up front, before the "already known" and `discovery_orgs` checks:

- **Item 1 — promote out of `NonMonitored`.** A repo blacklisted on a prior tick that now has explicit config is stripped from `NonMonitored` and appended to `Repositories`, instead of being short-circuited as "already known" and left in `NonMonitored` (where code reading the list directly would treat it as blacklisted, even though `MergeRepos` exempts it). The promotion is reported in `added` so `processDiscoveredRepos` actually persists the updated lists — it early-returns on an empty `added` set, so this is what makes the strip durable across reloads. New helper `removeRepo` (order-preserving, fresh allocation via a 3-index slice).
- **Item 2 — bypass the org filter.** The explicit-config check now precedes the `discovery_orgs` allowlist, so a configured repo whose org is outside `discovery_orgs` still lands in `Repositories` via upsert. Non-configured repos in out-of-list orgs are still filtered.

The split of the old single `known` set into `inRepositories` / `inNonMonitored` is what lets the promotion path tell "already monitored" from "blacklisted".

## Scope

**In scope:** items 1, 2, 4 from #527.

**Out of scope / already done:** item 3 (`Tier1Config.ConfiguredRepos` staleness on hot-reload) — verified already resolved within #485: `tier1ConfigFn` (`main.go:688-702`) is a closure that recomputes `ConfiguredRepos: aiRepoKeys(cfg)` live under `cfgMu`, symmetric with `StaticRepos`/`NonMonitored`. No code change needed.

## Production impact & what to watch

- **Runtime behavior change:** pure in-memory list reconciliation on the existing poll path — no new GitHub calls. Only repos with an explicit `[ai.repos.*]` entry take a different path; everything else is byte-for-byte the old behavior. A configured repo previously stuck unmonitored-in-`NonMonitored` (rescued only by `MergeRepos` at read time) now gets monitored *and* the persisted config matches.
- **Rollout failure modes:** no new startup invariant/secret/permission — cannot crashloop. A promoted repo emits one `repo_discovered` SSE and has its review deferred one tick (benign; UI keys by repo, `FirstSeen.Mark` is idempotent so the NEW badge is preserved).
- **Blast radius:** daemon discovery/poll path; only operators combining `[ai.repos.*]` with `auto_enable=false` and/or `discovery_orgs`. Single self-hosted daemon.
- **What to watch:** (1) a previously-misconfigured repo appears in `Repositories` and leaves `non_monitored` in GET `/config` / `heimdallm-cli status`; (2) no flip-flop churn in the persisted `non_monitored` row across ticks (the move should be one-time); (3) at most one extra `repo_discovered` SSE per promoted repo, not per tick.
- **Rollback & sequencing:** fully revertible, no migration. After revert, an already-promoted repo stays in `repositories` (harmless). No ordering/flag needed.

## Evidence

<details><summary>New tests pass</summary>

```
--- PASS: TestUpsertDiscoveredRepos_PromotesExplicitConfigOutOfNonMonitored (0.00s)
--- PASS: TestUpsertDiscoveredRepos_ExplicitConfigBypassesOrgFilter (0.00s)
--- PASS: TestMergeRepos_ConfiguredExemptWinsAcrossAllSources (0.00s)
```
</details>

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/... ./internal/discovery/...`
- [x] `go test ./cmd/heimdallm/... ./internal/discovery/...` — pass
- [x] Item 4 test `TestMergeRepos_ConfiguredExemptWinsAcrossAllSources` (static+configured+nonMonitored)
- [x] Item 1 test `TestUpsertDiscoveredRepos_PromotesExplicitConfigOutOfNonMonitored`
- [x] Item 2 test `TestUpsertDiscoveredRepos_ExplicitConfigBypassesOrgFilter`
- [ ] Reviewer: confirm promoted repos *should* surface a `repo_discovered` SSE (vs a dedicated state-change event)
- [ ] Note: pre-existing, unrelated failure `internal/executor TestDetect_Fallback` (environment-dependent — a real `codex` binary on PATH defeats the fallback assertion; fails on clean `main` too)

Closes #527
