### PR TITLE
fix(executor): keep coreutils on PATH in CLI-exec tests (Linux release gate)

### DIFF
--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -60,7 +60,12 @@ func TestDetect_NoneAvailable(t *testing.T) {
 func TestExecute(t *testing.T) {
 	_, file, _, _ := runtime.Caller(0)
 	binDir := filepath.Join(filepath.Dir(file), "testdata", "bin")
-	t.Setenv("PATH", binDir)
+	// Prepend (not replace) so the fake `claude` is resolved first while the
+	// system coreutils the fake script relies on (`cat`) stay on PATH. On a
+	// dash-based /bin/sh (Linux CI runners) `cat` is not a shell builtin, so a
+	// replaced PATH makes the fake CLI exit 127 with "cat: not found". The fake
+	// binary wins because binDir comes first.
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	e := executor.New()
 	result, err := e.Execute("claude", "Review this diff", executor.ExecOptions{})
@@ -179,7 +184,10 @@ func TestExecuteRawCodexUsesExecAndReadsPromptFromStdin(t *testing.T) {
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake CLI: %v", err)
 	}
-	t.Setenv("PATH", binDir)
+	// Prepend so the fake `codex` wins while the script's `cat > file`
+	// (stdin capture) can still resolve system `cat`. See TestExecute for why
+	// a replaced PATH breaks on dash-based /bin/sh.
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	prompt := "review this PR"
 	e := executor.New()


### PR DESCRIPTION
## Problema

El release de **v0.7.3** se cortó pero el build de binarios falló: el job `Tests` de `release.yml` (que corre en **ubuntu-22.04**) falló en el paquete `executor`, saltándose los 4 jobs de build de assets. El release quedó sin binarios.

Causa raíz:
```
executor_test.go:68: execute: run claude: exit status 127 (output: .../testdata/bin/claude: 3: cat: not found)
```
`TestExecute` y `TestExecuteRawCodexUsesExecAndReadsPromptFromStdin` **reemplazaban** `$PATH` por solo el directorio del CLI falso. Los scripts falsos (`claude`/`codex`) invocan `cat` (heredoc / captura de stdin), que **no es builtin** del `/bin/sh` basado en dash de los runners Linux → exit 127 `cat: not found`. En runners macOS (donde corre `tests.yml`) no se notaba.

Es fragilidad **pre-existente** (el código de test es byte-idéntico a v0.7.2); la salió a la luz la imagen actual del runner. No es regresión de #585.

## Fix

Anteponer el bin dir falso al `$PATH` existente en vez de reemplazarlo: el CLI falso sigue ganando (va primero) y los coreutils del sistema (`cat`) siguen resolviéndose. Los tests de aislamiento de detección (`TestDetect*`) no se tocan.

## Verificación

- Reproducido el bug con el script real bajo PATH restringido (`cat: command not found`) y confirmado que el fix lo resuelve.
- `go test ./internal/executor/` ✅ · `go vet ./...` ✅ · build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)