### PR TITLE
chore(pipeline): add repo/PR correlation id to severity-reconciliation warn logs (closes #557)

### DIFF
--- a/daemon/internal/pipeline/comment_signals_test.go
+++ b/daemon/internal/pipeline/comment_signals_test.go
@@ -1,6 +1,9 @@
 package pipeline
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/heimdallm/daemon/internal/executor"
@@ -394,6 +397,49 @@ func TestReconcileSeverity_NonCanonicalTopLevelNeverCaps(t *testing.T) {
 		if got := ReconcileSeverity(makeResult("critical", issues)); got != "high" {
 			t.Errorf("non-canonical top-level must stay high regardless of issues %v; got %q", issues, got)
 		}
+	}
+}
+
+func TestReconcileSeverity_ExtraAttrsAppendedToWarnings(t *testing.T) {
+	// extraAttrs let callers attach a correlation id (repo + PR number) so a
+	// fail-safe / reconciliation warning can be tied back to the review that
+	// triggered it (#557). Both warn paths must carry the fields.
+	cases := []struct {
+		name   string
+		result *executor.ReviewResult
+	}{
+		{
+			// Non-canonical top-level → "failing safe to high" warning.
+			"non-canonical fail-safe",
+			makeResult("critical", nil),
+		},
+		{
+			// Canonical top-level raised by a higher per-issue severity →
+			// "severity reconciled (AI inconsistency)" warning.
+			"ai inconsistency",
+			makeResult("low", []testIssue{{Severity: "high"}}),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			defer slog.SetDefault(prev)
+
+			ReconcileSeverity(tc.result, "repo", "owner/heimdallm", "pr_number", 42)
+
+			out := buf.String()
+			if !strings.Contains(out, "level=WARN") {
+				t.Fatalf("expected a WARN line, got: %q", out)
+			}
+			if !strings.Contains(out, "repo=owner/heimdallm") {
+				t.Errorf("warn line missing repo correlation field; got: %q", out)
+			}
+			if !strings.Contains(out, "pr_number=42") {
+				t.Errorf("warn line missing pr_number correlation field; got: %q", out)
+			}
+		})
 	}
 }
 

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -585,7 +585,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 
 	// 5b. Reconcile severity: ensure top-level severity >= max(issues[].severity).
 	// Guards against LLM inconsistencies (prompt injection, model errors).
-	reconciledSeverity := ReconcileSeverity(result)
+	reconciledSeverity := ReconcileSeverity(result, "repo", pr.Repo, "pr_number", pr.Number)
 
 	// 5c. Extract comment signals and apply escalation to the severity that
 	// will be persisted. By folding signal-driven escalation into the stored
