### PR TITLE
test(config): guard against poll_interval bounds drift between daemon and GUI (closes #546)

### DIFF
--- a/daemon/internal/config/poll_interval_drift_test.go
+++ b/daemon/internal/config/poll_interval_drift_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// dartConfigPath is the Flutter Settings screen, which carries a client-side
+// copy of the poll_interval bounds for immediate-feedback validation. The
+// daemon is authoritative (minPollInterval/maxPollInterval, enforced by
+// ValidatePollInterval); this guard makes sure the GUI's copy can't silently
+// drift from it. Path is relative to this package directory (daemon/internal/
+// config), so ../../../ lands at the repo root. See issue #546.
+const dartConfigPath = "../../../flutter_app/lib/features/config/config_screen.dart"
+
+var (
+	dartMinPollRe = regexp.MustCompile(`_minPollInterval\s*=\s*Duration\(([^)]*)\)`)
+	dartMaxPollRe = regexp.MustCompile(`_maxPollInterval\s*=\s*Duration\(([^)]*)\)`)
+	// Named arguments of Dart's Duration() constructor, e.g. `minutes: 1`.
+	dartDurationArgRe = regexp.MustCompile(`(days|hours|minutes|seconds|milliseconds|microseconds)\s*:\s*([0-9]+)`)
+)
+
+// TestPollIntervalBounds_MatchFlutterGUI fails if the [1m, 24h] poll_interval
+// range encoded in the Flutter GUI diverges from the authoritative daemon
+// bounds. It catches the silent drift described in issue #546: a change to the
+// Go constants without a matching change to the Dart guard (or vice versa).
+func TestPollIntervalBounds_MatchFlutterGUI(t *testing.T) {
+	src, err := os.ReadFile(dartConfigPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// The GUI lives in the same repo, so in CI this file is always
+			// present. Skip (rather than fail) for daemon-only checkouts where
+			// there is no Dart copy that could drift.
+			t.Skipf("Flutter config screen not present at %s; skipping cross-language drift check", filepath.Clean(dartConfigPath))
+		}
+		t.Fatalf("read %s: %v", dartConfigPath, err)
+	}
+
+	gotMin := parseDartDuration(t, "_minPollInterval", dartMinPollRe, src)
+	gotMax := parseDartDuration(t, "_maxPollInterval", dartMaxPollRe, src)
+
+	if gotMin != minPollInterval {
+		t.Errorf("poll_interval lower bound drift: daemon minPollInterval=%s but Flutter _minPollInterval=%s\n"+
+			"update %s to match daemon/internal/config/config.go (see issue #546)", minPollInterval, gotMin, dartConfigPath)
+	}
+	if gotMax != maxPollInterval {
+		t.Errorf("poll_interval upper bound drift: daemon maxPollInterval=%s but Flutter _maxPollInterval=%s\n"+
+			"update %s to match daemon/internal/config/config.go (see issue #546)", maxPollInterval, gotMax, dartConfigPath)
+	}
+}
+
+// parseDartDuration extracts the Dart Duration(...) literal named by re and
+// converts it to a time.Duration, summing all named arguments so equivalent
+// spellings (e.g. Duration(hours: 24) vs Duration(days: 1)) compare equal.
+func parseDartDuration(t *testing.T, name string, re *regexp.Regexp, src []byte) time.Duration {
+	t.Helper()
+	m := re.FindSubmatch(src)
+	if m == nil {
+		t.Fatalf("could not find %s = Duration(...) in %s; the drift guard needs updating (issue #546)", name, dartConfigPath)
+	}
+	args := dartDurationArgRe.FindAllSubmatch(m[1], -1)
+	if len(args) == 0 {
+		t.Fatalf("could not parse Duration arguments for %s (got %q)", name, m[1])
+	}
+	var total time.Duration
+	for _, a := range args {
+		n, err := strconv.Atoi(string(a[2]))
+		if err != nil {
+			t.Fatalf("invalid numeric literal %q for %s: %v", a[2], name, err)
+		}
+		total += dartDurationUnit(string(a[1])) * time.Duration(n)
+	}
+	return total
+}
+
+// dartDurationUnit maps a Dart Duration named argument to its time.Duration
+// equivalent.
+func dartDurationUnit(unit string) time.Duration {
+	switch unit {
+	case "days":
+		return 24 * time.Hour
+	case "hours":
+		return time.Hour
+	case "minutes":
+		return time.Minute
+	case "seconds":
+		return time.Second
+	case "milliseconds":
+		return time.Millisecond
+	case "microseconds":
+		return time.Microsecond
+	}
+	return 0
+}

--- a/daemon/internal/config/poll_interval_drift_test.go
+++ b/daemon/internal/config/poll_interval_drift_test.go
@@ -9,33 +9,53 @@ import (
 	"time"
 )
 
