### PR TITLE
fix: prevent automatic reviews for non-monitored repositories

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -146,6 +146,8 @@ func main() {
 	if err := cfg.MergeStoreLayer(s); err != nil {
 		slog.Warn("config: store layer not applied, continuing with TOML+env", "err", err)
 	}
+	var monitoringConflictWarner repoMonitoringConflictWarner
+	monitoringConflictWarner.warn(cfg)
 
 	if err := s.PurgeOldReviews(cfg.Retention.MaxDays); err != nil {
 		slog.Warn("retention purge failed", "err", err)
@@ -1052,15 +1054,22 @@ func main() {
 			_ = s.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC())
 			return nil // permanent — ack
 		}
-		inFlight, err := s.ReviewInFlight(pr.GithubID, rev.HeadSHA)
+		claimed, err := s.ClaimInFlightReview(pr.GithubID, rev.HeadSHA)
 		if err != nil {
-			return fmt.Errorf("check in-flight review: %w", err)
+			return fmt.Errorf("claim review for publish: %w", err)
 		}
-		if inFlight {
-			slog.Debug("publish-worker: initial publish still in flight, skipping retry",
+		if !claimed {
+			slog.Debug("publish-worker: review already claimed, skipping duplicate publish",
 				"review_id", msg.ReviewID, "github_id", pr.GithubID, "head_sha", rev.HeadSHA)
 			return nil // PublishPending re-enqueues if the row remains unpublished after release.
 		}
+		defer func() {
+			if err := s.ReleaseInFlightReview(pr.GithubID, rev.HeadSHA); err != nil {
+				slog.Warn("publish-worker: failed to release publish claim",
+					"review_id", msg.ReviewID, "github_id", pr.GithubID,
+					"head_sha", rev.HeadSHA, "err", err)
+			}
+		}()
 
 		// Rebuild ReviewResult from stored JSON
 		var issues []executor.Issue
@@ -1084,26 +1093,88 @@ func main() {
 		// legacy rows without a stored event fall back to severity. Mirrors the
 		// pipeline's Run / PublishPending paths.
 		publishEvent := pipeline.PublishEventFor(rev)
-		cancelled, err := cancelPublishIfUnmonitored(
-			s,
-			rev.ID,
-			pr.Repo,
-			repoCurrentlyMonitored,
-			time.Now().UTC(),
-		)
+		deferForMonitoringChange := func(stage string) bool {
+			if !deferPublishIfUnmonitored(pr.Repo, repoCurrentlyMonitored) {
+				return false
+			}
+			broker.Publish(sse.Event{
+				Type: sse.EventReviewSkipped,
+				Data: sseData(map[string]any{
+					"repo":      pr.Repo,
+					"pr_number": pr.Number,
+					"pr_title":  pr.Title,
+					"reason":    string(pipeline.SkipReasonNotMonitored),
+				}),
+			})
+			slog.Info("publish-worker: repo no longer monitored, deferring unpublished review",
+				"review_id", rev.ID, "repo", pr.Repo, "stage", stage)
+			return true
+		}
+		if deferForMonitoringChange("before_head_refresh") {
+			return nil // ack; PublishPending re-enqueues it after the repo is re-enabled
+		}
+
+		// A deferred review is valid only for the commit it analysed. Re-fetch
+		// the live PR snapshot immediately before SubmitReview so re-enabling a
+		// repo cannot attach stale findings to a newer HEAD. This uses the same
+		// rate-limit slot acquired above and happens while the atomic publish
+		// claim is held, so duplicate messages cannot race this decision.
+		snapshot, err := ghClient.GetPRSnapshot(pr.Repo, pr.Number)
 		if err != nil {
-			return err
+			var apiErr *gh.APIError
+			if errors.As(err, &apiErr) && (apiErr.StatusCode == http.StatusNotFound || apiErr.StatusCode == http.StatusGone) {
+				if markErr := s.MarkReviewPublished(rev.ID, -1, "", time.Now().UTC()); markErr != nil {
+					return fmt.Errorf("mark missing-PR review %d orphaned: %w", rev.ID, markErr)
+				}
+				slog.Info("publish-worker: PR no longer exists, marking review orphaned",
+					"review_id", rev.ID, "repo", pr.Repo, "pr", pr.Number)
+				return nil
+			}
+			return fmt.Errorf("refresh PR before publishing review: %w", err)
 		}
-		if cancelled {
-			slog.Info("publish-worker: repo no longer monitored, cancelling unpublished review",
-				"review_id", rev.ID, "repo", pr.Repo)
-			return nil // permanent — ack; the sentinel keeps it out of PublishPending
+		if reason := pendingReviewInvalidReason(rev, snapshot); reason != pipeline.SkipReasonNone {
+			terminalReviewID := int64(-1)
+			if reason == pipeline.SkipReasonHeadChanged {
+				terminalReviewID = pipeline.SupersededReviewID
+			}
+			if err := s.MarkReviewPublished(rev.ID, terminalReviewID, "", time.Now().UTC()); err != nil {
+				return fmt.Errorf("retire stale review %d: %w", rev.ID, err)
+			}
+			broker.Publish(sse.Event{
+				Type: sse.EventReviewSkipped,
+				Data: sseData(map[string]any{
+					"repo":      pr.Repo,
+					"pr_number": pr.Number,
+					"pr_title":  pr.Title,
+					"reason":    string(reason),
+				}),
+			})
+			slog.Info("publish-worker: stored review no longer matches live PR, retiring it",
+				"review_id", rev.ID, "repo", pr.Repo, "pr", pr.Number,
+				"review_head_sha", rev.HeadSHA, "current_head_sha", snapshot.HeadSHA,
+				"state", snapshot.State, "reason", string(reason))
+			return nil
 		}
-		ghID, ghState, err := ghClient.SubmitReview(
-			pr.Repo, pr.Number,
-			pipeline.AnnotateBodyForEvent(pipeline.BuildGitHubBody(result), publishEvent),
-			publishEvent,
-		)
+		if rev.HeadSHA != "" && snapshot.HeadSHA == "" {
+			return fmt.Errorf("refresh PR before publishing review: empty HEAD SHA for %s #%d", pr.Repo, pr.Number)
+		}
+		if deferForMonitoringChange("before_submit") {
+			return nil
+		}
+		reviewBody := pipeline.AnnotateBodyForEvent(pipeline.BuildGitHubBody(result), publishEvent)
+		var ghID int64
+		var ghState string
+		if rev.HeadSHA != "" {
+			ghID, ghState, err = ghClient.SubmitReviewForCommit(
+				pr.Repo, pr.Number, reviewBody, publishEvent, rev.HeadSHA,
+			)
+		} else {
+			// Preserve retry compatibility for legacy rows created before head_sha
+			// was populated. New reviews always use the commit-anchored path above.
+			ghID, ghState, err = ghClient.SubmitReview(
+				pr.Repo, pr.Number, reviewBody, publishEvent,
+			)
+		}
 		if err != nil {
 			errStr := err.Error()
 			// 4xx errors (except 429 rate limit) are permanent — no point retrying.
@@ -1804,6 +1875,7 @@ func main() {
 		if err := newCfg.MergeStoreLayer(s); err != nil {
 			return fmt.Errorf("reload: %w", err)
 		}
+		monitoringConflictWarner.warn(newCfg)
 
 		cfgMu.Lock()
 		restartPollers := configReloadRequiresPollerRestart(cfg, newCfg)
@@ -2741,9 +2813,10 @@ func runTier2(
 		// PublishPending lives in the PR tick on purpose: pending
 		// publishes are almost exclusively PR-review NATS messages
 		// from runPRTier, and retries are idempotent. It must still run
-		// when the live repo set is empty so reviews for repos disabled
-		// after their initial publish attempt reach the publish worker,
-		// which marks them terminal. If we ever
+		// when the live repo set is empty so the adapter can re-evaluate
+		// pending rows immediately after a config reload re-enables their
+		// repositories. Disabled repos remain pending and are not enqueued.
+		// If we ever
 		// route issue-side NATS publishes through the same queue,
 		// add a sibling call inside issueTick rather than removing
 		// this one.
@@ -2847,6 +2920,60 @@ func aiRepoKeys(c *config.Config) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// aiReposInNonMonitored returns repo-specific AI entries that are disabled by
+// the effective non_monitored set. Older releases could persist auto-discovery
+// decisions in the same SQLite row as explicit UI toggles, so there is no safe
+// way to rewrite either list automatically. Keeping this helper read-only lets
+// the daemon surface the ambiguity without changing operator state.
+func aiReposInNonMonitored(c *config.Config) []string {
+	if c == nil || len(c.AI.Repos) == 0 || len(c.GitHub.NonMonitored) == 0 {
+		return nil
+	}
+	disabled := make(map[string]struct{}, len(c.GitHub.NonMonitored))
+	for _, repo := range c.GitHub.NonMonitored {
+		if repo != "" {
+			disabled[repo] = struct{}{}
+		}
+	}
+	conflicts := make([]string, 0)
+	for _, repo := range aiRepoKeys(c) {
+		if _, ok := disabled[repo]; ok {
+			conflicts = append(conflicts, repo)
+		}
+	}
+	return conflicts
+}
+
+// repoMonitoringConflictWarner logs each distinct conflict set once per
+// process. Reloads are serialized by reloadMu, so this small deduper does not
+// need its own lock. Clearing the conflict resets the fingerprint so a later
+// reintroduction is reported again.
+type repoMonitoringConflictWarner struct {
+	lastFingerprint string
+}
+
+func (w *repoMonitoringConflictWarner) next(c *config.Config) []string {
+	conflicts := aiReposInNonMonitored(c)
+	fingerprint := strings.Join(conflicts, "\x00")
+	if fingerprint == w.lastFingerprint {
+		return nil
+	}
+	w.lastFingerprint = fingerprint
+	return conflicts
+}
+
+func (w *repoMonitoringConflictWarner) warn(c *config.Config) {
+	conflicts := w.next(c)
+	if len(conflicts) == 0 {
+		return
+	}
+	slog.Warn(
+		"config: repo-specific AI overrides are present for repos in github.non_monitored; automatic processing stays disabled and overrides are retained for manual runs",
+		"repos", conflicts,
+		"count", len(conflicts),
+	)
 }
 
 // effectiveRepoLists returns the same monitored view used by the schedulers
@@ -3516,6 +3643,12 @@ func (a *tier2Adapter) reviewReadyForPublishRetry(rev *store.Review) (bool, erro
 	pr, err := a.store.GetPR(rev.PRID)
 	if err != nil {
 		return false, err
+	}
+	// Tests and legacy callers may construct the adapter without live config.
+	// Production always wires it; there, keep disabled repos pending until a
+	// later config reload makes them eligible again.
+	if a.cfg != nil && !a.repoIsMonitored(pr.Repo) {
+		return false, nil
 	}
 	inFlight, err := a.store.ReviewInFlight(pr.GithubID, rev.HeadSHA)
 	if err != nil {
@@ -4923,23 +5056,30 @@ func repoIsMonitored(cfg *config.Config, repo string) bool {
 	return ok
 }
 
-// cancelPublishIfUnmonitored performs the final live eligibility check before
-// SubmitReview. Marking the local row with the established orphan sentinel
-// keeps PublishPending from re-enqueueing a review after its repo is disabled.
-func cancelPublishIfUnmonitored(
-	s *store.Store,
-	reviewID int64,
-	repo string,
-	isMonitored func(string) bool,
-	now time.Time,
-) (bool, error) {
-	if isMonitored == nil || isMonitored(repo) {
-		return false, nil
+// deferPublishIfUnmonitored performs the final live eligibility check before
+// SubmitReview. It deliberately leaves the stored review unpublished: unlike
+// a permanent GitHub error, an operator disabling a repo is reversible, and
+// PublishPending can safely resume the same review after re-enable.
+func deferPublishIfUnmonitored(repo string, isMonitored func(string) bool) bool {
+	return isMonitored != nil && !isMonitored(repo)
+}
+
+// pendingReviewInvalidReason protects retry/deferred publication from live PR
+// drift. Empty review SHAs are legacy rows whose provenance cannot be checked;
+// they retain the pre-existing retry behavior rather than being destroyed by
+// an upgrade. A non-empty current SHA is required before classifying a commit
+// mismatch so transient/incomplete API responses retry instead of orphaning.
+func pendingReviewInvalidReason(rev *store.Review, snapshot *gh.PRSnapshot) pipeline.SkipReason {
+	if rev == nil || snapshot == nil {
+		return pipeline.SkipReasonNone
 	}
-	if err := s.MarkReviewPublished(reviewID, -1, "", now.UTC()); err != nil {
-		return false, fmt.Errorf("cancel unpublished review %d for unmonitored repo %q: %w", reviewID, repo, err)
+	if snapshot.State != "open" {
+		return pipeline.SkipReasonNotOpen
 	}
-	return true, nil
+	if rev.HeadSHA != "" && snapshot.HeadSHA != "" && rev.HeadSHA != snapshot.HeadSHA {
+		return pipeline.SkipReasonHeadChanged
+	}
+	return pipeline.SkipReasonNone
 }
 
 // enrollOpenItems enrolls up to 10 open PRs/issues not yet in watch_state.

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -333,6 +333,11 @@ func main() {
 	issueFetcher.SetBotLogin(resolvedBotLogin) // break re-triage loop (#362)
 	// cfgMu protects cfg and the pipeline so reload is safe from any goroutine.
 	var cfgMu sync.Mutex
+	repoCurrentlyMonitored := func(repo string) bool {
+		cfgMu.Lock()
+		defer cfgMu.Unlock()
+		return repoIsMonitored(cfg, repo)
+	}
 	var reloadMu sync.Mutex // serialises config reloads to prevent duplicate pipelines
 	// restartMu serialises the BACKGROUND poller teardown+restart kicked off by
 	// a reload that changed a poller-relevant field. Kept separate from
@@ -570,7 +575,9 @@ func main() {
 		// doesn't pre-shape (the err.Error() string and the
 		// CircuitBreakerError discriminant). See theburrowhub/heimdallm#322
 		// Bugs 3+4 for the regression that made emitting from here unsafe.
-		rev, err := p.Run(pr, buildRunOpts(pr, aiCfg))
+		runOpts := buildRunOpts(pr, aiCfg)
+		runOpts.RepoEligible = repoCurrentlyMonitored
+		rev, err := p.Run(pr, runOpts)
 		if err != nil {
 			slog.Error("pipeline run failed", "repo", pr.Repo, "pr", pr.Number, "err", err)
 			var cbErr *pipeline.CircuitBreakerError
@@ -810,11 +817,11 @@ func main() {
 			tier2ConfigFn := func() []string {
 				cfgMu.Lock()
 				defer cfgMu.Unlock()
-				var discovered []string
-				if cfg.GitHub.DiscoveryTopic != "" {
-					discovered = discoverySvc.Discovered()
-				}
-				return discovery.MergeRepos(cfg.GitHub.Repositories, aiRepoKeys(cfg), discovered, cfg.GitHub.NonMonitored)
+				// Topic results become eligible only after Tier 2 classifies and
+				// persists them into Repositories/NonMonitored. Reading the raw
+				// discovery cache here would create a first-seen race when
+				// auto-enable is off.
+				return discovery.MergeRepos(cfg.GitHub.Repositories, aiRepoKeys(cfg), nil, cfg.GitHub.NonMonitored)
 			}
 			tier2RepoConcurrencyFn := func() int {
 				cfgMu.Lock()
@@ -857,11 +864,7 @@ func main() {
 		autonomousReposFn := func() []string {
 			cfgMu.Lock()
 			defer cfgMu.Unlock()
-			var discovered []string
-			if cfg.GitHub.DiscoveryTopic != "" {
-				discovered = discoverySvc.Discovered()
-			}
-			return discovery.MergeRepos(cfg.GitHub.Repositories, aiRepoKeys(cfg), discovered, cfg.GitHub.NonMonitored)
+			return discovery.MergeRepos(cfg.GitHub.Repositories, aiRepoKeys(cfg), nil, cfg.GitHub.NonMonitored)
 		}
 		autonomousStageR := &autonomousStageRunner{
 			ghClient:  ghClient,
@@ -924,6 +927,30 @@ func main() {
 	// existing review pipeline. This replaces the goroutine-per-PR
 	// pattern that Tier 2 used to use.
 	reviewHandler := func(ctx context.Context, msg bus.PRReviewMsg) {
+		skipIfUnmonitored := func(stage string) bool {
+			if repoCurrentlyMonitored(msg.Repo) {
+				return false
+			}
+			broker.Publish(sse.Event{
+				Type: sse.EventReviewSkipped,
+				Data: sseData(map[string]any{
+					"repo":      msg.Repo,
+					"pr_number": msg.Number,
+					"reason":    string(pipeline.SkipReasonNotMonitored),
+				}),
+			})
+			slog.Info("review-worker: repo no longer monitored, skipping",
+				"repo", msg.Repo, "pr", msg.Number, "stage", stage)
+			return true
+		}
+
+		// A repo may be disabled after Tier 2 publishes this Core NATS
+		// message but before a worker slot becomes available. Revalidate before
+		// spending rate-limit budget or starting the AI pipeline.
+		if skipIfUnmonitored("dequeue") {
+			return
+		}
+
 		// Acquire returns only ctx.Err() (shutdown). On cancellation the
 		// message is acked without processing — acceptable because the
 		// daemon is shutting down and the PR will be re-detected next startup.
@@ -945,6 +972,9 @@ func main() {
 				"msg_sha", msg.HeadSHA, "current_sha", pr.Head.SHA)
 			return
 		}
+		if skipIfUnmonitored("pre_run") {
+			return
+		}
 
 		cfgMu.Lock()
 		c := *cfg
@@ -958,6 +988,11 @@ func main() {
 		}
 		if repoHandle != nil {
 			defer repoHandle.Release()
+		}
+		// Repo acquisition may clone/fetch for several seconds. Recheck at the
+		// final execution boundary so a disable during that wait stops the CLI.
+		if skipIfUnmonitored("post_acquire") {
+			return
 		}
 
 		rev := runReview(pr, aiCfg)
@@ -1049,6 +1084,21 @@ func main() {
 		// legacy rows without a stored event fall back to severity. Mirrors the
 		// pipeline's Run / PublishPending paths.
 		publishEvent := pipeline.PublishEventFor(rev)
+		cancelled, err := cancelPublishIfUnmonitored(
+			s,
+			rev.ID,
+			pr.Repo,
+			repoCurrentlyMonitored,
+			time.Now().UTC(),
+		)
+		if err != nil {
+			return err
+		}
+		if cancelled {
+			slog.Info("publish-worker: repo no longer monitored, cancelling unpublished review",
+				"review_id", rev.ID, "repo", pr.Repo)
+			return nil // permanent — ack; the sentinel keeps it out of PublishPending
+		}
 		ghID, ghState, err := ghClient.SubmitReview(
 			pr.Repo, pr.Number,
 			pipeline.AnnotateBodyForEvent(pipeline.BuildGitHubBody(result), publishEvent),
@@ -1408,9 +1458,9 @@ func main() {
 			case <-statePollerCtx.Done():
 				return
 			case <-ticker.C:
-				// Gradually enroll one open item not yet in watch_state per tick.
+				// Gradually enroll one monitored open item not yet in watch_state per tick.
 				// Backfills items from before the NATS migration without blocking startup.
-				enrollOpenItems(statePollerCtx, s, watchStore)
+				enrollOpenItems(statePollerCtx, s, watchStore, adapter.monitoredRepos())
 
 				if evicted, err := watchStore.EvictStale(statePollerCtx); err != nil {
 					slog.Warn("state-poller: evict failed", "err", err)
@@ -1445,6 +1495,16 @@ func main() {
 			}
 			slog.Info("state-handler: auto-dismissed legacy item with empty repo",
 				"type", msg.Type, "number", msg.Number, "github_id", msg.GithubID)
+			return false, nil
+		}
+		if !adapter.repoIsMonitored(msg.Repo) {
+			key := fmt.Sprintf("%s.%d", msg.Type, msg.GithubID)
+			if err := watchStore.Delete(ctx, key); err != nil {
+				slog.Warn("state-handler: failed to remove unmonitored item",
+					"key", key, "repo", msg.Repo, "err", err)
+			}
+			slog.Info("state-handler: repo no longer monitored, skipping",
+				"type", msg.Type, "repo", msg.Repo, "number", msg.Number)
 			return false, nil
 		}
 
@@ -1535,8 +1595,7 @@ func main() {
 		// state with the live Config after we release the lock.
 		cfgMu.Lock()
 		c := cfg
-		reposList := append([]string(nil), c.GitHub.Repositories...)
-		nonMonList := append([]string(nil), c.GitHub.NonMonitored...)
+		reposList, nonMonList := effectiveRepoLists(c)
 		localDirBaseList := append([]string(nil), c.GitHub.LocalDirBase...)
 		cfgMu.Unlock()
 		loginMu.Lock()
@@ -2544,15 +2603,13 @@ func runTier2(
 			case <-ctx.Done():
 				return
 			case r := <-reposChan:
+				// Classify first so live eligibility callbacks can never observe a
+				// raw topic result before auto-enable=false records it disabled.
+				adapter.upsertDiscoveredFromTopics(r)
 				mu.Lock()
 				repos = r
 				mu.Unlock()
 				slog.Info("tier2: received repo list", "count", len(r))
-
-				// Persist topic-discovered repos so they appear in
-				// heimdallm-cli status and GET /config even when they
-				// have no open PRs. Fixes #507.
-				adapter.upsertDiscoveredFromTopics(r)
 			}
 		}
 	}()
@@ -2677,21 +2734,23 @@ func runTier2(
 	// extra ticks when its previous run is still in flight, so we
 	// never spawn two concurrent issue cycles.
 	prTick := func() {
-		currentRepos := snapshotRepos()
-		if len(currentRepos) == 0 {
-			return
+		currentRepos := intersectMonitoredRepos(snapshotRepos(), configFn)
+		if len(currentRepos) > 0 {
+			runPRTier(currentRepos)
 		}
-		runPRTier(currentRepos)
 		// PublishPending lives in the PR tick on purpose: pending
 		// publishes are almost exclusively PR-review NATS messages
-		// from runPRTier, and retries are idempotent. If we ever
+		// from runPRTier, and retries are idempotent. It must still run
+		// when the live repo set is empty so reviews for repos disabled
+		// after their initial publish attempt reach the publish worker,
+		// which marks them terminal. If we ever
 		// route issue-side NATS publishes through the same queue,
 		// add a sibling call inside issueTick rather than removing
 		// this one.
 		adapter.PublishPending()
 	}
 	issueTick := func() {
-		currentRepos := snapshotRepos()
+		currentRepos := intersectMonitoredRepos(snapshotRepos(), configFn)
 		if len(currentRepos) == 0 {
 			return
 		}
@@ -2728,6 +2787,44 @@ func runTier2(
 	wg.Wait()
 }
 
+// intersectMonitoredRepos applies the live config as a final eligibility gate
+// to Tier 1's last published repo snapshot. Tier 1 remains responsible for
+// discovery and archived-repo filtering, while the live set makes an explicit
+// disable effective immediately instead of waiting for the next discovery
+// publication. It also closes the first-discovery race where Tier 1 published
+// a new topic repo, Tier 2 persisted it as non_monitored, then reviewed it from
+// the stale pre-persistence snapshot.
+func intersectMonitoredRepos(current []string, configFn func() []string) []string {
+	if len(current) == 0 {
+		return nil
+	}
+	if configFn == nil {
+		return append([]string(nil), current...)
+	}
+
+	live := configFn()
+	if len(live) == 0 {
+		return nil
+	}
+	liveSet := make(map[string]struct{}, len(live))
+	for _, repo := range live {
+		if repo = strings.TrimSpace(repo); repo != "" {
+			liveSet[repo] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(current))
+	for _, repo := range current {
+		if _, ok := liveSet[strings.TrimSpace(repo)]; ok {
+			out = append(out, repo)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // aiRepoKeys returns the sorted list of repos with an explicit [ai.repos.*]
 // entry. Used to seed MergeRepos with the operator's TOML opt-ins so a repo
 // that is wired up but has no active PRs still receives issue polling.
@@ -2752,9 +2849,27 @@ func aiRepoKeys(c *config.Config) []string {
 	return out
 }
 
+// effectiveRepoLists returns the same monitored view used by the schedulers
+// for GET /config. Explicit [ai.repos.*] entries are implicit opt-ins unless
+// they also appear in non_monitored; exposing only the raw github.repositories
+// slice would make the UI label an actively-polled repo as Not monitored.
+func effectiveRepoLists(c *config.Config) (monitored, nonMonitored []string) {
+	if c == nil {
+		return nil, nil
+	}
+	nonMonitored = append([]string(nil), c.GitHub.NonMonitored...)
+	monitored = discovery.MergeRepos(
+		c.GitHub.Repositories,
+		aiRepoKeys(c),
+		nil,
+		nonMonitored,
+	)
+	return monitored, nonMonitored
+}
+
 // upsertDiscoveredRepos adds PRs' repos to the monitored (or non-monitored)
 // list when they're new. Returns the list of repos that were added.
-// Never removes; mutually-exclusive with NonMonitored when adding.
+// Never removes and never overrides an explicit NonMonitored entry.
 //
 // The Flutter UI maps prEnabled via list membership: prEnabled=true ⇔
 // Repositories, prEnabled=false ⇔ NonMonitored, neither ⇔ undiscovered.
@@ -2788,43 +2903,24 @@ func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
 		if pr.Repo == "" {
 			continue
 		}
+		// An explicit disable is authoritative. In particular, an
+		// [ai.repos.*] override may customize a repo without opting it back in;
+		// seeing a review-requested PR must never erase the operator's choice.
+		if _, disabled := inNonMonitored[pr.Repo]; disabled {
+			continue
+		}
 
-		// Repos with an explicit [ai.repos.*] entry are opted in by the
-		// operator. Explicit config is intent and must win over both guards:
-		//   - It bypasses the discovery_orgs allowlist (theburrowhub/heimdallm#527
-		//     item 2): a configured repo outside the discovery orgs must still
-		//     be monitored, so this check precedes the org filter below.
-		//   - It promotes the repo out of NonMonitored when a stale row from a
-		//     prior tick blacklisted it (#527 item 1). Leaving it in
-		//     NonMonitored keeps config state inconsistent for code that reads
-		//     the list directly, even though MergeRepos already exempts it. So
-		//     we strip the repo from NonMonitored and add it to Repositories.
-		// See also theburrowhub/heimdallm#281 for why a configured repo must
-		// never linger in NonMonitored (MergeRepos would otherwise blacklist it
-		// and silently stop issue polling).
+		// A repo with an explicit [ai.repos.*] entry is an implicit opt-in only
+		// while it is not explicitly disabled. It still bypasses the discovery
+		// org allowlist so a configured repo outside discovery_orgs can be
+		// monitored, but NonMonitored above always wins.
 		if _, hasExplicitAIConfig := c.AI.Repos[pr.Repo]; hasExplicitAIConfig {
-			// Within-tick duplicate PRs for the same repo are absorbed: after the
-			// first one promotes the repo, inRepositories/inNonMonitored reflect
-			// the new state, so a second PR for the same repo is a no-op here.
 			_, alreadyMonitored := inRepositories[pr.Repo]
-			_, blacklisted := inNonMonitored[pr.Repo]
-			if blacklisted {
-				c.GitHub.NonMonitored = removeRepo(c.GitHub.NonMonitored, pr.Repo)
-				delete(inNonMonitored, pr.Repo)
-			}
 			if !alreadyMonitored {
 				c.GitHub.Repositories = append(c.GitHub.Repositories, pr.Repo)
 				inRepositories[pr.Repo] = struct{}{}
-			}
-			// Report the repo as added whenever EITHER list was mutated — not
-			// only on the add-to-Repositories path. processDiscoveredRepos
-			// early-returns on an empty added set, so a strip-only change (repo
-			// already in Repositories but also stale in NonMonitored) must still
-			// land here, or the NonMonitored strip would not be persisted and the
-			// inconsistency would survive across reloads.
-			if blacklisted || !alreadyMonitored {
-				slog.Info("upsertDiscoveredRepos: promoted explicitly-configured repo",
-					"repo", pr.Repo, "added_to_repositories", !alreadyMonitored, "stripped_from_non_monitored", blacklisted)
+				slog.Info("upsertDiscoveredRepos: added explicitly-configured repo",
+					"repo", pr.Repo)
 				added = append(added, pr.Repo)
 			}
 			continue
@@ -2833,9 +2929,6 @@ func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
 		// Auto-discovered repos (no explicit config): skip when already tracked
 		// in either list.
 		if _, ok := inRepositories[pr.Repo]; ok {
-			continue
-		}
-		if _, ok := inNonMonitored[pr.Repo]; ok {
 			continue
 		}
 		// Filter by allowed orgs when configured.
@@ -2862,17 +2955,6 @@ func upsertDiscoveredRepos(c *config.Config, prs []*gh.PullRequest) []string {
 	return added
 }
 
-// removeRepo returns s without the first occurrence of repo, preserving order.
-// Returns s unchanged when repo is absent.
-func removeRepo(s []string, repo string) []string {
-	for i, r := range s {
-		if r == repo {
-			return append(s[:i:i], s[i+1:]...)
-		}
-	}
-	return s
-}
-
 // upsertDiscoveredFromTopics persists repos received from tier1's topic
 // discovery into cfg.GitHub.Repositories (or NonMonitored) and invokes
 // processDiscoveredRepos to write them to the K/V store. This ensures repos
@@ -2892,6 +2974,12 @@ func (a *tier2Adapter) upsertDiscoveredFromTopics(repos []string) {
 	}
 	for _, r := range cfg.GitHub.NonMonitored {
 		known[r] = struct{}{}
+	}
+	// Explicit [ai.repos.*] entries are already operator opt-ins. They may not
+	// also appear in github.repositories, and auto-enable=false must not
+	// misclassify them as newly discovered and append them to NonMonitored.
+	for repo := range cfg.AI.Repos {
+		known[repo] = struct{}{}
 	}
 
 	enable := cfg.GitHub.AutoEnablePRForDiscovery()
@@ -2957,6 +3045,35 @@ type tier2Adapter struct {
 }
 
 const breakerTripDedupTTL = 24 * time.Hour
+
+func (a *tier2Adapter) repoIsMonitored(repo string) bool {
+	if a == nil || a.cfg == nil {
+		return false
+	}
+	if a.cfgMu == nil {
+		return repoIsMonitored(*a.cfg, repo)
+	}
+	a.cfgMu.Lock()
+	defer a.cfgMu.Unlock()
+	return repoIsMonitored(*a.cfg, repo)
+}
+
+func (a *tier2Adapter) monitoredRepos() []string {
+	if a == nil || a.cfg == nil {
+		return nil
+	}
+	if a.cfgMu != nil {
+		a.cfgMu.Lock()
+		defer a.cfgMu.Unlock()
+	}
+	set := monitoredRepoSet(*a.cfg, nil)
+	repos := make([]string, 0, len(set))
+	for repo := range set {
+		repos = append(repos, repo)
+	}
+	sort.Strings(repos)
+	return repos
+}
 
 func (a *tier2Adapter) cachedAuthenticatedUser() string {
 	if a == nil || a.login == nil {
@@ -3897,8 +4014,22 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 		// cast (config cannot import pipeline — import cycle).
 		guards := pipeline.GateConfig((*a.cfg).ReviewGuards(botLogin))
 		c := *a.cfg
+		monitored := repoIsMonitored(c, item.Repo)
 		aiCfg := c.AIForRepo(item.Repo)
 		a.cfgMu.Unlock()
+		if !monitored {
+			a.broker.Publish(sse.Event{
+				Type: sse.EventReviewSkipped,
+				Data: sseData(map[string]any{
+					"repo":      item.Repo,
+					"pr_number": item.Number,
+					"reason":    string(pipeline.SkipReasonNotMonitored),
+				}),
+			})
+			slog.Info("tier3: repo no longer monitored, skipping PR",
+				"repo", item.Repo, "pr", item.Number)
+			return nil
+		}
 
 		stored, _ := a.store.GetPRByGithubID(item.GithubID)
 		title := ""
@@ -4779,53 +4910,127 @@ func monitoredRepoSet(cfg *config.Config, discovered []string) map[string]struct
 	return out
 }
 
+// repoIsMonitored is the shared live eligibility check for automatic review
+// paths. Passing no discovered slice is sufficient after discovery has been
+// persisted into Repositories/NonMonitored; callers that own a fresh discovery
+// snapshot should use monitoredRepoSet directly.
+func repoIsMonitored(cfg *config.Config, repo string) bool {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return false
+	}
+	_, ok := monitoredRepoSet(cfg, nil)[repo]
+	return ok
+}
+
+// cancelPublishIfUnmonitored performs the final live eligibility check before
+// SubmitReview. Marking the local row with the established orphan sentinel
+// keeps PublishPending from re-enqueueing a review after its repo is disabled.
+func cancelPublishIfUnmonitored(
+	s *store.Store,
+	reviewID int64,
+	repo string,
+	isMonitored func(string) bool,
+	now time.Time,
+) (bool, error) {
+	if isMonitored == nil || isMonitored(repo) {
+		return false, nil
+	}
+	if err := s.MarkReviewPublished(reviewID, -1, "", now.UTC()); err != nil {
+		return false, fmt.Errorf("cancel unpublished review %d for unmonitored repo %q: %w", reviewID, repo, err)
+	}
+	return true, nil
+}
+
 // enrollOpenItems enrolls up to 10 open PRs/issues not yet in watch_state.
 // Called once per state-poller tick (every 30s) to gradually backfill items
-// from before the NATS migration. Uses a batch query with LEFT JOIN to find
-// unenrolled items without holding a read lock during writes.
-func enrollOpenItems(ctx context.Context, s *store.Store, ws *bus.WatchStore) {
+// from before the NATS migration. The monitored set is snapshotted before the
+// query and pushed into SQL, so disabled rows cannot consume the LIMIT and the
+// daemon's single SQLite connection is never held during an unbounded scan.
+func enrollOpenItems(
+	ctx context.Context,
+	s *store.Store,
+	ws *bus.WatchStore,
+	monitoredRepos []string,
+) {
+	seen := make(map[string]struct{}, len(monitoredRepos))
+	normalizedRepos := make([]string, 0, len(monitoredRepos))
+	for _, repo := range monitoredRepos {
+		repo = strings.TrimSpace(repo)
+		if repo == "" {
+			continue
+		}
+		if _, ok := seen[repo]; ok {
+			continue
+		}
+		seen[repo] = struct{}{}
+		normalizedRepos = append(normalizedRepos, repo)
+	}
+	if len(normalizedRepos) == 0 {
+		return
+	}
+
 	for _, q := range []struct {
 		typ   string
-		query string
+		query string // one %s placeholder for a bounded repo IN clause
 	}{
 		{"pr", `SELECT p.github_id, p.repo, p.number FROM prs p
 			LEFT JOIN watch_state w ON w.key = 'pr.' || p.github_id
-			WHERE p.state='open' AND p.repo != '' AND w.key IS NULL LIMIT 10`},
+			WHERE p.state='open' AND p.repo != '' AND w.key IS NULL
+			AND p.repo IN (%s)
+			ORDER BY p.id LIMIT 10`},
 		{"issue", `SELECT i.github_id, i.repo, i.number FROM issues i
 			LEFT JOIN watch_state w ON w.key = 'issue.' || i.github_id
-			WHERE i.state='open' AND i.repo != '' AND w.key IS NULL LIMIT 10`},
+			WHERE i.state='open' AND i.repo != '' AND w.key IS NULL
+			AND i.repo IN (%s)
+			ORDER BY i.id LIMIT 10`},
 	} {
-		rows, err := s.DB().Query(q.query)
-		if err != nil {
-			continue
-		}
 		type item struct {
 			ghID   int64
 			repo   string
 			number int
 		}
 		var batch []item
-		for rows.Next() {
-			var it item
-			if err := rows.Scan(&it.ghID, &it.repo, &it.number); err != nil {
-				slog.Warn("state-poller: backfill scan failed", "type", q.typ, "err", err)
+		// Keep each query well below SQLite's bind-variable ceiling. Continue
+		// through chunks until ten eligible rows are found globally.
+		const repoChunkSize = 500
+		for start := 0; start < len(normalizedRepos) && len(batch) < 10; start += repoChunkSize {
+			end := min(start+repoChunkSize, len(normalizedRepos))
+			chunk := normalizedRepos[start:end]
+			args := make([]any, len(chunk))
+			for i, repo := range chunk {
+				args[i] = repo
+			}
+			placeholders := strings.TrimSuffix(strings.Repeat("?,", len(chunk)), ",")
+			rows, err := s.DB().Query(fmt.Sprintf(q.query, placeholders), args...)
+			if err != nil {
+				slog.Warn("state-poller: backfill query failed", "type", q.typ, "err", err)
 				continue
 			}
-			batch = append(batch, it)
+			for rows.Next() && len(batch) < 10 {
+				var it item
+				if err := rows.Scan(&it.ghID, &it.repo, &it.number); err != nil {
+					slog.Warn("state-poller: backfill scan failed", "type", q.typ, "err", err)
+					continue
+				}
+				batch = append(batch, it)
+			}
+			if err := rows.Err(); err != nil {
+				slog.Warn("state-poller: backfill iteration error", "type", q.typ, "err", err)
+			}
+			rows.Close() // release the daemon's single DB connection between chunks
 		}
-		if err := rows.Err(); err != nil {
-			slog.Warn("state-poller: backfill iteration error", "type", q.typ, "err", err)
-		}
-		rows.Close() // close before writing to avoid SQLite lock contention
 
+		enrolled := 0
 		for _, it := range batch {
 			if err := ws.Enroll(ctx, q.typ, it.repo, it.number, it.ghID); err != nil {
 				slog.Warn("state-poller: backfill enroll failed", "type", q.typ, "repo", it.repo, "number", it.number, "err", err)
 				break // skip rest of this type, try next type
 			}
+			enrolled++
 		}
-		if len(batch) > 0 {
-			slog.Debug("state-poller: backfill enrolled", "type", q.typ, "count", len(batch))
+		if enrolled > 0 {
+			slog.Debug("state-poller: backfill enrolled", "type", q.typ, "count", enrolled)
 		}
 	}
 }

--- a/daemon/cmd/heimdallm/main_discover_test.go
+++ b/daemon/cmd/heimdallm/main_discover_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/heimdallm/daemon/internal/config"
@@ -147,10 +148,60 @@ func TestUpsertDiscoveredRepos_OrgFilterCaseInsensitive(t *testing.T) {
 	}
 }
 
-// A repo with an explicit [ai.repos.*] entry must NEVER be added to
-// NonMonitored — even when AutoEnablePRForDiscovery is off. Otherwise the next
-// MergeRepos call would blacklist a repo the operator just configured, which
-// is exactly the regression described in theburrowhub/heimdallm#281.
+func TestIntersectMonitoredRepos_AppliesLiveDisableToStaleTier1Snapshot(t *testing.T) {
+	current := []string{"org/keep", "org/just-disabled", "org/archived-elsewhere"}
+	got := intersectMonitoredRepos(current, func() []string {
+		return []string{"org/keep", "org/not-in-tier1"}
+	})
+
+	if len(got) != 1 || got[0] != "org/keep" {
+		t.Fatalf("intersectMonitoredRepos = %v, want [org/keep]", got)
+	}
+}
+
+// On a repo's first topic-discovery cycle Tier 1 can publish it before Tier 2
+// persists the repo into NonMonitored (when auto-enable is off). The live
+// intersection must turn that now-stale publication into an empty work set.
+func TestIntersectMonitoredRepos_BlocksFirstCycleTopicRepoRecordedNonMonitored(t *testing.T) {
+	const repo = "org/new-disabled"
+	got := intersectMonitoredRepos([]string{repo}, func() []string { return nil })
+	if len(got) != 0 {
+		t.Fatalf("first-cycle non-monitored repo survived live gate: %v", got)
+	}
+}
+
+func TestRepoIsMonitored_NonMonitoredOverridesEveryOptInSource(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.Repositories = []string{"org/repo"}
+	cfg.GitHub.NonMonitored = []string{"org/repo"}
+	cfg.AI.Repos = map[string]config.RepoAI{"org/repo": {}}
+
+	if repoIsMonitored(cfg, "org/repo") {
+		t.Fatal("repoIsMonitored returned true for explicitly disabled repo")
+	}
+}
+
+func TestEffectiveRepoListsExposeImplicitAIOptInsUnlessDisabled(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.GitHub.Repositories = []string{"org/static", "org/static-disabled"}
+	cfg.GitHub.NonMonitored = []string{"org/static-disabled", "org/ai-disabled"}
+	cfg.AI.Repos = map[string]config.RepoAI{
+		"org/ai-enabled":  {},
+		"org/ai-disabled": {},
+	}
+
+	monitored, nonMonitored := effectiveRepoLists(cfg)
+	if want := []string{"org/static", "org/ai-enabled"}; !slices.Equal(monitored, want) {
+		t.Fatalf("monitored = %v, want %v", monitored, want)
+	}
+	if !slices.Equal(nonMonitored, cfg.GitHub.NonMonitored) {
+		t.Fatalf("nonMonitored = %v, want %v", nonMonitored, cfg.GitHub.NonMonitored)
+	}
+}
+
+// A previously unknown repo with an explicit [ai.repos.*] entry is an implicit
+// opt-in even when auto-enable is off. This does not apply once the operator
+// has explicitly put the repo in NonMonitored (covered below).
 func TestUpsertDiscoveredRepos_ExplicitAIConfigOverridesAutoEnableOff(t *testing.T) {
 	f := false
 	cfg := &config.Config{}
@@ -202,13 +253,10 @@ func TestUpsertDiscoveredRepos_ExplicitAIConfigOverridesAutoEnableOff(t *testing
 	}
 }
 
-// theburrowhub/heimdallm#527 item 1: a repo blacklisted in NonMonitored on a
-// prior tick that later gains explicit [ai.repos.*] config must be promoted —
-// stripped from NonMonitored and added to Repositories — so config state stays
-// consistent for code that reads NonMonitored directly (not just MergeRepos,
-// which already exempts it). The promotion is reported in `added` so the
-// updated lists are persisted.
-func TestUpsertDiscoveredRepos_PromotesExplicitConfigOutOfNonMonitored(t *testing.T) {
+// NonMonitored is explicit operator intent and must win over an [ai.repos.*]
+// override. Before this regression fix, seeing a review-requested PR silently
+// stripped the disable and re-enabled the repository.
+func TestUpsertDiscoveredRepos_NonMonitoredOverridesExplicitConfig(t *testing.T) {
 	f := false
 	cfg := &config.Config{}
 	cfg.GitHub.AutoEnablePROnDiscovery = &f
@@ -225,34 +273,31 @@ func TestUpsertDiscoveredRepos_PromotesExplicitConfigOutOfNonMonitored(t *testin
 	}
 
 	added := upsertDiscoveredRepos(cfg, prs)
-	if len(added) != 1 || added[0] != "a/wired-up" {
-		t.Fatalf("promoted repo must be reported in added (so lists persist), got %v", added)
+	if len(added) != 0 {
+		t.Fatalf("explicitly disabled repo must not be auto-added, got %v", added)
 	}
 
-	// Must now be in Repositories.
-	foundWired := false
 	for _, r := range cfg.GitHub.Repositories {
 		if r == "a/wired-up" {
-			foundWired = true
+			t.Fatalf("a/wired-up must remain out of Repositories, got %v", cfg.GitHub.Repositories)
 		}
 	}
-	if !foundWired {
-		t.Fatalf("a/wired-up must be promoted to Repositories, got %v", cfg.GitHub.Repositories)
-	}
 
-	// Must be stripped from NonMonitored, while the unrelated blacklist row stays.
-	wantNonMon := []string{"a/keep-blacklisted"}
-	if len(cfg.GitHub.NonMonitored) != len(wantNonMon) || cfg.GitHub.NonMonitored[0] != wantNonMon[0] {
-		t.Fatalf("NonMonitored = %v, want %v (wired-up stripped, other kept)", cfg.GitHub.NonMonitored, wantNonMon)
+	wantNonMon := []string{"a/keep-blacklisted", "a/wired-up"}
+	if len(cfg.GitHub.NonMonitored) != len(wantNonMon) {
+		t.Fatalf("NonMonitored = %v, want %v", cfg.GitHub.NonMonitored, wantNonMon)
+	}
+	for i := range wantNonMon {
+		if cfg.GitHub.NonMonitored[i] != wantNonMon[i] {
+			t.Fatalf("NonMonitored = %v, want %v", cfg.GitHub.NonMonitored, wantNonMon)
+		}
 	}
 }
 
-// Edge case (review of #527): a repo that is SIMULTANEOUSLY in Repositories and
-// NonMonitored — the inconsistent prior-tick state this fix targets — must still
-// have its NonMonitored strip reported in `added`, even though it is already
-// monitored. Otherwise, if it is the only change in the tick, the empty `added`
-// set makes processDiscoveredRepos early-return and the strip is never persisted.
-func TestUpsertDiscoveredRepos_PromotionPersistsWhenAlreadyMonitored(t *testing.T) {
+// Even an inconsistent legacy row present in both lists must not have its
+// disable erased by PR discovery. MergeRepos gives NonMonitored precedence;
+// config normalization is deliberately left to the config writer.
+func TestUpsertDiscoveredRepos_DoesNotEraseNonMonitoredFromLegacyConflict(t *testing.T) {
 	f := false
 	cfg := &config.Config{}
 	cfg.GitHub.AutoEnablePROnDiscovery = &f
@@ -271,25 +316,18 @@ func TestUpsertDiscoveredRepos_PromotionPersistsWhenAlreadyMonitored(t *testing.
 
 	added := upsertDiscoveredRepos(cfg, prs)
 
-	// The strip MUST be reported so the updated lists get persisted.
-	if len(added) != 1 || added[0] != "a/wired-up" {
-		t.Fatalf("strip-only promotion must be reported in added (else it is not persisted), got %v", added)
+	if len(added) != 0 {
+		t.Fatalf("legacy conflict must not trigger auto-promotion, got %v", added)
 	}
-	// Stripped from NonMonitored.
+	// The authoritative disable remains intact.
+	foundDisabled := false
 	for _, r := range cfg.GitHub.NonMonitored {
 		if r == "a/wired-up" {
-			t.Fatalf("a/wired-up must be stripped from NonMonitored, got %v", cfg.GitHub.NonMonitored)
+			foundDisabled = true
 		}
 	}
-	// Still present in Repositories exactly once (no duplicate append).
-	count := 0
-	for _, r := range cfg.GitHub.Repositories {
-		if r == "a/wired-up" {
-			count++
-		}
-	}
-	if count != 1 {
-		t.Fatalf("a/wired-up must appear exactly once in Repositories, got %v", cfg.GitHub.Repositories)
+	if !foundDisabled {
+		t.Fatalf("a/wired-up must remain in NonMonitored, got %v", cfg.GitHub.NonMonitored)
 	}
 }
 

--- a/daemon/cmd/heimdallm/main_discover_topics_test.go
+++ b/daemon/cmd/heimdallm/main_discover_topics_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/discovery"
 	"github.com/heimdallm/daemon/internal/sse"
 )
 
@@ -115,6 +116,39 @@ func TestUpsertDiscoveredFromTopics_RespectsDisabledFlag(t *testing.T) {
 	}
 	if len(cfg.GitHub.NonMonitored) != 1 || cfg.GitHub.NonMonitored[0] != "org/new" {
 		t.Fatalf("repo should be in NonMonitored, got %v", cfg.GitHub.NonMonitored)
+	}
+
+	// Even while the discovery service still reports the raw topic result,
+	// the just-persisted disable must win before Tier 2 exposes its snapshot.
+	live := func() []string {
+		return discovery.MergeRepos(
+			cfg.GitHub.Repositories,
+			aiRepoKeys(cfg),
+			[]string{"org/new"},
+			cfg.GitHub.NonMonitored,
+		)
+	}
+	if got := intersectMonitoredRepos([]string{"org/new"}, live); len(got) != 0 {
+		t.Fatalf("first-cycle topic repo survived non-monitored classification: %v", got)
+	}
+}
+
+func TestUpsertDiscoveredFromTopics_DoesNotDisableExplicitAIRepo(t *testing.T) {
+	autoEnable := false
+	cfg := &config.Config{}
+	cfg.GitHub.AutoEnablePROnDiscovery = &autoEnable
+	cfg.AI.Repos = map[string]config.RepoAI{"org/configured": {}}
+
+	s := newMemStore(t)
+	var mu sync.Mutex
+	a := &tier2Adapter{cfgMu: &mu, cfg: &cfg, store: s}
+	a.upsertDiscoveredFromTopics([]string{"org/configured"})
+
+	if len(cfg.GitHub.NonMonitored) != 0 {
+		t.Fatalf("explicit AI repo was auto-disabled: %v", cfg.GitHub.NonMonitored)
+	}
+	if !repoIsMonitored(cfg, "org/configured") {
+		t.Fatal("explicit AI repo is no longer monitored")
 	}
 }
 

--- a/daemon/cmd/heimdallm/main_inflight_plumb_test.go
+++ b/daemon/cmd/heimdallm/main_inflight_plumb_test.go
@@ -223,14 +223,14 @@ func TestTier2Adapter_ProcessPR_PlumbsHeadSHAIntoGhPR(t *testing.T) {
 	}
 
 	pr := scheduler.Tier2PR{
-		ID:     4242,
-		Number: 7,
-		Repo:   "org/repo",
-		Title:  "t",
-		Author: "alice",
-		State:  "open",
-		Draft:  false,
-		HeadSHA: wantSHA,
+		ID:        4242,
+		Number:    7,
+		Repo:      "org/repo",
+		Title:     "t",
+		Author:    "alice",
+		State:     "open",
+		Draft:     false,
+		HeadSHA:   wantSHA,
 		UpdatedAt: time.Now(),
 	}
 
@@ -294,7 +294,9 @@ func TestTier2Adapter_HandleChange_PlumbsHeadSHAIntoGhPR(t *testing.T) {
 		loginMu sync.Mutex
 		login   = "heimdallm-bot"
 		cfgMu   sync.Mutex
-		cfg     = &config.Config{}
+		cfg     = &config.Config{GitHub: config.GitHubConfig{
+			Repositories: []string{"org/repo"},
+		}}
 	)
 
 	a := &tier2Adapter{

--- a/daemon/cmd/heimdallm/main_monitoring_guards_test.go
+++ b/daemon/cmd/heimdallm/main_monitoring_guards_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/bus"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+func TestCancelPublishIfUnmonitoredMarksReviewTerminal(t *testing.T) {
+	s := newMemStore(t)
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	reviewID := seedPRWithReview(t, s, 901, now.Add(-time.Minute))
+
+	var checkedRepo string
+	cancelled, err := cancelPublishIfUnmonitored(
+		s,
+		reviewID,
+		"org/repo",
+		func(repo string) bool {
+			checkedRepo = repo
+			return false
+		},
+		now,
+	)
+	if err != nil {
+		t.Fatalf("cancel publish: %v", err)
+	}
+	if !cancelled {
+		t.Fatal("cancelled = false, want true for an unmonitored repo")
+	}
+	if checkedRepo != "org/repo" {
+		t.Fatalf("eligibility checked repo = %q, want org/repo", checkedRepo)
+	}
+
+	review, err := s.GetReview(reviewID)
+	if err != nil {
+		t.Fatalf("get review: %v", err)
+	}
+	if review.GitHubReviewID != -1 {
+		t.Fatalf("GitHubReviewID = %d, want -1 terminal sentinel", review.GitHubReviewID)
+	}
+	if !review.PublishedAt.Equal(now) {
+		t.Fatalf("PublishedAt = %v, want %v", review.PublishedAt, now)
+	}
+
+	pending, err := s.ListUnpublishedReviews()
+	if err != nil {
+		t.Fatalf("list unpublished reviews: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("unpublished reviews = %d, want 0 so PublishPending cannot re-enqueue it", len(pending))
+	}
+}
+
+func TestEnrollOpenItemsSkipsDisabledRowsBeforeBatchLimit(t *testing.T) {
+	s := newMemStore(t)
+	ws, err := bus.NewWatchStore(s.DB())
+	if err != nil {
+		t.Fatalf("new watch store: %v", err)
+	}
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+
+	for i := int64(1); i <= 10; i++ {
+		if _, err := s.UpsertPR(&store.PR{
+			GithubID:  i,
+			Repo:      fmt.Sprintf("org/disabled-%d", i),
+			Number:    int(i),
+			Title:     "disabled repo PR",
+			Author:    "alice",
+			URL:       fmt.Sprintf("https://github.test/org/disabled-%d/pull/%d", i, i),
+			State:     "open",
+			UpdatedAt: now,
+			FetchedAt: now,
+		}); err != nil {
+			t.Fatalf("upsert disabled PR %d: %v", i, err)
+		}
+	}
+
+	const monitoredID int64 = 101
+	if _, err := s.UpsertPR(&store.PR{
+		GithubID:  monitoredID,
+		Repo:      "org/monitored",
+		Number:    101,
+		Title:     "monitored repo PR",
+		Author:    "bob",
+		URL:       "https://github.test/org/monitored/pull/101",
+		State:     "open",
+		UpdatedAt: now,
+		FetchedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert monitored PR: %v", err)
+	}
+
+	enrollOpenItems(context.Background(), s, ws, []string{"org/monitored"})
+
+	entry, err := ws.Get(context.Background(), "pr.101")
+	if err != nil {
+		t.Fatalf("get monitored watch entry: %v", err)
+	}
+	if entry.Repo != "org/monitored" {
+		t.Fatalf("watch repo = %q, want org/monitored", entry.Repo)
+	}
+	if _, err := ws.Get(context.Background(), "pr.1"); err == nil {
+		t.Fatal("disabled repo PR was enrolled")
+	}
+}
+
+func TestEnrollOpenItemsChunksLargeMonitoredRepoSets(t *testing.T) {
+	s := newMemStore(t)
+	ws, err := bus.NewWatchStore(s.DB())
+	if err != nil {
+		t.Fatalf("new watch store: %v", err)
+	}
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	const targetID int64 = 202
+	if _, err := s.UpsertPR(&store.PR{
+		GithubID: targetID, Repo: "org/target", Number: 202,
+		Title: "target", Author: "alice", URL: "https://github.test/org/target/pull/202",
+		State: "open", UpdatedAt: now, FetchedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert target PR: %v", err)
+	}
+
+	repos := make([]string, 0, 502)
+	for i := range 501 {
+		repos = append(repos, fmt.Sprintf("org/empty-%d", i))
+	}
+	repos = append(repos, "org/target") // forces the second SQL chunk
+
+	enrollOpenItems(context.Background(), s, ws, repos)
+	if _, err := ws.Get(context.Background(), "pr.202"); err != nil {
+		t.Fatalf("target in later repo chunk was not enrolled: %v", err)
+	}
+}

--- a/daemon/cmd/heimdallm/main_monitoring_guards_test.go
+++ b/daemon/cmd/heimdallm/main_monitoring_guards_test.go
@@ -7,30 +7,26 @@ import (
 	"time"
 
 	"github.com/heimdallm/daemon/internal/bus"
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/pipeline"
 	"github.com/heimdallm/daemon/internal/store"
 )
 
-func TestCancelPublishIfUnmonitoredMarksReviewTerminal(t *testing.T) {
+func TestDeferPublishIfUnmonitoredLeavesReviewPending(t *testing.T) {
 	s := newMemStore(t)
 	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
 	reviewID := seedPRWithReview(t, s, 901, now.Add(-time.Minute))
 
 	var checkedRepo string
-	cancelled, err := cancelPublishIfUnmonitored(
-		s,
-		reviewID,
+	deferred := deferPublishIfUnmonitored(
 		"org/repo",
 		func(repo string) bool {
 			checkedRepo = repo
 			return false
 		},
-		now,
 	)
-	if err != nil {
-		t.Fatalf("cancel publish: %v", err)
-	}
-	if !cancelled {
-		t.Fatal("cancelled = false, want true for an unmonitored repo")
+	if !deferred {
+		t.Fatal("deferred = false, want true for an unmonitored repo")
 	}
 	if checkedRepo != "org/repo" {
 		t.Fatalf("eligibility checked repo = %q, want org/repo", checkedRepo)
@@ -40,19 +36,67 @@ func TestCancelPublishIfUnmonitoredMarksReviewTerminal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get review: %v", err)
 	}
-	if review.GitHubReviewID != -1 {
-		t.Fatalf("GitHubReviewID = %d, want -1 terminal sentinel", review.GitHubReviewID)
+	if review.GitHubReviewID != 0 {
+		t.Fatalf("GitHubReviewID = %d, want 0 pending", review.GitHubReviewID)
 	}
-	if !review.PublishedAt.Equal(now) {
-		t.Fatalf("PublishedAt = %v, want %v", review.PublishedAt, now)
+	if !review.PublishedAt.IsZero() {
+		t.Fatalf("PublishedAt = %v, want zero while deferred", review.PublishedAt)
 	}
 
 	pending, err := s.ListUnpublishedReviews()
 	if err != nil {
 		t.Fatalf("list unpublished reviews: %v", err)
 	}
-	if len(pending) != 0 {
-		t.Fatalf("unpublished reviews = %d, want 0 so PublishPending cannot re-enqueue it", len(pending))
+	if len(pending) != 1 || pending[0].ID != reviewID {
+		t.Fatalf("unpublished reviews = %+v, want deferred review %d", pending, reviewID)
+	}
+
+	if deferPublishIfUnmonitored("org/repo", func(string) bool { return true }) {
+		t.Fatal("deferred = true after repo re-enable")
+	}
+}
+
+func TestPendingReviewInvalidReason(t *testing.T) {
+	tests := []struct {
+		name     string
+		review   *store.Review
+		snapshot *gh.PRSnapshot
+		want     pipeline.SkipReason
+	}{
+		{
+			name:     "same head remains publishable",
+			review:   &store.Review{HeadSHA: "abc"},
+			snapshot: &gh.PRSnapshot{State: "open", HeadSHA: "abc"},
+		},
+		{
+			name:     "changed head retires stale review",
+			review:   &store.Review{HeadSHA: "abc"},
+			snapshot: &gh.PRSnapshot{State: "open", HeadSHA: "def"},
+			want:     pipeline.SkipReasonHeadChanged,
+		},
+		{
+			name:     "closed PR wins over head mismatch",
+			review:   &store.Review{HeadSHA: "abc"},
+			snapshot: &gh.PRSnapshot{State: "closed", HeadSHA: "def"},
+			want:     pipeline.SkipReasonNotOpen,
+		},
+		{
+			name:     "legacy empty review head keeps prior behavior",
+			review:   &store.Review{},
+			snapshot: &gh.PRSnapshot{State: "open", HeadSHA: "def"},
+		},
+		{
+			name:     "empty current head retries instead of retiring",
+			review:   &store.Review{HeadSHA: "abc"},
+			snapshot: &gh.PRSnapshot{State: "open"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pendingReviewInvalidReason(tt.review, tt.snapshot); got != tt.want {
+				t.Fatalf("pendingReviewInvalidReason = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/daemon/cmd/heimdallm/main_pr_review_state.go
+++ b/daemon/cmd/heimdallm/main_pr_review_state.go
@@ -53,9 +53,17 @@ type reviewFixDispatcher interface {
 func (a *tier2Adapter) refreshAutoImplementPRReviewState(
 	ctx context.Context, item *scheduler.WatchItem, stored *store.PR,
 ) error {
+	if a.repoMonitoringConfiguredAndDisabled(item.Repo) {
+		return nil
+	}
 	reviews, err := a.ghClient.GetPRReviews(item.Repo, item.Number)
 	if err != nil {
 		return fmt.Errorf("get pr reviews: %w", err)
+	}
+	// The repo may be disabled while the reviews request is in flight. Stop
+	// before persisting or dispatching any reaction from the stale watch item.
+	if a.repoMonitoringConfiguredAndDisabled(item.Repo) {
+		return nil
 	}
 	botLogin := a.cachedAuthenticatedUser()
 	state, reviewer, at := issuepipeline.LatestExternalReviewState(reviews, botLogin)
@@ -134,7 +142,7 @@ func (a *tier2Adapter) refreshAutoImplementPRReviewState(
 	// StateWorker's IncreaseBackoff branch.
 	switch state {
 	case issuepipeline.ReviewStateCommented:
-		if a.responder != nil {
+		if a.responder != nil && !a.repoMonitoringConfiguredAndDisabled(item.Repo) {
 			if err := a.responder.Run(ctx, stored, stored.AutoImplementIssueID); err != nil {
 				slog.Warn("tier3: responder run failed (retrying next tick)",
 					"repo", item.Repo, "number", item.Number, "err", err)
@@ -142,7 +150,7 @@ func (a *tier2Adapter) refreshAutoImplementPRReviewState(
 			}
 		}
 	case issuepipeline.ReviewStateChangesRequested:
-		if a.fixRunner != nil {
+		if a.fixRunner != nil && !a.repoMonitoringConfiguredAndDisabled(item.Repo) {
 			if err := a.fixRunner.Run(ctx, stored, stored.AutoImplementIssueID); err != nil {
 				slog.Warn("tier3: fix runner failed (retrying next tick)",
 					"repo", item.Repo, "number", item.Number, "err", err)
@@ -151,6 +159,13 @@ func (a *tier2Adapter) refreshAutoImplementPRReviewState(
 		}
 	}
 	return nil
+}
+
+// repoMonitoringConfiguredAndDisabled keeps the review-state helpers usable
+// in narrow unit tests that intentionally omit config, while production
+// adapters always enforce the live monitored set.
+func (a *tier2Adapter) repoMonitoringConfiguredAndDisabled(repo string) bool {
+	return a != nil && a.cfg != nil && !a.repoIsMonitored(repo)
 }
 
 // autonomousEnabledForRepo reports whether autonomous mode is enabled for the
@@ -194,6 +209,9 @@ func (a *tier2Adapter) autonomousEnabledForRepo(repo string) bool {
 func (a *tier2Adapter) dispatchAutonomousReview(
 	ctx context.Context, item *scheduler.WatchItem, stored *store.PR, reviews []gh.PRReview, state string,
 ) error {
+	if a.repoMonitoringConfiguredAndDisabled(item.Repo) {
+		return nil
+	}
 	decision := autonomous.ClassifyReview(toReviewInputs(reviews))
 
 	if a.broker != nil {

--- a/daemon/cmd/heimdallm/main_pr_review_state_test.go
+++ b/daemon/cmd/heimdallm/main_pr_review_state_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/heimdallm/daemon/internal/config"
 	gh "github.com/heimdallm/daemon/internal/github"
 	"github.com/heimdallm/daemon/internal/scheduler"
 	"github.com/heimdallm/daemon/internal/sse"
@@ -502,6 +503,57 @@ func TestCheckItem_AutoImplementPRBranch_ReturnsChangedSoLastSeenAdvances(t *tes
 	}
 	if snap != nil {
 		t.Errorf("snap must be nil so HandleChange short-circuits, got %+v", snap)
+	}
+}
+
+func TestCheckItem_AutoImplementPRBranch_DisabledAfterSnapshotSkipsReaction(t *testing.T) {
+	var (
+		cfgMu        sync.Mutex
+		cfg          = &config.Config{GitHub: config.GitHubConfig{Repositories: []string{"org/repo"}}}
+		reviewsCalls int
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls/42", func(w http.ResponseWriter, _ *http.Request) {
+		// Simulate an operator disabling the repo while the already-queued
+		// state check is fetching its fresh PR snapshot.
+		cfgMu.Lock()
+		cfg.GitHub.NonMonitored = []string{"org/repo"}
+		cfgMu.Unlock()
+		_, _ = w.Write([]byte(`{
+			"state":"open","draft":false,
+			"user":{"login":"heimdallm-bot"},
+			"updated_at":"2026-05-14T10:00:00Z",
+			"head":{"sha":"deadbeef","ref":"heimdallm/issue-99"}
+		}`))
+	})
+	mux.HandleFunc("/repos/org/repo/pulls/42/reviews", func(w http.ResponseWriter, _ *http.Request) {
+		reviewsCalls++
+		_, _ = w.Write([]byte(`[
+			{"id":1,"user":{"login":"alice"},"state":"CHANGES_REQUESTED","body":"x","submitted_at":"2026-05-14T09:00:00Z"}
+		]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	s := newMemStore(t)
+	seedAutoImplementPR(t, s, 5002, 42)
+	a, _, _ := makePRReviewStateAdapter(t, srv, s, "heimdallm-bot")
+	a.cfgMu = &cfgMu
+	a.cfg = &cfg
+	fixer := &reviewStateDispatcher{}
+	a.fixRunner = fixer
+
+	_, _, err := a.CheckItem(context.Background(), &scheduler.WatchItem{
+		Type: "pr", Repo: "org/repo", Number: 42, GithubID: 5002,
+	})
+	if err != nil {
+		t.Fatalf("CheckItem: %v", err)
+	}
+	if reviewsCalls != 0 {
+		t.Fatalf("reviews endpoint called %d time(s) after repo disable, want 0", reviewsCalls)
+	}
+	if fixer.count() != 0 {
+		t.Fatalf("FixRunner called %d time(s) after repo disable, want 0", fixer.count())
 	}
 }
 

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -445,6 +445,70 @@ func TestMonitoredRepoSetMergesDiscoveredAndExcludesNonMonitored(t *testing.T) {
 	}
 }
 
+func TestAIReposInNonMonitoredIsSortedExactAndReadOnly(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.AI.Repos = map[string]config.RepoAI{
+		"z/repo":    {},
+		"a/repo":    {},
+		"Org/Case":  {},
+		"keep/repo": {},
+	}
+	cfg.GitHub.NonMonitored = []string{"z/repo", "a/repo", "a/repo", "org/case"}
+	beforeNonMonitored := append([]string(nil), cfg.GitHub.NonMonitored...)
+
+	got := aiReposInNonMonitored(cfg)
+	want := []string{"a/repo", "z/repo"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("aiReposInNonMonitored = %v, want %v", got, want)
+	}
+	if strings.Join(cfg.GitHub.NonMonitored, "|") != strings.Join(beforeNonMonitored, "|") {
+		t.Fatalf("NonMonitored mutated: got %v, want %v", cfg.GitHub.NonMonitored, beforeNonMonitored)
+	}
+	if len(cfg.AI.Repos) != 4 {
+		t.Fatalf("AI.Repos mutated: %v", cfg.AI.Repos)
+	}
+}
+
+func TestAIReposInNonMonitoredDetectsStoreLayerConflict(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.AI.Repos = map[string]config.RepoAI{"legacy/repo": {}}
+	if err := cfg.ApplyStore(map[string]string{
+		"non_monitored": `["legacy/repo"]`,
+	}); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+	if got := aiReposInNonMonitored(cfg); len(got) != 1 || got[0] != "legacy/repo" {
+		t.Fatalf("store-backed conflict = %v, want [legacy/repo]", got)
+	}
+}
+
+func TestRepoMonitoringConflictWarnerDeduplicatesAndResets(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.AI.Repos = map[string]config.RepoAI{"a/repo": {}, "b/repo": {}}
+	cfg.GitHub.NonMonitored = []string{"a/repo"}
+	var w repoMonitoringConflictWarner
+
+	if got := w.next(cfg); len(got) != 1 || got[0] != "a/repo" {
+		t.Fatalf("first warning = %v, want [a/repo]", got)
+	}
+	if got := w.next(cfg); got != nil {
+		t.Fatalf("duplicate warning = %v, want nil", got)
+	}
+
+	cfg.GitHub.NonMonitored = []string{"b/repo"}
+	if got := w.next(cfg); len(got) != 1 || got[0] != "b/repo" {
+		t.Fatalf("changed warning = %v, want [b/repo]", got)
+	}
+	cfg.GitHub.NonMonitored = nil
+	if got := w.next(cfg); got != nil {
+		t.Fatalf("cleared warning = %v, want nil", got)
+	}
+	cfg.GitHub.NonMonitored = []string{"b/repo"}
+	if got := w.next(cfg); len(got) != 1 || got[0] != "b/repo" {
+		t.Fatalf("reintroduced warning = %v, want [b/repo]", got)
+	}
+}
+
 func TestPurgeStaleManagedClonesUsesRetentionAndConfiguredDirs(t *testing.T) {
 	base := t.TempDir()
 	oldRepo := filepath.Join(base, "org", "old")
@@ -667,7 +731,7 @@ func TestTier2AdapterPublishPendingDefersInFlightReviews(t *testing.T) {
 	}
 }
 
-func TestRunTier2PublishesPendingWhenLiveRepoSetIsEmpty(t *testing.T) {
+func TestTier2AdapterPublishPendingDefersUntilRepoReenabled(t *testing.T) {
 	s := newMemStore(t)
 	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
 	reviewID := seedPRWithReview(t, s, 103, now)
@@ -683,10 +747,8 @@ func TestRunTier2PublishesPendingWhenLiveRepoSetIsEmpty(t *testing.T) {
 		t.Fatalf("flush subscribe: %v", err)
 	}
 
-	// Tier 1's last snapshot can still contain a repo that the live config
-	// has just disabled. Keep that stale snapshot in the test so an empty
-	// intersection, rather than an empty discovery input, drives the branch.
 	cfg := &config.Config{}
+	cfg.GitHub.Repositories = []string{"org/repo"}
 	cfg.GitHub.NonMonitored = []string{"org/repo"}
 	var cfgMu sync.Mutex
 	adapter := &tier2Adapter{
@@ -695,9 +757,81 @@ func TestRunTier2PublishesPendingWhenLiveRepoSetIsEmpty(t *testing.T) {
 		cfgMu:      &cfgMu,
 		cfg:        &cfg,
 	}
-	reposCh := make(chan []string, 1)
-	reposCh <- []string{"org/repo"}
 
+	adapter.publishPending()
+	if err := conn.Flush(); err != nil {
+		t.Fatalf("flush deferred publish: %v", err)
+	}
+	select {
+	case msg := <-ch:
+		t.Fatalf("disabled repo was enqueued: %q", msg.Data)
+	case <-time.After(150 * time.Millisecond):
+	}
+	pending, err := s.ListUnpublishedReviews()
+	if err != nil {
+		t.Fatalf("list deferred review: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ID != reviewID {
+		t.Fatalf("pending reviews = %+v, want review %d", pending, reviewID)
+	}
+
+	cfgMu.Lock()
+	cfg.GitHub.NonMonitored = nil
+	cfgMu.Unlock()
+	adapter.publishPending()
+	if err := conn.Flush(); err != nil {
+		t.Fatalf("flush resumed publish: %v", err)
+	}
+
+	select {
+	case msg := <-ch:
+		var got bus.PRPublishMsg
+		if err := bus.Decode(msg.Data, &got); err != nil {
+			t.Fatalf("decode publish msg: %v", err)
+		}
+		if got.ReviewID != reviewID {
+			t.Fatalf("published review ID = %d, want pending review %d", got.ReviewID, reviewID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pending review was not enqueued after repo re-enable")
+	}
+
+	if err := s.MarkReviewPublished(reviewID, 12345, "APPROVED", now.Add(time.Minute)); err != nil {
+		t.Fatalf("mark review published: %v", err)
+	}
+	adapter.publishPending()
+	if err := conn.Flush(); err != nil {
+		t.Fatalf("flush idempotency check: %v", err)
+	}
+	select {
+	case msg := <-ch:
+		t.Fatalf("published review was enqueued again: %q", msg.Data)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestRunTier2PublishesPendingWhenLiveRepoSetIsEmpty(t *testing.T) {
+	s := newMemStore(t)
+	reviewID := seedPRWithReview(t, s, 104, time.Now().UTC())
+
+	conn := newInProcessNATS(t)
+	ch := make(chan *nats.Msg, 1)
+	sub, err := conn.ChanSubscribe(bus.SubjPRPublish, ch)
+	if err != nil {
+		t.Fatalf("subscribe publish subject: %v", err)
+	}
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	if err := conn.Flush(); err != nil {
+		t.Fatalf("flush subscribe: %v", err)
+	}
+
+	// No live repos means both review/issue polling branches are skipped. The
+	// PR tick must still call PublishPending so a review deferred by a prior
+	// disable can recover after config changes.
+	adapter := &tier2Adapter{
+		store:      s,
+		publishPub: bus.NewPRPublishPublisher(conn),
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
@@ -710,7 +844,7 @@ func TestRunTier2PublishesPendingWhenLiveRepoSetIsEmpty(t *testing.T) {
 			nil,
 			func() []string { return nil },
 			nil,
-			reposCh,
+			make(chan []string),
 			time.Hour,
 			true,
 			nil,

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -667,6 +667,74 @@ func TestTier2AdapterPublishPendingDefersInFlightReviews(t *testing.T) {
 	}
 }
 
+func TestRunTier2PublishesPendingWhenLiveRepoSetIsEmpty(t *testing.T) {
+	s := newMemStore(t)
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	reviewID := seedPRWithReview(t, s, 103, now)
+
+	conn := newInProcessNATS(t)
+	ch := make(chan *nats.Msg, 1)
+	sub, err := conn.ChanSubscribe(bus.SubjPRPublish, ch)
+	if err != nil {
+		t.Fatalf("subscribe publish subject: %v", err)
+	}
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	if err := conn.Flush(); err != nil {
+		t.Fatalf("flush subscribe: %v", err)
+	}
+
+	// Tier 1's last snapshot can still contain a repo that the live config
+	// has just disabled. Keep that stale snapshot in the test so an empty
+	// intersection, rather than an empty discovery input, drives the branch.
+	cfg := &config.Config{}
+	cfg.GitHub.NonMonitored = []string{"org/repo"}
+	var cfgMu sync.Mutex
+	adapter := &tier2Adapter{
+		store:      s,
+		publishPub: bus.NewPRPublishPublisher(conn),
+		cfgMu:      &cfgMu,
+		cfg:        &cfg,
+	}
+	reposCh := make(chan []string, 1)
+	reposCh <- []string{"org/repo"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runTier2(
+			ctx,
+			adapter,
+			nil,
+			nil,
+			nil,
+			func() []string { return nil },
+			nil,
+			reposCh,
+			time.Hour,
+			true,
+			nil,
+		)
+	}()
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	select {
+	case msg := <-ch:
+		var got bus.PRPublishMsg
+		if err := bus.Decode(msg.Data, &got); err != nil {
+			t.Fatalf("decode publish msg: %v", err)
+		}
+		if got.ReviewID != reviewID {
+			t.Fatalf("published review ID = %d, want pending review %d", got.ReviewID, reviewID)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("PublishPending was skipped when the live repo set was empty")
+	}
+}
+
 func TestTier2AdapterPromoteReadyUsesOrgScopedIssueTracking(t *testing.T) {
 	var addedLabels [][]string
 	removedLabels := 0

--- a/daemon/cmd/heimdallm/main_tier3_guards_test.go
+++ b/daemon/cmd/heimdallm/main_tier3_guards_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/heimdallm/daemon/internal/config"
 	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/pipeline"
 	"github.com/heimdallm/daemon/internal/scheduler"
 	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
@@ -35,7 +36,9 @@ func TestTier3Adapter_HandleChange_SkipsClosedPR(t *testing.T) {
 		loginMu sync.Mutex
 		login   = "heimdallm-bot"
 		cfgMu   sync.Mutex
-		cfg     = &config.Config{}
+		cfg     = &config.Config{GitHub: config.GitHubConfig{
+			Repositories: []string{"org/repo"},
+		}}
 	)
 
 	runReviewCalls := 0
@@ -98,6 +101,68 @@ func TestTier3Adapter_HandleChange_SkipsClosedPR(t *testing.T) {
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("no SSE event emitted within 1s")
+	}
+}
+
+func TestTier3Adapter_HandleChange_SkipsNonMonitoredRepo(t *testing.T) {
+	s := newMemStore(t)
+	broker := sse.NewBroker()
+	broker.Start()
+	defer broker.Stop()
+	events := broker.Subscribe()
+	defer broker.Unsubscribe(events)
+
+	var (
+		loginMu sync.Mutex
+		login   = "heimdallm-bot"
+		cfgMu   sync.Mutex
+		cfg     = &config.Config{GitHub: config.GitHubConfig{
+			Repositories: []string{"org/repo"},
+			NonMonitored: []string{"org/repo"},
+		}}
+	)
+	runReviewCalls := 0
+	a := &tier2Adapter{
+		store:   s,
+		broker:  broker,
+		cfgMu:   &cfgMu,
+		cfg:     &cfg,
+		loginMu: &loginMu,
+		login:   &login,
+		runReview: func(*gh.PullRequest, config.RepoAI) *store.Review {
+			runReviewCalls++
+			return nil
+		},
+	}
+
+	err := a.HandleChange(context.Background(), &scheduler.WatchItem{
+		Type: "pr", Repo: "org/repo", Number: 42, GithubID: 42,
+	}, &scheduler.ItemSnapshot{
+		State: "open", Author: "alice", UpdatedAt: time.Now(), HeadSHA: "abc",
+	})
+	if err != nil {
+		t.Fatalf("HandleChange: %v", err)
+	}
+	if runReviewCalls != 0 {
+		t.Fatalf("runReview called %d time(s), want 0", runReviewCalls)
+	}
+
+	select {
+	case ev := <-events:
+		if ev.Type != sse.EventReviewSkipped {
+			t.Fatalf("event type = %q, want %q", ev.Type, sse.EventReviewSkipped)
+		}
+		var payload struct {
+			Reason string `json:"reason"`
+		}
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			t.Fatalf("decode event: %v", err)
+		}
+		if payload.Reason != string(pipeline.SkipReasonNotMonitored) {
+			t.Fatalf("reason = %q, want %q", payload.Reason, pipeline.SkipReasonNotMonitored)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no review_skipped event emitted")
 	}
 }
 

--- a/daemon/internal/bus/watch.go
+++ b/daemon/internal/bus/watch.go
@@ -4,6 +4,7 @@ package bus
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -13,6 +14,11 @@ const (
 	MaxBackoff     = 15 * time.Minute
 	EvictAfter     = 1 * time.Hour
 )
+
+// ErrWatchNotFound identifies a watch entry that was removed after a state
+// check message had already been queued. State workers treat that race as a
+// successful no-op instead of logging a misleading backoff failure.
+var ErrWatchNotFound = errors.New("watch entry not found")
 
 // watchStateSchema is applied on construction to create the table if needed.
 const watchStateSchema = `
@@ -114,7 +120,7 @@ func (w *WatchStore) Get(_ context.Context, key string) (*WatchEntry, error) {
 		&nextCheckStr, &entry.BackoffNs, &lastSeenStr)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, fmt.Errorf("watch: key %s not found", key)
+			return nil, fmt.Errorf("%w: %s", ErrWatchNotFound, key)
 		}
 		return nil, fmt.Errorf("watch: get %s: %w", key, err)
 	}
@@ -139,7 +145,7 @@ func (w *WatchStore) ResetBackoff(_ context.Context, key string, observedAt time
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
-		return fmt.Errorf("watch: key %s not found", key)
+		return fmt.Errorf("%w: %s", ErrWatchNotFound, key)
 	}
 	return nil
 }

--- a/daemon/internal/bus/watch_test.go
+++ b/daemon/internal/bus/watch_test.go
@@ -4,6 +4,7 @@ package bus_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -227,5 +228,8 @@ func TestWatchStore_Delete(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected 'not found' error, got %v", err)
+	}
+	if !errors.Is(err, bus.ErrWatchNotFound) {
+		t.Errorf("expected ErrWatchNotFound, got %v", err)
 	}
 }

--- a/daemon/internal/discovery/discovery.go
+++ b/daemon/internal/discovery/discovery.go
@@ -128,10 +128,10 @@ func (s *Service) Run(ctx context.Context, interval time.Duration, topic string,
 // Order: static first (stable for TOML-driven overrides), then configured
 // ([ai.repos.*] explicit entries), then discovered (topic search results).
 //
-// Repos in nonMonitored are excluded — UNLESS they appear in configured.
-// Explicit [ai.repos.*] config wins over the NonMonitored blacklist: a stale
-// auto-discovery row in non_monitored must not silently demote a repo the
-// operator has explicitly wired up. See theburrowhub/heimdallm#281.
+// Repos in nonMonitored are always excluded. Configured repos still join the
+// union when they are not explicitly disabled, preserving issue polling for
+// repos wired through [ai.repos.*] without letting an override undo the
+// operator's Not monitored choice.
 func MergeRepos(static, configured, discovered, nonMonitored []string) []string {
 	if len(static) == 0 && len(configured) == 0 && len(discovered) == 0 {
 		return nil

--- a/daemon/internal/github/client.go
+++ b/daemon/internal/github/client.go
@@ -396,11 +396,30 @@ func classifyPermanentSubmit422(status int, body []byte) (string, bool) {
 // as orphaned instead of retrying every poll cycle. See
 // theburrowhub/heimdallm#325.
 func (c *Client) SubmitReview(repo string, number int, body, event string) (int64, string, error) {
+	return c.submitReview(repo, number, body, event, "")
+}
+
+// SubmitReviewForCommit posts a review anchored to the exact commit that was
+// analysed. GitHub otherwise defaults to the pull request's current HEAD,
+// which lets a concurrent push misattribute findings from an older commit.
+// Keeping this as a separate concrete-client method preserves the existing
+// SubmitReview interface implemented by pipeline test doubles and adapters.
+func (c *Client) SubmitReviewForCommit(repo string, number int, body, event, commitID string) (int64, string, error) {
+	if strings.TrimSpace(commitID) == "" {
+		return 0, "", fmt.Errorf("github: submit review: empty commit_id")
+	}
+	return c.submitReview(repo, number, body, event, commitID)
+}
+
+func (c *Client) submitReview(repo string, number int, body, event, commitID string) (int64, string, error) {
 	path := fmt.Sprintf("/repos/%s/pulls/%d/reviews", repo, number)
 
 	payload := map[string]any{
 		"body":  body,
 		"event": event,
+	}
+	if commitID != "" {
+		payload["commit_id"] = commitID
 	}
 
 	data, _ := json.Marshal(payload)

--- a/daemon/internal/github/poller_test.go
+++ b/daemon/internal/github/poller_test.go
@@ -1157,6 +1157,44 @@ func mustTime(s string) time.Time {
 	return t
 }
 
+func TestSubmitReviewForCommitIncludesCommitID(t *testing.T) {
+	const wantCommit = "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091"
+	var payload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/org/repo/pulls/1/reviews" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 42, "state": "APPROVED"})
+	}))
+	defer srv.Close()
+
+	client := gh.NewClient("fake-token", gh.WithBaseURL(srv.URL))
+	id, state, err := client.SubmitReviewForCommit("org/repo", 1, "body", "APPROVE", wantCommit)
+	if err != nil {
+		t.Fatalf("SubmitReviewForCommit: %v", err)
+	}
+	if id != 42 || state != "APPROVED" {
+		t.Fatalf("result = (%d, %q), want (42, APPROVED)", id, state)
+	}
+	if got, _ := payload["commit_id"].(string); got != wantCommit {
+		t.Fatalf("commit_id = %q, want %q", got, wantCommit)
+	}
+	if payload["body"] != "body" || payload["event"] != "APPROVE" {
+		t.Fatalf("review payload = %#v", payload)
+	}
+}
+
+func TestSubmitReviewForCommitRejectsEmptyCommitID(t *testing.T) {
+	client := gh.NewClient("fake-token")
+	if _, _, err := client.SubmitReviewForCommit("org/repo", 1, "body", "COMMENT", " "); err == nil {
+		t.Fatal("expected empty commit_id error")
+	}
+}
+
 // TestSubmitReview_LockedPRReturnsPermanentSubmitError locks in the
 // fix from theburrowhub/heimdallm#325: when GitHub returns 422 with a
 // "lock prevents review" body, the daemon must surface a typed

--- a/daemon/internal/pipeline/guards.go
+++ b/daemon/internal/pipeline/guards.go
@@ -9,6 +9,9 @@ const (
 	SkipReasonNotOpen      SkipReason = "not_open"
 	SkipReasonDraft        SkipReason = "draft"
 	SkipReasonSelfAuthored SkipReason = "self_authored"
+	// SkipReasonNotMonitored is emitted by automatic schedulers/workers when
+	// a repo was disabled after discovery or after a review job was queued.
+	SkipReasonNotMonitored SkipReason = "not_monitored"
 	// SkipReasonSHAUnchanged is emitted when pipeline.Run short-circuits
 	// because the previous review row already covers the current HEAD
 	// commit (the #245 fail-closed dedup) and no explicit re-request was

--- a/daemon/internal/pipeline/guards.go
+++ b/daemon/internal/pipeline/guards.go
@@ -24,6 +24,11 @@ const (
 	// is now backfilled from the current snapshot. The user must trigger
 	// a re-review manually to score that exact commit.
 	SkipReasonLegacyBackfill SkipReason = "legacy_backfill"
+	// SkipReasonHeadChanged is emitted when a stored unpublished review was
+	// generated for an older commit. Publishing it against the current HEAD
+	// would misrepresent stale findings, so the pending row is retired and a
+	// later review request can evaluate the new commit.
+	SkipReasonHeadChanged SkipReason = "head_changed"
 	// SkipReasonNoReReviewRequest is emitted when pipeline.Run skips a
 	// review because the HEAD SHA changed (push) but no explicit
 	// review_requested event was found in the timeline after the

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -166,6 +166,32 @@ func (p *Pipeline) SetPublisher(pub Publisher) {
 	p.publisher = pub
 }
 
+// stopIfRepoBecameIneligible is called at side-effect boundaries. When a
+// review has already been stored, mark it terminal before returning so no
+// delayed publisher can resurrect it.
+func (p *Pipeline) stopIfRepoBecameIneligible(
+	pr *github.PullRequest,
+	rev *store.Review,
+	check func(string) bool,
+) (bool, error) {
+	if check == nil || check(pr.Repo) {
+		return false, nil
+	}
+	if rev != nil {
+		cancelledAt := time.Now().UTC()
+		if err := p.store.MarkReviewPublished(rev.ID, orphanedReviewID, "", cancelledAt); err != nil {
+			return true, fmt.Errorf("pipeline: cancel review %d for unmonitored repo: %w", rev.ID, err)
+		}
+		rev.GitHubReviewID = orphanedReviewID
+		rev.GitHubReviewState = ""
+		rev.PublishedAt = cancelledAt
+	}
+	p.publishSkipped(pr, SkipReasonNotMonitored)
+	slog.Info("pipeline: repo no longer monitored, stopping review",
+		"repo", pr.Repo, "pr", pr.Number)
+	return true, nil
+}
+
 // publish emits an SSE lifecycle event with the given payload. No-op
 // when no publisher is wired. A marshal failure on a map[string]any
 // of basic types should not happen in practice (every payload site
@@ -300,6 +326,10 @@ type RunOptions struct {
 	// NeverApproveWithIssues, when true, publishes the review as COMMENT
 	// instead of APPROVE whenever the review found any issue (see ReviewEvent).
 	NeverApproveWithIssues bool
+	// RepoEligible is a live gate for automatic work. It is checked again at
+	// execution/publication boundaries so a config reload can stop an in-flight
+	// review. Nil intentionally allows explicit/manual calls to proceed.
+	RepoEligible func(string) bool
 }
 
 // Run executes the full review pipeline for one PR and publishes the review to GitHub.
@@ -338,6 +368,9 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	prID, err := p.store.UpsertPR(prRow)
 	if err != nil {
 		return nil, fmt.Errorf("pipeline: upsert PR: %w", err)
+	}
+	if stopped, err := p.stopIfRepoBecameIneligible(pr, nil, opts.RepoEligible); stopped {
+		return nil, err
 	}
 
 	// Defense-in-depth: refuse to run the CLI if the gate rejects this PR.
@@ -427,6 +460,9 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 			slog.Warn("pipeline: fetch comments for directives failed", "err", err, "repo", pr.Repo, "pr", pr.Number)
 		} else {
 			prComments = cs
+			if stopped, err := p.stopIfRepoBecameIneligible(pr, nil, opts.RepoEligible); stopped {
+				return nil, err
+			}
 			p.processDirectives(pr, prComments, opts.InstructionAuthors)
 		}
 	}
@@ -558,6 +594,9 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	// already wraps the CircuitBreakerError into its own SSE event, so
 	// the breaker-trip path remains observable without a bogus
 	// review_started preceding it.
+	if stopped, err := p.stopIfRepoBecameIneligible(pr, nil, opts.RepoEligible); stopped {
+		return nil, err
+	}
 	p.notify.Notify("PR Review Started", fmt.Sprintf("%s #%d", pr.Repo, pr.Number))
 	p.publish(sse.EventPRDetected, map[string]any{
 		"pr_number": pr.Number,
@@ -584,6 +623,9 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	result, err := p.executor.Execute(cli, prompt, execOpts)
 	if err != nil {
 		return nil, fmt.Errorf("pipeline: execute %s: %w", cli, err)
+	}
+	if stopped, err := p.stopIfRepoBecameIneligible(pr, nil, opts.RepoEligible); stopped {
+		return nil, err
 	}
 
 	// 5b. Reconcile severity: ensure top-level severity >= max(issues[].severity).
@@ -630,12 +672,18 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		return nil, fmt.Errorf("pipeline: store review: %w", err)
 	}
 	slog.Info("pipeline: review stored locally", "review_id", rev.ID)
+	if stopped, err := p.stopIfRepoBecameIneligible(pr, rev, opts.RepoEligible); stopped {
+		return nil, err
+	}
 
 	// 8. Publish review to GitHub
 	var reviewBody string
 	if reviewMode == "multi" && len(result.Issues) > 0 {
 		// Post one comment per issue (best-effort — failures are logged but don't abort)
 		for _, issue := range result.Issues {
+			if stopped, err := p.stopIfRepoBecameIneligible(pr, rev, opts.RepoEligible); stopped {
+				return nil, err
+			}
 			if _, err := p.gh.PostComment(pr.Repo, pr.Number, buildIssueComment(issue)); err != nil {
 				slog.Warn("pipeline: failed to post issue comment", "pr", pr.Number, "err", err)
 			}
@@ -645,6 +693,9 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		reviewBody = BuildGitHubBody(result)
 	}
 
+	if stopped, err := p.stopIfRepoBecameIneligible(pr, rev, opts.RepoEligible); stopped {
+		return nil, err
+	}
 	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
 		pr.Repo, pr.Number,
 		AnnotateBodyForEvent(reviewBody, reviewEvent),

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -166,28 +166,20 @@ func (p *Pipeline) SetPublisher(pub Publisher) {
 	p.publisher = pub
 }
 
-// stopIfRepoBecameIneligible is called at side-effect boundaries. When a
-// review has already been stored, mark it terminal before returning so no
-// delayed publisher can resurrect it.
+// stopIfRepoBecameIneligible is called at side-effect boundaries. A review
+// that has already been stored stays pending: disabling monitoring is
+// reversible, so the publish-pending scanner must be able to resume it after
+// the repo is re-enabled. The scanner and publish worker both apply the same
+// live eligibility gate before enqueueing/submitting it.
 func (p *Pipeline) stopIfRepoBecameIneligible(
 	pr *github.PullRequest,
-	rev *store.Review,
 	check func(string) bool,
 ) (bool, error) {
 	if check == nil || check(pr.Repo) {
 		return false, nil
 	}
-	if rev != nil {
-		cancelledAt := time.Now().UTC()
-		if err := p.store.MarkReviewPublished(rev.ID, orphanedReviewID, "", cancelledAt); err != nil {
-			return true, fmt.Errorf("pipeline: cancel review %d for unmonitored repo: %w", rev.ID, err)
-		}
-		rev.GitHubReviewID = orphanedReviewID
-		rev.GitHubReviewState = ""
-		rev.PublishedAt = cancelledAt
-	}
 	p.publishSkipped(pr, SkipReasonNotMonitored)
-	slog.Info("pipeline: repo no longer monitored, stopping review",
+	slog.Info("pipeline: repo no longer monitored, deferring review",
 		"repo", pr.Repo, "pr", pr.Number)
 	return true, nil
 }
@@ -369,7 +361,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	if err != nil {
 		return nil, fmt.Errorf("pipeline: upsert PR: %w", err)
 	}
-	if stopped, err := p.stopIfRepoBecameIneligible(pr, nil, opts.RepoEligible); stopped {
+	if stopped, err := p.stopIfRepoBecameIneligible(pr, opts.RepoEligible); stopped {
 		return nil, err
 	}
 
@@ -424,6 +416,18 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		pr.Head.SHA = sha
 	}
 	prevReview, _ := p.store.LatestReviewForPR(prID)
+	// A superseded pending review was generated for an older HEAD while the
+	// repo was temporarily disabled. It was never published, so it must not
+	// act like a completed prior review and require a fresh review_requested
+	// event. Treat it as absent; the current request can evaluate the new HEAD.
+	// Permanent/orphaned rows use a different sentinel and retain the existing
+	// fail-closed dedup behavior.
+	if prevReview != nil && prevReview.GitHubReviewID == SupersededReviewID {
+		slog.Info("pipeline: ignoring superseded unpublished review",
+			"repo", pr.Repo, "pr", pr.Number, "review_id", prevReview.ID,
+			"review_head_sha", prevReview.HeadSHA, "head_sha", pr.Head.SHA)
+		prevReview = nil
+	}
 	// Legacy rows (before the head_sha column was populated) have empty
 	// HeadSHA and would otherwise bypass the guard because "" never equals a
 	// real SHA. Treat as "cannot confirm safe" — backfill the column from the
@@ -460,7 +464,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 			slog.Warn("pipeline: fetch comments for directives failed", "err", err, "repo", pr.Repo, "pr", pr.Number)
 		} else {
 			prComments = cs
-			if stopped, err := p.stopIfRepoBecameIneligible(pr, nil, opts.RepoEligible); stopped {
+			if stopped, err := p.stopIfRepoBecameIneligible(pr, opts.RepoEligible); stopped {
 				return nil, err
 			}
 			p.processDirectives(pr, prComments, opts.InstructionAuthors)
@@ -594,7 +598,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	// already wraps the CircuitBreakerError into its own SSE event, so
 	// the breaker-trip path remains observable without a bogus
 	// review_started preceding it.
-	if stopped, err := p.stopIfRepoBecameIneligible(pr, nil, opts.RepoEligible); stopped {
+	if stopped, err := p.stopIfRepoBecameIneligible(pr, opts.RepoEligible); stopped {
 		return nil, err
 	}
 	p.notify.Notify("PR Review Started", fmt.Sprintf("%s #%d", pr.Repo, pr.Number))
@@ -623,9 +627,6 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	result, err := p.executor.Execute(cli, prompt, execOpts)
 	if err != nil {
 		return nil, fmt.Errorf("pipeline: execute %s: %w", cli, err)
-	}
-	if stopped, err := p.stopIfRepoBecameIneligible(pr, nil, opts.RepoEligible); stopped {
-		return nil, err
 	}
 
 	// 5b. Reconcile severity: ensure top-level severity >= max(issues[].severity).
@@ -672,7 +673,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		return nil, fmt.Errorf("pipeline: store review: %w", err)
 	}
 	slog.Info("pipeline: review stored locally", "review_id", rev.ID)
-	if stopped, err := p.stopIfRepoBecameIneligible(pr, rev, opts.RepoEligible); stopped {
+	if stopped, err := p.stopIfRepoBecameIneligible(pr, opts.RepoEligible); stopped {
 		return nil, err
 	}
 
@@ -681,7 +682,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	if reviewMode == "multi" && len(result.Issues) > 0 {
 		// Post one comment per issue (best-effort — failures are logged but don't abort)
 		for _, issue := range result.Issues {
-			if stopped, err := p.stopIfRepoBecameIneligible(pr, rev, opts.RepoEligible); stopped {
+			if stopped, err := p.stopIfRepoBecameIneligible(pr, opts.RepoEligible); stopped {
 				return nil, err
 			}
 			if _, err := p.gh.PostComment(pr.Repo, pr.Number, buildIssueComment(issue)); err != nil {
@@ -693,7 +694,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		reviewBody = BuildGitHubBody(result)
 	}
 
-	if stopped, err := p.stopIfRepoBecameIneligible(pr, rev, opts.RepoEligible); stopped {
+	if stopped, err := p.stopIfRepoBecameIneligible(pr, opts.RepoEligible); stopped {
 		return nil, err
 	}
 	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
@@ -756,6 +757,13 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 // failure). It marks the row as resolved so PublishPending stops retrying it,
 // while being distinguishable from a real GitHub review id.
 const orphanedReviewID = -1
+
+// SupersededReviewID marks an unpublished review whose analysed HEAD changed
+// before a deferred retry could publish it. Unlike orphanedReviewID, this
+// sentinel is intentionally ignored by the next pipeline run so an outstanding
+// review request can evaluate the replacement commit without an artificial
+// re-request. It is exported for the NATS publish worker in cmd/heimdallm.
+const SupersededReviewID int64 = -2
 
 // markOrphanIfPermanent inspects the error returned by SubmitReview and,
 // when it is a *github.PermanentSubmitError, marks the local review row

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -499,6 +499,52 @@ func TestPipeline_Run_SkipsReviewOnSameHeadSHA(t *testing.T) {
 	}
 }
 
+func TestPipeline_Run_SupersededPendingReviewDoesNotRequireRerequest(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	now := time.Now().UTC()
+	prID, err := s.UpsertPR(&store.PR{
+		GithubID: 77, Repo: "org/repo", Number: 77, Title: "Feature",
+		Author: "alice", URL: "https://github.com/org/repo/pull/77", State: "open",
+		UpdatedAt: now, FetchedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("seed PR: %v", err)
+	}
+	if _, err := s.InsertReview(&store.Review{
+		PRID: prID, CLIUsed: "claude", Summary: "old deferred result",
+		Issues: "[]", Suggestions: "[]", Severity: "low", CreatedAt: now,
+		GitHubReviewID: pipeline.SupersededReviewID, HeadSHA: "old-head",
+	}); err != nil {
+		t.Fatalf("seed superseded review: %v", err)
+	}
+
+	exec := &fakeExecCounter{}
+	gh := &fakeGHCounter{diff: "+line"}
+	p := pipeline.New(s, gh, exec, &fakeNotify{})
+	pr := &github.PullRequest{
+		ID: 77, Number: 77, Title: "Feature", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: now.Add(time.Minute), HTMLURL: "https://github.com/org/repo/pull/77",
+		Head: github.Branch{SHA: "new-head"},
+	}
+
+	rev, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"})
+	if err != nil {
+		t.Fatalf("run replacement HEAD: %v", err)
+	}
+	if rev == nil || rev.HeadSHA != "new-head" {
+		t.Fatalf("replacement review = %+v, want fresh review for new-head", rev)
+	}
+	if exec.calls != 1 || gh.submits != 1 {
+		t.Fatalf("replacement run: exec=%d submits=%d, want 1/1", exec.calls, gh.submits)
+	}
+}
+
 // TestPipeline_Run_GateSkipsReview: when the guard evaluator returns a skip
 // reason (here: state != "open"), the pipeline must not call the executor or
 // submit a review. Proves the defense-in-depth layer protects future callers
@@ -1106,7 +1152,7 @@ func TestPipeline_Run_NilPublisherIsNoop(t *testing.T) {
 	}
 }
 
-func TestPipeline_Run_DisabledDuringExecutionDoesNotPublish(t *testing.T) {
+func TestPipeline_Run_DisabledDuringExecutionPersistsPendingReview(t *testing.T) {
 	s, err := store.Open(":memory:")
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -1157,12 +1203,15 @@ func TestPipeline_Run_DisabledDuringExecutionDoesNotPublish(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list unpublished: %v", err)
 	}
-	if len(pending) != 0 {
-		t.Fatalf("unpublished reviews = %d, want 0", len(pending))
+	if len(pending) != 1 {
+		t.Fatalf("unpublished reviews = %d, want 1 deferred review", len(pending))
+	}
+	if pending[0].GitHubReviewID != 0 || !pending[0].PublishedAt.IsZero() {
+		t.Fatalf("deferred review = %+v, want unpublished row", pending[0])
 	}
 }
 
-func TestPipeline_Run_DisabledAfterStoreMarksReviewTerminal(t *testing.T) {
+func TestPipeline_Run_DisabledAfterStoreLeavesReviewPending(t *testing.T) {
 	s, err := store.Open(":memory:")
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -1182,8 +1231,8 @@ func TestPipeline_Run_DisabledAfterStoreMarksReviewTerminal(t *testing.T) {
 		Primary: "claude",
 		RepoEligible: func(string) bool {
 			checks++
-			// The fourth boundary is immediately after InsertReview.
-			return checks < 4
+			// The third boundary is immediately after InsertReview.
+			return checks < 3
 		},
 	})
 	if err != nil {
@@ -1203,15 +1252,18 @@ func TestPipeline_Run_DisabledAfterStoreMarksReviewTerminal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("latest review: %v", err)
 	}
-	if storedReview.GitHubReviewID != -1 {
-		t.Fatalf("GitHubReviewID = %d, want -1 terminal sentinel", storedReview.GitHubReviewID)
+	if storedReview.GitHubReviewID != 0 {
+		t.Fatalf("GitHubReviewID = %d, want 0 pending", storedReview.GitHubReviewID)
+	}
+	if !storedReview.PublishedAt.IsZero() {
+		t.Fatalf("PublishedAt = %v, want zero while deferred", storedReview.PublishedAt)
 	}
 	pending, err := s.ListUnpublishedReviews()
 	if err != nil {
 		t.Fatalf("list unpublished: %v", err)
 	}
-	if len(pending) != 0 {
-		t.Fatalf("unpublished reviews = %d, want 0", len(pending))
+	if len(pending) != 1 || pending[0].ID != storedReview.ID {
+		t.Fatalf("unpublished reviews = %+v, want deferred review %d", pending, storedReview.ID)
 	}
 }
 

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -300,7 +300,9 @@ func (f *fakeGHWithHeadSHA) SubmitReview(repo string, number int, body, event st
 	f.submits++
 	return 1, "COMMENTED", nil
 }
-func (f *fakeGHWithHeadSHA) PostComment(repo string, number int, body string) (time.Time, error) { return time.Now().UTC(), nil }
+func (f *fakeGHWithHeadSHA) PostComment(repo string, number int, body string) (time.Time, error) {
+	return time.Now().UTC(), nil
+}
 func (f *fakeGHWithHeadSHA) FetchComments(repo string, number int) ([]github.Comment, error) {
 	return nil, nil
 }
@@ -358,7 +360,8 @@ func TestPipeline_Run_HydratesHeadSHAWhenMissing(t *testing.T) {
 // fakeExecCounter records how many times Execute was called so tests can
 // assert whether the pipeline short-circuited before invoking the CLI.
 type fakeExecCounter struct {
-	calls int
+	calls     int
+	onExecute func()
 }
 
 func (f *fakeExecCounter) Detect(primary, fallback string) (string, error) {
@@ -367,14 +370,17 @@ func (f *fakeExecCounter) Detect(primary, fallback string) (string, error) {
 
 func (f *fakeExecCounter) Execute(cli, prompt string, _ executor.ExecOptions) (*executor.ReviewResult, error) {
 	f.calls++
+	if f.onExecute != nil {
+		f.onExecute()
+	}
 	return &executor.ReviewResult{Summary: "ok", Severity: "low"}, nil
 }
 
 // fakeGHCounter records SubmitReview calls so tests can verify no publish
 // happens on a skipped re-review.
 type fakeGHCounter struct {
-	diff     string
-	submits  int
+	diff    string
+	submits int
 }
 
 func (f *fakeGHCounter) FetchDiff(repo string, number int) (string, error) { return f.diff, nil }
@@ -382,9 +388,13 @@ func (f *fakeGHCounter) SubmitReview(repo string, number int, body, event string
 	f.submits++
 	return 1, "COMMENTED", nil
 }
-func (f *fakeGHCounter) PostComment(repo string, number int, body string) (time.Time, error) { return time.Now().UTC(), nil }
-func (f *fakeGHCounter) FetchComments(repo string, number int) ([]github.Comment, error) { return nil, nil }
-func (f *fakeGHCounter) GetPRHeadSHA(repo string, number int) (string, error)            { return "", nil }
+func (f *fakeGHCounter) PostComment(repo string, number int, body string) (time.Time, error) {
+	return time.Now().UTC(), nil
+}
+func (f *fakeGHCounter) FetchComments(repo string, number int) ([]github.Comment, error) {
+	return nil, nil
+}
+func (f *fakeGHCounter) GetPRHeadSHA(repo string, number int) (string, error) { return "", nil }
 
 // TestPipeline_Run_SkipsReviewOnSameHeadSHA is the regression guard for the
 // bot-feedback loop bug seen on theburrowhub/heimdallm#139: any review
@@ -417,7 +427,12 @@ func TestPipeline_Run_SkipsReviewOnSameHeadSHA(t *testing.T) {
 		t.Fatalf("first run: %v", err)
 	}
 	if rev1 == nil || rev1.HeadSHA != "deadbeef" {
-		t.Fatalf("first review HeadSHA = %q, want %q", func() string { if rev1 == nil { return "<nil>" }; return rev1.HeadSHA }(), "deadbeef")
+		t.Fatalf("first review HeadSHA = %q, want %q", func() string {
+			if rev1 == nil {
+				return "<nil>"
+			}
+			return rev1.HeadSHA
+		}(), "deadbeef")
 	}
 	if exec.calls != 1 || gh.submits != 1 {
 		t.Fatalf("first run: exec=%d submits=%d, want 1/1", exec.calls, gh.submits)
@@ -1088,6 +1103,115 @@ func TestPipeline_Run_NilPublisherIsNoop(t *testing.T) {
 	}
 	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude"}); err != nil {
 		t.Fatalf("run with nil publisher: %v", err)
+	}
+}
+
+func TestPipeline_Run_DisabledDuringExecutionDoesNotPublish(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	eligible := true
+	exec := &fakeExecCounter{onExecute: func() { eligible = false }}
+	gh := &fakeGHCounter{diff: "+line"}
+	pub := &fakePublisher{}
+	p := pipeline.New(s, gh, exec, &fakeNotify{})
+	p.SetPublisher(pub)
+
+	pr := &github.PullRequest{
+		ID: 301, Number: 301, Title: "t", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/301",
+		Head: github.Branch{SHA: "abc"},
+	}
+	rev, err := p.Run(pr, pipeline.RunOptions{
+		Primary: "claude",
+		RepoEligible: func(repo string) bool {
+			return repo == "org/repo" && eligible
+		},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev != nil {
+		t.Fatalf("review = %+v, want nil after live disable", rev)
+	}
+	if exec.calls != 1 {
+		t.Fatalf("Execute calls = %d, want 1", exec.calls)
+	}
+	if gh.submits != 0 {
+		t.Fatalf("SubmitReview calls = %d, want 0", gh.submits)
+	}
+	if got := pub.types(); !equalStringSlices(got, []string{
+		sse.EventPRDetected, sse.EventReviewStarted, sse.EventReviewSkipped,
+	}) {
+		t.Fatalf("events: got %v, want detected/started/skipped", got)
+	}
+	ev, _ := pub.firstOf(sse.EventReviewSkipped)
+	if !strings.Contains(ev.Data, `"reason":"not_monitored"`) {
+		t.Fatalf("review_skipped payload missing not_monitored: %q", ev.Data)
+	}
+	pending, err := s.ListUnpublishedReviews()
+	if err != nil {
+		t.Fatalf("list unpublished: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("unpublished reviews = %d, want 0", len(pending))
+	}
+}
+
+func TestPipeline_Run_DisabledAfterStoreMarksReviewTerminal(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	checks := 0
+	gh := &fakeGHCounter{diff: "+line"}
+	p := pipeline.New(s, gh, &fakeExecCounter{}, &fakeNotify{})
+	pr := &github.PullRequest{
+		ID: 302, Number: 302, Title: "t", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/302",
+		Head: github.Branch{SHA: "def"},
+	}
+	rev, err := p.Run(pr, pipeline.RunOptions{
+		Primary: "claude",
+		RepoEligible: func(string) bool {
+			checks++
+			// The fourth boundary is immediately after InsertReview.
+			return checks < 4
+		},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev != nil {
+		t.Fatalf("review = %+v, want nil after cancellation", rev)
+	}
+	if gh.submits != 0 {
+		t.Fatalf("SubmitReview calls = %d, want 0", gh.submits)
+	}
+	storedPR, err := s.GetPRByGithubID(302)
+	if err != nil {
+		t.Fatalf("get PR: %v", err)
+	}
+	storedReview, err := s.LatestReviewForPR(storedPR.ID)
+	if err != nil {
+		t.Fatalf("latest review: %v", err)
+	}
+	if storedReview.GitHubReviewID != -1 {
+		t.Fatalf("GitHubReviewID = %d, want -1 terminal sentinel", storedReview.GitHubReviewID)
+	}
+	pending, err := s.ListUnpublishedReviews()
+	if err != nil {
+		t.Fatalf("list unpublished: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("unpublished reviews = %d, want 0", len(pending))
 	}
 }
 

--- a/daemon/internal/scheduler/types.go
+++ b/daemon/internal/scheduler/types.go
@@ -21,10 +21,10 @@ type Tier1Publisher interface {
 // Tier1Config provides the repo lists for merging.
 //
 // ConfiguredRepos carries the keys of [ai.repos.*] from the live config so the
-// merge can include explicitly-configured repos in the union AND exempt them
-// from the NonMonitored blacklist. See theburrowhub/heimdallm#281: a repo wired
-// up under [ai.repos."org/repo"] but with no active PRs must still receive
-// issue polling.
+// merge can include explicitly-configured repos in the union. NonMonitored is
+// still authoritative: an override customizes a repo but does not undo an
+// explicit disable. A configured, non-disabled repo with no active PRs still
+// receives issue polling (theburrowhub/heimdallm#281).
 type Tier1Config struct {
 	StaticRepos     []string
 	ConfiguredRepos []string

--- a/daemon/internal/store/reviews.go
+++ b/daemon/internal/store/reviews.go
@@ -109,9 +109,11 @@ func (s *Store) UpdateReviewHeadSHA(reviewID int64, headSHA string) error {
 // is what closes the 2026-04-22 cost-runaway regression. See
 // theburrowhub/heimdallm#243.
 //
-// Pass the sentinel pair (-1, "") for ghReviewID / ghReviewState to mark an
-// orphan review that can never publish (e.g. the source PR's repo was
-// unset); publishedAt is still stored as a reference point.
+// Negative ghReviewID values are internal terminal sentinels (for example -1
+// for an orphan that can never publish, or -2 for a deferred result superseded
+// by a newer HEAD). They are excluded from unpublished retry scans while
+// remaining distinguishable from real positive GitHub review IDs; publishedAt
+// is still stored as a reference point.
 func (s *Store) MarkReviewPublished(reviewID, ghReviewID int64, ghReviewState string, publishedAt time.Time) error {
 	_, err := s.db.Exec(
 		"UPDATE reviews SET github_review_id=?, github_review_state=?, published_at=? WHERE id=?",

--- a/daemon/internal/worker/state.go
+++ b/daemon/internal/worker/state.go
@@ -3,6 +3,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -69,18 +70,18 @@ func (w *StateWorker) Start(ctx context.Context) error {
 				slog.Warn("state-worker: check failed",
 					"type", checkMsg.Type, "repo", checkMsg.Repo,
 					"number", checkMsg.Number, "err", handlerErr)
-				if kvErr := w.watchKV.IncreaseBackoff(ctx, key); kvErr != nil {
+				if kvErr := w.watchKV.IncreaseBackoff(ctx, key); kvErr != nil && !errors.Is(kvErr, bus.ErrWatchNotFound) {
 					slog.Warn("state-worker: increase backoff failed", "key", key, "err", kvErr)
 				}
 			} else if changed {
 				slog.Info("state-worker: change detected",
 					"type", checkMsg.Type, "repo", checkMsg.Repo,
 					"number", checkMsg.Number)
-				if kvErr := w.watchKV.ResetBackoff(ctx, key, time.Now()); kvErr != nil {
+				if kvErr := w.watchKV.ResetBackoff(ctx, key, time.Now()); kvErr != nil && !errors.Is(kvErr, bus.ErrWatchNotFound) {
 					slog.Warn("state-worker: reset backoff failed", "key", key, "err", kvErr)
 				}
 			} else {
-				if kvErr := w.watchKV.IncreaseBackoff(ctx, key); kvErr != nil {
+				if kvErr := w.watchKV.IncreaseBackoff(ctx, key); kvErr != nil && !errors.Is(kvErr, bus.ErrWatchNotFound) {
 					slog.Warn("state-worker: increase backoff failed", "key", key, "err", kvErr)
 				}
 			}

--- a/daemon/internal/worker/state_test.go
+++ b/daemon/internal/worker/state_test.go
@@ -2,8 +2,11 @@
 package worker_test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -75,5 +78,55 @@ func TestStateWorker_ConsumesAndCallsHandler(t *testing.T) {
 	}
 	if entry.Backoff() <= bus.InitialBackoff {
 		t.Errorf("expected backoff > initial after no-change, got %v", entry.Backoff())
+	}
+}
+
+func TestStateWorker_DeletedWatchDoesNotLogBackoffFailure(t *testing.T) {
+	b := newTestBus(t)
+	conn := b.Conn()
+	ws := newTestWatch(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := ws.Enroll(ctx, "pr", "org/disabled", 42, 9876); err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	handled := make(chan struct{})
+	handler := func(ctx context.Context, _ bus.StateCheckMsg) (bool, error) {
+		if err := ws.Delete(ctx, "pr.9876"); err != nil {
+			return false, err
+		}
+		close(handled)
+		return false, nil
+	}
+
+	w := worker.NewStateWorker(conn, 1, ws, handler)
+	go func() { _ = w.Start(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+
+	pub := bus.NewStateCheckPublisher(conn)
+	if err := pub.PublishStateCheck(ctx, "pr", "org/disabled", 42, 9876); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	select {
+	case <-handled:
+	case <-ctx.Done():
+		t.Fatal("state handler was not called")
+	}
+
+	// Give the worker time to apply its post-handler backoff update. A queued
+	// state check may legitimately outlive the watch row it references.
+	time.Sleep(50 * time.Millisecond)
+	if strings.Contains(logs.String(), "increase backoff failed") {
+		t.Fatalf("deleted watch produced a misleading warning: %s", logs.String())
+	}
+	if _, err := ws.Get(ctx, "pr.9876"); err == nil {
+		t.Fatal("deleted watch was unexpectedly recreated")
 	}
 }

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -131,6 +131,26 @@ Repos in `non_monitored` are excluded from the final set even if they appear in 
 non_monitored = ["myorg/archived-repo", "myorg/internal-mirror"]
 ```
 
+A repo-specific `[ai.repos."owner/name"]` section configures how a repo is
+processed; it does not override an explicit `non_monitored` entry. If both are
+present, automatic processing stays disabled while the AI override remains
+available for manual runs. The daemon logs a warning for this overlap at
+startup or config reload.
+
+Older Heimdallm versions could persist auto-discovery decisions in the same
+SQLite `non_monitored` setting used by the UI. Because that legacy data does
+not record whether an entry was automatic or an intentional user toggle,
+Heimdallm never deletes or re-enables these entries during an upgrade. Review
+the warning and re-enable the repository from the Repositories screen only
+after confirming that automatic reviews are desired.
+
+If a repository is disabled while an automatic review is already running,
+the computed result is kept pending rather than discarded. Re-enabling the
+repository resumes publication when the PR still has the same HEAD commit.
+If the HEAD changed while disabled, the stale result is retired and the
+outstanding review request can evaluate the replacement commit instead.
+Retry publication is anchored to the reviewed commit SHA.
+
 ### Poll interval
 
 ```bash

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/api/sse_client.dart';
 import '../../core/models/config_model.dart';
 import '../../core/platform/platform_services_provider.dart';
 import '../dashboard/dashboard_providers.dart';
@@ -15,37 +18,121 @@ final configProvider = FutureProvider<AppConfig>((ref) async {
 });
 
 class ConfigNotifier extends AsyncNotifier<AppConfig> {
+  AppConfig? _serverConfig;
+  Future<void> _operationQueue = Future<void>.value();
+  int _mutationGeneration = 0;
+  int _serverGeneration = 0;
+  final Map<String, dynamic> _pendingSaveDiff = {};
+  final Map<String, RepoConfig?> _pendingRepoMembershipChanges = {};
+
   @override
   Future<AppConfig> build() async {
     final api = ref.watch(apiClientProvider);
     final json = await api.fetchConfig();
-    return AppConfig.fromJson(json);
+    final config = AppConfig.fromJson(json);
+    _serverConfig = config;
+    _serverGeneration++;
+    _clearPendingSaveIntent();
+    return config;
   }
 
   /// Replaces local state with fresh config from the daemon. Called after
   /// PATCH/DELETE endpoints return the full config.
   void updateFromServer(Map<String, dynamic> json) {
-    state = AsyncValue.data(AppConfig.fromJson(json));
+    final config = AppConfig.fromJson(json);
+    _serverConfig = config;
+    _serverGeneration++;
+    _mutationGeneration++;
+    _clearPendingSaveIntent();
+    state = AsyncValue.data(config);
   }
 
   /// Save global config changes by computing the diff and sending only
   /// changed fields to the daemon via PATCH.
   /// Optimistic: updates UI state immediately, sends PATCH in background,
   /// then reconciles with the daemon's authoritative response.
-  Future<void> save(AppConfig updated) async {
+  Future<void> save(AppConfig updated) {
     final current = state.value;
-    if (current == null) return;
+    if (current == null) return Future<void>.value();
+    _serverConfig ??= current;
+
     final api = ref.read(apiClientProvider);
-    final diff = _computeGlobalDiff(current, updated);
-    if (diff.isEmpty) {
-      state = AsyncValue.data(updated);
-      return;
-    }
-    // Optimistic update — UI reflects the change immediately
+    _mergeConfigDiff(_pendingSaveDiff, _computeGlobalDiff(current, updated));
+    _pendingRepoMembershipChanges.addAll(
+      _computeRepoMembershipChanges(current, updated),
+    );
+    final requestedDiff = _copyConfigDiff(_pendingSaveDiff);
+    final repoMembershipChanges = Map<String, RepoConfig?>.from(
+      _pendingRepoMembershipChanges,
+    );
+    final generation = ++_mutationGeneration;
+    // Optimistic update — UI reflects the change immediately.
     state = AsyncValue.data(updated);
-    // Reconcile with daemon response in background
-    final freshJson = await api.patchConfig(diff);
-    state = AsyncValue.data(AppConfig.fromJson(freshJson));
+
+    return _enqueue(() async {
+      final baseline = _serverConfig;
+      if (baseline == null) return;
+      final serverGeneration = _serverGeneration;
+      final diff = _mergeRepoMembershipChanges(
+        requestedDiff,
+        baseline,
+        repoMembershipChanges,
+      );
+      if (diff.isEmpty) {
+        _clearPendingSaveIntentIfLatest(generation);
+        return;
+      }
+
+      final freshJson = await api.patchConfig(diff);
+      final fresh = AppConfig.fromJson(freshJson);
+      if (serverGeneration != _serverGeneration) return;
+      _serverConfig = fresh;
+      _serverGeneration++;
+      _clearPendingSaveIntentIfLatest(generation);
+      if (ref.mounted && generation == _mutationGeneration) {
+        state = AsyncValue.data(fresh);
+      }
+    });
+  }
+
+  /// Fetches the daemon's latest config. Refreshes share the same queue as
+  /// saves so a discovery event cannot race an in-flight PATCH.
+  Future<void> refresh() {
+    final api = ref.read(apiClientProvider);
+    final generation = _mutationGeneration;
+    return _enqueue(() async {
+      final serverGeneration = _serverGeneration;
+      final json = await api.fetchConfig();
+      final fresh = AppConfig.fromJson(json);
+      if (serverGeneration != _serverGeneration) return;
+      _serverConfig = fresh;
+      _serverGeneration++;
+      if (ref.mounted && generation == _mutationGeneration) {
+        _clearPendingSaveIntent();
+        state = AsyncValue.data(fresh);
+      }
+    });
+  }
+
+  Future<T> _enqueue<T>(Future<T> Function() operation) {
+    final completer = Completer<T>();
+    _operationQueue = _operationQueue.then((_) async {
+      try {
+        completer.complete(await operation());
+      } catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      }
+    });
+    return completer.future;
+  }
+
+  void _clearPendingSaveIntentIfLatest(int generation) {
+    if (generation == _mutationGeneration) _clearPendingSaveIntent();
+  }
+
+  void _clearPendingSaveIntent() {
+    _pendingSaveDiff.clear();
+    _pendingRepoMembershipChanges.clear();
   }
 
   /// First-run setup: write config file to disk, store token in Keychain,
@@ -55,6 +142,9 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
     required AppConfig config,
     required String daemonBinaryPath,
   }) async {
+    _mutationGeneration++;
+    _serverGeneration++;
+    _clearPendingSaveIntent();
     state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
       final platform = ref.read(platformServicesProvider);
@@ -83,12 +173,133 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
       ref.invalidate(daemonHealthProvider);
       return config;
     });
+    if (state case AsyncData(value: final savedConfig)) {
+      _serverConfig = savedConfig;
+    }
   }
 }
 
 final configNotifierProvider = AsyncNotifierProvider<ConfigNotifier, AppConfig>(
   ConfigNotifier.new,
 );
+
+/// Refreshes repository config after daemon events that change repository
+/// membership or identity. This provider is watched by ReposScreen so its SSE
+/// subscription exists only while the repository UI is mounted.
+class ConfigRefreshNotifier extends Notifier<int> {
+  @override
+  int build() {
+    ref.listen<AsyncValue<SseEvent>>(sseStreamProvider, (_, next) {
+      next.whenData((event) {
+        if (event.type != 'repo_discovered' && event.type != 'repo_renamed') {
+          return;
+        }
+        state++;
+        unawaited(_refreshAfterInitialLoad());
+      });
+    });
+    return 0;
+  }
+
+  Future<void> _refreshAfterInitialLoad() async {
+    try {
+      await ref.read(configNotifierProvider.future);
+      if (!ref.mounted) return;
+      await ref.read(configNotifierProvider.notifier).refresh();
+    } catch (_) {}
+  }
+}
+
+final configRefreshProvider =
+    NotifierProvider.autoDispose<ConfigRefreshNotifier, int>(
+      ConfigRefreshNotifier.new,
+    );
+
+void _mergeConfigDiff(
+  Map<String, dynamic> target,
+  Map<String, dynamic> update,
+) {
+  for (final entry in update.entries) {
+    final current = target[entry.key];
+    final next = entry.value;
+    if (current is Map<String, dynamic> && next is Map<String, dynamic>) {
+      _mergeConfigDiff(current, next);
+    } else {
+      target[entry.key] = _copyConfigValue(next);
+    }
+  }
+}
+
+Map<String, dynamic> _copyConfigDiff(Map<String, dynamic> source) => {
+  for (final entry in source.entries) entry.key: _copyConfigValue(entry.value),
+};
+
+dynamic _copyConfigValue(dynamic value) {
+  if (value is Map<String, dynamic>) return _copyConfigDiff(value);
+  if (value is List) return List<dynamic>.from(value);
+  return value;
+}
+
+Map<String, RepoConfig?> _computeRepoMembershipChanges(
+  AppConfig old,
+  AppConfig updated,
+) {
+  final changes = <String, RepoConfig?>{};
+  final allRepos = {...old.repoConfigs.keys, ...updated.repoConfigs.keys};
+  for (final repo in allRepos) {
+    final oldConfig = old.repoConfigs[repo];
+    final updatedConfig = updated.repoConfigs[repo];
+    if (oldConfig?.isMonitored != updatedConfig?.isMonitored) {
+      changes[repo] = updatedConfig;
+    }
+  }
+  return changes;
+}
+
+/// Repository membership is encoded as two aggregate arrays in the daemon
+/// config. Rebase per-repo user changes onto the latest server snapshot so an
+/// unrelated discovery or rename is not removed by a stale save snapshot.
+Map<String, dynamic> _mergeRepoMembershipChanges(
+  Map<String, dynamic> requestedDiff,
+  AppConfig baseline,
+  Map<String, RepoConfig?> changes,
+) {
+  if (changes.isEmpty) return requestedDiff;
+
+  final mergedRepos = Map<String, RepoConfig>.from(baseline.repoConfigs);
+  for (final entry in changes.entries) {
+    final config = entry.value;
+    if (config == null) {
+      mergedRepos.remove(entry.key);
+    } else {
+      mergedRepos[entry.key] = config;
+    }
+  }
+
+  final membershipDiff = _computeGlobalDiff(
+    baseline,
+    baseline.copyWith(repoConfigs: mergedRepos),
+  );
+  final membershipGithub = membershipDiff['github'] as Map<String, dynamic>?;
+  final github =
+      requestedDiff['github'] as Map<String, dynamic>? ?? <String, dynamic>{};
+  github.remove('repositories');
+  github.remove('non_monitored');
+  if (membershipGithub != null) {
+    if (membershipGithub.containsKey('repositories')) {
+      github['repositories'] = membershipGithub['repositories'];
+    }
+    if (membershipGithub.containsKey('non_monitored')) {
+      github['non_monitored'] = membershipGithub['non_monitored'];
+    }
+  }
+  if (github.isEmpty) {
+    requestedDiff.remove('github');
+  } else {
+    requestedDiff['github'] = github;
+  }
+  return requestedDiff;
+}
 
 /// Computes a nested diff between two AppConfig instances, returning only
 /// the fields that changed in the structure expected by PATCH /config
@@ -149,13 +360,17 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
   if (old.globalGeneratePRDescription != updated.globalGeneratePRDescription) {
     aiDiff['generate_pr_description'] = updated.globalGeneratePRDescription;
   }
-  if (old.globalNeverApproveWithIssues != updated.globalNeverApproveWithIssues) {
+  if (old.globalNeverApproveWithIssues !=
+      updated.globalNeverApproveWithIssues) {
     aiDiff['never_approve_with_issues'] = updated.globalNeverApproveWithIssues;
   }
 
   // Agent configs — diff each CLI agent's settings individually.
   final agentsDiff = <String, dynamic>{};
-  final allAgentNames = {...old.agentConfigs.keys, ...updated.agentConfigs.keys};
+  final allAgentNames = {
+    ...old.agentConfigs.keys,
+    ...updated.agentConfigs.keys,
+  };
   for (final name in allAgentNames) {
     final o = old.agentConfigs[name] ?? const CLIAgentConfig();
     final n = updated.agentConfigs[name] ?? const CLIAgentConfig();
@@ -166,10 +381,16 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
     if (o.extraFlags != n.extraFlags) ad['extra_flags'] = n.extraFlags;
     if (o.promptId != n.promptId) ad['prompt'] = n.promptId ?? '';
     if (o.effort != n.effort) ad['effort'] = n.effort;
-    if (o.permissionMode != n.permissionMode) ad['permission_mode'] = n.permissionMode;
+    if (o.permissionMode != n.permissionMode) {
+      ad['permission_mode'] = n.permissionMode;
+    }
     if (o.bare != n.bare) ad['bare'] = n.bare;
-    if (o.dangerouslySkipPerms != n.dangerouslySkipPerms) ad['dangerously_skip_perms'] = n.dangerouslySkipPerms;
-    if (o.noSessionPersistence != n.noSessionPersistence) ad['no_session_persistence'] = n.noSessionPersistence;
+    if (o.dangerouslySkipPerms != n.dangerouslySkipPerms) {
+      ad['dangerously_skip_perms'] = n.dangerouslySkipPerms;
+    }
+    if (o.noSessionPersistence != n.noSessionPersistence) {
+      ad['no_session_persistence'] = n.noSessionPersistence;
+    }
     if (ad.isNotEmpty) agentsDiff[name] = ad;
   }
   if (agentsDiff.isNotEmpty) aiDiff['agents'] = agentsDiff;
@@ -264,10 +485,12 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
   if (old.circuitBreaker.perIssue24h != updated.circuitBreaker.perIssue24h) {
     cbDiff['per_issue_24h'] = updated.circuitBreaker.perIssue24h;
   }
-  if (old.circuitBreaker.perIssueRepoHr != updated.circuitBreaker.perIssueRepoHr) {
+  if (old.circuitBreaker.perIssueRepoHr !=
+      updated.circuitBreaker.perIssueRepoHr) {
     cbDiff['per_issue_repo_hr'] = updated.circuitBreaker.perIssueRepoHr;
   }
-  if (old.circuitBreaker.perImplRepoHr != updated.circuitBreaker.perImplRepoHr) {
+  if (old.circuitBreaker.perImplRepoHr !=
+      updated.circuitBreaker.perImplRepoHr) {
     cbDiff['per_impl_repo_hr'] = updated.circuitBreaker.perImplRepoHr;
   }
   if (cbDiff.isNotEmpty) diff['circuit_breaker'] = cbDiff;

--- a/flutter_app/lib/features/repositories/repos_screen.dart
+++ b/flutter_app/lib/features/repositories/repos_screen.dart
@@ -23,7 +23,8 @@ enum _SyncStatus { idle, saving, saved }
 
 class _ReposScreenState extends ConsumerState<ReposScreen> {
   Map<String, RepoConfig> _repoConfigs = {};
-  bool _initialized = false;
+  AppConfig? _sourceConfig;
+  final Set<String> _dirtyRepos = {};
   String _search = '';
   String _filter = 'all'; // 'all' | 'monitored' | 'not_monitored'
   String _viewMode = 'list'; // 'list' | 'grid'
@@ -117,6 +118,7 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
           Feature.issueTracking => c.copyWith(itEnabled: enable),
           Feature.develop => c.copyWith(devEnabled: enable),
         };
+        _dirtyRepos.add(r);
       }
     });
     _debounce?.cancel();
@@ -143,15 +145,25 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
     super.dispose();
   }
 
-  void _initFrom(AppConfig config) {
-    if (_initialized) return;
-    _initialized = true;
+  void _syncFrom(AppConfig config, {bool force = false}) {
+    if (!force && identical(_sourceConfig, config)) return;
+    final localConfigs = _repoConfigs;
+    _sourceConfig = config;
     _repoConfigs = Map.from(config.repoConfigs);
+    for (final repo in _dirtyRepos) {
+      final local = localConfigs[repo];
+      if (local != null) _repoConfigs[repo] = local;
+    }
+    _dirtyRepos.removeWhere((repo) => !_repoConfigs.containsKey(repo));
+    _selected.retainAll(_repoConfigs.keys);
   }
 
   /// Called whenever a repo config changes — schedules an auto-save.
   void _onChange(String repo, RepoConfig rc) {
-    setState(() => _repoConfigs[repo] = rc);
+    setState(() {
+      _repoConfigs[repo] = rc;
+      _dirtyRepos.add(repo);
+    });
     _debounce?.cancel();
     _debounce = Timer(const Duration(milliseconds: 800), _autoSave);
   }
@@ -159,12 +171,27 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
   Future<void> _autoSave() async {
     final current = ref.read(configNotifierProvider).value;
     if (current == null) return;
+    final submitted = <String, RepoConfig>{};
+    for (final repo in _dirtyRepos) {
+      final config = _repoConfigs[repo];
+      if (config != null) submitted[repo] = config;
+    }
+    if (submitted.isEmpty) return;
     if (mounted) setState(() => _syncStatus = _SyncStatus.saving);
     final updated = current.copyWith(repoConfigs: Map.from(_repoConfigs));
     try {
       await ref.read(configNotifierProvider.notifier).save(updated);
       if (!mounted) return;
-      setState(() => _syncStatus = _SyncStatus.saved);
+      final latest = ref.read(configNotifierProvider).value;
+      setState(() {
+        for (final entry in submitted.entries) {
+          if (identical(_repoConfigs[entry.key], entry.value)) {
+            _dirtyRepos.remove(entry.key);
+          }
+        }
+        if (latest != null) _syncFrom(latest, force: true);
+        _syncStatus = _SyncStatus.saved;
+      });
       _savedResetTimer?.cancel();
       _savedResetTimer = Timer(const Duration(seconds: 2), () {
         if (mounted) setState(() => _syncStatus = _SyncStatus.idle);
@@ -179,13 +206,14 @@ class _ReposScreenState extends ConsumerState<ReposScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.watch(configRefreshProvider);
     final configAsync = ref.watch(configNotifierProvider);
 
     return configAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (_, _) => const Center(child: Text('Could not load config')),
       data: (config) {
-        _initFrom(config);
+        _syncFrom(config);
 
         // Monitored first, disabled last; both groups sorted alphabetically
         final allRepos = _repoConfigs.keys.toList()

--- a/flutter_app/test/features/dashboard/config_refresh_test.dart
+++ b/flutter_app/test/features/dashboard/config_refresh_test.dart
@@ -1,0 +1,505 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/api/api_client.dart';
+import 'package:heimdallm/core/api/sse_client.dart';
+import 'package:heimdallm/core/models/config_model.dart';
+import 'package:heimdallm/features/config/config_providers.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  for (final eventType in ['repo_discovered', 'repo_renamed']) {
+    test('$eventType refreshes config from the daemon', () async {
+      final api = MockApiClient();
+      var fetches = 0;
+      when(() => api.fetchConfig()).thenAnswer((_) async {
+        fetches++;
+        return {
+          'repositories': fetches == 1
+              ? <String>['acme/old']
+              : <String>['acme/old', 'acme/new'],
+        };
+      });
+
+      final events = StreamController<SseEvent>.broadcast();
+      final container = ProviderContainer(
+        overrides: [
+          apiClientProvider.overrideWithValue(api),
+          sseStreamProvider.overrideWith((_) => events.stream),
+        ],
+      );
+      addTearDown(() async {
+        await events.close();
+        container.dispose();
+      });
+
+      // Repositories owns the SSE refresh dependency. Activate the same two
+      // providers that ReposScreen watches.
+      container.listen(configNotifierProvider, (_, _) {});
+      container.listen(configRefreshProvider, (_, _) {});
+
+      final initial = await container.read(configNotifierProvider.future);
+      expect(fetches, 1);
+      expect(initial.repoConfigs['acme/new'], isNull);
+
+      // The overridden stream is broadcast; wait until Riverpod has attached
+      // the SSE listener so the event cannot be dropped between provider
+      // construction and subscription.
+      await _waitFor(() => events.hasListener);
+      events.add(SseEvent(type: eventType, data: '{"repo":"acme/new"}'));
+
+      await _waitFor(() {
+        final refreshed = container.read(configNotifierProvider).value;
+        return fetches > 1 &&
+            refreshed?.repoConfigs['acme/new']?.isMonitored == true;
+      });
+
+      expect(fetches, 2);
+      expect(
+        container
+            .read(configNotifierProvider)
+            .requireValue
+            .repoConfigs['acme/new']
+            ?.isMonitored,
+        isTrue,
+      );
+    });
+  }
+
+  test('SSE during initial load refreshes after build completes', () async {
+    const initial = AppConfig(
+      repoConfigs: {'acme/existing': RepoConfig(prEnabled: true)},
+    );
+    const refreshed = AppConfig(
+      repoConfigs: {
+        'acme/existing': RepoConfig(prEnabled: true),
+        'acme/discovered': RepoConfig(prEnabled: true),
+      },
+    );
+    final initialResponse = Completer<Map<String, dynamic>>();
+    final events = StreamController<SseEvent>.broadcast();
+    var fetches = 0;
+    final api = MockApiClient();
+
+    when(() => api.fetchConfig()).thenAnswer((_) {
+      fetches++;
+      return fetches == 1
+          ? initialResponse.future
+          : Future.value(refreshed.toJson());
+    });
+
+    final container = ProviderContainer(
+      overrides: [
+        apiClientProvider.overrideWithValue(api),
+        sseStreamProvider.overrideWith((_) => events.stream),
+      ],
+    );
+    addTearDown(() async {
+      await events.close();
+      container.dispose();
+    });
+    container.listen(configRefreshProvider, (_, _) {});
+    final initialLoad = container.read(configNotifierProvider.future);
+    await _waitFor(() => fetches == 1 && events.hasListener);
+
+    events.add(
+      const SseEvent(
+        type: 'repo_discovered',
+        data: '{"repo":"acme/discovered"}',
+      ),
+    );
+    await _waitFor(() => container.read(configRefreshProvider) == 1);
+    await Future<void>.delayed(Duration.zero);
+    expect(fetches, 1, reason: 'refresh must wait for the initial fetch');
+
+    initialResponse.complete(initial.toJson());
+    await initialLoad;
+    await _waitFor(() {
+      return fetches == 2 &&
+          container
+                  .read(configNotifierProvider)
+                  .value
+                  ?.repoConfigs['acme/discovered']
+                  ?.isMonitored ==
+              true;
+    });
+  });
+
+  test('overlapping saves are serialized without stale UI rollback', () async {
+    const initial = AppConfig(pollInterval: '1m');
+    final firstPatch = Completer<Map<String, dynamic>>();
+    final secondPatch = Completer<Map<String, dynamic>>();
+    final patches = <Map<String, dynamic>>[];
+    final api = MockApiClient();
+
+    when(() => api.fetchConfig()).thenAnswer((_) async => initial.toJson());
+    when(() => api.patchConfig(any())).thenAnswer((invocation) {
+      patches.add(
+        invocation.positionalArguments.single as Map<String, dynamic>,
+      );
+      return patches.length == 1 ? firstPatch.future : secondPatch.future;
+    });
+
+    final container = ProviderContainer(
+      overrides: [apiClientProvider.overrideWithValue(api)],
+    );
+    addTearDown(container.dispose);
+    await container.read(configNotifierProvider.future);
+
+    final notifier = container.read(configNotifierProvider.notifier);
+    final first = initial.copyWith(pollInterval: '2m');
+    final second = initial.copyWith(pollInterval: '3m');
+    final firstSave = notifier.save(first);
+    await _waitFor(() => patches.length == 1);
+    final secondSave = notifier.save(second);
+
+    expect(
+      container.read(configNotifierProvider).requireValue.pollInterval,
+      '3m',
+    );
+    expect(patches, hasLength(1));
+
+    firstPatch.complete(first.toJson());
+    await firstSave;
+    await _waitFor(() => patches.length == 2);
+
+    // The first response is authoritative for the next diff, but must not
+    // overwrite the newer optimistic edit still visible in the UI.
+    expect(
+      container.read(configNotifierProvider).requireValue.pollInterval,
+      '3m',
+    );
+    expect(patches[0]['github']['poll_interval'], '2m');
+    expect(patches[1]['github']['poll_interval'], '3m');
+
+    secondPatch.complete(second.toJson());
+    await secondSave;
+    expect(
+      container.read(configNotifierProvider).requireValue.pollInterval,
+      '3m',
+    );
+  });
+
+  test(
+    'later save reapplies earlier intent after failure and keeps discovery',
+    () async {
+      const initial = AppConfig(
+        pollInterval: '1m',
+        retentionDays: 30,
+        repoConfigs: {'acme/existing': RepoConfig(prEnabled: true)},
+      );
+      const refreshed = AppConfig(
+        pollInterval: '1m',
+        retentionDays: 30,
+        repoConfigs: {
+          'acme/existing': RepoConfig(prEnabled: true),
+          'acme/discovered': RepoConfig(prEnabled: true),
+        },
+      );
+      final refreshResponse = Completer<Map<String, dynamic>>();
+      final firstPatch = Completer<Map<String, dynamic>>();
+      final secondPatch = Completer<Map<String, dynamic>>();
+      final patches = <Map<String, dynamic>>[];
+      var fetches = 0;
+      final api = MockApiClient();
+
+      when(() => api.fetchConfig()).thenAnswer((_) {
+        fetches++;
+        return fetches == 1
+            ? Future.value(initial.toJson())
+            : refreshResponse.future;
+      });
+      when(() => api.patchConfig(any())).thenAnswer((invocation) {
+        patches.add(
+          invocation.positionalArguments.single as Map<String, dynamic>,
+        );
+        return patches.length == 1 ? firstPatch.future : secondPatch.future;
+      });
+
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(api)],
+      );
+      addTearDown(container.dispose);
+      await container.read(configNotifierProvider.future);
+
+      final notifier = container.read(configNotifierProvider.notifier);
+      final saveA = notifier.save(initial.copyWith(pollInterval: '2m'));
+      await _waitFor(() => patches.length == 1);
+      final refresh = notifier.refresh();
+      final optimisticA = container.read(configNotifierProvider).requireValue;
+      final saveB = notifier.save(optimisticA.copyWith(retentionDays: 60));
+
+      final firstFailure = expectLater(saveA, throwsA(isA<StateError>()));
+      firstPatch.completeError(StateError('first patch failed'));
+      await firstFailure;
+      await _waitFor(() => fetches == 2);
+
+      refreshResponse.complete(refreshed.toJson());
+      await refresh;
+      await _waitFor(() => patches.length == 2);
+
+      final retry = patches[1];
+      final github = retry['github'] as Map<String, dynamic>;
+      expect(github['poll_interval'], '2m');
+      expect(github, isNot(contains('repositories')));
+      expect(github, isNot(contains('non_monitored')));
+      expect((retry['retention'] as Map<String, dynamic>)['max_days'], 60);
+
+      secondPatch.complete(
+        refreshed.copyWith(pollInterval: '2m', retentionDays: 60).toJson(),
+      );
+      await saveB;
+      final saved = container.read(configNotifierProvider).requireValue;
+      expect(saved.pollInterval, '2m');
+      expect(saved.retentionDays, 60);
+      expect(saved.repoConfigs['acme/discovered']?.isMonitored, isTrue);
+    },
+  );
+
+  test('queued refresh cannot overwrite a newer optimistic save', () async {
+    const initial = AppConfig(pollInterval: '1m');
+    final refreshed = initial.copyWith(pollInterval: '2m');
+    final updated = initial.copyWith(pollInterval: '3m');
+    final refreshResponse = Completer<Map<String, dynamic>>();
+    final patchResponse = Completer<Map<String, dynamic>>();
+    final patches = <Map<String, dynamic>>[];
+    var fetches = 0;
+    final api = MockApiClient();
+
+    when(() => api.fetchConfig()).thenAnswer((_) {
+      fetches++;
+      return fetches == 1
+          ? Future.value(initial.toJson())
+          : refreshResponse.future;
+    });
+    when(() => api.patchConfig(any())).thenAnswer((invocation) {
+      patches.add(
+        invocation.positionalArguments.single as Map<String, dynamic>,
+      );
+      return patchResponse.future;
+    });
+
+    final container = ProviderContainer(
+      overrides: [apiClientProvider.overrideWithValue(api)],
+    );
+    addTearDown(container.dispose);
+    await container.read(configNotifierProvider.future);
+
+    final notifier = container.read(configNotifierProvider.notifier);
+    final refresh = notifier.refresh();
+    await _waitFor(() => fetches == 2);
+    final save = notifier.save(updated);
+
+    expect(
+      container.read(configNotifierProvider).requireValue.pollInterval,
+      '3m',
+    );
+    expect(patches, isEmpty);
+
+    refreshResponse.complete(refreshed.toJson());
+    await refresh;
+    await _waitFor(() => patches.length == 1);
+
+    expect(
+      container.read(configNotifierProvider).requireValue.pollInterval,
+      '3m',
+    );
+    expect(patches.single['github']['poll_interval'], '3m');
+
+    patchResponse.complete(updated.toJson());
+    await save;
+    expect(
+      container.read(configNotifierProvider).requireValue.pollInterval,
+      '3m',
+    );
+  });
+
+  test('SSE discovery survives a scalar save queued behind refresh', () async {
+    const initial = AppConfig(
+      pollInterval: '1m',
+      repoConfigs: {'acme/existing': RepoConfig(prEnabled: true)},
+    );
+    const refreshed = AppConfig(
+      pollInterval: '1m',
+      repoConfigs: {
+        'acme/existing': RepoConfig(prEnabled: true),
+        'acme/discovered': RepoConfig(prEnabled: true),
+      },
+    );
+    final refreshResponse = Completer<Map<String, dynamic>>();
+    final patchResponse = Completer<Map<String, dynamic>>();
+    final patches = <Map<String, dynamic>>[];
+    final events = StreamController<SseEvent>.broadcast();
+    var fetches = 0;
+    final api = MockApiClient();
+
+    when(() => api.fetchConfig()).thenAnswer((_) {
+      fetches++;
+      return fetches == 1
+          ? Future.value(initial.toJson())
+          : refreshResponse.future;
+    });
+    when(() => api.patchConfig(any())).thenAnswer((invocation) {
+      patches.add(
+        invocation.positionalArguments.single as Map<String, dynamic>,
+      );
+      return patchResponse.future;
+    });
+
+    final container = ProviderContainer(
+      overrides: [
+        apiClientProvider.overrideWithValue(api),
+        sseStreamProvider.overrideWith((_) => events.stream),
+      ],
+    );
+    addTearDown(() async {
+      await events.close();
+      container.dispose();
+    });
+    container.listen(configNotifierProvider, (_, _) {});
+    container.listen(configRefreshProvider, (_, _) {});
+    await container.read(configNotifierProvider.future);
+    await _waitFor(() => events.hasListener);
+
+    events.add(
+      const SseEvent(
+        type: 'repo_discovered',
+        data: '{"repo":"acme/discovered"}',
+      ),
+    );
+    await _waitFor(() => fetches == 2);
+    final current = container.read(configNotifierProvider).requireValue;
+    final save = container
+        .read(configNotifierProvider.notifier)
+        .save(current.copyWith(pollInterval: '3m'));
+
+    refreshResponse.complete(refreshed.toJson());
+    await _waitFor(() => patches.length == 1);
+
+    final github = patches.single['github'] as Map<String, dynamic>;
+    expect(github['poll_interval'], '3m');
+    expect(github, isNot(contains('repositories')));
+    expect(github, isNot(contains('non_monitored')));
+
+    patchResponse.complete(refreshed.copyWith(pollInterval: '3m').toJson());
+    await save;
+    final saved = container.read(configNotifierProvider).requireValue;
+    expect(saved.repoConfigs['acme/discovered']?.isMonitored, isTrue);
+  });
+
+  test('SSE rename survives a queued edit to another repo', () async {
+    final refreshResponse = Completer<Map<String, dynamic>>();
+    final patchResponse = Completer<Map<String, dynamic>>();
+    final patches = <Map<String, dynamic>>[];
+    final events = StreamController<SseEvent>.broadcast();
+    var fetches = 0;
+    final api = MockApiClient();
+
+    when(() => api.fetchConfig()).thenAnswer((_) {
+      fetches++;
+      return fetches == 1
+          ? Future.value({
+              'repositories': <String>['acme/old', 'acme/other'],
+            })
+          : refreshResponse.future;
+    });
+    when(() => api.patchConfig(any())).thenAnswer((invocation) {
+      patches.add(
+        invocation.positionalArguments.single as Map<String, dynamic>,
+      );
+      return patchResponse.future;
+    });
+
+    final container = ProviderContainer(
+      overrides: [
+        apiClientProvider.overrideWithValue(api),
+        sseStreamProvider.overrideWith((_) => events.stream),
+      ],
+    );
+    addTearDown(() async {
+      await events.close();
+      container.dispose();
+    });
+    container.listen(configNotifierProvider, (_, _) {});
+    container.listen(configRefreshProvider, (_, _) {});
+    await container.read(configNotifierProvider.future);
+    await _waitFor(() => events.hasListener);
+
+    events.add(
+      const SseEvent(type: 'repo_renamed', data: '{"repo":"acme/new"}'),
+    );
+    await _waitFor(() => fetches == 2);
+    final current = container.read(configNotifierProvider).requireValue;
+    final editedRepos = Map<String, RepoConfig>.from(current.repoConfigs);
+    editedRepos['acme/other'] = const RepoConfig(prEnabled: false);
+    final save = container
+        .read(configNotifierProvider.notifier)
+        .save(current.copyWith(repoConfigs: editedRepos));
+
+    refreshResponse.complete({
+      'repositories': <String>['acme/new', 'acme/other'],
+    });
+    await _waitFor(() => patches.length == 1);
+
+    final github = patches.single['github'] as Map<String, dynamic>;
+    expect(github['repositories'], <String>['acme/new']);
+    expect(github['non_monitored'], <String>['acme/other']);
+
+    patchResponse.complete({
+      'repositories': <String>['acme/new'],
+      'non_monitored': <String>['acme/other'],
+    });
+    await save;
+    final saved = container.read(configNotifierProvider).requireValue;
+    expect(saved.repoConfigs['acme/old'], isNull);
+    expect(saved.repoConfigs['acme/new']?.isMonitored, isTrue);
+    expect(saved.repoConfigs['acme/other']?.isMonitored, isFalse);
+  });
+
+  test(
+    'a failed save propagates without poisoning the operation queue',
+    () async {
+      const initial = AppConfig(pollInterval: '1m');
+      final first = initial.copyWith(pollInterval: '2m');
+      final second = initial.copyWith(pollInterval: '3m');
+      var patches = 0;
+      final api = MockApiClient();
+
+      when(() => api.fetchConfig()).thenAnswer((_) async => initial.toJson());
+      when(() => api.patchConfig(any())).thenAnswer((_) async {
+        patches++;
+        if (patches == 1) throw StateError('patch failed');
+        return second.toJson();
+      });
+
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(api)],
+      );
+      addTearDown(container.dispose);
+      await container.read(configNotifierProvider.future);
+
+      final notifier = container.read(configNotifierProvider.notifier);
+      await expectLater(notifier.save(first), throwsA(isA<StateError>()));
+      await notifier.save(second);
+
+      expect(patches, 2);
+      expect(
+        container.read(configNotifierProvider).requireValue.pollInterval,
+        '3m',
+      );
+    },
+  );
+}
+
+Future<void> _waitFor(bool Function() condition) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 2));
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail('condition was not met before timeout');
+}

--- a/flutter_app/test/features/repositories/repos_screen_test.dart
+++ b/flutter_app/test/features/repositories/repos_screen_test.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/api/sse_client.dart';
 import 'package:heimdallm/core/models/config_model.dart';
 import 'package:heimdallm/core/platform/platform_services_provider.dart';
 import 'package:heimdallm/features/config/config_providers.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
 import 'package:heimdallm/features/repositories/repos_screen.dart';
 import 'package:heimdallm/features/repositories/widgets/bulk_actions_bar.dart';
 import 'package:heimdallm/features/repositories/widgets/repo_grid_tile.dart';
@@ -12,37 +16,61 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/platform/fake_platform_services.dart';
 
 Widget _host(AppConfig cfg) => ProviderScope(
-      overrides: [
-        platformServicesProvider.overrideWithValue(FakePlatformServices()),
-        configNotifierProvider.overrideWith(() => _FakeConfig(cfg)),
-      ],
-      child: const MaterialApp(home: Scaffold(body: ReposScreen())),
-    );
+  overrides: [
+    platformServicesProvider.overrideWithValue(FakePlatformServices()),
+    configNotifierProvider.overrideWith(() => _FakeConfig(cfg)),
+    sseStreamProvider.overrideWith((_) => const Stream<SseEvent>.empty()),
+  ],
+  child: const MaterialApp(home: Scaffold(body: ReposScreen())),
+);
+
+Widget _hostWithConfig(_FakeConfig config) => ProviderScope(
+  overrides: [
+    platformServicesProvider.overrideWithValue(FakePlatformServices()),
+    configNotifierProvider.overrideWith(() => config),
+    sseStreamProvider.overrideWith((_) => const Stream<SseEvent>.empty()),
+  ],
+  child: const MaterialApp(home: Scaffold(body: ReposScreen())),
+);
 
 class _FakeConfig extends ConfigNotifier {
   _FakeConfig(this.initial);
   final AppConfig initial;
+  final List<AppConfig> saves = [];
+  Completer<void>? saveGate;
   @override
   Future<AppConfig> build() async => initial;
   @override
   Future<void> save(AppConfig next) async {
+    saves.add(next);
+    final gate = saveGate;
+    saveGate = null;
+    if (gate != null) await gate.future;
+    state = AsyncData(next);
+  }
+
+  void replace(AppConfig next) {
     state = AsyncData(next);
   }
 }
 
+Finder _bulkPrSwitch() => find
+    .descendant(of: find.byType(BulkActionsBar), matching: find.byType(Switch))
+    .first;
+
 AppConfig _cfg() => const AppConfig(
-      serverPort: 1,
-      pollInterval: '60s',
-      retentionDays: 30,
-      aiPrimary: 'claude',
-      aiFallback: '',
-      reviewMode: 'single',
-      repoConfigs: {
-        'a/one': RepoConfig(prEnabled: true),
-        'a/two': RepoConfig(prEnabled: true),
-      },
-      issueTracking: IssueTrackingConfig(),
-    );
+  serverPort: 1,
+  pollInterval: '60s',
+  retentionDays: 30,
+  aiPrimary: 'claude',
+  aiFallback: '',
+  reviewMode: 'single',
+  repoConfigs: {
+    'a/one': RepoConfig(prEnabled: true),
+    'a/two': RepoConfig(prEnabled: true),
+  },
+  issueTracking: IssueTrackingConfig(),
+);
 
 void main() {
   testWidgets('bulk bar appears when a repo is selected', (tester) async {
@@ -70,11 +98,14 @@ void main() {
     expect(find.byType(BulkActionsBar), findsNothing);
   });
 
-  testWidgets('selecting Monitored hides non-monitored repos',
-      (tester) async {
+  testWidgets('selecting Monitored hides non-monitored repos', (tester) async {
     const cfg = AppConfig(
-      serverPort: 1, pollInterval: '60s', retentionDays: 30,
-      aiPrimary: 'claude', aiFallback: '', reviewMode: 'single',
+      serverPort: 1,
+      pollInterval: '60s',
+      retentionDays: 30,
+      aiPrimary: 'claude',
+      aiFallback: '',
+      reviewMode: 'single',
       repoConfigs: {
         'a/one': RepoConfig(prEnabled: true),
         'a/two': RepoConfig(prEnabled: false),
@@ -94,8 +125,9 @@ void main() {
     expect(find.text('a/two'), findsNothing);
   });
 
-  testWidgets('view toggle persists choice in SharedPreferences',
-      (tester) async {
+  testWidgets('view toggle persists choice in SharedPreferences', (
+    tester,
+  ) async {
     SharedPreferences.setMockInitialValues({});
     await tester.pumpWidget(_host(_cfg()));
     await tester.pumpAndSettle();
@@ -107,13 +139,183 @@ void main() {
     expect(prefs.getString('repos_view'), 'grid');
   });
 
-  testWidgets('grid view renders RepoGridTile instead of RepoListTile',
-      (tester) async {
+  testWidgets('grid view renders RepoGridTile instead of RepoListTile', (
+    tester,
+  ) async {
     SharedPreferences.setMockInitialValues({'repos_view': 'grid'});
     await tester.pumpWidget(_host(_cfg()));
     await tester.pumpAndSettle();
 
     expect(find.byType(RepoGridTile), findsWidgets);
     expect(find.byType(RepoListTile), findsNothing);
+  });
+
+  testWidgets(
+    'provider refresh moves a mounted repo from not monitored to monitored',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({'repos_view': 'grid'});
+      const initial = AppConfig(
+        repoConfigs: {'a/repo': RepoConfig(prEnabled: false)},
+      );
+      final config = _FakeConfig(initial);
+
+      await tester.pumpWidget(_hostWithConfig(config));
+      await tester.pumpAndSettle();
+
+      final screen = tester.element(find.byType(ReposScreen));
+      expect(find.text('NOT MONITORED · 1'), findsOneWidget);
+      expect(find.text('MONITORED · 1'), findsNothing);
+
+      config.replace(
+        initial.copyWith(
+          repoConfigs: const {'a/repo': RepoConfig(prEnabled: true)},
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        identical(tester.element(find.byType(ReposScreen)), screen),
+        isTrue,
+      );
+      expect(find.text('MONITORED · 1'), findsOneWidget);
+      expect(find.text('NOT MONITORED · 1'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'provider refresh moves a mounted repo from monitored to not monitored',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({'repos_view': 'grid'});
+      const initial = AppConfig(
+        repoConfigs: {'a/repo': RepoConfig(prEnabled: true)},
+      );
+      final config = _FakeConfig(initial);
+
+      await tester.pumpWidget(_hostWithConfig(config));
+      await tester.pumpAndSettle();
+
+      final screen = tester.element(find.byType(ReposScreen));
+      expect(find.text('MONITORED · 1'), findsOneWidget);
+      expect(find.text('NOT MONITORED · 1'), findsNothing);
+
+      config.replace(
+        initial.copyWith(
+          repoConfigs: const {'a/repo': RepoConfig(prEnabled: false)},
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        identical(tester.element(find.byType(ReposScreen)), screen),
+        isTrue,
+      );
+      expect(find.text('NOT MONITORED · 1'), findsOneWidget);
+      expect(find.text('MONITORED · 1'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'provider refresh removes selections for repos no longer present',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({'repos_view': 'list'});
+      const initial = AppConfig(
+        repoConfigs: {'a/repo': RepoConfig(prEnabled: true)},
+      );
+      final config = _FakeConfig(initial);
+
+      await tester.pumpWidget(_hostWithConfig(config));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('RepoListTile_checkbox')));
+      await tester.pump();
+      expect(find.text('1 selected'), findsOneWidget);
+
+      config.replace(initial.copyWith(repoConfigs: const {}));
+      await tester.pump();
+
+      expect(find.byType(BulkActionsBar), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'provider refresh merges discovery without overwriting a dirty bulk edit',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({'repos_view': 'list'});
+      const initial = AppConfig(
+        repoConfigs: {'a/existing': RepoConfig(prEnabled: false)},
+      );
+      final config = _FakeConfig(initial);
+
+      await tester.pumpWidget(_hostWithConfig(config));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('RepoListTile_checkbox')));
+      await tester.pump();
+
+      // The first bulk switch is PR Review. Toggle it, but refresh the
+      // provider before the 400 ms auto-save debounce fires.
+      await tester.tap(_bulkPrSwitch());
+      await tester.pump();
+      config.replace(
+        initial.copyWith(
+          repoConfigs: const {
+            'a/existing': RepoConfig(prEnabled: false),
+            'a/discovered': RepoConfig(prEnabled: false),
+          },
+        ),
+      );
+      await tester.pump();
+
+      final existing = tester.widget<RepoListTile>(
+        find.widgetWithText(RepoListTile, 'a/existing'),
+      );
+      final discovered = tester.widget<RepoListTile>(
+        find.widgetWithText(RepoListTile, 'a/discovered'),
+      );
+      expect(existing.config.prEnabled, isTrue);
+      expect(discovered.config.prEnabled, isFalse);
+
+      // Let the pending save and saved-status timer finish cleanly.
+      await tester.pump(const Duration(milliseconds: 401));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 2));
+    },
+  );
+
+  testWidgets('a delayed save does not overwrite a newer bulk edit', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({'repos_view': 'list'});
+    const initial = AppConfig(
+      repoConfigs: {'a/existing': RepoConfig(prEnabled: false)},
+    );
+    final firstSave = Completer<void>();
+    final config = _FakeConfig(initial)..saveGate = firstSave;
+
+    await tester.pumpWidget(_hostWithConfig(config));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('RepoListTile_checkbox')));
+    await tester.pump();
+
+    await tester.tap(_bulkPrSwitch());
+    await tester.pump(const Duration(milliseconds: 401));
+    expect(config.saves, hasLength(1));
+    expect(config.saves.first.repoConfigs['a/existing']?.prEnabled, isTrue);
+
+    // Make a second edit while the first daemon response is still pending.
+    await tester.tap(_bulkPrSwitch());
+    await tester.pump();
+    firstSave.complete();
+    await tester.pump();
+
+    final afterFirstResponse = tester.widget<RepoListTile>(
+      find.widgetWithText(RepoListTile, 'a/existing'),
+    );
+    expect(afterFirstResponse.config.prEnabled, isFalse);
+
+    await tester.pump(const Duration(milliseconds: 401));
+    await tester.pump();
+    expect(config.saves, hasLength(2));
+    expect(config.saves.last.repoConfigs['a/existing']?.prEnabled, isFalse);
+
+    await tester.pump(const Duration(seconds: 2));
   });
 }


### PR DESCRIPTION
Closes #599

## Summary

- make `github.non_monitored` authoritative, including for repositories with `[ai.repos.*]` overrides
- revalidate live repository eligibility before queued, in-flight, state-watch, and retry publication work
- keep the repository screen synchronized with discovery/rename events without stale config responses overwriting newer edits
- expose the daemon's effective monitored set so the UI and schedulers classify repositories consistently

## Compatibility

- no SQLite schema changes or migrations
- no CLI changes
- `GET /config` keeps the same response shape and now reports the effective monitored list

## Validation

- `make test-docker`
- `flutter test --no-pub` — 216 tests passed
- `flutter analyze --no-pub`
- `make build-web`

