### PR TITLE
feat(stats): GitHub API rate-limit section

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -1509,6 +1509,9 @@ func main() {
 	// Expose live config for GET /config
 	srv.SetRepoMetaFns(ghClient.FetchLabels, ghClient.FetchCollaborators)
 
+	// Live GitHub API rate-limit lookup for GET /github/rate_limit.
+	srv.SetRateLimitFn(func() (any, error) { return ghClient.RateLimit() })
+
 	srv.SetConfigFn(func() map[string]any {
 		// Snapshot the mutable slice fields under cfgMu. The poll-cycle
 		// auto-discovery path (upsertDiscoveredRepos) appends to

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -547,6 +547,47 @@ func (c *Client) IsRepoArchived(repo string) (bool, error) {
 	return result.Archived, nil
 }
 
+// RateLimitResource is one GitHub rate-limit bucket (REST core, Search, GraphQL…).
+// Reset is a Unix timestamp (seconds) when the window rolls over.
+type RateLimitResource struct {
+	Limit     int   `json:"limit"`
+	Remaining int   `json:"remaining"`
+	Reset     int64 `json:"reset"`
+	Used      int   `json:"used"`
+}
+
+// RateLimit holds the GitHub API rate-limit buckets the app actually consumes:
+// the REST core pool, the Search API pool, and the GraphQL pool.
+type RateLimit struct {
+	Core    RateLimitResource `json:"core"`
+	Search  RateLimitResource `json:"search"`
+	GraphQL RateLimitResource `json:"graphql"`
+}
+
+// RateLimit queries GitHub's GET /rate_limit for the current token. This
+// endpoint does not itself count against the core rate limit.
+func (c *Client) RateLimit() (*RateLimit, error) {
+	resp, err := c.do("GET", "/rate_limit", "application/vnd.github+json")
+	if err != nil {
+		return nil, fmt.Errorf("github: rate limit: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if resp.StatusCode != http.StatusOK {
+		errBody := safeTruncate(string(body), maxErrBodyLen)
+		return nil, fmt.Errorf("github: rate limit: status %d: %s", resp.StatusCode, errBody)
+	}
+
+	var result struct {
+		Resources RateLimit `json:"resources"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("github: decode rate limit: %w", err)
+	}
+	return &result.Resources, nil
+}
+
 // PRHeadInfo bundles the HEAD SHA and the pending-reviewer logins returned by
 // the Pulls API. Tier 2 uses ReviewRequestedFor to confirm the bot is still a
 // pending reviewer (the Search API index can lag behind the actual

--- a/daemon/internal/github/rate_limit_test.go
+++ b/daemon/internal/github/rate_limit_test.go
@@ -1,0 +1,58 @@
+package github_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+)
+
+func TestRateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/rate_limit" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer fake" {
+			t.Errorf("Authorization = %q, want Bearer fake", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"resources": {
+				"core":    {"limit": 5000, "remaining": 4990, "reset": 1700000000, "used": 10},
+				"search":  {"limit": 30,   "remaining": 28,   "reset": 1700000060, "used": 2},
+				"graphql": {"limit": 5000, "remaining": 5000, "reset": 1700000120, "used": 0}
+			},
+			"rate": {"limit": 5000, "remaining": 4990, "reset": 1700000000, "used": 10}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	rl, err := c.RateLimit()
+	if err != nil {
+		t.Fatalf("RateLimit: %v", err)
+	}
+	if rl.Core.Limit != 5000 || rl.Core.Remaining != 4990 || rl.Core.Used != 10 || rl.Core.Reset != 1700000000 {
+		t.Errorf("core = %+v, want limit=5000 remaining=4990 used=10 reset=1700000000", rl.Core)
+	}
+	if rl.Search.Limit != 30 || rl.Search.Remaining != 28 {
+		t.Errorf("search = %+v, want limit=30 remaining=28", rl.Search)
+	}
+	if rl.GraphQL.Limit != 5000 || rl.GraphQL.Remaining != 5000 {
+		t.Errorf("graphql = %+v, want limit=5000 remaining=5000", rl.GraphQL)
+	}
+}
+
+func TestRateLimit_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	if _, err := c.RateLimit(); err == nil {
+		t.Fatal("expected error on 401, got nil")
+	}
+}

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -55,6 +55,10 @@ type Server struct {
 	// tests that don't need it).
 	repoRenameFn func(ctx context.Context, oldRepo, newRepo string) error
 	meFn         func() (string, error)
+	// rateLimitFn returns the live GitHub API rate-limit buckets for the
+	// daemon's token. Wired by main; nil disables the /github/rate_limit
+	// endpoint (returns 503).
+	rateLimitFn func() (any, error)
 	// configFn returns the current running config as a JSON-serializable map.
 	configFn func() map[string]any
 	// healthSnapshotFn returns live daemon liveness metadata for /health and SSE heartbeat.
@@ -145,6 +149,7 @@ var sensitiveGETPaths = []string{
 	"/stats",  // exposes review activity metadata
 	"/issues", // covers /issues and /issues/{id}
 	"/repos",  // covers /repos/{name}/labels and /repos/{name}/collaborators
+	"/github", // covers /github/rate_limit (live GitHub API usage)
 }
 
 // authMiddleware rejects:
@@ -234,6 +239,9 @@ func (srv *Server) SetCleanClonesFn(fn func(ctx context.Context) (int, error)) {
 
 // SetMeFn wires the authenticated-user callback called by GET /me.
 func (srv *Server) SetMeFn(fn func() (string, error)) { srv.meFn = fn }
+
+// SetRateLimitFn wires the live GitHub rate-limit lookup for GET /github/rate_limit.
+func (srv *Server) SetRateLimitFn(fn func() (any, error)) { srv.rateLimitFn = fn }
 
 // SetConfigFn wires the callback that returns the live config for GET /config.
 func (srv *Server) SetConfigFn(fn func() map[string]any) { srv.configFn = fn }
@@ -359,6 +367,7 @@ func (srv *Server) buildRouter() chi.Router {
 	r.Get("/repos/{name}/collaborators", srv.handleRepoCollaborators)
 	r.Get("/activity", srv.handleActivity)
 	r.Get("/stats", srv.handleStats)
+	r.Get("/github/rate_limit", srv.handleGitHubRateLimit)
 	r.Get("/agents", srv.handleListAgents)
 	r.Post("/agents", srv.handleUpsertAgent)
 	r.Delete("/agents/{id}", srv.handleDeleteAgent)
@@ -1646,6 +1655,23 @@ func (srv *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, stats)
+}
+
+// handleGitHubRateLimit returns the live GitHub API rate-limit buckets for the
+// daemon's token (core / search / graphql). It queries GitHub on each call, so
+// the UI should fetch it on demand rather than polling.
+func (srv *Server) handleGitHubRateLimit(w http.ResponseWriter, r *http.Request) {
+	if srv.rateLimitFn == nil {
+		http.Error(w, `{"error":"rate limit lookup not available"}`, http.StatusServiceUnavailable)
+		return
+	}
+	rl, err := srv.rateLimitFn()
+	if err != nil {
+		slog.Error("handleGitHubRateLimit: fetch failed", "err", err)
+		http.Error(w, `{"error":"failed to fetch GitHub rate limit"}`, http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, http.StatusOK, rl)
 }
 
 // handleActivity returns rows from activity_log matching the query.

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -229,6 +229,19 @@ class ApiClient {
     return jsonDecode(resp.body) as Map<String, dynamic>;
   }
 
+  /// Live GitHub API rate-limit buckets (core / search / graphql) for the
+  /// daemon's token. Queries GitHub on each call — fetch on demand, not polled.
+  Future<Map<String, dynamic>> fetchGitHubRateLimit() async {
+    final resp = await _client.get(
+      _uri('/github/rate_limit'),
+      headers: await _authHeaders(),
+    );
+    if (resp.statusCode != 200) {
+      throw ApiException('GET /github/rate_limit failed: ${resp.statusCode}');
+    }
+    return jsonDecode(resp.body) as Map<String, dynamic>;
+  }
+
   Future<void> updateConfig(Map<String, dynamic> config) async {
     final resp = await _client.put(
       _uri('/config'),

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -479,6 +479,15 @@ final statsProvider = FutureProvider<Map<String, dynamic>>((ref) async {
   );
 });
 
+/// Live GitHub API rate limits. Fetched on demand (not polled); invalidate to
+/// refresh from the Stats screen.
+final githubRateLimitProvider = FutureProvider.autoDispose<Map<String, dynamic>>(
+  (ref) async {
+    final api = ref.watch(apiClientProvider);
+    return api.fetchGitHubRateLimit();
+  },
+);
+
 void _rebuildTray(Ref ref, List<PR> prs) {
   Future(() async {
     try {

--- a/flutter_app/lib/features/stats/stats_screen.dart
+++ b/flutter_app/lib/features/stats/stats_screen.dart
@@ -23,6 +23,7 @@ class StatsScreen extends ConsumerWidget {
     return Column(
       children: [
         StatsFilterBar(allRepos: allRepos),
+        const _GitHubRateLimitCard(),
         Expanded(
           child: statsAsync.when(
             loading: () => const Center(child: CircularProgressIndicator()),
@@ -399,5 +400,133 @@ class _BarChart extends StatelessWidget {
         }).toList(),
       ),
     );
+  }
+}
+
+/// Live GitHub API rate limits (core / search / graphql) for the daemon's
+/// token. Fetched on demand via [githubRateLimitProvider]; the refresh button
+/// re-queries GitHub.
+class _GitHubRateLimitCard extends ConsumerWidget {
+  const _GitHubRateLimitCard();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(githubRateLimitProvider);
+    return Card(
+      margin: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.speed, size: 18),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    'GitHub API limits',
+                    style: TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.refresh, size: 18),
+                  tooltip: 'Refresh',
+                  visualDensity: VisualDensity.compact,
+                  onPressed: () => ref.invalidate(githubRateLimitProvider),
+                ),
+              ],
+            ),
+            async.when(
+              loading: () => const Padding(
+                padding: EdgeInsets.symmetric(vertical: 12),
+                child: Center(
+                  child: SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                ),
+              ),
+              error: (e, _) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Text(
+                  'Could not load rate limits: $e',
+                  style: TextStyle(color: Colors.red.shade400, fontSize: 12),
+                ),
+              ),
+              data: (rl) => Column(
+                children: [
+                  _bucket('Core (REST)', rl['core']),
+                  _bucket('Search', rl['search']),
+                  _bucket('GraphQL', rl['graphql']),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _bucket(String label, Object? raw) {
+    if (raw is! Map) return const SizedBox.shrink();
+    final limit = (raw['limit'] as num?)?.toInt() ?? 0;
+    final remaining = (raw['remaining'] as num?)?.toInt() ?? 0;
+    final reset = (raw['reset'] as num?)?.toInt() ?? 0;
+    final frac = limit > 0 ? (remaining / limit).clamp(0.0, 1.0) : 0.0;
+    final low = frac <= 0.1;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 92,
+            child: Text(label, style: const TextStyle(fontSize: 12)),
+          ),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: frac,
+                minHeight: 6,
+                color: low ? Colors.red.shade400 : null,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          SizedBox(
+            width: 92,
+            child: Text(
+              '$remaining / $limit',
+              textAlign: TextAlign.right,
+              style: TextStyle(
+                fontSize: 12,
+                color: low ? Colors.red.shade400 : null,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          SizedBox(
+            width: 78,
+            child: Text(
+              _resetLabel(reset),
+              textAlign: TextAlign.right,
+              style: TextStyle(fontSize: 10, color: Colors.grey.shade600),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _resetLabel(int resetUnixSecs) {
+    if (resetUnixSecs <= 0) return '';
+    final reset = DateTime.fromMillisecondsSinceEpoch(resetUnixSecs * 1000);
+    final diff = reset.difference(DateTime.now());
+    if (diff.isNegative) return 'reset now';
+    if (diff.inMinutes < 1) return 'resets ${diff.inSeconds}s';
+    if (diff.inMinutes < 60) return 'resets ${diff.inMinutes}m';
+    return 'resets ${diff.inHours}h';
   }
 }


### PR DESCRIPTION
## Qué

Añade una sección **"GitHub API limits"** a la pestaña **Stats** para consultar (bajo demanda) los límites de la API de GitHub que la app consume con su token: buckets **core (REST)**, **search** y **graphql**, con `remaining / limit`, barra de progreso, cuenta atrás de reset, y resaltado en rojo cuando queda <10%. Botón de **refresh** para re-consultar.

## Cómo

- **Daemon**: `github.Client.RateLimit()` consulta `GET /rate_limit` de GitHub (endpoint que no cuenta contra el core). Nuevo endpoint autenticado **`GET /github/rate_limit`** (cableado vía `SetRateLimitFn`, patrón de las demás fns inyectadas del server) que devuelve los tres buckets. Añadido `/github` a `sensitiveGETPaths`.
- **GUI**: `ApiClient.fetchGitHubRateLimit` + `githubRateLimitProvider` (`autoDispose`, on-demand) + `_GitHubRateLimitCard` en `StatsScreen`.

## Tests / verificación

- Go: `TestRateLimit` (parseo del JSON de `/rate_limit`) + `TestRateLimit_ErrorStatus` (401). Paquetes github/server verdes; `go build`/`vet` OK.
- Flutter: `flutter analyze` limpio + **194/194**.
- **End-to-end** contra GitHub real (app en local): el endpoint devuelve los límites vivos (`core`, `search`, `graphql`); auth correcto (sin token → 401, con token → 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
