### PR TITLE
fix(daemon): periodic in-flight claim sweep + unconditional startup wipe

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -133,20 +133,30 @@ func main() {
 	}
 
 	// Clear in-flight review claims leaked by a daemon that crashed between
-	// claim and release. The 30-minute cutoff gives normal reviews (which
-	// finish in seconds-minutes) plenty of headroom while still cleaning up
-	// anything stuck from a previous process. See theburrowhub/heimdallm#243.
-	if n, err := s.ClearStaleInFlight(30 * time.Minute); err != nil {
-		slog.Warn("startup: clear stale inflight failed", "err", err)
+	// claim and release. See theburrowhub/heimdallm#243.
+	//
+	// Single-instance deployment: any claim that survives a restart is, by
+	// definition, orphaned — no goroutine from the previous process can still
+	// be holding the work. The earlier 30-minute cutoff left a "dead zone"
+	// (#544) where a claim younger than the cutoff would survive forever —
+	// the daemon's restart-only sweep skipped it, and there was no periodic
+	// sweep to reap it later. Clearing unconditionally at startup eliminates
+	// that dead zone. The periodic sweep in startPollers handles claims
+	// leaked at runtime (still uses the age-based cutoff so live reviews are
+	// not killed). If multi-instance support is ever added (see #243/#426)
+	// this must be replaced by a lease + instance-id scheme — a time-based
+	// cutoff is the wrong abstraction for multi-instance.
+	if n, err := s.ClearAllInFlight(); err != nil {
+		slog.Warn("startup: clear all inflight failed", "err", err)
 	} else if n > 0 {
-		slog.Info("startup: cleared stale inflight rows", "count", n)
+		slog.Info("startup: cleared inflight rows", "count", n)
 	}
 
 	// Mirror of the PR-side sweep above for issue-triage claims (#292).
-	if n, err := s.ClearStaleIssueTriageInFlight(30 * time.Minute); err != nil {
-		slog.Warn("startup: clear stale issue triage inflight failed", "err", err)
+	if n, err := s.ClearAllIssueTriageInFlight(); err != nil {
+		slog.Warn("startup: clear all issue triage inflight failed", "err", err)
 	} else if n > 0 {
-		slog.Info("startup: cleared stale issue triage inflight rows", "count", n)
+		slog.Info("startup: cleared issue triage inflight rows", "count", n)
 	}
 
 	// ── NATS event bus (core only, no JetStream) ───────────────────────
@@ -671,6 +681,40 @@ func main() {
 				case <-ticker.C:
 					limiter.Refill()
 					slog.Info("pollers: rate limiter refilled")
+				}
+			}
+		}()
+
+		// In-flight claim sweep (#544). Catches reviews_in_flight and
+		// issue_triage_in_flight claims that were leaked at runtime (panic,
+		// SIGKILL between claim and the deferred release, etc.). Worst-case
+		// reap latency is sweepInterval + inflightSweepMaxAge ≈ 35 min, well
+		// under the previous "forever" failure mode. The 30-min maxAge gives
+		// normal reviews (seconds to a few minutes) plenty of headroom; the
+		// PeriodicSweepPreservesYoungClaims tests in package store lock in
+		// that a fresh claim survives this sweep.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			const sweepInterval = 5 * time.Minute
+			const inflightSweepMaxAge = 30 * time.Minute
+			ticker := time.NewTicker(sweepInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if n, err := s.ClearStaleInFlight(inflightSweepMaxAge); err != nil {
+						slog.Warn("sweep: clear stale inflight failed", "err", err)
+					} else if n > 0 {
+						slog.Info("sweep: cleared stale inflight rows", "count", n)
+					}
+					if n, err := s.ClearStaleIssueTriageInFlight(inflightSweepMaxAge); err != nil {
+						slog.Warn("sweep: clear stale issue triage inflight failed", "err", err)
+					} else if n > 0 {
+						slog.Info("sweep: cleared stale issue triage inflight rows", "count", n)
+					}
 				}
 			}
 		}()

--- a/daemon/internal/store/inflight.go
+++ b/daemon/internal/store/inflight.go
@@ -77,3 +77,23 @@ func (s *Store) ClearStaleInFlight(maxAge time.Duration) (int, error) {
 	}
 	return int(n), nil
 }
