### PR TITLE
fix: restore macOS entitlements in local package + stop false "Server unavailable"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,7 +404,13 @@ restart: _check-docker
 
 package-macos: _check-macos build-daemon build-app
 	cp $(DAEMON_BIN) "$(APP_BUNDLE)/Contents/MacOS/heimdalld"
-	codesign --force --deep --sign - "$(APP_BUNDLE)"
+	# Re-sign WITH the entitlements — a bare `codesign --sign -` strips the
+	# entitlements `flutter build` applied, dropping the
+	# files.user-selected.read-write capability so file_picker's native
+	# directory picker silently no-ops. Mirrors the release.yml build-macos job.
+	codesign --force --deep --sign - \
+	  --entitlements flutter_app/macos/Runner/Release.entitlements \
+	  "$(APP_BUNDLE)"
 	mkdir -p dist
 	hdiutil create \
 	  -volname "Heimdallm" \

--- a/flutter_app/lib/features/dashboard/dashboard_providers.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_providers.dart
@@ -89,11 +89,22 @@ class DaemonConnectionNotifier extends Notifier<DaemonConnectionStatus> {
         state = const DaemonConnectionStatus.connecting();
       }
       if (next.hasError) {
-        state = DaemonConnectionStatus(
-          phase: DaemonConnectionPhase.offline,
-          lastEventAt: state.lastEventAt,
-          message: next.error.toString(),
-        );
+        // A dropped/errored SSE stream does NOT mean the daemon is down: the
+        // long-lived connection resets for many benign reasons (idle timeout,
+        // the daemon momentarily busy, a network blip). Going straight to
+        // "offline" here is what flashes a bogus "Server unavailable" while the
+        // daemon is perfectly healthy. Instead show "reconnecting" and verify
+        // health first — _verifyAndReconnect reconnects when the daemon answers
+        // and only falls back to offline when it genuinely doesn't.
+        if (state.phase != DaemonConnectionPhase.offline &&
+            state.phase != DaemonConnectionPhase.connecting) {
+          state = DaemonConnectionStatus(
+            phase: DaemonConnectionPhase.connecting,
+            lastEventAt: state.lastEventAt,
+            message: 'Reconnecting…',
+          );
+        }
+        unawaited(_verifyAndReconnect());
       }
       next.whenData((_) {
         _reconnectAttempts = 0;
@@ -139,6 +150,13 @@ class DaemonConnectionNotifier extends Notifier<DaemonConnectionStatus> {
           phase: DaemonConnectionPhase.connecting,
           lastEventAt: DateTime.now(),
         );
+        // Back off before reconnecting so a stream that errors instantly
+        // (daemon healthy but the SSE endpoint flapping) can't hot-loop:
+        // 1s, 2s, 4s… capped. _checkingHealth stays true across the delay,
+        // so overlapping error emissions collapse into this one attempt.
+        final backoffShift = _reconnectAttempts > 4 ? 4 : _reconnectAttempts;
+        await Future<void>.delayed(Duration(seconds: 1 << backoffShift));
+        if (!ref.mounted) return;
         ref.invalidate(sseStreamProvider);
       } else {
         state = DaemonConnectionStatus(


### PR DESCRIPTION
Dos defectos sobre la app de escritorio en marcha:

## 1. Los botones Browse (carpeta) no hacían nada en builds locales
`make package-macos` re-firmaba con `codesign --sign -` **sin `--entitlements`**, lo que **borra** los entitlements que `flutter build` había aplicado — quitando `com.apple.security.files.user-selected.read-write`, así que el diálogo nativo de `file_picker` no-op silenciosamente.

El job `build-macos` de `release.yml` ya firmaba con `--entitlements`; el Makefile ahora hace lo mismo. (El código del picker y `Release.entitlements` ya eran correctos; solo la re-firma local era destructiva. El DMG distribuido en las releases nunca tuvo este problema.)

Verificado: la app reinstalada ahora expone `files.user-selected.read-write` y el picker abre.

## 2. "Server unavailable" intermitente con el daemon sano
El watchdog de conexión saltaba directo a `offline` ante **cualquier** error del stream SSE, aunque una conexión SSE de larga duración se resetea por muchas razones benignas (idle, daemon ocupado un instante, blip de red). Eso es lo que hacía parpadear el "Server unavailable" falso.

Ahora un error de SSE muestra "Reconnecting…" y pasa por la verificación de salud existente: reconecta si el daemon responde y **solo** reporta offline si un health check falla de verdad. Añade backoff 1→16s antes de reconectar para que un stream que falla al instante no haga hot-loop.

## Verificación
- `flutter analyze` sin issues ✅ · `flutter test` 202/202 ✅
- Daemon local: log sin errores de servidor; estaba sano mientras se veía "unavailable" → confirma que era falso positivo del cliente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)