### PR TITLE
fix(app): folder pickers + explicit Org save (no lost edits)

### DIFF
--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -1,3 +1,4 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -87,6 +88,7 @@ class ConfigScreen extends ConsumerStatefulWidget {
 class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   final _tokenController = TextEditingController();
   final _pollController = TextEditingController();
+  final _cloneDirController = TextEditingController();
   final _pollFieldKey = GlobalKey<FormFieldState<String>>();
   bool _obscureToken = true;
   bool _tokenFromGh = false; // true = auto-detected from gh CLI
@@ -133,6 +135,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   void dispose() {
     _tokenController.dispose();
     _pollController.dispose();
+    _cloneDirController.dispose();
     _devMaxTurnsController.dispose();
     _devTimeoutController.dispose();
     _claimLeaseController.dispose();
@@ -610,6 +613,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     _globalNeverApproveWithIssues = config.globalNeverApproveWithIssues;
     _globalTriageOwner = config.globalTriageOwner;
     _globalCloneDir = config.globalCloneDir;
+    _cloneDirController.text = config.globalCloneDir;
     _globalAutoPromoteTriage = config.globalAutoPromoteTriage ?? false;
     _globalAutoPromoteRefinement = config.globalAutoPromoteRefinement ?? false;
     _globalGeneratePRDescription = config.globalGeneratePRDescription;
@@ -657,11 +661,24 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       ),
       const SizedBox(height: 12),
       TextFormField(
-        initialValue: _globalCloneDir,
-        decoration: const InputDecoration(
+        controller: _cloneDirController,
+        decoration: InputDecoration(
           labelText: 'Clone directory',
           hintText: 'Base directory for managed repo clones',
           isDense: true,
+          suffixIcon: IconButton(
+            tooltip: 'Browse…',
+            icon: const Icon(Icons.folder_open, size: 18),
+            onPressed: () async {
+              final dir = await FilePicker.getDirectoryPath(
+                dialogTitle: 'Select clone directory',
+                lockParentWindow: true,
+              );
+              if (dir == null || dir.isEmpty) return;
+              _cloneDirController.text = dir;
+              _globalCloneDir = dir;
+            },
+          ),
         ),
         onChanged: (v) => _globalCloneDir = v.trim(),
       ),

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -25,7 +25,13 @@ class OrgDetailScreen extends ConsumerStatefulWidget {
 
 class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
   OrgConfig _config = const OrgConfig();
+  // Last value successfully persisted to the daemon. All diffs are computed
+  // against this baseline (not the pre-edit value) so that rapid edits to
+  // several fields all reach the server, and so the Save button / dirty state
+  // reflect "unsaved since last persist".
+  OrgConfig _saved = const OrgConfig();
   bool _initialized = false;
+  bool _saving = false;
   Timer? _debounce;
 
   @override
@@ -38,29 +44,37 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
     if (_initialized) return;
     _initialized = true;
     _config = config.orgConfigs[widget.orgName] ?? const OrgConfig();
+    _saved = _config;
   }
+
+  bool get _dirty => _computeOrgDiff(_saved, _config).isNotEmpty;
 
   void _update(OrgConfig updated) {
-    final previous = _config;
     setState(() => _config = updated);
+    // Debounced convenience auto-save; the explicit Save button and the
+    // save-on-leave guard (PopScope) cover the sub-debounce window so edits
+    // are never silently dropped.
     _debounce?.cancel();
-    _debounce = Timer(
-      const Duration(milliseconds: 800),
-      () => _autoSave(previous),
-    );
+    _debounce = Timer(const Duration(milliseconds: 800), _save);
   }
 
-  Future<void> _autoSave(OrgConfig previous) async {
-    final diff = _computeOrgDiff(previous, _config);
+  Future<void> _save() async {
+    _debounce?.cancel();
+    final diff = _computeOrgDiff(_saved, _config);
     if (diff.isEmpty) return;
+    final target = _config;
+    if (mounted) setState(() => _saving = true);
     try {
       final freshJson = await ref
           .read(apiClientProvider)
           .patchOrgConfig(widget.orgName, diff);
       ref.read(configNotifierProvider.notifier).updateFromServer(freshJson);
+      _saved = target;
       if (mounted) showToast(context, 'Saved');
     } catch (e) {
       if (mounted) showToast(context, 'Error: $e', isError: true);
+    } finally {
+      if (mounted) setState(() => _saving = false);
     }
   }
 
@@ -73,6 +87,7 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
       final freshConfig = AppConfig.fromJson(freshJson);
       setState(() {
         _config = freshConfig.orgConfigs[widget.orgName] ?? const OrgConfig();
+        _saved = _config;
       });
       if (mounted) showToast(context, 'Reset to global');
     } catch (e) {
@@ -188,15 +203,44 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
   @override
   Widget build(BuildContext context) {
     final configAsync = ref.watch(configNotifierProvider);
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.orgName),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.canPop() ? context.pop() : context.go('/'),
+    return PopScope(
+      // Block the pop while there are unsaved edits so the sub-debounce window
+      // can't drop them: flush the save, then leave. When nothing is pending
+      // (canPop true) navigation proceeds normally.
+      canPop: !_dirty,
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop) return;
+        await _save();
+        if (!context.mounted) return;
+        if (context.canPop()) context.pop();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(widget.orgName),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => context.canPop() ? context.pop() : context.go('/'),
+          ),
+          actions: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: _saving
+                  ? const Center(
+                      child: SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    )
+                  : TextButton.icon(
+                      onPressed: _dirty ? _save : null,
+                      icon: const Icon(Icons.save, size: 18),
+                      label: const Text('Save'),
+                    ),
+            ),
+          ],
         ),
