### PR TITLE
fix(pipeline): orphan pending reviews with corrupt issues JSON instead of posting empty (closes #549)

### DIFF
--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -696,6 +696,12 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	return rev, nil
 }
 
+// orphanedReviewID is the sentinel github_review_id stored for a review that
+// can never be published (no repo, corrupt stored JSON, or a permanent submit
+// failure). It marks the row as resolved so PublishPending stops retrying it,
+// while being distinguishable from a real GitHub review id.
+const orphanedReviewID = -1
+
 // markOrphanIfPermanent inspects the error returned by SubmitReview and,
 // when it is a *github.PermanentSubmitError, marks the local review row
 // as orphaned via the (-1, "") sentinel that PublishPending also uses
@@ -714,7 +720,7 @@ func (p *Pipeline) markOrphanIfPermanent(reviewID int64, submitErr error, source
 	if !errors.As(submitErr, &permErr) {
 		return false
 	}
-	if mErr := p.store.MarkReviewPublished(reviewID, -1, "", time.Now().UTC()); mErr != nil {
+	if mErr := p.store.MarkReviewPublished(reviewID, orphanedReviewID, "", time.Now().UTC()); mErr != nil {
 		slog.Warn("pipeline: failed to mark orphaned review, will retry next tick",
 			"review_id", reviewID, "source", source, "reason", permErr.Reason, "err", mErr)
 		return true
@@ -737,9 +743,9 @@ func (p *Pipeline) PublishPending() {
 			continue
 		}
 		// Skip reviews for PRs with no repo — orphaned records that will never publish.
-		// Mark them as permanently published (fake ID -1, empty state) to stop retry noise.
+		// Mark them as permanently published (orphanedReviewID, empty state) to stop retry noise.
 		if pr.Repo == "" {
-			_ = p.store.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
+			_ = p.store.MarkReviewPublished(rev.ID, orphanedReviewID, "", time.Now().UTC())
 			slog.Info("pipeline: skipping pending review for PR with no repo", "review_id", rev.ID)
 			continue
 		}
@@ -752,7 +758,7 @@ func (p *Pipeline) PublishPending() {
 		if err := json.Unmarshal([]byte(rev.Issues), &issues); err != nil {
 			slog.Warn("pipeline: skipping pending review with corrupt issues JSON",
 				"review_id", rev.ID, "pr", pr.Number, "repo", pr.Repo, "err", err)
-			_ = p.store.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
+			_ = p.store.MarkReviewPublished(rev.ID, orphanedReviewID, "", time.Now().UTC())
 			continue
 		}
 		result := &executor.ReviewResult{

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -758,7 +758,10 @@ func (p *Pipeline) PublishPending() {
 		if err := json.Unmarshal([]byte(rev.Issues), &issues); err != nil {
 			slog.Warn("pipeline: skipping pending review with corrupt issues JSON",
 				"review_id", rev.ID, "pr", pr.Number, "repo", pr.Repo, "err", err)
-			_ = p.store.MarkReviewPublished(rev.ID, orphanedReviewID, "", time.Now().UTC())
+			if mErr := p.store.MarkReviewPublished(rev.ID, orphanedReviewID, "", time.Now().UTC()); mErr != nil {
+				slog.Warn("pipeline: failed to orphan corrupt review, will retry next tick",
+					"review_id", rev.ID, "err", mErr)
+			}
 			continue
 		}
 		result := &executor.ReviewResult{

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -743,9 +743,18 @@ func (p *Pipeline) PublishPending() {
 			slog.Info("pipeline: skipping pending review for PR with no repo", "review_id", rev.ID)
 			continue
 		}
-		// Rebuild a minimal result from stored JSON for the body
+		// Rebuild a minimal result from stored JSON for the body. The daemon
+		// always writes well-formed JSON here, so a decode failure means the
+		// stored row is corrupt and the issue list is unrecoverable. Don't
+		// publish a misleading review missing its findings, and don't retry a
+		// deterministic failure forever — orphan it like the no-repo case above.
 		var issues []executor.Issue
-		json.Unmarshal([]byte(rev.Issues), &issues)
+		if err := json.Unmarshal([]byte(rev.Issues), &issues); err != nil {
+			slog.Warn("pipeline: skipping pending review with corrupt issues JSON",
+				"review_id", rev.ID, "pr", pr.Number, "repo", pr.Repo, "err", err)
+			_ = p.store.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
+			continue
+		}
 		result := &executor.ReviewResult{
 			Summary:  rev.Summary,
 			Issues:   issues,

--- a/daemon/internal/pipeline/pipeline_orphan_test.go
+++ b/daemon/internal/pipeline/pipeline_orphan_test.go
@@ -231,10 +231,11 @@ func TestPublishPending_CorruptIssuesJSONOrphansWithoutPublishing(t *testing.T) 
 		t.Fatalf("upsert pr: %v", err)
 	}
 	// Seed an unpublished review whose Issues column is corrupt JSON.
-	if _, err := s.InsertReview(&store.Review{
+	prevReviewID, err := s.InsertReview(&store.Review{
 		PRID: prID, CLIUsed: "claude", Issues: "{not valid json", Suggestions: "[]",
 		Severity: "high", CreatedAt: time.Now(), HeadSHA: "abc", GitHubReviewID: 0,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("insert review: %v", err)
 	}
 
@@ -254,6 +255,16 @@ func TestPublishPending_CorruptIssuesJSONOrphansWithoutPublishing(t *testing.T) 
 	}
 	if len(unpub) != 0 {
 		t.Errorf("expected 0 unpublished reviews after corrupt-JSON orphaning, got %d", len(unpub))
+	}
+
+	// Lock in the orphan-sentinel contract: the row is stamped with the
+	// orphaned-review id (-1), not a real GitHub review id.
+	got, err := s.GetReview(prevReviewID)
+	if err != nil {
+		t.Fatalf("get review: %v", err)
+	}
+	if got.GitHubReviewID != -1 {
+		t.Errorf("orphaned review GitHubReviewID = %d, want -1 (sentinel)", got.GitHubReviewID)
 	}
 
 	// Subsequent ticks must remain a no-op.

--- a/daemon/internal/pipeline/pipeline_orphan_test.go
+++ b/daemon/internal/pipeline/pipeline_orphan_test.go
@@ -211,3 +211,54 @@ func (f *fakeGHTransientSubmit) FetchComments(_ string, _ int) ([]gh.Comment, er
 	return nil, nil
 }
 func (f *fakeGHTransientSubmit) GetPRHeadSHA(_ string, _ int) (string, error) { return "", nil }
+
+// TestPublishPending_CorruptIssuesJSONOrphansWithoutPublishing covers #549: a
+// stored review whose issues JSON is corrupt must NOT be posted to GitHub with
+// its findings silently dropped, and must be orphaned so the deterministic
+// decode failure doesn't loop the retry forever.
+func TestPublishPending_CorruptIssuesJSONOrphansWithoutPublishing(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	prID, err := s.UpsertPR(&store.PR{
+		GithubID: 300, Repo: "org/repo", Number: 9, Title: "t", Author: "alice",
+		State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	// Seed an unpublished review whose Issues column is corrupt JSON.
+	if _, err := s.InsertReview(&store.Review{
+		PRID: prID, CLIUsed: "claude", Issues: "{not valid json", Suggestions: "[]",
+		Severity: "high", CreatedAt: time.Now(), HeadSHA: "abc", GitHubReviewID: 0,
+	}); err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+
+	fgh := &fakeGHTransientSubmit{} // would be called if the bug were present; we assert it isn't
+	p := pipeline.New(s, fgh, &fakeExecOrphan{}, &fakeNotify{})
+
+	p.PublishPending()
+
+	// Must NOT post a misleading (issue-less) review to GitHub.
+	if fgh.submitCalls != 0 {
+		t.Errorf("SubmitReview called on corrupt-JSON review: calls=%d, want 0", fgh.submitCalls)
+	}
+	// Must be orphaned so it doesn't retry forever.
+	unpub, err := s.ListUnpublishedReviews()
+	if err != nil {
+		t.Fatalf("list unpublished: %v", err)
+	}
+	if len(unpub) != 0 {
+		t.Errorf("expected 0 unpublished reviews after corrupt-JSON orphaning, got %d", len(unpub))
+	}
+
+	// Subsequent ticks must remain a no-op.
+	p.PublishPending()
+	if fgh.submitCalls != 0 {
+		t.Errorf("PublishPending re-attempted on orphaned corrupt row: calls=%d, want 0", fgh.submitCalls)
+	}
+}


### PR DESCRIPTION
## Summary

`PublishPending` (the retry path for reviews that failed their initial GitHub publish) decoded the stored `rev.Issues` JSON with the error discarded. On a corrupt row, `issues` stayed empty and the retry posted a review to GitHub **with its findings dropped** — then `MarkReviewPublished` stamped it done, so it never retried: silent data loss (#549). The daemon always writes well-formed JSON here (`json.Marshal` at insert), so this only triggers on DB corruption / a `Review.Issues` format drift — rare, hence MEDIUM.

## How it works

`daemon/internal/pipeline/pipeline.go` — check the `json.Unmarshal` error; on failure, log a Warn and **orphan the row** via `MarkReviewPublished(rev.ID, -1, "", now)` + `continue`, mirroring the no-repo orphan case 8 lines above and the #245 fail-closed posture (transient errors keep retrying; deterministic/permanent ones orphan to avoid an infinite retry loop). A corrupt review can't be faithfully reconstructed, so we neither post a misleading findings-less review nor loop forever.

## Scope

**In scope:** the corrupt-`Issues`-JSON branch of `PublishPending`.
**Out of scope:** the initial `Run` publish path (it builds the result in-memory from a freshly-decoded agent response, so there's no stored-JSON decode there); changing the storage format; the `Suggestions` JSON (same pattern but not in the issue — left as-is to keep the change minimal).

Decision (resolved by existing house style, not a new policy): drop+orphan rather than post a degraded Summary-only review — consistent with the issue's "rather than posting an empty-issues review" and the orphan precedent.

## Production impact & what to watch

- **Runtime behavior change:** none for normal reviews (valid JSON). Only when a stored review's `Issues` is corrupt: instead of posting a findings-less review, the daemon logs a Warn, orphans the row (sentinel `github_review_id = -1`), and does **not** call `SubmitReview`. Net effect removes one misleading GitHub call in that case.
- **Rollout failure modes:** none — pure in-process logic in the retry loop; no config/secret/permission/API/migration; can't crashloop; compatible with old/new pods.
- **Blast radius:** the `PublishPending` retry path only, and only for reviews whose stored `Issues` JSON is corrupt. Normal reviews unaffected.
- **What to watch:** the new Warn line `pipeline: skipping pending review with corrupt issues JSON` (carries `review_id`, `pr`, `repo`, `err`). If it fires, a stored row is corrupt — investigate (DB integrity or a `Review.Issues` serialization-format drift). A growing count of sentinel `-1` reviews would indicate systematic corruption. Previously this was near-invisible (a posted review missing its issues).
- **Rollback & sequencing:** fully revertible, single file, no flag/migration/ordering. Reverting restores the silent issue-less post.

## Evidence

Acceptance: a corrupt-`Issues` review must not be posted issue-less, and must not retry forever.

<details><summary><code>make test-docker</code> — pipeline orphan/retry suite incl. the new test</summary>

```
--- PASS: TestPublishPending_LockedPRStopsRetrying (0.00s)
--- PASS: TestPublishPending_TransientErrorStillRetries (0.00s)
--- PASS: TestPublishPending_CorruptIssuesJSONOrphansWithoutPublishing (0.00s)
ok  	github.com/heimdallm/daemon/internal/pipeline
```
</details>

<details><summary>Full daemon suite — <code>go vet ./...</code> + <code>go test ./...</code> all green</summary>

```
ok  github.com/heimdallm/daemon/cmd/heimdallm
ok  github.com/heimdallm/daemon/internal/pipeline
ok  github.com/heimdallm/daemon/internal/store
... (all packages ok; vet clean)
```
</details>

## Test plan

- [x] `make test-docker` scoped to `./internal/pipeline/...` — new test + existing orphan/transient tests pass
- [x] `make test-docker` full daemon suite — `go vet` + `go test ./...` all green
- [ ] Reviewer: confirm orphan-and-drop (vs post Summary-only) is the desired behavior for a corrupt stored review

Closes #549
