### PR TITLE
fix(github): deterministic same-second timeline order so re-requests win re-review (refs ai-platform-workspace#602)

### DIFF
--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -1019,10 +1019,13 @@ func (c *Client) GetPRTimelineEventsForReviewer(repo string, number int, login s
 			// about half the time. On a tie we order review_dismissed BEFORE
 			// review_requested — the explicit re-request wins and ends up last
 			// — because when we cannot recover the true sub-second order we
-			// honour the operator's intent to be re-reviewed.
+			// honour the operator's intent to be re-reviewed. The tiebreak is
+			// kept total (a strict weak ordering): two same-second events of
+			// the same type compare as equal so the stable sort preserves
+			// their input order, rather than reporting both i<j and j<i.
 			sort.SliceStable(out, func(i, j int) bool {
 				if out[i].CreatedAt.Equal(out[j].CreatedAt) {
-					return out[i].Event == "review_dismissed"
+					return out[i].Event == "review_dismissed" && out[j].Event == "review_requested"
 				}
 				return out[i].CreatedAt.Before(out[j].CreatedAt)
 			})

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -1009,7 +1009,21 @@ func (c *Client) GetPRTimelineEventsForReviewer(repo string, number int, login s
 			// A single sort here is cheap (events is filtered down to just
 			// review_requested / review_dismissed for one login) and immunises
 			// the caller against an undocumented re-ordering on GitHub's side.
-			sort.Slice(out, func(i, j int) bool {
+			//
+			// Stable sort + an explicit same-second tiebreak (#602): both
+			// GitHub's created_at and our stored review anchor are RFC3339
+			// second-granularity, so a dismiss and a re-request done back to
+			// back (or by automation) collapse to the same timestamp. The
+			// caller decides on the single most-recent relevant event, so a
+			// non-deterministic order silently dropped legitimate re-reviews
+			// about half the time. On a tie we order review_dismissed BEFORE
+			// review_requested — the explicit re-request wins and ends up last
+			// — because when we cannot recover the true sub-second order we
+			// honour the operator's intent to be re-reviewed.
+			sort.SliceStable(out, func(i, j int) bool {
+				if out[i].CreatedAt.Equal(out[j].CreatedAt) {
+					return out[i].Event == "review_dismissed"
+				}
 				return out[i].CreatedAt.Before(out[j].CreatedAt)
 			})
 			return out, nil

--- a/daemon/internal/github/timeline_test.go
+++ b/daemon/internal/github/timeline_test.go
@@ -17,6 +17,7 @@ func timelineServer(t *testing.T, raw string) *httptest.Server {
 		if r.URL.Path != "/repos/org/repo/issues/7/timeline" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
+		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(raw))
 	}))
 }
@@ -34,10 +35,20 @@ func timelineServer(t *testing.T, raw string) *httptest.Server {
 // Both raw input orderings are exercised to prove the result is
 // order-independent (a non-stable sort would pass one and fail the
 // other).
+// reqEventAt / disEventAt build raw timeline JSON for a review_requested /
+// review_dismissed event targeting heimdallm-bot at the given created_at.
+func reqEventAt(ts string) string {
+	return fmt.Sprintf(`{"event":"review_requested","created_at":%q,"actor":{"login":"alice"},"requested_reviewer":{"login":"heimdallm-bot"}}`, ts)
+}
+
+func disEventAt(ts string) string {
+	return fmt.Sprintf(`{"event":"review_dismissed","created_at":%q,"actor":{"login":"alice"},"dismissed_review":{"user":{"login":"heimdallm-bot"}}}`, ts)
+}
+
 func TestGetPRTimelineEventsForReviewer_SameSecondReRequestWins(t *testing.T) {
 	const ts = "2026-06-24T11:00:00Z"
-	reqEvent := fmt.Sprintf(`{"event":"review_requested","created_at":%q,"actor":{"login":"alice"},"requested_reviewer":{"login":"heimdallm-bot"}}`, ts)
-	disEvent := fmt.Sprintf(`{"event":"review_dismissed","created_at":%q,"actor":{"login":"alice"},"dismissed_review":{"user":{"login":"heimdallm-bot"}}}`, ts)
+	reqEvent := reqEventAt(ts)
+	disEvent := disEventAt(ts)
 
 	cases := []struct {
 		name string
@@ -61,6 +72,61 @@ func TestGetPRTimelineEventsForReviewer_SameSecondReRequestWins(t *testing.T) {
 			}
 			if last := events[len(events)-1]; last.Event != "review_requested" {
 				t.Errorf("most-recent event = %q, want review_requested to win the same-second tie", last.Event)
+			}
+		})
+	}
+}
+
+// TestGetPRTimelineEventsForReviewer_SameSecondDuplicateTypes locks in the
+// totality of the same-second tiebreak (#602 review follow-up). Two events
+// of the SAME type at the same created_at must compare as equal — not as
+// both i<j and j<i — so the comparator stays a strict weak ordering. A
+// non-total comparator (returning true for less(i,j) AND less(j,i)) can
+// make sort produce undefined output or panic. The expected last event is
+// still driven by the policy: a review_requested at the tie always wins.
+func TestGetPRTimelineEventsForReviewer_SameSecondDuplicateTypes(t *testing.T) {
+	const ts = "2026-06-24T11:00:00Z"
+
+	cases := []struct {
+		name     string
+		raw      string
+		wantLen  int
+		wantLast string
+	}{
+		{
+			name:     "two_dismissed_then_request",
+			raw:      "[" + disEventAt(ts) + "," + disEventAt(ts) + "," + reqEventAt(ts) + "]",
+			wantLen:  3,
+			wantLast: "review_requested",
+		},
+		{
+			name:     "two_requests_only",
+			raw:      "[" + reqEventAt(ts) + "," + reqEventAt(ts) + "]",
+			wantLen:  2,
+			wantLast: "review_requested",
+		},
+		{
+			name:     "request_between_dismissals",
+			raw:      "[" + disEventAt(ts) + "," + reqEventAt(ts) + "," + disEventAt(ts) + "]",
+			wantLen:  3,
+			wantLast: "review_requested",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := timelineServer(t, tc.raw)
+			defer srv.Close()
+
+			c := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+			events, err := c.GetPRTimelineEventsForReviewer("org/repo", 7, "heimdallm-bot")
+			if err != nil {
+				t.Fatalf("GetPRTimelineEventsForReviewer: %v", err)
+			}
+			if len(events) != tc.wantLen {
+				t.Fatalf("len(events) = %d, want %d", len(events), tc.wantLen)
+			}
+			if last := events[len(events)-1]; last.Event != tc.wantLast {
+				t.Errorf("most-recent event = %q, want %q", last.Event, tc.wantLast)
 			}
 		})
 	}

