### PR TITLE
fix(daemon): GitHub rate-limit handling, honor non_monitored, non-blocking config saves

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -764,8 +764,15 @@ func main() {
 				}
 			}
 
+			// Cache archived-status lookups: an archived/active repo almost
+			// never flips, but FilterArchived otherwise re-checks every repo
+			// (one GET /repos each) on every discovery tick — a large slice of
+			// the hourly GitHub budget for no new information. See the constant
+			// rate-limit exhaustion with 80+ monitored repos.
+			archiveChecker := newCachingArchivedChecker(ghClient, 6*time.Hour)
+
 			// Publish initial repos immediately
-			sendDiscoveryRepos(ctx, discoverySvc, limiter, repoPublisher, tier1ConfigFn, ghClient)
+			sendDiscoveryRepos(ctx, discoverySvc, limiter, repoPublisher, tier1ConfigFn, archiveChecker)
 
 			ticker := time.NewTicker(discoveryInterval)
 			defer ticker.Stop()
@@ -774,7 +781,7 @@ func main() {
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-					sendDiscoveryRepos(ctx, discoverySvc, limiter, repoPublisher, tier1ConfigFn, ghClient)
+					sendDiscoveryRepos(ctx, discoverySvc, limiter, repoPublisher, tier1ConfigFn, archiveChecker)
 				}
 			}
 		}()
