### PR TITLE
fix(server): PUT /config returns 500 when SetConfig persist fails (closes #550)

### DIFF
--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -786,6 +787,7 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		body["agent_configs"] = normalized
 	}
 
+	var failedKeys []string
 	for k, v := range body {
 		// Read-only keys were accepted above to avoid 400s on UI saves that
 		// round-trip the GET payload, but they must not land in the store.
@@ -809,7 +811,20 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		}
 		if _, err := srv.store.SetConfig(k, val); err != nil {
 			slog.Error("config: set", "key", k, "err", err)
+			failedKeys = append(failedKeys, k)
 		}
+	}
+	// A swallowed persist error here would 200-OK a save that never hit disk,
+	// so the UI shows success while the next reload silently re-applies stale
+	// values (#550). Report 500 with the offending keys instead. Note this is
+	// not transactional: earlier keys in the loop may already be persisted.
+	if len(failedKeys) > 0 {
+		sort.Strings(failedKeys) // deterministic: Go map iteration order is random
+		writeJSON(w, http.StatusInternalServerError, map[string]any{
+			"error":       "failed to persist one or more config keys",
+			"failed_keys": failedKeys,
+		})
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -788,12 +788,14 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var failedKeys []string
+	var attempted int
 	for k, v := range body {
 		// Read-only keys were accepted above to avoid 400s on UI saves that
 		// round-trip the GET payload, but they must not land in the store.
 		if _, readOnly := readOnlyConfigKeys[k]; readOnly {
 			continue
 		}
+		attempted++
 		var val string
 		switch typed := v.(type) {
 		case string:
@@ -820,6 +822,7 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	// not transactional: earlier keys in the loop may already be persisted.
 	if len(failedKeys) > 0 {
 		sort.Strings(failedKeys) // deterministic: Go map iteration order is random
+		slog.Warn("config: partial persist failure", "failed", len(failedKeys), "attempted", attempted)
 		writeJSON(w, http.StatusInternalServerError, map[string]any{
 			"error":       "failed to persist one or more config keys",
 			"failed_keys": failedKeys,

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -329,13 +330,22 @@ func TestHandlerPutConfig(t *testing.T) {
 // TestHandlerPutConfig_PersistFailureReturns500 guards #550: a failed
 // SetConfig must surface as 500 with the offending keys, not a misleading
 // 200 OK that makes the UI believe a never-persisted save succeeded.
+//
+// The multi-key payload also locks the contract that the loop accumulates
+// EVERY failed key (not just the first) and returns them sorted, so the
+// response is deterministic regardless of Go's random map iteration order.
+// Forcing only a subset to fail would require a store seam to inject per-key
+// errors; the store is a concrete *store.Store, so we close it to fail all
+// writes and assert the full sorted set instead.
 func TestHandlerPutConfig_PersistFailureReturns500(t *testing.T) {
 	srv, s := setupServer(t)
-	// Close the store so the write fails (sql: database is closed) while the
+	// Close the store so the writes fail (sql: database is closed) while the
 	// pure key/value validation above still passes.
 	s.Close()
 
-	body := `{"poll_interval":"5m"}`
+	// Several writable keys, deliberately not in alphabetical order in the
+	// payload, so the assertion proves sort.Strings ordered the result.
+	body := `{"review_mode":"single","poll_interval":"5m","retention_days":90}`
 	req := httptest.NewRequest("PUT", "/config", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -354,8 +364,9 @@ func TestHandlerPutConfig_PersistFailureReturns500(t *testing.T) {
 	if resp.Error == "" {
 		t.Errorf("expected non-empty error message, got body: %s", w.Body.String())
 	}
-	if len(resp.FailedKeys) != 1 || resp.FailedKeys[0] != "poll_interval" {
-		t.Errorf("failed_keys = %v, want [poll_interval]", resp.FailedKeys)
+	want := []string{"poll_interval", "retention_days", "review_mode"} // sorted
+	if !reflect.DeepEqual(resp.FailedKeys, want) {
+		t.Errorf("failed_keys = %v, want %v (exact set, sorted)", resp.FailedKeys, want)
 	}
 }
 

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -326,6 +326,39 @@ func TestHandlerPutConfig(t *testing.T) {
 	}
 }
 
+// TestHandlerPutConfig_PersistFailureReturns500 guards #550: a failed
+// SetConfig must surface as 500 with the offending keys, not a misleading
+// 200 OK that makes the UI believe a never-persisted save succeeded.
+func TestHandlerPutConfig_PersistFailureReturns500(t *testing.T) {
+	srv, s := setupServer(t)
+	// Close the store so the write fails (sql: database is closed) while the
+	// pure key/value validation above still passes.
+	s.Close()
+
+	body := `{"poll_interval":"5m"}`
+	req := httptest.NewRequest("PUT", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on persist failure, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Error      string   `json:"error"`
+		FailedKeys []string `json:"failed_keys"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v (body: %s)", err, w.Body.String())
+	}
+	if resp.Error == "" {
+		t.Errorf("expected non-empty error message, got body: %s", w.Body.String())
+	}
+	if len(resp.FailedKeys) != 1 || resp.FailedKeys[0] != "poll_interval" {
+		t.Errorf("failed_keys = %v, want [poll_interval]", resp.FailedKeys)
+	}
+}
+
 func TestHandlerShutdown(t *testing.T) {
 	srv, _ := setupServer(t)
 	shutdown := make(chan struct{}, 1)


### PR DESCRIPTION
## Summary
`PUT /config` logged a failed `SetConfig` but fell through to `200 {"status":"ok"}`, so the client/UI believed the config was saved when the DB write actually failed (disk full, lock, permission) — and the next config reload silently re-applied the stale values. This makes the response honest: if any key fails to persist, the endpoint returns **500** with the offending keys. Fixes #550.

## How it works
`daemon/internal/server/handlers.go` (`handlePutConfig`):
- The per-key write loop now accumulates `failedKeys` when `SetConfig` returns an error (still logged via `slog.Error`, as before).
- After the loop, if `failedKeys` is non-empty, the handler returns `500` with `{"error": "...", "failed_keys": [...]}`. The keys are sorted so the payload is deterministic (Go map iteration order is random).
- The happy path is byte-for-byte unchanged: all writes succeed → `200 {"status":"ok"}`.

## Scope
**In scope**
- Honest status code + `failed_keys` payload on persist failure for `PUT /config`.
- Test that forces a store-write failure and asserts `500` + `failed_keys`.

**Out of scope**
- Transactional / all-or-nothing multi-key writes. The fix is intentionally **not** atomic — keys processed before the failing one may already be persisted. Making the write a single transaction is a larger, separate change; the bug in #550 is specifically the *misleading 200*, which this fixes. Called out in a code comment too.

## Production impact & what to watch
- **Runtime behavior change**: `PUT /config` now returns `500` (JSON `{error, failed_keys}`) when a `SetConfig` write fails, instead of a misleading `200`. No new outbound calls, startup invariants, or resource usage. Success path is identical to before.
- **Rollout failure modes**: None at startup — no new config/secret/permission, cannot crashloop. For existing clients the response changes **only in the failure case** (a write that actually fails). The Flutter client already treats any non-200 as an error (`api_client.dart:238` throws `ApiException`), so it surfaces a real error toast instead of a silent false success — the intended correction, not a regression. No success-path contract change.
- **Blast radius**: `PUT /config` only (config save from UI/CLI), and only on requests where a DB write genuinely fails — normally zero. No other endpoint touched.
- **What to watch**: post-deploy, a spike in `500` on `PUT /config` and the `config: set` `slog.Error` lines now indicates real persistence failures (disk/lock/permission) that were previously invisible. The `200` rate on successful saves should be unchanged (no false positives).
- **Rollback & sequencing**: Fully revertible, no migrations, no flags, no deploy ordering. Reverting restores the old swallow-and-200 behavior.

## Evidence
<details><summary>New test: persist failure → 500 + failed_keys (and happy path still 200)</summary>

```
=== RUN   TestHandlerPutConfig
--- PASS: TestHandlerPutConfig (0.01s)
=== RUN   TestHandlerPutConfig_PersistFailureReturns500
--- PASS: TestHandlerPutConfig_PersistFailureReturns500 (0.01s)
PASS
ok  	github.com/heimdallm/daemon/internal/server	0.049s
```
</details>

## Test plan
- [x] `go vet ./internal/server/`
- [x] `go test ./internal/server/` (new + existing PUT /config tests green)
- [x] `make verify-linux` (full Linux build verification passed)
- [ ] Reviewer: confirm the non-transactional behavior is acceptable for the multi-key case, or request a follow-up for atomic writes.

Closes #550