### PR TITLE
fix(config): bound retention.max_days to [0,3650]; guard negative purge (closes #551)

### DIFF
--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -1257,6 +1257,13 @@ func (c *Config) Validate() error {
 	if err := c.validateScopedIssueTracking(); err != nil {
 		return err
 	}
+	if c.Retention.MaxDays < 0 || c.Retention.MaxDays > 3650 {
+		// Bounds the review-retention window. The HTTP PUT /config path already
+		// rejects out-of-range retention_days; this catches the TOML-file and
+		// HEIMDALLM_RETENTION_DAYS env paths too. Without it, a negative value
+		// pushes PurgeOldReviews' cutoff into the future and wipes all reviews.
+		return fmt.Errorf("config: retention.max_days must be between 0 and 3650, got %d", c.Retention.MaxDays)
+	}
 	if c.ActivityLog.RetentionDays != nil {
 		d := *c.ActivityLog.RetentionDays
 		if d < 0 || d > 3650 {

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -613,6 +613,11 @@ type OrgAI struct {
 	CircuitBreaker *CircuitBreakerConfig `toml:"circuit_breaker,omitempty"`
 }
 
+// MaxRetentionDays is the upper bound (≈10 years) shared by every retention
+// limit: retention.max_days, activity_log.retention_days, and the HTTP
+// PUT /config validator. Keeping it in one place stops the three checks drifting.
+const MaxRetentionDays = 3650
+
 type RetentionConfig struct {
 	MaxDays int `toml:"max_days"`
 }
@@ -1257,17 +1262,16 @@ func (c *Config) Validate() error {
 	if err := c.validateScopedIssueTracking(); err != nil {
 		return err
 	}
-	if c.Retention.MaxDays < 0 || c.Retention.MaxDays > 3650 {
-		// Bounds the review-retention window. The HTTP PUT /config path already
-		// rejects out-of-range retention_days; this catches the TOML-file and
-		// HEIMDALLM_RETENTION_DAYS env paths too. Without it, a negative value
-		// pushes PurgeOldReviews' cutoff into the future and wipes all reviews.
-		return fmt.Errorf("config: retention.max_days must be between 0 and 3650, got %d", c.Retention.MaxDays)
+	// Bound the review-retention window for the TOML and env paths (the HTTP
+	// PUT /config validator covers its own path). A negative value would push
+	// PurgeOldReviews' cutoff into the future and wipe all reviews (#551).
+	if c.Retention.MaxDays < 0 || c.Retention.MaxDays > MaxRetentionDays {
+		return fmt.Errorf("config: retention.max_days must be between 0 and %d, got %d", MaxRetentionDays, c.Retention.MaxDays)
 	}
 	if c.ActivityLog.RetentionDays != nil {
 		d := *c.ActivityLog.RetentionDays
-		if d < 0 || d > 3650 {
-			return fmt.Errorf("config: activity_log.retention_days must be between 0 and 3650, got %d", d)
+		if d < 0 || d > MaxRetentionDays {
+			return fmt.Errorf("config: activity_log.retention_days must be between 0 and %d, got %d", MaxRetentionDays, d)
 		}
 	}
 	return nil

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -308,27 +309,31 @@ func TestValidate_AllValidIntervals(t *testing.T) {
 
 func TestValidate_RetentionMaxDaysOutOfRange(t *testing.T) {
 	for _, days := range []int{-1, -365, 3651} {
-		cfg := &Config{}
-		cfg.applyDefaults()
-		cfg.AI.Primary = "claude"
-		cfg.Retention.MaxDays = days // set after applyDefaults, which coerces 0 -> 90
+		t.Run(fmt.Sprintf("days=%d", days), func(t *testing.T) {
+			cfg := &Config{}
+			cfg.applyDefaults()
+			cfg.AI.Primary = "claude"
+			cfg.Retention.MaxDays = days // set after applyDefaults, which coerces 0 -> 90
 
-		if err := cfg.Validate(); err == nil {
-			t.Errorf("Validate() with retention.max_days=%d = nil, want error", days)
-		}
+			if err := cfg.Validate(); err == nil {
+				t.Errorf("Validate() with retention.max_days=%d = nil, want error", days)
+			}
+		})
 	}
 }
 
 func TestValidate_RetentionMaxDaysValid(t *testing.T) {
 	for _, days := range []int{0, 1, 90, 3650} {
-		cfg := &Config{}
-		cfg.applyDefaults()
-		cfg.AI.Primary = "claude"
-		cfg.Retention.MaxDays = days
+		t.Run(fmt.Sprintf("days=%d", days), func(t *testing.T) {
+			cfg := &Config{}
+			cfg.applyDefaults()
+			cfg.AI.Primary = "claude"
+			cfg.Retention.MaxDays = days
 
-		if err := cfg.Validate(); err != nil {
-			t.Errorf("Validate() with retention.max_days=%d = %v, want nil", days, err)
-		}
+			if err := cfg.Validate(); err != nil {
+				t.Errorf("Validate() with retention.max_days=%d = %v, want nil", days, err)
+			}
+		})
 	}
 }
 

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -306,6 +306,50 @@ func TestValidate_AllValidIntervals(t *testing.T) {
 	}
 }
 
+func TestValidate_RetentionMaxDaysOutOfRange(t *testing.T) {
+	for _, days := range []int{-1, -365, 3651} {
+		cfg := &Config{}
+		cfg.applyDefaults()
+		cfg.AI.Primary = "claude"
+		cfg.Retention.MaxDays = days // set after applyDefaults, which coerces 0 -> 90
+
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("Validate() with retention.max_days=%d = nil, want error", days)
+		}
+	}
+}
+
+func TestValidate_RetentionMaxDaysValid(t *testing.T) {
+	for _, days := range []int{0, 1, 90, 3650} {
+		cfg := &Config{}
+		cfg.applyDefaults()
+		cfg.AI.Primary = "claude"
+		cfg.Retention.MaxDays = days
+
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() with retention.max_days=%d = %v, want nil", days, err)
+		}
+	}
+}
+
+// Regression for #551: a negative HEIMDALLM_RETENTION_DAYS must be rejected at
+// load time rather than silently flowing into PurgeOldReviews (whose cutoff
+// would land in the future and wipe the entire review history).
+func TestApplyEnvOverrides_NegativeRetentionRejectedByValidate(t *testing.T) {
+	t.Setenv("HEIMDALLM_RETENTION_DAYS", "-1")
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.AI.Primary = "claude"
+	cfg.applyEnvOverrides()
+
+	if cfg.Retention.MaxDays != -1 {
+		t.Fatalf("env override not applied: MaxDays = %d, want -1", cfg.Retention.MaxDays)
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate() = nil for HEIMDALLM_RETENTION_DAYS=-1, want error")
+	}
+}
+
 func TestValidate_InvalidRefinementTimeout(t *testing.T) {
 	cases := []struct {
 		name string

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -722,8 +722,8 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	if v, ok := body["retention_days"]; ok {
 		n, isNum := v.(float64) // JSON numbers decode as float64
-		if !isNum || n < 0 || n > 3650 {
-			http.Error(w, "retention_days must be between 0 and 3650", http.StatusBadRequest)
+		if !isNum || n < 0 || n > config.MaxRetentionDays {
+			http.Error(w, fmt.Sprintf("retention_days must be between 0 and %d", config.MaxRetentionDays), http.StatusBadRequest)
 			return
 		}
 	}

--- a/daemon/internal/store/reviews.go
+++ b/daemon/internal/store/reviews.go
@@ -146,14 +146,11 @@ func (s *Store) LatestReviewForPR(prID int64) (*Review, error) {
 	return scanReview(row)
 }
 
-// PurgeOldReviews deletes reviews older than maxDays. No-op if maxDays <= 0.
+// PurgeOldReviews deletes reviews older than maxDays. No-op if maxDays <= 0
+// (a negative value is a defensive no-op rather than a future cutoff that would
+// wipe every review; config validation already rejects negatives — see #551).
 // The cutoff is computed in Go and passed as an RFC3339 string so that the
 // comparison is consistent with how the modernc.org/sqlite driver stores values.
-//
-// A negative maxDays is treated as a no-op rather than computing a future
-// cutoff (which would delete every review). Config validation already rejects
-// negative retention, so this is a defensive last barrier before a destructive
-// DELETE.
 func (s *Store) PurgeOldReviews(maxDays int) error {
 	if maxDays <= 0 {
 		return nil

--- a/daemon/internal/store/reviews.go
+++ b/daemon/internal/store/reviews.go
@@ -146,11 +146,16 @@ func (s *Store) LatestReviewForPR(prID int64) (*Review, error) {
 	return scanReview(row)
 }
 
-// PurgeOldReviews deletes reviews older than maxDays. No-op if maxDays == 0.
+// PurgeOldReviews deletes reviews older than maxDays. No-op if maxDays <= 0.
 // The cutoff is computed in Go and passed as an RFC3339 string so that the
 // comparison is consistent with how the modernc.org/sqlite driver stores values.
+//
+// A negative maxDays is treated as a no-op rather than computing a future
+// cutoff (which would delete every review). Config validation already rejects
+// negative retention, so this is a defensive last barrier before a destructive
+// DELETE.
 func (s *Store) PurgeOldReviews(maxDays int) error {
-	if maxDays == 0 {
+	if maxDays <= 0 {
 		return nil
 	}
 	cutoff := time.Now().UTC().Add(-time.Duration(maxDays) * 24 * time.Hour).Format(sqliteTimeFormat)

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -238,6 +238,26 @@ func TestRetentionPurge(t *testing.T) {
 	}
 }
 
+// Regression for #551: a negative maxDays must not compute a future cutoff and
+// delete the entire review history; it is treated as a no-op.
+func TestPurgeOldReviews_NegativeIsNoOp(t *testing.T) {
+	s := newTestStore(t)
+	prID, _ := s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/r", Number: 1, Title: "t", Author: "a", URL: "u", State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now()})
+	for _, age := range []time.Duration{-100 * 24 * time.Hour, -1 * time.Hour} {
+		s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Summary: "s", Issues: "[]", Suggestions: "[]", Severity: "low",
+			CreatedAt: time.Now().Add(age),
+		})
+	}
+	if err := s.PurgeOldReviews(-1); err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	reviews, _ := s.ListReviewsForPR(prID)
+	if len(reviews) != 2 {
+		t.Errorf("negative maxDays wiped reviews: got %d, want 2 (no-op expected)", len(reviews))
+	}
+}
+
 func TestConfigs_ListReturnsAllRows(t *testing.T) {
 	s := newTestStore(t)
 

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -238,23 +239,35 @@ func TestRetentionPurge(t *testing.T) {
 	}
 }
 
-// Regression for #551: a negative maxDays must not compute a future cutoff and
-// delete the entire review history; it is treated as a no-op.
-func TestPurgeOldReviews_NegativeIsNoOp(t *testing.T) {
-	s := newTestStore(t)
-	prID, _ := s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/r", Number: 1, Title: "t", Author: "a", URL: "u", State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now()})
-	for _, age := range []time.Duration{-100 * 24 * time.Hour, -1 * time.Hour} {
-		s.InsertReview(&store.Review{
-			PRID: prID, CLIUsed: "claude", Summary: "s", Issues: "[]", Suggestions: "[]", Severity: "low",
-			CreatedAt: time.Now().Add(age),
+// Regression for #551: a non-positive maxDays must not compute a future cutoff
+// and delete the entire review history; both 0 and negatives are no-ops.
+func TestPurgeOldReviews_NonPositiveIsNoOp(t *testing.T) {
+	for _, maxDays := range []int{0, -1, -365} {
+		t.Run(fmt.Sprintf("maxDays=%d", maxDays), func(t *testing.T) {
+			s := newTestStore(t)
+			prID, err := s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/r", Number: 1, Title: "t", Author: "a", URL: "u", State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now()})
+			if err != nil {
+				t.Fatalf("upsert pr: %v", err)
+			}
+			for _, age := range []time.Duration{-100 * 24 * time.Hour, -1 * time.Hour} {
+				if _, err := s.InsertReview(&store.Review{
+					PRID: prID, CLIUsed: "claude", Summary: "s", Issues: "[]", Suggestions: "[]", Severity: "low",
+					CreatedAt: time.Now().Add(age),
+				}); err != nil {
+					t.Fatalf("insert review: %v", err)
+				}
+			}
+			if err := s.PurgeOldReviews(maxDays); err != nil {
+				t.Fatalf("purge: %v", err)
+			}
+			reviews, err := s.ListReviewsForPR(prID)
+			if err != nil {
+				t.Fatalf("list reviews: %v", err)
+			}
+			if len(reviews) != 2 {
+				t.Errorf("maxDays=%d wiped reviews: got %d, want 2 (no-op expected)", maxDays, len(reviews))
+			}
 		})
-	}
-	if err := s.PurgeOldReviews(-1); err != nil {
-		t.Fatalf("purge: %v", err)
-	}
-	reviews, _ := s.ListReviewsForPR(prID)
-	if len(reviews) != 2 {
-		t.Errorf("negative maxDays wiped reviews: got %d, want 2 (no-op expected)", len(reviews))
 	}
 }
 


### PR DESCRIPTION
## Summary

`HEIMDALLM_RETENTION_DAYS` (env) and the TOML `retention.max_days` had no range check — only the HTTP `PUT /config` path validated `[0,3650]`. A negative value flowed unchecked into `PurgeOldReviews`, whose cutoff is `now − maxDays×24h`; with a negative `maxDays` the cutoff lands in the **future**, so `DELETE FROM reviews WHERE created_at < cutoff` deletes the **entire review history**. Low trigger likelihood (operator misconfig), high blast radius. Closes #551.

## How it works

Two layers, mirroring how the codebase already bounds `activity_log.retention_days`:

- **`daemon/internal/config/config.go` — `Validate()`** now rejects `Retention.MaxDays` outside `[0,3650]`. Both `Load` and `LoadOrCreate` run `applyDefaults → applyEnvOverrides → Validate`, so this single check catches **both** the env override and the TOML-file value at load time.
- **`daemon/internal/store/reviews.go` — `PurgeOldReviews`** now no-ops on `maxDays <= 0` (was `== 0`), a defensive last barrier immediately before the destructive `DELETE`.

**Deliberate deviation from the issue's suggested fix:** the issue proposed *clamping* in `applyEnvOverrides` as well. I skipped that — silently clamping would hide an operator misconfig and diverge from the TOML path, which fails loudly via `Validate()`. Letting `Validate()` reject the value fails fast and consistently for both env and file paths, and avoids redundant bounding logic.

## Scope

In scope:
- Bound `retention.max_days` at config-load time (env + TOML).
- Defensive negative-guard in `PurgeOldReviews`.
- Regression tests in `internal/config` and `internal/store`.

Out of scope:
- The HTTP `PUT /config` path — already validates `retention_days ∈ [0,3650]` (`handlers.go:725`); unchanged.
- `ActivityLog.RetentionDays` — already validated; unchanged.

## Production impact & what to watch

Turns a silent data-loss bug into a fail-fast startup error.

- **Runtime behavior change:** `Validate()` rejects out-of-range `retention.max_days`/`HEIMDALLM_RETENTION_DAYS` → `Load`/`LoadOrCreate` error. `PurgeOldReviews(maxDays<=0)` is now a no-op (was a full-table wipe on negatives). In-range configs (default 90): **identical behavior**.
- **Rollout failure modes:** **new startup invariant** — if a currently deployed environment sets `HEIMDALLM_RETENTION_DAYS` (or `config.toml max_days`) outside `[0,3650]`, the daemon now **refuses to start** instead of starting and wiping data. No new secret/permission; no client contract change (HTTP already returned 400 for these values).
- **Blast radius:** the single daemon process at startup. No consumer/endpoint touched.
- **What to watch:** daemon **failing to start / CrashLoopBackOff** with log line `config: retention.max_days must be between 0 and 3650, got N`. If it appears, the deployed retention value is out of range and must be fixed. Otherwise no signal.
- **Rollback & sequencing:** trivially revertible (revert the commit); no data migration. Pre-deploy, confirm no live env sets `HEIMDALLM_RETENTION_DAYS` outside `[0,3650]` so the new invariant doesn't crashloop (default is 90, so almost certainly fine).

## Evidence

The issue's claim is that a negative retention wipes history and that env/`Validate()` are unguarded. Both regression tests fail on the pre-fix code and pass after:

<details>
<summary>Without the <code>PurgeOldReviews</code> guard — negative maxDays wipes the table</summary>

```
--- FAIL: TestPurgeOldReviews_NegativeIsNoOp (0.00s)
    store_test.go:257: negative maxDays wiped reviews: got 0, want 2 (no-op expected)
```
</details>

<details>
<summary>Without the <code>Validate()</code> bound — out-of-range values accepted</summary>

```
--- FAIL: TestValidate_RetentionMaxDaysOutOfRange (0.00s)
    config_test.go:317: Validate() with retention.max_days=-1 = nil, want error
    config_test.go:317: Validate() with retention.max_days=-365 = nil, want error
    config_test.go:317: Validate() with retention.max_days=3651 = nil, want error
--- FAIL: TestApplyEnvOverrides_NegativeRetentionRejectedByValidate (0.00s)
    config_test.go:349: Validate() = nil for HEIMDALLM_RETENTION_DAYS=-1, want error
```
</details>

<details>
<summary>With the fix — all green</summary>

```
ok  	github.com/heimdallm/daemon/internal/config	0.035s
ok  	github.com/heimdallm/daemon/internal/store	0.396s
```
</details>

## Test plan

- [x] `go test ./internal/config/ ./internal/store/ -count=1` passes.
- [x] New tests fail on pre-fix code, pass after the fix (both layers verified independently).
- [x] `go vet ./...` clean; `gofmt -l` clean on changed files.
- [ ] Reviewer: confirm no deployed environment sets `HEIMDALLM_RETENTION_DAYS` outside `[0,3650]` before merge/deploy (new startup invariant).
- [ ] Note: pre-existing `TestDetect_Fallback` failure in `internal/executor` is environment-dependent (local CLI binaries on PATH) and unrelated to this change.

Closes #551