@@ -2293,6 +2300,44 @@ func resolveRefinementTimeout(refinementTimeout, globalTimeout, agentTimeout str
 
 // sendDiscoveryRepos merges static + discovered repos and publishes the
 // full list to NATS. Extracted from the old tier1.go sendRepos.
+// cachingArchivedChecker wraps a discovery.ArchivedChecker with a TTL cache so
+// the tier1 discovery loop does not spend one GET /repos per monitored repo on
+// every tick re-confirming near-static archived status. Only successful lookups
+// are cached (errors fall through, preserving FilterArchived's fail-open
+// behavior).
+type cachingArchivedChecker struct {
+	inner discovery.ArchivedChecker
+	ttl   time.Duration
+	mu    sync.Mutex
+	cache map[string]archivedCacheEntry
+}
+
+type archivedCacheEntry struct {
+	archived bool
+	at       time.Time
+}
+
+func newCachingArchivedChecker(inner discovery.ArchivedChecker, ttl time.Duration) *cachingArchivedChecker {
+	return &cachingArchivedChecker{inner: inner, ttl: ttl, cache: make(map[string]archivedCacheEntry)}
+}
+
+func (c *cachingArchivedChecker) IsRepoArchived(repo string) (bool, error) {
+	c.mu.Lock()
+	e, ok := c.cache[repo]
+	c.mu.Unlock()
+	if ok && time.Since(e.at) < c.ttl {
+		return e.archived, nil
+	}
+	archived, err := c.inner.IsRepoArchived(repo)
+	if err != nil {
+		return archived, err // don't cache transient failures
+	}
+	c.mu.Lock()
+	c.cache[repo] = archivedCacheEntry{archived: archived, at: time.Now()}
+	c.mu.Unlock()
+	return archived, nil
+}
+
 func sendDiscoveryRepos(
 	ctx context.Context,
 	disc scheduler.Tier1Discovery,

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -334,6 +334,12 @@ func main() {
 	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
 	var reloadMu sync.Mutex // serialises config reloads to prevent duplicate pipelines
+	// restartMu serialises the BACKGROUND poller teardown+restart kicked off by
+	// a reload that changed a poller-relevant field. Kept separate from
+	// reloadMu so a config save never blocks (waiting out in-flight poll
+	// cycles/reviews in oldWg.Wait()) — the reload applies cfg and returns,
+	// while at most one restart runs at a time here.
+	var restartMu sync.Mutex
 	var lastPollUnixNano int64
 	var pollIntervalNano int64
 	storePollInterval := func(interval time.Duration) {
@@ -1721,34 +1727,44 @@ func main() {
 		}
 		cfgMu.Unlock()
 
-		// Read the current cancel/wg under cfgMu, then stop OUTSIDE the lock.
-		// Holding cfgMu across Wait() risks deadlock: if Wait() blocks
-		// waiting for in-flight goroutines that also acquire cfgMu (e.g.
-		// tier2Adapter callbacks), both sides block forever.
-		cfgMu.Lock()
-		oldCancel := pollerCancel
-		oldWg := pollerWg
-		cfgMu.Unlock()
-
-		oldCancel()
-		oldWg.Wait()
-
-		// Swap cfg + pollers atomically under the lock so readers never
-		// see a half-updated state.
+		// Apply the new config immediately so config reads (GET /config, the
+		// next tier1ConfigFn tick, etc.) reflect it right away.
 		cfgMu.Lock()
 		cfg = newCfg
 		cfgMu.Unlock()
 
-		// Reload path → coldStart=false so Tier 2 waits one full PollInterval
-		// before its first tick. A UI config PATCH triggers this path; firing
-		// an immediate tick on every PATCH would fan out reviews across the
-		// whole fleet and amplify the cost-runaway loop #243 closed.
-		newCancel, newWg := startPollers(context.Background(), false)
+		// Restart the pollers in the BACKGROUND. oldWg.Wait() can block for
+		// tens of seconds (an in-flight poll cycle or agent review must finish
+		// first); doing it inline made every restart-triggering config save
+		// hang that long and froze the UI. restartMu serialises restarts so a
+		// burst of saves can never leave two poller sets racing on the same
+		// GitHub budget, and each restart tears the old set fully down before
+		// starting the new one (no overlap).
+		//
+		// coldStart=false: Tier 2 waits one full PollInterval before its first
+		// tick. Firing an immediate tick on every PATCH would fan out reviews
+		// across the whole fleet and amplify the cost-runaway loop #243 closed.
+		go func() {
+			restartMu.Lock()
+			defer restartMu.Unlock()
 
-		cfgMu.Lock()
-		pollerCancel = newCancel
-		pollerWg = newWg
-		cfgMu.Unlock()
+			cfgMu.Lock()
+			oldCancel := pollerCancel
+			oldWg := pollerWg
+			cfgMu.Unlock()
+
+			oldCancel()
+			oldWg.Wait()
+
+			newCancel, newWg := startPollers(context.Background(), false)
+
+			cfgMu.Lock()
+			pollerCancel = newCancel
+			pollerWg = newWg
+			cfgMu.Unlock()
+
+			slog.Info("config reload: pollers restarted")
+		}()
 
 		return nil
 	})

--- a/daemon/internal/discovery/discovery.go
+++ b/daemon/internal/discovery/discovery.go
@@ -136,18 +136,17 @@ func MergeRepos(static, configured, discovered, nonMonitored []string) []string 
 	if len(static) == 0 && len(configured) == 0 && len(discovered) == 0 {
 		return nil
 	}
-	exempt := make(map[string]struct{}, len(configured))
-	for _, r := range configured {
-		if r != "" {
-			exempt[r] = struct{}{}
-		}
-	}
+	// non_monitored is authoritative: an explicit entry (e.g. the user
+	// disabling a repo in the Repositories view) excludes it even when the
+	// repo has [ai.repos.*] config. Previously configured repos were exempt
+	// from the blacklist (to survive a stale auto-discovery non_monitored row),
+	// but that made disabling a configured repo a silent no-op — the far more
+	// common and surprising case. Configured repos still join the union when
+	// NOT listed in non_monitored (the #281 fix), so issue polling for wired-up
+	// repos with no active PRs is unaffected.
 	blacklist := make(map[string]struct{}, len(nonMonitored))
 	for _, r := range nonMonitored {
 		if r == "" {
-			continue
-		}
-		if _, ok := exempt[r]; ok {
 			continue
 		}
 		blacklist[r] = struct{}{}

--- a/daemon/internal/discovery/discovery_test.go
+++ b/daemon/internal/discovery/discovery_test.go
@@ -133,19 +133,20 @@ func TestMergeRepos_ConfiguredIncludedInUnion(t *testing.T) {
 	}
 }
 
-// Repos in configured are exempt from the NonMonitored blacklist. A stale
-// auto-discovery row in non_monitored must not silently demote a repo that
-// the operator has explicitly wired up under [ai.repos.*].
-// See theburrowhub/heimdallm#281.
-func TestMergeRepos_ConfiguredOverridesNonMonitored(t *testing.T) {
+// An explicit non_monitored entry (e.g. the user disabling the repo in the
+// Repositories view) takes precedence even when the repo has [ai.repos.*]
+// config. Otherwise disabling a configured repo would be a silent no-op — the
+// bug reported after #281's exemption. Configured repos still join the union
+// when they are NOT in non_monitored (see TestMergeRepos_ConfiguredIncludedInUnion).
+func TestMergeRepos_NonMonitoredOverridesConfigured(t *testing.T) {
 	got := discovery.MergeRepos(
 		nil,
 		[]string{"org/wired-up"},
 		nil,
 		[]string{"org/wired-up"},
 	)
-	if len(got) != 1 || got[0] != "org/wired-up" {
-		t.Errorf("configured repo must override non_monitored blacklist, got %v", got)
+	if len(got) != 0 {
+		t.Errorf("explicit non_monitored must disable even a configured repo, got %v", got)
 	}
 }
 
@@ -153,16 +154,19 @@ func TestMergeRepos_ConfiguredOverridesNonMonitored(t *testing.T) {
 // nonMonitored simultaneously must survive — explicit [ai.repos.*] config
 // (exempt) wins over the NonMonitored blacklist across all three sources, and
 // the repo is deduplicated to a single entry.
-func TestMergeRepos_ConfiguredExemptWinsAcrossAllSources(t *testing.T) {
+func TestMergeRepos_NonMonitoredWinsAcrossAllSources(t *testing.T) {
+	// org/triple appears in static, configured AND discovered, but is also
+	// explicitly non_monitored → excluded from every source. org/static-only
+	// (not blacklisted) survives.
 	got := discovery.MergeRepos(
 		[]string{"org/triple", "org/static-only"},
 		[]string{"org/triple"},
 		[]string{"org/triple"},
 		[]string{"org/triple"},
 	)
-	want := []string{"org/triple", "org/static-only"}
+	want := []string{"org/static-only"}
 	if len(got) != len(want) {
-		t.Fatalf("got %v, want %v (exempt config must win over non_monitored, deduped)", got, want)
+		t.Fatalf("got %v, want %v (non_monitored must win over every source, deduped)", got, want)
 	}
 	for i := range want {
 		if got[i] != want[i] {

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 )
@@ -62,6 +63,23 @@ type Client struct {
 	token   string
 	baseURL string
 	http    *http.Client
+
+	// rate-limit circuit breaker: when GitHub rejects a request with a rate
+	// limit (primary exhaustion or a secondary/abuse burst block), every
+	// subsequent request fails fast until rlPausedUntil instead of piling more
+	// traffic onto GitHub — which is what keeps a secondary block from ever
+	// clearing. Shared across all callers of this client.
+	rlMu          sync.Mutex
+	rlPausedUntil time.Time
+}
+
+// RateLimitError is returned (without contacting GitHub) while the client is in
+// its rate-limit cooldown window. Callers treat it like any transient fetch
+// error; the point is that no request is actually sent until RetryAt.
+type RateLimitError struct{ RetryAt time.Time }
+
+func (e *RateLimitError) Error() string {
+	return "github: rate limited, paused until " + e.RetryAt.Format(time.RFC3339)
 }
 
 type Option func(*Client)
@@ -117,59 +135,77 @@ func (c *Client) do(method, path string, accept string) (*http.Response, error) 
 // TODO: migrate SubmitReview and PostComment to doWithBody as well — they
 // still build their request inline, duplicating the header setup.
 func (c *Client) doWithBody(method, path, accept, contentType string, body io.Reader) (*http.Response, error) {
-	// Bodyless (GET-like) requests are safe to re-issue after a rate-limit
-	// backoff. Requests with a body are attempted once — the reader would be
-	// consumed and cannot be rewound for a retry.
-	maxAttempts := 1
-	if body == nil {
-		maxAttempts = 3
+	// Circuit breaker: while a rate-limit cooldown is active, fail fast without
+	// touching GitHub. Sending more traffic during a secondary/abuse block only
+	// keeps it alive; going quiet lets it clear.
+	if until, paused := c.rateLimitPaused(); paused {
+		return nil, &RateLimitError{RetryAt: until}
 	}
-	for attempt := 1; ; attempt++ {
-		req, err := http.NewRequest(method, c.baseURL+path, body)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Authorization", "Bearer "+c.token)
-		req.Header.Set("Accept", accept)
-		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-		if contentType != "" {
-			req.Header.Set("Content-Type", contentType)
-		}
-		resp, err := c.http.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		// When GitHub rate-limits us (primary exhaustion or a secondary/abuse
-		// burst limit), pause and retry instead of hammering. This paces the
-		// sequential bursts (discovery archive-checks, per-repo issue fetches)
-		// that otherwise trip the secondary limit even while the hourly budget
-		// is healthy. A far-off primary reset (beyond the cap) is returned to
-		// the caller so the daemon never blocks for the full hour.
-		if attempt < maxAttempts {
-			if wait, ok := rateLimitBackoff(resp); ok && wait <= maxRateLimitBackoff {
-				resp.Body.Close()
-				slog.Warn("github: rate limited, backing off before retry",
-					"path", path, "wait", wait.Round(time.Second), "attempt", attempt)
-				time.Sleep(wait)
-				continue
-			}
-		}
-		return resp, nil
+
+	req, err := http.NewRequest(method, c.baseURL+path, body)
+	if err != nil {
+		return nil, err
 	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", accept)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// If GitHub rate-limited this request, open the breaker so the rest of the
+	// poll cycle stops hammering. The current response is still returned so the
+	// caller handles this one as it always has.
+	if wait, limited := rateLimitDelay(resp); limited {
+		c.pauseRateLimit(wait)
+	}
+	return resp, nil
 }
 
-// maxRateLimitBackoff caps how long a single request blocks waiting out a
-// rate-limit window before giving up. Secondary-limit Retry-After delays are
-// usually seconds; a primary-limit reset can be up to an hour away, and we must
-// not stall the daemon that long.
-const maxRateLimitBackoff = 90 * time.Second
+// rateLimitCooldown is the default pause applied when GitHub reports a rate
+// limit without a usable Retry-After. Secondary/abuse blocks typically clear
+// within a minute; a primary reset is far longer, but pausing a minute and
+// re-checking keeps traffic near zero without stalling the daemon for an hour.
+const rateLimitCooldown = 60 * time.Second
 
-// rateLimitBackoff reports whether resp is a GitHub rate-limit rejection and,
-// if so, how long to wait before retrying. It honors Retry-After (secondary /
-// abuse limits) first, then X-RateLimit-Remaining==0 with X-RateLimit-Reset
-// (primary), with a small default when a limit is signaled without a usable
-// delay. A one-second cushion is added so the retry lands after the window.
-func rateLimitBackoff(resp *http.Response) (time.Duration, bool) {
+// maxRateLimitCooldown caps how long the breaker stays open from a single
+// signal, so an over-large Retry-After can never wedge the daemon.
+const maxRateLimitCooldown = 5 * time.Minute
+
+func (c *Client) rateLimitPaused() (time.Time, bool) {
+	c.rlMu.Lock()
+	defer c.rlMu.Unlock()
+	if c.rlPausedUntil.IsZero() {
+		return time.Time{}, false
+	}
+	if time.Now().Before(c.rlPausedUntil) {
+		return c.rlPausedUntil, true
+	}
+	return time.Time{}, false
+}
+
+func (c *Client) pauseRateLimit(d time.Duration) {
+	if d <= 0 || d > maxRateLimitCooldown {
+		d = rateLimitCooldown
+	}
+	until := time.Now().Add(d)
+	c.rlMu.Lock()
+	if until.After(c.rlPausedUntil) {
+		c.rlPausedUntil = until
+		slog.Warn("github: rate limited, pausing API calls", "until", until.Format(time.RFC3339), "for", d.Round(time.Second))
+	}
+	c.rlMu.Unlock()
+}
+
+// rateLimitDelay reports whether resp is a GitHub rate-limit rejection and, if
+// so, a suggested cooldown. It honors a numeric Retry-After (secondary/abuse
+// limits); otherwise a 403/429 with X-RateLimit-Remaining==0 falls back to the
+// default cooldown.
+func rateLimitDelay(resp *http.Response) (time.Duration, bool) {
 	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
 		return 0, false
 	}
@@ -179,16 +215,7 @@ func rateLimitBackoff(resp *http.Response) (time.Duration, bool) {
 		}
 	}
 	if resp.Header.Get("X-RateLimit-Remaining") == "0" {
-		if rs := resp.Header.Get("X-RateLimit-Reset"); rs != "" {
-			if epoch, err := strconv.ParseInt(strings.TrimSpace(rs), 10, 64); err == nil {
-				wait := time.Until(time.Unix(epoch, 0)) + time.Second
-				if wait < time.Second {
-					wait = time.Second
-				}
-				return wait, true
-			}
-		}
-		return 2 * time.Second, true
+		return rateLimitCooldown, true
 	}
 	return 0, false
 }

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -117,17 +117,80 @@ func (c *Client) do(method, path string, accept string) (*http.Response, error) 
 // TODO: migrate SubmitReview and PostComment to doWithBody as well — they
 // still build their request inline, duplicating the header setup.
 func (c *Client) doWithBody(method, path, accept, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(method, c.baseURL+path, body)
-	if err != nil {
-		return nil, err
+	// Bodyless (GET-like) requests are safe to re-issue after a rate-limit
+	// backoff. Requests with a body are attempted once — the reader would be
+	// consumed and cannot be rewound for a retry.
+	maxAttempts := 1
+	if body == nil {
+		maxAttempts = 3
 	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Accept", accept)
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	if contentType != "" {
-		req.Header.Set("Content-Type", contentType)
+	for attempt := 1; ; attempt++ {
+		req, err := http.NewRequest(method, c.baseURL+path, body)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Accept", accept)
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		// When GitHub rate-limits us (primary exhaustion or a secondary/abuse
+		// burst limit), pause and retry instead of hammering. This paces the
+		// sequential bursts (discovery archive-checks, per-repo issue fetches)
+		// that otherwise trip the secondary limit even while the hourly budget
+		// is healthy. A far-off primary reset (beyond the cap) is returned to
+		// the caller so the daemon never blocks for the full hour.
+		if attempt < maxAttempts {
+			if wait, ok := rateLimitBackoff(resp); ok && wait <= maxRateLimitBackoff {
+				resp.Body.Close()
+				slog.Warn("github: rate limited, backing off before retry",
+					"path", path, "wait", wait.Round(time.Second), "attempt", attempt)
+				time.Sleep(wait)
+				continue
+			}
+		}
+		return resp, nil
 	}
-	return c.http.Do(req)
+}
+
+// maxRateLimitBackoff caps how long a single request blocks waiting out a
+// rate-limit window before giving up. Secondary-limit Retry-After delays are
+// usually seconds; a primary-limit reset can be up to an hour away, and we must
+// not stall the daemon that long.
+const maxRateLimitBackoff = 90 * time.Second
+
+// rateLimitBackoff reports whether resp is a GitHub rate-limit rejection and,
+// if so, how long to wait before retrying. It honors Retry-After (secondary /
+// abuse limits) first, then X-RateLimit-Remaining==0 with X-RateLimit-Reset
+// (primary), with a small default when a limit is signaled without a usable
+// delay. A one-second cushion is added so the retry lands after the window.
+func rateLimitBackoff(resp *http.Response) (time.Duration, bool) {
+	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
+		return 0, false
+	}
+	if ra := resp.Header.Get("Retry-After"); ra != "" {
+		if secs, err := strconv.Atoi(strings.TrimSpace(ra)); err == nil && secs >= 0 {
+			return time.Duration(secs)*time.Second + time.Second, true
+		}
+	}
+	if resp.Header.Get("X-RateLimit-Remaining") == "0" {
+		if rs := resp.Header.Get("X-RateLimit-Reset"); rs != "" {
+			if epoch, err := strconv.ParseInt(strings.TrimSpace(rs), 10, 64); err == nil {
+				wait := time.Until(time.Unix(epoch, 0)) + time.Second
+				if wait < time.Second {
+					wait = time.Second
+				}
+				return wait, true
+			}
+		}
+		return 2 * time.Second, true
+	}
+	return 0, false
 }
 
 // FetchPRsToReview returns all open PRs where the authenticated user is explicitly

--- a/daemon/internal/github/rate_limit_backoff_internal_test.go
+++ b/daemon/internal/github/rate_limit_backoff_internal_test.go
@@ -1,0 +1,56 @@
+package github
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func respWith(status int, headers map[string]string) *http.Response {
+	h := http.Header{}
+	for k, v := range headers {
+		h.Set(k, v)
+	}
+	return &http.Response{StatusCode: status, Header: h}
+}
+
+func TestRateLimitBackoff(t *testing.T) {
+	// Non-rate-limit responses never back off.
+	for _, status := range []int{200, 404, 422, 500} {
+		if _, ok := rateLimitBackoff(respWith(status, nil)); ok {
+			t.Errorf("status %d should not back off", status)
+		}
+	}
+	// A bare 403 (permission denied, no rate-limit signal) is not a backoff.
+	if _, ok := rateLimitBackoff(respWith(403, nil)); ok {
+		t.Error("403 without rate-limit headers should not back off")
+	}
+
+	// Retry-After (secondary/abuse limit) — honored on 403 and 429, +1s cushion.
+	if w, ok := rateLimitBackoff(respWith(403, map[string]string{"Retry-After": "30"})); !ok || w != 31*time.Second {
+		t.Errorf("403 Retry-After=30 → (%v,%v), want (31s,true)", w, ok)
+	}
+	if w, ok := rateLimitBackoff(respWith(429, map[string]string{"Retry-After": "5"})); !ok || w != 6*time.Second {
+		t.Errorf("429 Retry-After=5 → (%v,%v), want (6s,true)", w, ok)
+	}
+
+	// Primary exhaustion: remaining=0 + reset in the future → wait ~until reset.
+	reset := time.Now().Add(40 * time.Second).Unix()
+	if w, ok := rateLimitBackoff(respWith(403, map[string]string{
+		"X-RateLimit-Remaining": "0",
+		"X-RateLimit-Reset":     strconv.FormatInt(reset, 10),
+	})); !ok || w < 30*time.Second || w > 45*time.Second {
+		t.Errorf("remaining=0 reset+40s → (%v,%v), want ~41s true", w, ok)
+	}
+
+	// remaining=0 without a reset header → small default backoff.
+	if w, ok := rateLimitBackoff(respWith(403, map[string]string{"X-RateLimit-Remaining": "0"})); !ok || w != 2*time.Second {
+		t.Errorf("remaining=0 no reset → (%v,%v), want (2s,true)", w, ok)
+	}
+
+	// remaining>0 on a 403 → not a rate limit.
+	if _, ok := rateLimitBackoff(respWith(403, map[string]string{"X-RateLimit-Remaining": "12"})); ok {
+		t.Error("403 with remaining>0 should not back off")
+	}
+}

--- a/daemon/internal/github/rate_limit_backoff_internal_test.go
+++ b/daemon/internal/github/rate_limit_backoff_internal_test.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 )
@@ -15,42 +14,53 @@ func respWith(status int, headers map[string]string) *http.Response {
 	return &http.Response{StatusCode: status, Header: h}
 }
 
-func TestRateLimitBackoff(t *testing.T) {
-	// Non-rate-limit responses never back off.
+func TestRateLimitDelay(t *testing.T) {
+	// Non-rate-limit responses.
 	for _, status := range []int{200, 404, 422, 500} {
-		if _, ok := rateLimitBackoff(respWith(status, nil)); ok {
-			t.Errorf("status %d should not back off", status)
+		if _, ok := rateLimitDelay(respWith(status, nil)); ok {
+			t.Errorf("status %d should not be a rate limit", status)
 		}
 	}
-	// A bare 403 (permission denied, no rate-limit signal) is not a backoff.
-	if _, ok := rateLimitBackoff(respWith(403, nil)); ok {
-		t.Error("403 without rate-limit headers should not back off")
+	// A bare 403 (permission denied) or a 403 with budget left is not a limit.
+	if _, ok := rateLimitDelay(respWith(403, nil)); ok {
+		t.Error("bare 403 should not be a rate limit")
+	}
+	if _, ok := rateLimitDelay(respWith(403, map[string]string{"X-RateLimit-Remaining": "12"})); ok {
+		t.Error("403 with remaining>0 should not be a rate limit")
 	}
 
-	// Retry-After (secondary/abuse limit) — honored on 403 and 429, +1s cushion.
-	if w, ok := rateLimitBackoff(respWith(403, map[string]string{"Retry-After": "30"})); !ok || w != 31*time.Second {
-		t.Errorf("403 Retry-After=30 → (%v,%v), want (31s,true)", w, ok)
+	// Numeric Retry-After honored, +1s cushion, on 403 and 429.
+	if d, ok := rateLimitDelay(respWith(403, map[string]string{"Retry-After": "30"})); !ok || d != 31*time.Second {
+		t.Errorf("403 Retry-After=30 → (%v,%v), want (31s,true)", d, ok)
 	}
-	if w, ok := rateLimitBackoff(respWith(429, map[string]string{"Retry-After": "5"})); !ok || w != 6*time.Second {
-		t.Errorf("429 Retry-After=5 → (%v,%v), want (6s,true)", w, ok)
-	}
-
-	// Primary exhaustion: remaining=0 + reset in the future → wait ~until reset.
-	reset := time.Now().Add(40 * time.Second).Unix()
-	if w, ok := rateLimitBackoff(respWith(403, map[string]string{
-		"X-RateLimit-Remaining": "0",
-		"X-RateLimit-Reset":     strconv.FormatInt(reset, 10),
-	})); !ok || w < 30*time.Second || w > 45*time.Second {
-		t.Errorf("remaining=0 reset+40s → (%v,%v), want ~41s true", w, ok)
+	if d, ok := rateLimitDelay(respWith(429, map[string]string{"Retry-After": "5"})); !ok || d != 6*time.Second {
+		t.Errorf("429 Retry-After=5 → (%v,%v), want (6s,true)", d, ok)
 	}
 
-	// remaining=0 without a reset header → small default backoff.
-	if w, ok := rateLimitBackoff(respWith(403, map[string]string{"X-RateLimit-Remaining": "0"})); !ok || w != 2*time.Second {
-		t.Errorf("remaining=0 no reset → (%v,%v), want (2s,true)", w, ok)
+	// Exhausted (remaining==0) without a usable Retry-After → default cooldown.
+	if d, ok := rateLimitDelay(respWith(403, map[string]string{"X-RateLimit-Remaining": "0"})); !ok || d != rateLimitCooldown {
+		t.Errorf("remaining=0 → (%v,%v), want (%v,true)", d, ok, rateLimitCooldown)
 	}
+}
 
-	// remaining>0 on a 403 → not a rate limit.
-	if _, ok := rateLimitBackoff(respWith(403, map[string]string{"X-RateLimit-Remaining": "12"})); ok {
-		t.Error("403 with remaining>0 should not back off")
+func TestPauseRateLimit(t *testing.T) {
+	c := &Client{}
+	if _, paused := c.rateLimitPaused(); paused {
+		t.Fatal("fresh client should not be paused")
+	}
+	c.pauseRateLimit(30 * time.Second)
+	until, paused := c.rateLimitPaused()
+	if !paused {
+		t.Fatal("client should be paused after pauseRateLimit")
+	}
+	if d := time.Until(until); d < 25*time.Second || d > 31*time.Second {
+		t.Errorf("pause window ≈ %v, want ~30s", d)
+	}
+	// An over-large delay is clamped to the default cooldown, not honored raw.
+	c2 := &Client{}
+	c2.pauseRateLimit(2 * time.Hour)
+	until2, _ := c2.rateLimitPaused()
+	if d := time.Until(until2); d > maxRateLimitCooldown+time.Second {
+		t.Errorf("over-large pause not clamped: %v", d)
 	}
 }

--- a/daemon/internal/github/rate_limit_test.go
+++ b/daemon/internal/github/rate_limit_test.go
@@ -1,6 +1,7 @@
 package github_test
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -58,31 +59,37 @@ func TestRateLimit_ErrorStatus(t *testing.T) {
 	}
 }
 
-// TestRateLimit_RetriesAfterBackoff verifies a GET that is rate-limited (403 +
-// Retry-After) is transparently retried after backing off, then succeeds.
-func TestRateLimit_RetriesAfterBackoff(t *testing.T) {
+// TestRateLimit_CircuitBreakerPausesAfter403 verifies that once GitHub
+// rate-limits a request, the client opens its breaker and subsequent calls fail
+// fast WITHOUT hitting GitHub — so the daemon stops piling traffic onto an
+// active (secondary) block instead of keeping it alive.
+func TestRateLimit_CircuitBreakerPausesAfter403(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if atomic.AddInt32(&calls, 1) == 1 {
-			w.Header().Set("Retry-After", "0") // rate limited; retry immediately
-			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte(`{"message":"API rate limit exceeded"}`))
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"archived": false}`))
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"API rate limit exceeded"}`))
 	}))
 	defer srv.Close()
 
 	c := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
-	archived, err := c.IsRepoArchived("acme/widget")
-	if err != nil {
-		t.Fatalf("IsRepoArchived: %v", err)
+
+	// First call reaches GitHub, is rate-limited → surfaced as an error.
+	if _, err := c.IsRepoArchived("acme/widget"); err == nil {
+		t.Fatal("expected an error on the first rate-limited call")
 	}
-	if archived {
-		t.Error("archived = true, want false")
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("after first call server calls = %d, want 1", got)
 	}
-	if got := atomic.LoadInt32(&calls); got != 2 {
-		t.Errorf("server calls = %d, want 2 (rate-limited then retried)", got)
+
+	// Breaker is open: the next call fails fast without contacting GitHub.
+	_, err := c.IsRepoArchived("acme/other")
+	var rle *gh.RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("second call error = %v, want *github.RateLimitError", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("second call hit the server (calls=%d); breaker should short-circuit", got)
 	}
 }

--- a/daemon/internal/github/rate_limit_test.go
+++ b/daemon/internal/github/rate_limit_test.go
@@ -3,6 +3,7 @@ package github_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	gh "github.com/heimdallm/daemon/internal/github"
@@ -54,5 +55,34 @@ func TestRateLimit_ErrorStatus(t *testing.T) {
 	c := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
 	if _, err := c.RateLimit(); err == nil {
 		t.Fatal("expected error on 401, got nil")
+	}
+}
+
+// TestRateLimit_RetriesAfterBackoff verifies a GET that is rate-limited (403 +
+// Retry-After) is transparently retried after backing off, then succeeds.
+func TestRateLimit_RetriesAfterBackoff(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("Retry-After", "0") // rate limited; retry immediately
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"API rate limit exceeded"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"archived": false}`))
+	}))
+	defer srv.Close()
+
+	c := gh.NewClient("fake", gh.WithBaseURL(srv.URL))
+	archived, err := c.IsRepoArchived("acme/widget")
+	if err != nil {
+		t.Fatalf("IsRepoArchived: %v", err)
+	}
+	if archived {
+		t.Error("archived = true, want false")
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("server calls = %d, want 2 (rate-limited then retried)", got)
 	}
 }


### PR DESCRIPTION
## Qué

Tres arreglos de fiabilidad del daemon que surgieron de la sesión de depuración:

### 1. Rate limit de GitHub (errores 403 constantes / "servidor no disponible")
Con 80+ repos monitorizados, las ráfagas secuenciales del daemon (archive-checks de discovery + fetch de issues por repo) disparaban el **secondary rate limit** de GitHub (el core primario seguía sano, pero cada request daba 403). El cliente no tenía ningún manejo de rate limit → seguía machacando → el bloqueo nunca se levantaba, y como `/user` también caía, el bot no resolvía su login → **no revisaba PRs**.
- **Circuit breaker** (`ea60d2c`): al recibir un 403/429 de rate limit, el cliente abre una ventana de enfriamiento (honra `Retry-After`, si no 60s, tope 5m) y **todas las llamadas siguientes fallan rápido sin tocar GitHub** → el tráfico cae a cero y el bloqueo se levanta.
- **Caché TTL de archived** (`85a3965`): evita 1 `GET /repos` por repo en cada tick de discovery para un dato casi estático.
- (`2ad0711`: backoff por-request inicial, sustituido por el breaker.)

### 2. `non_monitored` no se respetaba para repos con `[ai.repos.*]` (`2a0bfb3`)
Desactivar un repo desde la vista de Repositories era un **no-op** si el repo tenía override AI: `MergeRepos` eximía a los repos "configured" de la blacklist de `non_monitored`. Ahora `non_monitored` es autoritativo (el disable explícito gana); los repos configured siguen entrando en la unión cuando **no** están en `non_monitored` (se preserva el fix de #281).

### 3. Guardado de settings lentísimo / inoperativo (`7d96242`)
Un guardado que cambiaba un campo relevante para los pollers bloqueaba en `reloadFn` esperando (`oldWg.Wait()`) a que terminara el ciclo de poll / review en vuelo → **20-30s** de "guardando" congelado, y serializado (guardados concurrentes en cola). Ahora la recarga **aplica la config al instante y devuelve**; el teardown+restart de pollers va en una goroutine de fondo serializada (sin dos juegos de pollers, sin solape). Medido: PATCH que dispara restart **23s → ~2s**.

## Verificación
- Tests Go: `internal/github` (breaker, delay, e2e), `internal/discovery` (non_monitored gana), `internal/server`, `cmd/heimdallm` — verdes; `go build`/`vet` ok; race test del reload ok.
- En vivo (daemon en local): 0 errores de rate limit tras el fix, PRs revisándose; PATCH /config ~2s (antes 23-30s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
