### PR TITLE
feat: never_approve_with_issues (comment instead of approve when review has issues)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1615,6 +1615,7 @@ func main() {
 			"triage_owner":                c.AI.TriageOwner,
 			"clone_dir":                   c.AI.CloneDir,
 			"generate_pr_description":     c.AI.GeneratePRDescription,
+			"never_approve_with_issues":   c.AI.NeverApproveWithIssues,
 		}
 		if c.AI.AutoPromoteTriage != nil {
 			result["auto_promote_triage"] = *c.AI.AutoPromoteTriage
@@ -2225,6 +2226,7 @@ func configReloadRestartSnapshot(c *config.Config) config.Config {
 	snap.AI.AutoPromoteRefinement = nil
 	snap.AI.Tier2RepoConcurrency = 0
 	snap.AI.GeneratePRDescription = false
+	snap.AI.NeverApproveWithIssues = false
 	snap.AI.ReviewResponse = config.ReviewResponseConfig{}
 	snap.AI.ReviewFix = config.ReviewFixConfig{}
 
@@ -4409,19 +4411,20 @@ func repoAIOverrideMap(ai config.RepoAI) map[string]any {
 		"local_dir":   ai.LocalDir,
 	}
 	addCommonAIOverrideFields(out, aiOverrideFields{
-		Prompt:                ai.Prompt,
-		IssuePrompt:           ai.IssuePrompt,
-		ImplementPrompt:       ai.ImplementPrompt,
-		RefinementTimeout:     ai.RefinementTimeout,
-		TriageOwner:           ai.TriageOwner,
-		CloneDir:              ai.CloneDir,
-		AutoPromoteTriage:     ai.AutoPromoteTriage,
-		AutoPromoteRefinement: ai.AutoPromoteRefinement,
-		PRReviewers:           ai.PRReviewers,
-		PRAssignee:            ai.PRAssignee,
-		PRLabels:              ai.PRLabels,
-		PRDraft:               ai.PRDraft,
-		GeneratePRDescription: ai.GeneratePRDescription,
+		Prompt:                 ai.Prompt,
+		IssuePrompt:            ai.IssuePrompt,
+		ImplementPrompt:        ai.ImplementPrompt,
+		RefinementTimeout:      ai.RefinementTimeout,
+		TriageOwner:            ai.TriageOwner,
+		CloneDir:               ai.CloneDir,
+		AutoPromoteTriage:      ai.AutoPromoteTriage,
+		AutoPromoteRefinement:  ai.AutoPromoteRefinement,
+		PRReviewers:            ai.PRReviewers,
+		PRAssignee:             ai.PRAssignee,
+		PRLabels:               ai.PRLabels,
+		PRDraft:                ai.PRDraft,
+		GeneratePRDescription:  ai.GeneratePRDescription,
+		NeverApproveWithIssues: ai.NeverApproveWithIssues,
 	})
 	if ai.IssueTracking != nil {
 		out["issue_tracking"] = issueTrackingOverrideMap(ai.IssueTracking)
@@ -4444,19 +4447,20 @@ func orgAIOverrideMap(ai config.OrgAI) map[string]any {
 		out["local_dir"] = ai.LocalDir
 	}
 	addCommonAIOverrideFields(out, aiOverrideFields{
-		Prompt:                ai.Prompt,
-		IssuePrompt:           ai.IssuePrompt,
-		ImplementPrompt:       ai.ImplementPrompt,
-		RefinementTimeout:     ai.RefinementTimeout,
-		TriageOwner:           ai.TriageOwner,
-		CloneDir:              ai.CloneDir,
-		AutoPromoteTriage:     ai.AutoPromoteTriage,
-		AutoPromoteRefinement: ai.AutoPromoteRefinement,
-		PRReviewers:           ai.PRReviewers,
-		PRAssignee:            ai.PRAssignee,
-		PRLabels:              ai.PRLabels,
-		PRDraft:               ai.PRDraft,
-		GeneratePRDescription: ai.GeneratePRDescription,
+		Prompt:                 ai.Prompt,
+		IssuePrompt:            ai.IssuePrompt,
+		ImplementPrompt:        ai.ImplementPrompt,
+		RefinementTimeout:      ai.RefinementTimeout,
+		TriageOwner:            ai.TriageOwner,
+		CloneDir:               ai.CloneDir,
+		AutoPromoteTriage:      ai.AutoPromoteTriage,
+		AutoPromoteRefinement:  ai.AutoPromoteRefinement,
+		PRReviewers:            ai.PRReviewers,
+		PRAssignee:             ai.PRAssignee,
+		PRLabels:               ai.PRLabels,
+		PRDraft:                ai.PRDraft,
+		GeneratePRDescription:  ai.GeneratePRDescription,
+		NeverApproveWithIssues: ai.NeverApproveWithIssues,
 	})
 	if ai.IssueTracking != nil {
 		out["issue_tracking"] = issueTrackingOverrideMap(ai.IssueTracking)
@@ -4465,19 +4469,20 @@ func orgAIOverrideMap(ai config.OrgAI) map[string]any {
 }
 
 type aiOverrideFields struct {
-	Prompt                string
-	IssuePrompt           string
-	ImplementPrompt       string
-	RefinementTimeout     string
-	TriageOwner           string
-	CloneDir              string
-	AutoPromoteTriage     *bool
-	AutoPromoteRefinement *bool
-	PRReviewers           []string
-	PRAssignee            string
-	PRLabels              []string
-	PRDraft               *bool
-	GeneratePRDescription *bool
+	Prompt                 string
+	IssuePrompt            string
+	ImplementPrompt        string
+	RefinementTimeout      string
+	TriageOwner            string
+	CloneDir               string
+	AutoPromoteTriage      *bool
+	AutoPromoteRefinement  *bool
+	PRReviewers            []string
+	PRAssignee             string
+	PRLabels               []string
+	PRDraft                *bool
+	GeneratePRDescription  *bool
+	NeverApproveWithIssues *bool
 }
 
 func addCommonAIOverrideFields(out map[string]any, fields aiOverrideFields) {
@@ -4519,6 +4524,9 @@ func addCommonAIOverrideFields(out map[string]any, fields aiOverrideFields) {
 	}
 	if fields.GeneratePRDescription != nil {
 		out["generate_pr_description"] = *fields.GeneratePRDescription
+	}
+	if fields.NeverApproveWithIssues != nil {
+		out["never_approve_with_issues"] = *fields.NeverApproveWithIssues
 	}
 }
 

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -443,12 +443,13 @@ func main() {
 			}
 		}
 		return pipeline.RunOptions{
-			Primary:            aiCfg.Primary,
-			Fallback:           aiCfg.Fallback,
-			PromptOverride:     aiCfg.Prompt,
-			AgentPromptID:      agentCfg.PromptID,
-			ReviewMode:         aiCfg.ReviewMode,
-			InstructionAuthors: aiCfg.InstructionAuthors,
+			Primary:                aiCfg.Primary,
+			Fallback:               aiCfg.Fallback,
+			PromptOverride:         aiCfg.Prompt,
+			AgentPromptID:          agentCfg.PromptID,
+			ReviewMode:             aiCfg.ReviewMode,
+			InstructionAuthors:     aiCfg.InstructionAuthors,
+			NeverApproveWithIssues: aiCfg.NeverApproveWithIssues != nil && *aiCfg.NeverApproveWithIssues,
 			ExecOpts: executor.ExecOptions{
 				Model:                agentCfg.Model,
 				MaxTurns:             agentCfg.MaxTurns,

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1031,10 +1031,15 @@ func main() {
 			return fmt.Errorf("rate limit cancelled: %w", err)
 		}
 
+		// Use the event decided and persisted at review time so a COMMENT
+		// (never_approve_with_issues) is never resubmitted as APPROVE on retry;
+		// legacy rows without a stored event fall back to severity. Mirrors the
+		// pipeline's Run / PublishPending paths.
+		publishEvent := pipeline.PublishEventFor(rev)
 		ghID, ghState, err := ghClient.SubmitReview(
 			pr.Repo, pr.Number,
-			pipeline.BuildGitHubBody(result),
-			pipeline.SeverityToEvent(rev.Severity),
+			pipeline.AnnotateBodyForEvent(pipeline.BuildGitHubBody(result), publishEvent),
+			publishEvent,
 		)
 		if err != nil {
 			errStr := err.Error()

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -1043,6 +1043,30 @@ func TestPRAlreadyReviewedCircuitBreakerAllowsNewHeadSHA(t *testing.T) {
 	}
 }
 
+// TestRepoAIOverrideMap_ExposesNeverApproveWithIssues guards that the
+// per-repo AI override map GET /config serves under repo_overrides[repo]
+// carries never_approve_with_issues through, mirroring how
+// generate_pr_description is wired for the same map.
+func TestRepoAIOverrideMap_ExposesNeverApproveWithIssues(t *testing.T) {
+	no := false
+	out := repoAIOverrideMap(config.RepoAI{NeverApproveWithIssues: &no})
+	v, ok := out["never_approve_with_issues"].(bool)
+	if !ok || v != false {
+		t.Errorf("never_approve_with_issues = %v (present=%v), want false", out["never_approve_with_issues"], ok)
+	}
+}
+
+// TestOrgAIOverrideMap_ExposesNeverApproveWithIssues is the org-level
+// counterpart of TestRepoAIOverrideMap_ExposesNeverApproveWithIssues.
+func TestOrgAIOverrideMap_ExposesNeverApproveWithIssues(t *testing.T) {
+	yes := true
+	out := orgAIOverrideMap(config.OrgAI{NeverApproveWithIssues: &yes})
+	v, ok := out["never_approve_with_issues"].(bool)
+	if !ok || v != true {
+		t.Errorf("never_approve_with_issues = %v (present=%v), want true", out["never_approve_with_issues"], ok)
+	}
+}
+
 func TestResolveImplementPrompt_RepoOverrideWins(t *testing.T) {
 	s := newMemStore(t)
 	seedAgent(t, s, store.Agent{

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -457,6 +457,12 @@ type AIConfig struct {
 	// Default: false (backwards compat).
 	GeneratePRDescription bool `toml:"generate_pr_description"`
 
+	// NeverApproveWithIssues, when true, downgrades an otherwise-APPROVE review
+	// to COMMENT whenever the review found any issue. REQUEST_CHANGES (high
+	// severity) is unaffected. Default: false (backwards compat). Overridable
+	// per-org and per-repo.
+	NeverApproveWithIssues bool `toml:"never_approve_with_issues"`
+
 	// ReviewResponse configures phase 2 of the PR review-state vigilance
 	// feature (#482): the daemon optionally posts an AI-generated reply
 	// when an external reviewer leaves COMMENTED feedback on a PR that
@@ -546,6 +552,10 @@ type RepoAI struct {
 	// for this repo. nil = inherit from global.
 	GeneratePRDescription *bool `toml:"generate_pr_description,omitempty"`
 
+	// NeverApproveWithIssues overrides ai.never_approve_with_issues for this
+	// repo. nil = inherit from org/global.
+	NeverApproveWithIssues *bool `toml:"never_approve_with_issues,omitempty"`
+
 	// Per-repo issue tracking override. Nil fields inherit from org/global.
 	IssueTracking *IssueTrackingOverride `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
 	// CircuitBreaker overrides circuit-breaker caps for this repo.
@@ -606,8 +616,9 @@ type OrgAI struct {
 	PRDraft            *bool    `toml:"pr_draft,omitempty"`
 	InstructionAuthors []string `toml:"instruction_authors"` // see RepoAI.InstructionAuthors (#383)
 
-	GeneratePRDescription *bool                  `toml:"generate_pr_description,omitempty"`
-	IssueTracking         *IssueTrackingOverride `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
+	GeneratePRDescription  *bool                  `toml:"generate_pr_description,omitempty"`
+	NeverApproveWithIssues *bool                  `toml:"never_approve_with_issues,omitempty"`
+	IssueTracking          *IssueTrackingOverride `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
 	// CircuitBreaker overrides circuit-breaker caps for all repos in this org.
 	// nil = inherit from global. Present fields overlay the global baseline.
 	CircuitBreaker *CircuitBreakerConfig `toml:"circuit_breaker,omitempty"`
@@ -743,23 +754,25 @@ func (c *Config) ResolvedPRMetadata() (reviewers, labels []string, assignee stri
 func (c *Config) AIForRepo(repo string) RepoAI {
 	gReviewers, gLabels, gAssignee, gDraft := c.ResolvedPRMetadata()
 	gGenDesc := c.AI.GeneratePRDescription
+	gNever := c.AI.NeverApproveWithIssues
 	out := RepoAI{
-		Primary:               c.AI.Primary,
-		Fallback:              c.AI.Fallback,
-		ReviewMode:            c.AI.ReviewMode,
-		IssuePrompt:           c.AI.IssuePrompt,
-		ImplementPrompt:       c.AI.ImplementPrompt,
-		RefinementTimeout:     c.AI.RefinementTimeout,
-		PRReviewers:           gReviewers,
-		PRLabels:              gLabels,
-		PRAssignee:            gAssignee,
-		PRDraft:               gDraft,
-		GeneratePRDescription: &gGenDesc,
-		TriageOwner:           c.AI.TriageOwner,
-		CloneDir:              c.AI.CloneDir,
-		AutoPromoteTriage:     c.AI.AutoPromoteTriage,
-		AutoPromoteRefinement: c.AI.AutoPromoteRefinement,
-		InstructionAuthors:    c.AI.InstructionAuthors,
+		Primary:                c.AI.Primary,
+		Fallback:               c.AI.Fallback,
+		ReviewMode:             c.AI.ReviewMode,
+		IssuePrompt:            c.AI.IssuePrompt,
+		ImplementPrompt:        c.AI.ImplementPrompt,
+		RefinementTimeout:      c.AI.RefinementTimeout,
+		PRReviewers:            gReviewers,
+		PRLabels:               gLabels,
+		PRAssignee:             gAssignee,
+		PRDraft:                gDraft,
+		GeneratePRDescription:  &gGenDesc,
+		NeverApproveWithIssues: &gNever,
+		TriageOwner:            c.AI.TriageOwner,
+		CloneDir:               c.AI.CloneDir,
+		AutoPromoteTriage:      c.AI.AutoPromoteTriage,
+		AutoPromoteRefinement:  c.AI.AutoPromoteRefinement,
+		InstructionAuthors:     c.AI.InstructionAuthors,
 	}
 	if org := repoOrg(repo); org != "" && c.AI.Orgs != nil {
 		if o, ok := c.AI.Orgs[org]; ok {
@@ -776,69 +789,72 @@ func (c *Config) AIForRepo(repo string) RepoAI {
 
 func applyOrgAI(out *RepoAI, o OrgAI) {
 	applyScopedAI(out, scopedAIFields{
-		Primary:               o.Primary,
-		Fallback:              o.Fallback,
-		ReviewMode:            o.ReviewMode,
-		Prompt:                o.Prompt,
-		IssuePrompt:           o.IssuePrompt,
-		ImplementPrompt:       o.ImplementPrompt,
-		RefinementTimeout:     o.RefinementTimeout,
-		LocalDir:              o.LocalDir,
-		TriageOwner:           o.TriageOwner,
-		CloneDir:              o.CloneDir,
-		AutoPromoteTriage:     o.AutoPromoteTriage,
-		AutoPromoteRefinement: o.AutoPromoteRefinement,
-		PRReviewers:           o.PRReviewers,
-		PRLabels:              o.PRLabels,
-		PRAssignee:            o.PRAssignee,
-		PRDraft:               o.PRDraft,
-		GeneratePRDescription: o.GeneratePRDescription,
-		InstructionAuthors:    o.InstructionAuthors,
+		Primary:                o.Primary,
+		Fallback:               o.Fallback,
+		ReviewMode:             o.ReviewMode,
+		Prompt:                 o.Prompt,
+		IssuePrompt:            o.IssuePrompt,
+		ImplementPrompt:        o.ImplementPrompt,
+		RefinementTimeout:      o.RefinementTimeout,
+		LocalDir:               o.LocalDir,
+		TriageOwner:            o.TriageOwner,
+		CloneDir:               o.CloneDir,
+		AutoPromoteTriage:      o.AutoPromoteTriage,
+		AutoPromoteRefinement:  o.AutoPromoteRefinement,
+		PRReviewers:            o.PRReviewers,
+		PRLabels:               o.PRLabels,
+		PRAssignee:             o.PRAssignee,
+		PRDraft:                o.PRDraft,
+		GeneratePRDescription:  o.GeneratePRDescription,
+		NeverApproveWithIssues: o.NeverApproveWithIssues,
+		InstructionAuthors:     o.InstructionAuthors,
 	})
 }
 
 func applyRepoAI(out *RepoAI, r RepoAI) {
 	applyScopedAI(out, scopedAIFields{
-		Primary:               r.Primary,
-		Fallback:              r.Fallback,
-		ReviewMode:            r.ReviewMode,
-		Prompt:                r.Prompt,
-		IssuePrompt:           r.IssuePrompt,
-		ImplementPrompt:       r.ImplementPrompt,
-		RefinementTimeout:     r.RefinementTimeout,
-		LocalDir:              r.LocalDir,
-		TriageOwner:           r.TriageOwner,
-		CloneDir:              r.CloneDir,
-		AutoPromoteTriage:     r.AutoPromoteTriage,
-		AutoPromoteRefinement: r.AutoPromoteRefinement,
-		PRReviewers:           r.PRReviewers,
-		PRLabels:              r.PRLabels,
-		PRAssignee:            r.PRAssignee,
-		PRDraft:               r.PRDraft,
-		GeneratePRDescription: r.GeneratePRDescription,
-		InstructionAuthors:    r.InstructionAuthors,
+		Primary:                r.Primary,
+		Fallback:               r.Fallback,
+		ReviewMode:             r.ReviewMode,
+		Prompt:                 r.Prompt,
+		IssuePrompt:            r.IssuePrompt,
+		ImplementPrompt:        r.ImplementPrompt,
+		RefinementTimeout:      r.RefinementTimeout,
+		LocalDir:               r.LocalDir,
+		TriageOwner:            r.TriageOwner,
+		CloneDir:               r.CloneDir,
+		AutoPromoteTriage:      r.AutoPromoteTriage,
+		AutoPromoteRefinement:  r.AutoPromoteRefinement,
+		PRReviewers:            r.PRReviewers,
+		PRLabels:               r.PRLabels,
+		PRAssignee:             r.PRAssignee,
+		PRDraft:                r.PRDraft,
+		GeneratePRDescription:  r.GeneratePRDescription,
+		NeverApproveWithIssues: r.NeverApproveWithIssues,
+		InstructionAuthors:     r.InstructionAuthors,
 	})
 }
 
 type scopedAIFields struct {
-	Primary               string
-	Fallback              string
-	ReviewMode            string
-	Prompt                string
-	IssuePrompt           string
-	ImplementPrompt       string
-	RefinementTimeout     string
-	LocalDir              string
-	TriageOwner           string
-	CloneDir              string
-	AutoPromoteTriage     *bool
-	AutoPromoteRefinement *bool
-	PRReviewers           []string
-	PRLabels              []string
-	PRAssignee            string
-	PRDraft               *bool
-	GeneratePRDescription *bool
-	InstructionAuthors    []string
+	Primary                string
+	Fallback               string
+	ReviewMode             string
+	Prompt                 string
+	IssuePrompt            string
+	ImplementPrompt        string
+	RefinementTimeout      string
+	LocalDir               string
+	TriageOwner            string
+	CloneDir               string
+	AutoPromoteTriage      *bool
+	AutoPromoteRefinement  *bool
+	PRReviewers            []string
+	PRLabels               []string
+	PRAssignee             string
+	PRDraft                *bool
+	GeneratePRDescription  *bool
+	NeverApproveWithIssues *bool
+	InstructionAuthors     []string
 }
 
 func applyScopedAI(out *RepoAI, fields scopedAIFields) {
@@ -892,6 +908,9 @@ func applyScopedAI(out *RepoAI, fields scopedAIFields) {
 	}
 	if fields.GeneratePRDescription != nil {
 		out.GeneratePRDescription = fields.GeneratePRDescription
+	}
+	if fields.NeverApproveWithIssues != nil {
+		out.NeverApproveWithIssues = fields.NeverApproveWithIssues
 	}
 	if fields.InstructionAuthors != nil {
 		out.InstructionAuthors = fields.InstructionAuthors

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -2785,3 +2785,36 @@ func TestAIForRepo_InstructionAuthorsResolution(t *testing.T) {
 		t.Errorf("global fallback: got %v", got)
 	}
 }
+
+func TestNeverApproveWithIssues_Resolution(t *testing.T) {
+	tru := true
+	fal := false
+	cases := []struct {
+		name   string
+		global bool
+		org    *bool
+		repo   *bool
+		want   bool
+	}{
+		{"global off, no overrides", false, nil, nil, false},
+		{"global on, no overrides", true, nil, nil, true},
+		{"org on over global off", false, &tru, nil, true},
+		{"repo off over org on", false, &tru, &fal, false},
+		{"repo on over global off", false, nil, &tru, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{}
+			c.AI.NeverApproveWithIssues = tc.global
+			c.AI.Orgs = map[string]OrgAI{"acme": {NeverApproveWithIssues: tc.org}}
+			c.AI.Repos = map[string]RepoAI{"acme/widget": {NeverApproveWithIssues: tc.repo}}
+			got := c.AIForRepo("acme/widget").NeverApproveWithIssues
+			if got == nil {
+				t.Fatalf("NeverApproveWithIssues is nil, want non-nil")
+			}
+			if *got != tc.want {
+				t.Errorf("NeverApproveWithIssues = %v, want %v", *got, tc.want)
+			}
+		})
+	}
+}

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -243,9 +243,19 @@ func resolveCLIPath(name string) string {
 	if path, err := exec.LookPath(name); err == nil && path != "" {
 		return path
 	}
-	// Try login shell — picks up ~/.zshrc, ~/.bashrc, Homebrew, nvm, etc.
-	// Pass name as $1 (positional arg) so it is never shell-interpolated,
-	// even though validateCLIName already guarantees it is safe.
+	// Fall back to the user's login shell.
+	return loginShellLookPath(name)
+}
+
+// loginShellLookPath resolves name via the user's login shell, which sources
+// ~/.zshrc, ~/.bashrc, Homebrew, nvm, etc. It is a package-level var so tests
+// can stub this profile-dependent probe and stay hermetic — otherwise a real
+// CLI installed on the developer's machine leaks in regardless of the test's
+// $PATH. Returns "" if not found.
+//
+// Pass name as $1 (positional arg) so it is never shell-interpolated, even
+// though validateCLIName already guarantees it is safe.
+var loginShellLookPath = func(name string) string {
 	for _, shell := range []string{"/bin/zsh", "/bin/bash"} {
 		cmd := exec.Command(shell, "-l", "-c", `which "$1"`, "--", name)
 		out, err := cmd.Output()

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -13,9 +13,7 @@ import (
 func TestDetect(t *testing.T) {
 	_, file, _, _ := runtime.Caller(0)
 	binDir := filepath.Join(filepath.Dir(file), "testdata", "bin")
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+oldPath)
-	defer os.Setenv("PATH", oldPath)
+	t.Setenv("PATH", binDir)
 
 	e := executor.New()
 	cli, err := e.Detect("claude", "")
@@ -30,9 +28,12 @@ func TestDetect(t *testing.T) {
 func TestDetect_Fallback(t *testing.T) {
 	_, file, _, _ := runtime.Caller(0)
 	binDir := filepath.Join(filepath.Dir(file), "testdata", "bin")
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+oldPath)
-	defer os.Setenv("PATH", oldPath)
+	t.Setenv("PATH", binDir)
+	// Neutralize the login-shell probe: without this, a real `codex` installed
+	// on the developer's machine is resolved via the login shell regardless of
+	// the isolated $PATH, so the primary never "fails" and the fallback path is
+	// never exercised (the test then flakes on any dev box with codex present).
+	defer executor.SetLoginShellLookPathForTest(func(string) string { return "" })()
 
 	e := executor.New()
 	cli, err := e.Detect("codex", "gemini")
@@ -59,9 +60,7 @@ func TestDetect_NoneAvailable(t *testing.T) {
 func TestExecute(t *testing.T) {
 	_, file, _, _ := runtime.Caller(0)
 	binDir := filepath.Join(filepath.Dir(file), "testdata", "bin")
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+oldPath)
-	defer os.Setenv("PATH", oldPath)
+	t.Setenv("PATH", binDir)
 
 	e := executor.New()
 	result, err := e.Execute("claude", "Review this diff", executor.ExecOptions{})

--- a/daemon/internal/executor/export_test.go
+++ b/daemon/internal/executor/export_test.go
@@ -1,0 +1,11 @@
+package executor
+
+// SetLoginShellLookPathForTest overrides the login-shell CLI probe so tests can
+// stay hermetic. The real probe sources the developer's shell profile and would
+// otherwise resolve a CLI installed outside the test's $PATH, defeating $PATH
+// isolation. Returns a restore func to defer.
+func SetLoginShellLookPathForTest(f func(string) string) func() {
+	old := loginShellLookPath
+	loginShellLookPath = f
+	return func() { loginShellLookPath = old }
+}

--- a/daemon/internal/pipeline/directives_test.go
+++ b/daemon/internal/pipeline/directives_test.go
@@ -164,19 +164,3 @@ func TestProcessDirectives_UnauthorizedIsSilent(t *testing.T) {
 		t.Fatalf("unauthorized directive must get no reply, got %d", len(gh.posted))
 	}
 }
-
-func TestReviewEvent_PersistedAndReused(t *testing.T) {
-	// Unit-level guard: the decision helper + persistence contract.
-	// Run path: COMMENT chosen when flag on and issues present.
-	ev := ReviewEvent("medium", true, true)
-	if ev != "COMMENT" {
-		t.Fatalf("decision = %q, want COMMENT", ev)
-	}
-	// Publish reproduction: a stored event is used verbatim; empty falls back.
-	if got := publishEventFor(&store.Review{Event: "COMMENT", Severity: "low"}); got != "COMMENT" {
-		t.Errorf("publishEventFor(stored COMMENT) = %q, want COMMENT", got)
-	}
-	if got := publishEventFor(&store.Review{Event: "", Severity: "high"}); got != "REQUEST_CHANGES" {
-		t.Errorf("publishEventFor(legacy high) = %q, want REQUEST_CHANGES", got)
-	}
-}

--- a/daemon/internal/pipeline/directives_test.go
+++ b/daemon/internal/pipeline/directives_test.go
@@ -164,3 +164,19 @@ func TestProcessDirectives_UnauthorizedIsSilent(t *testing.T) {
 		t.Fatalf("unauthorized directive must get no reply, got %d", len(gh.posted))
 	}
 }
+
+func TestReviewEvent_PersistedAndReused(t *testing.T) {
+	// Unit-level guard: the decision helper + persistence contract.
+	// Run path: COMMENT chosen when flag on and issues present.
+	ev := ReviewEvent("medium", true, true)
+	if ev != "COMMENT" {
+		t.Fatalf("decision = %q, want COMMENT", ev)
+	}
+	// Publish reproduction: a stored event is used verbatim; empty falls back.
+	if got := publishEventFor(&store.Review{Event: "COMMENT", Severity: "low"}); got != "COMMENT" {
+		t.Errorf("publishEventFor(stored COMMENT) = %q, want COMMENT", got)
+	}
+	if got := publishEventFor(&store.Review{Event: "", Severity: "high"}); got != "REQUEST_CHANGES" {
+		t.Errorf("publishEventFor(legacy high) = %q, want REQUEST_CHANGES", got)
+	}
+}

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -648,7 +648,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 
 	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
 		pr.Repo, pr.Number,
-		reviewBody,
+		AnnotateBodyForEvent(reviewBody, reviewEvent),
 		reviewEvent,
 	)
 	if publishErr != nil {
@@ -780,10 +780,11 @@ func (p *Pipeline) PublishPending() {
 		// never-approve-with-issues decision from the initial review; legacy
 		// rows without a stored event fall back to SeverityToEvent via
 		// publishEventFor.
+		retryEvent := PublishEventFor(rev)
 		ghID, ghState, err := p.gh.SubmitReview(
 			pr.Repo, pr.Number,
-			BuildGitHubBody(result),
-			publishEventFor(rev),
+			AnnotateBodyForEvent(BuildGitHubBody(result), retryEvent),
+			retryEvent,
 		)
 		if err != nil {
 			// Permanent submit failures (currently HTTP 422 "lock
@@ -1026,14 +1027,34 @@ func ReviewEvent(finalSeverity string, hasIssues bool, neverApproveWithIssues bo
 	return event
 }
 
-// publishEventFor returns the GitHub event to submit for a stored review:
+// PublishEventFor returns the GitHub event to submit for a stored review:
 // the decided event persisted at review time, or — for legacy rows written
-// before the event column existed — the severity-derived fallback.
-func publishEventFor(rev *store.Review) string {
+// before the event column existed — the severity-derived fallback. Exported so
+// every publish path (Run, PublishPending, the NATS publish-worker) reproduces
+// the persisted decision with the same legacy fallback.
+func PublishEventFor(rev *store.Review) string {
 	if rev.Event != "" {
 		return rev.Event
 	}
 	return SeverityToEvent(rev.Severity)
+}
+
+// downgradeNote is appended to a review body when the event was downgraded to
+// COMMENT, so PR authors understand why Heimdallm commented instead of
+// approving. COMMENT is only ever produced by ReviewEvent's
+// never-approve-with-issues downgrade, so keying on the event is sufficient.
+const downgradeNote = "\n\n---\n_Not approving: issues were found and " +
+	"`never_approve_with_issues` is enabled for this repo — posting as a " +
+	"comment instead of an approval._"
+
+// AnnotateBodyForEvent appends an explanatory note to the review body when the
+// event is COMMENT (the never-approve-with-issues downgrade); otherwise the
+// body is returned unchanged.
+func AnnotateBodyForEvent(body, event string) string {
+	if event == "COMMENT" {
+		return body + downgradeNote
+	}
+	return body
 }
 
 // maxCommentsBytes limits the total formatted PR comments included in the prompt.

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -297,6 +297,9 @@ type RunOptions struct {
 	// to set persistent per-repo instructions via comment directives (#383).
 	// Empty disables the comment-driven path for this repo.
 	InstructionAuthors []string
+	// NeverApproveWithIssues, when true, publishes the review as COMMENT
+	// instead of APPROVE whenever the review found any issue (see ReviewEvent).
+	NeverApproveWithIssues bool
 }
 
 // Run executes the full review pipeline for one PR and publishes the review to GitHub.
@@ -598,6 +601,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	signalComments := filterBotComments(prComments, p.botLogin)
 	commentSignals := ExtractCommentSignals(signalComments, pr.User.Login)
 	finalSeverity := ApplySignalEscalation(reconciledSeverity, commentSignals)
+	reviewEvent := ReviewEvent(finalSeverity, len(result.Issues) > 0, opts.NeverApproveWithIssues)
 
 	// 6. Marshal issues and suggestions to JSON for storage
 	issuesJSON, err := json.Marshal(result.Issues)
@@ -617,6 +621,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		Issues:         string(issuesJSON),
 		Suggestions:    string(suggestionsJSON),
 		Severity:       finalSeverity,
+		Event:          reviewEvent,
 		CreatedAt:      time.Now().UTC(),
 		GitHubReviewID: 0, // will be set after GitHub publish
 		HeadSHA:        pr.Head.SHA,
@@ -644,7 +649,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
 		pr.Repo, pr.Number,
 		reviewBody,
-		SeverityToEvent(finalSeverity),
+		reviewEvent,
 	)
 	if publishErr != nil {
 		// Permanent submit failure (PR locked etc.): mark the freshly
@@ -771,12 +776,14 @@ func (p *Pipeline) PublishPending() {
 		}
 		// PublishPending always uses single-mode body (individual comments were
 		// already posted when the review first ran; we only retry the formal review).
-		// The stored severity already incorporates signal escalation from the
-		// initial review, so SeverityToEvent reproduces the original decision.
+		// The stored event already incorporates signal escalation and the
+		// never-approve-with-issues decision from the initial review; legacy
+		// rows without a stored event fall back to SeverityToEvent via
+		// publishEventFor.
 		ghID, ghState, err := p.gh.SubmitReview(
 			pr.Repo, pr.Number,
 			BuildGitHubBody(result),
-			SeverityToEvent(rev.Severity),
+			publishEventFor(rev),
 		)
 		if err != nil {
 			// Permanent submit failures (currently HTTP 422 "lock
@@ -1017,6 +1024,16 @@ func ReviewEvent(finalSeverity string, hasIssues bool, neverApproveWithIssues bo
 		return "COMMENT"
 	}
 	return event
+}
+
+// publishEventFor returns the GitHub event to submit for a stored review:
+// the decided event persisted at review time, or — for legacy rows written
+// before the event column existed — the severity-derived fallback.
+func publishEventFor(rev *store.Review) string {
+	if rev.Event != "" {
+		return rev.Event
+	}
+	return SeverityToEvent(rev.Severity)
 }
 
 // maxCommentsBytes limits the total formatted PR comments included in the prompt.

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -1006,6 +1006,19 @@ func SeverityToEvent(severity string) string {
 	return "APPROVE"
 }
 
+// ReviewEvent decides the GitHub review event, honoring the
+// never-approve-with-issues setting. It builds on SeverityToEvent: when the
+// base decision would be APPROVE, the setting is on, and the review found at
+// least one issue, it downgrades APPROVE to COMMENT. REQUEST_CHANGES is never
+// altered, and a clean review (no issues) still approves.
+func ReviewEvent(finalSeverity string, hasIssues bool, neverApproveWithIssues bool) string {
+	event := SeverityToEvent(finalSeverity)
+	if event == "APPROVE" && neverApproveWithIssues && hasIssues {
+		return "COMMENT"
+	}
+	return event
+}
+
 // maxCommentsBytes limits the total formatted PR comments included in the prompt.
 const maxCommentsBytes = 16 * 1024 // 16KB
 

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -1107,3 +1107,32 @@ func equalStringSlices(a, b []string) bool {
 	}
 	return true
 }
+
+func TestReviewEvent(t *testing.T) {
+	cases := []struct {
+		sev       string
+		hasIssues bool
+		never     bool
+		want      string
+	}{
+		// flag OFF → identical to SeverityToEvent
+		{"low", true, false, "APPROVE"},
+		{"medium", true, false, "APPROVE"},
+		{"high", true, false, "REQUEST_CHANGES"},
+		{"", false, false, "APPROVE"},
+		// flag ON
+		{"low", true, true, "COMMENT"},
+		{"medium", true, true, "COMMENT"},
+		{"", true, true, "COMMENT"},
+		{"high", true, true, "REQUEST_CHANGES"}, // high never downgraded
+		{"low", false, true, "APPROVE"},         // clean review still approves
+		{"medium", false, true, "APPROVE"},
+	}
+	for _, tc := range cases {
+		got := pipeline.ReviewEvent(tc.sev, tc.hasIssues, tc.never)
+		if got != tc.want {
+			t.Errorf("ReviewEvent(%q, %v, %v) = %q, want %q",
+				tc.sev, tc.hasIssues, tc.never, got, tc.want)
+		}
+	}
+}

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -1136,3 +1136,38 @@ func TestReviewEvent(t *testing.T) {
 		}
 	}
 }
+
+func TestPublishEventFor(t *testing.T) {
+	cases := []struct {
+		name string
+		rev  store.Review
+		want string
+	}{
+		{"stored COMMENT used verbatim", store.Review{Event: "COMMENT", Severity: "low"}, "COMMENT"},
+		{"stored REQUEST_CHANGES used verbatim", store.Review{Event: "REQUEST_CHANGES", Severity: "low"}, "REQUEST_CHANGES"},
+		{"stored APPROVE used verbatim", store.Review{Event: "APPROVE", Severity: "high"}, "APPROVE"},
+		{"legacy empty high falls back to severity", store.Review{Event: "", Severity: "high"}, "REQUEST_CHANGES"},
+		{"legacy empty low falls back to severity", store.Review{Event: "", Severity: "low"}, "APPROVE"},
+	}
+	for _, tc := range cases {
+		rev := tc.rev
+		if got := pipeline.PublishEventFor(&rev); got != tc.want {
+			t.Errorf("%s: PublishEventFor = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestAnnotateBodyForEvent(t *testing.T) {
+	const body = "## Review\nlgtm"
+	// COMMENT keeps the original body and appends the downgrade note.
+	got := pipeline.AnnotateBodyForEvent(body, "COMMENT")
+	if !strings.Contains(got, body) || !strings.Contains(got, "never_approve_with_issues") {
+		t.Errorf("COMMENT body should keep body and add the note, got %q", got)
+	}
+	// Non-downgrade events leave the body untouched.
+	for _, ev := range []string{"APPROVE", "REQUEST_CHANGES"} {
+		if got := pipeline.AnnotateBodyForEvent(body, ev); got != body {
+			t.Errorf("event %s: body should be unchanged, got %q", ev, got)
+		}
+	}
+}

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -315,6 +315,53 @@ func TestHandlerGetConfig_ExposesRepoFirstSeenAt(t *testing.T) {
 	}
 }
 
+// TestGetConfig_ExposesNeverApproveWithIssues pins the JSON contract for the
+// never_approve_with_issues field added in main.go's GET /config result map
+// (global) and repoAIOverrideMap/orgAIOverrideMap (per-repo override), the
+// same way TestHandlerGetConfig_ExposesRepoFirstSeenAt pins first_seen_at.
+// The real map-building logic lives in cmd/heimdallm/main.go (package main,
+// not importable here); this test guards that whatever main.go's configFn
+// produces survives the HTTP handler unchanged.
+func TestGetConfig_ExposesNeverApproveWithIssues(t *testing.T) {
+	srv, _ := setupServer(t)
+	srv.SetConfigFn(func() map[string]any {
+		return map[string]any{
+			"never_approve_with_issues": true,
+			"repo_overrides": map[string]any{
+				"org/repo1": map[string]any{
+					"never_approve_with_issues": false,
+				},
+			},
+		}
+	})
+
+	req := httptest.NewRequest("GET", "/config", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v (body: %s)", err, w.Body.String())
+	}
+	if body["never_approve_with_issues"] != true {
+		t.Errorf("global never_approve_with_issues = %v, want true", body["never_approve_with_issues"])
+	}
+	overrides, ok := body["repo_overrides"].(map[string]any)
+	if !ok {
+		t.Fatalf("repo_overrides missing or wrong type: %T: %v", body["repo_overrides"], body["repo_overrides"])
+	}
+	ro, ok := overrides["org/repo1"].(map[string]any)
+	if !ok {
+		t.Fatalf("repo_overrides[org/repo1] missing or wrong type: %T: %v", overrides["org/repo1"], overrides["org/repo1"])
+	}
+	if ro["never_approve_with_issues"] != false {
+		t.Errorf("repo override never_approve_with_issues = %v, want false", ro["never_approve_with_issues"])
+	}
+}
+
 func TestHandlerPutConfig(t *testing.T) {
 	srv, _ := setupServer(t)
 	body := `{"poll_interval":"5m"}`

--- a/daemon/internal/store/reviews.go
+++ b/daemon/internal/store/reviews.go
@@ -35,6 +35,11 @@ type Review struct {
 	// dedup key: if we've already reviewed this SHA, peer-bot review submissions
 	// bumping the PR's updated_at must not trigger a re-review.
 	HeadSHA string `json:"head_sha"`
+	// Event is the GitHub review event the daemon decided to submit
+	// (APPROVE | COMMENT | REQUEST_CHANGES). Persisted so retry/publish paths
+	// reproduce the exact decision even if config changes afterwards. Empty on
+	// legacy rows — callers fall back to SeverityToEvent(Severity).
+	Event string `json:"event"`
 }
 
 // InsertReview inserts a new review record and returns its row ID.
@@ -44,11 +49,11 @@ func (s *Store) InsertReview(r *Review) (int64, error) {
 		publishedAt = r.PublishedAt.UTC().Format(sqliteTimeFormat)
 	}
 	res, err := s.db.Exec(`
-		INSERT INTO reviews (pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO reviews (pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha, event)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, r.PRID, r.CLIUsed, r.Summary, r.Issues, r.Suggestions, r.Severity,
 		r.CreatedAt.UTC().Format(sqliteTimeFormat), publishedAt,
-		r.GitHubReviewID, r.GitHubReviewState, r.HeadSHA,
+		r.GitHubReviewID, r.GitHubReviewState, r.HeadSHA, r.Event,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("store: insert review: %w", err)
@@ -59,7 +64,7 @@ func (s *Store) InsertReview(r *Review) (int64, error) {
 // ListUnpublishedReviews returns reviews not yet submitted to GitHub (github_review_id == 0).
 func (s *Store) ListUnpublishedReviews() ([]*Review, error) {
 	rows, err := s.db.Query(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha FROM reviews WHERE github_review_id=0 ORDER BY created_at ASC",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha, event FROM reviews WHERE github_review_id=0 ORDER BY created_at ASC",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("store: list unpublished: %w", err)
@@ -79,7 +84,7 @@ func (s *Store) ListUnpublishedReviews() ([]*Review, error) {
 // GetReview returns a single review by its local row ID.
 func (s *Store) GetReview(id int64) (*Review, error) {
 	row := s.db.QueryRow(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha FROM reviews WHERE id = ?",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha, event FROM reviews WHERE id = ?",
 		id,
 	)
 	return scanReview(row)
@@ -119,7 +124,7 @@ func (s *Store) MarkReviewPublished(reviewID, ghReviewID int64, ghReviewState st
 // ListReviewsForPR returns all reviews for a given PR, ordered by created_at descending.
 func (s *Store) ListReviewsForPR(prID int64) ([]*Review, error) {
 	rows, err := s.db.Query(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha FROM reviews WHERE pr_id = ? ORDER BY created_at DESC",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha, event FROM reviews WHERE pr_id = ? ORDER BY created_at DESC",
 		prID,
 	)
 	if err != nil {
@@ -140,7 +145,7 @@ func (s *Store) ListReviewsForPR(prID int64) ([]*Review, error) {
 // LatestReviewForPR returns the most recent review for a PR. Returns sql.ErrNoRows if none.
 func (s *Store) LatestReviewForPR(prID int64) (*Review, error) {
 	row := s.db.QueryRow(
-		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha FROM reviews WHERE pr_id = ? ORDER BY created_at DESC LIMIT 1",
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha, event FROM reviews WHERE pr_id = ? ORDER BY created_at DESC LIMIT 1",
 		prID,
 	)
 	return scanReview(row)
@@ -169,7 +174,7 @@ func scanReview(s scanner) (*Review, error) {
 	var err error
 	if err = s.Scan(&rev.ID, &rev.PRID, &rev.CLIUsed, &rev.Summary,
 		&rev.Issues, &rev.Suggestions, &rev.Severity, &createdAt, &publishedAt,
-		&rev.GitHubReviewID, &rev.GitHubReviewState, &rev.HeadSHA); err != nil {
+		&rev.GitHubReviewID, &rev.GitHubReviewState, &rev.HeadSHA, &rev.Event); err != nil {
 		return nil, fmt.Errorf("store: scan review: %w", err)
 	}
 	if rev.CreatedAt, err = time.Parse(sqliteTimeFormat, createdAt); err != nil {

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -61,7 +61,8 @@ CREATE TABLE IF NOT EXISTS reviews (
   published_at        TEXT NOT NULL DEFAULT '',
   github_review_id    INTEGER NOT NULL DEFAULT 0,
   github_review_state TEXT NOT NULL DEFAULT '',
-  head_sha            TEXT NOT NULL DEFAULT ''
+  head_sha            TEXT NOT NULL DEFAULT '',
+  event               TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS configs (
@@ -201,6 +202,10 @@ func Open(dsn string) (*Store, error) {
 	// time.Time{} and callers can fall back to created_at. See
 	// theburrowhub/heimdallm#243 Fix 3.
 	db.Exec("ALTER TABLE reviews ADD COLUMN published_at TEXT NOT NULL DEFAULT ''")
+	// event stores the decided review event (APPROVE|COMMENT|REQUEST_CHANGES)
+	// so retry/publish paths reproduce the decision. Empty default => legacy
+	// rows fall back to SeverityToEvent(severity).
+	db.Exec("ALTER TABLE reviews ADD COLUMN event TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents ADD COLUMN instructions TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents ADD COLUMN cli_flags TEXT NOT NULL DEFAULT ''")
 	db.Exec("ALTER TABLE agents RENAME COLUMN prompt TO prompt") // no-op, ensures column exists

--- a/daemon/internal/store/store_test.go
+++ b/daemon/internal/store/store_test.go
@@ -208,6 +208,37 @@ func TestReview_HeadSHARoundTrip(t *testing.T) {
 	}
 }
 
+// TestReview_EventRoundTrip covers the event column added so the daemon's
+// decided GitHub review event (APPROVE|COMMENT|REQUEST_CHANGES) is persisted
+// and reproduced on retry rather than re-derived from severity, which could
+// drift if config changes between the original decision and a later retry.
+func TestReview_EventRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	prID, _ := s.UpsertPR(&store.PR{
+		GithubID: 1, Repo: "org/r", Number: 1, Title: "t", Author: "a",
+		URL: "u", State: "open", UpdatedAt: time.Now(), FetchedAt: time.Now(),
+	})
+
+	rev := &store.Review{
+		PRID: prID, CLIUsed: "claude",
+		Issues: "[]", Suggestions: "[]", Severity: "low",
+		Event:     "COMMENT",
+		CreatedAt: time.Now().UTC(),
+		HeadSHA:   "abc123",
+	}
+	id, err := s.InsertReview(rev)
+	if err != nil {
+		t.Fatalf("InsertReview: %v", err)
+	}
+	got, err := s.GetReview(id)
+	if err != nil {
+		t.Fatalf("GetReview: %v", err)
+	}
+	if got.Event != "COMMENT" {
+		t.Errorf("Event = %q, want %q", got.Event, "COMMENT")
+	}
+}
+
 func TestPR_ListAll(t *testing.T) {
 	s := newTestStore(t)
 	for i := 0; i < 3; i++ {

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -60,6 +60,12 @@ review_mode = "single"   # "single" or "multi"
 # change list, and test plan.
 # generate_pr_description = false
 
+# When true, a review that finds ANY issue is posted as a COMMENT instead of an
+# APPROVE (high-severity reviews still REQUEST_CHANGES; a clean review still
+# approves). Overridable per org ([ai.orgs.*]) and per repo ([ai.repos.*]).
+# Default: false.
+# never_approve_with_issues = false
+
 # Per-CLI settings (optional)
 # [ai.agents.claude]
 # model = "claude-sonnet-4-20250514"

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -651,6 +651,7 @@ clone_dir = "/home/heimdallm/repos/myorg-worktrees"
 auto_promote_triage = true
 auto_promote_refinement = false
 generate_pr_description = true
+never_approve_with_issues = false   # true = comment instead of approving when any issue is found
 
 pr_reviewers = ["alice", "bob", "carol"]
 pr_labels    = ["auto-generated", "ai-platform"]
@@ -1253,6 +1254,12 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # Generate LLM-produced PR titles and descriptions for auto_implement PRs.
 # generate_pr_description = false
 
+# When true, a review that finds ANY issue is published as a COMMENT instead of
+# an APPROVE (a high-severity review is still REQUEST_CHANGES; a clean review
+# still approves). Overridable per org ([ai.orgs.*]) and per repo ([ai.repos.*]).
+# Default: false.
+# never_approve_with_issues = false
+
 # When local_dir is unset, Heimdallm prepares a managed shallow clone for agent
 # context under clone_dir. If clone_dir is also unset, the default is
 # os.TempDir()/heimdallm/<org>/<repo>. Existing directories are mutated only
@@ -1317,6 +1324,7 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # auto_promote_triage = true
 # auto_promote_refinement = false
 # generate_pr_description = true
+# never_approve_with_issues = false
 # pr_reviewers = ["alice", "bob"]
 # pr_labels    = ["auto-generated", "myorg-team"]
 # pr_assignee  = "myusername"

--- a/docs/superpowers/plans/2026-07-06-never-approve-with-issues.md
+++ b/docs/superpowers/plans/2026-07-06-never-approve-with-issues.md
@@ -1,0 +1,866 @@
+# never_approve_with_issues Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a global setting (with per-org and per-repo override) that publishes a PR review as `COMMENT` instead of `APPROVE` whenever the review found any issue.
+
+**Architecture:** Mirror the existing `generate_pr_description` bool-with-override pattern in the config layer (`AIConfig` global + `*bool` in `RepoAI`/`OrgAI`, resolved by `AIForRepo`/`applyScopedAI`). A new pure function `ReviewEvent` maps `(finalSeverity, hasIssues, flag)` → GitHub event, building on the existing `SeverityToEvent`. The decided event is **persisted** on the `store.Review` row (new `event` column) so retry paths reproduce it verbatim (Enfoque A). The global toggle is edited via the existing generic `PATCH /config` route (writes `[ai].never_approve_with_issues` in config.toml); the per-repo/org override via the existing generic `PATCH /config/repos/{repo}` and `.../orgs/{org}` routes.
+
+**Tech Stack:** Go 1.x (daemon), Flutter/Dart (GUI), SQLite (BurntSushi TOML + database/sql), Riverpod.
+
+## Global Constraints
+
+- Canonical severity values are exactly `low` | `medium` | `high` (empty string treated as `low`). No other values exist.
+- TOML/JSON key everywhere: `never_approve_with_issues`. Go field: `NeverApproveWithIssues`. Dart global field: `globalNeverApproveWithIssues`; Dart repo/org override field: `neverApproveWithIssues` (`bool?`, null = inherit).
+- Default is `false` at the global level → the change must be 100% backward-compatible (OFF = today's behavior).
+- "Contains issues" is defined as `len(result.Issues) > 0`.
+- `REQUEST_CHANGES` (severity `high`) is NEVER altered by this setting. Only the `APPROVE`-with-issues case becomes `COMMENT`.
+- Retry/publish paths must publish the persisted `Review.Event`; legacy rows with empty `Event` fall back to `SeverityToEvent(Review.Severity)`.
+- Test commands: daemon → `cd daemon && make test` (`go test ./... -timeout 60s`); Flutter → `cd flutter_app && flutter test`. Build check: `cd daemon && make build`.
+- TDD, small commits, one deliverable per task.
+
+---
+
+### Task 1: Config field + resolution (repo > org > global)
+
+**Files:**
+- Modify: `daemon/internal/config/config.go` (AIConfig ~458, RepoAI ~547, OrgAI ~609, AIForRepo 743-775, applyOrgAI 777-798, applyRepoAI 800-821, scopedAIFields 823-842, applyScopedAI 844+)
+- Test: `daemon/internal/config/config_test.go`
+
+**Interfaces:**
+- Produces: `Config.AIForRepo(repo string) RepoAI` where the returned `RepoAI.NeverApproveWithIssues *bool` is always non-nil (global seeds it), resolved repo > org > global.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `daemon/internal/config/config_test.go`:
+
+```go
+func TestNeverApproveWithIssues_Resolution(t *testing.T) {
+	tru := true
+	fal := false
+	cases := []struct {
+		name   string
+		global bool
+		org    *bool
+		repo   *bool
+		want   bool
+	}{
+		{"global off, no overrides", false, nil, nil, false},
+		{"global on, no overrides", true, nil, nil, true},
+		{"org on over global off", false, &tru, nil, true},
+		{"repo off over org on", false, &tru, &fal, false},
+		{"repo on over global off", false, nil, &tru, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{}
+			c.AI.NeverApproveWithIssues = tc.global
+			c.AI.Orgs = map[string]OrgAI{"acme": {NeverApproveWithIssues: tc.org}}
+			c.AI.Repos = map[string]RepoAI{"acme/widget": {NeverApproveWithIssues: tc.repo}}
+			got := c.AIForRepo("acme/widget").NeverApproveWithIssues
+			if got == nil {
+				t.Fatalf("NeverApproveWithIssues is nil, want non-nil")
+			}
+			if *got != tc.want {
+				t.Errorf("NeverApproveWithIssues = %v, want %v", *got, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd daemon && go test ./internal/config/ -run TestNeverApproveWithIssues_Resolution -v`
+Expected: FAIL (compile error — `NeverApproveWithIssues` field does not exist).
+
+- [ ] **Step 3: Add the struct fields and resolution wiring**
+
+In `AIConfig` (right after the `GeneratePRDescription bool` field, ~line 458):
+
+```go
+	// NeverApproveWithIssues, when true, downgrades an otherwise-APPROVE review
+	// to COMMENT whenever the review found any issue. REQUEST_CHANGES (high
+	// severity) is unaffected. Default: false (backwards compat). Overridable
+	// per-org and per-repo.
+	NeverApproveWithIssues bool `toml:"never_approve_with_issues"`
+```
+
+In `RepoAI` (right after its `GeneratePRDescription *bool` field, ~line 547):
+
+```go
+	// NeverApproveWithIssues overrides ai.never_approve_with_issues for this
+	// repo. nil = inherit from org/global.
+	NeverApproveWithIssues *bool `toml:"never_approve_with_issues,omitempty"`
+```
+
+In `OrgAI` (right after its `GeneratePRDescription *bool` field, ~line 609):
+
+```go
+	NeverApproveWithIssues *bool `toml:"never_approve_with_issues,omitempty"`
+```
+
+In `AIForRepo` — seed the global value. After `gGenDesc := c.AI.GeneratePRDescription` (~745):
+
+```go
+	gNever := c.AI.NeverApproveWithIssues
+```
+
+And in the `out := RepoAI{...}` literal, after `GeneratePRDescription: &gGenDesc,` (~757):
+
+```go
+		NeverApproveWithIssues: &gNever,
+```
+
+In `applyOrgAI` — inside the `scopedAIFields{...}` literal, after `GeneratePRDescription: o.GeneratePRDescription,` (~795):
+
+```go
+		NeverApproveWithIssues: o.NeverApproveWithIssues,
+```
+
+In `applyRepoAI` — inside the `scopedAIFields{...}` literal, after `GeneratePRDescription: r.GeneratePRDescription,` (~818):
+
+```go
+		NeverApproveWithIssues: r.NeverApproveWithIssues,
+```
+
+In `scopedAIFields` struct, after `GeneratePRDescription *bool` (~840):
+
+```go
+	NeverApproveWithIssues *bool
+```
+
+In `applyScopedAI`, after the `GeneratePRDescription` block (~893-895):
+
+```go
+	if fields.NeverApproveWithIssues != nil {
+		out.NeverApproveWithIssues = fields.NeverApproveWithIssues
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd daemon && go test ./internal/config/ -run TestNeverApproveWithIssues_Resolution -v`
+Expected: PASS (all 5 subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add daemon/internal/config/config.go daemon/internal/config/config_test.go
+git commit -m "feat(config): add never_approve_with_issues with repo/org/global merge"
+```
+
+---
+
+### Task 2: `ReviewEvent` pure function
+
+**Files:**
+- Modify: `daemon/internal/pipeline/pipeline.go` (add function next to `SeverityToEvent`, ~1007)
+- Test: `daemon/internal/pipeline/pipeline_test.go` (create if absent, else append)
+
+**Interfaces:**
+- Produces: `func ReviewEvent(finalSeverity string, hasIssues bool, neverApproveWithIssues bool) string` returning one of `"APPROVE"`, `"COMMENT"`, `"REQUEST_CHANGES"`.
+- Consumes: existing `func SeverityToEvent(severity string) string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `daemon/internal/pipeline/pipeline_test.go` (create the file with `package pipeline` + imports `testing` if it does not exist):
+
+```go
+func TestReviewEvent(t *testing.T) {
+	cases := []struct {
+		sev       string
+		hasIssues bool
+		never     bool
+		want      string
+	}{
+		// flag OFF → identical to SeverityToEvent
+		{"low", true, false, "APPROVE"},
+		{"medium", true, false, "APPROVE"},
+		{"high", true, false, "REQUEST_CHANGES"},
+		{"", false, false, "APPROVE"},
+		// flag ON
+		{"low", true, true, "COMMENT"},
+		{"medium", true, true, "COMMENT"},
+		{"", true, true, "COMMENT"},
+		{"high", true, true, "REQUEST_CHANGES"}, // high never downgraded
+		{"low", false, true, "APPROVE"},         // clean review still approves
+		{"medium", false, true, "APPROVE"},
+	}
+	for _, tc := range cases {
+		got := ReviewEvent(tc.sev, tc.hasIssues, tc.never)
+		if got != tc.want {
+			t.Errorf("ReviewEvent(%q, %v, %v) = %q, want %q",
+				tc.sev, tc.hasIssues, tc.never, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd daemon && go test ./internal/pipeline/ -run TestReviewEvent -v`
+Expected: FAIL (compile error — `ReviewEvent` undefined).
+
+- [ ] **Step 3: Implement `ReviewEvent`**
+
+Add directly below `SeverityToEvent` (after line ~1007) in `daemon/internal/pipeline/pipeline.go`:
+
+```go
+// ReviewEvent decides the GitHub review event, honoring the
+// never-approve-with-issues setting. It builds on SeverityToEvent: when the
+// base decision would be APPROVE, the setting is on, and the review found at
+// least one issue, it downgrades APPROVE to COMMENT. REQUEST_CHANGES is never
+// altered, and a clean review (no issues) still approves.
+func ReviewEvent(finalSeverity string, hasIssues bool, neverApproveWithIssues bool) string {
+	event := SeverityToEvent(finalSeverity)
+	if event == "APPROVE" && neverApproveWithIssues && hasIssues {
+		return "COMMENT"
+	}
+	return event
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd daemon && go test ./internal/pipeline/ -run TestReviewEvent -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add daemon/internal/pipeline/pipeline.go daemon/internal/pipeline/pipeline_test.go
+git commit -m "feat(pipeline): add ReviewEvent mapping issues+flag to review event"
+```
+
+---
+
+### Task 3: Persist the decided event on `store.Review`
+
+**Files:**
+- Modify: `daemon/internal/store/reviews.go` (Review struct 16-38, InsertReview 41-57, the 4 SELECT queries at 62/82/122/143, scanReview 166+)
+- Modify: `daemon/internal/store/store.go` (schema CREATE TABLE reviews 52-65, migrations block ~195-203)
+- Test: `daemon/internal/store/store_test.go`
+
+**Interfaces:**
+- Produces: `store.Review.Event string` (JSON tag `event`) round-tripped through insert/select. Empty string on legacy rows.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `daemon/internal/store/store_test.go`:
+
+```go
+func TestReview_EventRoundTrip(t *testing.T) {
+	s := newTestStore(t) // existing helper used by other tests in this file
+	prID := insertTestPR(t, s) // existing helper; if named differently, reuse the file's PR-insert helper
+	rev := &Review{
+		PRID: prID, CLIUsed: "claude",
+		Issues: "[]", Suggestions: "[]", Severity: "low",
+		Event:     "COMMENT",
+		CreatedAt: time.Now().UTC(),
+		HeadSHA:   "abc123",
+	}
+	id, err := s.InsertReview(rev)
+	if err != nil {
+		t.Fatalf("InsertReview: %v", err)
+	}
+	got, err := s.GetReview(id)
+	if err != nil {
+		t.Fatalf("GetReview: %v", err)
+	}
+	if got.Event != "COMMENT" {
+		t.Errorf("Event = %q, want %q", got.Event, "COMMENT")
+	}
+}
+```
+
+> If `newTestStore`/`insertTestPR` helper names differ, match the exact helpers already used in `store_test.go` (see `TestReview_HeadSHARoundTrip`, ~line 185, for the canonical setup in this file).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd daemon && go test ./internal/store/ -run TestReview_EventRoundTrip -v`
+Expected: FAIL (compile error — `Event` field does not exist).
+
+- [ ] **Step 3: Add field, column, migration, and wire all queries**
+
+In `daemon/internal/store/reviews.go`, add to the `Review` struct after `HeadSHA` (line 37):
+
+```go
+	// Event is the GitHub review event the daemon decided to submit
+	// (APPROVE | COMMENT | REQUEST_CHANGES). Persisted so retry/publish paths
+	// reproduce the exact decision even if config changes afterwards. Empty on
+	// legacy rows — callers fall back to SeverityToEvent(Severity).
+	Event string `json:"event"`
+```
+
+In `InsertReview`, update the SQL to add the column and placeholder, and pass `r.Event`:
+
+```go
+	res, err := s.db.Exec(`
+		INSERT INTO reviews (pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha, event)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, r.PRID, r.CLIUsed, r.Summary, r.Issues, r.Suggestions, r.Severity,
+		r.CreatedAt.UTC().Format(sqliteTimeFormat), publishedAt,
+		r.GitHubReviewID, r.GitHubReviewState, r.HeadSHA, r.Event,
+	)
+```
+
+Append `, event` to the column list of ALL FOUR SELECT statements (lines 62, 82, 122, 143) so each ends with `... head_sha, event FROM reviews ...`. Example for line 62:
+
+```go
+		"SELECT id, pr_id, cli_used, summary, issues, suggestions, severity, created_at, published_at, github_review_id, github_review_state, head_sha, event FROM reviews WHERE github_review_id=0 ORDER BY created_at ASC",
+```
+
+Do the same for the queries at lines 82, 122, and 143 (keep their existing WHERE/ORDER clauses).
+
+In `scanReview`, add `&rev.Event` as the final scan target:
+
+```go
+	if err = s.Scan(&rev.ID, &rev.PRID, &rev.CLIUsed, &rev.Summary,
+		&rev.Issues, &rev.Suggestions, &rev.Severity, &createdAt, &publishedAt,
+		&rev.GitHubReviewID, &rev.GitHubReviewState, &rev.HeadSHA, &rev.Event); err != nil {
+		return nil, fmt.Errorf("store: scan review: %w", err)
+	}
+```
+
+In `daemon/internal/store/store.go`, add the column to the fresh-install schema (inside `CREATE TABLE IF NOT EXISTS reviews`, after `head_sha ... DEFAULT ''` on line 64 — add a comma to that line):
+
+```sql
+  head_sha            TEXT NOT NULL DEFAULT '',
+  event               TEXT NOT NULL DEFAULT ''
+```
+
+And add the idempotent migration next to the other reviews ALTERs (after line 203):
+
+```go
+	// event stores the decided review event (APPROVE|COMMENT|REQUEST_CHANGES)
+	// so retry/publish paths reproduce the decision. Empty default => legacy
+	// rows fall back to SeverityToEvent(severity).
+	db.Exec("ALTER TABLE reviews ADD COLUMN event TEXT NOT NULL DEFAULT ''")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd daemon && go test ./internal/store/ -run TestReview_EventRoundTrip -v`
+Then run the whole store package to catch any missed query: `cd daemon && go test ./internal/store/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add daemon/internal/store/reviews.go daemon/internal/store/store.go daemon/internal/store/store_test.go
+git commit -m "feat(store): persist decided review event on reviews rows"
+```
+
+---
+
+### Task 4: Wire the decision + persistence into the pipeline
+
+**Files:**
+- Modify: `daemon/internal/pipeline/pipeline.go` (RunOptions 284-300, Run submit block ~600-648, PublishPending submit ~776-780)
+- Modify: `daemon/cmd/heimdallm/main.go` (buildRunOpts RunOptions literal ~445-451)
+- Test: `daemon/internal/pipeline/pipeline_test.go`
+
+**Interfaces:**
+- Consumes: `ReviewEvent` (Task 2), `store.Review.Event` (Task 3), `Config.AIForRepo(...).NeverApproveWithIssues` (Task 1).
+- Produces: `RunOptions.NeverApproveWithIssues bool`.
+
+- [ ] **Step 1: Add the RunOptions field**
+
+In `daemon/internal/pipeline/pipeline.go`, add to the `RunOptions` struct (after `InstructionAuthors []string`, ~line 299):
+
+```go
+	// NeverApproveWithIssues, when true, publishes the review as COMMENT
+	// instead of APPROVE whenever the review found any issue (see ReviewEvent).
+	NeverApproveWithIssues bool
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `daemon/internal/pipeline/pipeline_test.go`. This pins the two contract points that Task 4 wires — the decision helper and the "use persisted event, else fall back" rule — without standing up a full `Run`:
+
+```go
+func TestReviewEvent_PersistedAndReused(t *testing.T) {
+	// Unit-level guard: the decision helper + persistence contract.
+	// Run path: COMMENT chosen when flag on and issues present.
+	ev := ReviewEvent("medium", true, true)
+	if ev != "COMMENT" {
+		t.Fatalf("decision = %q, want COMMENT", ev)
+	}
+	// Publish reproduction: a stored event is used verbatim; empty falls back.
+	if got := publishEventFor(&store.Review{Event: "COMMENT", Severity: "low"}); got != "COMMENT" {
+		t.Errorf("publishEventFor(stored COMMENT) = %q, want COMMENT", got)
+	}
+	if got := publishEventFor(&store.Review{Event: "", Severity: "high"}); got != "REQUEST_CHANGES" {
+		t.Errorf("publishEventFor(legacy high) = %q, want REQUEST_CHANGES", got)
+	}
+}
+```
+
+This test references a small helper `publishEventFor` that Step 3 introduces to centralize the "use persisted event, else fall back" rule (so both `Run` and `PublishPending` share it and the test can pin it).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd daemon && go test ./internal/pipeline/ -run TestReviewEvent_PersistedAndReused -v`
+Expected: FAIL (compile error — `publishEventFor` undefined).
+
+- [ ] **Step 4: Implement the helper and wire both call sites**
+
+Add the helper near `ReviewEvent` in `pipeline.go`:
+
+```go
+// publishEventFor returns the GitHub event to submit for a stored review:
+// the decided event persisted at review time, or — for legacy rows written
+// before the event column existed — the severity-derived fallback.
+func publishEventFor(rev *store.Review) string {
+	if rev.Event != "" {
+		return rev.Event
+	}
+	return SeverityToEvent(rev.Severity)
+}
+```
+
+In `Run`, compute the event before building the `rev` struct. Immediately after `finalSeverity := ApplySignalEscalation(...)` (~line 600), add:
+
+```go
+	reviewEvent := ReviewEvent(finalSeverity, len(result.Issues) > 0, opts.NeverApproveWithIssues)
+```
+
+Add `Event: reviewEvent,` to the `rev := &store.Review{...}` literal (~line 613, e.g. right after `Severity: finalSeverity,`):
+
+```go
+		Severity:       finalSeverity,
+		Event:          reviewEvent,
+```
+
+Change the submit call (~line 644-648) from `SeverityToEvent(finalSeverity)` to `reviewEvent`:
+
+```go
+	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
+		pr.Repo, pr.Number,
+		reviewBody,
+		reviewEvent,
+	)
+```
+
+In `PublishPending` (~line 776-780), change `SeverityToEvent(rev.Severity)` to `publishEventFor(rev)`:
+
+```go
+	ghID, ghState, err := p.gh.SubmitReview(
+		pr.Repo, pr.Number,
+		BuildGitHubBody(result),
+		publishEventFor(rev),
+	)
+```
+
+In `daemon/cmd/heimdallm/main.go`, set the RunOptions field in `buildRunOpts` (in the `pipeline.RunOptions{...}` literal ~445-451, after `InstructionAuthors: aiCfg.InstructionAuthors,`):
+
+```go
+			NeverApproveWithIssues: aiCfg.NeverApproveWithIssues != nil && *aiCfg.NeverApproveWithIssues,
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd daemon && go test ./internal/pipeline/ -run TestReviewEvent -v`
+Then build: `cd daemon && make build`
+Expected: tests PASS; binary builds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add daemon/internal/pipeline/pipeline.go daemon/cmd/heimdallm/main.go daemon/internal/pipeline/pipeline_test.go
+git commit -m "feat(pipeline): publish COMMENT for reviews with issues when flag on"
+```
+
+---
+
+### Task 5: Expose the setting over the HTTP config API
+
+**Files:**
+- Modify: `daemon/cmd/heimdallm/main.go` (GET /config result map ~1616; `aiOverrideFields` struct 4466-4480; `repoAIOverrideMap` 4410-4423 & `orgAIOverrideMap` 4445-4458; `addCommonAIOverrideFields` ~4519; AI-clearing snapshot ~2226)
+- Test: `daemon/internal/server/handlers_test.go`
+
+**Interfaces:**
+- Produces: GET `/config` includes top-level `never_approve_with_issues` (global) and, inside each `repo_overrides[repo]` / `org_overrides[org]`, a `never_approve_with_issues` bool when set.
+- Note: the write paths need NO code — `PATCH /config` (global, merges into `[ai]`) and `PATCH /config/repos/{repo}` / `.../orgs/{org}` (merge into `[ai.repos."…"]` / `[ai.orgs."…"]`) are generic TOML merges keyed by the `toml:"never_approve_with_issues"` tag added in Task 1. `DELETE /config/repos/{repo}/never_approve_with_issues` likewise works generically.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `daemon/internal/server/handlers_test.go` (follow the existing GET /config test helper style; look at the test around line 1634 that asserts on `gh["repositories"]` for the canonical request/decode pattern):
+
+```go
+func TestGetConfig_ExposesNeverApproveWithIssues(t *testing.T) {
+	srv := newTestServerWithConfig(t, &config.Config{
+		AI: config.AIConfig{
+			NeverApproveWithIssues: true,
+			Repos: map[string]config.RepoAI{
+				"org/repo1": {NeverApproveWithIssues: boolPtr(false)},
+			},
+		},
+	}) // reuse whatever constructor the other GET /config tests use
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/config", nil)
+	withAuth(req) // reuse existing auth helper if GET /config requires token
+	srv.Router().ServeHTTP(rec, req)
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["never_approve_with_issues"] != true {
+		t.Errorf("global never_approve_with_issues = %v, want true", body["never_approve_with_issues"])
+	}
+	ro := body["repo_overrides"].(map[string]any)["org/repo1"].(map[string]any)
+	if ro["never_approve_with_issues"] != false {
+		t.Errorf("repo override = %v, want false", ro["never_approve_with_issues"])
+	}
+}
+```
+
+> Match the exact server constructor / auth helper / `boolPtr` used by neighboring tests in `handlers_test.go`. If a `boolPtr` helper does not exist, add `func boolPtr(b bool) *bool { return &b }` once.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd daemon && go test ./internal/server/ -run TestGetConfig_ExposesNeverApproveWithIssues -v`
+Expected: FAIL (`never_approve_with_issues` absent from the response).
+
+- [ ] **Step 3: Add serialization**
+
+In `daemon/cmd/heimdallm/main.go`, add to the GET /config result map (after `"generate_pr_description": c.AI.GeneratePRDescription,` ~line 1616):
+
+```go
+			"never_approve_with_issues":   c.AI.NeverApproveWithIssues,
+```
+
+Add the field to `aiOverrideFields` (after `GeneratePRDescription *bool` ~line 4479):
+
+```go
+	NeverApproveWithIssues *bool
+```
+
+Pass it in BOTH `repoAIOverrideMap` (after `GeneratePRDescription: ai.GeneratePRDescription,` ~line 4423) and `orgAIOverrideMap` (~line 4458):
+
+```go
+		NeverApproveWithIssues: ai.NeverApproveWithIssues,
+```
+
+Emit it in `addCommonAIOverrideFields` (after the `GeneratePRDescription` block ~line 4519-4521):
+
+```go
+	if fields.NeverApproveWithIssues != nil {
+		out["never_approve_with_issues"] = *fields.NeverApproveWithIssues
+	}
+```
+
+In the AI-clearing snapshot helper, add the reset next to `snap.AI.GeneratePRDescription = false` (~line 2226) for consistency:
+
+```go
+	snap.AI.NeverApproveWithIssues = false
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd daemon && go test ./internal/server/ -run TestGetConfig_ExposesNeverApproveWithIssues -v`
+Then the full daemon suite: `cd daemon && make test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add daemon/cmd/heimdallm/main.go daemon/internal/server/handlers_test.go
+git commit -m "feat(api): expose never_approve_with_issues in GET /config and overrides"
+```
+
+---
+
+### Task 6: Flutter model support
+
+**Files:**
+- Modify: `flutter_app/lib/core/models/config_model.dart` (RepoConfig field 151/constructor 180/hasAiOverride 229/copyWith 287+357/fromJson repo-override parse ~953; OrgConfig field 392/constructor 420/copyWith 477+540/parse ~991; AppConfig field/constructor, copyWith 842+868, toJson 901, fromJson ~1063)
+- Test: `flutter_app/test/features/config_test.dart`
+
+**Interfaces:**
+- Produces: `AppConfig.globalNeverApproveWithIssues` (bool, default false); `RepoConfig.neverApproveWithIssues` and `OrgConfig.neverApproveWithIssues` (`bool?`, null = inherit). JSON key `never_approve_with_issues` (global at top level; overrides inside repo/org override maps).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `flutter_app/test/features/config_test.dart`:
+
+```dart
+test('never_approve_with_issues round-trips (global + repo override)', () {
+  final json = {
+    'never_approve_with_issues': true,
+    'repositories': <String>[],
+    'repo_overrides': {
+      'org/repo1': {'never_approve_with_issues': false},
+    },
+  };
+  final cfg = AppConfig.fromJson(json);
+  expect(cfg.globalNeverApproveWithIssues, isTrue);
+  expect(cfg.repoConfigs['org/repo1']!.neverApproveWithIssues, isFalse);
+
+  // Global survives toJson round-trip.
+  expect(cfg.toJson()['never_approve_with_issues'], isTrue);
+
+  // copyWith sentinel: repo override can be cleared to inherit (null).
+  final cleared = cfg.repoConfigs['org/repo1']!.copyWith(
+    neverApproveWithIssues: null,
+  );
+  expect(cleared.neverApproveWithIssues, isNull);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd flutter_app && flutter test test/features/config_test.dart --plain-name "never_approve_with_issues"`
+Expected: FAIL (getters/fields do not exist).
+
+- [ ] **Step 3: Add the fields, mirroring `prDraft` (repo/org) and a global bool**
+
+RepoConfig — declare after `final bool? prDraft;` (line 151):
+
+```dart
+  final bool? neverApproveWithIssues;
+```
+
+Add `this.neverApproveWithIssues,` to the `const RepoConfig({...})` constructor (after `this.prDraft,` ~line 180). Add `|| neverApproveWithIssues != null` to the `hasAiOverride` getter chain (after `prDraft != null` ~line 229 — turn that line into `prDraft != null ||` and append the new clause, keeping the final `;`). In `copyWith`, add the sentinel param `Object? neverApproveWithIssues = _sentinel,` (near `Object? prDraft = _sentinel,` ~line 287) and the resolution line (near ~357):
+
+```dart
+      neverApproveWithIssues: neverApproveWithIssues == _sentinel
+          ? this.neverApproveWithIssues
+          : neverApproveWithIssues as bool?,
+```
+
+OrgConfig — mirror the same four edits (field after `final bool? prDraft;` line 392; constructor ~420; copyWith param ~477 and resolution ~540). OrgConfig has no `hasAiOverride`; skip that part.
+
+Repo-override parse (the `RepoConfig(...)` built from `ov` inside `AppConfig.fromJson`, ~line 953 where `generatePRDescription: ov['generate_pr_description'] as bool?` lives) — add:
+
+```dart
+          neverApproveWithIssues: ov['never_approve_with_issues'] as bool?,
+```
+
+Org-override parse (the `OrgConfig(...)` built from `ov`, ~line 991 near `prDraft: ov['pr_draft'] as bool?`) — add the same line.
+
+AppConfig — declare the field (place it next to `globalGeneratePRDescription`), default false:
+
+```dart
+  final bool globalNeverApproveWithIssues;
+```
+
+Add it to the `const AppConfig({...})` constructor with a default: `this.globalNeverApproveWithIssues = false,`. Add to `copyWith`: parameter `bool? globalNeverApproveWithIssues,` (near line 849) and body `globalNeverApproveWithIssues: globalNeverApproveWithIssues ?? this.globalNeverApproveWithIssues,` (near line 880). Add to `toJson` (after `'generate_pr_description': globalGeneratePRDescription,` ~line 901):
+
+```dart
+    'never_approve_with_issues': globalNeverApproveWithIssues,
+```
+
+Add to `AppConfig.fromJson` (near where `globalGeneratePRDescription` is read, ~line 1063):
+
+```dart
+      globalNeverApproveWithIssues:
+          (json['never_approve_with_issues'] as bool?) ?? false,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd flutter_app && flutter test test/features/config_test.dart --plain-name "never_approve_with_issues"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flutter_app/lib/core/models/config_model.dart flutter_app/test/features/config_test.dart
+git commit -m "feat(gui): model support for never_approve_with_issues"
+```
+
+---
+
+### Task 7: Global settings toggle (config screen)
+
+**Files:**
+- Modify: `flutter_app/lib/features/config/config_screen.dart` (state field near 635, init near 644, a `SwitchListTile` near the draft one 726-738, `_buildConfig` 947-959)
+- Modify: `flutter_app/lib/features/config/config_providers.dart` (`_computeGlobalDiff` ~149-151)
+- Test: covered by Task 6 model tests + a diff test below (optional; the UI widget itself is thin).
+
+**Interfaces:**
+- Consumes: `AppConfig.globalNeverApproveWithIssues` (Task 6).
+- Produces: PATCH `/config` body `{"ai": {"never_approve_with_issues": <bool>}}` when the toggle changes.
+
+- [ ] **Step 1: Add state + init**
+
+In `config_screen.dart`, near `bool _globalPRDraft = false;` (line 635):
+
+```dart
+  bool _globalNeverApproveWithIssues = false;
+```
+
+In the same init method that sets `_globalPRDraft = config.globalPRDraft;` (line 644):
+
+```dart
+    _globalNeverApproveWithIssues = config.globalNeverApproveWithIssues;
+```
+
+- [ ] **Step 2: Add the SwitchListTile**
+
+Near the existing draft `SwitchListTile` (726-738), add (match the surrounding `Material`/wrapper the sibling switches use — see the commit that wrapped config switches in `Material`):
+
+```dart
+        SwitchListTile(
+          title: const Text('No aprobar PRs con issues'),
+          subtitle: const Text(
+            'Si la review encuentra issues (de cualquier severidad), se publica '
+            'como comentario en la PR en vez de una aprobación. Los casos que '
+            'bloquean (severidad alta) siguen siendo "cambios solicitados".',
+          ),
+          value: _globalNeverApproveWithIssues,
+          onChanged: (v) =>
+              setState(() => _globalNeverApproveWithIssues = v),
+        ),
+```
+
+- [ ] **Step 3: Include it in `_buildConfig`**
+
+In `_buildConfig` (947-959), add to the `base.copyWith(...)` call (after `globalPRDraft: _globalPRDraft,` ~line 955):
+
+```dart
+    globalNeverApproveWithIssues: _globalNeverApproveWithIssues,
+```
+
+- [ ] **Step 4: Add it to the global diff**
+
+In `config_providers.dart`, in `_computeGlobalDiff`, after the `generate_pr_description` block (149-151):
+
+```dart
+  if (old.globalNeverApproveWithIssues != updated.globalNeverApproveWithIssues) {
+    aiDiff['never_approve_with_issues'] = updated.globalNeverApproveWithIssues;
+  }
+```
+
+- [ ] **Step 5: Verify the app analyzes and tests pass**
+
+Run: `cd flutter_app && flutter analyze && flutter test`
+Expected: no analyzer errors; all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add flutter_app/lib/features/config/config_screen.dart flutter_app/lib/features/config/config_providers.dart
+git commit -m "feat(gui): global toggle for never_approve_with_issues"
+```
+
+---
+
+### Task 8: Per-repo override (repo detail screen)
+
+**Files:**
+- Modify: `flutter_app/lib/features/repositories/repo_detail_screen.dart` (`_computeRepoDiff` ~144-165; an `OverrideDropdown` near the `pr_draft` one 631-639; reset via `_resetField`)
+- Test: `flutter_app/test/features/config_test.dart` (or the repo-detail test file if one exists)
+
+**Interfaces:**
+- Consumes: `RepoConfig.neverApproveWithIssues`, `OrgConfig.neverApproveWithIssues`, `AppConfig.globalNeverApproveWithIssues` (Task 6).
+- Produces: PATCH `/config/repos/{repo}` body `{"never_approve_with_issues": <bool>}` when set; `DELETE /config/repos/{repo}/never_approve_with_issues` on reset.
+
+- [ ] **Step 1: Write the failing diff test**
+
+Append to `flutter_app/test/features/config_test.dart`:
+
+```dart
+test('repo diff includes never_approve_with_issues when set', () {
+  const oldCfg = RepoConfig();
+  final updated = oldCfg.copyWith(neverApproveWithIssues: true);
+  final diff = computeRepoDiff(oldCfg, updated); // expose the same fn used by the screen
+  expect(diff['never_approve_with_issues'], isTrue);
+});
+```
+
+> If `_computeRepoDiff` is private to the screen, either (a) lift it to a top-level `computeRepoDiff` in a small `repo_diff.dart` helper imported by the screen and the test, or (b) mirror the existing repo-detail test's approach for exercising the diff. Prefer (a) only if no test currently reaches `_computeRepoDiff`; otherwise follow the existing test pattern.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd flutter_app && flutter test test/features/config_test.dart --plain-name "repo diff includes never_approve_with_issues"`
+Expected: FAIL.
+
+- [ ] **Step 3: Add to `_computeRepoDiff`**
+
+In `repo_detail_screen.dart`, next to the `pr_draft` diff block (164-165):
+
+```dart
+    if (old.neverApproveWithIssues != updated.neverApproveWithIssues &&
+        updated.neverApproveWithIssues != null) {
+      diff['never_approve_with_issues'] = updated.neverApproveWithIssues!;
+    }
+```
+
+- [ ] **Step 4: Add the override control**
+
+Near the `pr_draft` `OverrideDropdown` (631-639), add (mirror it exactly, swapping field + reset key):
+
+```dart
+        OverrideDropdown(
+          label: 'No aprobar PRs con issues',
+          globalValue:
+              (orgConfig?.neverApproveWithIssues ??
+                      appConfig.globalNeverApproveWithIssues)
+                  .toString(),
+          inheritedLabel: source(orgConfig?.neverApproveWithIssues != null),
+          overrideValue: _config.neverApproveWithIssues?.toString(),
+          options: const ['true', 'false'],
+          onChanged: (v) => _update(
+            _config.copyWith(
+              neverApproveWithIssues: v != null ? v == 'true' : null,
+            ),
+          ),
+          onReset: () => _resetField('never_approve_with_issues'),
+        ),
+```
+
+> Match the exact named parameters of `OverrideDropdown` as used by the `pr_draft` instance in this file (label/globalValue/inheritedLabel/overrideValue/onChanged/onReset). If the constructor differs, copy the sibling verbatim and change only the field, label, and reset key.
+
+- [ ] **Step 5: Run tests + analyze**
+
+Run: `cd flutter_app && flutter analyze && flutter test`
+Expected: no analyzer errors; all tests PASS (including the new diff test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add flutter_app/lib/features/repositories/repo_detail_screen.dart flutter_app/test/features/config_test.dart
+git commit -m "feat(gui): per-repo override for never_approve_with_issues"
+```
+
+---
+
+### Task 9: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the whole daemon suite (with race)**
+
+Run: `cd daemon && make test-race`
+Expected: PASS.
+
+- [ ] **Step 2: Build the daemon binary**
+
+Run: `cd daemon && make build`
+Expected: `bin/heimdallm` builds without error.
+
+- [ ] **Step 3: Run the whole Flutter suite + analyzer**
+
+Run: `cd flutter_app && flutter analyze && flutter test`
+Expected: no analyzer errors; all tests PASS.
+
+- [ ] **Step 4: Manual end-to-end sanity (config round-trip)**
+
+With a scratch config, confirm the setting flows through the daemon:
+```bash
+cd daemon && make build
+# Point at a scratch config dir; enable per-repo override via PATCH and read it back.
+```
+Verify: GET `/config` shows `never_approve_with_issues`, PATCH `/config/repos/{repo}` persists it into `[ai.repos."…"]`, and DELETE removes it. (This is the same generic path exercised earlier when adding a repo to config.toml.)
+
+---
+
+## Notes for the implementer
+
+- The global write path is `PATCH /config` (generic TOML merge into `[ai]`), NOT `PUT /config` (which has an allow-list). Do not add the key to `validConfigKeys`/`ApplyStore` — that path is unused by the GUI for this family of settings and would be dead code.
+- `AIForRepo(repo).NeverApproveWithIssues` is always non-nil (global seeds it), but consumers should still nil-check defensively; `buildRunOpts` uses `!= nil && *ptr`.
+- `SeverityToEvent` is intentionally left unchanged and remains the single source for the base mapping; `ReviewEvent` only layers the downgrade on top.

--- a/docs/superpowers/specs/2026-07-06-never-approve-with-issues-design.md
+++ b/docs/superpowers/specs/2026-07-06-never-approve-with-issues-design.md
@@ -1,0 +1,176 @@
+# Diseño: "No aprobar PRs con issues" (never_approve_with_issues)
+
+- **Fecha:** 2026-07-06
+- **Estado:** Aprobado (diseño), pendiente de plan de implementación
+- **Autor:** jamuriano
+
+## Resumen
+
+Añadir un setting booleano, global y con override por org y por repo (jerarquía
+**repo > org > global**), que cuando resuelve a `true` cambia el veredicto de las
+reviews propias de la app: cualquier review que contenga issues deja de publicarse
+como **APPROVE** y pasa a publicarse como **COMMENT**. Las reviews limpias (sin
+issues) siguen aprobando, y los casos de severidad `high` siguen siendo
+**REQUEST_CHANGES**.
+
+Por defecto **OFF** a nivel global → cambio 100% backward-compatible.
+
+## Motivación
+
+Hoy la app aprueba PRs aunque haya encontrado issues de severidad `low`/`medium`.
+Algunos repos/equipos prefieren que la app **nunca** ponga un Approval cuando
+detectó algo que comentar, dejando la aprobación final a un humano. Este setting
+lo permite sin forzarlo globalmente.
+
+## Comportamiento (contrato)
+
+Con el setting resuelto a `true` para un repo, en el momento de decidir el evento
+de una review propia:
+
+| Situación | Hoy | Con setting ON |
+|---|---|---|
+| 0 issues | APPROVE | APPROVE (sin cambio) |
+| Issues presentes, severidad final `high` | REQUEST_CHANGES | REQUEST_CHANGES (sin cambio) |
+| Issues presentes, severidad final `low`/`medium`/vacía | **APPROVE** | **COMMENT** |
+
+Definición de "contiene issues": `len(ReviewResult.Issues) > 0`.
+
+Con el setting OFF (default), el comportamiento es idéntico al actual.
+
+## Estado actual del código (referencia)
+
+- Mapeo severidad → evento: `SeverityToEvent` en `daemon/internal/pipeline/pipeline.go:998-1007`
+  (`high → REQUEST_CHANGES`, resto → `APPROVE`; **no existe camino a `COMMENT`**).
+- Submit a GitHub: `Client.SubmitReview(repo, number, body, event)` en
+  `daemon/internal/github/client.go:464-503` — **ya acepta `COMMENT`**.
+- Callers de `SubmitReview(..., SeverityToEvent(...))`:
+  - Camino principal: `pipeline.go:644-648`.
+  - Reintento de publicación (`PublishPending`): `pipeline.go:776-780`.
+  - Camino en `main`: `daemon/cmd/heimdallm/main.go:1063-1066`.
+- Modelo persistido: `store.Review` en `daemon/internal/store/reviews.go:16`.
+  Migraciones de la tabla `reviews` = `ALTER TABLE reviews ADD COLUMN ...`
+  idempotentes en `daemon/internal/store/store.go:195-203`.
+- Precedente de setting global-con-override (bool tri-estado): `GeneratePRDescription`
+  — global `AIConfig` (`config.go:459`), `*bool` en `RepoAI` (`config.go:548`) y
+  `OrgAI` (`config.go:610`), resuelto por `AIForRepo`/`applyScopedAI`
+  (`config.go:746,796,819,894`).
+
+## Decisión de arquitectura: reintentos (Enfoque A)
+
+El nuevo veredicto depende de "¿hay issues?" además de la severidad. El `Review`
+persistido es la fuente de verdad para reproducir la decisión en reintentos sin
+re-analizar la PR. Por tanto:
+
+**Enfoque A (elegido): persistir el evento ya decidido.** El evento
+(`APPROVE`/`COMMENT`/`REQUEST_CHANGES`) se calcula una sola vez en el momento de la
+review resolviendo el setting del repo, y se guarda en el `Review`. Los reintentos
+publican exactamente lo decidido, aunque el setting cambie entremedias. Determinista
+y auditable.
+
+Descartado el Enfoque B (recalcular en cada publicación): un cambio de config entre
+el análisis y la publicación produciría un veredicto sorpresa.
+
+## Diseño detallado
+
+### 1. Config (Go) — `daemon/internal/config/config.go`
+
+Reutilizar la maquinaria de merge existente de `AIConfig`/`AIForRepo` (misma que
+`GeneratePRDescription`), en lugar de un resolver ad-hoc:
+
+- **Global:** nuevo campo `NeverApproveWithIssues bool` en `AIConfig`, TOML key
+  `never_approve_with_issues`. Default `false` (en `applyDefaults`; también en
+  `applyEnvOverrides` si se sigue el patrón de `GeneratePRDescription`, opcional).
+- **Override org:** `NeverApproveWithIssues *bool` en `OrgAI` (`toml:"...,omitempty"`;
+  `nil` = heredar).
+- **Override repo:** `NeverApproveWithIssues *bool` en `RepoAI` (`toml:"...,omitempty"`;
+  `nil` = heredar).
+- **Resolución:** extender `AIForRepo`/`applyScopedAI` para incluir el nuevo campo
+  (igual que `GeneratePRDescription`: string vacío no aplica; `*bool` no-nil gana).
+  El valor efectivo se lee como `cfg.AIForRepo(repo).NeverApproveWithIssues`.
+
+### 2. Pipeline — decisión y persistencia del evento
+
+- **Función pura nueva** en `pipeline.go`:
+  ```go
+  // ReviewEvent decides the GitHub review event, honoring the
+  // never-approve-with-issues setting. It builds on SeverityToEvent: when the
+  // base decision would be APPROVE, the setting is on, and the review found
+  // issues, it downgrades APPROVE to COMMENT. REQUEST_CHANGES is never altered.
+  func ReviewEvent(finalSeverity string, hasIssues bool, neverApproveWithIssues bool) string {
+      event := SeverityToEvent(finalSeverity)
+      if event == "APPROVE" && neverApproveWithIssues && hasIssues {
+          return "COMMENT"
+      }
+      return event
+  }
+  ```
+  `SeverityToEvent` se mantiene intacta como building block.
+
+- **`Review(...)`** (`pipeline.go`, tras calcular `finalSeverity` en `:600` y antes
+  del submit en `:644-648`): resolver el setting del repo y calcular
+  `event := ReviewEvent(finalSeverity, len(result.Issues) > 0, neverApprove)`.
+  Guardar el evento en el `Review` (`rev.Event = event`, ver §3) **antes** de
+  `InsertReview`, y pasar `event` a `SubmitReview` en lugar de
+  `SeverityToEvent(finalSeverity)`.
+
+- **`PublishPending`** (`pipeline.go:776-780`) y **`main.go:1063-1066`:** publicar
+  usando `rev.Event` persistido. Fallback para filas antiguas sin evento:
+  `if rev.Event == "" { event = SeverityToEvent(rev.Severity) }`. Esto respeta el
+  Enfoque A y no rompe reviews pendientes ya guardadas antes de la migración.
+
+### 3. Store — `daemon/internal/store/reviews.go` + `store.go`
+
+- Añadir campo `Event string` al struct `store.Review` (`json:"event"`).
+- Migración idempotente en `store.go` (junto a `:195-203`):
+  `db.Exec("ALTER TABLE reviews ADD COLUMN event TEXT NOT NULL DEFAULT ''")`.
+- Incluir `event` en el `INSERT` de `InsertReview` y en los `SELECT`/scan de las
+  lecturas (`GetLatestReview`, y la query de `PublishPending`), manteniendo el orden
+  de columnas coherente.
+
+### 4. GUI Flutter
+
+- **Modelo** `flutter_app/lib/core/models/config_model.dart`:
+  - `AppConfig`: `bool neverApproveWithIssues` (default `false`) + (de)serialización.
+  - `RepoConfig`: `bool? neverApproveWithIssues` (nullable = heredar) con centinela
+    en `copyWith` (igual que los demás overrides) + (de)serialización.
+  - `OrgConfig`: `bool? neverApproveWithIssues` + (de)serialización.
+- **Settings global** `flutter_app/lib/features/config/config_screen.dart`: un
+  `SwitchListTile` junto a los toggles de comportamiento de review; label
+  *"No aprobar PRs con issues"*, subtítulo *"Si la review encuentra issues (de
+  cualquier severidad), se publica como comentario en la PR en vez de una
+  aprobación."* Serializar en `_buildConfig` (`:1117`).
+- **Settings por-repo** `flutter_app/lib/features/repositories/repo_detail_screen.dart`:
+  control de override tri-estado reutilizando el patrón existente
+  (`feature_switch`/`OverrideDropdown` con badge "overridden" + reset vía
+  `deleteRepoField`), mostrando el valor heredado repo→org→global (p.ej.
+  `repoConfig?.neverApproveWithIssues ?? orgConfig?.neverApproveWithIssues ?? appConfig.neverApproveWithIssues`).
+- **PATCH parcial:** añadir la key al diff `_computeRepoDiff` (`:144`) y verificar
+  que el writer TOML parcial (`daemon/internal/config/writer.go`) la escribe/borra.
+
+## Tests
+
+### Go (unit)
+- `ReviewEvent`: tabla severidad × `hasIssues` × `flag`:
+  - flag off → idéntico a `SeverityToEvent` en todos los casos.
+  - flag on + `high` + issues → `REQUEST_CHANGES`.
+  - flag on + `low`/`medium`/`""` + issues → `COMMENT`.
+  - flag on + sin issues → `APPROVE`.
+- `AIForRepo`/`NeverApproveWithIssues`: merge tri-estado repo > org > global
+  (nil hereda; no-nil gana en cada nivel; combinaciones repo-nil/org-set, etc.).
+- Persistencia + reintento (Enfoque A): un `Review` con `Event="COMMENT"` se
+  republica como `COMMENT` aunque el flag se apague después; fila legacy con
+  `Event=""` cae al fallback `SeverityToEvent(Severity)`.
+- Round-trip del nuevo campo `event` en el store (insert → select).
+
+### Flutter
+- (De)serialización del nuevo campo en `AppConfig`, `RepoConfig`, `OrgConfig`
+  (incluyendo `null` = heredar en repo/org).
+- Diff PATCH del override por repo (set y reset/borrado).
+
+## Fuera de alcance (YAGNI)
+
+- No se añade granularidad por severidad (p.ej. "comentar solo si medium"): el
+  contrato es binario (hay issues / no hay issues).
+- No se modifica el comportamiento de `REQUEST_CHANGES`.
+- No se toca la clasificación de reviews de humanos externos
+  (`autonomous/review_class.go`, `issues/reviewstate.go`).

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -149,6 +149,7 @@ class RepoConfig {
   final String? prAssignee;
   final List<String>? prLabels;
   final bool? prDraft;
+  final bool? neverApproveWithIssues;
 
   const RepoConfig({
     this.prEnabled,
@@ -178,6 +179,7 @@ class RepoConfig {
     this.prAssignee,
     this.prLabels,
     this.prDraft,
+    this.neverApproveWithIssues,
     this.firstSeenAt,
   });
 
@@ -226,7 +228,8 @@ class RepoConfig {
       prReviewers != null ||
       prAssignee != null ||
       prLabels != null ||
-      prDraft != null;
+      prDraft != null ||
+      neverApproveWithIssues != null;
 
   /// LED status for each feature: 'off', 'global', 'repo'
   String prLedStatus(bool globalMonitored) {
@@ -285,6 +288,7 @@ class RepoConfig {
     Object? prAssignee = _sentinel,
     Object? prLabels = _sentinel,
     Object? prDraft = _sentinel,
+    Object? neverApproveWithIssues = _sentinel,
     Object? firstSeenAt = _sentinel,
   }) {
     return RepoConfig(
@@ -355,6 +359,9 @@ class RepoConfig {
           ? this.prLabels
           : prLabels as List<String>?,
       prDraft: prDraft == _sentinel ? this.prDraft : prDraft as bool?,
+      neverApproveWithIssues: neverApproveWithIssues == _sentinel
+          ? this.neverApproveWithIssues
+          : neverApproveWithIssues as bool?,
       firstSeenAt: firstSeenAt == _sentinel
           ? this.firstSeenAt
           : firstSeenAt as DateTime?,
@@ -390,6 +397,7 @@ class OrgConfig {
   final String? prAssignee;
   final List<String>? prLabels;
   final bool? prDraft;
+  final bool? neverApproveWithIssues;
 
   const OrgConfig({
     this.aiPrimary,
@@ -418,6 +426,7 @@ class OrgConfig {
     this.prAssignee,
     this.prLabels,
     this.prDraft,
+    this.neverApproveWithIssues,
   });
 
   bool get hasOverride =>
@@ -475,6 +484,7 @@ class OrgConfig {
     Object? prAssignee = _sentinel,
     Object? prLabels = _sentinel,
     Object? prDraft = _sentinel,
+    Object? neverApproveWithIssues = _sentinel,
   }) => OrgConfig(
     aiPrimary: aiPrimary == _sentinel ? this.aiPrimary : aiPrimary as String?,
     aiFallback: aiFallback == _sentinel
@@ -538,6 +548,9 @@ class OrgConfig {
         : prAssignee as String?,
     prLabels: prLabels == _sentinel ? this.prLabels : prLabels as List<String>?,
     prDraft: prDraft == _sentinel ? this.prDraft : prDraft as bool?,
+    neverApproveWithIssues: neverApproveWithIssues == _sentinel
+        ? this.neverApproveWithIssues
+        : neverApproveWithIssues as bool?,
   );
 
   factory OrgConfig.fromJson(Map<String, dynamic> json) {
@@ -597,6 +610,7 @@ class OrgConfig {
       prAssignee: _nonEmpty(json['pr_assignee']),
       prLabels: _nullableStringListAllowEmpty(json['pr_labels']),
       prDraft: json['pr_draft'] as bool?,
+      neverApproveWithIssues: json['never_approve_with_issues'] as bool?,
     );
   }
 }
@@ -736,6 +750,7 @@ class AppConfig {
   final bool? globalAutoPromoteTriage;
   final bool? globalAutoPromoteRefinement;
   final bool globalGeneratePRDescription;
+  final bool globalNeverApproveWithIssues;
 
   /// Host paths the daemon scans (in order) when a repo has no explicit
   /// `local_dir` set — first match at `{base}/{short-repo-name}` wins.
@@ -773,6 +788,7 @@ class AppConfig {
     this.globalAutoPromoteTriage,
     this.globalAutoPromoteRefinement,
     this.globalGeneratePRDescription = false,
+    this.globalNeverApproveWithIssues = false,
     this.localDirBase = const [],
     this.localDirsDetected = const {},
   });
@@ -847,6 +863,7 @@ class AppConfig {
     Object? globalAutoPromoteTriage = _sentinel,
     Object? globalAutoPromoteRefinement = _sentinel,
     bool? globalGeneratePRDescription,
+    bool? globalNeverApproveWithIssues,
     List<String>? localDirBase,
     Map<String, String>? localDirsDetected,
   }) {
@@ -879,6 +896,8 @@ class AppConfig {
           : globalAutoPromoteRefinement as bool?,
       globalGeneratePRDescription:
           globalGeneratePRDescription ?? this.globalGeneratePRDescription,
+      globalNeverApproveWithIssues:
+          globalNeverApproveWithIssues ?? this.globalNeverApproveWithIssues,
       localDirBase: localDirBase ?? this.localDirBase,
       localDirsDetected: localDirsDetected ?? this.localDirsDetected,
     );
@@ -899,6 +918,7 @@ class AppConfig {
     'auto_promote_triage': globalAutoPromoteTriage,
     'auto_promote_refinement': globalAutoPromoteRefinement,
     'generate_pr_description': globalGeneratePRDescription,
+    'never_approve_with_issues': globalNeverApproveWithIssues,
   };
 
   factory AppConfig.fromJson(Map<String, dynamic> json) {
@@ -989,6 +1009,7 @@ class AppConfig {
           prAssignee: _nonEmpty(ov['pr_assignee']),
           prLabels: _nullableStringListAllowEmpty(ov['pr_labels']),
           prDraft: ov['pr_draft'] as bool?,
+          neverApproveWithIssues: ov['never_approve_with_issues'] as bool?,
           firstSeenAt: firstSeen,
         );
       }
@@ -1061,6 +1082,8 @@ class AppConfig {
       globalAutoPromoteRefinement: json['auto_promote_refinement'] as bool?,
       globalGeneratePRDescription:
           (json['generate_pr_description'] as bool?) ?? false,
+      globalNeverApproveWithIssues:
+          (json['never_approve_with_issues'] as bool?) ?? false,
       localDirBase: _parseStringList(json['local_dir_base']),
       localDirsDetected: localDirsDetected,
     );

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -440,6 +440,7 @@ class OrgConfig {
       autoPromoteTriage != null ||
       autoPromoteRefinement != null ||
       generatePRDescription != null ||
+      neverApproveWithIssues != null ||
       issuePromptId != null ||
       developPromptId != null ||
       itEnabled != null ||

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -149,6 +149,9 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
   if (old.globalGeneratePRDescription != updated.globalGeneratePRDescription) {
     aiDiff['generate_pr_description'] = updated.globalGeneratePRDescription;
   }
+  if (old.globalNeverApproveWithIssues != updated.globalNeverApproveWithIssues) {
+    aiDiff['never_approve_with_issues'] = updated.globalNeverApproveWithIssues;
+  }
 
   // Agent configs — diff each CLI agent's settings individually.
   final agentsDiff = <String, dynamic>{};

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -633,6 +633,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   List<String> _globalPRLabels = [];
   String _globalPRAssignee = '';
   bool _globalPRDraft = false;
+  bool _globalNeverApproveWithIssues = false;
   bool _developInitialized = false;
 
   void _initDevelopFromConfig(AppConfig config) {
@@ -642,6 +643,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     _globalPRLabels = List.from(config.globalPRLabels);
     _globalPRAssignee = config.globalPRAssignee;
     _globalPRDraft = config.globalPRDraft;
+    _globalNeverApproveWithIssues = config.globalNeverApproveWithIssues;
   }
 
   Widget _developSection(AppConfig config) {
@@ -736,6 +738,33 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             contentPadding: EdgeInsets.zero,
             value: _globalPRDraft,
             onChanged: (v) => setState(() => _globalPRDraft = v),
+          ),
+        ),
+        const SizedBox(height: 10),
+        Container(
+          decoration: BoxDecoration(
+            color: Theme.of(
+              context,
+            ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+          child: SwitchListTile(
+            title: const Text(
+              'No aprobar PRs con issues',
+              style: TextStyle(fontSize: 11),
+            ),
+            subtitle: Text(
+              'Si la review encuentra issues (de cualquier severidad), se publica '
+              'como comentario en la PR en vez de una aprobación. Los casos que '
+              'bloquean (severidad alta) siguen siendo "cambios solicitados".',
+              style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+            ),
+            dense: true,
+            contentPadding: EdgeInsets.zero,
+            value: _globalNeverApproveWithIssues,
+            onChanged: (v) =>
+                setState(() => _globalNeverApproveWithIssues = v),
           ),
         ),
         const SizedBox(height: 10),
@@ -953,6 +982,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     globalPRLabels: _globalPRLabels,
     globalPRAssignee: _globalPRAssignee,
     globalPRDraft: _globalPRDraft,
+    globalNeverApproveWithIssues: _globalNeverApproveWithIssues,
     globalIssuePrompt: _issuePromptId ?? '',
     globalImplementPrompt: _developPromptId ?? '',
     // aiPrimary, aiFallback, reviewMode, agentConfigs managed in Agents tab

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -127,6 +127,10 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
     if (old.prDraft != updated.prDraft && updated.prDraft != null) {
       diff['pr_draft'] = updated.prDraft!;
     }
+    if (old.neverApproveWithIssues != updated.neverApproveWithIssues &&
+        updated.neverApproveWithIssues != null) {
+      diff['never_approve_with_issues'] = updated.neverApproveWithIssues!;
+    }
     if (!_listsEqual(old.prReviewers, updated.prReviewers)) {
       diff['pr_reviewers'] = updated.prReviewers ?? <String>[];
     }
@@ -251,6 +255,20 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                     options: promptOptions,
                     onChanged: (v) => _update(_config.copyWith(promptId: v)),
                     onReset: () => _resetField('prompt'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'No aprobar PRs con issues',
+                    globalValue: appConfig.globalNeverApproveWithIssues
+                        .toString(),
+                    overrideValue: _config.neverApproveWithIssues?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        neverApproveWithIssues: v != null ? v == 'true' : null,
+                      ),
+                    ),
+                    onReset: () => _resetField('never_approve_with_issues'),
                   ),
                 ], accent: FeaturePalette.prReview),
                 _sectionCard('Issue Tracking', [

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -256,7 +256,8 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                     onChanged: (v) => _update(_config.copyWith(promptId: v)),
                     onReset: () => _resetField('prompt'),
                   ),
-                  const SizedBox(height: 10),
+                ], accent: FeaturePalette.prReview),
+                _sectionCard('Organizations', [
                   OverrideDropdown(
                     label: 'No aprobar PRs con issues',
                     globalValue: appConfig.globalNeverApproveWithIssues
@@ -270,7 +271,7 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                     ),
                     onReset: () => _resetField('never_approve_with_issues'),
                   ),
-                ], accent: FeaturePalette.prReview),
+                ]),
                 _sectionCard('Issue Tracking', [
                   Row(
                     children: [

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -301,6 +301,28 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                   ),
                 ], accent: FeaturePalette.prReview),
 
+                // ── Section: Organizations (org-inherited review policy) ─
+                _sectionCard('Organizations', [
+                  OverrideDropdown(
+                    label: 'No aprobar PRs con issues',
+                    globalValue:
+                        (orgConfig?.neverApproveWithIssues ??
+                                appConfig.globalNeverApproveWithIssues)
+                            .toString(),
+                    inheritedLabel: source(
+                      orgConfig?.neverApproveWithIssues != null,
+                    ),
+                    overrideValue: _config.neverApproveWithIssues?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        neverApproveWithIssues: v != null ? v == 'true' : null,
+                      ),
+                    ),
+                    onReset: () => _resetField('never_approve_with_issues'),
+                  ),
+                ]),
+
                 // ── Section 3: Issue Tracking ──────────────────────────
                 _sectionCard('Issue Tracking', [
                   Row(
@@ -558,25 +580,6 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                       _config.copyWith(prDraft: v != null ? v == 'true' : null),
                     ),
                     onReset: () => _resetField('pr_draft'),
-                  ),
-                  const SizedBox(height: 10),
-                  OverrideDropdown(
-                    label: 'No aprobar PRs con issues',
-                    globalValue:
-                        (orgConfig?.neverApproveWithIssues ??
-                                appConfig.globalNeverApproveWithIssues)
-                            .toString(),
-                    inheritedLabel: source(
-                      orgConfig?.neverApproveWithIssues != null,
-                    ),
-                    overrideValue: _config.neverApproveWithIssues?.toString(),
-                    options: const ['true', 'false'],
-                    onChanged: (v) => _update(
-                      _config.copyWith(
-                        neverApproveWithIssues: v != null ? v == 'true' : null,
-                      ),
-                    ),
-                    onReset: () => _resetField('never_approve_with_issues'),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -12,6 +12,7 @@ import '../../shared/widgets/toast.dart';
 import '../agents/agents_screen.dart' show agentsProvider;
 import '../config/config_providers.dart';
 import '../dashboard/dashboard_providers.dart';
+import 'repo_diff.dart';
 import 'widgets/feature_palette.dart';
 import 'widgets/feature_switch.dart';
 
@@ -77,7 +78,7 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
   Future<void> _autoSave(RepoConfig previous) async {
     final api = ref.read(apiClientProvider);
     try {
-      final repoDiff = _computeRepoDiff(previous, _config);
+      final repoDiff = computeRepoDiff(previous, _config);
       Map<String, dynamic>? lastResponse;
       if (repoDiff.isNotEmpty) {
         lastResponse = await api.patchRepoConfig(widget.repoName, repoDiff);
@@ -139,86 +140,6 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
     } catch (e) {
       if (mounted) showToast(context, 'Error: $e', isError: true);
     }
-  }
-
-  Map<String, dynamic> _computeRepoDiff(RepoConfig old, RepoConfig updated) {
-    final diff = <String, dynamic>{};
-    if (old.aiPrimary != updated.aiPrimary) {
-      diff['primary'] = updated.aiPrimary ?? '';
-    }
-    if (old.aiFallback != updated.aiFallback) {
-      diff['fallback'] = updated.aiFallback ?? '';
-    }
-    if (old.reviewMode != updated.reviewMode) {
-      diff['review_mode'] = updated.reviewMode ?? '';
-    }
-    if (old.promptId != updated.promptId) {
-      diff['prompt'] = updated.promptId ?? '';
-    }
-    if (old.localDir != updated.localDir) {
-      diff['local_dir'] = updated.localDir ?? '';
-    }
-    if (old.prAssignee != updated.prAssignee) {
-      diff['pr_assignee'] = updated.prAssignee ?? '';
-    }
-    if (old.prDraft != updated.prDraft && updated.prDraft != null) {
-      diff['pr_draft'] = updated.prDraft!;
-    }
-    if (old.developPromptId != updated.developPromptId) {
-      diff['implement_prompt'] = updated.developPromptId ?? '';
-    }
-    if (old.issuePromptId != updated.issuePromptId) {
-      diff['issue_prompt'] = updated.issuePromptId ?? '';
-    }
-
-    if (!_listsEqual(old.prReviewers, updated.prReviewers)) {
-      diff['pr_reviewers'] = updated.prReviewers ?? <String>[];
-    }
-    if (!_listsEqual(old.prLabels, updated.prLabels)) {
-      diff['pr_labels'] = updated.prLabels ?? <String>[];
-    }
-
-    final itDiff = <String, dynamic>{};
-    if (old.itEnabled != updated.itEnabled && updated.itEnabled != null) {
-      itDiff['enabled'] = updated.itEnabled!;
-    }
-    if (old.devEnabled != updated.devEnabled && updated.devEnabled != null) {
-      itDiff['develop_enabled'] = updated.devEnabled!;
-    }
-    if (old.issueFilterMode != updated.issueFilterMode) {
-      itDiff['filter_mode'] = updated.issueFilterMode ?? '';
-    }
-    if (old.issueDefaultAction != updated.issueDefaultAction) {
-      itDiff['default_action'] = updated.issueDefaultAction ?? '';
-    }
-    if (!_listsEqual(old.reviewOnlyLabels, updated.reviewOnlyLabels)) {
-      itDiff['review_only_labels'] = updated.reviewOnlyLabels ?? <String>[];
-    }
-    if (!_listsEqual(old.refinementLabels, updated.refinementLabels)) {
-      itDiff['refinement_labels'] = updated.refinementLabels ?? <String>[];
-    }
-    if (!_listsEqual(old.skipLabels, updated.skipLabels)) {
-      itDiff['skip_labels'] = updated.skipLabels ?? <String>[];
-    }
-    if (!_listsEqual(old.developLabels, updated.developLabels)) {
-      itDiff['develop_labels'] = updated.developLabels ?? <String>[];
-    }
-    if (!_listsEqual(old.issueAssignees, updated.issueAssignees)) {
-      itDiff['assignees'] = updated.issueAssignees ?? <String>[];
-    }
-
-    if (itDiff.isNotEmpty) diff['issue_tracking'] = itDiff;
-    return diff;
-  }
-
-  bool _listsEqual(List<String>? a, List<String>? b) {
-    if (a == null && b == null) return true;
-    if (a == null || b == null) return false;
-    if (a.length != b.length) return false;
-    for (var i = 0; i < a.length; i++) {
-      if (a[i] != b[i]) return false;
-    }
-    return true;
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -637,6 +558,25 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                       _config.copyWith(prDraft: v != null ? v == 'true' : null),
                     ),
                     onReset: () => _resetField('pr_draft'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'No aprobar PRs con issues',
+                    globalValue:
+                        (orgConfig?.neverApproveWithIssues ??
+                                appConfig.globalNeverApproveWithIssues)
+                            .toString(),
+                    inheritedLabel: source(
+                      orgConfig?.neverApproveWithIssues != null,
+                    ),
+                    overrideValue: _config.neverApproveWithIssues?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        neverApproveWithIssues: v != null ? v == 'true' : null,
+                      ),
+                    ),
+                    onReset: () => _resetField('never_approve_with_issues'),
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(

--- a/flutter_app/lib/features/repositories/repo_diff.dart
+++ b/flutter_app/lib/features/repositories/repo_diff.dart
@@ -1,0 +1,90 @@
+import '../../core/models/config_model.dart';
+
+/// Computes the PATCH body diff between the previously-saved [old] repo
+/// config and the [updated] one currently held by the repo detail screen.
+///
+/// Lifted out of `RepoDetailScreen` (was `_computeRepoDiff`) so it can be
+/// unit-tested directly without needing to mount the widget.
+Map<String, dynamic> computeRepoDiff(RepoConfig old, RepoConfig updated) {
+  final diff = <String, dynamic>{};
+  if (old.aiPrimary != updated.aiPrimary) {
+    diff['primary'] = updated.aiPrimary ?? '';
+  }
+  if (old.aiFallback != updated.aiFallback) {
+    diff['fallback'] = updated.aiFallback ?? '';
+  }
+  if (old.reviewMode != updated.reviewMode) {
+    diff['review_mode'] = updated.reviewMode ?? '';
+  }
+  if (old.promptId != updated.promptId) {
+    diff['prompt'] = updated.promptId ?? '';
+  }
+  if (old.localDir != updated.localDir) {
+    diff['local_dir'] = updated.localDir ?? '';
+  }
+  if (old.prAssignee != updated.prAssignee) {
+    diff['pr_assignee'] = updated.prAssignee ?? '';
+  }
+  if (old.prDraft != updated.prDraft && updated.prDraft != null) {
+    diff['pr_draft'] = updated.prDraft!;
+  }
+  if (old.neverApproveWithIssues != updated.neverApproveWithIssues &&
+      updated.neverApproveWithIssues != null) {
+    diff['never_approve_with_issues'] = updated.neverApproveWithIssues!;
+  }
+  if (old.developPromptId != updated.developPromptId) {
+    diff['implement_prompt'] = updated.developPromptId ?? '';
+  }
+  if (old.issuePromptId != updated.issuePromptId) {
+    diff['issue_prompt'] = updated.issuePromptId ?? '';
+  }
+
+  if (!_listsEqual(old.prReviewers, updated.prReviewers)) {
+    diff['pr_reviewers'] = updated.prReviewers ?? <String>[];
+  }
+  if (!_listsEqual(old.prLabels, updated.prLabels)) {
+    diff['pr_labels'] = updated.prLabels ?? <String>[];
+  }
+
+  final itDiff = <String, dynamic>{};
+  if (old.itEnabled != updated.itEnabled && updated.itEnabled != null) {
+    itDiff['enabled'] = updated.itEnabled!;
+  }
+  if (old.devEnabled != updated.devEnabled && updated.devEnabled != null) {
+    itDiff['develop_enabled'] = updated.devEnabled!;
+  }
+  if (old.issueFilterMode != updated.issueFilterMode) {
+    itDiff['filter_mode'] = updated.issueFilterMode ?? '';
+  }
+  if (old.issueDefaultAction != updated.issueDefaultAction) {
+    itDiff['default_action'] = updated.issueDefaultAction ?? '';
+  }
+  if (!_listsEqual(old.reviewOnlyLabels, updated.reviewOnlyLabels)) {
+    itDiff['review_only_labels'] = updated.reviewOnlyLabels ?? <String>[];
+  }
+  if (!_listsEqual(old.refinementLabels, updated.refinementLabels)) {
+    itDiff['refinement_labels'] = updated.refinementLabels ?? <String>[];
+  }
+  if (!_listsEqual(old.skipLabels, updated.skipLabels)) {
+    itDiff['skip_labels'] = updated.skipLabels ?? <String>[];
+  }
+  if (!_listsEqual(old.developLabels, updated.developLabels)) {
+    itDiff['develop_labels'] = updated.developLabels ?? <String>[];
+  }
+  if (!_listsEqual(old.issueAssignees, updated.issueAssignees)) {
+    itDiff['assignees'] = updated.issueAssignees ?? <String>[];
+  }
+
+  if (itDiff.isNotEmpty) diff['issue_tracking'] = itDiff;
+  return diff;
+}
+
+bool _listsEqual(List<String>? a, List<String>? b) {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -11,6 +11,7 @@ import 'package:heimdallm/core/setup/first_run_setup.dart';
 import 'package:heimdallm/features/config/config_providers.dart';
 import 'package:heimdallm/features/config/config_screen.dart';
 import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
+import 'package:heimdallm/features/repositories/repo_diff.dart';
 import '../core/platform/fake_platform_services.dart';
 
 class MockApiClient extends Mock implements ApiClient {}
@@ -547,5 +548,12 @@ void main() {
   test('OrgConfig.hasOverride true when only never_approve_with_issues set', () {
     const org = OrgConfig(neverApproveWithIssues: true);
     expect(org.hasOverride, isTrue);
+  });
+
+  test('repo diff includes never_approve_with_issues when set', () {
+    const oldCfg = RepoConfig();
+    final updated = oldCfg.copyWith(neverApproveWithIssues: true);
+    final diff = computeRepoDiff(oldCfg, updated);
+    expect(diff['never_approve_with_issues'], isTrue);
   });
 }

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -521,4 +521,26 @@ void main() {
       expect(platform.spawnedDaemons, contains('/fake/bin/heimdalld'));
     },
   );
+
+  test('never_approve_with_issues round-trips (global + repo override)', () {
+    final json = {
+      'never_approve_with_issues': true,
+      'repositories': <String>[],
+      'repo_overrides': {
+        'org/repo1': {'never_approve_with_issues': false},
+      },
+    };
+    final cfg = AppConfig.fromJson(json);
+    expect(cfg.globalNeverApproveWithIssues, isTrue);
+    expect(cfg.repoConfigs['org/repo1']!.neverApproveWithIssues, isFalse);
+
+    // Global survives toJson round-trip.
+    expect(cfg.toJson()['never_approve_with_issues'], isTrue);
+
+    // copyWith sentinel: repo override can be cleared to inherit (null).
+    final cleared = cfg.repoConfigs['org/repo1']!.copyWith(
+      neverApproveWithIssues: null,
+    );
+    expect(cleared.neverApproveWithIssues, isNull);
+  });
 }

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -543,4 +543,9 @@ void main() {
     );
     expect(cleared.neverApproveWithIssues, isNull);
   });
+
+  test('OrgConfig.hasOverride true when only never_approve_with_issues set', () {
+    const org = OrgConfig(neverApproveWithIssues: true);
+    expect(org.hasOverride, isTrue);
+  });
 }

--- a/flutter_app/test/features/organizations/org_detail_screen_test.dart
+++ b/flutter_app/test/features/organizations/org_detail_screen_test.dart
@@ -36,6 +36,7 @@ void main() {
             'auto_promote_triage': true,
             'auto_promote_refinement': true,
             'generate_pr_description': true,
+            'never_approve_with_issues': true,
             'issue_tracking': {
               'organizations': ['acme'],
               'assignees': ['alice'],
@@ -64,6 +65,7 @@ void main() {
     expect(find.text('Auto-promote refinement'), findsOneWidget);
     expect(find.text('Refinement labels'), findsOneWidget);
     expect(find.text('Generate PR description'), findsOneWidget);
+    expect(find.text('No aprobar PRs con issues'), findsOneWidget);
     expect(find.text('Organizations'), findsOneWidget);
     expect(find.text('Assignees'), findsOneWidget);
   });

--- a/flutter_app/test/features/organizations/org_detail_screen_test.dart
+++ b/flutter_app/test/features/organizations/org_detail_screen_test.dart
@@ -66,7 +66,9 @@ void main() {
     expect(find.text('Refinement labels'), findsOneWidget);
     expect(find.text('Generate PR description'), findsOneWidget);
     expect(find.text('No aprobar PRs con issues'), findsOneWidget);
-    expect(find.text('Organizations'), findsOneWidget);
+    // "Organizations" now names both the new review-policy section header and
+    // the Issue Tracking org filter; target the filter by its unique helper.
+    expect(find.text('GitHub org names to filter issues'), findsOneWidget);
     expect(find.text('Assignees'), findsOneWidget);
   });
 }

--- a/flutter_app/test/features/repositories/repo_detail_screen_test.dart
+++ b/flutter_app/test/features/repositories/repo_detail_screen_test.dart
@@ -49,8 +49,14 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Regression guard: Organizations field must not appear at repo scope.
-    expect(find.text('Organizations'), findsNothing);
+    // Regression guard: the Issue Tracking "Organizations" filter field must
+    // not appear at repo scope (it is a global/org-only filter). Target its
+    // unique helper text so the guard is not confused by the unrelated
+    // "Organizations" review-policy section header on this screen.
+    expect(
+      find.textContaining('Limit to issues from these orgs'),
+      findsNothing,
+    );
 
     // Sanity: surrounding Issue Tracking fields still render.
     expect(find.text('Review-only labels'), findsOneWidget);


### PR DESCRIPTION
## Qué

Añade un ajuste **`never_approve_with_issues`**: global, con override por **org** y por **repo** (jerarquía `repo > org > global`), **editable a los tres niveles desde la GUI**. Cuando resuelve a `true`, una review propia que contenga **cualquier issue** (`len(issues) > 0`) se publica como **`COMMENT`** en GitHub en vez de **`APPROVE`**.

| Situación | Antes | Con el ajuste ON |
|---|---|---|
| 0 issues | APPROVE | APPROVE (sin cambio) |
| Issues, severidad final `high` | REQUEST_CHANGES | REQUEST_CHANGES (sin cambio) |
| Issues, severidad `low`/`medium`/vacía | **APPROVE** | **COMMENT** |

Por defecto **OFF** a nivel global → 100% backward-compatible.

## Por qué

Algunos repos/equipos prefieren que la app **nunca** ponga un Approval cuando encontró algo que comentar, dejando la aprobación final a un humano — sin forzarlo globalmente.

## Cómo

- **Config** (`daemon/internal/config`): `AIConfig.NeverApproveWithIssues bool` (global) + `*bool` en `RepoAI`/`OrgAI`, resuelto por `AIForRepo`/`applyScopedAI` (mismo patrón que `generate_pr_description`).
- **Decisión** (`daemon/internal/pipeline`): nueva función pura `ReviewEvent(finalSeverity, hasIssues, flag)` sobre `SeverityToEvent` (intacta). `REQUEST_CHANGES` nunca se altera.
- **Persistencia** (`daemon/internal/store`): nueva columna `event` en `reviews` (migración idempotente + esquema fresco). El evento decidido se guarda una vez y los reintentos (`PublishPending`) lo reproducen vía `publishEventFor(rev)`, con fallback `SeverityToEvent(Severity)` para filas legacy.
- **API HTTP**: expuesto en `GET /config` (global) y en `repo_overrides`/`org_overrides`. Escrituras por las rutas `PATCH` genéricas existentes (sin tocar `validConfigKeys`/PUT).
- **GUI Flutter**: campo en el modelo (`AppConfig`/`RepoConfig`/`OrgConfig`), toggle global en settings, control de override por **repo** (sección propia "Organizations" en el detalle de repo) y por **org** (sección "PR Review" del detalle de org).

## Boy Scout

- **Fix de test flaky preexistente** (`internal/executor.TestDetect_Fallback`): el probe de CLI por login-shell (`zsh -l which`) sorteaba el `$PATH` aislado del test (sourcing del perfil del usuario), así que un `codex` real en la máquina hacía fallar el test. Extraído el probe a una var de paquete con costura `export_test.go` (comportamiento de producción intacto), test hecho hermético, y los tres tests con `PATH` antepuesto migrados al idioma `t.Setenv(PATH, binDir)` del propio archivo.

## Tests

- **Daemon**: `ReviewEvent` (tabla severidad × hasIssues × flag), merge repo>org>global, round-trip de `event`, persistencia+reintento, contrato del override map en la API. `make build` OK; **suite completa verde** (incluido el executor tras el fix).
- **Flutter**: (de)serialización en los 3 modelos, `copyWith` con centinela, `OrgConfig.hasOverride`, diff PATCH del override por repo, y render del control a nivel org. `flutter analyze` limpio, **192/192**.

## Plan de implementación

Ejecutado task-by-task con TDD y revisión por tarea + revisión final de rama. Diseño y plan en `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
