### PR TITLE
feat(gui): unified config — Settings/Organizations/Repos parity + first-class Organizations tab

### DIFF
--- a/flutter_app/lib/features/cli_agents/cli_agents_screen.dart
+++ b/flutter_app/lib/features/cli_agents/cli_agents_screen.dart
@@ -16,11 +16,6 @@ class CLIAgentsScreen extends ConsumerStatefulWidget {
 }
 
 class _CLIAgentsScreenState extends ConsumerState<CLIAgentsScreen> {
-  // Global
-  String _aiPrimary = 'claude';
-  String _aiFallback = '';
-  String _reviewMode = 'single';
-
   // Per-agent — keys match _cliNames
   final Map<String, _AgentState> _agents = {
     for (final n in _cliNames) n: _AgentState(),
@@ -42,9 +37,6 @@ class _CLIAgentsScreenState extends ConsumerState<CLIAgentsScreen> {
   void _initFrom(AppConfig config) {
     if (_initialized) return;
     _initialized = true;
-    _aiPrimary  = config.aiPrimary;
-    _aiFallback = config.aiFallback;
-    _reviewMode = config.reviewMode;
     for (final name in _cliNames) {
       final ac = config.agentConfigs[name] ?? const CLIAgentConfig();
       _agents[name] = _AgentState.from(ac);
@@ -70,9 +62,6 @@ class _CLIAgentsScreenState extends ConsumerState<CLIAgentsScreen> {
         name: _agents[name]!.toConfig(),
     };
     final updated = current.copyWith(
-      aiPrimary:    _aiPrimary,
-      aiFallback:   _aiFallback,
-      reviewMode:   _reviewMode,
       agentConfigs: agentConfigs,
     );
     try {
@@ -106,49 +95,6 @@ class _CLIAgentsScreenState extends ConsumerState<CLIAgentsScreen> {
               child: ListView(
                 padding: const EdgeInsets.all(16),
                 children: [
-                  // ── Global ──────────────────────────────────────────────
-                  _sectionHeader('Global defaults'),
-                  const SizedBox(height: 12),
-                  Row(children: [
-                    Expanded(child: _dropdown(
-                      label: 'Primary agent',
-                      value: _aiPrimary,
-                      items: _cliNames,
-                      onChanged: (v) { setState(() => _aiPrimary = v!); _markDirty(); },
-                    )),
-                    const SizedBox(width: 12),
-                    Expanded(child: DropdownButtonFormField<String?>(
-                      // ignore: deprecated_member_use
-                      value: _aiFallback.isEmpty ? null : _aiFallback,
-                      decoration: const InputDecoration(
-                        labelText: 'Fallback agent',
-                        border: OutlineInputBorder(),
-                      ),
-                      items: [
-                        const DropdownMenuItem<String?>(value: null, child: Text('None')),
-                        ..._cliNames.map((v) => DropdownMenuItem<String?>(
-                          value: v, child: Text(v))),
-                      ],
-                      onChanged: (v) { setState(() => _aiFallback = v ?? ''); _markDirty(); },
-                    )),
-                    const SizedBox(width: 12),
-                    Expanded(child: DropdownButtonFormField<String>(
-                      // ignore: deprecated_member_use
-                      value: _reviewMode,
-                      decoration: const InputDecoration(
-                        labelText: 'Feedback mode',
-                        border: OutlineInputBorder(),
-                      ),
-                      items: const [
-                        DropdownMenuItem(value: 'single', child: Text('Single (consolidated)')),
-                        DropdownMenuItem(value: 'multi',  child: Text('Multi (per issue)')),
-                      ],
-                      onChanged: (v) { setState(() => _reviewMode = v!); _markDirty(); },
-                    )),
-                  ]),
-                  const SizedBox(height: 24),
-                  const Divider(),
-
                   // ── Per-agent sections ───────────────────────────────────
                   for (final name in _cliNames) ...[
                     const SizedBox(height: 16),
@@ -186,23 +132,6 @@ class _CLIAgentsScreenState extends ConsumerState<CLIAgentsScreen> {
     );
   }
 
-  Widget _sectionHeader(String title) => Text(
-    title,
-    style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
-  );
-
-  Widget _dropdown({
-    required String label,
-    required String value,
-    required List<String> items,
-    required ValueChanged<String?> onChanged,
-  }) => DropdownButtonFormField<String>(
-    // ignore: deprecated_member_use
-    value: value,
-    decoration: InputDecoration(labelText: label, border: const OutlineInputBorder()),
-    items: items.map((v) => DropdownMenuItem(value: v, child: Text(v))).toList(),
-    onChanged: onChanged,
-  );
 }
 
 // ── Per-agent editable state ────────────────────────────────────────────────

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -248,6 +248,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             const SizedBox(height: 20),
             _retentionSection(),
             const SizedBox(height: 20),
+            _aiSection(config),
+            const SizedBox(height: 20),
             _issueTrackingSection(config),
             const SizedBox(height: 20),
             _pipelineSection(config),
@@ -642,6 +644,66 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   bool _globalAutoPromoteRefinement = false;
   bool _globalGeneratePRDescription = false;
   bool _developInitialized = false;
+
+  String _aiPrimary = 'claude';
+  String _aiFallback = '';
+  String _reviewMode = 'single';
+  bool _aiInitialized = false;
+
+  void _initAiFromConfig(AppConfig config) {
+    if (_aiInitialized) return;
+    _aiInitialized = true;
+    _aiPrimary = config.aiPrimary.isEmpty ? 'claude' : config.aiPrimary;
+    _aiFallback = config.aiFallback;
+    _reviewMode = config.reviewMode.isEmpty ? 'single' : config.reviewMode;
+  }
+
+  Widget _aiSection(AppConfig config) {
+    _initAiFromConfig(config);
+    return _settingsCard('AI defaults', [
+      DropdownButtonFormField<String>(
+        initialValue: _aiPrimary,
+        decoration: const InputDecoration(
+          labelText: 'Primary agent',
+          border: OutlineInputBorder(),
+          isDense: true,
+        ),
+        items: const ['claude', 'gemini', 'codex']
+            .map((v) => DropdownMenuItem(value: v, child: Text(v)))
+            .toList(),
+        onChanged: (v) => setState(() => _aiPrimary = v ?? 'claude'),
+      ),
+      const SizedBox(height: 12),
+      DropdownButtonFormField<String>(
+        initialValue: _aiFallback.isEmpty ? 'none' : _aiFallback,
+        decoration: const InputDecoration(
+          labelText: 'Fallback agent',
+          border: OutlineInputBorder(),
+          isDense: true,
+        ),
+        items: const ['none', 'claude', 'gemini', 'codex']
+            .map((v) => DropdownMenuItem(value: v, child: Text(v)))
+            .toList(),
+        onChanged: (v) =>
+            setState(() => _aiFallback = (v == null || v == 'none') ? '' : v),
+      ),
+      const SizedBox(height: 12),
+      DropdownButtonFormField<String>(
+        initialValue: _reviewMode,
+        decoration: const InputDecoration(
+          labelText: 'Feedback mode',
+          helperText:
+              'single = one consolidated review; multi = one comment per issue',
+          border: OutlineInputBorder(),
+          isDense: true,
+        ),
+        items: const ['single', 'multi']
+            .map((v) => DropdownMenuItem(value: v, child: Text(v)))
+            .toList(),
+        onChanged: (v) => setState(() => _reviewMode = v ?? 'single'),
+      ),
+    ]);
+  }
 
   void _initDevelopFromConfig(AppConfig config) {
     if (_developInitialized) return;
@@ -1076,7 +1138,10 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     globalGeneratePRDescription: _globalGeneratePRDescription,
     globalIssuePrompt: _issuePromptId ?? '',
     globalImplementPrompt: _developPromptId ?? '',
-    // aiPrimary, aiFallback, reviewMode, agentConfigs managed in Agents tab
+    aiPrimary: _aiPrimary,
+    aiFallback: _aiFallback,
+    reviewMode: _reviewMode,
+    // agentConfigs (per-CLI) managed in Agents tab
   );
 
   // ── Helpers ──────────────────────────────────────────────────────────────

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -250,6 +250,8 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             const SizedBox(height: 20),
             _issueTrackingSection(config),
             const SizedBox(height: 20),
+            _pipelineSection(config),
+            const SizedBox(height: 20),
             _developSection(config),
             const SizedBox(height: 28),
             _saveButton(context, config, daemonRunning),
@@ -634,6 +636,11 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   String _globalPRAssignee = '';
   bool _globalPRDraft = false;
   bool _globalNeverApproveWithIssues = false;
+  String _globalTriageOwner = '';
+  String _globalCloneDir = '';
+  bool _globalAutoPromoteTriage = false;
+  bool _globalAutoPromoteRefinement = false;
+  bool _globalGeneratePRDescription = false;
   bool _developInitialized = false;
 
   void _initDevelopFromConfig(AppConfig config) {
@@ -644,6 +651,85 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     _globalPRAssignee = config.globalPRAssignee;
     _globalPRDraft = config.globalPRDraft;
     _globalNeverApproveWithIssues = config.globalNeverApproveWithIssues;
+    _globalTriageOwner = config.globalTriageOwner;
+    _globalCloneDir = config.globalCloneDir;
+    _globalAutoPromoteTriage = config.globalAutoPromoteTriage ?? false;
+    _globalAutoPromoteRefinement = config.globalAutoPromoteRefinement ?? false;
+    _globalGeneratePRDescription = config.globalGeneratePRDescription;
+  }
+
+  Widget _globalSwitchTile(
+    String title,
+    String subtitle,
+    bool value,
+    ValueChanged<bool> onChanged,
+  ) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(
+          context,
+        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+      child: SwitchListTile(
+        title: Text(title, style: const TextStyle(fontSize: 11)),
+        subtitle: Text(
+          subtitle,
+          style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+        ),
+        dense: true,
+        contentPadding: EdgeInsets.zero,
+        value: value,
+        onChanged: (v) => setState(() => onChanged(v)),
+      ),
+    );
+  }
+
+  Widget _pipelineSection(AppConfig config) {
+    _initDevelopFromConfig(config);
+    return _settingsCard('Pipeline', [
+      TextFormField(
+        initialValue: _globalTriageOwner,
+        decoration: const InputDecoration(
+          labelText: 'Triage owner',
+          hintText: 'GitHub username that owns triaged issues',
+          isDense: true,
+        ),
+        onChanged: (v) => _globalTriageOwner = v.trim(),
+      ),
+      const SizedBox(height: 12),
+      TextFormField(
+        initialValue: _globalCloneDir,
+        decoration: const InputDecoration(
+          labelText: 'Clone directory',
+          hintText: 'Base directory for managed repo clones',
+          isDense: true,
+        ),
+        onChanged: (v) => _globalCloneDir = v.trim(),
+      ),
+      const SizedBox(height: 12),
+      _globalSwitchTile(
+        'Auto-promote triage',
+        'Promote triaged issues to refinement automatically',
+        _globalAutoPromoteTriage,
+        (v) => _globalAutoPromoteTriage = v,
+      ),
+      const SizedBox(height: 10),
+      _globalSwitchTile(
+        'Auto-promote refinement',
+        'Promote refined issues to develop automatically',
+        _globalAutoPromoteRefinement,
+        (v) => _globalAutoPromoteRefinement = v,
+      ),
+      const SizedBox(height: 10),
+      _globalSwitchTile(
+        'Generate PR description',
+        'Use an LLM to generate PR titles and descriptions for auto_implement PRs',
+        _globalGeneratePRDescription,
+        (v) => _globalGeneratePRDescription = v,
+      ),
+    ]);
   }
 
   Widget _developSection(AppConfig config) {
@@ -983,6 +1069,11 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     globalPRAssignee: _globalPRAssignee,
     globalPRDraft: _globalPRDraft,
     globalNeverApproveWithIssues: _globalNeverApproveWithIssues,
+    globalTriageOwner: _globalTriageOwner,
+    globalCloneDir: _globalCloneDir,
+    globalAutoPromoteTriage: _globalAutoPromoteTriage,
+    globalAutoPromoteRefinement: _globalAutoPromoteRefinement,
+    globalGeneratePRDescription: _globalGeneratePRDescription,
     globalIssuePrompt: _issuePromptId ?? '',
     globalImplementPrompt: _developPromptId ?? '',
     // aiPrimary, aiFallback, reviewMode, agentConfigs managed in Agents tab

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -660,6 +660,10 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
 
   Widget _aiSection(AppConfig config) {
     _initAiFromConfig(config);
+    // never_approve lives here but is initialized by _initDevelopFromConfig,
+    // which otherwise only runs in the later Pipeline/Develop sections — call
+    // it now (idempotent) so the switch shows the real value on the first frame.
+    _initDevelopFromConfig(config);
     return _settingsCard('AI defaults', [
       DropdownButtonFormField<String>(
         initialValue: _aiPrimary,
@@ -704,9 +708,9 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       ),
       const SizedBox(height: 12),
       _globalSwitchTile(
-        'No aprobar PRs con issues',
-        'Si la review encuentra issues, se publica como comentario en la PR en '
-            'vez de una aprobación (severidad alta sigue siendo cambios solicitados)',
+        'Never approve PRs with issues',
+        "If the review finds any issue, it's posted as a comment on the PR "
+            'instead of an approval (high severity still requests changes)',
         _globalNeverApproveWithIssues,
         (v) => _globalNeverApproveWithIssues = v,
       ),
@@ -734,14 +738,14 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     bool value,
     ValueChanged<bool> onChanged,
   ) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(
-          context,
-        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+    // Material (not a colored DecoratedBox) so the SwitchListTile's ink/bg
+    // paints on it — a colored Container here throws a ListTile assertion in
+    // widget tests (see theburrowhub/heimdallm c1eb4e7).
+    return Material(
+      color: Theme.of(
+        context,
+      ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+      borderRadius: BorderRadius.circular(6),
       child: SwitchListTile(
         title: Text(title, style: const TextStyle(fontSize: 11)),
         subtitle: Text(
@@ -749,7 +753,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
         ),
         dense: true,
-        contentPadding: EdgeInsets.zero,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
         value: value,
         onChanged: (v) => setState(() => onChanged(v)),
       ),
@@ -873,28 +877,11 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
           }),
         ),
         const SizedBox(height: 10),
-        Container(
-          decoration: BoxDecoration(
-            color: Theme.of(
-              context,
-            ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
-            borderRadius: BorderRadius.circular(6),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
-          child: SwitchListTile(
-            title: const Text(
-              'Create as draft',
-              style: TextStyle(fontSize: 11),
-            ),
-            subtitle: Text(
-              'PRs are created as drafts by default',
-              style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
-            ),
-            dense: true,
-            contentPadding: EdgeInsets.zero,
-            value: _globalPRDraft,
-            onChanged: (v) => setState(() => _globalPRDraft = v),
-          ),
+        _globalSwitchTile(
+          'Create as draft',
+          'PRs are created as drafts by default',
+          _globalPRDraft,
+          (v) => _globalPRDraft = v,
         ),
         const SizedBox(height: 10),
         _agentDropdown(

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -702,6 +702,14 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             .toList(),
         onChanged: (v) => setState(() => _reviewMode = v ?? 'single'),
       ),
+      const SizedBox(height: 12),
+      _globalSwitchTile(
+        'No aprobar PRs con issues',
+        'Si la review encuentra issues, se publica como comentario en la PR en '
+            'vez de una aprobación (severidad alta sigue siendo cambios solicitados)',
+        _globalNeverApproveWithIssues,
+        (v) => _globalNeverApproveWithIssues = v,
+      ),
     ]);
   }
 
@@ -886,33 +894,6 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
             contentPadding: EdgeInsets.zero,
             value: _globalPRDraft,
             onChanged: (v) => setState(() => _globalPRDraft = v),
-          ),
-        ),
-        const SizedBox(height: 10),
-        Container(
-          decoration: BoxDecoration(
-            color: Theme.of(
-              context,
-            ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
-            borderRadius: BorderRadius.circular(6),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
-          child: SwitchListTile(
-            title: const Text(
-              'No aprobar PRs con issues',
-              style: TextStyle(fontSize: 11),
-            ),
-            subtitle: Text(
-              'Si la review encuentra issues (de cualquier severidad), se publica '
-              'como comentario en la PR en vez de una aprobación. Los casos que '
-              'bloquean (severidad alta) siguen siendo "cambios solicitados".',
-              style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
-            ),
-            dense: true,
-            contentPadding: EdgeInsets.zero,
-            value: _globalNeverApproveWithIssues,
-            onChanged: (v) =>
-                setState(() => _globalNeverApproveWithIssues = v),
           ),
         ),
         const SizedBox(height: 10),

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -19,6 +19,7 @@ import '../cli_agents/cli_agents_screen.dart';
 import '../config/config_providers.dart';
 import '../issues/issues_providers.dart';
 import '../repositories/repos_screen.dart';
+import '../organizations/orgs_screen.dart';
 import '../stats/stats_screen.dart';
 import 'activity_filter_bar.dart';
 import 'activity_filters.dart';
@@ -37,7 +38,7 @@ class DashboardScreen extends ConsumerWidget {
         ? ref.watch(daemonConnectionProvider)
         : null;
     return DefaultTabController(
-      length: 6,
+      length: 7,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Heimdallm'),
@@ -86,6 +87,7 @@ class DashboardScreen extends ConsumerWidget {
               Tab(icon: Icon(Icons.dashboard), text: 'Activity'),
               Tab(icon: Icon(Icons.timeline), text: 'Activity log'),
               Tab(icon: Icon(Icons.folder_outlined), text: 'Repositories'),
+              Tab(icon: Icon(Icons.business_outlined), text: 'Organizations'),
               Tab(icon: Icon(Icons.auto_awesome), text: 'Prompts'),
               Tab(icon: Icon(Icons.smart_toy), text: 'Agents'),
               Tab(icon: Icon(Icons.bar_chart), text: 'Stats'),
@@ -112,6 +114,7 @@ class DashboardScreen extends ConsumerWidget {
                   KeepAliveTab(child: _ActivityTab()),
                   KeepAliveTab(child: ActivityScreen()),
                   KeepAliveTab(child: ReposScreen()),
+                  KeepAliveTab(child: OrgsScreen()),
                   KeepAliveTab(child: AgentsScreen()),
                   KeepAliveTab(child: CLIAgentsScreen()),
                   KeepAliveTab(child: StatsScreen()),

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -258,7 +258,7 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
-                    label: 'No aprobar PRs con issues',
+                    label: 'Never approve PRs with issues',
                     globalValue: appConfig.globalNeverApproveWithIssues
                         .toString(),
                     overrideValue: _config.neverApproveWithIssues?.toString(),

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -256,8 +256,7 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                     onChanged: (v) => _update(_config.copyWith(promptId: v)),
                     onReset: () => _resetField('prompt'),
                   ),
-                ], accent: FeaturePalette.prReview),
-                _sectionCard('Organizations', [
+                  const SizedBox(height: 10),
                   OverrideDropdown(
                     label: 'No aprobar PRs con issues',
                     globalValue: appConfig.globalNeverApproveWithIssues
@@ -271,7 +270,7 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                     ),
                     onReset: () => _resetField('never_approve_with_issues'),
                   ),
-                ]),
+                ], accent: FeaturePalette.prReview),
                 _sectionCard('Issue Tracking', [
                   Row(
                     children: [

--- a/flutter_app/lib/features/organizations/orgs_screen.dart
+++ b/flutter_app/lib/features/organizations/orgs_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../config/config_providers.dart';
+
+/// First-class Organizations list (top-level tab). Each entry opens the
+/// organization's config (OrgDetailScreen), where every option overrides the
+/// global default and is in turn overridable per-repo.
+class OrgsScreen extends ConsumerWidget {
+  const OrgsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final configAsync = ref.watch(configNotifierProvider);
+    return configAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('Could not load config: $e')),
+      data: (config) {
+        final orgs = config.knownOrganizations;
+        if (orgs.isEmpty) {
+          return const Center(
+            child: Padding(
+              padding: EdgeInsets.all(24),
+              child: Text(
+                'No organizations yet — they appear automatically from your '
+                'monitored repositories.',
+                textAlign: TextAlign.center,
+              ),
+            ),
+          );
+        }
+        return ListView.separated(
+          padding: const EdgeInsets.all(12),
+          itemCount: orgs.length,
+          separatorBuilder: (_, _) => const SizedBox(height: 4),
+          itemBuilder: (context, i) {
+            final org = orgs[i];
+            final overridden = config.orgConfigs[org]?.hasOverride ?? false;
+            return Card(
+              margin: EdgeInsets.zero,
+              child: ListTile(
+                leading: const Icon(Icons.business_outlined),
+                title: Text(org),
+                subtitle: Text(
+                  overridden
+                      ? 'Custom overrides on global defaults'
+                      : 'Inherits global defaults',
+                  style: const TextStyle(fontSize: 12),
+                ),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => context.push('/orgs/${Uri.encodeComponent(org)}'),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -301,7 +301,7 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                   ),
                   const SizedBox(height: 10),
                   OverrideDropdown(
-                    label: 'No aprobar PRs con issues',
+                    label: 'Never approve PRs with issues',
                     globalValue:
                         (orgConfig?.neverApproveWithIssues ??
                                 appConfig.globalNeverApproveWithIssues)

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -434,6 +434,27 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                   ),
                   const SizedBox(height: 10),
                   AutocompleteChipField(
+                    label: 'Organizations',
+                    helper: 'GitHub org names to filter issues',
+                    selectedValues:
+                        _config.issueOrganizations ??
+                        orgConfig?.issueOrganizations ??
+                        appConfig.issueTracking.organizations,
+                    availableOptions: appConfig.knownOrganizations,
+                    isOverridden: _config.issueOrganizations != null,
+                    inheritedLabel: source(
+                      orgConfig?.issueOrganizations != null,
+                    ),
+                    globalHint: _joinList(
+                      orgConfig?.issueOrganizations ??
+                          appConfig.issueTracking.organizations,
+                    ),
+                    onChanged: (v) =>
+                        _update(_config.copyWith(issueOrganizations: v)),
+                    onReset: () => _resetField('issue_tracking/organizations'),
+                  ),
+                  const SizedBox(height: 10),
+                  AutocompleteChipField(
                     label: 'Assignees',
                     helper: 'Only process issues assigned to these users',
                     selectedValues:
@@ -470,6 +491,86 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                     onReset: () => _resetField('issue_prompt'),
                   ),
                 ], accent: FeaturePalette.issueTracking),
+
+                // ── Section: Pipeline ──────────────────────────────────
+                _sectionCard('Pipeline', [
+                  OverrideTextField(
+                    label: 'Triage owner',
+                    globalValue:
+                        orgConfig?.triageOwner ?? appConfig.globalTriageOwner,
+                    inheritedLabel: source(orgConfig?.triageOwner != null),
+                    overrideValue: _config.triageOwner,
+                    onChanged: (v) => _update(_config.copyWith(triageOwner: v)),
+                    onReset: () => _resetField('triage_owner'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideTextField(
+                    label: 'Clone directory',
+                    globalValue:
+                        orgConfig?.cloneDir ?? appConfig.globalCloneDir,
+                    inheritedLabel: source(orgConfig?.cloneDir != null),
+                    overrideValue: _config.cloneDir,
+                    onChanged: (v) => _update(_config.copyWith(cloneDir: v)),
+                    onReset: () => _resetField('clone_dir'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Auto-promote triage',
+                    globalValue:
+                        (orgConfig?.autoPromoteTriage ??
+                                appConfig.globalAutoPromoteTriage ??
+                                false)
+                            .toString(),
+                    inheritedLabel: source(orgConfig?.autoPromoteTriage != null),
+                    overrideValue: _config.autoPromoteTriage?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        autoPromoteTriage: v != null ? v == 'true' : null,
+                      ),
+                    ),
+                    onReset: () => _resetField('auto_promote_triage'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Auto-promote refinement',
+                    globalValue:
+                        (orgConfig?.autoPromoteRefinement ??
+                                appConfig.globalAutoPromoteRefinement ??
+                                false)
+                            .toString(),
+                    inheritedLabel: source(
+                      orgConfig?.autoPromoteRefinement != null,
+                    ),
+                    overrideValue: _config.autoPromoteRefinement?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        autoPromoteRefinement: v != null ? v == 'true' : null,
+                      ),
+                    ),
+                    onReset: () => _resetField('auto_promote_refinement'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Generate PR description',
+                    globalValue:
+                        (orgConfig?.generatePRDescription ??
+                                appConfig.globalGeneratePRDescription)
+                            .toString(),
+                    inheritedLabel: source(
+                      orgConfig?.generatePRDescription != null,
+                    ),
+                    overrideValue: _config.generatePRDescription?.toString(),
+                    options: const ['true', 'false'],
+                    onChanged: (v) => _update(
+                      _config.copyWith(
+                        generatePRDescription: v != null ? v == 'true' : null,
+                      ),
+                    ),
+                    onReset: () => _resetField('generate_pr_description'),
+                  ),
+                ]),
 
                 // ── Section 4: Develop ─────────────────────────────────
                 _sectionCard('Develop', [

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -299,10 +299,7 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                     onChanged: (v) => _update(_config.copyWith(promptId: v)),
                     onReset: () => _resetField('prompt'),
                   ),
-                ], accent: FeaturePalette.prReview),
-
-                // ── Section: Organizations (org-inherited review policy) ─
-                _sectionCard('Organizations', [
+                  const SizedBox(height: 10),
                   OverrideDropdown(
                     label: 'No aprobar PRs con issues',
                     globalValue:
@@ -321,7 +318,7 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                     ),
                     onReset: () => _resetField('never_approve_with_issues'),
                   ),
-                ]),
+                ], accent: FeaturePalette.prReview),
 
                 // ── Section 3: Issue Tracking ──────────────────────────
                 _sectionCard('Issue Tracking', [

--- a/flutter_app/lib/features/repositories/repo_diff.dart
+++ b/flutter_app/lib/features/repositories/repo_diff.dart
@@ -39,6 +39,26 @@ Map<String, dynamic> computeRepoDiff(RepoConfig old, RepoConfig updated) {
     diff['issue_prompt'] = updated.issuePromptId ?? '';
   }
 
+  // Pipeline overrides.
+  if (old.triageOwner != updated.triageOwner) {
+    diff['triage_owner'] = updated.triageOwner ?? '';
+  }
+  if (old.cloneDir != updated.cloneDir) {
+    diff['clone_dir'] = updated.cloneDir ?? '';
+  }
+  if (old.autoPromoteTriage != updated.autoPromoteTriage &&
+      updated.autoPromoteTriage != null) {
+    diff['auto_promote_triage'] = updated.autoPromoteTriage!;
+  }
+  if (old.autoPromoteRefinement != updated.autoPromoteRefinement &&
+      updated.autoPromoteRefinement != null) {
+    diff['auto_promote_refinement'] = updated.autoPromoteRefinement!;
+  }
+  if (old.generatePRDescription != updated.generatePRDescription &&
+      updated.generatePRDescription != null) {
+    diff['generate_pr_description'] = updated.generatePRDescription!;
+  }
+
   if (!_listsEqual(old.prReviewers, updated.prReviewers)) {
     diff['pr_reviewers'] = updated.prReviewers ?? <String>[];
   }
@@ -73,6 +93,9 @@ Map<String, dynamic> computeRepoDiff(RepoConfig old, RepoConfig updated) {
   }
   if (!_listsEqual(old.issueAssignees, updated.issueAssignees)) {
     itDiff['assignees'] = updated.issueAssignees ?? <String>[];
+  }
+  if (!_listsEqual(old.issueOrganizations, updated.issueOrganizations)) {
+    itDiff['organizations'] = updated.issueOrganizations ?? <String>[];
   }
 
   if (itDiff.isNotEmpty) diff['issue_tracking'] = itDiff;

--- a/flutter_app/lib/features/repositories/repo_diff.dart
+++ b/flutter_app/lib/features/repositories/repo_diff.dart
@@ -39,7 +39,10 @@ Map<String, dynamic> computeRepoDiff(RepoConfig old, RepoConfig updated) {
     diff['issue_prompt'] = updated.issuePromptId ?? '';
   }
 
-  // Pipeline overrides.
+  // Pipeline overrides. Note the intentional asymmetry (same as pr_draft etc.):
+  // string overrides emit '' to clear, but bool overrides only emit when
+  // non-null — clearing a bool override is done via _resetField (DELETE), never
+  // by diffing a null back into the PATCH body.
   if (old.triageOwner != updated.triageOwner) {
     diff['triage_owner'] = updated.triageOwner ?? '';
   }

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -556,4 +556,31 @@ void main() {
     final diff = computeRepoDiff(oldCfg, updated);
     expect(diff['never_approve_with_issues'], isTrue);
   });
+
+  test('repo diff includes Pipeline overrides when set', () {
+    const oldCfg = RepoConfig();
+    final updated = oldCfg.copyWith(
+      triageOwner: 'alice',
+      cloneDir: '/work/x',
+      autoPromoteTriage: true,
+      autoPromoteRefinement: false,
+      generatePRDescription: true,
+    );
+    final diff = computeRepoDiff(oldCfg, updated);
+    expect(diff['triage_owner'], 'alice');
+    expect(diff['clone_dir'], '/work/x');
+    expect(diff['auto_promote_triage'], isTrue);
+    expect(diff['auto_promote_refinement'], isFalse);
+    expect(diff['generate_pr_description'], isTrue);
+  });
+
+  test('repo diff includes issue_tracking organizations when set', () {
+    const oldCfg = RepoConfig();
+    final updated = oldCfg.copyWith(issueOrganizations: ['acme']);
+    final diff = computeRepoDiff(oldCfg, updated);
+    expect(
+      (diff['issue_tracking'] as Map)['organizations'],
+      ['acme'],
+    );
+  });
 }

--- a/flutter_app/test/features/organizations/org_detail_screen_test.dart
+++ b/flutter_app/test/features/organizations/org_detail_screen_test.dart
@@ -65,7 +65,7 @@ void main() {
     expect(find.text('Auto-promote refinement'), findsOneWidget);
     expect(find.text('Refinement labels'), findsOneWidget);
     expect(find.text('Generate PR description'), findsOneWidget);
-    expect(find.text('No aprobar PRs con issues'), findsOneWidget);
+    expect(find.text('Never approve PRs with issues'), findsOneWidget);
     // "Organizations" now names both the new review-policy section header and
     // the Issue Tracking org filter; target the filter by its unique helper.
     expect(find.text('GitHub org names to filter issues'), findsOneWidget);


### PR DESCRIPTION
## Qué

Replantea la configuración hacia el modelo de tres vistas con jerarquía `repo > org > global`:

- **Settings (globals)** — todas las opciones globales, unificadas. Se traen aquí ajustes que estaban dispersos:
  - Nueva sección **AI defaults** (Primary / Fallback / Feedback mode) — antes solo en la pestaña Agents.
  - Nueva sección **Pipeline** (triage owner, clone dir, auto-promote triage/refinement, generate PR description).
- **Organizations** — **nueva pestaña de primer nivel**: lista de organizaciones → cada una abre su config (override sobre global). Antes solo se llegaba de rebote desde la pantalla de Repositories.
- **Repos** — gana la sección **Pipeline** y el filtro **Organizations** en Issue Tracking que le faltaban frente a org (paridad).

Resultado: Settings / Organizations / Repos comparten las mismas secciones (General · PR Review · Issue Tracking · Pipeline · Develop) para toda opción con semántica de override.

Además: `never_approve_with_issues` se coloca donde corresponde — sección **PR Review** (repo/org) y **AI defaults** (Settings) — y se elimina la sección "Organizations" (un único toggle) que era una interpretación errónea de una petición anterior.

## Estado / alcance

Paridad completa para el conjunto de opciones **sobreescribibles** ya expuestas. Pendiente en trabajo posterior sobre esta base: traer los Prompts a Settings y los overrides aún no expuestos (`refinement_timeout`, `instruction_authors`, `circuit_breaker`, `blocked_labels`, `promote_to_label`), que requieren tocar modelo Dart + serialización del daemon.

## Tests

`flutter analyze` limpio y **192/192** tests. Sin cambios en el daemon (solo GUI). App verificada arrancando en local (`make dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
