### PR TITLE
feat(activity): "ADD" — add a PR by GitHub link and review it now

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2103,6 +2103,37 @@ func main() {
 		return nil
 	})
 
+	// Manual PR add (Activity view "ADD" action → POST /prs/add): fetch the PR
+	// from GitHub by (repo, number) and upsert it into the store. The server
+	// handler adds the repo to the monitored list and triggers the review;
+	// this callback owns only the GitHub fetch + store write. The base repo
+	// from the URL is authoritative for the stored Repo (GetPR would otherwise
+	// use head.repo.full_name, which is the fork for cross-repo PRs).
+	srv.SetAddPRFn(func(repo string, number int) (*store.PR, error) {
+		ghPR, err := ghClient.GetPR(repo, number)
+		if err != nil {
+			return nil, err
+		}
+		storePR := &store.PR{
+			GithubID:  ghPR.ID,
+			Repo:      repo,
+			Number:    ghPR.Number,
+			Title:     ghPR.Title,
+			Author:    ghPR.User.Login,
+			URL:       ghPR.HTMLURL,
+			State:     ghPR.State,
+			UpdatedAt: ghPR.UpdatedAt,
+			FetchedAt: time.Now().UTC(),
+		}
+		id, err := s.UpsertPR(storePR)
+		if err != nil {
+			return nil, fmt.Errorf("upsert pr: %w", err)
+		}
+		storePR.ID = id
+		slog.Info("manual PR add: stored", "repo", repo, "number", number, "store_pr_id", id, "github_id", ghPR.ID)
+		return storePR, nil
+	})
+
 	// Wire the issue-review trigger callback: re-run the issue at its
 	// CURRENT stage. Triggered by POST /issues/{id}/review (the GUI's
 	// "Re-review" button). The endpoint path is historical — when it was

--- a/daemon/internal/server/add_pr_internal_test.go
+++ b/daemon/internal/server/add_pr_internal_test.go
@@ -1,0 +1,86 @@
+package server
+
+import "testing"
+
+func TestParsePRURL(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		wantRepo   string
+		wantNumber int
+		wantErr    bool
+	}{
+		{"canonical", "https://github.com/owner/repo/pull/123", "owner/repo", 123, false},
+		{"trailing slash", "https://github.com/owner/repo/pull/7/", "owner/repo", 7, false},
+		{"files tab", "https://github.com/owner/repo/pull/42/files", "owner/repo", 42, false},
+		{"query string", "https://github.com/owner/repo/pull/9?w=1", "owner/repo", 9, false},
+		{"whitespace", "  https://github.com/o/r/pull/5  ", "o/r", 5, false},
+		{"www host", "https://www.github.com/o/r/pull/5", "o/r", 5, false},
+		{"empty", "", "", 0, true},
+		{"not github", "https://gitlab.com/o/r/pull/5", "", 0, true},
+		{"issue not pr", "https://github.com/o/r/issues/5", "", 0, true},
+		{"missing number", "https://github.com/o/r/pull/", "", 0, true},
+		{"non-numeric", "https://github.com/o/r/pull/abc", "", 0, true},
+		{"zero number", "https://github.com/o/r/pull/0", "", 0, true},
+		{"too short", "https://github.com/o/r", "", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			repo, number, err := parsePRURL(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got repo=%q number=%d", c.in, repo, number)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", c.in, err)
+			}
+			if repo != c.wantRepo || number != c.wantNumber {
+				t.Errorf("parsePRURL(%q) = (%q, %d), want (%q, %d)", c.in, repo, number, c.wantRepo, c.wantNumber)
+			}
+		})
+	}
+}
+
+func TestAddRepoToTOMLMap(t *testing.T) {
+	// Fresh map with no github table: creates it and adds the repo.
+	m := map[string]any{}
+	addRepoToTOMLMap(m, "org/new")
+	gh := m["github"].(map[string]any)
+	if got := gh["repositories"].([]any); len(got) != 1 || got[0] != "org/new" {
+		t.Fatalf("repositories = %v, want [org/new]", gh["repositories"])
+	}
+
+	// Existing repo is not duplicated; and it is stripped from non_monitored.
+	m = map[string]any{"github": map[string]any{
+		"repositories":  []any{"org/a", "org/b"},
+		"non_monitored": []any{"org/b", "org/c"},
+	}}
+	addRepoToTOMLMap(m, "org/b")
+	gh = m["github"].(map[string]any)
+	repos := gh["repositories"].([]any)
+	if len(repos) != 2 {
+		t.Errorf("repositories must not duplicate an existing repo, got %v", repos)
+	}
+	for _, r := range gh["non_monitored"].([]any) {
+		if r == "org/b" {
+			t.Errorf("org/b must be removed from non_monitored, got %v", gh["non_monitored"])
+		}
+	}
+
+	// New repo appended and removed from non_monitored simultaneously.
+	m = map[string]any{"github": map[string]any{
+		"repositories":  []any{"org/a"},
+		"non_monitored": []any{"org/x"},
+	}}
+	addRepoToTOMLMap(m, "org/x")
+	gh = m["github"].(map[string]any)
+	repos = gh["repositories"].([]any)
+	if len(repos) != 2 || repos[1] != "org/x" {
+		t.Errorf("repositories = %v, want [org/a org/x]", repos)
+	}
+	if len(gh["non_monitored"].([]any)) != 0 {
+		t.Errorf("non_monitored must be empty after moving org/x, got %v", gh["non_monitored"])
+	}
+}

