### PR TITLE
fix(store): propagate ComputeStats query/scan errors (closes #553)

### DIFF
--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -487,39 +487,29 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 	}
 
 	// By severity
-	rows, err := s.db.Query("SELECT severity, COUNT(*) FROM reviews r WHERE 1=1"+repoFilter+" GROUP BY severity", repoArgs...)
-	if err != nil {
-		return nil, fmt.Errorf("store: stats by severity: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
+	if err := queryRows(s.db, "SELECT severity, COUNT(*) FROM reviews r WHERE 1=1"+repoFilter+" GROUP BY severity", repoArgs, func(rows *sql.Rows) error {
 		var sev string
 		var cnt int
 		if err := rows.Scan(&sev, &cnt); err != nil {
-			return nil, fmt.Errorf("store: stats by severity scan: %w", err)
+			return err
 		}
 		stats.BySeverity[sev] = cnt
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("store: stats by severity rows: %w", err)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("store: stats by severity: %w", err)
 	}
 
 	// By CLI
-	rows2, err := s.db.Query("SELECT cli_used, COUNT(*) FROM reviews r WHERE 1=1"+repoFilter+" GROUP BY cli_used", repoArgs...)
-	if err != nil {
-		return nil, fmt.Errorf("store: stats by cli: %w", err)
-	}
-	defer rows2.Close()
-	for rows2.Next() {
+	if err := queryRows(s.db, "SELECT cli_used, COUNT(*) FROM reviews r WHERE 1=1"+repoFilter+" GROUP BY cli_used", repoArgs, func(rows *sql.Rows) error {
 		var cli string
 		var cnt int
-		if err := rows2.Scan(&cli, &cnt); err != nil {
-			return nil, fmt.Errorf("store: stats by cli scan: %w", err)
+		if err := rows.Scan(&cli, &cnt); err != nil {
+			return err
 		}
 		stats.ByCLI[cli] = cnt
-	}
-	if err := rows2.Err(); err != nil {
-		return nil, fmt.Errorf("store: stats by cli rows: %w", err)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("store: stats by cli: %w", err)
 	}
 
 	// Top repos by review count
@@ -528,20 +518,15 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 		FROM reviews r JOIN prs p ON p.id = r.pr_id
 		WHERE p.repo != ''` + repoFilterJoined + `
 		GROUP BY p.repo ORDER BY cnt DESC LIMIT 8`
-	rows3, err := s.db.Query(topRepoQuery, repoArgs...)
-	if err != nil {
-		return nil, fmt.Errorf("store: stats top repos: %w", err)
-	}
-	defer rows3.Close()
-	for rows3.Next() {
+	if err := queryRows(s.db, topRepoQuery, repoArgs, func(rows *sql.Rows) error {
 		var rc RepoCount
-		if err := rows3.Scan(&rc.Repo, &rc.Count); err != nil {
-			return nil, fmt.Errorf("store: stats top repos scan: %w", err)
+		if err := rows.Scan(&rc.Repo, &rc.Count); err != nil {
+			return err
 		}
 		stats.TopRepos = append(stats.TopRepos, rc)
-	}
-	if err := rows3.Err(); err != nil {
-		return nil, fmt.Errorf("store: stats top repos rows: %w", err)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("store: stats top repos: %w", err)
 	}
 
 	// Reviews per day last 7 days
@@ -550,20 +535,15 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 		FROM reviews r
 		WHERE r.created_at >= datetime('now', '-7 days')` + repoFilter + `
 		GROUP BY day ORDER BY day ASC`
-	rows4, err := s.db.Query(last7Query, repoArgs...)
-	if err != nil {
-		return nil, fmt.Errorf("store: stats last 7 days: %w", err)
-	}
-	defer rows4.Close()
-	for rows4.Next() {
+	if err := queryRows(s.db, last7Query, repoArgs, func(rows *sql.Rows) error {
 		var dc DayCount
-		if err := rows4.Scan(&dc.Day, &dc.Count); err != nil {
-			return nil, fmt.Errorf("store: stats last 7 days scan: %w", err)
+		if err := rows.Scan(&dc.Day, &dc.Count); err != nil {
+			return err
 		}
 		stats.ReviewsLast7Days = append(stats.ReviewsLast7Days, dc)
-	}
-	if err := rows4.Err(); err != nil {
-		return nil, fmt.Errorf("store: stats last 7 days rows: %w", err)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("store: stats last 7 days: %w", err)
 	}
 
 	// Avg issues per review (issues is a JSON array stored as text)
@@ -590,24 +570,19 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 		  AND p.fetched_at != ''` + repoFilterJoined + `
 		ORDER BY r.created_at DESC
 		LIMIT 200`
-	timingRows, err := s.db.Query(timingQuery, repoArgs...)
-	if err != nil {
-		return nil, fmt.Errorf("store: stats timing: %w", err)
-	}
-	defer timingRows.Close()
 	var durations []float64
-	for timingRows.Next() {
+	if err := queryRows(s.db, timingQuery, repoArgs, func(rows *sql.Rows) error {
 		var d float64
-		if err := timingRows.Scan(&d); err != nil {
-			return nil, fmt.Errorf("store: stats timing scan: %w", err)
+		if err := rows.Scan(&d); err != nil {
+			return err
 		}
 		// Sanity check: 5s–3600s (ignore implausible values)
 		if d >= 5 && d <= 3600 {
 			durations = append(durations, d)
 		}
-	}
-	if err := timingRows.Err(); err != nil {
-		return nil, fmt.Errorf("store: stats timing rows: %w", err)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("store: stats timing: %w", err)
 	}
 	if n := len(durations); n > 0 {
 		t := &stats.ReviewTiming
@@ -658,4 +633,22 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 	}
 
 	return stats, nil
+}
+
+// queryRows runs query and calls scan once per row, returning the first of any
+// Query, scan, or iteration (rows.Err) error. The *sql.Rows is closed before
+// queryRows returns, so each result set is released as soon as its caller block
+// finishes rather than being held open until the enclosing function returns.
+func queryRows(db *sql.DB, query string, args []any, scan func(*sql.Rows) error) error {
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := scan(rows); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
 }

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -482,30 +482,44 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 	}
 
 	// Total reviews
-	s.db.QueryRow("SELECT COUNT(*) FROM reviews r WHERE 1=1"+repoFilter, repoArgs...).Scan(&stats.TotalReviews)
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM reviews r WHERE 1=1"+repoFilter, repoArgs...).Scan(&stats.TotalReviews); err != nil {
+		return nil, fmt.Errorf("store: stats total reviews: %w", err)
+	}
 
 	// By severity
-	rows, _ := s.db.Query("SELECT severity, COUNT(*) FROM reviews r WHERE 1=1"+repoFilter+" GROUP BY severity", repoArgs...)
-	if rows != nil {
-		defer rows.Close()
-		for rows.Next() {
-			var sev string
-			var cnt int
-			rows.Scan(&sev, &cnt)
-			stats.BySeverity[sev] = cnt
+	rows, err := s.db.Query("SELECT severity, COUNT(*) FROM reviews r WHERE 1=1"+repoFilter+" GROUP BY severity", repoArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("store: stats by severity: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var sev string
+		var cnt int
+		if err := rows.Scan(&sev, &cnt); err != nil {
+			return nil, fmt.Errorf("store: stats by severity scan: %w", err)
 		}
+		stats.BySeverity[sev] = cnt
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: stats by severity rows: %w", err)
 	}
 
 	// By CLI
-	rows2, _ := s.db.Query("SELECT cli_used, COUNT(*) FROM reviews r WHERE 1=1"+repoFilter+" GROUP BY cli_used", repoArgs...)
-	if rows2 != nil {
-		defer rows2.Close()
-		for rows2.Next() {
-			var cli string
-			var cnt int
-			rows2.Scan(&cli, &cnt)
-			stats.ByCLI[cli] = cnt
+	rows2, err := s.db.Query("SELECT cli_used, COUNT(*) FROM reviews r WHERE 1=1"+repoFilter+" GROUP BY cli_used", repoArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("store: stats by cli: %w", err)
+	}
+	defer rows2.Close()
+	for rows2.Next() {
+		var cli string
+		var cnt int
+		if err := rows2.Scan(&cli, &cnt); err != nil {
+			return nil, fmt.Errorf("store: stats by cli scan: %w", err)
 		}
+		stats.ByCLI[cli] = cnt
+	}
+	if err := rows2.Err(); err != nil {
+		return nil, fmt.Errorf("store: stats by cli rows: %w", err)
 	}
 
 	// Top repos by review count
@@ -514,14 +528,20 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 		FROM reviews r JOIN prs p ON p.id = r.pr_id
 		WHERE p.repo != ''` + repoFilterJoined + `
 		GROUP BY p.repo ORDER BY cnt DESC LIMIT 8`
-	rows3, _ := s.db.Query(topRepoQuery, repoArgs...)
-	if rows3 != nil {
-		defer rows3.Close()
-		for rows3.Next() {
-			var rc RepoCount
-			rows3.Scan(&rc.Repo, &rc.Count)
-			stats.TopRepos = append(stats.TopRepos, rc)
+	rows3, err := s.db.Query(topRepoQuery, repoArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("store: stats top repos: %w", err)
+	}
+	defer rows3.Close()
+	for rows3.Next() {
+		var rc RepoCount
+		if err := rows3.Scan(&rc.Repo, &rc.Count); err != nil {
+			return nil, fmt.Errorf("store: stats top repos scan: %w", err)
 		}
+		stats.TopRepos = append(stats.TopRepos, rc)
+	}
+	if err := rows3.Err(); err != nil {
+		return nil, fmt.Errorf("store: stats top repos rows: %w", err)
 	}
 
 	// Reviews per day last 7 days
@@ -530,21 +550,31 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 		FROM reviews r
 		WHERE r.created_at >= datetime('now', '-7 days')` + repoFilter + `
 		GROUP BY day ORDER BY day ASC`
-	rows4, _ := s.db.Query(last7Query, repoArgs...)
-	if rows4 != nil {
-		defer rows4.Close()
-		for rows4.Next() {
-			var dc DayCount
-			rows4.Scan(&dc.Day, &dc.Count)
-			stats.ReviewsLast7Days = append(stats.ReviewsLast7Days, dc)
+	rows4, err := s.db.Query(last7Query, repoArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("store: stats last 7 days: %w", err)
+	}
+	defer rows4.Close()
+	for rows4.Next() {
+		var dc DayCount
+		if err := rows4.Scan(&dc.Day, &dc.Count); err != nil {
+			return nil, fmt.Errorf("store: stats last 7 days scan: %w", err)
 		}
+		stats.ReviewsLast7Days = append(stats.ReviewsLast7Days, dc)
+	}
+	if err := rows4.Err(); err != nil {
+		return nil, fmt.Errorf("store: stats last 7 days rows: %w", err)
 	}
 
 	// Avg issues per review (issues is a JSON array stored as text)
 	var totalIssues, reviewsWithIssues int
-	s.db.QueryRow("SELECT COUNT(*) FROM reviews r WHERE issues != '[]' AND issues != 'null'"+repoFilter, repoArgs...).Scan(&reviewsWithIssues)
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM reviews r WHERE issues != '[]' AND issues != 'null'"+repoFilter, repoArgs...).Scan(&reviewsWithIssues); err != nil {
+		return nil, fmt.Errorf("store: stats reviews with issues: %w", err)
+	}
 	if reviewsWithIssues > 0 {
-		s.db.QueryRow("SELECT COALESCE(SUM(json_array_length(issues)),0) FROM reviews r WHERE issues IS NOT NULL"+repoFilter, repoArgs...).Scan(&totalIssues)
+		if err := s.db.QueryRow("SELECT COALESCE(SUM(json_array_length(issues)),0) FROM reviews r WHERE issues IS NOT NULL"+repoFilter, repoArgs...).Scan(&totalIssues); err != nil {
+			return nil, fmt.Errorf("store: stats total issues: %w", err)
+		}
 		if stats.TotalReviews > 0 {
 			stats.AvgIssuesPerReview = float64(totalIssues) / float64(stats.TotalReviews)
 		}
@@ -560,58 +590,64 @@ func (s *Store) ComputeStats(repos []string, orgs []string) (*Stats, error) {
 		  AND p.fetched_at != ''` + repoFilterJoined + `
 		ORDER BY r.created_at DESC
 		LIMIT 200`
-	timingRows, _ := s.db.Query(timingQuery, repoArgs...)
-	if timingRows != nil {
-		var durations []float64
-		for timingRows.Next() {
-			var d float64
-			timingRows.Scan(&d)
-			// Sanity check: 5s–3600s (ignore implausible values)
-			if d >= 5 && d <= 3600 {
-				durations = append(durations, d)
+	timingRows, err := s.db.Query(timingQuery, repoArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("store: stats timing: %w", err)
+	}
+	defer timingRows.Close()
+	var durations []float64
+	for timingRows.Next() {
+		var d float64
+		if err := timingRows.Scan(&d); err != nil {
+			return nil, fmt.Errorf("store: stats timing scan: %w", err)
+		}
+		// Sanity check: 5s–3600s (ignore implausible values)
+		if d >= 5 && d <= 3600 {
+			durations = append(durations, d)
+		}
+	}
+	if err := timingRows.Err(); err != nil {
+		return nil, fmt.Errorf("store: stats timing rows: %w", err)
+	}
+	if n := len(durations); n > 0 {
+		t := &stats.ReviewTiming
+		t.SampleCount = n
+		sum, minD, maxD := 0.0, durations[0], durations[0]
+		for _, d := range durations {
+			sum += d
+			if d < minD {
+				minD = d
+			}
+			if d > maxD {
+				maxD = d
+			}
+			switch {
+			case d < 30:
+				t.BucketFast++
+			case d < 120:
+				t.BucketMedium++
+			case d < 300:
+				t.BucketSlow++
+			default:
+				t.BucketVerySlow++
 			}
 		}
-		timingRows.Close()
-		if n := len(durations); n > 0 {
-			t := &stats.ReviewTiming
-			t.SampleCount = n
-			sum, minD, maxD := 0.0, durations[0], durations[0]
-			for _, d := range durations {
-				sum += d
-				if d < minD {
-					minD = d
-				}
-				if d > maxD {
-					maxD = d
-				}
-				switch {
-				case d < 30:
-					t.BucketFast++
-				case d < 120:
-					t.BucketMedium++
-				case d < 300:
-					t.BucketSlow++
-				default:
-					t.BucketVerySlow++
-				}
+		t.AvgSeconds = sum / float64(n)
+		t.MinSeconds = minD
+		t.MaxSeconds = maxD
+		// Median (durations are already in insertion order, approximate)
+		sorted := make([]float64, n)
+		copy(sorted, durations)
+		// Simple insertion sort for small N
+		for i := 1; i < n; i++ {
+			for j := i; j > 0 && sorted[j] < sorted[j-1]; j-- {
+				sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
 			}
-			t.AvgSeconds = sum / float64(n)
-			t.MinSeconds = minD
-			t.MaxSeconds = maxD
-			// Median (durations are already in insertion order, approximate)
-			sorted := make([]float64, n)
-			copy(sorted, durations)
-			// Simple insertion sort for small N
-			for i := 1; i < n; i++ {
-				for j := i; j > 0 && sorted[j] < sorted[j-1]; j-- {
-					sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
-				}
-			}
-			if n%2 == 0 {
-				t.MedianSeconds = (sorted[n/2-1] + sorted[n/2]) / 2
-			} else {
-				t.MedianSeconds = sorted[n/2]
-			}
+		}
+		if n%2 == 0 {
+			t.MedianSeconds = (sorted[n/2-1] + sorted[n/2]) / 2
+		} else {
+			t.MedianSeconds = sorted[n/2]
 		}
 	}
 

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -271,6 +271,47 @@ func TestPurgeOldReviews_NonPositiveIsNoOp(t *testing.T) {
 	}
 }
 
+func TestComputeStats_CountsBasics(t *testing.T) {
+	s := newTestStore(t)
+	prID, err := s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/r", Number: 1, Title: "t", Author: "a", URL: "u", State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now()})
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	for _, sev := range []string{"low", "low", "high"} {
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Summary: "s", Issues: "[]", Suggestions: "[]", Severity: sev,
+			CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("insert review: %v", err)
+		}
+	}
+
+	stats, err := s.ComputeStats(nil, nil)
+	if err != nil {
+		t.Fatalf("ComputeStats: %v", err)
+	}
+	if stats.TotalReviews != 3 {
+		t.Errorf("TotalReviews = %d, want 3", stats.TotalReviews)
+	}
+	if stats.BySeverity["low"] != 2 || stats.BySeverity["high"] != 1 {
+		t.Errorf("BySeverity = %v, want low:2 high:1", stats.BySeverity)
+	}
+}
+
+// Regression for #553: a DB error must surface through the error return rather
+// than yielding zeroed/partial stats with a nil error. Closing the store makes
+// every query fail, so ComputeStats must report it instead of returning ok.
+func TestComputeStats_DBErrorPropagates(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	stats, err := s.ComputeStats(nil, nil)
+	if err == nil {
+		t.Fatalf("ComputeStats on closed DB = nil error (stats=%+v), want error", stats)
+	}
+}
+
 func TestConfigs_ListReturnsAllRows(t *testing.T) {
 	s := newTestStore(t)
 

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -298,6 +299,36 @@ func TestComputeStats_CountsBasics(t *testing.T) {
 	}
 }
 
+func TestComputeStats_AvgIssuesPerReview(t *testing.T) {
+	s := newTestStore(t)
+	prID, err := s.UpsertPR(&store.PR{GithubID: 1, Repo: "org/r", Number: 1, Title: "t", Author: "a", URL: "u", State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now()})
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	// Two reviews carrying 3 and 1 issues, plus one with none — avg over all 3
+	// reviews is (3+1+0)/3 = 1.333…
+	for _, issues := range []string{
+		`[{"a":1},{"a":2},{"a":3}]`,
+		`[{"a":1}]`,
+		`[]`,
+	} {
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Summary: "s", Issues: issues, Suggestions: "[]", Severity: "low",
+			CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("insert review: %v", err)
+		}
+	}
+
+	stats, err := s.ComputeStats(nil, nil)
+	if err != nil {
+		t.Fatalf("ComputeStats: %v", err)
+	}
+	if want := 4.0 / 3.0; stats.AvgIssuesPerReview != want {
+		t.Errorf("AvgIssuesPerReview = %v, want %v", stats.AvgIssuesPerReview, want)
+	}
+}
+
 // Regression for #553: a DB error must surface through the error return rather
 // than yielding zeroed/partial stats with a nil error. Closing the store makes
 // every query fail, so ComputeStats must report it instead of returning ok.
@@ -309,6 +340,11 @@ func TestComputeStats_DBErrorPropagates(t *testing.T) {
 	stats, err := s.ComputeStats(nil, nil)
 	if err == nil {
 		t.Fatalf("ComputeStats on closed DB = nil error (stats=%+v), want error", stats)
+	}
+	// The first query (total reviews) is what fails; assert the wrapped message
+	// localizes it, so a future reorder of the queries is caught.
+	if !strings.Contains(err.Error(), "total reviews") {
+		t.Errorf("error = %q, want it to mention %q", err, "total reviews")
 	}
 }
 


### PR DESCRIPTION
## Summary

`ComputeStats` declared an `error` return but hard-coded `return stats, nil`, discarding every `Query`, `Scan`, and `QueryRow().Scan` error via blank assignment and never checking `rows.Err()`. On any DB error the `/stats` endpoint served **partial or zeroed** numbers with a 200 — the dashboard silently lied, and the handler's existing 500 branch was effectively dead code. Closes #553.

## How it works

In `ComputeStats` (`daemon/internal/store/store.go`), every `Query`/`Scan`/`QueryRow().Scan` is now checked and wrapped with `fmt.Errorf("store: stats …: %w", err)` and propagated via the already-present `error` return; each row loop now also checks `rows.Err()`. The timing block's `if rows != nil` guard is replaced by proper error handling + `defer Close()`.

Two deliberate decisions:
- The last-24h **activity counter stays non-fatal** — it was already documented as best-effort (`a failing query leaves the field zero rather than breaking /stats entirely`), so a failure there still leaves the field zero.
- The `/stats` handler (`handlers.go:1641`) already maps a non-nil error to `500` + a logged `handleStats: store error`, so no handler change is needed — the fix simply makes that path reachable.

## Scope

In scope:
- Error checking + propagation for all queries in `ComputeStats`.
- `rows.Err()` after each row loop.
- Regression tests (happy path + error propagation).

Out of scope:
- The non-fatal activity counter (intentional, documented).
- Other store methods (the audit flagged `ComputeStats` specifically).

## Production impact & what to watch

Makes `/stats` honest about DB failures instead of masking them.

- **Runtime behavior change:** on a DB error during stats computation, `GET /stats` now returns **500** (previously a dead path) instead of **200 with zeroed/partial numbers**. Happy path is byte-identical (same numbers). No new calls or resource use; errors are `slog.Error`-logged.
- **Rollout failure modes:** none at startup — pure read-path logic, no new secret/config/permission. Client-visible change: a `/stats` request hitting a transient DB error now gets 500 rather than misleading zeros (the intended fix). If SQLite ever returns `database is locked`/`busy` under write contention, `/stats` will surface it as 500 where it was previously hidden.
- **Blast radius:** the single auth-gated `/stats` dashboard endpoint. Read-only; no write path or other endpoint affected.
- **What to watch:** the **500 rate on `GET /stats`** and the `handleStats: store error` log line (now carrying wrapped `store: stats …` causes). A spike means a previously-masked DB problem (e.g. SQLite lock contention) is now visible; dashboard shows an error state instead of zeroed metrics.
- **Rollback & sequencing:** trivially revertible (one commit); no migration or coordination.

## Evidence

The error-path regression test fails on the pre-fix code (proving the swallow) and passes after:

<details>
<summary>Before the fix — closed DB yields zeroed stats + nil error</summary>

```
--- FAIL: TestComputeStats_DBErrorPropagates (0.00s)
    store_test.go:278: ComputeStats on closed DB = nil error (stats=&{TotalReviews:0 BySeverity:map[] ByCLI:map[] TopRepos:[] ReviewsLast7Days:[] AvgIssuesPerReview:0 ReviewTiming:{...} ActivityCount24h:0}), want error
```
</details>

<details>
<summary>After the fix — error propagates; happy-path counts correct</summary>

```
--- PASS: TestComputeStats_CountsBasics (0.00s)
--- PASS: TestComputeStats_DBErrorPropagates (0.00s)
ok  	github.com/heimdallm/daemon/internal/store
```
</details>

## Test plan

- [x] `go test ./internal/store/ -count=1` passes (full package).
- [x] Error-path test fails on pre-fix code, passes after the fix.
- [x] `go build ./...` clean; `go vet ./internal/store/` clean; `gofmt -l` clean.
- [ ] Reviewer: confirm the non-fatal activity-counter exception is intended (it is — pre-existing documented behavior).

Closes #553