+
+// ClearAllInFlight removes every row from reviews_in_flight unconditionally.
+// Used at single-instance startup (#544): any claim that survives a daemon
+// restart is, by definition, orphaned — no goroutine from the previous
+// process can still be holding the work. Distinct from ClearStaleInFlight
+// because the latter compares against a sqliteTimeFormat cutoff with
+// second precision, and would silently skip rows inserted in the same
+// second as the call (which is exactly the dead zone #544 reports).
+// Returns the number of rows cleared.
+func (s *Store) ClearAllInFlight() (int, error) {
+	res, err := s.db.Exec("DELETE FROM reviews_in_flight")
+	if err != nil {
+		return 0, fmt.Errorf("store: clear all inflight: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("store: clear all inflight rowsaffected: %w", err)
+	}
+	return int(n), nil
+}

--- a/daemon/internal/store/inflight_test.go
+++ b/daemon/internal/store/inflight_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -91,5 +92,77 @@ func TestInFlight_StaleEntriesAreCleared(t *testing.T) {
 	}
 	if !claimed {
 		t.Errorf("claim after stale-clear must succeed")
+	}
+}
+
+// TestInFlight_ClearAllInFlight locks in the invariant that the
+// single-instance startup sweep (#544) needs: ClearAllInFlight removes every
+// row regardless of age, including ones inserted moments ago. Any claim that
+// survives a daemon restart is, by definition, orphaned in a single-instance
+// deployment, so the previous 30-min cutoff left a "dead zone" where a claim
+// younger than the cutoff would survive forever (the daemon's restart-only
+// sweep would skip it and there was no periodic sweep to catch it later).
+//
+// Distinct from ClearStaleInFlight(0): the latter is age-based with second
+// precision and would silently skip rows inserted in the same second as the
+// call — which is exactly the dead-zone shape #544 reports.
+func TestInFlight_ClearAllInFlight(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.InsertStaleInFlight(1, "sha1", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertStaleInFlight(2, "sha2", time.Now().Add(-1*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertStaleInFlight(3, "sha3", time.Now().Add(-29*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	n, err := s.ClearAllInFlight()
+	if err != nil {
+		t.Fatalf("clear all: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("ClearAllInFlight want 3 cleared, got %d", n)
+	}
+	// All three claims must be reclaimable.
+	for _, pr := range []int64{1, 2, 3} {
+		sha := fmt.Sprintf("sha%d", pr)
+		claimed, err := s.ClaimInFlightReview(pr, sha)
+		if err != nil {
+			t.Fatalf("re-claim pr=%d: %v", pr, err)
+		}
+		if !claimed {
+			t.Errorf("re-claim pr=%d sha=%s: want true after ClearAllInFlight", pr, sha)
+		}
+	}
+}
+
+// TestInFlight_PeriodicSweepPreservesYoungClaims is the dual invariant: while
+// the daemon is running, a periodic ClearStaleInFlight(maxAge) MUST NOT kill
+// a fresh in-flight review. Locks in the safety property of the periodic sweep
+// added in #544 — without this, a 5-min ticker calling ClearStaleInFlight(30m)
+// could accidentally reap a long-running but still-live review.
+func TestInFlight_PeriodicSweepPreservesYoungClaims(t *testing.T) {
+	s := newTestStore(t)
+	claimed, err := s.ClaimInFlightReview(42, "freshsha")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if !claimed {
+		t.Fatal("initial claim must succeed")
+	}
+	n, err := s.ClearStaleInFlight(30 * time.Minute)
+	if err != nil {
+		t.Fatalf("periodic sweep: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("periodic sweep killed a fresh claim: cleared %d, want 0", n)
+	}
+	inFlight, err := s.ReviewInFlight(42, "freshsha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inFlight {
+		t.Error("fresh claim disappeared after periodic sweep")
 	}
 }

--- a/daemon/internal/store/issue_inflight.go
+++ b/daemon/internal/store/issue_inflight.go
@@ -75,3 +75,19 @@ func (s *Store) ClearStaleIssueTriageInFlight(maxAge time.Duration) (int, error)
 	}
 	return int(n), nil
 }
+
+// ClearAllIssueTriageInFlight is the issue-triage mirror of
+// ClearAllInFlight (#544). Removes every row from issue_triage_in_flight
+// unconditionally — used at single-instance startup where any surviving
+// claim is, by definition, orphaned.
+func (s *Store) ClearAllIssueTriageInFlight() (int, error) {
+	res, err := s.db.Exec("DELETE FROM issue_triage_in_flight")
+	if err != nil {
+		return 0, fmt.Errorf("store: clear all issue triage inflight: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("store: clear all issue triage inflight rowsaffected: %w", err)
+	}
+	return int(n), nil
+}

--- a/daemon/internal/store/issue_inflight_test.go
+++ b/daemon/internal/store/issue_inflight_test.go
@@ -76,3 +76,43 @@ func TestIssueInflight_StaleEntriesAreCleared(t *testing.T) {
 		t.Errorf("claim after stale-clear must succeed")
 	}
 }
+
+// TestIssueInflight_ClearAllIssueTriageInFlight — mirror of
+// TestInFlight_ClearAllInFlight for issue-triage claims (#544).
+func TestIssueInflight_ClearAllIssueTriageInFlight(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.InsertStaleIssueTriageInFlight(1, "2026-06-19T10:00:00Z", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertStaleIssueTriageInFlight(2, "2026-06-19T10:00:00Z", time.Now().Add(-29*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	n, err := s.ClearAllIssueTriageInFlight()
+	if err != nil {
+		t.Fatalf("clear all: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("ClearAllIssueTriageInFlight want 2 cleared, got %d", n)
+	}
+}
+
+// TestIssueInflight_PeriodicSweepPreservesYoungClaims — mirror of the
+// PR-side invariant for issue-triage. The periodic sweep with maxAge=30m
+// must not reap a freshly-claimed triage. (#544)
+func TestIssueInflight_PeriodicSweepPreservesYoungClaims(t *testing.T) {
+	s := newTestStore(t)
+	claimed, err := s.ClaimIssueTriageInFlight(42, "2026-06-19T10:00:00Z")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if !claimed {
+		t.Fatal("initial claim must succeed")
+	}
+	n, err := s.ClearStaleIssueTriageInFlight(30 * time.Minute)
+	if err != nil {
+		t.Fatalf("periodic sweep: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("periodic sweep killed a fresh claim: cleared %d, want 0", n)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #544.

The persistent in-flight review claim (#359) could block forever: if the daemon was killed between `ClaimInFlightReview` and the deferred `ReleaseInFlightReview`, and then restarted within 30 min, the startup sweep skipped the leaked claim. With no periodic sweep elsewhere, the row stayed in `reviews_in_flight` indefinitely and every subsequent `runReview` for that `(pr_id, head_sha)` was silently dropped with `already in flight (persistent), skipping`. Observed in `overmind-swarm/app` PRs #491–#495 — 21 h with no review.

This PR implements both proposals from the issue:

### 1. Periodic sweep (5-min ticker)
A new goroutine in `startPollers` calls `ClearStaleInFlight(30m)` + `ClearStaleIssueTriageInFlight(30m)` every 5 min. Aligns the code with the "30 min sweep" already assumed by comments in `daemon/internal/issues/pipeline.go` (which were aspirational — no periodic task ever existed). Worst-case reap latency drops from "forever" to `sweepInterval + maxAge ≈ 35 min`.

### 2. Unconditional startup wipe
Replaces the 30-min cutoff at startup with new `ClearAllInFlight` / `ClearAllIssueTriageInFlight` store methods that `DELETE` every row. In a single-instance deployment any claim that survives a restart is, by definition, orphaned — the time-based cutoff has no upside and created the dead zone #544 reports.

`ClearStaleInFlight(0)` was tried first but is not sufficient: `sqliteTimeFormat` has second precision and `started_at < cutoff` is strict, so rows inserted in the same wall-clock second as the call survived. The dedicated `ClearAll*` methods avoid that ambiguity. The periodic sweep retains the 30-min cutoff because killing a live review is much worse than waiting one extra sweep cycle.

If multi-instance support is ever added (see #243/#426) the startup wipe must be replaced by a lease + instance-id scheme — the new comment in `main.go` calls this out explicitly.

## Test plan
- [x] `go test ./internal/store/ -run "InFlight|IssueInflight" -race -count=3` passes (8 tests, including 4 new).
- [x] `go build ./...` and `go vet ./...` clean.
- [x] Full `go test ./...` — only pre-existing local-env failures in `internal/executor` (`TestDetect_Fallback`, `TestExecuteRawAddsDetectedWorkDirFlags/claude`) that depend on which CLIs are installed; not introduced by this change (verified by re-running on `main` with my work stashed).
- [ ] Reviewer to confirm the worst-case reap latency (~35 min) is acceptable for the deployment; the alternative — shorter `sweepInterval` — only narrows by a few minutes and adds DB churn.

### New tests
- `TestInFlight_ClearAllInFlight` — locks in that the startup wipe removes rows of any age, including ones inserted in the current second.
- `TestInFlight_PeriodicSweepPreservesYoungClaims` — locks in that a freshly-claimed in-flight row survives a periodic `ClearStaleInFlight(30m)` call (so the new ticker can't accidentally reap a live review).
- Same two invariants mirrored for the issue-triage claim table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)