### PR TITLE
feat(flutter): free-form poll_interval input in Settings (closes #543)

### DIFF
--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -11,6 +11,65 @@ import 'config_providers.dart';
 
 const _aiOptions = ['claude', 'gemini', 'codex'];
 
+// Poll-interval bounds, mirrored from the daemon's config.ValidatePollInterval
+// (daemon/internal/config/config.go: minPollInterval=1m, maxPollInterval=24h).
+// The daemon is authoritative — these power a client-side UX guard so the
+// operator gets immediate feedback instead of a round-trip 400.
+const _minPollInterval = Duration(minutes: 1);
+const _maxPollInterval = Duration(hours: 24);
+const _pollIntervalSuggestions = ['1m', '5m', '30m', '1h'];
+
+const _durationUnitMicros = <String, double>{
+  'ns': 0.001,
+  'us': 1,
+  'µs': 1,
+  'ms': 1000,
+  's': 1000 * 1000.0,
+  'm': 60 * 1000 * 1000.0,
+  'h': 60 * 60 * 1000 * 1000.0,
+};
+
+// Order matters: multi-char units (ns, ms, µs/us) must precede the bare 's'
+// so the regex consumes "ms" rather than matching "m" then leaving "s".
+final _goDurationToken = RegExp(r'([0-9]*\.?[0-9]+)(ns|µs|us|ms|s|m|h)');
+
+/// Parses the common subset of Go's `time.ParseDuration` that operators use for
+/// `poll_interval` (e.g. `5m`, `90m`, `1h30m`, `1.5h`, `300s`) into a
+/// [Duration], or returns null if the string is not a clean sequence of
+/// number+unit tokens. This is a UX guard, not a full reimplementation — the
+/// daemon still validates authoritatively, so anything missed here surfaces as
+/// a backend error on save.
+Duration? _parseGoDuration(String raw) {
+  final s = raw.trim();
+  if (s.isEmpty) return null;
+  var consumed = 0;
+  var micros = 0.0;
+  for (final m in _goDurationToken.allMatches(s)) {
+    if (m.start != consumed) return null; // junk between tokens
+    consumed = m.end;
+    final value = double.tryParse(m.group(1)!);
+    final mult = _durationUnitMicros[m.group(2)];
+    if (value == null || mult == null) return null;
+    micros += value * mult;
+  }
+  if (consumed != s.length) return null; // leading/trailing junk
+  return Duration(microseconds: micros.round());
+}
+
+/// Form validator for `poll_interval`: parseable as a duration within
+/// [1m, 24h], mirroring the daemon. Returns an error string for the field, or
+/// null when acceptable.
+String? validatePollInterval(String? raw) {
+  final s = (raw ?? '').trim();
+  if (s.isEmpty) return 'Required (e.g. 5m, 90m, 1h30m)';
+  final d = _parseGoDuration(s);
+  if (d == null) return 'Invalid duration (e.g. 5m, 90m, 1h30m)';
+  if (d < _minPollInterval || d > _maxPollInterval) {
+    return 'Must be between 1m and 24h';
+  }
+  return null;
+}
+
 class ConfigScreen extends ConsumerStatefulWidget {
   const ConfigScreen({super.key});
 
@@ -20,6 +79,7 @@ class ConfigScreen extends ConsumerStatefulWidget {
 
 class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   final _tokenController = TextEditingController();
+  final _pollController = TextEditingController();
   bool _obscureToken = true;
   bool _tokenFromGh = false; // true = auto-detected from gh CLI
 
@@ -45,6 +105,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   @override
   void dispose() {
     _tokenController.dispose();
+    _pollController.dispose();
     super.dispose();
   }
 
@@ -74,6 +135,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     if (_initialized) return;
     _initialized = true;
     _pollInterval = config.pollInterval;
+    _pollController.text = config.pollInterval;
     _retentionDays = config.retentionDays;
     _repoConfigs = Map.from(config.repoConfigs);
     _issueTracking = config.issueTracking;
@@ -368,21 +430,33 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _sectionHeader('Polling'),
-        DropdownButtonFormField<String>(
-          // ignore: deprecated_member_use
-          value: _pollInterval,
+        TextFormField(
+          controller: _pollController,
           decoration: const InputDecoration(
             labelText: 'Poll interval',
-            helperText: 'How often to check GitHub for new review requests',
+            helperText:
+                'How often to check GitHub for new review requests '
+                '(any duration from 1m to 24h, e.g. 5m, 90m, 1h30m)',
             border: OutlineInputBorder(),
           ),
-          items: [
-            '1m',
-            '5m',
-            '30m',
-            '1h',
-          ].map((v) => DropdownMenuItem(value: v, child: Text(v))).toList(),
-          onChanged: (v) => setState(() => _pollInterval = v!),
+          autovalidateMode: AutovalidateMode.onUserInteraction,
+          validator: validatePollInterval,
+          onChanged: (v) => setState(() => _pollInterval = v.trim()),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          children: _pollIntervalSuggestions
+              .map(
+                (v) => ActionChip(
+                  label: Text(v),
+                  onPressed: () => setState(() {
+                    _pollInterval = v;
+                    _pollController.text = v;
+                  }),
+                ),
+              )
+              .toList(),
         ),
       ],
     );

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -19,6 +19,12 @@ const _minPollInterval = Duration(minutes: 1);
 const _maxPollInterval = Duration(hours: 24);
 const _pollIntervalSuggestions = ['1m', '5m', '30m', '1h'];
 
+// Intentionally covers only the units that make sense for a [1m, 24h] poll
+// interval. Sub-second units are accepted (so the parser stays a faithful
+// subset of Go) but always fall below the 1m floor. Go's day-like 'd' is not a
+// real unit and is correctly rejected; the Greek-mu micro variant ('μs',
+// U+03BC) is not special-cased — irrelevant at this scale, and the daemon
+// remains authoritative either way.
 const _durationUnitMicros = <String, double>{
   'ns': 0.001,
   'us': 1,
@@ -50,6 +56,8 @@ Duration? _parseGoDuration(String raw) {
     final value = double.tryParse(m.group(1)!);
     final mult = _durationUnitMicros[m.group(2)];
     if (value == null || mult == null) return null;
+    // Like Go's time.ParseDuration, repeated units accumulate
+    // (e.g. "1h30m" → 90m, and "1h2h" → 3h).
     micros += value * mult;
   }
   if (consumed != s.length) return null; // leading/trailing junk
@@ -80,6 +88,7 @@ class ConfigScreen extends ConsumerStatefulWidget {
 class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   final _tokenController = TextEditingController();
   final _pollController = TextEditingController();
+  final _pollFieldKey = GlobalKey<FormFieldState<String>>();
   bool _obscureToken = true;
   bool _tokenFromGh = false; // true = auto-detected from gh CLI
 
@@ -431,6 +440,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       children: [
         _sectionHeader('Polling'),
         TextFormField(
+          key: _pollFieldKey,
           controller: _pollController,
           decoration: const InputDecoration(
             labelText: 'Poll interval',
@@ -447,19 +457,27 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
         Wrap(
           spacing: 8,
           children: _pollIntervalSuggestions
-              .map(
-                (v) => ActionChip(
-                  label: Text(v),
-                  onPressed: () => setState(() {
-                    _pollInterval = v;
-                    _pollController.text = v;
-                  }),
-                ),
-              )
+              .map((v) => ActionChip(label: Text(v), onPressed: () => _pickPollInterval(v)))
               .toList(),
         ),
       ],
     );
+  }
+
+  /// Applies a quick-pick suggestion. Sets the controller value (cursor at end,
+  /// since a bare `.text =` would reset it to 0) and re-runs the field
+  /// validator — a programmatic change does not count as user interaction under
+  /// [AutovalidateMode.onUserInteraction], so without this an error from prior
+  /// typing would linger even though the chosen value is valid.
+  void _pickPollInterval(String v) {
+    setState(() {
+      _pollInterval = v;
+      _pollController.value = TextEditingValue(
+        text: v,
+        selection: TextSelection.collapsed(offset: v.length),
+      );
+    });
+    _pollFieldKey.currentState?.validate();
   }
 
   // ── Retention ────────────────────────────────────────────────────────────
@@ -838,29 +856,39 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     // always reads the current state at the moment the user taps Save, avoiding
     // stale closure captures when setState and Save happen in the same frame.
 
+    // Gate Save on a valid poll_interval so the client-side check actually
+    // prevents the round-trip 400 (the inline validator alone only displays the
+    // error). onChanged/_pickPollInterval call setState, so this re-evaluates as
+    // the user types or picks a chip. The daemon stays authoritative.
+    final pollInvalid = validatePollInterval(_pollInterval) != null;
+
     if (daemonRunning) {
       return SizedBox(
         width: double.infinity,
         child: ElevatedButton(
-          onPressed: () async {
-            final updated = _buildConfig(base);
-            try {
-              final token = _tokenController.text.trim();
-              if (token.isNotEmpty && !_tokenFromGh) {
-                await ref
-                    .read(platformServicesProvider)
-                    .storeGitHubToken(token);
-                // Invalidate the cached token so the ApiClient re-reads it on the next request.
-                ref.read(apiClientProvider).clearTokenCache();
-              }
-              await ref.read(configNotifierProvider.notifier).save(updated);
-              if (context.mounted) showToast(context, 'Settings saved');
-            } catch (e) {
-              if (context.mounted) {
-                showToast(context, 'Error: $e', isError: true);
-              }
-            }
-          },
+          onPressed: pollInvalid
+              ? null
+              : () async {
+                  final updated = _buildConfig(base);
+                  try {
+                    final token = _tokenController.text.trim();
+                    if (token.isNotEmpty && !_tokenFromGh) {
+                      await ref
+                          .read(platformServicesProvider)
+                          .storeGitHubToken(token);
+                      // Invalidate the cached token so the ApiClient re-reads it on the next request.
+                      ref.read(apiClientProvider).clearTokenCache();
+                    }
+                    await ref
+                        .read(configNotifierProvider.notifier)
+                        .save(updated);
+                    if (context.mounted) showToast(context, 'Settings saved');
+                  } catch (e) {
+                    if (context.mounted) {
+                      showToast(context, 'Error: $e', isError: true);
+                    }
+                  }
+                },
           child: const Text('Save'),
         ),
       );
@@ -880,7 +908,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
               )
             : const Icon(Icons.rocket_launch),
         label: Text(isLoading ? 'Starting…' : 'Save and start Heimdallm'),
-        onPressed: isLoading
+        onPressed: (isLoading || pollInvalid)
             ? null
             : () async {
                 final updated = _buildConfig(base);

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -55,6 +55,59 @@ void main() {
     // Primary agent ('claude') moved to Agents tab — no longer in ConfigScreen
   });
 
+  testWidgets('Save is gated on a valid poll interval', (tester) async {
+    const config = AppConfig(
+      pollInterval: '5m',
+      aiPrimary: 'claude',
+      repoConfigs: {'org/repo': RepoConfig(prEnabled: true)},
+    );
+
+    final mockApi = MockApiClient();
+    when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
+    when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
+    when(() => mockApi.checkHealth()).thenAnswer((_) async => false);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiClientProvider.overrideWithValue(mockApi),
+          configNotifierProvider.overrideWith(ConfigNotifier.new),
+          platformServicesProvider.overrideWithValue(FakePlatformServices()),
+        ],
+        child: MaterialApp.router(
+          routerConfig: GoRouter(
+            routes: [
+              GoRoute(path: '/', builder: (_, _) => const ConfigScreen()),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final pollField = find.ancestor(
+      of: find.text('Poll interval'),
+      matching: find.byType(TextField),
+    );
+    final saveButton = find.widgetWithText(
+      FilledButton,
+      'Save and start Heimdallm',
+    );
+
+    // Valid default → Save is enabled.
+    expect(tester.widget<FilledButton>(saveButton).onPressed, isNotNull);
+
+    // Out-of-range value → Save is disabled (no round-trip to a daemon 400).
+    await tester.enterText(pollField, '30s');
+    await tester.pumpAndSettle();
+    expect(tester.widget<FilledButton>(saveButton).onPressed, isNull);
+
+    // Back to a valid value → Save is re-enabled.
+    await tester.enterText(pollField, '90m');
+    await tester.pumpAndSettle();
+    expect(tester.widget<FilledButton>(saveButton).onPressed, isNotNull);
+  });
+
   group('validatePollInterval', () {
     test('accepts arbitrary durations within [1m, 24h]', () {
       for (final v in ['1m', '5m', '3m', '90m', '1h', '1h30m', '1.5h', '24h']) {
@@ -69,18 +122,25 @@ void main() {
     });
 
     test('rejects values above the 24h ceiling', () {
-      for (final v in ['25h', '1441m', '2d']) {
-        expect(validatePollInterval(v), isNotNull, reason: v);
+      // Parseable but out of range → the range message, not a parse error.
+      for (final v in ['25h', '1441m']) {
+        expect(validatePollInterval(v), 'Must be between 1m and 24h', reason: v);
       }
     });
 
+    test('exercises the accumulation path near the upper bound', () {
+      // Compound durations must sum correctly: 23h59m is under the ceiling,
+      // 24h1m is just over it. Guards against regressions in the micros sum.
+      expect(validatePollInterval('23h59m'), isNull);
+      expect(validatePollInterval('24h1m'), 'Must be between 1m and 24h');
+    });
+
     test('rejects empty and unparseable input', () {
-      expect(validatePollInterval(''), isNotNull);
-      expect(validatePollInterval('  '), isNotNull);
-      expect(validatePollInterval('abc'), isNotNull);
-      expect(validatePollInterval('5'), isNotNull);
-      expect(validatePollInterval('5 m'), isNotNull);
-      expect(validatePollInterval('5minutes'), isNotNull);
+      // '2d' is rejected here (Go has no 'd' unit → unparseable), not as an
+      // out-of-range value.
+      for (final v in ['', '  ', 'abc', '5', '5 m', '5minutes', '2d']) {
+        expect(validatePollInterval(v), isNotNull, reason: '"$v"');
+      }
     });
   });
 

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -55,6 +55,35 @@ void main() {
     // Primary agent ('claude') moved to Agents tab — no longer in ConfigScreen
   });
 
+  group('validatePollInterval', () {
+    test('accepts arbitrary durations within [1m, 24h]', () {
+      for (final v in ['1m', '5m', '3m', '90m', '1h', '1h30m', '1.5h', '24h']) {
+        expect(validatePollInterval(v), isNull, reason: v);
+      }
+    });
+
+    test('rejects values below the 1m floor', () {
+      for (final v in ['59s', '30s', '0s', '1ms']) {
+        expect(validatePollInterval(v), 'Must be between 1m and 24h', reason: v);
+      }
+    });
+
+    test('rejects values above the 24h ceiling', () {
+      for (final v in ['25h', '1441m', '2d']) {
+        expect(validatePollInterval(v), isNotNull, reason: v);
+      }
+    });
+
+    test('rejects empty and unparseable input', () {
+      expect(validatePollInterval(''), isNotNull);
+      expect(validatePollInterval('  '), isNotNull);
+      expect(validatePollInterval('abc'), isNotNull);
+      expect(validatePollInterval('5'), isNotNull);
+      expect(validatePollInterval('5 m'), isNotNull);
+      expect(validatePollInterval('5minutes'), isNotNull);
+    });
+  });
+
   test('RepoConfig parses first_seen_at when provided', () {
     final json = {
       'repositories': ['a/b'],


### PR DESCRIPTION
## Summary

The Settings screen hardcoded `poll_interval` to a 4-item dropdown (`1m`, `5m`, `30m`, `1h`), but since #539 the daemon accepts **any** `time.ParseDuration` value within `[1m, 24h]` (enforced by `config.ValidatePollInterval` on config load and on `PUT/PATCH /config`). As a result an operator could not select a valid value like `3m` or `90m` from the GUI, even though the backend accepts it. This was flagged in the AI review of #539. Closes #543.

## How it works

`flutter_app/lib/features/config/config_screen.dart`:
- Replaces `DropdownButtonFormField` with a free-form `TextFormField` (mirroring the adjacent Retention field's pattern), bound to a `TextEditingController` so quick-pick chips can update it.
- Adds top-level `validatePollInterval` + `_parseGoDuration`, which validate client-side against the daemon's bounds (`_minPollInterval = 1m`, `_maxPollInterval = 24h`, mirrored from `daemon/internal/config/config.go`). `_parseGoDuration` handles the common Go duration forms operators use (`5m`, `90m`, `1h30m`, `1.5h`, `300s`) — it is a **UX guard, not a reimplementation** of Go's full `ParseDuration`; anything it misses is still caught by the daemon's `400`, which is already surfaced as an error toast on save.
- Keeps `1m`, `5m`, `30m`, `1h` as quick-pick `ActionChip`s.

## Scope

**In scope:**
- Free-form, client-validated `poll_interval` input in the Flutter Settings screen.
- Quick-pick chips for the common values.

**Out of scope:**
- Backend validation (already shipped in #539; unchanged here).
- TUI (read-only display of the value; not affected).

## Production impact & what to watch

This is a **client-side-only UI change** in the Flutter app — no daemon code, no API contract change. The saved config JSON shape is identical (`pollInterval` is still a string).

- **Runtime behavior change:** GUI only — operators can now type any duration in `[1m, 24h]` instead of choosing from 4 fixed values; the daemon still validates authoritatively on save. Also **fixes a latent crash**: `DropdownButtonFormField` asserts its `value` matches exactly one item, so loading a config whose `poll_interval` was not one of the 4 whitelisted values (e.g. `60s`, `3m`) could throw on the Settings screen. The text field has no such constraint.
- **Rollout failure modes:** None at the process level — nothing new to start, no secret/config/permission. No contract change, so old and new app builds both interoperate with the daemon. Out-of-range values are still rejected by the daemon `400` (surfaced as a toast).
- **Blast radius:** GUI users only (desktop + web build). Daemon, TUI, and HTTP API consumers are unaffected.
- **What to watch (client-side, ships in the app bundle — no server metric):** after release, the Settings screen renders for users whose stored `poll_interval` is non-whitelisted (no blank/crash); saving an out-of-range value shows the backend `400` toast; `flutter test` stays green in CI.
- **Rollback & sequencing:** Fully revertible — single-file UI change, no migration, no flag, no deploy ordering. Reverting restores the dropdown (and the latent crash). No coordination with backend needed (#539 already shipped the permissive backend).

## Evidence (issue asks for arbitrary values within [1m, 24h])

<details>
<summary><code>flutter test test/features/config_test.dart</code> — 15/15 pass (incl. 4 new validator cases + unchanged widget render test)</summary>

```
00:00 +0: ConfigScreen shows current poll interval
00:00 +1: validatePollInterval accepts arbitrary durations within [1m, 24h]
00:00 +2: validatePollInterval rejects values below the 1m floor
00:00 +3: validatePollInterval rejects values above the 24h ceiling
00:00 +4: validatePollInterval rejects empty and unparseable input
...
00:01 +15: All tests passed!
```
</details>

<details>
<summary>Full <code>make verify-linux</code> (daemon tests → flutter pub get → flutter test → daemon build → flutter build linux --release) + <code>flutter analyze</code></summary>

```
✅  Linux build verification passed

Analyzing config_screen.dart...
No issues found! (ran in 11.2s)
```
</details>

## Test plan

- [x] `make verify-linux` (full CI-equivalent pipeline) passes from the worktree
- [x] `flutter test test/features/config_test.dart` — 15/15, including new `validatePollInterval` cases (`3m`, `90m`, `1h30m`, `1.5h` accepted; `59s`, `25h`, `2d`, junk rejected)
- [x] `flutter analyze` clean on the changed file
- [ ] Reviewer: in the running app, type `3m` / `90m` and confirm it saves; type `30s` and confirm the inline validation + backend `400` toast
- [ ] Reviewer: open Settings with a config whose `poll_interval` is `60s` (or other non-whitelisted value) and confirm the screen renders (previously could throw)

Closes #543
