### PR TITLE
fix(pipeline): fail-safe non-canonical agent severity to high (closes #547)

### DIFF
--- a/daemon/internal/pipeline/comment_signals_test.go
+++ b/daemon/internal/pipeline/comment_signals_test.go
@@ -359,6 +359,44 @@ func TestReconcileSeverity_CaseInsensitiveCanonicalNotEscalated(t *testing.T) {
 	}
 }
 
+func TestReconcileSeverity_EmptyTopLevelStaysLow(t *testing.T) {
+	// Empty top-level severity is the documented no-issues default (parseResult
+	// coerces a missing severity to "low" upstream). It must NOT fail-safe to
+	// high — that would over-block legitimately clean reviews.
+	if got := ReconcileSeverity(makeResult("", nil)); got != "low" {
+		t.Errorf(`ReconcileSeverity("") = %q, want low (no-issues default, not fail-safe)`, got)
+	}
+	// A real per-issue severity still escalates an empty top-level.
+	if got := ReconcileSeverity(makeResult("", []testIssue{{Severity: "high"}})); got != "high" {
+		t.Errorf(`empty top-level with a high issue should escalate; got %q, want high`, got)
+	}
+}
+
+func TestReconcileSeverity_WhitespacePaddedCanonicalNotEscalated(t *testing.T) {
+	// Padded canonical values must rank by their trimmed value, not be treated
+	// as non-canonical (which would wrongly escalate " low " to high).
+	for in, want := range map[string]string{" high ": "high", " low ": "low", "  medium": "medium"} {
+		if got := ReconcileSeverity(makeResult(in, nil)); got != want {
+			t.Errorf("ReconcileSeverity(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestReconcileSeverity_NonCanonicalTopLevelNeverCaps(t *testing.T) {
+	// The fail-safe only ever raises to high; combined with any mix of per-issue
+	// severities it must stay high, never be capped below it.
+	for _, issues := range [][]testIssue{
+		nil,
+		{{Severity: "low"}, {Severity: "low"}},
+		{{Severity: "high"}},
+		{{Severity: "medium"}, {Severity: "info"}},
+	} {
+		if got := ReconcileSeverity(makeResult("critical", issues)); got != "high" {
+			t.Errorf("non-canonical top-level must stay high regardless of issues %v; got %q", issues, got)
+		}
+	}
+}
+
 func TestReconcileThenEvent_CriticalBlocks(t *testing.T) {
 	// End-to-end gate: a "critical" top-level severity must drive REQUEST_CHANGES,
 	// not a silent APPROVE (the bug in #547).

--- a/daemon/internal/pipeline/comment_signals_test.go
+++ b/daemon/internal/pipeline/comment_signals_test.go
@@ -324,6 +324,50 @@ func TestReconcileSeverity_NeverLowers(t *testing.T) {
 	}
 }
 
+func TestReconcileSeverity_NonCanonicalTopLevelFailsSafeToHigh(t *testing.T) {
+	// A model that escalates with an out-of-vocabulary label (or emits garbage)
+	// must NOT be silently downgraded to low and APPROVEd. Top-level
+	// non-canonical → high.
+	for _, sev := range []string{"critical", "blocker", "severe", "CRITICAL", "🔥", "definitely-bad"} {
+		got := ReconcileSeverity(makeResult(sev, nil))
+		if got != "high" {
+			t.Errorf("ReconcileSeverity(top-level %q) = %q, want high (fail-safe)", sev, got)
+		}
+	}
+}
+
+func TestReconcileSeverity_NonCanonicalPerIssueStaysTolerant(t *testing.T) {
+	// Stray below-the-bar issue labels must not escalate the whole review.
+	result := makeResult("low", []testIssue{
+		{Severity: "info"},
+		{Severity: "nit"},
+		{Severity: "trivial"},
+	})
+	if got := ReconcileSeverity(result); got != "low" {
+		t.Errorf("non-canonical per-issue severities should not escalate; got %q, want low", got)
+	}
+}
+
+func TestReconcileSeverity_CaseInsensitiveCanonicalNotEscalated(t *testing.T) {
+	// "High"/"Medium" are canonical (case-insensitive) and must keep their
+	// own rank, not be treated as non-canonical.
+	if got := ReconcileSeverity(makeResult("High", nil)); got != "high" {
+		t.Errorf(`ReconcileSeverity("High") = %q, want high`, got)
+	}
+	if got := ReconcileSeverity(makeResult("Medium", nil)); got != "medium" {
+		t.Errorf(`ReconcileSeverity("Medium") = %q, want medium`, got)
+	}
+}
+
+func TestReconcileThenEvent_CriticalBlocks(t *testing.T) {
+	// End-to-end gate: a "critical" top-level severity must drive REQUEST_CHANGES,
+	// not a silent APPROVE (the bug in #547).
+	reconciled := ReconcileSeverity(makeResult("critical", nil))
+	if event := SeverityToEvent(reconciled); event != "REQUEST_CHANGES" {
+		t.Errorf("critical severity must block: SeverityToEvent(%q) = %q, want REQUEST_CHANGES", reconciled, event)
+	}
+}
+
 // --- Tests for ApplySignalEscalation ---
 
 func TestApplySignalEscalation_MediumWithBlocker(t *testing.T) {

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -877,7 +877,7 @@ func BuildGitHubBody(r *executor.ReviewResult) string {
 
 // severityRank maps a severity string to a numeric rank for comparison.
 func severityRank(s string) int {
-	switch strings.ToLower(s) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "high":
 		return 3
 	case "medium":
@@ -890,7 +890,7 @@ func severityRank(s string) int {
 // isCanonicalSeverity reports whether s is one of the severities the agent
 // prompt mandates (low|medium|high), case-insensitive.
 func isCanonicalSeverity(s string) bool {
-	switch strings.ToLower(s) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "low", "medium", "high":
 		return true
 	default:
@@ -922,11 +922,19 @@ func ReconcileSeverity(result *executor.ReviewResult) string {
 	// unrecognized top-level severity as "high" so a human reviews it. Per-issue
 	// severities stay tolerant (unknown → low) so a stray "nit"/"info" label
 	// cannot escalate the whole review.
-	maxRank := severityRank(result.Severity)
-	if result.Severity != "" && !isCanonicalSeverity(result.Severity) {
+	//
+	// An empty top-level severity is intentionally NOT failed-safe: parseResult
+	// coerces a missing severity to "low" before this runs, and an omitted
+	// severity is the documented "no issues" default — not a blocked escalation
+	// (the #547 failure mode). Escalating empty would over-block clean reviews.
+	nonCanonical := result.Severity != "" && !isCanonicalSeverity(result.Severity)
+	var maxRank int
+	if nonCanonical {
 		slog.Warn("pipeline: non-canonical top-level severity from agent; failing safe to high",
 			"ai_severity", result.Severity)
 		maxRank = severityRank("high")
+	} else {
+		maxRank = severityRank(result.Severity)
 	}
 	for _, iss := range result.Issues {
 		if r := severityRank(iss.Severity); r > maxRank {
@@ -934,7 +942,11 @@ func ReconcileSeverity(result *executor.ReviewResult) string {
 		}
 	}
 	reconciled := rankToSeverity(maxRank)
-	if reconciled != result.Severity {
+	// Only emit the "AI inconsistency" warning for the case it actually
+	// describes — a canonical top-level raised by a higher per-issue severity.
+	// The non-canonical path already logged its own accurate warning above, so
+	// guarding here avoids a misleading double log on the same call.
+	if !nonCanonical && reconciled != result.Severity {
 		slog.Warn("pipeline: severity reconciled (AI inconsistency)",
 			"ai_severity", result.Severity,
 			"reconciled", reconciled,

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -887,6 +887,17 @@ func severityRank(s string) int {
 	}
 }
 
+// isCanonicalSeverity reports whether s is one of the severities the agent
+// prompt mandates (low|medium|high), case-insensitive.
+func isCanonicalSeverity(s string) bool {
+	switch strings.ToLower(s) {
+	case "low", "medium", "high":
+		return true
+	default:
+		return false
+	}
+}
+
 // rankToSeverity converts a numeric rank back to a severity string.
 func rankToSeverity(r int) string {
 	switch r {
@@ -904,7 +915,19 @@ func rankToSeverity(r int) string {
 // inconsistencies where issues are flagged high but the global field is set
 // low (prompt injection, model error, hallucination).
 func ReconcileSeverity(result *executor.ReviewResult) string {
+	// Fail-safe on the top-level severity. The agent prompt mandates one of
+	// low|medium|high; a non-canonical value ("critical", "blocker", or model
+	// garbage) would otherwise fall through severityRank's default to rank 1
+	// ("low") and silently APPROVE a PR the model meant to block. Treat any
+	// unrecognized top-level severity as "high" so a human reviews it. Per-issue
+	// severities stay tolerant (unknown → low) so a stray "nit"/"info" label
+	// cannot escalate the whole review.
 	maxRank := severityRank(result.Severity)
+	if result.Severity != "" && !isCanonicalSeverity(result.Severity) {
+		slog.Warn("pipeline: non-canonical top-level severity from agent; failing safe to high",
+			"ai_severity", result.Severity)
+		maxRank = severityRank("high")
+	}
 	for _, iss := range result.Issues {
 		if r := severityRank(iss.Severity); r > maxRank {
 			maxRank = r


### PR DESCRIPTION
## Summary

The agent review prompt mandates a top-level `severity` of `low|medium|high`, but `severityRank`'s `default` branch mapped **any** other token to rank `1` (`"low"`). So when an agent emitted an over-severe label to block a PR — e.g. `"critical"`, `"blocker"`, `"severe"` — or any garbage, `ReconcileSeverity` normalized it to `"low"` and `SeverityToEvent` returned `APPROVE`. An agent trying to escalate was silently downgraded and the PR auto-approved — a security-gate bypass (#547).

## How it works

Single locus: `daemon/internal/pipeline/pipeline.go`.
- New `isCanonicalSeverity(s)` helper (case-insensitive `low|medium|high`).
- In `ReconcileSeverity`, a **non-empty, non-canonical top-level** severity is now treated as `"high"` (→ `REQUEST_CHANGES`) with a `slog.Warn("…failing safe to high", ai_severity=…)`.
- **Per-issue** severities stay tolerant: an unknown per-issue label still ranks `low`, so a stray `"nit"`/`"info"` cannot escalate the whole review (avoids over-blocking).

`SeverityToEvent` is left unchanged on purpose — every value that reaches it (`finalSeverity` on the main path, the stored `rev.Severity` on retry/publish paths) is normalized through `ReconcileSeverity`, so this is the single correct fix point rather than scattering defensive checks.

## Scope

**In scope:** top-level PR-review severity normalization + fail-safe.
**Out of scope:** the issue-triage severity switch (`pipeline.go:798`, separate path, unaffected); empty severity (already coerced to `"low"` by `executor.parseResult`, semantics preserved); adding above/below-canonical synonym tables (rejected design option — a guess-list that still silently approves novel tokens).

## Production impact & what to watch

- **Runtime behavior change:** identical for the normal case (agents emit canonical values). The *only* difference: when an agent returns a non-canonical top-level severity, Heimdallm now posts **REQUEST_CHANGES** and stores `high` (+ a Warn log) instead of **APPROVE**/`low`. No new outbound calls (same `SubmitReview`, different event), no new resource use, no startup invariant.
- **Rollout failure modes:** none — no config/secret/permission, no API/contract change, no migration; can't crashloop. Pure in-process logic, compatible with older/newer pods. Already-stored reviews are not rewritten.
- **Blast radius:** PR-review verdicts only, and only for reviews whose agent emits a non-canonical top-level severity — rare (prompt constrains to three values), so effectively a no-op in normal operation; when it fires, that one PR is blocked instead of approved.
- **What to watch:** the new log line `pipeline: non-canonical top-level severity from agent; failing safe to high` (carries `ai_severity`). Its frequency = how often models drift from the `low|medium|high` contract. Watch for an unexpected uptick in **REQUEST_CHANGES** rate (would mean frequent non-canonical values → over-blocking → a prompt problem). Silence in logs = the gap was latent and agents are compliant (expected).
- **Rollback & sequencing:** fully revertible, single-package change, no flag/migration/ordering. Reverting reinstates the silent-approve bug.

## Evidence

Acceptance: a non-canonical top-level severity must NOT silently approve.

<details><summary><code>make test-docker</code> — pipeline package (4 new tests + existing), all pass</summary>

```
--- PASS: TestReconcileSeverity_Consistent (0.00s)
--- PASS: TestReconcileSeverity_EscalatesFromLowToHigh (0.00s)
--- PASS: TestReconcileSeverity_NeverLowers (0.00s)
--- PASS: TestReconcileSeverity_NonCanonicalTopLevelFailsSafeToHigh (0.00s)
--- PASS: TestReconcileSeverity_NonCanonicalPerIssueStaysTolerant (0.00s)
--- PASS: TestReconcileSeverity_CaseInsensitiveCanonicalNotEscalated (0.00s)
--- PASS: TestReconcileThenEvent_CriticalBlocks (0.00s)
--- PASS: TestSeverityToEvent_HighRequestsChanges (0.00s)
--- PASS: TestSeverityToEvent_MediumApproves (0.00s)
--- PASS: TestSeverityToEvent_LowApproves (0.00s)
ok  	github.com/heimdallm/daemon/internal/pipeline
```
</details>

<details><summary>Full daemon suite — <code>go vet ./...</code> + <code>go test ./...</code> all green</summary>

```
ok  github.com/heimdallm/daemon/cmd/heimdallm
ok  github.com/heimdallm/daemon/internal/activity
ok  github.com/heimdallm/daemon/internal/bus
ok  github.com/heimdallm/daemon/internal/config
ok  github.com/heimdallm/daemon/internal/executor
ok  github.com/heimdallm/daemon/internal/github
ok  github.com/heimdallm/daemon/internal/issues
ok  github.com/heimdallm/daemon/internal/pipeline
ok  github.com/heimdallm/daemon/internal/server
ok  github.com/heimdallm/daemon/internal/store
ok  github.com/heimdallm/daemon/internal/worker
... (all packages ok; vet clean)
```
</details>

## Test plan

- [x] `make test-docker` scoped to `./internal/pipeline/...` — 4 new tests pass
- [x] `make test-docker` full daemon suite — `go vet` + `go test ./...` all green
- [x] Per-issue tolerance verified (stray `info`/`nit`/`trivial` does not escalate)
- [x] Case-insensitive canonical (`High`/`Medium`) preserved
- [ ] Reviewer: confirm the fail-safe-to-high (vs tolerant) policy matches intended product behavior for unrecognized severities

Closes #547
