### PR TITLE
chore(pipeline): add PR/repo correlation id to severity-reconciliation warn logs (closes #557)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ daemon/heimdallm
 cli/heimdallm-cli
 .superpowers/
 .claude/scheduled_tasks.lock
+# repox dev-tool artifacts — local-only cleanup script and lock dir; the script
+# hardcodes a developer's absolute home path, so never commit either.
+.repox-cleanup.sh
+.repox.lock/

--- a/daemon/internal/pipeline/comment_signals_test.go
+++ b/daemon/internal/pipeline/comment_signals_test.go
@@ -1,6 +1,9 @@
 package pipeline
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/heimdallm/daemon/internal/executor"
@@ -394,6 +397,43 @@ func TestReconcileSeverity_NonCanonicalTopLevelNeverCaps(t *testing.T) {
 		if got := ReconcileSeverity(makeResult("critical", issues)); got != "high" {
 			t.Errorf("non-canonical top-level must stay high regardless of issues %v; got %q", issues, got)
 		}
+	}
+}
+
+func TestReconcileSeverity_LogAttrsThreadedIntoWarnLines(t *testing.T) {
+	// The correlation id passed by the caller (repo + PR number) must appear on
+	// BOTH warn lines so a production warning can be tied back to the review that
+	// triggered it (#557). Capture slog output and assert the attrs are present.
+	//
+	// NOTE: this captures via slog.SetDefault, which mutates package-global state.
+	// It is safe only because this test does not call t.Parallel() and no other
+	// test in this package does. Do NOT add t.Parallel() here or to a concurrent
+	// test that also touches the default logger — they would race.
+	capture := func(result *executor.ReviewResult) string {
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		defer slog.SetDefault(prev)
+		ReconcileSeverity(result, "repo", "owner/heimdallm", "pr", 557)
+		return buf.String()
+	}
+
+	// Non-canonical top-level → "failing safe to high" warn line.
+	out := capture(makeResult("critical", nil))
+	if !strings.Contains(out, "failing safe to high") {
+		t.Fatalf("expected the fail-safe warn line, got: %q", out)
+	}
+	if !strings.Contains(out, `repo=owner/heimdallm`) || !strings.Contains(out, "pr=557") {
+		t.Errorf("fail-safe warn line missing correlation id; got: %q", out)
+	}
+
+	// Canonical top-level raised by a higher per-issue severity → "AI inconsistency".
+	out = capture(makeResult("low", []testIssue{{Severity: "high"}}))
+	if !strings.Contains(out, "AI inconsistency") {
+		t.Fatalf("expected the AI-inconsistency warn line, got: %q", out)
+	}
+	if !strings.Contains(out, `repo=owner/heimdallm`) || !strings.Contains(out, "pr=557") {
+		t.Errorf("AI-inconsistency warn line missing correlation id; got: %q", out)
 	}
 }
 

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -585,7 +585,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 
 	// 5b. Reconcile severity: ensure top-level severity >= max(issues[].severity).
 	// Guards against LLM inconsistencies (prompt injection, model errors).
-	reconciledSeverity := ReconcileSeverity(result)
+	reconciledSeverity := ReconcileSeverity(result, "repo", pr.Repo, "pr", pr.Number)
 
 	// 5c. Extract comment signals and apply escalation to the severity that
 	// will be persisted. By folding signal-driven escalation into the stored