+// flutterAppDir is the root of the Flutter GUI module. Its presence is what
+// distinguishes a daemon-only checkout (no Dart copy that could drift, so the
+// guard skips) from an in-repo build where the GUI must exist (a missing config
+// screen then means a rename/move that should fail the guard). Path is relative
+// to this package directory (daemon/internal/config), so ../../../ lands at the
+// repo root.
+const flutterAppDir = "../../../flutter_app"
+
 // dartConfigPath is the Flutter Settings screen, which carries a client-side
 // copy of the poll_interval bounds for immediate-feedback validation. The
 // daemon is authoritative (minPollInterval/maxPollInterval, enforced by
 // ValidatePollInterval); this guard makes sure the GUI's copy can't silently
-// drift from it. Path is relative to this package directory (daemon/internal/
-// config), so ../../../ lands at the repo root. See issue #546.
-const dartConfigPath = "../../../flutter_app/lib/features/config/config_screen.dart"
+// drift from it. See issue #546.
+const dartConfigPath = flutterAppDir + "/lib/features/config/config_screen.dart"
 
 var (
-	dartMinPollRe = regexp.MustCompile(`_minPollInterval\s*=\s*Duration\(([^)]*)\)`)
-	dartMaxPollRe = regexp.MustCompile(`_maxPollInterval\s*=\s*Duration\(([^)]*)\)`)
+	// The optional `const` tolerates an equivalent Dart refactor from
+	// `= Duration(...)` to `= const Duration(...)`. `[^)]*` assumes the
+	// argument list has no nested parentheses, which holds because Dart's
+	// Duration only takes integer-literal named args (e.g. `minutes: 1`).
+	// FindSubmatch validates only the first match of each constant, which is
+	// sufficient: each is declared exactly once in the config screen.
+	dartMinPollRe = regexp.MustCompile(`_minPollInterval\s*=\s*(?:const\s+)?Duration\(([^)]*)\)`)
+	dartMaxPollRe = regexp.MustCompile(`_maxPollInterval\s*=\s*(?:const\s+)?Duration\(([^)]*)\)`)
 	// Named arguments of Dart's Duration() constructor, e.g. `minutes: 1`.
 	dartDurationArgRe = regexp.MustCompile(`(days|hours|minutes|seconds|milliseconds|microseconds)\s*:\s*([0-9]+)`)
 )
 
 // TestPollIntervalBounds_MatchFlutterGUI fails if the [1m, 24h] poll_interval
 // range encoded in the Flutter GUI diverges from the authoritative daemon
-// bounds. It catches the silent drift described in issue #546: a change to the
-// Go constants without a matching change to the Dart guard (or vice versa).
+// bounds (currently 1m and 24h). It catches the silent drift described in issue
+// #546: a change to the Go constants without a matching change to the Dart
+// guard (or vice versa).
 func TestPollIntervalBounds_MatchFlutterGUI(t *testing.T) {
 	src, err := os.ReadFile(dartConfigPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// The GUI lives in the same repo, so in CI this file is always
-			// present. Skip (rather than fail) for daemon-only checkouts where
-			// there is no Dart copy that could drift.
-			t.Skipf("Flutter config screen not present at %s; skipping cross-language drift check", filepath.Clean(dartConfigPath))
+			// Distinguish "no GUI here" from "GUI here but the file moved". A
+			// daemon-only checkout has no flutter_app dir at all → skip, there
+			// is nothing that could drift. But if flutter_app exists and only
+			// the config screen is missing, the file was renamed/moved — which
+			// is exactly the drift this guard must catch, so fail loudly rather
+			// than silently turning into a no-op.
+			if _, statErr := os.Stat(flutterAppDir); os.IsNotExist(statErr) {
+				t.Skipf("Flutter app not present at %s; skipping cross-language drift check", filepath.Clean(flutterAppDir))
+			}
+			t.Fatalf("Flutter app exists but %s is missing — was it renamed/moved? Update this guard to match (issue #546)", dartConfigPath)
 		}
 		t.Fatalf("read %s: %v", dartConfigPath, err)
 	}
@@ -72,27 +92,35 @@ func parseDartDuration(t *testing.T, name string, re *regexp.Regexp, src []byte)
 		if err != nil {
 			t.Fatalf("invalid numeric literal %q for %s: %v", a[2], name, err)
 		}
-		total += dartDurationUnit(string(a[1])) * time.Duration(n)
+		unit, ok := dartDurationUnit(string(a[1]))
+		if !ok {
+			// Unreachable while dartDurationArgRe only captures known units;
+			// the explicit failure makes the invariant safe if that regex is
+			// ever broadened, rather than silently contributing zero.
+			t.Fatalf("unrecognized Dart Duration unit %q for %s; update dartDurationUnit (issue #546)", a[1], name)
+		}
+		total += unit * time.Duration(n)
 	}
 	return total
 }
 
 // dartDurationUnit maps a Dart Duration named argument to its time.Duration
