### PR TITLE
fix(flutter): surface SSE transport errors to listeners (closes #554)

### DIFF
--- a/flutter_app/lib/core/api/sse_client.dart
+++ b/flutter_app/lib/core/api/sse_client.dart
@@ -123,7 +123,10 @@ class SseClient {
             },
             onError: (e) {
               _cancelSubscription();
-              // Reconnect after a delay instead of propagating the error permanently.
+              // Surface the transport error to listeners (mirrors the outer
+              // catch below) so the UI can reflect the dropped connection,
+              // then reconnect after a delay rather than giving up.
+              _controller?.addError(e);
               _scheduleReconnect(_errorReconnectDelay);
             },
             onDone: () {

--- a/flutter_app/lib/features/server/widgets/events_tab.dart
+++ b/flutter_app/lib/features/server/widgets/events_tab.dart
@@ -46,7 +46,11 @@ class _EventsTabState extends ConsumerState<EventsTab> {
     super.initState();
     final platform = ref.read(platformServicesProvider);
     _client = SseClient(platform: platform, path: '/events');
-    _sub = _client!.connect().listen(_onEvent);
+    // The SSE stream now forwards transport errors to listeners; swallow them
+    // here so a transient drop doesn't surface as an unhandled async error.
+    // The client auto-reconnects and the global connection indicator already
+    // reflects the offline state.
+    _sub = _client!.connect().listen(_onEvent, onError: (_) {});
   }
 
   @override

--- a/flutter_app/test/core/sse_client_test.dart
+++ b/flutter_app/test/core/sse_client_test.dart
@@ -156,7 +156,7 @@ void main() {
           doneReconnectDelay: const Duration(milliseconds: 10),
         );
 
-        final sub = client.connect().listen((_) {});
+        final sub = client.connect().listen((_) {}, onError: (_) {});
         await Future<void>.delayed(const Duration(milliseconds: 20));
         expect(requests, 1);
 
@@ -174,6 +174,49 @@ void main() {
         }
       },
     );