@@ -932,7 +932,12 @@ func rankToSeverity(r int) string {
 // the maximum severity found in individual issues. This guards against LLM
 // inconsistencies where issues are flagged high but the global field is set
 // low (prompt injection, model error, hallucination).
-func ReconcileSeverity(result *executor.ReviewResult) string {
+//
+// extraAttrs are appended to any warning this emits (as slog key/value pairs)
+// so callers can attach a correlation id — e.g. "repo", pr.Repo, "pr_number",
+// pr.Number — to tie a fail-safe/reconciliation warning back to the review
+// that triggered it. Pass none to log without correlation fields (tests do).
+func ReconcileSeverity(result *executor.ReviewResult, extraAttrs ...any) string {
 	// Fail-safe on the top-level severity. The agent prompt mandates one of
 	// low|medium|high; a non-canonical value ("critical", "blocker", or model
 	// garbage) would otherwise fall through severityRank's default to rank 1
@@ -949,7 +954,7 @@ func ReconcileSeverity(result *executor.ReviewResult) string {
 	var maxRank int
 	if nonCanonical {
 		slog.Warn("pipeline: non-canonical top-level severity from agent; failing safe to high",
-			"ai_severity", result.Severity)
+			append([]any{"ai_severity", result.Severity}, extraAttrs...)...)
 		maxRank = severityRank("high")
 	} else {
 		maxRank = severityRank(result.Severity)
@@ -966,9 +971,11 @@ func ReconcileSeverity(result *executor.ReviewResult) string {
 	// guarding here avoids a misleading double log on the same call.
 	if !nonCanonical && reconciled != result.Severity {
 		slog.Warn("pipeline: severity reconciled (AI inconsistency)",
-			"ai_severity", result.Severity,
-			"reconciled", reconciled,
-			"issue_count", len(result.Issues))
+			append([]any{
+				"ai_severity", result.Severity,
+				"reconciled", reconciled,
+				"issue_count", len(result.Issues),
+			}, extraAttrs...)...)
 	}
 	return reconciled
 }


### PR DESCRIPTION
## Summary

`ReconcileSeverity` emits two `slog.Warn` lines — the non-canonical top-level fail-safe (`failing safe to high`) and the pre-existing `severity reconciled (AI inconsistency)` — but both carried only `ai_severity`, with no PR/repo/review identifier. When triaging in production ("why did this review fail-safe to high?", "why is the REQUEST_CHANGES rate up?") there was no way to tie a warning back to the specific review that produced it.

This threads a correlation id (repo + PR number) into both warn lines. Observability-only — no behavior change.

Follow-up from the #556 review, raised by @Muriano. Closes #557.

## How it works

- `ReconcileSeverity` gains a backward-compatible variadic parameter `extraAttrs ...any`, appended (as slog key/value pairs) to **both** warn lines.
- The sole production call site (`pipeline.Run`, `pipeline.go:588`, where `pr` is in scope) passes `"repo", pr.Repo, "pr_number", pr.Number`.
- Chosen over a hard signature change / moving logging to the call site because the variadic keeps all ~15 existing `ReconcileSeverity(result)` test call sites compiling and behaving unchanged, and keeps the two carefully-guarded warn branches inside the function.

## Scope

In scope:
- Correlation fields (`repo`, `pr_number`) on both reconciliation warn lines.
- Unit test asserting both warn paths carry the fields.

Out of scope:
- Review-id correlation — no review record exists yet at this call site; repo + PR number is the available and sufficient key (as the issue notes).
- Any change to the reconciled-severity logic or the APPROVE/REQUEST_CHANGES decision.

## Production impact & what to watch

Observability-only daemon change; no runtime behavior, contract, config, or persistence change.

- **Runtime behavior change:** the two reconciliation warn lines now include `repo=` and `pr_number=` fields. The returned reconciled severity is byte-for-byte unchanged. Marginally larger log lines on those two warns; no new calls/allocations of note.
- **Rollout failure modes:** none — the variadic is backward compatible (no caller break), no new startup invariant, config, or secret; cannot crashloop.
- **Blast radius:** daemon review pipeline only; specifically anyone reading/parsing the severity-reconciliation warn logs.
- **What to watch:** after deploy, confirm `pipeline: non-canonical top-level severity from agent; failing safe to high` and `pipeline: severity reconciled (AI inconsistency)` now carry `repo`/`pr_number`. The message strings are unchanged, so exact-message log alerts keep matching; structured-field consumers simply gain the two keys.
- **Rollback & sequencing:** trivially revertible; no coordination, migration, or deploy ordering.

## Evidence

<details>
<summary><code>go test ./internal/pipeline/ -run TestReconcileSeverity_ExtraAttrsAppendedToWarnings -v</code></summary>

```
=== RUN   TestReconcileSeverity_ExtraAttrsAppendedToWarnings
=== RUN   TestReconcileSeverity_ExtraAttrsAppendedToWarnings/non-canonical_fail-safe
=== RUN   TestReconcileSeverity_ExtraAttrsAppendedToWarnings/ai_inconsistency
--- PASS: TestReconcileSeverity_ExtraAttrsAppendedToWarnings (0.00s)
    --- PASS: .../non-canonical_fail-safe (0.00s)
    --- PASS: .../ai_inconsistency (0.00s)
PASS
ok  	github.com/heimdallm/daemon/internal/pipeline
```
</details>

## Test plan

- [x] `go vet ./internal/pipeline/` clean
- [x] `go test ./internal/pipeline/` — full package green (existing reconcile tests unchanged + new test)
- [x] `go build ./...` — whole daemon builds
- [x] New test asserts **both** warn paths carry `repo` + `pr_number`
- [ ] Reviewer: confirm `repo`/`pr_number` is the desired correlation key (vs. also wanting a review/run id)

Note: the only full-suite failure is the pre-existing `TestDetect_Fallback` local-env flake (a real `codex` binary on PATH); it fails identically on clean `main` and is green in CI containers.