-// equivalent.
-func dartDurationUnit(unit string) time.Duration {
+// equivalent. The bool is false for an unrecognized unit so callers can fail
+// loudly instead of treating an unknown unit as a zero contribution.
+func dartDurationUnit(unit string) (time.Duration, bool) {
 	switch unit {
 	case "days":
-		return 24 * time.Hour
+		return 24 * time.Hour, true
 	case "hours":
-		return time.Hour
+		return time.Hour, true
 	case "minutes":
-		return time.Minute
+		return time.Minute, true
 	case "seconds":
-		return time.Second
+		return time.Second, true
 	case "milliseconds":
-		return time.Millisecond
+		return time.Millisecond, true
 	case "microseconds":
-		return time.Microsecond
+		return time.Microsecond, true
 	}
-	return 0
+	return 0, false
 }


### PR DESCRIPTION
## Summary

The acceptable `poll_interval` range `[1m, 24h]` is encoded independently in two places — the authoritative daemon constants (`minPollInterval`/`maxPollInterval`, enforced by `ValidatePollInterval`) and the Flutter GUI's client-side validation guard (`_minPollInterval`/`_maxPollInterval`). A change to the Go bounds without a matching change to Dart (or vice versa) would drift silently: the GUI would reject values the daemon accepts, or pass values the daemon rejects — defeating the immediate-feedback goal even though the daemon stays authoritative. This adds the lightweight contract check requested in the #545 review follow-up.

## How it works

New internal test `daemon/internal/config/poll_interval_drift_test.go` (`package config`, so it can read the unexported bounds):

- Reads the Flutter config screen at `../../../flutter_app/lib/features/config/config_screen.dart`.
- Extracts the `_minPollInterval` / `_maxPollInterval` `Duration(...)` literals and converts them to `time.Duration` (summing named args, so equivalent spellings like `Duration(hours: 24)` and `Duration(days: 1)` compare equal).
- Asserts they equal the daemon's `minPollInterval` / `maxPollInterval`, with an error message pointing at the file to fix.
- Skips (rather than fails) if the Dart file is absent, for daemon-only checkouts; in-repo CI always has it.

Runs inside the existing `go test ./...` daemon CI job — no new workflow, no runtime/production code change. Follows the existing `config_guards_drift_test.go` convention of catching drift at test time.

## Scope

In scope:
- A test-time contract assertion that the two `[1m, 24h]` copies stay in sync.

Out of scope (deliberately — the issue tags this low-priority UX polish):
- Exporting the bounds over the HTTP `/config` surface and having the GUI fetch them live. That adds an endpoint + async client loading + fallback handling; not warranted for a UX-quality guard while the daemon remains authoritative.

## Production impact & what to watch

**Low impact — test-only; nothing changes at runtime.** The new file is `package config` test code and is never compiled into the daemon binary.

- **Runtime behavior change:** none — binary is unchanged; no new calls, startup invariants, responses, or resource use.
- **Rollout failure modes:** none in production. The only new gate is in **CI**: the `Daemon (Go)` job fails if the Flutter bounds diverge from the Go constants, or if the Dart constant is refactored into a shape the parser can't read (clear `t.Fatalf` tells the author to update the guard). That's a red build, not a prod incident.
- **Blast radius:** CI only. No deployed artifact, consumer, or endpoint affected.
- **What to watch:** the `Daemon (Go)` CI check on PRs touching the bounds in `config.go` or `config_screen.dart`. Caveat: Go's test cache keys on the package's Go sources, not the external Dart file, so a *local* incremental run editing only the Dart file may return a stale cached pass — CI uses fresh checkouts so it always executes; locally use `-count=1`.
- **Rollback & sequencing:** trivially revertible (delete one file). No coordination needed.

## Evidence

The issue's goal is that drift can't pass unnoticed. Verified the guard passes on the current (aligned) tree and fails on induced drift:

<details>
<summary>Aligned tree — PASS</summary>

```
$ go test ./internal/config/ -run TestPollIntervalBounds_MatchFlutterGUI -count=1 -v
=== RUN   TestPollIntervalBounds_MatchFlutterGUI
--- PASS: TestPollIntervalBounds_MatchFlutterGUI (0.00s)
PASS
ok  	github.com/heimdallm/daemon/internal/config
```
</details>

<details>
<summary>Induced drift (temporarily set Flutter <code>_maxPollInterval</code> to 12h) — FAIL</summary>

```
=== RUN   TestPollIntervalBounds_MatchFlutterGUI
    poll_interval_drift_test.go:51: poll_interval upper bound drift: daemon maxPollInterval=24h0m0s but Flutter _maxPollInterval=12h0m0s
        update ../../../flutter_app/lib/features/config/config_screen.dart to match daemon/internal/config/config.go (see issue #546)
--- FAIL: TestPollIntervalBounds_MatchFlutterGUI (0.00s)
FAIL
```
</details>

## Test plan

- [x] `go test ./internal/config/ -count=1` passes (full package).
- [x] New test passes on the aligned tree.
- [x] New test fails with a clear message on induced drift (12h), then passes again after revert.
- [x] `go vet ./...` clean; `gofmt -l` clean.
- [ ] Reviewer: confirm CI `Daemon (Go)` job runs and passes on this PR.

Closes #546