--- a/daemon/internal/server/add_pr_test.go
+++ b/daemon/internal/server/add_pr_test.go
@@ -1,0 +1,148 @@
+package server_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/server"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// TestHandleAddPR_AddsRepoFetchesAndReviews is the end-to-end guard for the
+// Activity "ADD" action: POST /prs/add must add the repo to the monitored
+// list (and strip it from non_monitored), fetch+store the PR, and trigger a
+// review.
+func TestHandleAddPR_AddsRepoFetchesAndReviews(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	broker := sse.NewBroker()
+	broker.Start()
+	t.Cleanup(broker.Stop)
+	srv := server.NewWithOptions(s, broker, nil, "", server.Options{})
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(
+		"[ai]\nprimary = \"claude\"\n\n"+
+			"[github]\nrepositories = [\"org/existing\"]\nnon_monitored = [\"org/repo\"]\n",
+	), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	srv.SetConfigPath(cfgPath)
+	srv.SetReloadFn(func() error { return nil })
+
+	var addCalls int32
+	srv.SetAddPRFn(func(repo string, number int) (*store.PR, error) {
+		atomic.AddInt32(&addCalls, 1)
+		if repo != "org/repo" || number != 123 {
+			t.Errorf("addPRFn got %s#%d, want org/repo#123", repo, number)
+		}
+		id, err := s.UpsertPR(&store.PR{
+			GithubID: 999, Repo: repo, Number: number, State: "open",
+			UpdatedAt: time.Now(), FetchedAt: time.Now(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &store.PR{ID: id, Repo: repo, Number: number}, nil
+	})
+
+	var reviewedID int64
+	done := make(chan struct{})
+	srv.SetTriggerReviewFn(func(prID int64) error {
+		atomic.StoreInt64(&reviewedID, prID)
+		close(done)
+		return nil
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/prs/add",
+		strings.NewReader(`{"url":"https://github.com/org/repo/pull/123"}`))
+	srv.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d want 202, body=%s", rr.Code, rr.Body.String())
+	}
+	if atomic.LoadInt32(&addCalls) != 1 {
+		t.Errorf("addPRFn called %d times, want 1", addCalls)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("triggerReviewFn was not called")
+	}
+	if atomic.LoadInt64(&reviewedID) == 0 {
+		t.Error("triggerReviewFn called with zero prID")
+	}
+
+	// config.toml now monitors org/repo and no longer lists it as non_monitored.
+	m, err := config.ReadTOMLMap(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	gh := m["github"].(map[string]any)
+	if !tomlListContains(gh["repositories"], "org/repo") {
+		t.Errorf("org/repo not added to repositories: %v", gh["repositories"])
+	}
+	if tomlListContains(gh["non_monitored"], "org/repo") {
+		t.Errorf("org/repo still in non_monitored: %v", gh["non_monitored"])
+	}
+	if !tomlListContains(gh["repositories"], "org/existing") {
+		t.Errorf("pre-existing repo was dropped: %v", gh["repositories"])
+	}
+}
+
+// TestHandleAddPR_RejectsBadURL verifies invalid input is a 400 and never
+// touches config or the review trigger.
+func TestHandleAddPR_RejectsBadURL(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	broker := sse.NewBroker()
+	broker.Start()
+	t.Cleanup(broker.Stop)
+	srv := server.NewWithOptions(s, broker, nil, "", server.Options{})
+	srv.SetAddPRFn(func(string, int) (*store.PR, error) {
+		t.Fatal("addPRFn must not be called on a bad URL")
+		return nil, nil
+	})
+	srv.SetTriggerReviewFn(func(int64) error {
+		t.Fatal("triggerReviewFn must not be called on a bad URL")
+		return nil
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/prs/add",
+		strings.NewReader(`{"url":"https://gitlab.com/o/r/pull/1"}`))
+	srv.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400, body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func tomlListContains(raw any, target string) bool {
+	list, ok := raw.([]any)
+	if !ok {
+		return false
+	}
+	for _, it := range list {
+		if s, ok := it.(string); ok && s == target {
+			return true
+		}
+	}
+	return false
+}

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -44,6 +44,10 @@ type Server struct {
 	reloadFn             func() error
 	shutdownFn           func()
 	triggerReviewFn      func(prID int64) error
+	// addPRFn fetches a PR from GitHub by (repo, number), upserts it into the
+	// store, and returns the stored row. Wired by main (needs the GitHub
+	// client + store). Nil disables POST /prs/add.
+	addPRFn              func(repo string, number int) (*store.PR, error)
 	triggerIssueReviewFn func(issueID int64) error
 	triggerIssueRefineFn func(issueID int64, force bool) error
 	triggerPromoteFn     func(issueID int64) error
@@ -193,6 +197,13 @@ func (srv *Server) SetShutdownFn(fn func()) { srv.shutdownFn = fn }
 
 // SetTriggerReviewFn wires the review-trigger callback called by POST /prs/{id}/review.
 func (srv *Server) SetTriggerReviewFn(fn func(prID int64) error) { srv.triggerReviewFn = fn }
+
+// SetAddPRFn wires the manual-add callback called by POST /prs/add: it fetches
+// a PR from GitHub by (repo, number), upserts it into the store, and returns
+// the stored row.
+func (srv *Server) SetAddPRFn(fn func(repo string, number int) (*store.PR, error)) {
+	srv.addPRFn = fn
+}
 
 // SetTriggerIssueReviewFn wires the issue-review-trigger callback called by POST /issues/{id}/review.
 func (srv *Server) SetTriggerIssueReviewFn(fn func(issueID int64) error) {
@@ -352,6 +363,7 @@ func (srv *Server) buildRouter() chi.Router {
 	r.Get("/health", srv.handleHealth)
 	r.Get("/me", srv.handleMe)
 	r.Get("/prs", srv.handleListPRs)
+	r.Post("/prs/add", srv.handleAddPR)
 	r.Get("/prs/{id}", srv.handleGetPR)
 	r.Post("/prs/{id}/review", srv.handleTriggerReview)
 	r.Post("/prs/{id}/dismiss", srv.handleDismissPR)
@@ -626,6 +638,134 @@ func (srv *Server) handleTriggerReview(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "review queued"})
+}
+
+// handleAddPR accepts a GitHub pull-request URL, adds its repository to the
+// monitored list (persisted to config.toml + reload), fetches and stores the
+// PR, and triggers an immediate review. Wired by the Activity view's "ADD"
+// action. Body: {"url": "https://github.com/owner/repo/pull/123"}.
+func (srv *Server) handleAddPR(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+		return
+	}
+	repo, number, err := parsePRURL(body.URL)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if srv.addPRFn == nil || srv.triggerReviewFn == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "manual PR add not configured"})
+		return
+	}
+
+	// 1. Ensure the repo is monitored: add to github.repositories (and strip
+	// from non_monitored) in config.toml, then reload so the poller tracks it.
+	if srv.configPath != "" {
+		if _, err := srv.patchTOML(func(m map[string]any) error {
+			addRepoToTOMLMap(m, repo)
+			return nil
+		}); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("add repo to config: %v", err)})
+			return
+		}
+	}
+
+	// 2. Fetch the PR from GitHub and store it.
+	pr, err := srv.addPRFn(repo, number)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": fmt.Sprintf("fetch PR %s#%d: %v", repo, number, err)})
+		return
+	}
+
+	// 3. Review it now (async, bounded by the shared review semaphore). If all
+	// slots are busy the PR is still stored/monitored; the operator can retry
+	// or the next poll cycle picks it up.
+	select {
+	case srv.reviewSem <- struct{}{}:
+	default:
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"status": "pr added; review deferred (busy)", "pr": pr,
+		})
+		return
+	}
+	go func() {
+		defer func() { <-srv.reviewSem }()
+		if err := srv.triggerReviewFn(pr.ID); err != nil {
+			slog.Error("add PR: trigger review failed", "pr_id", pr.ID, "repo", repo, "number", number, "err", err)
+		}
+	}()
+	writeJSON(w, http.StatusAccepted, map[string]any{"status": "pr added; review queued", "pr": pr})
+}
+
+// parsePRURL extracts the "owner/repo" slug and PR number from a GitHub PR URL
+// such as https://github.com/owner/repo/pull/123 (trailing segments like
+// /files and query strings are tolerated).
+func parsePRURL(raw string) (repo string, number int, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", 0, fmt.Errorf("empty URL")
+	}
+	u, perr := url.Parse(raw)
+	if perr != nil {
+		return "", 0, fmt.Errorf("invalid URL")
+	}
+	host := strings.ToLower(u.Host)
+	if host != "github.com" && host != "www.github.com" {
+		return "", 0, fmt.Errorf("not a github.com URL")
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" {
+		return "", 0, fmt.Errorf("not a pull request URL (expected github.com/owner/repo/pull/N)")
+	}
+	owner, name := parts[0], parts[1]
+	if owner == "" || name == "" {
+		return "", 0, fmt.Errorf("missing owner/repo in URL")
+	}
+	number, perr = strconv.Atoi(parts[3])
+	if perr != nil || number <= 0 {
+		return "", 0, fmt.Errorf("invalid PR number %q", parts[3])
+	}
+	return owner + "/" + name, number, nil
+}
+
+// addRepoToTOMLMap appends repo to github.repositories (if absent) and removes
+// it from github.non_monitored, mutating the decoded TOML map in place.
+func addRepoToTOMLMap(m map[string]any, repo string) {
+	gh, ok := m["github"].(map[string]any)
+	if !ok || gh == nil {
+		gh = map[string]any{}
+		m["github"] = gh
+	}
+	gh["non_monitored"] = removeFromTOMLList(gh["non_monitored"], repo)
+
+	repos, _ := gh["repositories"].([]any)
+	for _, it := range repos {
+		if s, ok := it.(string); ok && s == repo {
+			return // already monitored
+		}
+	}
+	gh["repositories"] = append(repos, repo)
+}
+
+// removeFromTOMLList returns raw with every string element equal to target
+// removed. Non-list inputs are returned unchanged.
+func removeFromTOMLList(raw any, target string) any {
+	list, ok := raw.([]any)
+	if !ok {
+		return raw
+	}
+	out := make([]any, 0, len(list))
+	for _, it := range list {
+		if s, ok := it.(string); ok && s == target {
+			continue
+		}
+		out = append(out, it)
+	}
+	return out
 }
 
 func (srv *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -116,6 +116,33 @@ class ApiClient {
     }
   }
 