--- a/daemon/internal/github/timeline_test.go
+++ b/daemon/internal/github/timeline_test.go
@@ -1,0 +1,67 @@
+package github_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+// timelineServer returns an httptest server that serves the given raw
+// timeline JSON for GET /repos/{repo}/issues/{n}/timeline (single page).
+func timelineServer(t *testing.T, raw string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/org/repo/issues/7/timeline" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(raw))
+	}))
+}
+
+// TestGetPRTimelineEventsForReviewer_SameSecondReRequestWins is the
+// regression guard for the intermittent re-review drop (#602). When a
+// review_dismissed and a review_requested for the bot share the same
+// whole-second created_at (GitHub timestamps and our stored anchor are
+// both RFC3339 second-granularity), the slice MUST be ordered so the
+// review_requested is last — i.e. the operator's explicit re-request
+// wins the tie. pipeline.shouldBypassSHASkipForReReview inspects only
+// the most recent (last) relevant event, so a non-deterministic order
+// here silently skipped legitimate re-reviews about half the time.
+//
+// Both raw input orderings are exercised to prove the result is
+// order-independent (a non-stable sort would pass one and fail the
+// other).
+func TestGetPRTimelineEventsForReviewer_SameSecondReRequestWins(t *testing.T) {
+	const ts = "2026-06-24T11:00:00Z"
+	reqEvent := fmt.Sprintf(`{"event":"review_requested","created_at":%q,"actor":{"login":"alice"},"requested_reviewer":{"login":"heimdallm-bot"}}`, ts)
+	disEvent := fmt.Sprintf(`{"event":"review_dismissed","created_at":%q,"actor":{"login":"alice"},"dismissed_review":{"user":{"login":"heimdallm-bot"}}}`, ts)
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"request_then_dismiss_in_payload", "[" + reqEvent + "," + disEvent + "]"},
+		{"dismiss_then_request_in_payload", "[" + disEvent + "," + reqEvent + "]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := timelineServer(t, tc.raw)
+			defer srv.Close()
+
+			c := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+			events, err := c.GetPRTimelineEventsForReviewer("org/repo", 7, "heimdallm-bot")
+			if err != nil {
+				t.Fatalf("GetPRTimelineEventsForReviewer: %v", err)
+			}
+			if len(events) != 2 {
+				t.Fatalf("len(events) = %d, want 2", len(events))
+			}
+			if last := events[len(events)-1]; last.Event != "review_requested" {
+				t.Errorf("most-recent event = %q, want review_requested to win the same-second tie", last.Event)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Heimdallm intermittently failed to re-review a PR after the author resolved a *request changes* review and explicitly re-requested a review — exactly the symptom in freepik-company/ai-platform-workspace#602. Root cause: a non-deterministic ordering of timeline events when a dismiss and a re-request share the same whole-second timestamp, which made the re-review gate skip a legitimately requested re-review about half the time.

## How it works

The re-review gate `pipeline.shouldBypassSHASkipForReReview` (`daemon/internal/pipeline/pipeline.go`) proceeds with a re-review **only** when the single most-recent `review_requested`/`review_dismissed` timeline event for the bot is a `review_requested` newer than the previous review. It relies on `GetPRTimelineEventsForReviewer` (`daemon/internal/github/client.go`) returning those events sorted ascending and reads the **last** element.

Both GitHub's `created_at` and our stored review anchor are RFC3339 **second-granularity** (`store.go`: `sqliteTimeFormat = time.RFC3339`). When an author dismisses the blocking review and re-requests back-to-back (or automation does both), the two events collapse to the same second. The previous `sort.Slice` is **not stable**, so the dismiss landed last ≈50% of the time → the gate read "most recent event = dismiss" → silently skipped the re-review. Intermittent by construction.

Fix: `sort.SliceStable` with an explicit same-second tiebreak that orders `review_dismissed` **before** `review_requested`, so the explicit re-request ends up last and wins the tie. When the true sub-second order is unrecoverable, we honour the operator's intent to be re-reviewed.

Key files:
- `daemon/internal/github/client.go` — the ordering fix in `GetPRTimelineEventsForReviewer`.
- `daemon/internal/github/timeline_test.go` — new regression test (both raw input orderings).

## Scope

In scope:
- Deterministic ordering of bot timeline events on a same-second `review_dismissed`/`review_requested` tie.

Out of scope (deliberately unchanged — these are by-design fail-closed guards, not the reported bug):
- Fail-closed on timeline API error / pagination cap (`pipeline.go`, `client.go`).
- Tier-2 "ghost" skip when the Pulls API lags the Search index (`cmd/heimdallm/main.go`).
- Circuit-breaker per-PR/per-repo rate caps.
- Distinct-timestamp `dismiss-after-request` still correctly keeps the skip.

## Production impact & what to watch

- **Runtime behavior change**: only when the bot's timeline has a `review_dismissed` and `review_requested` at the same whole-second — that tie now deterministically resolves to "proceed with re-review" instead of a coin-flip. Same single timeline fetch, no new outbound calls, no new resource use (`SliceStable` over a tiny per-bot filtered slice), no contract/response changes.
- **Rollout failure modes**: none. Pure in-process logic; no secret/config/permission/migration. Mixed-version pods during a rolling deploy are both safe.
- **Blast radius**: narrow — only PRs where the bot already reviewed *and* a dismiss+request collide in the same second. Outcome is one Claude re-review the operator explicitly asked for. The fail-closed posture for API errors, missing deps, and distinct-timestamp dismiss-after-request is unchanged, so it does **not** widen the surface for non-requested reviews.
- **What to watch**: the skip log `pipeline: skipping re-review, no explicit re-request` (`reason=sha_unchanged` / `no_rereview_request`) should **drop** for genuinely re-requested PRs (success signal), with a small matching rise in `explicit re-request detected — proceeding with review`. Watch circuit-breaker per-PR-24h counters for any uptick on hyperactive PRs (realistically negligible). Claude spend stays effectively flat.
- **Rollback & sequencing**: trivially revertible — single stateless function, no migration, no flag.

## Evidence

The new test reproduces the bug, then proves the fix (and order-independence — a non-stable sort passes one ordering and fails the other):

<details>
<summary>Before the fix (non-stable sort.Slice)</summary>

```
=== RUN   TestGetPRTimelineEventsForReviewer_SameSecondReRequestWins/request_then_dismiss_in_payload
    timeline_test.go:63: most-recent event = "review_dismissed", want review_requested to win the same-second tie
--- FAIL: .../request_then_dismiss_in_payload
--- PASS: .../dismiss_then_request_in_payload
```
</details>

<details>
<summary>After the fix (sort.SliceStable + tiebreak)</summary>

```
=== RUN   TestGetPRTimelineEventsForReviewer_SameSecondReRequestWins
--- PASS: .../request_then_dismiss_in_payload
--- PASS: .../dismiss_then_request_in_payload
ok  	github.com/heimdallm/daemon/internal/github
ok  	github.com/heimdallm/daemon/internal/pipeline
```
</details>

## Test plan

- [x] New regression test fails on the old code and passes on the new code (both raw orderings).
- [x] `go test ./internal/github/ ./internal/pipeline/` green (incl. existing `TestPipeline_Run_DismissAfterReRequestKeepsSkip` — distinct-timestamp dismiss-after-request still keeps the skip).
- [x] `go build ./...` and `go vet ./...` clean.
- [x] Pre-existing unrelated failures confirmed on base `main` too: `TestDetect_Fallback` (host has a real `codex` binary) and a flaky `cmd/heimdallm` timing test (passes on re-run).
- [ ] Reviewer: confirm the same-second tiebreak semantics (re-request wins) match the desired fail-closed/honour-intent policy.

Refs freepik-company/ai-platform-workspace#602
