### PR TITLE
fix(server): make PUT /config persist atomically (closes #565)

### DIFF
--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -644,8 +644,8 @@ var validConfigKeys = map[string]struct{}{
 // render them) but that PUT /config must not persist. The SvelteKit page
 // round-trips the entire GET payload as a forward-compat safeguard, so
 // rejecting these would 400 every save. We accept them at the endpoint
-// boundary and drop them before SetConfig — still a strict allowlist, no
-// arbitrary keys permitted.
+// boundary and drop them before the persist batch — still a strict allowlist,
+// no arbitrary keys permitted.
 //
 // Why each key is here:
 //   - repositories  : repo-list changes belong in config.toml via PATCH
@@ -787,15 +787,13 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		body["agent_configs"] = normalized
 	}
 
-	var failedKeys []string
-	var attempted int
+	kv := make(map[string]string, len(body))
 	for k, v := range body {
 		// Read-only keys were accepted above to avoid 400s on UI saves that
 		// round-trip the GET payload, but they must not land in the store.
 		if _, readOnly := readOnlyConfigKeys[k]; readOnly {
 			continue
 		}
-		attempted++
 		var val string
 		switch typed := v.(type) {
 		case string:
@@ -811,20 +809,23 @@ func (srv *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 			}
 			val = string(b)
 		}
-		if _, err := srv.store.SetConfig(k, val); err != nil {
-			slog.Error("config: set", "key", k, "err", err)
-			failedKeys = append(failedKeys, k)
-		}
+		kv[k] = val
 	}
+	// Persist all keys in one transaction: the save is all-or-nothing (#565).
 	// A swallowed persist error here would 200-OK a save that never hit disk,
 	// so the UI shows success while the next reload silently re-applies stale
-	// values (#550). Report 500 with the offending keys instead. Note this is
-	// not transactional: earlier keys in the loop may already be persisted.
-	if len(failedKeys) > 0 {
+	// values (#550). On failure SetConfigs rolls back, so NO key is persisted —
+	// we report 500 with the full attempted key set (none of them landed), and
+	// the client recovers by simply retrying the whole payload.
+	if err := srv.store.SetConfigs(kv); err != nil {
+		failedKeys := make([]string, 0, len(kv))
+		for k := range kv {
+			failedKeys = append(failedKeys, k)
+		}
 		sort.Strings(failedKeys) // deterministic: Go map iteration order is random
-		slog.Warn("config: partial persist failure", "failed", len(failedKeys), "attempted", attempted)
+		slog.Error("config: set (atomic)", "keys", len(failedKeys), "err", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]any{
-			"error":       "failed to persist one or more config keys",
+			"error":       "failed to persist config; no keys were saved (transaction rolled back)",
 			"failed_keys": failedKeys,
 		})
 		return

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -327,16 +327,15 @@ func TestHandlerPutConfig(t *testing.T) {
 	}
 }
 
-// TestHandlerPutConfig_PersistFailureReturns500 guards #550: a failed
-// SetConfig must surface as 500 with the offending keys, not a misleading
-// 200 OK that makes the UI believe a never-persisted save succeeded.
+// TestHandlerPutConfig_PersistFailureReturns500 guards #550 + #565: a failed
+// persist must surface as 500 with the offending keys, not a misleading 200 OK
+// that makes the UI believe a never-persisted save succeeded.
 //
-// The multi-key payload also locks the contract that the loop accumulates
-// EVERY failed key (not just the first) and returns them sorted, so the
-// response is deterministic regardless of Go's random map iteration order.
-// Forcing only a subset to fail would require a store seam to inject per-key
-// errors; the store is a concrete *store.Store, so we close it to fail all
-// writes and assert the full sorted set instead.
+// The write is now atomic (#565): handlePutConfig calls SetConfigs once and the
+// whole batch is rolled back on any error, so on failure NONE of the keys
+// persisted. The handler therefore reports the full attempted key set, sorted,
+// which is exactly what closing the store produces here — every write fails and
+// the response lists all keys deterministically regardless of map order.
 func TestHandlerPutConfig_PersistFailureReturns500(t *testing.T) {
 	srv, s := setupServer(t)
 	// Close the store so the writes fail (sql: database is closed) while the

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -373,6 +373,36 @@ func (s *Store) SetConfig(key, value string) (int64, error) {
 	return res.LastInsertId()
 }
 
+// SetConfigs upserts multiple key/value config entries atomically in a single
+// transaction. If any write fails, the whole batch is rolled back, so the store
+// is never left in a partial state (see #565: PUT /config must be all-or-nothing).
+// An empty map is a no-op that returns nil.
+func (s *Store) SetConfigs(kv map[string]string) error {
+	if len(kv) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("store: set configs: begin: %w", err)
+	}
+	// Rollback is a no-op once the tx has committed, so this defer safely
+	// unwinds the transaction on any early return below.
+	defer func() { _ = tx.Rollback() }()
+
+	for key, value := range kv {
+		if _, err := tx.Exec(
+			"INSERT INTO configs (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+			key, value,
+		); err != nil {
+			return fmt.Errorf("store: set config %q: %w", key, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("store: set configs: commit: %w", err)
+	}
+	return nil
+}
+
 // GetConfig retrieves the value for a config key. Returns sql.ErrNoRows if not found.
 func (s *Store) GetConfig(key string) (string, error) {
 	var value string

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -385,6 +385,77 @@ func TestConfigs_ListOnEmptyTableReturnsEmptyMap(t *testing.T) {
 	}
 }
 
+// TestSetConfigs_PersistsAllKeysAtomically guards #565: a multi-key save must
+// write every key in one transaction (all-or-nothing), so PUT /config can't
+// leave the store in a partial state after a failure.
+func TestSetConfigs_PersistsAllKeysAtomically(t *testing.T) {
+	s := newTestStore(t)
+
+	in := map[string]string{
+		"poll_interval":  "30m",
+		"review_mode":    "single",
+		"retention_days": "90",
+		"repositories":   `["org/a","org/b"]`,
+	}
+	if err := s.SetConfigs(in); err != nil {
+		t.Fatalf("SetConfigs: %v", err)
+	}
+
+	got, err := s.ListConfigs()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != len(in) {
+		t.Fatalf("expected %d rows, got %d: %v", len(in), len(got), got)
+	}
+	for k, want := range in {
+		if got[k] != want {
+			t.Errorf("%s = %q, want %q", k, got[k], want)
+		}
+	}
+}
+
+func TestSetConfigs_EmptyMapIsNoOp(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.SetConfigs(nil); err != nil {
+		t.Errorf("SetConfigs(nil): %v", err)
+	}
+	if err := s.SetConfigs(map[string]string{}); err != nil {
+		t.Errorf("SetConfigs(empty): %v", err)
+	}
+	got, err := s.ListConfigs()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty configs after no-op, got %v", got)
+	}
+}
+
+// TestSetConfigs_SurfacesWriteFailure proves that when the batch cannot be
+// committed, SetConfigs returns an error rather than silently succeeding —
+// the signal handlePutConfig turns into a 500 instead of a misleading 200
+// (#550). Atomicity itself (single BEGIN/COMMIT, rollback on any error) is
+// structural in the implementation and exercised by the happy-path test above;
+// a partial commit is impossible because every key shares one transaction.
+func TestSetConfigs_SurfacesWriteFailure(t *testing.T) {
+	s := newTestStore(t)
+
+	// Close the DB so the transaction cannot begin/commit.
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	err := s.SetConfigs(map[string]string{
+		"poll_interval":  "5m",
+		"review_mode":    "multi",
+		"retention_days": "7",
+	})
+	if err == nil {
+		t.Fatal("expected error from SetConfigs on a closed store, got nil")
+	}
+}
+
 func TestStore_AgentImplementFieldsRoundTrip(t *testing.T) {
 	s := newTestStore(t)
 


### PR DESCRIPTION
## Summary
Follow-up hardening from #564 (which closed #550). `PUT /config` wrote each key with its own `SetConfig` call inside a loop, so if a later key failed, earlier keys in the same request were already persisted. After a `500` the store was left in a **partial state** and the client — told only `failed_keys` — had no clean way to reconcile (raised by @alepalma91 on #564). This makes the multi-key write **all-or-nothing**.

## How it works
- **New `Store.SetConfigs(map[string]string) error`** (`daemon/internal/store/store.go`): upserts every key inside a single SQLite transaction (`BEGIN` → N `INSERT … ON CONFLICT DO UPDATE` → `COMMIT`). Any error rolls back the whole batch via a `defer tx.Rollback()`, so the store is never left partially written. An empty map is a no-op.
- **`handlePutConfig`** (`daemon/internal/server/handlers.go`): the validation loop now builds a `key→value` map and calls `SetConfigs` once instead of writing per-key. On failure **no key persists**, so the handler returns `500 {error, failed_keys}` where `failed_keys` is the **full attempted set** (all sorted) — now semantically correct, since none of them landed. The recovery path is "retry the whole payload", and the error message says so explicitly.
- The single-key `Store.SetConfig` is unchanged; the discovery path in `main.go` still uses it for its independent single-key writes.

## Scope
**In scope**
- Atomic, transactional multi-key persistence for `PUT /config` (the direction the issue preferred).
- `failed_keys` now reports the whole attempted set (none persisted) instead of a best-effort subset.
- Store-level tests for the atomic happy path, empty-map no-op, and write-failure surfacing; updated the existing handler 500 test's rationale.

**Out of scope**
- No change to the single-key `SetConfig` API or its callers.
- No HTTP contract reshaping beyond the `error` string and `failed_keys` semantics (response *shape* is unchanged: `{error, failed_keys}` on 500, `{status:ok}` on 200).

## Production impact & what to watch
- **Runtime behavior change**: multi-key saves now run in one transaction (one `COMMIT` instead of N autocommits — marginally fewer fsyncs). Success path is observably identical (`200 {status:ok}`). On a persist failure the batch **rolls back**, so earlier keys no longer leak — the substantive behavior change. The `500` body keeps its shape; the `error` text and `failed_keys` meaning (now the whole set) changed. No new outbound calls, startup invariants, or resource usage (tx is short-lived, bounded by the existing 1 MB body limit).
- **Rollout failure modes**: cannot crashloop — no new config/secret/permission, no schema change (`configs` table already exists), no migration. Success path is byte-identical for existing clients. The Flutter client treats any non-200 as an error (`api_client.dart`), so the changed error string/`failed_keys` semantics don't affect it. No deploy-ordering constraint.
- **Blast radius**: `PUT /config` only (config save from web UI / CLI), and only on requests where a DB write genuinely fails — normally zero. No other endpoint or the single-key `SetConfig` path is touched.
- **What to watch**: post-deploy, the new `config: set (atomic)` `slog.Error` line (it replaces the old `config: set` + `config: partial persist failure` lines) fires on any persist failure — a spike means real DB trouble (disk full / lock / permission). `500` rate on `PUT /config` should stay ~0; `200` rate on saves unchanged.
- **Rollback & sequencing**: fully revertible — pure code change, no schema/migration/flag/ordering. Reverting restores the per-key best-effort loop.

## Evidence
<details><summary>New store tests: atomic persist, no-op, failure surfacing</summary>

```
=== RUN   TestSetConfigs_PersistsAllKeysAtomically
--- PASS: TestSetConfigs_PersistsAllKeysAtomically (0.00s)
=== RUN   TestSetConfigs_EmptyMapIsNoOp
--- PASS: TestSetConfigs_EmptyMapIsNoOp (0.00s)
=== RUN   TestSetConfigs_SurfacesWriteFailure
--- PASS: TestSetConfigs_SurfacesWriteFailure (0.00s)
ok  	github.com/heimdallm/daemon/internal/store
```
</details>

<details><summary>Existing PUT /config contract still holds (200 happy path, 500 + sorted failed_keys)</summary>

```
=== RUN   TestHandlerPutConfig
--- PASS: TestHandlerPutConfig (0.01s)
=== RUN   TestHandlerPutConfig_PersistFailureReturns500
--- PASS: TestHandlerPutConfig_PersistFailureReturns500 (0.00s)
ok  	github.com/heimdallm/daemon/internal/server
```
</details>

## Test plan
- [x] `go vet ./internal/server/ ./internal/store/`
- [x] `go test ./internal/server/ ./internal/store/` (new + existing tests green)
- [x] `make verify-linux` (full Linux build verification passed)
- [ ] Reviewer: confirm all-or-nothing semantics + the `failed_keys`=full-set meaning is the desired contract (vs. documenting best-effort).

Closes #565
