### PR TITLE
fix(daemon): recover from panics in the SSE→NATS bridge goroutine (closes #548)

### DIFF
--- a/daemon/cmd/heimdallm/bridge_test.go
+++ b/daemon/cmd/heimdallm/bridge_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
+	"github.com/heimdallm/daemon/internal/bus"
 	"github.com/heimdallm/daemon/internal/sse"
 )
 
@@ -19,7 +21,7 @@ func TestPublishBridgeEvents_RecoversFromPanicAndContinues(t *testing.T) {
 
 	var got []string
 	publish := func(subject string, data []byte) error {
-		if subject == "heimdallm.events.boom" {
+		if subject == bus.SubjEventPrefix+"boom" {
 			panic("simulated nats publish panic")
 		}
 		got = append(got, subject)
@@ -29,9 +31,34 @@ func TestPublishBridgeEvents_RecoversFromPanicAndContinues(t *testing.T) {
 	// Returns (does not propagate the panic) once the channel is drained.
 	publishBridgeEvents(events, publish)
 
-	want := []string{"heimdallm.events.a", "heimdallm.events.c"}
-	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+	want := []string{bus.SubjEventPrefix + "a", bus.SubjEventPrefix + "c"}
+	if !slices.Equal(got, want) {
 		t.Fatalf("expected bridge to process %v after recovering, got %v", want, got)
+	}
+}
+
+// recover() must also catch a non-string / runtime panic (here, assignment to
+// a nil map), not just explicit panic("string") calls.
+func TestPublishBridgeEvents_RecoversFromRuntimePanic(t *testing.T) {
+	events := make(chan sse.Event, 2)
+	events <- sse.Event{Type: "nilmap", Data: "1"}
+	events <- sse.Event{Type: "ok", Data: "2"}
+	close(events)
+
+	var got []string
+	publish := func(subject string, data []byte) error {
+		if subject == bus.SubjEventPrefix+"nilmap" {
+			var m map[string]int
+			m["boom"] = 1 // runtime panic: assignment to entry in nil map
+		}
+		got = append(got, subject)
+		return nil
+	}
+
+	publishBridgeEvents(events, publish)
+
+	if want := []string{bus.SubjEventPrefix + "ok"}; !slices.Equal(got, want) {
+		t.Fatalf("expected bridge to recover from a runtime panic and continue; want %v, got %v", want, got)
 	}
 }
 

--- a/daemon/cmd/heimdallm/bridge_test.go
+++ b/daemon/cmd/heimdallm/bridge_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/sse"
+)
+
+// A panic while publishing one event must not propagate (which, in the real
+// bare goroutine, would crash the whole daemon) and must not stop the bridge:
+// the events before and after the panicking one are still published.
+func TestPublishBridgeEvents_RecoversFromPanicAndContinues(t *testing.T) {
+	events := make(chan sse.Event, 3)
+	events <- sse.Event{Type: "a", Data: "1"}
+	events <- sse.Event{Type: "boom", Data: "2"}
+	events <- sse.Event{Type: "c", Data: "3"}
+	close(events)
+
+	var got []string
+	publish := func(subject string, data []byte) error {
+		if subject == "heimdallm.events.boom" {
+			panic("simulated nats publish panic")
+		}
+		got = append(got, subject)
+		return nil
+	}
+
+	// Returns (does not propagate the panic) once the channel is drained.
+	publishBridgeEvents(events, publish)
+
+	want := []string{"heimdallm.events.a", "heimdallm.events.c"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("expected bridge to process %v after recovering, got %v", want, got)
+	}
+}
+
+// A publish error is logged but must not stop the bridge — every event is
+// still attempted.
+func TestPublishBridgeEvents_ContinuesAfterPublishError(t *testing.T) {
+	events := make(chan sse.Event, 2)
+	events <- sse.Event{Type: "x", Data: "1"}
+	events <- sse.Event{Type: "y", Data: "2"}
+	close(events)
+
+	attempts := 0
+	publish := func(subject string, data []byte) error {
+		attempts++
+		return fmt.Errorf("publish failed")
+	}
+
+	publishBridgeEvents(events, publish)
+
+	if attempts != 2 {
+		t.Fatalf("expected both events attempted despite errors, got %d", attempts)
+	}
+}

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"reflect"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -47,6 +48,28 @@ import (
 var version = "dev"
 
 func versionString() string { return version }
+
+// publishBridgeEvents re-publishes every SSE broker event to NATS so the SSE
+// handler (which reads from NATS) sees events from all broker publishers.
+// Each event is processed under its own recover(): a panic on one event is
+// logged with a stack and the loop continues to the next, so a single bad
+// event can neither crash the daemon (a panic in a bare goroutine is fatal)
+// nor permanently kill the bridge that feeds every SSE client.
+func publishBridgeEvents(events <-chan sse.Event, publish func(subject string, data []byte) error) {
+	for event := range events {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("sse-bridge: recovered from panic; continuing",
+						"type", event.Type, "panic", r, "stack", string(debug.Stack()))
+				}
+			}()
+			if err := publish("heimdallm.events."+event.Type, []byte(event.Data)); err != nil {
+				slog.Warn("sse-bridge: publish to NATS failed", "type", event.Type, "err", err)
+			}
+		}()
+	}
+}
 
 func main() {
 	if len(os.Args) > 1 {
@@ -176,14 +199,7 @@ func main() {
 	// to NATS events subjects, removing the need for the broker entirely.
 	bridgeCh := broker.Subscribe()
 	if bridgeCh != nil {
-		go func() {
-			for event := range bridgeCh {
-				subj := "heimdallm.events." + event.Type
-				if err := eventBus.Conn().Publish(subj, []byte(event.Data)); err != nil {
-					slog.Warn("sse-bridge: publish to NATS failed", "type", event.Type, "err", err)
-				}
-			}
-		}()
+		go publishBridgeEvents(bridgeCh, eventBus.Conn().Publish)
 	} else {
 		slog.Warn("sse-bridge: broker subscriber cap reached, SSE bridge disabled")
 	}

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -64,7 +64,7 @@ func publishBridgeEvents(events <-chan sse.Event, publish func(subject string, d
 						"type", event.Type, "panic", r, "stack", string(debug.Stack()))
 				}
 			}()
-			if err := publish("heimdallm.events."+event.Type, []byte(event.Data)); err != nil {
+			if err := publish(bus.SubjEventPrefix+event.Type, []byte(event.Data)); err != nil {
 				slog.Warn("sse-bridge: publish to NATS failed", "type", event.Type, "err", err)
 			}
 		}()
@@ -199,6 +199,8 @@ func main() {
 	// to NATS events subjects, removing the need for the broker entirely.
 	bridgeCh := broker.Subscribe()
 	if bridgeCh != nil {
+		// publishBridgeEvents recovers per event and never panics outward, so
+		// it is safe to run in this bare goroutine.
 		go publishBridgeEvents(bridgeCh, eventBus.Conn().Publish)
 	} else {
 		slog.Warn("sse-bridge: broker subscriber cap reached, SSE bridge disabled")


### PR DESCRIPTION
## Summary

The SSE→NATS bridge ran in a bare goroutine with no `recover()`. A panic while publishing an event would crash the **entire daemon** — Go does not recover panics in arbitrary goroutines (#548). No reproducible panic exists in the current loop body (`sse.Event` fields are strings; a nil `*nats.Conn` returns an error, not a panic), so this is defensive hardening at an architectural boundary — but the blast radius of any future/library panic there is the whole process, which is why it's worth fixing.

## How it works

`daemon/cmd/heimdallm/main.go`:
- Extracted the inline bridge loop into a named, testable helper `publishBridgeEvents(events <-chan sse.Event, publish func(subject string, data []byte) error)`.
- Each event's publish runs inside a per-iteration `recover()` that logs the panic + stack (`runtime/debug.Stack()`) at Error and **continues to the next event**. So a single bad event can neither crash the daemon nor permanently kill the bridge that feeds every SSE client.
- Call site becomes `go publishBridgeEvents(bridgeCh, eventBus.Conn().Publish)`.

Design choice: **per-iteration recover-and-continue** (not goroutine-level recover-and-exit), so one panic doesn't silently stop live updates for all SSE consumers.

## Scope

**In scope:** panic recovery for the SSE→NATS bridge goroutine + a testable extraction.
**Out of scope:** the NATS worker goroutines (review/triage/publish/etc.) also lack `recover()` — a broader, separate concern; this PR is scoped to the bridge per #548. Not adding a shared recover helper (no existing convention in the repo; would be speculative).

## Production impact & what to watch

- **Runtime behavior change:** none in the normal path — same `Publish` call per event, same warn-on-error. The only difference: a panic during a single event publish is now caught, logged with a stack, and skipped instead of crashing the process. (`eventBus.Conn().Publish` is bound once as a method value at goroutine start vs called each iteration — equivalent, the conn is stable for the daemon's life.)
- **Rollout failure modes:** none — pure in-process wiring change, no config/secret/permission/API/migration; can't crashloop; compatible with old/new pods.
- **Blast radius:** the SSE→NATS bridge only (feeds the Flutter GUI events tab + CLI `follow`). No behavioral change in normal operation; matters only in the panic case, where it converts a daemon-wide crash into logged-and-continue.
- **What to watch:** the new Error log line `sse-bridge: recovered from panic; continuing` (carries `type`, `panic`, `stack`). If it ever fires, a real panic occurred in the publish path that previously would have crashed the daemon — investigate the value/stack. Conversely, daemon restarts correlated with SSE activity should no longer occur from this cause.
- **Rollback & sequencing:** fully revertible, single file, no flag/migration/ordering. Reverting restores the bare goroutine (and the crash exposure).

## Evidence

Acceptance: a panic in the bridge must not crash the daemon (and shouldn't kill the bridge).

<details><summary><code>make test-docker</code> — new bridge tests pass</summary>

```
=== RUN   TestPublishBridgeEvents_RecoversFromPanicAndContinues
--- PASS: TestPublishBridgeEvents_RecoversFromPanicAndContinues (0.00s)
=== RUN   TestPublishBridgeEvents_ContinuesAfterPublishError
--- PASS: TestPublishBridgeEvents_ContinuesAfterPublishError (0.00s)
ok  	github.com/heimdallm/daemon/cmd/heimdallm
```
</details>

<details><summary>Full daemon suite — <code>go vet ./...</code> + <code>go test ./...</code> all green</summary>

```
ok  github.com/heimdallm/daemon/cmd/heimdallm
ok  github.com/heimdallm/daemon/internal/bus
ok  github.com/heimdallm/daemon/internal/pipeline
ok  github.com/heimdallm/daemon/internal/server
ok  github.com/heimdallm/daemon/internal/sse
... (all packages ok; vet clean)
```
</details>

## Test plan

- [x] `make test-docker` scoped to `./cmd/...` — both new tests pass
- [x] `make test-docker` full daemon suite — `go vet` + `go test ./...` all green
- [ ] Reviewer: confirm recover-and-continue (vs recover-and-exit) is the desired behavior for the bridge

Closes #548