@@ -932,7 +932,12 @@ func rankToSeverity(r int) string {
 // the maximum severity found in individual issues. This guards against LLM
 // inconsistencies where issues are flagged high but the global field is set
 // low (prompt injection, model error, hallucination).
-func ReconcileSeverity(result *executor.ReviewResult) string {
+//
+// logAttrs are appended verbatim to any warn line this function emits, so the
+// caller can thread a correlation id (e.g. "repo", pr.Repo, "pr", pr.Number)
+// to tie a reconciliation warning back to the specific review that triggered
+// it. They are key/value pairs in slog's variadic form; pass none to omit.
+func ReconcileSeverity(result *executor.ReviewResult, logAttrs ...any) string {
 	// Fail-safe on the top-level severity. The agent prompt mandates one of
 	// low|medium|high; a non-canonical value ("critical", "blocker", or model
 	// garbage) would otherwise fall through severityRank's default to rank 1
@@ -949,7 +954,7 @@ func ReconcileSeverity(result *executor.ReviewResult) string {
 	var maxRank int
 	if nonCanonical {
 		slog.Warn("pipeline: non-canonical top-level severity from agent; failing safe to high",
-			"ai_severity", result.Severity)
+			append([]any{"ai_severity", result.Severity}, logAttrs...)...)
 		maxRank = severityRank("high")
 	} else {
 		maxRank = severityRank(result.Severity)
@@ -966,9 +971,11 @@ func ReconcileSeverity(result *executor.ReviewResult) string {
 	// guarding here avoids a misleading double log on the same call.
 	if !nonCanonical && reconciled != result.Severity {
 		slog.Warn("pipeline: severity reconciled (AI inconsistency)",
-			"ai_severity", result.Severity,
-			"reconciled", reconciled,
-			"issue_count", len(result.Issues))
+			append([]any{
+				"ai_severity", result.Severity,
+				"reconciled", reconciled,
+				"issue_count", len(result.Issues),
+			}, logAttrs...)...)
 	}
 	return reconciled
 }


### PR DESCRIPTION
## Summary
`ReconcileSeverity`'s two `slog.Warn` lines — the `#556`-added *"non-canonical top-level severity … failing safe to high"* and the pre-existing *"severity reconciled (AI inconsistency)"* — emitted only `ai_severity`, with no PR/repo/review identifier. During production triage (*"why did this review fail-safe to high / why is the REQUEST_CHANGES rate up?"*) there was no way to tie a warning back to the review that triggered it. This threads a correlation id (repo + PR number) into both lines. Follow-up from the review of #556, raised by Muriano. Closes #557.

## How it works
- `ReconcileSeverity` gains a variadic `logAttrs ...any` parameter (slog key/value form). It is appended verbatim to **both** warn lines via `append([]any{…}, logAttrs...)...`.
- The single call site in `pipeline.Run` (`pipeline.go:588`) now passes `"repo", pr.Repo, "pr", pr.Number` — matching the file's existing slog convention (`"repo", pr.Repo, "pr", pr.Number`).
- Variadic was chosen over an explicit `(repo, prNumber)` signature so all existing `ReconcileSeverity(result)` test callers compile unchanged and the change stays minimal.

## Scope
**In scope:** correlation id on both reconciliation warn lines; one test proving propagation.
**Out of scope:** any change to reconciliation logic or the returned severity (untouched); threading a richer review-id type; touching other log lines in the pipeline.

## Production impact & what to watch
- **Runtime behavior change:** none functional — `ReconcileSeverity` returns the identical severity as before. The only difference is two warn lines now carry extra `repo`/`pr` fields when they fire (a rare AI-inconsistency path). One small slice allocation per warn.
- **Rollout failure modes:** none. No new config/secret/permission (no crashloop risk); no contract/response/status-code change; variadic signature is backward-compatible.
- **Blast radius:** daemon log output only. No consumer/endpoint/API affected. Additive fields only — nothing renamed or removed.
- **What to watch:** after deploy, confirm the two warn lines (`pipeline: non-canonical top-level severity from agent; failing safe to high` and `pipeline: severity reconciled (AI inconsistency)`) now include `repo=` and `pr=`. No error-rate/metric signal to monitor — purely additive observability.
- **Rollback & sequencing:** trivially revertible (one commit, one file + test). No coordination, flags, or deploy ordering needed.

## Evidence
The issue requires the correlation id on **both** warn lines. New test `TestReconcileSeverity_LogAttrsThreadedIntoWarnLines` captures slog output and asserts `repo=` and `pr=` on each.

<details><summary>go test ./internal/pipeline/ -run TestReconcile -v</summary>

```
=== RUN   TestReconcileSeverity_LogAttrsThreadedIntoWarnLines
--- PASS: TestReconcileSeverity_LogAttrsThreadedIntoWarnLines (0.00s)
...
PASS
ok  	github.com/heimdallm/daemon/internal/pipeline	0.117s
```
</details>

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/pipeline/` clean
- [x] `go test ./internal/pipeline/` passes (full package)
- [x] New test asserts both warn lines carry `repo`/`pr`
- [ ] Reviewer: confirm correlation id is acceptable as `repo`+`pr` (vs a review-id type)

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)