### PR TITLE
feat(flutter): in-tab connection indicator for events_tab SSE drops (closes #572)

### DIFF
--- a/flutter_app/lib/features/server/widgets/connection_status_banner.dart
+++ b/flutter_app/lib/features/server/widgets/connection_status_banner.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// Thin in-tab banner shown when the Events tab's own SSE stream has dropped.
+///
+/// The tab owns a separate [SseClient] from the shared stream that drives the
+/// global connection indicator, so a drop isolated to this connection would
+/// otherwise leave the tab silently stalled while the global indicator still
+/// reads "connected" (#572). The client auto-reconnects, hence the
+/// "reconnecting" wording rather than a hard "offline".
+class ConnectionStatusBanner extends StatelessWidget {
+  const ConnectionStatusBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    const amber = Color(0xFFFFB347);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      color: amber.withValues(alpha: 0.15),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox(
+            width: 12,
+            height: 12,
+            child: CircularProgressIndicator(strokeWidth: 2, color: amber),
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              'Live stream disconnected — reconnecting…',
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/features/server/widgets/connection_status_banner.dart
+++ b/flutter_app/lib/features/server/widgets/connection_status_banner.dart
@@ -13,29 +13,34 @@ class ConnectionStatusBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const amber = Color(0xFFFFB347);
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-      color: amber.withValues(alpha: 0.15),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const SizedBox(
-            width: 12,
-            height: 12,
-            child: CircularProgressIndicator(strokeWidth: 2, color: amber),
-          ),
-          const SizedBox(width: 8),
-          Flexible(
-            child: Text(
-              'Live stream disconnected — reconnecting…',
-              style: TextStyle(
-                fontSize: 12,
-                color: Theme.of(context).colorScheme.onSurface,
+    // liveRegion so assistive tech announces the drop/recovery as it toggles.
+    return Semantics(
+      liveRegion: true,
+      label: 'Live stream disconnected, reconnecting',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        color: amber.withValues(alpha: 0.15),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(
+              width: 12,
+              height: 12,
+              child: CircularProgressIndicator(strokeWidth: 2, color: amber),
+            ),
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                'Live stream disconnected — reconnecting…',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/flutter_app/lib/features/server/widgets/events_tab.dart
+++ b/flutter_app/lib/features/server/widgets/events_tab.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/api/sse_client.dart';
 import '../../../core/platform/platform_services_provider.dart';
 import '../event_summary.dart';
+import 'connection_status_banner.dart';
 import 'event_row.dart';
 
 /// Server > Events tab — operational dashboard of live SSE events.
@@ -38,6 +39,11 @@ class _EventsTabState extends ConsumerState<EventsTab> {
   final _expanded = <int>{};
   int _nextRowId = 0;
   bool _autoScroll = true;
+  // This tab's own SSE connection health. The shared stream that drives the
+  // global indicator is separate, so a drop isolated to this connection needs
+  // its own in-tab signal (#572). Optimistic on connect — no events arrive for
+  // up to a polling cycle (60 s) under normal operation.
+  bool _connected = true;
   final Set<String> _enabledGroups = {'pr', 'issue', 'polling', 'state', 'circuit_breaker'};
   String _searchQuery = '';
 
@@ -46,11 +52,20 @@ class _EventsTabState extends ConsumerState<EventsTab> {
     super.initState();
     final platform = ref.read(platformServicesProvider);
     _client = SseClient(platform: platform, path: '/events');
-    // The SSE stream now forwards transport errors to listeners; swallow them
-    // here so a transient drop doesn't surface as an unhandled async error.
-    // The client auto-reconnects and the global connection indicator already
-    // reflects the offline state.
-    _sub = _client!.connect().listen(_onEvent, onError: (_) {});
+    // The SSE stream forwards transport errors to listeners; the client
+    // auto-reconnects, so flip a local flag to drive an in-tab banner instead
+    // of letting the drop surface as an unhandled async error. _connected is
+    // restored in _onEvent when the stream resumes.
+    _sub = _client!.connect().listen(
+      _onEvent,
+      onError: (_) => _setConnected(false),
+      onDone: () => _setConnected(false),
+    );
+  }
+
+  void _setConnected(bool value) {
+    if (_connected == value || !mounted) return;
+    setState(() => _connected = value);
   }
 
   @override
@@ -79,6 +94,8 @@ class _EventsTabState extends ConsumerState<EventsTab> {
     } catch (_) {
       payload = const {};
     }
+    // An event arriving means the stream is live again — clear any banner.
+    _connected = true;
     setState(() {
       final row = _EventRow(
         id: _nextRowId++,
@@ -121,6 +138,7 @@ class _EventsTabState extends ConsumerState<EventsTab> {
             _expanded.clear();
           }),
         ),
+        if (!_connected) const ConnectionStatusBanner(),
         Expanded(
           child: visible.isEmpty
               ? Center(

--- a/flutter_app/lib/features/server/widgets/events_tab.dart
+++ b/flutter_app/lib/features/server/widgets/events_tab.dart
@@ -22,7 +22,14 @@ import 'event_row.dart';
 /// without chasing the scroll; auto-scroll keeps the view pinned to the
 /// freshest row until paused.
 class EventsTab extends ConsumerStatefulWidget {
-  const EventsTab({super.key});
+  const EventsTab({super.key, @visibleForTesting this.client});
+
+  /// Test-only seam: inject a pre-built [SseClient] (typically backed by a
+  /// mock HTTP client) so the connection-indicator behaviour can be driven
+  /// deterministically. Production code leaves this null and the tab builds
+  /// its own client against the daemon.
+  final SseClient? client;
+
   @override
   ConsumerState<EventsTab> createState() => _EventsTabState();
 }
@@ -51,7 +58,7 @@ class _EventsTabState extends ConsumerState<EventsTab> {
   void initState() {
     super.initState();
     final platform = ref.read(platformServicesProvider);
-    _client = SseClient(platform: platform, path: '/events');
+    _client = widget.client ?? SseClient(platform: platform, path: '/events');
     // The SSE stream forwards transport errors to listeners; the client
     // auto-reconnects, so flip a local flag to drive an in-tab banner instead
     // of letting the drop surface as an unhandled async error. _connected is
@@ -87,6 +94,9 @@ class _EventsTabState extends ConsumerState<EventsTab> {
   }
 
   void _onEvent(SseEvent ev) {
+    // A late event can arrive after dispose() cancels the subscription; bail
+    // before touching state so setState() is never called after dispose.
+    if (!mounted) return;
     Map<String, dynamic> payload;
     try {
       final decoded = jsonDecode(ev.data);
@@ -94,9 +104,9 @@ class _EventsTabState extends ConsumerState<EventsTab> {
     } catch (_) {
       payload = const {};
     }
-    // An event arriving means the stream is live again — clear any banner.
-    _connected = true;
     setState(() {
+      // An event arriving means the stream is live again — clear any banner.
+      _connected = true;
       final row = _EventRow(
         id: _nextRowId++,
         timestamp: DateTime.now(),

--- a/flutter_app/test/features/server/widgets/connection_status_banner_test.dart
+++ b/flutter_app/test/features/server/widgets/connection_status_banner_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/features/server/widgets/connection_status_banner.dart';
+
+void main() {
+  testWidgets('ConnectionStatusBanner shows reconnecting message and spinner', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: ConnectionStatusBanner()),
+      ),
+    );
+
+    expect(find.textContaining('reconnecting'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+}

--- a/flutter_app/test/features/server/widgets/events_tab_test.dart
+++ b/flutter_app/test/features/server/widgets/events_tab_test.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:heimdallm/core/api/sse_client.dart';
+import 'package:heimdallm/core/platform/platform_services_provider.dart';
+import 'package:heimdallm/features/server/widgets/connection_status_banner.dart';
+import 'package:heimdallm/features/server/widgets/events_tab.dart';
+
+import '../../../core/platform/fake_platform_services.dart';
+
+void main() {
+  testWidgets(
+    'EventsTab shows the reconnecting banner on a stream error and clears it '
+    'when events resume',
+    (tester) async {
+      final platform = FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842');
+      // One controllable transport per HTTP attempt: the first carries the
+      // error, the reconnect opens a second on which we deliver an event.
+      final transports = <StreamController<List<int>>>[];
+      final mockClient = MockClient.streaming((request, _) async {
+        final controller = StreamController<List<int>>();
+        transports.add(controller);
+        return http.StreamedResponse(
+          controller.stream,
+          200,
+          headers: const {'content-type': 'text/event-stream'},
+        );
+      });
+      final client = SseClient(
+        httpClient: mockClient,
+        platform: platform,
+        path: '/events',
+        errorReconnectDelay: const Duration(milliseconds: 10),
+      );
+      addTearDown(() async {
+        for (final t in transports) {
+          if (!t.isClosed) await t.close();
+        }
+      });
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            platformServicesProvider.overrideWithValue(platform),
+          ],
+          child: MaterialApp(home: Scaffold(body: EventsTab(client: client))),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 20));
+
+      // Optimistic on connect: no banner before anything goes wrong.
+      expect(transports, hasLength(1));
+      expect(find.byType(ConnectionStatusBanner), findsNothing);
+
+      // Transport drops → banner appears.
+      transports[0].addError(Exception('socket closed'));
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(find.byType(ConnectionStatusBanner), findsOneWidget);
+
+      // Client reconnects (second attempt) and an event arrives → banner clears.
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(transports, hasLength(2));
+      transports[1].add(utf8.encode('event: polling_started\ndata: {}\n\n'));
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(find.byType(ConnectionStatusBanner), findsNothing);
+
+      // Dispose the tab so the SSE client cancels its pending reconnect timer.
+      await tester.pumpWidget(const SizedBox());
+    },
+  );
+}


### PR DESCRIPTION
## Summary

The Server > Events tab creates its **own** `SseClient` (`path: '/events'`), separate from the shared `sseStreamProvider` that drives the global `DaemonConnectionNotifier` indicator. After PR #571 made `SseClient` forward transport errors to listeners, `events_tab` deliberately swallowed them (`onError: (_) {}`), relying entirely on the global indicator for offline state. That leaves a gap: a drop isolated to *this tab's* connection stalls the live stream while the global indicator still reads "connected", with no in-tab signal. This PR closes that gap by giving the tab its own connection indicator. Follow-up from #571 (fix for #554), raised in review by @sergiotejon.

## How it works

- **`events_tab.dart`** — adds a local `bool _connected` (optimistically `true`, since under normal operation no events arrive for up to a 60 s polling cycle). It flips to `false` on the stream's `onError`/`onDone`, and is restored to `true` in `_onEvent` when an event arrives (the only signal the auto-reconnecting `SseClient` gives that the stream is live again — it emits no explicit "connected" event). A small banner renders below the toolbar while `!_connected`.
- **`connection_status_banner.dart`** (new) — a thin stateless amber "Live stream disconnected — reconnecting…" banner with a spinner. Extracted as its own widget (mirroring the existing `CircuitBreakerBanner`) so it is unit-testable without driving a live SSE stream.
- This mirrors `logs_screen.dart`'s `_connected` pattern, and goes one step further: `logs_screen` only sets `_connected = true` at initial connect and never restores it after a reconnect, whereas this tab restores it when events resume.

## Scope

In scope:
- In-tab connection indicator for the Events tab's own `/events` SSE connection.

Out of scope:
- The global `DaemonConnectionNotifier` indicator (unchanged — still covers whole-daemon outages).
- `logs_screen.dart`'s latent "never restores after reconnect" behavior (left as-is; not part of this issue).
- Any change to `SseClient` reconnect semantics.

## Production impact & what to watch

Low impact, UI-only, desktop GUI client — no daemon/server/API change.

- **Runtime behavior change:** adds a local boolean and a conditional banner widget in one tab. No new network calls (reuses the existing `SseClient`), no API/contract change. The `onError` callback that #571 left as a no-op now drives UI state instead.
- **Rollout failure modes:** none of the server-side kind — it ships inside the desktop app, can't crashloop, needs no config/secret. Optimistic initial state means no banner flash on startup before the first event.
- **Blast radius:** only the Server > Events tab; no effect on the daemon, other tabs, the web build, or the global indicator.
- **What to watch:** nothing server-side / no metrics or alerts. Post-release visual check only — banner appears on a forced `/events` disconnect and clears when events resume.
- **Rollback & sequencing:** trivially revertible; no migration, no persisted state, no deploy ordering.

## Test plan

- [x] `make verify-linux` from the worktree (daemon `go test`, `flutter pub get`, `flutter test`, Linux build) — passed (exit 0, "✅ Linux build verification passed").
- [x] Added `connection_status_banner_test.dart` widget test (asserts the reconnecting message + spinner render), mirroring `circuit_breaker_banner_test.dart`.
- [ ] `flutter analyze` — not run locally (no Flutter toolchain on host; `verify-linux` covers `flutter test` but not analyze); CI runs it.
- [ ] Reviewer: manually confirm the banner appears on an isolated `/events` drop and clears on reconnect, while the global indicator behaves as before.

Closes #572
EOF