### PR TITLE
fix(config): cleaner poll_interval out-of-range error message (review follow-up to #539)

### DIFF
--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -15,13 +15,17 @@ import (
 )
 
 // Poll interval bounds. Any time.ParseDuration value within this range is
-// accepted; the discrete whitelist {1m,5m,30m,1h} was removed in favour of a
-// continuous range so values like 3m or 10m are valid everywhere (TOML, GUI,
-// TUI). 1m keeps the GitHub rate-limit floor; 24h is a generous ceiling that
-// still rejects pathological values like 1s or 0.
+// accepted by the daemon (config.toml load and the HTTP config API); the
+// discrete whitelist {1m,5m,30m,1h} was removed in favour of a continuous range
+// so values like 3m or 10m are valid. 1m keeps the GitHub rate-limit floor; 24h
+// is a generous ceiling that still rejects pathological values like 1s or 0.
 const (
 	minPollInterval = time.Minute
 	maxPollInterval = 24 * time.Hour
+	// Display forms for error messages — time.Duration.String() renders the
+	// constants as "1m0s"/"24h0s", which is noisier than the units operators type.
+	minPollIntervalStr = "1m"
+	maxPollIntervalStr = "24h"
 )
 
 // ValidatePollInterval reports whether raw is an acceptable poll_interval: a
@@ -37,7 +41,7 @@ func ValidatePollInterval(raw string) error {
 		return fmt.Errorf("invalid poll_interval %q: %w", raw, err)
 	}
 	if d < minPollInterval || d > maxPollInterval {
-		return fmt.Errorf("poll_interval %q out of range (must be between %s and %s)", raw, minPollInterval, maxPollInterval)
+		return fmt.Errorf("poll_interval %q out of range (must be between %s and %s)", raw, minPollIntervalStr, maxPollIntervalStr)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Post-merge follow-up to the AI review of #539 (now merged). The out-of-range `poll_interval` error rendered the bounds via `time.Duration.String()` as `must be between 1m0s and 24h0s`. This uses display constants so the message reads `1m`/`24h` — matching the units operators actually type. Also softens the in-code comment that claimed the range is valid "everywhere (GUI, TUI)": the daemon accepts it, but the Flutter GUI still has its own selector (tracked separately — see linked issue).

## How it works

`daemon/internal/config/config.go` — adds `minPollIntervalStr = "1m"` / `maxPollIntervalStr = "24h"` display constants and uses them in `ValidatePollInterval`'s out-of-range error instead of formatting the `time.Duration` constants.

## Scope

**In scope:** error-message wording (review suggestion F) + comment accuracy.
**Out of scope:** the Flutter GUI dropdown still hardcoding `{1m,5m,30m,1h}` — tracked as a follow-up issue.

## Production impact & what to watch

Pure string change in one validation error path. No runtime/behavior/contract change — the same inputs are accepted/rejected as before; only the rejection message text differs. No new calls, resources, or startup invariants. Blast radius: operators who submit an out-of-range `poll_interval` see a cleaner message. Fully revertible, no sequencing. Nothing specific to watch.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/config/... ./internal/server/...` — pass (existing edge-case tests cover the rejection paths)