-      ),
-      body: configAsync.when(
+        body: configAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (_, _) => const Center(child: Text('Could not load config')),
         data: (appConfig) {
@@ -214,6 +258,7 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                     label: 'Local directory',
                     globalValue: '',
                     overrideValue: _config.localDir,
+                    isDirectory: true,
                     onChanged: (v) => _update(_config.copyWith(localDir: v)),
                     onReset: () => _resetField('local_dir'),
                   ),
@@ -549,6 +594,7 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
             ),
           );
         },
+        ),
       ),
     );
   }

--- a/flutter_app/lib/shared/widgets/override_field.dart
+++ b/flutter_app/lib/shared/widgets/override_field.dart
@@ -1,3 +1,4 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 
 /// A field that shows the effective value (global or overridden) with
@@ -15,6 +16,10 @@ class OverrideTextField extends StatefulWidget {
   final ValueChanged<String?> onChanged;
   final VoidCallback? onReset;
 
+  /// When true, renders a folder-picker button so the user can browse the
+  /// filesystem instead of typing the path by hand.
+  final bool isDirectory;
+
   const OverrideTextField({
     super.key,
     required this.label,
@@ -24,6 +29,7 @@ class OverrideTextField extends StatefulWidget {
     required this.overrideValue,
     required this.onChanged,
     this.onReset,
+    this.isDirectory = false,
   });
 
   @override
@@ -83,6 +89,16 @@ class _OverrideTextFieldState extends State<OverrideTextField> {
     } else {
       widget.onChanged(trimmed);
     }
+  }
+
+  Future<void> _pickDirectory() async {
+    final selected = await FilePicker.getDirectoryPath(
+      dialogTitle: 'Select ${widget.label}',
+      lockParentWindow: true,
+    );
+    if (selected == null || selected.isEmpty) return;
+    _ctrl.text = selected;
+    _handleChange(selected);
   }
 
   @override
@@ -173,6 +189,13 @@ class _OverrideTextFieldState extends State<OverrideTextField> {
                 horizontal: 8,
                 vertical: 8,
               ),
+              suffixIcon: widget.isDirectory
+                  ? IconButton(
+                      tooltip: 'Browse…',
+                      icon: const Icon(Icons.folder_open, size: 18),
+                      onPressed: _pickDirectory,
+                    )
+                  : null,
             ),
             onChanged: _handleChange,
           ),


### PR DESCRIPTION
Tres problemas reportados en Settings y la vista Organizations:

## 1. No se puede seleccionar carpeta (Global + Organization)
"Clone directory" (Global) y "Local directory" (Organization) solo se podían escribir a mano. Ahora tienen un **botón de carpeta (Browse)**:
- `OverrideTextField` (compartido) gana un flag `isDirectory` cableado a `FilePicker.getDirectoryPath`.
- El campo global de clone-dir usa el mismo botón.
- (Repositories ya tenía picker nativo.)

## 2. Organization: no había botón de guardar + se perdían cambios
El auto-guardado con debounce **se cancelaba en `dispose()` sin flush**: editar un campo y salir de la pantalla antes de 800ms **descartaba el cambio en silencio**. Además el baseline era el valor pre-edición, así que editar varios campos rápido solo persistía el último.

Ahora:
- **Botón "Save" explícito** en el AppBar (activo mientras hay cambios sin guardar).
- Diffs calculados contra el último valor **persistido** (`_saved`), no el pre-edición.
- `PopScope` que **hace flush del guardado antes de cerrar** la pantalla.
- El auto-save se mantiene como conveniencia.

## Retrocompatibilidad
No hay cambios de formato de config ni del daemon: `config.toml` y la tabla `configs` de SQLite ya **persisten** entre reinstalaciones de la app (verificado en disco). La pérdida que veías era este descarte client-side de la vista de org, ahora corregido.

## Verificación
- `flutter analyze` sin issues ✅ · `flutter test` 202/202 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)