### PR TITLE
feat(review): clearer never-approve downgrade note + min-severity threshold (closes #597)

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -462,13 +462,14 @@ func main() {
 			}
 		}
 		return pipeline.RunOptions{
-			Primary:                aiCfg.Primary,
-			Fallback:               aiCfg.Fallback,
-			PromptOverride:         aiCfg.Prompt,
-			AgentPromptID:          agentCfg.PromptID,
-			ReviewMode:             aiCfg.ReviewMode,
-			InstructionAuthors:     aiCfg.InstructionAuthors,
-			NeverApproveWithIssues: aiCfg.NeverApproveWithIssues != nil && *aiCfg.NeverApproveWithIssues,
+			Primary:                 aiCfg.Primary,
+			Fallback:                aiCfg.Fallback,
+			PromptOverride:          aiCfg.Prompt,
+			AgentPromptID:           agentCfg.PromptID,
+			ReviewMode:              aiCfg.ReviewMode,
+			InstructionAuthors:      aiCfg.InstructionAuthors,
+			NeverApproveWithIssues:  aiCfg.NeverApproveWithIssues != nil && *aiCfg.NeverApproveWithIssues,
+			NeverApproveMinSeverity: aiCfg.NeverApproveMinSeverity,
 			ExecOpts: executor.ExecOptions{
 				Model:                agentCfg.Model,
 				MaxTurns:             agentCfg.MaxTurns,
@@ -1167,7 +1168,7 @@ func main() {
 		if deferForMonitoringChange("before_submit") {
 			return nil
 		}
-		reviewBody := pipeline.AnnotateBodyForEvent(pipeline.BuildGitHubBody(result), publishEvent)
+		reviewBody := pipeline.AnnotateBodyForEvent(pipeline.BuildGitHubBody(result), publishEvent, len(result.Issues))
 		var ghID int64
 		var ghState string
 		if rev.HeadSHA != "" {
@@ -1773,6 +1774,7 @@ func main() {
 			"clone_dir":                   c.AI.CloneDir,
 			"generate_pr_description":     c.AI.GeneratePRDescription,
 			"never_approve_with_issues":   c.AI.NeverApproveWithIssues,
+			"never_approve_min_severity":  c.AI.NeverApproveMinSeverity,
 		}
 		if c.AI.AutoPromoteTriage != nil {
 			result["auto_promote_triage"] = *c.AI.AutoPromoteTriage
@@ -2479,6 +2481,7 @@ func configReloadRestartSnapshot(c *config.Config) config.Config {
 	snap.AI.Tier2RepoConcurrency = 0
 	snap.AI.GeneratePRDescription = false
 	snap.AI.NeverApproveWithIssues = false
+	snap.AI.NeverApproveMinSeverity = ""
 	snap.AI.ReviewResponse = config.ReviewResponseConfig{}
 	snap.AI.ReviewFix = config.ReviewFixConfig{}
 
@@ -4870,20 +4873,21 @@ func repoAIOverrideMap(ai config.RepoAI) map[string]any {
 		"local_dir":   ai.LocalDir,
 	}
 	addCommonAIOverrideFields(out, aiOverrideFields{
-		Prompt:                 ai.Prompt,
-		IssuePrompt:            ai.IssuePrompt,
-		ImplementPrompt:        ai.ImplementPrompt,
-		RefinementTimeout:      ai.RefinementTimeout,
-		TriageOwner:            ai.TriageOwner,
-		CloneDir:               ai.CloneDir,
-		AutoPromoteTriage:      ai.AutoPromoteTriage,
-		AutoPromoteRefinement:  ai.AutoPromoteRefinement,
-		PRReviewers:            ai.PRReviewers,
-		PRAssignee:             ai.PRAssignee,
-		PRLabels:               ai.PRLabels,
-		PRDraft:                ai.PRDraft,
-		GeneratePRDescription:  ai.GeneratePRDescription,
-		NeverApproveWithIssues: ai.NeverApproveWithIssues,
+		Prompt:                  ai.Prompt,
+		IssuePrompt:             ai.IssuePrompt,
+		ImplementPrompt:         ai.ImplementPrompt,
+		RefinementTimeout:       ai.RefinementTimeout,
+		TriageOwner:             ai.TriageOwner,
+		CloneDir:                ai.CloneDir,
+		AutoPromoteTriage:       ai.AutoPromoteTriage,
+		AutoPromoteRefinement:   ai.AutoPromoteRefinement,
+		PRReviewers:             ai.PRReviewers,
+		PRAssignee:              ai.PRAssignee,
+		PRLabels:                ai.PRLabels,
+		PRDraft:                 ai.PRDraft,
+		GeneratePRDescription:   ai.GeneratePRDescription,
+		NeverApproveWithIssues:  ai.NeverApproveWithIssues,
+		NeverApproveMinSeverity: ai.NeverApproveMinSeverity,
 	})
 	if ai.IssueTracking != nil {
 		out["issue_tracking"] = issueTrackingOverrideMap(ai.IssueTracking)
@@ -4906,20 +4910,21 @@ func orgAIOverrideMap(ai config.OrgAI) map[string]any {
 		out["local_dir"] = ai.LocalDir
 	}
 	addCommonAIOverrideFields(out, aiOverrideFields{
-		Prompt:                 ai.Prompt,
-		IssuePrompt:            ai.IssuePrompt,
-		ImplementPrompt:        ai.ImplementPrompt,
-		RefinementTimeout:      ai.RefinementTimeout,
-		TriageOwner:            ai.TriageOwner,
-		CloneDir:               ai.CloneDir,
-		AutoPromoteTriage:      ai.AutoPromoteTriage,
-		AutoPromoteRefinement:  ai.AutoPromoteRefinement,
-		PRReviewers:            ai.PRReviewers,
-		PRAssignee:             ai.PRAssignee,
-		PRLabels:               ai.PRLabels,
-		PRDraft:                ai.PRDraft,
-		GeneratePRDescription:  ai.GeneratePRDescription,
-		NeverApproveWithIssues: ai.NeverApproveWithIssues,
+		Prompt:                  ai.Prompt,
+		IssuePrompt:             ai.IssuePrompt,
+		ImplementPrompt:         ai.ImplementPrompt,
+		RefinementTimeout:       ai.RefinementTimeout,
+		TriageOwner:             ai.TriageOwner,
+		CloneDir:                ai.CloneDir,
+		AutoPromoteTriage:       ai.AutoPromoteTriage,
+		AutoPromoteRefinement:   ai.AutoPromoteRefinement,
+		PRReviewers:             ai.PRReviewers,
+		PRAssignee:              ai.PRAssignee,
+		PRLabels:                ai.PRLabels,
+		PRDraft:                 ai.PRDraft,
+		GeneratePRDescription:   ai.GeneratePRDescription,
+		NeverApproveWithIssues:  ai.NeverApproveWithIssues,
+		NeverApproveMinSeverity: ai.NeverApproveMinSeverity,
 	})
 	if ai.IssueTracking != nil {
 		out["issue_tracking"] = issueTrackingOverrideMap(ai.IssueTracking)
@@ -4928,20 +4933,21 @@ func orgAIOverrideMap(ai config.OrgAI) map[string]any {
 }
 
 type aiOverrideFields struct {
-	Prompt                 string
-	IssuePrompt            string
-	ImplementPrompt        string
-	RefinementTimeout      string
-	TriageOwner            string
-	CloneDir               string
-	AutoPromoteTriage      *bool
-	AutoPromoteRefinement  *bool
-	PRReviewers            []string
-	PRAssignee             string
-	PRLabels               []string
-	PRDraft                *bool
-	GeneratePRDescription  *bool
-	NeverApproveWithIssues *bool
+	Prompt                  string
+	IssuePrompt             string
+	ImplementPrompt         string
+	RefinementTimeout       string
+	TriageOwner             string
+	CloneDir                string
+	AutoPromoteTriage       *bool
+	AutoPromoteRefinement   *bool
+	PRReviewers             []string
+	PRAssignee              string
+	PRLabels                []string
+	PRDraft                 *bool
+	GeneratePRDescription   *bool
+	NeverApproveWithIssues  *bool
+	NeverApproveMinSeverity string
 }
 
 func addCommonAIOverrideFields(out map[string]any, fields aiOverrideFields) {
@@ -4986,6 +4992,9 @@ func addCommonAIOverrideFields(out map[string]any, fields aiOverrideFields) {
 	}
 	if fields.NeverApproveWithIssues != nil {
 		out["never_approve_with_issues"] = *fields.NeverApproveWithIssues
+	}
+	if fields.NeverApproveMinSeverity != "" {
+		out["never_approve_min_severity"] = fields.NeverApproveMinSeverity
 	}
 }
 

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -1269,6 +1269,24 @@ func TestOrgAIOverrideMap_ExposesNeverApproveWithIssues(t *testing.T) {
 	}
 }
 
+// TestAIOverrideMaps_ExposeNeverApproveMinSeverity guards that both override
+// maps GET /config serves carry never_approve_min_severity through when set,
+// and omit it when empty (= inherit).
+func TestAIOverrideMaps_ExposeNeverApproveMinSeverity(t *testing.T) {
+	out := repoAIOverrideMap(config.RepoAI{NeverApproveMinSeverity: "medium"})
+	if v, ok := out["never_approve_min_severity"].(string); !ok || v != "medium" {
+		t.Errorf("repo never_approve_min_severity = %v (present=%v), want \"medium\"", out["never_approve_min_severity"], ok)
+	}
+	out = orgAIOverrideMap(config.OrgAI{NeverApproveMinSeverity: "high"})
+	if v, ok := out["never_approve_min_severity"].(string); !ok || v != "high" {
+		t.Errorf("org never_approve_min_severity = %v (present=%v), want \"high\"", out["never_approve_min_severity"], ok)
+	}
+	out = orgAIOverrideMap(config.OrgAI{})
+	if _, present := out["never_approve_min_severity"]; present {
+		t.Errorf("empty override should omit never_approve_min_severity, got %v", out["never_approve_min_severity"])
+	}
+}
+
 func TestResolveImplementPrompt_RepoOverrideWins(t *testing.T) {
 	s := newMemStore(t)
 	seedAgent(t, s, store.Agent{

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -472,6 +472,14 @@ type AIConfig struct {
 	// per-org and per-repo.
 	NeverApproveWithIssues bool `toml:"never_approve_with_issues"`
 
+	// NeverApproveMinSeverity is the minimum finding severity that triggers
+	// the NeverApproveWithIssues downgrade: "low", "medium" or "high".
+	// Empty defaults to "low" (any finding downgrades — backwards compat).
+	// With "medium", reviews whose findings are all low-severity nits still
+	// approve. Only meaningful when NeverApproveWithIssues is on.
+	// Overridable per-org and per-repo.
+	NeverApproveMinSeverity string `toml:"never_approve_min_severity"`
+
 	// ReviewResponse configures phase 2 of the PR review-state vigilance
 	// feature (#482): the daemon optionally posts an AI-generated reply
 	// when an external reviewer leaves COMMENTED feedback on a PR that
@@ -565,6 +573,10 @@ type RepoAI struct {
 	// repo. nil = inherit from org/global.
 	NeverApproveWithIssues *bool `toml:"never_approve_with_issues,omitempty"`
 
+	// NeverApproveMinSeverity overrides ai.never_approve_min_severity for
+	// this repo. Empty = inherit from org/global.
+	NeverApproveMinSeverity string `toml:"never_approve_min_severity,omitempty"`
+
 	// Per-repo issue tracking override. Nil fields inherit from org/global.
 	IssueTracking *IssueTrackingOverride `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
 	// CircuitBreaker overrides circuit-breaker caps for this repo.
@@ -625,9 +637,10 @@ type OrgAI struct {
 	PRDraft            *bool    `toml:"pr_draft,omitempty"`
 	InstructionAuthors []string `toml:"instruction_authors"` // see RepoAI.InstructionAuthors (#383)
 
-	GeneratePRDescription  *bool                  `toml:"generate_pr_description,omitempty"`
-	NeverApproveWithIssues *bool                  `toml:"never_approve_with_issues,omitempty"`
-	IssueTracking          *IssueTrackingOverride `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
+	GeneratePRDescription   *bool                  `toml:"generate_pr_description,omitempty"`
+	NeverApproveWithIssues  *bool                  `toml:"never_approve_with_issues,omitempty"`
+	NeverApproveMinSeverity string                 `toml:"never_approve_min_severity,omitempty"`
+	IssueTracking           *IssueTrackingOverride `toml:"issue_tracking,omitempty" json:"issue_tracking,omitempty"`
 	// CircuitBreaker overrides circuit-breaker caps for all repos in this org.
 	// nil = inherit from global. Present fields overlay the global baseline.
 	CircuitBreaker *CircuitBreakerConfig `toml:"circuit_breaker,omitempty"`
@@ -765,23 +778,24 @@ func (c *Config) AIForRepo(repo string) RepoAI {
 	gGenDesc := c.AI.GeneratePRDescription
 	gNever := c.AI.NeverApproveWithIssues
 	out := RepoAI{
-		Primary:                c.AI.Primary,
-		Fallback:               c.AI.Fallback,
-		ReviewMode:             c.AI.ReviewMode,
-		IssuePrompt:            c.AI.IssuePrompt,
-		ImplementPrompt:        c.AI.ImplementPrompt,
-		RefinementTimeout:      c.AI.RefinementTimeout,
-		PRReviewers:            gReviewers,
-		PRLabels:               gLabels,
-		PRAssignee:             gAssignee,
-		PRDraft:                gDraft,
-		GeneratePRDescription:  &gGenDesc,
-		NeverApproveWithIssues: &gNever,
-		TriageOwner:            c.AI.TriageOwner,
-		CloneDir:               c.AI.CloneDir,
-		AutoPromoteTriage:      c.AI.AutoPromoteTriage,
-		AutoPromoteRefinement:  c.AI.AutoPromoteRefinement,
-		InstructionAuthors:     c.AI.InstructionAuthors,
+		Primary:                 c.AI.Primary,
+		Fallback:                c.AI.Fallback,
+		ReviewMode:              c.AI.ReviewMode,
+		IssuePrompt:             c.AI.IssuePrompt,
+		ImplementPrompt:         c.AI.ImplementPrompt,
+		RefinementTimeout:       c.AI.RefinementTimeout,
+		PRReviewers:             gReviewers,
+		PRLabels:                gLabels,
+		PRAssignee:              gAssignee,
+		PRDraft:                 gDraft,
+		GeneratePRDescription:   &gGenDesc,
+		NeverApproveWithIssues:  &gNever,
+		NeverApproveMinSeverity: c.AI.NeverApproveMinSeverity,
+		TriageOwner:             c.AI.TriageOwner,
+		CloneDir:                c.AI.CloneDir,
+		AutoPromoteTriage:       c.AI.AutoPromoteTriage,
+		AutoPromoteRefinement:   c.AI.AutoPromoteRefinement,
+		InstructionAuthors:      c.AI.InstructionAuthors,
 	}
 	if org := repoOrg(repo); org != "" && c.AI.Orgs != nil {
 		if o, ok := c.AI.Orgs[org]; ok {
@@ -798,72 +812,75 @@ func (c *Config) AIForRepo(repo string) RepoAI {
 
 func applyOrgAI(out *RepoAI, o OrgAI) {
 	applyScopedAI(out, scopedAIFields{
-		Primary:                o.Primary,
-		Fallback:               o.Fallback,
-		ReviewMode:             o.ReviewMode,
-		Prompt:                 o.Prompt,
-		IssuePrompt:            o.IssuePrompt,
-		ImplementPrompt:        o.ImplementPrompt,
-		RefinementTimeout:      o.RefinementTimeout,
-		LocalDir:               o.LocalDir,
-		TriageOwner:            o.TriageOwner,
-		CloneDir:               o.CloneDir,
-		AutoPromoteTriage:      o.AutoPromoteTriage,
-		AutoPromoteRefinement:  o.AutoPromoteRefinement,
-		PRReviewers:            o.PRReviewers,
-		PRLabels:               o.PRLabels,
-		PRAssignee:             o.PRAssignee,
-		PRDraft:                o.PRDraft,
-		GeneratePRDescription:  o.GeneratePRDescription,
-		NeverApproveWithIssues: o.NeverApproveWithIssues,
-		InstructionAuthors:     o.InstructionAuthors,
+		Primary:                 o.Primary,
+		Fallback:                o.Fallback,
+		ReviewMode:              o.ReviewMode,
+		Prompt:                  o.Prompt,
+		IssuePrompt:             o.IssuePrompt,
+		ImplementPrompt:         o.ImplementPrompt,
+		RefinementTimeout:       o.RefinementTimeout,
+		LocalDir:                o.LocalDir,
+		TriageOwner:             o.TriageOwner,
+		CloneDir:                o.CloneDir,
+		AutoPromoteTriage:       o.AutoPromoteTriage,
+		AutoPromoteRefinement:   o.AutoPromoteRefinement,
+		PRReviewers:             o.PRReviewers,
+		PRLabels:                o.PRLabels,
+		PRAssignee:              o.PRAssignee,
+		PRDraft:                 o.PRDraft,
+		GeneratePRDescription:   o.GeneratePRDescription,
+		NeverApproveWithIssues:  o.NeverApproveWithIssues,
+		NeverApproveMinSeverity: o.NeverApproveMinSeverity,
+		InstructionAuthors:      o.InstructionAuthors,
 	})
 }
 
 func applyRepoAI(out *RepoAI, r RepoAI) {
 	applyScopedAI(out, scopedAIFields{
-		Primary:                r.Primary,
-		Fallback:               r.Fallback,
-		ReviewMode:             r.ReviewMode,
-		Prompt:                 r.Prompt,
-		IssuePrompt:            r.IssuePrompt,
-		ImplementPrompt:        r.ImplementPrompt,
-		RefinementTimeout:      r.RefinementTimeout,
-		LocalDir:               r.LocalDir,
-		TriageOwner:            r.TriageOwner,
-		CloneDir:               r.CloneDir,
-		AutoPromoteTriage:      r.AutoPromoteTriage,
-		AutoPromoteRefinement:  r.AutoPromoteRefinement,
-		PRReviewers:            r.PRReviewers,
-		PRLabels:               r.PRLabels,
-		PRAssignee:             r.PRAssignee,
-		PRDraft:                r.PRDraft,
-		GeneratePRDescription:  r.GeneratePRDescription,
-		NeverApproveWithIssues: r.NeverApproveWithIssues,
-		InstructionAuthors:     r.InstructionAuthors,
+		Primary:                 r.Primary,
+		Fallback:                r.Fallback,
+		ReviewMode:              r.ReviewMode,
+		Prompt:                  r.Prompt,
+		IssuePrompt:             r.IssuePrompt,
+		ImplementPrompt:         r.ImplementPrompt,
+		RefinementTimeout:       r.RefinementTimeout,
+		LocalDir:                r.LocalDir,
+		TriageOwner:             r.TriageOwner,
+		CloneDir:                r.CloneDir,
+		AutoPromoteTriage:       r.AutoPromoteTriage,
+		AutoPromoteRefinement:   r.AutoPromoteRefinement,
+		PRReviewers:             r.PRReviewers,
+		PRLabels:                r.PRLabels,
+		PRAssignee:              r.PRAssignee,
+		PRDraft:                 r.PRDraft,
+		GeneratePRDescription:   r.GeneratePRDescription,
+		NeverApproveWithIssues:  r.NeverApproveWithIssues,
+		NeverApproveMinSeverity: r.NeverApproveMinSeverity,
+		InstructionAuthors:      r.InstructionAuthors,
 	})
 }
 
 type scopedAIFields struct {
-	Primary                string
-	Fallback               string
-	ReviewMode             string
-	Prompt                 string
-	IssuePrompt            string
-	ImplementPrompt        string
-	RefinementTimeout      string
-	LocalDir               string
-	TriageOwner            string
-	CloneDir               string
-	AutoPromoteTriage      *bool
-	AutoPromoteRefinement  *bool
-	PRReviewers            []string
-	PRLabels               []string
-	PRAssignee             string
-	PRDraft                *bool
-	GeneratePRDescription  *bool
-	NeverApproveWithIssues *bool
-	InstructionAuthors     []string
+	Primary                 string
+	Fallback                string
+	ReviewMode              string
+	Prompt                  string
+	IssuePrompt             string
+	ImplementPrompt         string
+	RefinementTimeout       string
+	LocalDir                string
+	TriageOwner             string
+	CloneDir                string
+	AutoPromoteTriage       *bool
+	AutoPromoteRefinement   *bool
+	PRReviewers             []string
+	PRLabels                []string
+	PRAssignee              string
+	PRDraft                 *bool
+	GeneratePRDescription   *bool
+	NeverApproveWithIssues  *bool
+	NeverApproveMinSeverity string
+	InstructionAuthors      []string
 }
 
 func applyScopedAI(out *RepoAI, fields scopedAIFields) {
@@ -920,6 +937,9 @@ func applyScopedAI(out *RepoAI, fields scopedAIFields) {
 	}
 	if fields.NeverApproveWithIssues != nil {
 		out.NeverApproveWithIssues = fields.NeverApproveWithIssues
+	}
+	if fields.NeverApproveMinSeverity != "" {
+		out.NeverApproveMinSeverity = fields.NeverApproveMinSeverity
 	}
 	if fields.InstructionAuthors != nil {
 		out.InstructionAuthors = fields.InstructionAuthors
@@ -1290,6 +1310,9 @@ func (c *Config) Validate() error {
 	if err := c.validateScopedIssueTracking(); err != nil {
 		return err
 	}
+	if err := c.validateNeverApproveMinSeverity(); err != nil {
+		return err
+	}
 	// Bound the review-retention window for the TOML and env paths (the HTTP
 	// PUT /config validator covers its own path). A negative value would push
 	// PurgeOldReviews' cutoff into the future and wipe all reviews (#551).
@@ -1300,6 +1323,34 @@ func (c *Config) Validate() error {
 		d := *c.ActivityLog.RetentionDays
 		if d < 0 || d > MaxRetentionDays {
 			return fmt.Errorf("config: activity_log.retention_days must be between 0 and %d, got %d", MaxRetentionDays, d)
+		}
+	}
+	return nil
+}
+
+// validateNeverApproveMinSeverity bounds never_approve_min_severity to the
+// canonical severities at every scope. Empty means "inherit" (repo/org) or
+// "low" (global), so it is always accepted.
+func (c *Config) validateNeverApproveMinSeverity() error {
+	check := func(scope, v string) error {
+		switch v {
+		case "", "low", "medium", "high":
+			return nil
+		default:
+			return fmt.Errorf("config: %s.never_approve_min_severity must be one of: low, medium, high; got %q", scope, v)
+		}
+	}
+	if err := check("ai", c.AI.NeverApproveMinSeverity); err != nil {
+		return err
+	}
+	for org, o := range c.AI.Orgs {
+		if err := check(fmt.Sprintf("ai.orgs[%s]", org), o.NeverApproveMinSeverity); err != nil {
+			return err
+		}
+	}
+	for repo, r := range c.AI.Repos {
+		if err := check(fmt.Sprintf("ai.repos[%s]", repo), r.NeverApproveMinSeverity); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -2818,3 +2818,62 @@ func TestNeverApproveWithIssues_Resolution(t *testing.T) {
 		})
 	}
 }
+
+func TestNeverApproveMinSeverity_Resolution(t *testing.T) {
+	cases := []struct {
+		name   string
+		global string
+		org    string
+		repo   string
+		want   string
+	}{
+		{"all empty inherits empty (low)", "", "", "", ""},
+		{"global only", "medium", "", "", "medium"},
+		{"org over global", "medium", "high", "", "high"},
+		{"repo over org", "medium", "high", "low", "low"},
+		{"repo over global", "medium", "", "high", "high"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{}
+			c.AI.NeverApproveMinSeverity = tc.global
+			c.AI.Orgs = map[string]OrgAI{"acme": {NeverApproveMinSeverity: tc.org}}
+			c.AI.Repos = map[string]RepoAI{"acme/widget": {NeverApproveMinSeverity: tc.repo}}
+			got := c.AIForRepo("acme/widget").NeverApproveMinSeverity
+			if got != tc.want {
+				t.Errorf("NeverApproveMinSeverity = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNeverApproveMinSeverity_Validate(t *testing.T) {
+	base := func() *Config {
+		c := &Config{}
+		c.AI.Primary = "claude"
+		c.GitHub.PollInterval = "1m"
+		return c
+	}
+	for _, v := range []string{"", "low", "medium", "high"} {
+		c := base()
+		c.AI.NeverApproveMinSeverity = v
+		if err := c.Validate(); err != nil {
+			t.Errorf("valid value %q rejected: %v", v, err)
+		}
+	}
+	c := base()
+	c.AI.NeverApproveMinSeverity = "critical"
+	if err := c.Validate(); err == nil {
+		t.Errorf("invalid global value accepted")
+	}
+	c = base()
+	c.AI.Orgs = map[string]OrgAI{"acme": {NeverApproveMinSeverity: "urgent"}}
+	if err := c.Validate(); err == nil {
+		t.Errorf("invalid org value accepted")
+	}
+	c = base()
+	c.AI.Repos = map[string]RepoAI{"acme/widget": {NeverApproveMinSeverity: "nit"}}
+	if err := c.Validate(); err == nil {
+		t.Errorf("invalid repo value accepted")
+	}
+}

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -1237,6 +1237,14 @@ func PublishEventFor(rev *store.Review) string {
 // never-approve-with-issues downgrade, so keying on the event is sufficient.
 // It deliberately says "review finding(s)", not "issues": "issues were found"
 // was misread as "no GitHub issue is linked to this PR" (#597).
+//
+// findingCount is the TOTAL number of findings listed above the note, not
+// just those at or above never_approve_min_severity. The retry publish paths
+// (PublishPending, the NATS publish-worker) rebuild the note from the stored
+// review, which persists the decided event but not the threshold in effect
+// at decision time — re-reading the live config there could drift from the
+// original decision. The total matches the visible list, so it is always
+// accurate; "the blocking findings" carries the threshold nuance instead.
 func downgradeNoteFor(findingCount int) string {
 	findings := "findings"
 	if findingCount == 1 {
@@ -1245,7 +1253,7 @@ func downgradeNoteFor(findingCount int) string {
 	return fmt.Sprintf("\n\n---\n_Not approving: this review raised %d %s "+
 		"above, and `never_approve_with_issues` is enabled for this repo, so "+
 		"it is posted as a comment instead of an approval. Address or dispute "+
-		"the findings and re-request a review to get an approval._",
+		"the blocking findings and re-request a review to get an approval._",
 		findingCount, findings)
 }
 

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -382,6 +382,10 @@ type RunOptions struct {
 	// NeverApproveWithIssues, when true, publishes the review as COMMENT
 	// instead of APPROVE whenever the review found any issue (see ReviewEvent).
 	NeverApproveWithIssues bool
+	// NeverApproveMinSeverity is the minimum finding severity that triggers
+	// the NeverApproveWithIssues downgrade ("low"|"medium"|"high"). Empty is
+	// equivalent to "low": any finding downgrades (see ReviewEvent).
+	NeverApproveMinSeverity string
 	// RepoEligible is a live gate for automatic work. It is checked again at
 	// execution/publication boundaries so a config reload can stop an in-flight
 	// review. Nil intentionally allows explicit/manual calls to proceed.
@@ -765,7 +769,8 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	signalComments := filterBotComments(prComments, p.botLogin)
 	commentSignals := ExtractCommentSignals(signalComments, pr.User.Login)
 	finalSeverity := ApplySignalEscalation(reconciledSeverity, commentSignals)
-	reviewEvent := ReviewEvent(finalSeverity, len(result.Issues) > 0, opts.NeverApproveWithIssues)
+	reviewEvent := ReviewEvent(finalSeverity, MaxIssueSeverity(result.Issues),
+		opts.NeverApproveWithIssues, opts.NeverApproveMinSeverity)
 
 	// 6. Marshal issues to JSON for storage
 	issuesJSON, err := json.Marshal(result.Issues)
@@ -820,7 +825,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	}
 	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
 		pr.Repo, pr.Number,
-		AnnotateBodyForEvent(reviewBody, reviewEvent),
+		AnnotateBodyForEvent(reviewBody, reviewEvent, len(result.Issues)),
 		reviewEvent,
 	)
 	if publishErr != nil {
@@ -962,7 +967,7 @@ func (p *Pipeline) PublishPending() {
 		retryEvent := PublishEventFor(rev)
 		ghID, ghState, err := p.gh.SubmitReview(
 			pr.Repo, pr.Number,
-			AnnotateBodyForEvent(BuildGitHubBody(result), retryEvent),
+			AnnotateBodyForEvent(BuildGitHubBody(result), retryEvent, len(result.Issues)),
 			retryEvent,
 		)
 		if err != nil {
@@ -1178,14 +1183,37 @@ func SeverityToEvent(severity string) string {
 	return "APPROVE"
 }
 
+// MaxIssueSeverity returns the highest severity among the review's findings,
+// or "" when the review found none. Non-canonical severities rank as "low",
+// mirroring severityRank's default.
+func MaxIssueSeverity(issues []executor.Issue) string {
+	if len(issues) == 0 {
+		return ""
+	}
+	maxRank := severityRank("low")
+	for _, iss := range issues {
+		if r := severityRank(iss.Severity); r > maxRank {
+			maxRank = r
+		}
+	}
+	return rankToSeverity(maxRank)
+}
+
 // ReviewEvent decides the GitHub review event, honoring the
 // never-approve-with-issues setting. It builds on SeverityToEvent: when the
 // base decision would be APPROVE, the setting is on, and the review found at
-// least one issue, it downgrades APPROVE to COMMENT. REQUEST_CHANGES is never
-// altered, and a clean review (no issues) still approves.
-func ReviewEvent(finalSeverity string, hasIssues bool, neverApproveWithIssues bool) string {
+// least one issue of severity >= minSeverity, it downgrades APPROVE to
+// COMMENT. REQUEST_CHANGES is never altered, and a clean review (no issues)
+// still approves.
+//
+// maxIssueSeverity is MaxIssueSeverity(issues): "" means no findings.
+// minSeverity is the never_approve_min_severity setting; empty means "low"
+// (any finding downgrades — the pre-#597 behavior), matching severityRank's
+// default rank for unknown values.
+func ReviewEvent(finalSeverity, maxIssueSeverity string, neverApproveWithIssues bool, minSeverity string) string {
 	event := SeverityToEvent(finalSeverity)
-	if event == "APPROVE" && neverApproveWithIssues && hasIssues {
+	if event == "APPROVE" && neverApproveWithIssues && maxIssueSeverity != "" &&
+		severityRank(maxIssueSeverity) >= severityRank(minSeverity) {
 		return "COMMENT"
 	}
 	return event
@@ -1203,20 +1231,31 @@ func PublishEventFor(rev *store.Review) string {
 	return SeverityToEvent(rev.Severity)
 }
 
-// downgradeNote is appended to a review body when the event was downgraded to
-// COMMENT, so PR authors understand why Heimdallm commented instead of
+// downgradeNoteFor is appended to a review body when the event was downgraded
+// to COMMENT, so PR authors understand why Heimdallm commented instead of
 // approving. COMMENT is only ever produced by ReviewEvent's
 // never-approve-with-issues downgrade, so keying on the event is sufficient.
-const downgradeNote = "\n\n---\n_Not approving: issues were found and " +
-	"`never_approve_with_issues` is enabled for this repo — posting as a " +
-	"comment instead of an approval._"
+// It deliberately says "review finding(s)", not "issues": "issues were found"
+// was misread as "no GitHub issue is linked to this PR" (#597).
+func downgradeNoteFor(findingCount int) string {
+	findings := "findings"
+	if findingCount == 1 {
+		findings = "finding"
+	}
+	return fmt.Sprintf("\n\n---\n_Not approving: this review raised %d %s "+
+		"above, and `never_approve_with_issues` is enabled for this repo, so "+
+		"it is posted as a comment instead of an approval. Address or dispute "+
+		"the findings and re-request a review to get an approval._",
+		findingCount, findings)
+}
 
 // AnnotateBodyForEvent appends an explanatory note to the review body when the
 // event is COMMENT (the never-approve-with-issues downgrade); otherwise the
-// body is returned unchanged.
-func AnnotateBodyForEvent(body, event string) string {
+// body is returned unchanged. findingCount is the number of findings the
+// review raised, quoted in the note.
+func AnnotateBodyForEvent(body, event string, findingCount int) string {
 	if event == "COMMENT" {
-		return body + downgradeNote
+		return body + downgradeNoteFor(findingCount)
 	}
 	return body
 }

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -1575,29 +1575,58 @@ func equalStringSlices(a, b []string) bool {
 
 func TestReviewEvent(t *testing.T) {
 	cases := []struct {
-		sev       string
-		hasIssues bool
-		never     bool
-		want      string
+		sev    string
+		maxIss string // MaxIssueSeverity: "" = no findings
+		never  bool
+		minSev string
+		want   string
 	}{
 		// flag OFF → identical to SeverityToEvent
-		{"low", true, false, "APPROVE"},
-		{"medium", true, false, "APPROVE"},
-		{"high", true, false, "REQUEST_CHANGES"},
-		{"", false, false, "APPROVE"},
-		// flag ON
-		{"low", true, true, "COMMENT"},
-		{"medium", true, true, "COMMENT"},
-		{"", true, true, "COMMENT"},
-		{"high", true, true, "REQUEST_CHANGES"}, // high never downgraded
-		{"low", false, true, "APPROVE"},         // clean review still approves
-		{"medium", false, true, "APPROVE"},
+		{"low", "low", false, "", "APPROVE"},
+		{"medium", "medium", false, "", "APPROVE"},
+		{"high", "high", false, "", "REQUEST_CHANGES"},
+		{"", "", false, "", "APPROVE"},
+		// flag ON, default threshold ("" = low: any finding downgrades)
+		{"low", "low", true, "", "COMMENT"},
+		{"medium", "medium", true, "", "COMMENT"},
+		{"", "low", true, "", "COMMENT"},
+		{"high", "high", true, "", "REQUEST_CHANGES"}, // high never downgraded
+		{"low", "", true, "", "APPROVE"},              // clean review still approves
+		{"medium", "", true, "", "APPROVE"},
+		// flag ON, explicit "low" threshold — same as default
+		{"low", "low", true, "low", "COMMENT"},
+		// flag ON, "medium" threshold: low-only findings keep the approval
+		{"low", "low", true, "medium", "APPROVE"},
+		{"medium", "medium", true, "medium", "COMMENT"},
+		{"medium", "low", true, "medium", "APPROVE"}, // escalated top-level, low findings
+		// flag ON, "high" threshold: medium findings keep the approval
+		{"medium", "medium", true, "high", "APPROVE"},
+		{"low", "low", true, "high", "APPROVE"},
 	}
 	for _, tc := range cases {
-		got := pipeline.ReviewEvent(tc.sev, tc.hasIssues, tc.never)
+		got := pipeline.ReviewEvent(tc.sev, tc.maxIss, tc.never, tc.minSev)
 		if got != tc.want {
-			t.Errorf("ReviewEvent(%q, %v, %v) = %q, want %q",
-				tc.sev, tc.hasIssues, tc.never, got, tc.want)
+			t.Errorf("ReviewEvent(%q, %q, %v, %q) = %q, want %q",
+				tc.sev, tc.maxIss, tc.never, tc.minSev, got, tc.want)
+		}
+	}
+}
+
+func TestMaxIssueSeverity(t *testing.T) {
+	cases := []struct {
+		name   string
+		issues []executor.Issue
+		want   string
+	}{
+		{"no findings", nil, ""},
+		{"single low", []executor.Issue{{Severity: "low"}}, "low"},
+		{"mixed picks max", []executor.Issue{{Severity: "low"}, {Severity: "medium"}}, "medium"},
+		{"high wins", []executor.Issue{{Severity: "medium"}, {Severity: "high"}, {Severity: "low"}}, "high"},
+		{"unknown severity ranks low", []executor.Issue{{Severity: "bogus"}}, "low"},
+	}
+	for _, tc := range cases {
+		if got := pipeline.MaxIssueSeverity(tc.issues); got != tc.want {
+			t.Errorf("%s: MaxIssueSeverity = %q, want %q", tc.name, got, tc.want)
 		}
 	}
 }
@@ -1625,13 +1654,25 @@ func TestPublishEventFor(t *testing.T) {
 func TestAnnotateBodyForEvent(t *testing.T) {
 	const body = "## Review\nlgtm"
 	// COMMENT keeps the original body and appends the downgrade note.
-	got := pipeline.AnnotateBodyForEvent(body, "COMMENT")
+	got := pipeline.AnnotateBodyForEvent(body, "COMMENT", 2)
 	if !strings.Contains(got, body) || !strings.Contains(got, "never_approve_with_issues") {
 		t.Errorf("COMMENT body should keep body and add the note, got %q", got)
 	}
+	// The note quotes the finding count and says "findings", not the
+	// GitHub-ambiguous "issues were found" (#597).
+	if !strings.Contains(got, "raised 2 findings") {
+		t.Errorf("note should quote the finding count, got %q", got)
+	}
+	if strings.Contains(got, "issues were found") {
+		t.Errorf("note must not use the ambiguous \"issues were found\" wording, got %q", got)
+	}
+	// Singular form for a single finding.
+	if got := pipeline.AnnotateBodyForEvent(body, "COMMENT", 1); !strings.Contains(got, "raised 1 finding above") {
+		t.Errorf("single-finding note should be singular, got %q", got)
+	}
 	// Non-downgrade events leave the body untouched.
 	for _, ev := range []string{"APPROVE", "REQUEST_CHANGES"} {
-		if got := pipeline.AnnotateBodyForEvent(body, ev); got != body {
+		if got := pipeline.AnnotateBodyForEvent(body, ev, 2); got != body {
 			t.Errorf("event %s: body should be unchanged, got %q", ev, got)
 		}
 	}

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -1663,6 +1663,11 @@ func TestAnnotateBodyForEvent(t *testing.T) {
 	if !strings.Contains(got, "raised 2 findings") {
 		t.Errorf("note should quote the finding count, got %q", got)
 	}
+	// The action sentence says "the blocking findings" — with a min-severity
+	// threshold, not every listed finding withholds the approval.
+	if !strings.Contains(got, "Address or dispute the blocking findings") {
+		t.Errorf("note should point at the blocking findings, got %q", got)
+	}
 	if strings.Contains(got, "issues were found") {
 		t.Errorf("note must not use the ambiguous \"issues were found\" wording, got %q", got)
 	}

--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -66,6 +66,12 @@ review_mode = "single"   # "single" or "multi"
 # Default: false.
 # never_approve_with_issues = false
 
+# Minimum finding severity that triggers the never_approve_with_issues
+# downgrade: "low", "medium" or "high". Unset/empty = "low" (any finding
+# downgrades). With "medium", reviews whose findings are all low-severity nits
+# still approve. Overridable per org and per repo.
+# never_approve_min_severity = "low"
+
 # Per-CLI settings (optional)
 # [ai.agents.claude]
 # model = "claude-sonnet-4-20250514"

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -671,7 +671,8 @@ clone_dir = "/home/heimdallm/repos/myorg-worktrees"
 auto_promote_triage = true
 auto_promote_refinement = false
 generate_pr_description = true
-never_approve_with_issues = false   # true = comment instead of approving when any issue is found
+never_approve_with_issues = false   # true = comment instead of approving when any finding is raised
+never_approve_min_severity = "low"  # findings below this severity don't trigger the downgrade
 
 pr_reviewers = ["alice", "bob", "carol"]
 pr_labels    = ["auto-generated", "ai-platform"]
@@ -1280,6 +1281,13 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # Default: false.
 # never_approve_with_issues = false
 
+# Minimum finding severity that triggers the never_approve_with_issues
+# downgrade: "low", "medium" or "high". Unset/empty = "low" (any finding
+# downgrades). With "medium", reviews whose findings are all low-severity
+# nits still approve. Overridable per org ([ai.orgs.*]) and per repo
+# ([ai.repos.*]).
+# never_approve_min_severity = "low"
+
 # When local_dir is unset, Heimdallm prepares a managed shallow clone for agent
 # context under clone_dir. If clone_dir is also unset, the default is
 # os.TempDir()/heimdallm/<org>/<repo>. Existing directories are mutated only
@@ -1345,6 +1353,7 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # auto_promote_refinement = false
 # generate_pr_description = true
 # never_approve_with_issues = false
+# never_approve_min_severity = "low"
 # pr_reviewers = ["alice", "bob"]
 # pr_labels    = ["auto-generated", "myorg-team"]
 # pr_assignee  = "myusername"


### PR DESCRIPTION
## Summary

Fixes the two actionable problems from #597. The `never_approve_with_issues` downgrade note said "issues were found", which a PR author misread as "no GitHub issue is linked to this PR" — the note now quotes the number of review findings and tells the author how to get an approval. And the downgrade fired on ANY finding (even a single 🟡 LOW nit), which silently removed auto-approval for repos with required approvals; a new companion setting `never_approve_min_severity` lets repos keep approvals flowing past low-severity nits while still withholding on medium+.

## How it works

- `daemon/internal/pipeline/pipeline.go` — `downgradeNote` const becomes `downgradeNoteFor(findingCount)`: *"Not approving: this review raised N finding(s) above, and `never_approve_with_issues` is enabled for this repo, so it is posted as a comment instead of an approval. Address or dispute the findings and re-request a review to get an approval."* All three `AnnotateBodyForEvent` call sites (initial publish, `PublishPending` retry, NATS publish-worker) pass the stored finding count.
- `ReviewEvent` now takes the max finding severity (new helper `MaxIssueSeverity`, "" = no findings) plus the threshold. The downgrade only fires when at least one finding ranks ≥ `never_approve_min_severity`. Empty/unset threshold ranks as "low" (any finding downgrades) — exactly the pre-#597 behavior, so existing configs are unaffected.
- `daemon/internal/config/config.go` — `never_approve_min_severity` (`"low"|"medium"|"high"`) mirrors the base flag's plumbing: global `[ai]`, `[ai.orgs.*]`, `[ai.repos.*]` overrides with empty = inherit, resolved in `AIForRepo`, validated at load (`Validate()` rejects anything outside the enum at every scope).
- `daemon/cmd/heimdallm/main.go` — threaded into `pipeline.RunOptions`, exposed in `GET /config` (global map + org/repo override maps), and classified as a dynamic field in `configReloadRestartSnapshot` (no poller restart on change). `PATCH /config` needs no changes (generic TOML deep-merge).

## Scope

**In scope:** Problem 1 (note wording) and Problem 2 (severity threshold) from #597.
**Out of scope:**
- Problem 3 (per-user config divergence visible on the PR) — needs its own design discussion.
- Flutter GUI field for the new setting (Settings/Org/Repo screens). The GUI sends config diffs through the deep-merging PATCH endpoint, so GUI saves cannot wipe the TOML-configured value; a parity field can follow up.

## Production impact & what to watch

- **Runtime behavior change:** With the new setting unset, review decisions are bit-for-bit identical to today (empty threshold ranks as "low"); the only visible change is the downgrade note's wording/finding count on COMMENT reviews. Once an operator sets `never_approve_min_severity = "medium"`, nit-only reviews flip from COMMENT back to APPROVE — that's the intended, opt-in change.
- **Rollout failure modes:** Config validation is new — a typo in the new key (e.g. `"med"`) fails daemon startup with a clear error. No existing config can trip it (the key didn't exist before). Stored pending reviews republish with their persisted event; only the appended note text differs on retry (cosmetic).
- **Blast radius:** Only daemons/repos with `never_approve_with_issues` enabled; everyone else's APPROVE/REQUEST_CHANGES decisions are untouched.
- **What to watch:** review event types on PRs of flag-enabled repos after deploy — nit-only reviews should still post as COMMENT until the threshold is raised. After raising it, expect APPROVE on low-only reviews. Daemon startup logs after any config edit that adds the new key (validation error = typo).
- **Rollback & sequencing:** plain revert, no migration, no ordering constraints. An older daemon ignores the unknown TOML key (`toml.Unmarshal` is non-strict), so rolling back the binary with the key still in config.toml is safe — it just reverts to always-downgrade.

## Test plan

- [x] `go test ./...` in `daemon/` — all packages pass (see below)
- [x] New: `TestReviewEvent` threshold matrix (default/low/medium/high × finding severities), `TestMaxIssueSeverity`, `TestNeverApproveMinSeverity_Resolution` (repo > org > global), `TestNeverApproveMinSeverity_Validate` (enum enforcement at all scopes), `TestAIOverrideMaps_ExposeNeverApproveMinSeverity`, wording assertions in `TestAnnotateBodyForEvent` (finding count quoted, singular/plural, old ambiguous phrase banned)
- [ ] Reviewers: sanity-check the new note wording reads unambiguously on a real downgraded review

<details>
<summary>go test ./... output</summary>

```
ok  	github.com/heimdallm/daemon/cmd/heimdallm	3.853s
ok  	github.com/heimdallm/daemon/internal/activity	0.259s
ok  	github.com/heimdallm/daemon/internal/autonomous	0.006s
ok  	github.com/heimdallm/daemon/internal/bus	2.170s
ok  	github.com/heimdallm/daemon/internal/config	0.034s
ok  	github.com/heimdallm/daemon/internal/discovery	0.078s
ok  	github.com/heimdallm/daemon/internal/executor	0.053s
ok  	github.com/heimdallm/daemon/internal/github	0.917s
ok  	github.com/heimdallm/daemon/internal/issues	0.487s
ok  	github.com/heimdallm/daemon/internal/pipeline	0.729s
ok  	github.com/heimdallm/daemon/internal/rename	0.018s
ok  	github.com/heimdallm/daemon/internal/repoctx	0.239s
ok  	github.com/heimdallm/daemon/internal/scheduler	0.954s
ok  	github.com/heimdallm/daemon/internal/server	2.528s
ok  	github.com/heimdallm/daemon/internal/sse	0.004s
ok  	github.com/heimdallm/daemon/internal/store	0.687s
ok  	github.com/heimdallm/daemon/internal/worker	4.743s
```
</details>

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)