+  /// Adds a PR by its GitHub URL. The daemon adds the PR's repository to the
+  /// monitored list (persisted to config) and reviews the PR immediately.
+  /// Returns the created PR's store id (0 if the daemon deferred/omitted it).
+  Future<int> addPRByUrl(String url) async {
+    final resp = await _client.post(
+      _uri('/prs/add'),
+      headers: await _authHeaders(),
+      body: jsonEncode({'url': url}),
+    );
+    if (resp.statusCode != 202) {
+      String msg = 'POST /prs/add failed: ${resp.statusCode}';
+      try {
+        final err = (jsonDecode(resp.body) as Map<String, dynamic>)['error'];
+        if (err is String && err.isNotEmpty) msg = err;
+      } catch (_) {}
+      throw ApiException(msg);
+    }
+    try {
+      final pr =
+          (jsonDecode(resp.body) as Map<String, dynamic>)['pr']
+              as Map<String, dynamic>?;
+      return (pr?['id'] as num?)?.toInt() ?? 0;
+    } catch (_) {
+      return 0;
+    }
+  }
+
   Future<void> dismissPR(int prId) async {
     final resp = await _client.post(
       _uri('/prs/$prId/dismiss'),

--- a/flutter_app/lib/features/activity/activity_screen.dart
+++ b/flutter_app/lib/features/activity/activity_screen.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../core/api/api_client.dart';
 import '../../core/models/activity.dart';
+import '../dashboard/dashboard_providers.dart' show apiClientProvider;
 import 'activity_providers.dart';
 import 'widgets/activity_entry_tile.dart';
 import 'widgets/activity_filter_chips.dart';
@@ -125,6 +127,12 @@ class _DatePickerBar extends ConsumerWidget {
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       child: Row(
         children: [
+          ElevatedButton.icon(
+            icon: const Icon(Icons.add, size: 18),
+            label: const Text('ADD'),
+            onPressed: () => _showAddPRDialog(context),
+          ),
+          const SizedBox(width: 12),
           ChoiceChip(
             label: const Text('Today'),
             selected: isToday,
@@ -424,6 +432,131 @@ class _ActivityDetailSheet extends StatelessWidget {
     final date =
         '${t.year.toString().padLeft(4, '0')}-${t.month.toString().padLeft(2, '0')}-${t.day.toString().padLeft(2, '0')}';
     return '$date ${activityTimeLabel(t)}';
+  }
+}
+
+Future<void> _showAddPRDialog(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    builder: (_) => const _AddPRDialog(),
+  );
+}
+
+/// Dialog for the Activity view "ADD" action: paste a GitHub PR URL. On submit
+/// the daemon adds the PR's repository to the monitored list and reviews the
+/// PR immediately.
+class _AddPRDialog extends ConsumerStatefulWidget {
+  const _AddPRDialog();
+
+  @override
+  ConsumerState<_AddPRDialog> createState() => _AddPRDialogState();
+}
+
+class _AddPRDialogState extends ConsumerState<_AddPRDialog> {
+  final _controller = TextEditingController();
+  bool _submitting = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  static bool _looksLikePRUrl(String s) {
+    final t = s.trim();
+    return t.contains('github.com/') && t.contains('/pull/');
+  }
+
+  Future<void> _submit() async {
+    final url = _controller.text.trim();
+    if (!_looksLikePRUrl(url)) {
+      setState(
+        () => _error =
+            'Enter a GitHub PR link, e.g. https://github.com/owner/repo/pull/123',
+      );
+      return;
+    }
+    setState(() {
+      _submitting = true;
+      _error = null;
+    });
+    try {
+      await ref.read(apiClientProvider).addPRByUrl(url);
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      ref.invalidate(activityEntriesProvider);
+      ref.invalidate(activityOptionsProvider);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('PR added — repository monitored and review started.'),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _submitting = false;
+        _error = e is ApiException ? e.message : e.toString();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Add a pull request'),
+      content: SizedBox(
+        width: 460,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Paste a GitHub PR link. Its repository is added to the '
+              'monitored list and the PR is reviewed right away.',
+            ),
+            const SizedBox(height: 14),
+            TextField(
+              controller: _controller,
+              autofocus: true,
+              enabled: !_submitting,
+              keyboardType: TextInputType.url,
+              decoration: const InputDecoration(
+                labelText: 'GitHub PR URL',
+                hintText: 'https://github.com/owner/repo/pull/123',
+                border: OutlineInputBorder(),
+              ),
+              onSubmitted: (_) {
+                if (!_submitting) _submit();
+              },
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 10),
+              Text(
+                _error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _submitting ? null : () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _submitting ? null : _submit,
+          child: _submitting
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Add & review'),
+        ),
+      ],
+    );
   }
 }
 


### PR DESCRIPTION
## Qué hace

Añade un botón **"ADD"** a la vista **Activity**. Abre un diálogo donde pegas un **link de PR de GitHub**; al enviarlo:

1. **Añade el repositorio de la PR a la lista monitorizada** (`github.repositories` en `config.toml`, quitándolo de `non_monitored`, persistido + reload).
2. **Descarga la PR** de GitHub y la guarda.
3. **Lanza la revisión en el momento**.

## Backend

- Nuevo endpoint `POST /prs/add` con body `{"url":"https://github.com/owner/repo/pull/123"}` → `handleAddPR`.
- `parsePRURL` extrae `owner/repo` + número (tolera `/files`, query string, trailing slash, `www.`).
- `addRepoToTOMLMap` + el `patchTOML` existente (read-merge-write + reload) para persistir el repo.
- `addPRFn` (cableado en `main`): `GetPR` de GitHub + `UpsertPR`. El repo base de la URL es el autoritativo para el `Repo` guardado (`GetPR` usaría `head.repo.full_name`, que es el fork en PRs cross-repo).
- Revisión disparada async con el semáforo de reviews + `triggerReviewFn` existente (202).

## Frontend

- `ApiClient.addPRByUrl(url)` → `POST /prs/add`.
- Botón `ADD` en la barra de Activity → `_AddPRDialog` (valida el link, muestra errores del servidor, refresca el timeline al terminar).

## Tests

- `parsePRURL` (13 casos), `addRepoToTOMLMap` (3 escenarios).
- Test HTTP de integración de `handleAddPR`: repo añadido + `non_monitored` limpiado + repo previo preservado + review disparada; URL inválida → 400 sin efectos secundarios.
- Suite del daemon verde (`-race`); `flutter analyze` limpio; binario compila.

## Nota

No se ejecutó contra el daemon vivo a propósito (tocaría `config.toml` real, gastaría créditos de Claude y publicaría en GitHub). Verificado a nivel de integración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)