+
+    test('forwards stream transport errors to listeners', () async {
+      final platform = FakePlatformServices(
+        apiBaseUrl: 'http://127.0.0.1:7842',
+      );
+      final controllers = <StreamController<List<int>>>[];
+      final mockClient = MockClient.streaming((request, _) async {
+        final controller = StreamController<List<int>>();
+        controllers.add(controller);
+        return http.StreamedResponse(
+          controller.stream,
+          200,
+          headers: {'content-type': 'text/event-stream'},
+        );
+      });
+      final client = SseClient(
+        httpClient: mockClient,
+        platform: platform,
+        path: '/events',
+        errorReconnectDelay: const Duration(milliseconds: 10),
+      );
+
+      Object? forwarded;
+      final sub = client.connect().listen((_) {}, onError: (e) => forwarded = e);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(controllers, isNotEmpty);
+
+      controllers.first.addError(Exception('socket closed'));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(
+        forwarded,
+        isNotNull,
+        reason: 'transport error must reach listeners, not be swallowed',
+      );
+
+      await sub.cancel();
+      for (final controller in controllers) {
+        if (!controller.isClosed) {
+          await controller.close();
+        }
+      }
+    });
 
     test('send failure schedules a reconnect', () async {
       final platform = FakePlatformServices(

--- a/flutter_app/test/core/sse_client_test.dart
+++ b/flutter_app/test/core/sse_client_test.dart
@@ -199,15 +199,26 @@ void main() {
       Object? forwarded;
       final sub = client.connect().listen((_) {}, onError: (e) => forwarded = e);
       await Future<void>.delayed(const Duration(milliseconds: 20));
-      expect(controllers, isNotEmpty);
+      expect(controllers, hasLength(1));
 
-      controllers.first.addError(Exception('socket closed'));
-      await Future<void>.delayed(const Duration(milliseconds: 10));
+      final injected = Exception('socket closed');
+      controllers.first.addError(injected);
+      await Future<void>.delayed(const Duration(milliseconds: 40));
 
+      // The original transport error is forwarded unwrapped — not swallowed,
+      // not transformed into a different/wrapped error.
       expect(
         forwarded,
-        isNotNull,
-        reason: 'transport error must reach listeners, not be swallowed',
+        same(injected),
+        reason: 'the exact transport error must reach listeners, unwrapped',
+      );
+      // ...and forwarding does not disrupt auto-reconnect: a second request
+      // is issued after errorReconnectDelay. Surfacing the error and recovering
+      // are both part of the contract.
+      expect(
+        controllers,
+        hasLength(2),
+        reason: 'client must reconnect after surfacing the error',
       );
 
       await sub.cancel();


### PR DESCRIPTION
## Summary

`SseClient`'s stream `onError` handler reconnected after a transport/stream error but never forwarded the error to listeners, so the dropped connection was swallowed. The UI only learned the stream had failed via the dashboard's 60s stale watchdog (`DaemonConnectionNotifier.staleAfter`), and `LogsView`'s `onError: → _connected = false` handler never fired at all. This mirrors the inconsistency the issue flagged: the outer `catch` (sse_client.dart:137) already does `_controller?.addError(e)`, but the mid-stream `onError` did not.

Fixes the swallowed-error path so connection failures surface promptly instead of waiting up to 60s.

Closes #554

## How it works

- **`flutter_app/lib/core/api/sse_client.dart`** — the stream `onError` handler now calls `_controller?.addError(e)` before scheduling the reconnect, matching the outer `catch`. The auto-reconnect behavior is unchanged; we additionally propagate the error so listeners can react.
- **`flutter_app/lib/features/server/widgets/events_tab.dart`** — this was the one consumer that listened with **no** `onError`. Now that the stream forwards errors, an unhandled one would surface as an uncaught async (zone) error. Added a no-op `onError` here: the global connection indicator already reflects offline state and the client auto-reconnects, so the events tab just needs to not crash on a transient drop.
- The other two consumers already handle errors: `LogsView` (`logs_screen.dart:72`, flips its `_connected` flag) and the dashboard's `sseStreamProvider` (a Riverpod `StreamProvider`, which turns the error into `AsyncError` → `DaemonConnectionNotifier` sets phase `offline`).

## Scope

In scope:
- Forward mid-stream transport errors to listeners.
- Keep all three `connect()` consumers free of unhandled errors.

Out of scope:
- The buffer-overflow guard path (sse_client.dart:109-114) still reconnects silently — it guards against a malformed/malicious stream rather than a transport failure, so surfacing it as a connection error would be misleading. Left unchanged.
- No new visible "reconnecting" UI element beyond the existing dashboard connection indicator.

## Production impact & what to watch

This is a Flutter GUI/web client change only — no daemon, API, or contract change.

- **Runtime behavior change:** the dashboard connection indicator now flips to `offline` on a transport error within ~1 stream tick instead of after up to 60s. On a flapping connection the indicator may transition offline→connecting→connected more visibly than before. The logs screen's "connected" indicator now correctly reflects drops.
- **Rollout failure modes:** none at startup — pure client logic, no new config/secret/permission. The one behavioral risk is the new error propagation reaching a listener without an `onError`; audited all three `connect()` consumers and the only bare listener (`events_tab`) now has one, so no new uncaught zone errors.
- **Blast radius:** GUI/web users only. No effect on daemon, CLI, or persisted state.
- **What to watch:** after release, the dashboard connection banner may show transient offline/reconnecting states it previously hid — this is the intended surfacing, not a regression. Watch for any uncaught-async-error reports from the Flutter app (FlutterError) tied to the `/events` or `/logs/stream` SSE streams, which would indicate a consumer still missing an `onError`.
- **Rollback & sequencing:** safely revertible in isolation; no migration or deploy ordering required.

## Evidence

<details>
<summary>New test: <code>forwards stream transport errors to listeners</code></summary>

Asserts that an error injected into the underlying HTTP stream reaches a `connect()` listener's `onError` (previously swallowed). Also updated the existing "stream error followed by close" test to attach an `onError` now that errors propagate.

```
$ flutter test test/core/sse_client_test.dart   # inside heimdallm-verify image
00:00 +6: SseClient connect stream error followed by close schedules only one reconnect
00:00 +7: SseClient connect forwards stream transport errors to listeners
...
00:00 +11: All tests passed!
```
</details>

## Test plan

- [x] `flutter test` (run inside `make verify-linux` Docker image)
- [x] Full Linux verification: daemon tests, `flutter test`, `flutter build linux --release`
- [ ] Reviewer: sanity-check that the events-tab no-op `onError` is the desired UX (vs. a visible disconnect marker)
