### PR TITLE
ci: unblock release-please PR checks (workflow_dispatch + PAT option)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,9 @@ name: Docker Build Validation
 on:
   pull_request:
     branches: [main]
+  # Manual trigger for branches GitHub won't auto-run (e.g. the release-please
+  # PR, created by GITHUB_TOKEN). See tests.yml for the rationale.
+  workflow_dispatch:
 
 env:
   # Opt-in to Node.js 24 for all JavaScript actions (Node 20 deprecated Sep 2026)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,14 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a PAT (RELEASE_PLEASE_TOKEN) so the release PR's commits are
+          # attributed to a user and DO trigger the Tests / Docker workflows.
+          # PRs created with the default GITHUB_TOKEN never trigger further
+          # workflows, which left the release PR with no checks (UNSTABLE) and
+          # unmergeable. Falls back to GITHUB_TOKEN when the secret is absent
+          # (release PR is still created, but its checks must be run manually
+          # via the workflow_dispatch added to tests.yml / docker-publish.yml).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Test gate — all build jobs depend on this

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual trigger: lets a maintainer run the checks on a branch that GitHub
+  # won't auto-run them on — notably the release-please PR, whose commits come
+  # from GITHUB_TOKEN and therefore never trigger pull_request workflows.
+  workflow_dispatch:
 
 concurrency:
   group: tests-${{ github.ref }}


### PR DESCRIPTION
Fixes the release PR (#560) sitting UNSTABLE with no checks: release-please creates it with GITHUB_TOKEN, so GitHub never triggers its workflows. Adds `workflow_dispatch` to tests.yml + docker-publish.yml (manual run for such branches) and a RELEASE_PLEASE_TOKEN PAT option in release.yml (fallback to GITHUB_TOKEN). 🤖 Generated with [Claude Code](https://claude.com/claude-code)