### PR TITLE
feat(makefile): add macOS install and uninstall targets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Syntax and pure-logic tests
-        run: make test-install-macos
+        run: |
+          set -eu
+          for script in scripts/macos-install.sh scripts/test-macos-install.sh; do
+            if [ ! -x "$script" ]; then
+              echo "::error::$script must be executable"
+              exit 1
+            fi
+          done
+          make test-install-macos
 
       - name: Existing Linux install targets still parse
         run: |
@@ -38,19 +46,27 @@ jobs:
               exit 1
             fi
             printf '%s\n' "$output"
-            printf '%s\n' "$output" | grep -F "This target requires macOS." >/dev/null
+            if ! printf '%s\n' "$output" |
+              grep -Fq "This target requires macOS."; then
+              echo "::error::$target did not stop at the expected macOS guard"
+              exit 1
+            fi
           done
 
       - name: Direct helper invocation is also harmless on Linux
         run: |
           set -eu
           for operation in install uninstall; do
-            if output="$(sh scripts/macos-install.sh "$operation" 2>&1)"; then
+            if output="$(./scripts/macos-install.sh "$operation" 2>&1)"; then
               echo "::error::direct $operation unexpectedly succeeded on Linux"
               exit 1
             fi
             printf '%s\n' "$output"
-            printf '%s\n' "$output" | grep -F "This installer requires macOS." >/dev/null
+            if ! printf '%s\n' "$output" |
+              grep -Fq "This installer requires macOS."; then
+              echo "::error::direct $operation did not stop at the expected Linux guard"
+              exit 1
+            fi
           done
 
   daemon:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  installer-shell:
+    name: macOS installer shell (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Syntax and pure-logic tests
+        run: make test-install-macos
+
+      - name: Existing Linux install targets still parse
+        run: |
+          make -n install-linux >/dev/null
+          make -n uninstall-linux >/dev/null
+
+      - name: macOS targets stop at the platform guard
+        run: |
+          set -eu
+          for target in install-macos uninstall-macos; do
+            if output="$(make "$target" 2>&1)"; then
+              echo "::error::$target unexpectedly succeeded on Linux"
+              exit 1
+            fi
+            printf '%s\n' "$output"
+            printf '%s\n' "$output" | grep -F "This target requires macOS." >/dev/null
+          done
+
+      - name: Direct helper invocation is also harmless on Linux
+        run: |
+          set -eu
+          for operation in install uninstall; do
+            if output="$(sh scripts/macos-install.sh "$operation" 2>&1)"; then
+              echo "::error::direct $operation unexpectedly succeeded on Linux"
+              exit 1
+            fi
+            printf '%s\n' "$output"
+            printf '%s\n' "$output" | grep -F "This installer requires macOS." >/dev/null
+          done
+
   daemon:
     name: Daemon (Go)
     runs-on: macos-14

--- a/LLM-HOW-TO-INSTALL.md
+++ b/LLM-HOW-TO-INSTALL.md
@@ -2,10 +2,58 @@
 
 Step-by-step guide for Claude Code or any AI agent to install Heimdallm on macOS or Linux.
 
-- **macOS**: steps 1–5 below (DMG installer)
+- **macOS with a repository checkout**: use the preferred Make target below
+- **macOS without a checkout**: use steps 1–5 (manual DMG fallback)
 - **Linux**: jump to [Linux installation](#linux-installation)
 
 ---
+
+## macOS from a repository checkout (preferred)
+
+Run from the repository root as the normal user:
+
+```bash
+make install-macos                  # latest release
+make install-macos RELEASE=v0.7.5   # specific release
+```
+
+Never run `sudo make install-macos` or `sudo make uninstall-macos`. If writing
+to `/Applications` requires elevation, the helper obtains one sudo ticket and
+elevates only the app-bundle operations. It keeps LaunchAgent and home-directory
+work in the invoking user's domain.
+
+If a Heimdallm LaunchAgent already exists, install migrates it to the daemon
+inside `/Applications/Heimdallm.app`. Uninstall removes the app and LaunchAgent
+even without purge:
+
+```bash
+make uninstall-macos                # preserve config, history, logs, and Keychain
+make uninstall-macos PURGE=1        # irreversibly delete canonical user state
+```
+
+`PURGE=1` deletes exactly `~/.config/heimdallm`,
+`~/.local/share/heimdallm` (including the review database), and
+`~/Library/Logs/heimdallm`. It does not follow custom config/data path
+overrides, and it preserves the Keychain item. To remove the credential too,
+run:
+
+```bash
+security delete-generic-password -s heimdallm -a github-token
+```
+
+After a successful install, skip the manual download steps and continue at
+[Launch](#4-launch).
+
+---
+
+## macOS manual DMG fallback (no checkout)
+
+Use this path only when the repository and its Make target are unavailable.
+Unlike the preferred target, these commands do not migrate a pre-existing
+LaunchAgent. If
+`~/Library/LaunchAgents/com.heimdallm.daemon.plist` exists, stop here and use
+the repository target; the manual fallback can otherwise leave an old
+`KeepAlive` service running against the replacement app.
 
 ## 1. Get the latest version
 
@@ -49,7 +97,10 @@ fi
 echo "✓ Bundle looks good ($(ls -lh "$DAEMON_BIN" | awk '{print $5}') daemon, $(ls -lh "$FLUTTER_BIN" | awk '{print $5}') launcher)"
 
 # Install
-pkill -9 -f Heimdallm 2>/dev/null; sleep 1
+APP_PATTERN='^/Applications/Heimdallm[.]app/Contents/MacOS/(Heimdallm|heimdalld)([[:space:]]|$)'
+pkill -TERM -U "$(id -u)" -f "$APP_PATTERN" 2>/dev/null || true
+sleep 2
+pkill -KILL -U "$(id -u)" -f "$APP_PATTERN" 2>/dev/null || true
 rm -rf /Applications/Heimdallm.app
 cp -R "$APP_SRC" /Applications/Heimdallm.app
 echo "✓ Installed to /Applications"
@@ -216,4 +267,7 @@ If it exits, there's no config yet — the app creates it on first launch.
 
 ## Updating
 
-Repeat from step 1. Config (`~/.config/heimdallm/`) and history (`~/.local/share/heimdallm/`) are preserved.
+From a repository checkout, rerun `make install-macos` (optionally with
+`RELEASE=vX.Y.Z`). It preserves config (`~/.config/heimdallm/`), history
+(`~/.local/share/heimdallm/`), logs, custom override paths, and the Keychain
+credential. Without a checkout, repeat the manual macOS steps from step 1.

--- a/LLM-HOW-TO-INSTALL.md
+++ b/LLM-HOW-TO-INSTALL.md
@@ -23,8 +23,11 @@ elevates only the app-bundle operations. It keeps LaunchAgent and home-directory
 work in the invoking user's domain.
 
 If a Heimdallm LaunchAgent already exists, install migrates it to the daemon
-inside `/Applications/Heimdallm.app`. Uninstall removes the app and LaunchAgent
-even without purge:
+inside `/Applications/Heimdallm.app`. A loaded, enabled LaunchAgent is
+regenerated from the bundled daemon, which discards manual plist edits. For an
+unloaded or disabled LaunchAgent, only the daemon executable path changes and
+the remaining plist keys are preserved. Uninstall removes the app and
+LaunchAgent even without purge:
 
 ```bash
 make uninstall-macos                # preserve config, history, logs, and Keychain
@@ -40,6 +43,10 @@ run:
 ```bash
 security delete-generic-password -s heimdallm -a github-token
 ```
+
+Leave `PURGE` empty for a normal uninstall. Any non-empty value other than
+exact `PURGE=1` is an error and aborts before changing the LaunchAgent, app, or
+user data.
 
 After a successful install, skip the manual download steps and continue at
 [Launch](#4-launch).
@@ -99,7 +106,7 @@ echo "✓ Bundle looks good ($(ls -lh "$DAEMON_BIN" | awk '{print $5}') daemon, 
 # Install
 APP_PATTERN='^/Applications/Heimdallm[.]app/Contents/MacOS/(Heimdallm|heimdalld)([[:space:]]|$)'
 pkill -TERM -U "$(id -u)" -f "$APP_PATTERN" 2>/dev/null || true
-sleep 2
+sleep 6
 pkill -KILL -U "$(id -u)" -f "$APP_PATTERN" 2>/dev/null || true
 rm -rf /Applications/Heimdallm.app
 cp -R "$APP_SRC" /Applications/Heimdallm.app

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,6 @@ release-local: _check-macos _check-signing _check-gh build-daemon
 _check-macos:
 	@if [ "$$(uname -s)" != "Darwin" ]; then \
 	  echo "❌  This target requires macOS."; \
-	  echo "    For a Linux install, use 'make install-linux'."; \
 	  exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ else
 endif
 
 .PHONY: build-daemon build-app build-web build-cli test test-cli lint-cli dev-cli test-docker dev dev-daemon dev-stop \
-        release-local package-macos install-service verify-linux run-linux \
-        install-linux uninstall-linux \
+        release-local package-macos install-service verify-linux run-linux test-install-macos \
+        install-macos uninstall-macos install-linux uninstall-linux \
         setup up up-build up-daemon up-build-daemon down logs logs-daemon \
-        ps restart clean clean-clones _check-docker _check-env _check-linux _post-up-hints
+        ps restart clean clean-clones _check-docker _check-env _check-macos _check-linux _post-up-hints
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 
@@ -50,6 +50,11 @@ test-cli:
 
 lint-cli:
 	$(MAKE) -C cli lint
+
+test-install-macos:
+	@sh -n scripts/macos-install.sh
+	@sh -n scripts/test-macos-install.sh
+	@sh scripts/test-macos-install.sh
 
 # ── Sandboxed Go tests (EDR-safe) ─────────────────────────────────────────────
 #
@@ -233,6 +238,7 @@ release-local: _check-macos _check-signing _check-gh build-daemon
 _check-macos:
 	@if [ "$$(uname -s)" != "Darwin" ]; then \
 	  echo "❌  This target requires macOS."; \
+	  echo "    For a Linux install, use 'make install-linux'."; \
 	  exit 1; \
 	fi
 
@@ -417,6 +423,27 @@ package-macos: _check-macos build-daemon build-app
 	  -srcfolder "$(APP_BUNDLE)" \
 	  -ov -format UDZO \
 	  "dist/Heimdallm.dmg"
+
+# ── Native macOS install / uninstall (release DMG) ────────────────────────────
+#
+# Downloads a release DMG and installs the validated app bundle transactionally
+# into /Applications. The helper owns launchd state, rollback, selective sudo,
+# and cleanup; keep these recipes thin so Make never evaluates macOS commands at
+# parse time.
+#
+# Usage:
+#   make install-macos
+#   make install-macos RELEASE=v0.7.5
+#   make uninstall-macos
+#   make uninstall-macos PURGE=1
+
+install-macos: export RELEASE := $(RELEASE)
+install-macos: _check-macos
+	@./scripts/macos-install.sh install
+
+uninstall-macos: export PURGE := $(PURGE)
+uninstall-macos: _check-macos
+	@./scripts/macos-install.sh uninstall
 
 # ── Docker-based Linux build verification ─────────────────────────────────────
 #

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
         release-local package-macos install-service verify-linux run-linux test-install-macos \
         install-macos uninstall-macos install-linux uninstall-linux \
         setup up up-build up-daemon up-build-daemon down logs logs-daemon \
-        ps restart clean clean-clones _check-docker _check-env _check-macos _check-linux _post-up-hints
+        ps restart clean clean-clones _check-docker _check-env _check-macos _check-macos-user _check-linux _post-up-hints
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 
@@ -54,7 +54,7 @@ lint-cli:
 test-install-macos:
 	@sh -n scripts/macos-install.sh
 	@sh -n scripts/test-macos-install.sh
-	@sh scripts/test-macos-install.sh
+	@./scripts/test-macos-install.sh
 
 # ── Sandboxed Go tests (EDR-safe) ─────────────────────────────────────────────
 #
@@ -239,6 +239,13 @@ _check-macos:
 	@if [ "$$(uname -s)" != "Darwin" ]; then \
 	  echo "❌  This target requires macOS."; \
 	  echo "    For a Linux install, use 'make install-linux'."; \
+	  exit 1; \
+	fi
+
+_check-macos-user: _check-macos
+	@if [ "$$(id -u)" -eq 0 ]; then \
+	  echo "❌  Do not install or uninstall Heimdallm as root."; \
+	  echo "    Run the macOS target as your normal user, without 'sudo make'."; \
 	  exit 1; \
 	fi
 
@@ -436,13 +443,15 @@ package-macos: _check-macos build-daemon build-app
 #   make install-macos RELEASE=v0.7.5
 #   make uninstall-macos
 #   make uninstall-macos PURGE=1
+#
+# RELEASE/PURGE supplied on the make command line or inherited from the
+# environment already reach the recipe environment; do not export them
+# globally, where they could leak into unrelated targets.
 
-install-macos: export RELEASE := $(RELEASE)
-install-macos: _check-macos
+install-macos: _check-macos-user
 	@./scripts/macos-install.sh install
 
-uninstall-macos: export PURGE := $(PURGE)
-uninstall-macos: _check-macos
+uninstall-macos: _check-macos-user
 	@./scripts/macos-install.sh uninstall
 
 # ── Docker-based Linux build verification ─────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -37,7 +37,32 @@ A Flutter Web dashboard (`:3000`) with Dashboard, PR list, Issue list, prompt/ag
 
 ## Installation
 
-### macOS (DMG)
+### macOS
+
+From a checkout of this repository, use the Make targets (preferred):
+
+```bash
+make install-macos                  # install the latest release
+make install-macos RELEASE=v0.7.5   # install a specific release
+make uninstall-macos                # remove app + service; keep user state
+make uninstall-macos PURGE=1        # also delete config, history, and logs
+```
+
+Run these targets as your normal user, never with `sudo make`. If
+`/Applications` needs elevated permissions, the installer requests a sudo
+ticket once and limits it to the app-bundle operations. A pre-existing
+LaunchAgent is migrated to the installed bundle; uninstall always removes the
+LaunchAgent so `launchd` cannot keep retrying a missing executable.
+
+Normal uninstall preserves config, review history, logs, and the macOS
+Keychain credential. `PURGE=1` irreversibly removes only the canonical
+`~/.config/heimdallm`, `~/.local/share/heimdallm`, and
+`~/Library/Logs/heimdallm` directories. It does not follow custom config/data
+path overrides, and it still preserves the Keychain credential. Remove that
+separately, if desired, with
+`security delete-generic-password -s heimdallm -a github-token`.
+
+Without a checkout, use the manual DMG fallback:
 
 1. Download `Heimdallm-vX.Y.Z.dmg` from [Releases](https://github.com/theburrowhub/heimdallm/releases)
 2. Open the DMG and drag **Heimdallm** to **Applications**
@@ -456,6 +481,9 @@ make restart       # Docker: bounce both containers
 make ps            # Docker: container status
 make setup         # Docker: copy daemon API token into docker/.env (optional)
 make release-local # Build signed + notarized DMG and publish GitHub release
+make install-macos     # macOS: install the latest release into /Applications
+make uninstall-macos   # macOS: remove app + LaunchAgent (add PURGE=1 to wipe user state)
+make test-install-macos # macOS installer: run portable shell logic tests
 make verify-linux      # Linux: build the heimdallm-verify Docker image (full CI pipeline inside)
 make run-linux         # Linux: launch the Flutter bundle from inside the Docker image (X11)
 make install-linux     # Linux: native install to ~/.local/ (no sudo, Docker-built)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ ticket once and limits it to the app-bundle operations. A pre-existing
 LaunchAgent is migrated to the installed bundle; uninstall always removes the
 LaunchAgent so `launchd` cannot keep retrying a missing executable.
 
+Migration of a loaded, enabled LaunchAgent regenerates its canonical plist from
+the bundled daemon, so manual plist edits are discarded. If the LaunchAgent
+was unloaded or disabled, install changes only its daemon executable path and
+preserves the other plist keys.
+
 Normal uninstall preserves config, review history, logs, and the macOS
 Keychain credential. `PURGE=1` irreversibly removes only the canonical
 `~/.config/heimdallm`, `~/.local/share/heimdallm`, and
@@ -61,6 +66,8 @@ Keychain credential. `PURGE=1` irreversibly removes only the canonical
 path overrides, and it still preserves the Keychain credential. Remove that
 separately, if desired, with
 `security delete-generic-password -s heimdallm -a github-token`.
+An empty `PURGE` means normal uninstall; any non-empty value other than exact
+`PURGE=1` is rejected before the LaunchAgent, app, or user data is changed.
 
 Without a checkout, use the manual DMG fallback:
 

--- a/docs/superpowers/specs/2026-07-29-install-macos-target-design.md
+++ b/docs/superpowers/specs/2026-07-29-install-macos-target-design.md
@@ -1,382 +1,223 @@
-# `make install-macos` / `make uninstall-macos` (#604)
+# ADR: native macOS install and uninstall targets
 
 **Date:** 2026-07-29
-**Issue:** [#604 — feat(makefile): add install-macos / uninstall-macos targets](https://github.com/theburrowhub/heimdallm/issues/604)
-**Status:** Approved after review
-**Revision:** 2026-07-29 — hardened LaunchAgent teardown, port preflight,
-privilege boundaries, rollback/purge safety, and Linux non-regression.
 
-## Problem
+**Issue:** [#604](https://github.com/theburrowhub/heimdallm/issues/604)
 
-The repo cannot install itself on macOS. `Makefile:586-754` provides
-`install-linux` / `uninstall-linux` — user-local, no sudo, driven by Docker —
-but the macOS side only has `package-macos` (build a DMG) and `release-local`
-(build, sign, notarize, publish). Neither puts an app on the machine.
+**Status:** Accepted design; implementation under review
 
-So the documented macOS path is manual: `curl` the release asset, `hdiutil
-attach`, `cp -R` to `/Applications`, `xattr -cr` (`README.md:38-48`,
-`LLM-HOW-TO-INSTALL.md` steps 1-3). In practice developers skip it and run
-`make dev`, which builds the daemon and launches Flutter in **debug** mode —
-a development loop, not an installation.
+## Context
 
-## Context that shapes the design
+macOS users can build a DMG or install one manually, but the repository has no
+equivalent to `install-linux` / `uninstall-linux`. A safe native installer must
+coordinate a release DMG, `/Applications`, running UI/daemon processes, and a
+per-user LaunchAgent without changing the existing Linux flow.
 
-- **`VERSION` is already taken.** `Makefile:146` defines it as the *next*
-  auto-incremented semver, consumed by `release-local`. A target reusing it
-  would resolve to a tag that does not exist yet (today: `v0.7.8`). The new
-  targets use `RELEASE`, empty meaning "latest".
-- **The repo is public**, so `api.github.com/.../releases/latest` needs no
-  authentication and `gh` is not required. `jq` is not a dependency of this
-  repo either, so the tag is extracted with `sed`.
-- **The release DMG is ad-hoc signed, not notarized.** `release.yml:487-505`
-  runs `codesign --force --deep --sign -`. Gatekeeper therefore blocks it and
-  `xattr -cr` is mandatory; `spctl --assess` is not usable as a verification
-  step.
-- **The DMG has no published checksum.** `checksums.txt` in a release covers
-  only the GoReleaser CLI binaries, and `heimdallm_<v>_checksums.txt` only the
-  `.deb`/`.rpm`. Neither lists the DMG or the AppImage.
-- **The bundle can be born corrupt.** On case-insensitive APFS, `heimdallm`
-  resolves to the Flutter binary `Heimdallm`; if the daemon copy step in CI
-  degrades, both binaries end up identical and spawning the daemon fork-bombs
-  the machine. `install-linux` guards against exactly this
-  (`Makefile:605-608`) and `LLM-HOW-TO-INSTALL.md` repeats the check.
-- **The daemon can uninstall its own LaunchAgent.** `daemon/cmd/heimdallm/main.go:84`
-  handles the `uninstall` subcommand, calling `launchagent.Uninstall()`.
-  The new helper does not rely on that path for cleanup: it would be
-  unavailable with a missing bundle, and the current implementation ignores a
-  `launchctl bootout` error before removing the plist.
-- **A LaunchAgent is executable state, not user data.** Its plist uses both
-  `RunAtLoad` and `KeepAlive`, so leaving it installed after an uninstall would
-  either keep Heimdallm running or repeatedly try to launch a binary that no
-  longer exists. `uninstall-macos` therefore removes it even without `PURGE=1`.
-- **`make install-service` points at the checkout.** It embeds the absolute
-  `daemon/bin/heimdallm` path in the plist, not the copy inside
-  `/Applications`. An install/update must migrate an existing LaunchAgent to
-  the new bundle or the UI can keep talking to an older checkout daemon. The
-  Flutter startup health gate (`main.dart:119-121` and
-  `DaemonLifecycle.ensureRunning`) reuses any healthy daemon already listening
-  on port 7842.
-- **Privilege escalation must not cover user state.** LaunchAgent operations,
-  process discovery, `~/.config`, `~/.local/share`, and Keychain all belong to
-  the invoking user. Running the complete target through `sudo` changes the
-  effective UID and can address the wrong launchd domain or home directory.
+Several facts constrain the design:
+
+- `VERSION` names the next local release, so the installer uses `RELEASE`
+  (empty means latest).
+- Release DMGs are ad-hoc signed and have no published DMG checksum.
+- `make install-service` writes the checkout daemon path into a `KeepAlive`
+  LaunchAgent; an installed app must not continue serving that old daemon.
+- The UI and daemon names can collide on case-insensitive APFS, so identical
+  bundle executables are an unsafe, known corruption mode.
+- LaunchAgent state belongs to the invoking user. Running the target as root
+  selects the wrong home and launchd domain.
 
 ## Decision
 
-Add two thin public targets to the root `Makefile`, next to the Linux pair,
-reusing the existing `_check-macos` guard (`Makefile:233`):
+### Public interface and platform boundary
 
-- add `install-macos`, `uninstall-macos`, `test-install-macos`, and the existing
-  `_check-macos` guard to `.PHONY`;
-- `install-macos` exports `RELEASE` as a target-specific environment value and
-  invokes `scripts/macos-install.sh install`;
-- `uninstall-macos` exports `PURGE` the same way and invokes
-  `scripts/macos-install.sh uninstall`;
-- `test-install-macos` runs a small dependency-free shell harness over the
-  helper's pure validation/path/flag logic.
+Add these POSIX-shell-backed targets:
 
-The helper is POSIX shell and owns the transaction, traps, launchd state, and
-privilege boundary. Keeping that state machine in one normal script avoids
-Make's per-line subshells and double-dollar escaping, and lets the destructive
-paths be reviewed without Make escaping. This deliberately departs from
-`install-linux`'s inline recipe: the reviewed macOS flow coordinates an app
-bundle, a mounted volume, selective `sudo`, and a LaunchAgent, so symmetry is
-less valuable than auditable cleanup. Real launchd, mount, privilege, and swap
-behavior remains integration-tested on macOS rather than simulated in shell.
-
-Rejected alternatives: one large inline Make recipe (too fragile for the
-transaction and signal handling described below), and building locally with
-`package-macos` instead of downloading (slower, and the point of the request is
-to get a working app without a Flutter toolchain run).
-
-```
-make install-macos                  # latest release → /Applications
-make install-macos RELEASE=v0.7.5   # pinned release
-make uninstall-macos                # remove app + service; user state preserved
-make uninstall-macos PURGE=1        # permanently wipe config, history and logs
+```text
+make install-macos
+make install-macos RELEASE=v0.7.5
+make uninstall-macos
+make uninstall-macos PURGE=1
+make test-install-macos
 ```
 
-`/Applications` over `~/Applications`: it matches what `README.md:43` and
-`LLM-HOW-TO-INSTALL.md` already document, and it is writable without `sudo` for
-an admin user in the common case. The targets themselves must never be invoked
-as root. When `/Applications` needs elevation, the recipe uses `sudo` only for
-the narrowly scoped bundle staging, swap, `xattr`, and removal commands; all
-LaunchAgent and home-directory work remains under the invoking user.
+`install-macos` and `uninstall-macos` depend on `_check-macos-user`, which first
+depends on `_check-macos` and then rejects effective UID 0. The script repeats
+both guards, with the OS check as its first runtime action. This prerequisite
+is exclusive to install/uninstall: packaging and release targets retain their
+existing behavior.
 
-## Design
+The recipes invoke `scripts/macos-install.sh` directly. `RELEASE` and `PURGE`
+supplied on the make command line or inherited from the environment already
+reach recipe commands; neither variable is defined or exported globally.
+Linux install/uninstall recipes remain unchanged.
 
-### `install-macos`
+### Release and bundle integrity
 
-1. `_check-macos` — fail fast on Linux with a pointer to `install-linux`.
-   Reject effective UID 0 with a clear "run `make install-macos` without
-   sudo" message, and validate the invoking user's home/UID before resolving
-   any path.
-2. Snapshot the LaunchAgent state read-only: whether the plist exists, whether
-   the job is loaded (including its PID), and whether its label is disabled in
-   the user's launchd domain. Abort before downloading anything if inspection
-   fails or a loaded job has no plist and therefore cannot be reconstructed.
-   A loaded-and-disabled job is legitimate: `launchctl disable` persists the
-   flag without stopping an already-running process, so preserve that state for
-   the migration in step 14.
-3. Inspect port 7842 before downloading anything and classify its listener:
-   - a PID running either exact executable inside
-     `/Applications/Heimdallm.app` is bundle-owned;
-   - the PID captured from the known LaunchAgent is service-owned;
-   - anything else is a foreign daemon.
+The helper resolves latest release metadata without `gh` or `jq`, or accepts a
+safe `RELEASE` containing only letters, digits, `.`, `_`, and `-`. It downloads
+the exact `Heimdallm-<tag>.dmg` asset into a private temporary directory,
+verifies it, and mounts it read-only at a dedicated private mountpoint.
 
-   Known bundle/service listeners are expected and will be stopped later. A
-   foreign daemon normally does **not** block file installation: record its PID
-   and executable and print a prominent warning before and after install that
-   it must be stopped before opening the app. If an enabled, loaded LaunchAgent
-   must be restarted, however, abort here while the operation is still
-   read-only; restarting a `KeepAlive` job against an occupied port would cause
-   a failure loop.
-4. Resolve the tag: use `RELEASE` when set; otherwise `curl -fsSL` the
-   `releases/latest` endpoint and extract `tag_name` via `sed`. Fail if the
-   result is empty or contains characters outside the release-tag-safe set
-   (`A-Z`, `a-z`, digits, `.`, `_`, and `-`).
-5. Create a private `mktemp -d` containing the DMG and a dedicated empty mount
-   directory. The helper has separate idempotent `cleanup` and `rollback`
-   functions plus explicit success/transaction flags. `EXIT` performs cleanup
-   and rolls back only an armed, unsuccessful transaction. `HUP`, `INT`, and
-   `TERM` disable their own traps, run the same idempotent rollback/cleanup,
-   then terminate with the corresponding signal status; execution must never
-   resume after a signal handler. A successful commit disarms rollback before
-   normal `EXIT` cleanup runs.
-6. `curl -fL` the exact
-   `releases/download/<tag>/Heimdallm-<tag>.dmg` asset. A missing asset must
-   produce a clear "this release has no macOS DMG" message rather than a later
-   `hdiutil` failure.
-7. Run `hdiutil verify`, then attach read-only with
-   `hdiutil attach -readonly -nobrowse -quiet -mountpoint <private-mount>`.
-   The source is exactly `<private-mount>/Heimdallm.app`; never search global
-   `/Volumes`, where a stale mount from another release could be selected.
-8. Validate the source before touching the installed app:
-   - `Contents/MacOS/Heimdallm` and `Contents/MacOS/heimdalld` both exist and
-     are executable.
-   - `cmp -s` shows they differ — abort on identical binaries (fork-bomb state).
-   - `codesign --verify --deep --strict` succeeds. The signature is ad-hoc, so
-     this detects structural corruption but does not authenticate the publisher.
-9. Copy the validated bundle with macOS `ditto` to a unique staging path on
-   the `/Applications` filesystem, apply `xattr -cr` there, and re-run the
-   binary/signature guards against the staged copy. The current installed app
-   remains untouched throughout this step. If elevation is needed, request and
-   validate the sudo ticket with one interactive `sudo -v` immediately before
-   staging; this is the only operation allowed to prompt. All subsequent
-   transactional privileged commands use non-interactive `sudo -n` so a prompt
-   can never appear halfway through rollback. Never suggest
-   `sudo make install-macos`. Do not preserve UID/GID values from the DMG:
-   explicitly run `/usr/sbin/chown -R` on the exact staging path before the
-   swap, using `sudo -n` for `root:admin` when elevated or the invoking user's
-   UID and primary GID when unprivileged.
-10. If a plist was present, back up its exact contents and permissions. If its
-    job was loaded, `bootout`, verify it is absent, and wait up to six seconds
-    for the captured PID to exit. If that process remains alive, restore the
-    original plist but leave the job unloaded and abort; bootstrapping another
-    `KeepAlive` instance while the old process lingers is unsafe. Print the
-    exact manual bootstrap command to run after the captured PID has exited.
-11. Stop bundle-owned processes with one scoped pattern:
-   `^/Applications/Heimdallm[.]app/Contents/MacOS/(Heimdallm|heimdalld)([[:space:]]|$)`.
-   Anchoring at argv[0] avoids matching diagnostics that merely mention a
-   bundle path. Signal only the invoking user's real UID with
-   `pkill -TERM -U <uid> -f <pattern>`. This one expression covers both exact
-   executables; no second daemon-specific `pkill` is needed. Wait up to six
-   seconds, then use `KILL` with the same UID/pattern only as a last resort. If
-   a matching process owned by another user remains, abort rather than
-   replacing a shared bundle that another login session is using. Never use a
-   bare Heimdallm name, so a concurrent `make dev` survives.
-12. Recheck the port classification to catch a listener that appeared after
-    preflight. A newly foreign listener follows the same policy as step 3:
-    record-and-warn when no service must be restarted. When an enabled
-    LaunchAgent was loaded, restore its original plist but deliberately leave
-    the job unloaded, then abort before swap; re-bootstrapping it against the
-    now-occupied port would create the `KeepAlive` loop preflight was designed
-    to prevent. Print the exact manual bootstrap command to run after port 7842
-    is free. This second check is only a race guard; predictable conflicts were
-    handled before download or mutation.
-13. Swap on the same filesystem: move the current bundle to a unique backup,
-    move the staged bundle to `/Applications/Heimdallm.app`, and keep the
-    backup until all remaining checks pass. Rollback first attempts to restore
-    the old bundle and service using the prevalidated `sudo -n` ticket. If that
-    recovery itself fails, never delete the backup: exit non-zero and print its
-    exact path plus explicit manual recovery commands. Do not claim success or
-    claim that rollback completed when it did not. Safety overrides exact state
-    restoration while a foreign listener owns port 7842 or the original daemon
-    has not exited: restore the plist but leave the job unloaded until the
-    process/port conflict is gone.
-14. Migrate a pre-existing plist according to its original state:
-    - **Loaded and enabled (normal `make install-service` case):** invoke
-      `/Applications/Heimdallm.app/Contents/MacOS/heimdalld install` as the
-      invoking user. `os.Executable()` regenerates the canonical plist pointing
-      at the installed daemon and bootstraps it. Verify the new path and loaded
-      PID.
-    - **Unloaded or disabled:** use system `/usr/bin/plutil` to replace only
-      `ProgramArguments[0]` (`-replace ProgramArguments.0 -string`), restore the
-      original plist permissions and persistent disabled flag, and do not
-      bootstrap it. This includes a job that was both loaded and disabled:
-      step 10 boots it out, this branch migrates its plist, and the job remains
-      disabled and unloaded.
+Before download, runtime output states that the DMG has no published checksum
+and uses an ad-hoc signature. `hdiutil verify` and
+`codesign --verify --deep --strict` detect structural corruption; they do not
+authenticate the publisher.
 
-    If a foreign listener appeared before restarting the normal loaded case,
-    roll back and abort rather than starting a `KeepAlive` failure loop.
-    Restore the original plist but leave it unloaded, and print the manual
-    bootstrap command. Any other migration failure arms restoration of both the
-    old bundle and exact original plist/job state.
-15. Remove the app/service backups, detach the private mount, and print the
-    installed tag, the launch hint (`open -a Heimdallm`), and a note that
-    config, history, logs, and the Keychain credential are untouched. Repeat
-    the recorded foreign-daemon warning, including PID/executable and the
-    instruction to stop it before opening Heimdallm.
+Both source and staged bundles must be real directories, not symlinks. Their
+UI and daemon executables must be real, executable, and different files.
+Staging uses `ditto` on the `/Applications` filesystem, clears quarantine with
+`xattr -cr`, and repeats all validation before any installed bundle is moved.
 
-### `uninstall-macos`
+### LaunchAgent and port preflight
 
-1. `_check-macos`, reject effective UID 0, and resolve the invoking user's
-   absolute home and UID once. Refuse to continue if the home is empty, not
-   absolute, or `/`.
-2. Remove the LaunchAgent on every uninstall, before signaling processes.
-   Address the known `gui/<uid>/com.heimdallm.daemon` job and
-   `~/Library/LaunchAgents/com.heimdallm.daemon.plist` directly, so cleanup does
-   not depend on an intact bundle. Capture its PID when loaded, `bootout`,
-   verify the job is absent, wait up to six seconds for that PID to exit, and
-   only then remove the plist. Already-missing job/plist is success; a job or
-   process that remains alive is an error and aborts the uninstall.
-3. Stop bundle-owned UI and daemon processes with the same single
-   exact-executable pattern, invoking-user UID restriction, and bounded
-   TERM→wait→KILL sequence used by install. If another user's matching process
-   remains, abort. Verify that no match remains before removing the bundle.
-4. Clean `~/.local/share/heimdallm/ui.pid` when it is stale or belongs to the
-   installed UI. If it names a live Heimdallm UI outside `/Applications`
-   (for example `flutter run`), preserve it and print a warning instead of
-   breaking that session's single-instance tracking during a normal uninstall;
-   with `PURGE=1`, abort before deleting any user data because the purge would
-   remove that live development session's data directory.
-5. Remove `/Applications/Heimdallm.app`, elevating only this exact operation
-   when required. Running `sudo make uninstall-macos` is unsupported.
-6. Without `PURGE=1`, preserve and print the config, data/history, logs, and
-   Keychain credential locations. The LaunchAgent is still removed because it
-   is executable/autostart state, not user data.
-7. With `PURGE=1`:
-   - Print an explicit warning before deletion:
-     **"PURGE=1 permanently deletes the Heimdallm database and all review
-     history; this cannot be undone."**
-   - Verify the LaunchAgent and bundle processes are gone.
-   - If `~/.local/share/heimdallm/heimdallm.db` exists, inspect that exact file
-     with system `/usr/sbin/lsof`. A live daemon holds the main SQLite file even
-     when WAL mode is active. Abort if it is open. Fail closed if `lsof` is
-     unavailable or cannot inspect the file; only its documented "no open
-     handles" result permits deletion. Avoid `lsof +D`, which is slower and can
-     fail on unrelated files below the data directory.
-   - Remove exactly `~/.config/heimdallm`, `~/.local/share/heimdallm`, and
-     `~/Library/Logs/heimdallm`, without `sudo`.
-   - Do not follow `HEIMDALLM_CONFIG_PATH` or `HEIMDALLM_DATA_DIR` to arbitrary
-     locations. State that custom override paths are outside the purge contract.
-   - Preserve the macOS Keychain item (`service=heimdallm`,
-     `account=github-token`) to match the external credential-store behavior on
-     Linux. Print this explicitly and provide
-     `security delete-generic-password -s heimdallm -a github-token` for users
-     who also want to remove the local credential.
+Preflight is read-only. It snapshots plist presence/content/mode, loaded PID,
+and persistent disabled state. Loaded-and-disabled is valid. Inspection errors,
+or a loaded job without a reconstructable plist, abort before download.
 
-Both modes are idempotent on a never-installed machine and recover cleanly from
-partial state such as "bundle absent, plist present".
+Port 7842 is classified as:
 
-### Authenticity and integrity
+- `free`;
+- `bundle`, for either exact executable in the installed app;
+- `service`, for the captured LaunchAgent PID; or
+- `foreign`, for everything else.
 
-The release has no published checksum covering the DMG, and its ad-hoc
-signature carries no trusted Developer ID identity. `hdiutil verify` and
-`codesign --verify` detect accidental container/bundle corruption, but neither
-authenticates the publisher; provenance is still trusted through GitHub HTTPS.
-Publishing a DMG checksum and using a Developer ID/notarization flow are release
-pipeline changes deliberately out of scope. The limitation remains recorded in
-#604 so these structural checks are not mistaken for authenticity guarantees.
+This matrix is the authoritative preflight policy and the pure-test oracle.
+The two inconsistent `service` cells are defensive states:
 
-### Documentation
+| LaunchAgent | Free | Bundle | Service | Foreign |
+|---|---|---|---|---|
+| Absent | proceed | stop bundle | abort | warn |
+| Present, unloaded | migrate unloaded | stop + migrate | abort | warn + migrate |
+| Loaded, enabled | restart | stop + restart | restart | abort |
+| Loaded, disabled | migrate disabled | stop + migrate | migrate disabled | warn + migrate |
 
-`README.md` and `LLM-HOW-TO-INSTALL.md` lead with the target and keep the
-manual commands as the fallback for machines without a checkout. They also
-state:
+A foreign listener does not prevent copying files unless a loaded/enabled
+service must restart; otherwise it is reported before and after install. A
+second classification immediately before swap closes the preflight race and
+may fail more strictly, but cannot reinterpret the table silently.
 
-- run the Make targets as the normal user, never through `sudo`;
-- an existing LaunchAgent is migrated on install and removed on uninstall;
-- normal uninstall preserves config, history, logs, and Keychain;
-- `PURGE=1` irreversibly removes all review history at the three canonical
-  desktop paths, but preserves Keychain and ignores custom path overrides.
+### Privileges, transaction, and rollback
 
-## Testing
+All LaunchAgent, process-discovery, and home-directory operations run as the
+invoking user. If `/Applications` requires elevation, one interactive
+`sudo -v` is allowed immediately before staging. Every later privileged
+staging, ownership, swap, cleanup, and rollback command uses `sudo -n`.
+There is no second interactive refresh: scoped sudo commands renew the normal
+timestamp, while expiration remains a fail-closed rollback condition.
 
-### Automated pure-logic checks
+Staged ownership is explicit: `root:admin` for an elevated install, otherwise
+the invoking UID and primary GID. The current bundle is moved to a same-filesystem
+backup, then staging is renamed into place. The backup survives until bundle
+and LaunchAgent checks succeed.
 
-Add `scripts/test-macos-install.sh`, invoked by `make test-install-macos`. Keep
-it deliberately small: `sh -n` plus unit checks for release-tag validation,
-exact `PURGE=1` parsing, safe canonical-path construction, listener
-classification from supplied PID/path facts, and idempotent cleanup state when
-no external resource is armed.
+Cleanup and rollback are separate, idempotent functions driven by explicit
+intent/completion flags plus filesystem evidence for signal windows. `EXIT`,
+`HUP`, `INT`, and `TERM` cannot resume the transaction after handling. Commit
+disarms rollback. If privileged restoration fails, backups are preserved and
+the exact manual recovery commands are printed; success or complete rollback
+is never claimed falsely. A lingering process or foreign port may force the
+restored plist to remain unloaded for safety.
 
-Do not stub a successful `hdiutil`, `launchctl`, `sudo`, process signal, or
-filesystem swap. Such tests would mostly assert that the implementation calls
-the commands encoded in the test while missing the behavior that makes an
-installer risky. Those integrations are exercised with the real macOS tools.
+Only exact installed executables are stopped, for the invoking UID, with one
+anchored UI/daemon pattern. Shutdown is TERM, up to six seconds of waiting,
+then KILL as a last resort. Checkout/dev processes and other users are never
+killed implicitly.
 
-### Required macOS verification
+### LaunchAgent migration
 
-Record these five scenarios in the PR:
+An uninstall always removes the LaunchAgent because `RunAtLoad` + `KeepAlive`
+is executable state, not user data. Cleanup addresses the exact launchctl label
+and plist directly rather than relying on a still-present daemon binary.
 
-1. **Clean install.** No prior bundle or LaunchAgent. Confirm the release
-   version, distinct executables, signature check, expected ownership, launch,
-   `/health`, and mount/temp cleanup.
-2. **Reinstall while running.** Start the installed UI and bundle daemon, then
-   reinstall. Confirm the single UID-scoped process pattern stops both,
-   staging/swap succeeds, user state is preserved, and the replacement launches.
-3. **LaunchAgent migration.** Start with `make install-service`, then install.
-   Confirm preflight classifies the listener as known, the bundled
-   `heimdalld install` path regenerates the plist under `/Applications`, and the
-   loaded service runs the installed version.
-4. **Normal uninstall preserves history.** Seed a review row plus config/log/
-   Keychain sentinels. Confirm app and LaunchAgent disappear while the review
-   remains queryable and all user-state sentinels remain.
-5. **Purge guard and purge.** With a development daemon outside the installed
-   bundle/LaunchAgent holding `heimdallm.db`, confirm `PURGE=1` stops the known
-   installed components but aborts before deleting any user state. Stop the
-   development daemon and rerun; confirm the irreversible warning, removal of
-   the three canonical directories, and preservation of Keychain/custom
-   override paths.
+Install preserves the original state:
 
-### Optional macOS edge checklist
+- Loaded and enabled: run the bundled `heimdalld install`, which regenerates
+  the canonical plist and therefore discards manual plist edits. Require a
+  stable loaded PID at the installed path, listening on port 7842, within
+  60 seconds; otherwise restore the prior bundle and service state.
+- Unloaded or disabled: replace only `ProgramArguments[0]` with `plutil`,
+  preserve other keys/mode/disabled flag, and do not bootstrap. A previously
+  loaded-and-disabled job ends disabled and unloaded.
 
-Exercise when the implementation or environment touches the relevant path:
+### Uninstall and purge
 
-- pinned/invalid/missing/truncated releases and the identical-binary guard;
-- a forced swap or migration failure, including manual recovery output if
-  privileged rollback cannot complete;
-- non-writable `/Applications`, root invocation rejection, and ownership in
-  both privileged and unprivileged installs;
-- a foreign `make dev-daemon` listener: installation succeeds without killing
-  it and prints the warning before and after;
-- unloaded/disabled plist migration via `plutil`;
-- partial states (bundle/plist/job independently absent), another user's
-  bundle process, stale versus live-development `ui.pid`, repeated uninstall,
-  and values other than exact `PURGE=1`.
+Empty `PURGE` means normal uninstall; exact `PURGE=1` requests deletion. Every
+other non-empty value aborts before the LaunchAgent, processes, app, or user
+data is changed.
 
-### Linux non-regression gate
+Normal uninstall unloads/removes the LaunchAgent, stops exact installed
+processes, removes the app, and preserves config, review history, logs, custom
+paths, and the Keychain credential. A stale/installed `ui.pid` is removed; a
+live development UI's PID tracking is preserved.
 
-This feature is macOS-only, but the Makefile change must remain additive:
+For `PURGE=1`, print the irreversible review-history warning before a read-only
+preflight. The preflight:
 
-- do not change the recipes or variables used by `install-linux` and
-  `uninstall-linux`;
-- keep `RELEASE` and `PURGE` target-specific so they do not leak into other
-  targets;
-- run no `hdiutil`, `launchctl`, `codesign`, `ditto`, macOS `pkill`, or `lsof`
-  command at Make parse time;
-- keep `_check-macos` as the Make prerequisite and repeat the `uname -s` guard
-  as the helper's first executable check, so direct script invocation is also
-  harmless on Linux.
+- allows holders proven to be the installed bundle or captured LaunchAgent,
+  because teardown owns them;
+- rejects a live foreign `ui.pid` or foreign holder of the exact SQLite file;
+- fails closed on ambiguous ownership or inspection errors; and
+- makes no launchd, process, app, plist, or data mutation.
 
-Run the following on a Linux runner/container before merge:
+After known components are removed, a late strict `lsof` check of
+`~/.local/share/heimdallm/heimdallm.db` permits no holder; this is the race
+guard before deletion. It does not use slow/broad `lsof +D`.
 
-1. `sh -n scripts/macos-install.sh && sh -n scripts/test-macos-install.sh`.
-2. `make test-install-macos` — pure logic only, no macOS integration.
-3. `make -n install-linux` and `make -n uninstall-linux` — both existing recipes
-   still parse unchanged.
-4. Execute `make install-macos` and `make uninstall-macos` and assert that both
-   fail at `_check-macos`, before invoking the helper or changing any file.
-5. `make test-docker`, as required by `AGENTS.md`; never run daemon `go test`
-   directly on the host.
+Purge removes exactly these canonical paths, without sudo:
+
+- `~/.config/heimdallm`
+- `~/.local/share/heimdallm`
+- `~/Library/Logs/heimdallm`
+
+It never follows `HEIMDALLM_CONFIG_PATH` or `HEIMDALLM_DATA_DIR`. The Keychain
+item (`heimdallm` / `github-token`) is preserved and its explicit `security
+delete-generic-password` command is printed. Both uninstall modes are
+idempotent across absent/partial bundle, plist, and job states.
+
+## Consequences
+
+- The installed bundle is swapped transactionally rather than overwritten.
+- A normal uninstall cannot leave launchd retrying a missing executable.
+- Purge matches Linux data-directory semantics while preserving the external
+  credential store.
+- Authenticity still depends on GitHub HTTPS. Publishing a DMG checksum and
+  Developer ID/notarization are separate release-pipeline work.
+- The manual DMG fallback remains available, but it cannot migrate an existing
+  LaunchAgent and must document the same six-second TERM→KILL grace period.
+
+## Verification
+
+### Automated
+
+`make test-install-macos` performs shell syntax checks and dependency-free pure
+tests for release/PURGE validation, canonical paths, listener classification,
+all 16 matrix cells, rollback-required decisions, unarmed/armed/idempotent
+cleanup, and known-versus-foreign purge-holder decisions. It does not fake
+successful `hdiutil`, launchd, sudo, process signals, or filesystem swaps.
+
+Linux CI additionally:
+
+1. asserts both scripts are executable and exercises their shebangs;
+2. dry-runs unchanged Linux install/uninstall recipes;
+3. checks Make targets fail at the macOS guard with explicit diagnostics;
+4. checks direct helper operations fail at their Linux guard with diagnostics.
+
+The existing daemon, CLI, and Flutter CI jobs remain unchanged. On an
+EDR-protected development machine, the local daemon gate is `make test-docker`
+as required by `AGENTS.md`; GitHub's macOS runner may run its existing native
+Go test job.
+
+### Required macOS scenarios
+
+1. Clean install: integrity, ownership, launch/health, and temp/mount cleanup.
+2. Reinstall while UI/daemon run: scoped shutdown, swap, preserved user state.
+3. LaunchAgent migration: checkout service becomes the installed 60-second-
+   readiness-verified service.
+4. Normal uninstall: app/service gone; database/config/log/Keychain preserved.
+5. Purge: a foreign development DB holder aborts read-only; after it stops,
+   known holders are torn down, the late DB guard passes, canonical data is
+   removed, and Keychain/custom paths remain.
+
+Optional edge checks cover invalid/missing releases, identical binaries,
+forced rollback failure, writable/non-writable `/Applications`, root rejection,
+foreign listeners, unloaded/disabled plist migration, partial states,
+other-user processes, `ui.pid`, repeated uninstall, and invalid `PURGE`.

--- a/docs/superpowers/specs/2026-07-29-install-macos-target-design.md
+++ b/docs/superpowers/specs/2026-07-29-install-macos-target-design.md
@@ -2,7 +2,9 @@
 
 **Date:** 2026-07-29
 **Issue:** [#604 — feat(makefile): add install-macos / uninstall-macos targets](https://github.com/theburrowhub/heimdallm/issues/604)
-**Status:** Approved
+**Status:** Approved after review
+**Revision:** 2026-07-29 — hardened LaunchAgent teardown, port preflight,
+privilege boundaries, rollback/purge safety, and Linux non-regression.
 
 ## Problem
 
@@ -40,92 +42,341 @@ a development loop, not an installation.
   (`Makefile:605-608`) and `LLM-HOW-TO-INSTALL.md` repeats the check.
 - **The daemon can uninstall its own LaunchAgent.** `daemon/cmd/heimdallm/main.go:84`
   handles the `uninstall` subcommand, calling `launchagent.Uninstall()`.
+  The new helper does not rely on that path for cleanup: it would be
+  unavailable with a missing bundle, and the current implementation ignores a
+  `launchctl bootout` error before removing the plist.
+- **A LaunchAgent is executable state, not user data.** Its plist uses both
+  `RunAtLoad` and `KeepAlive`, so leaving it installed after an uninstall would
+  either keep Heimdallm running or repeatedly try to launch a binary that no
+  longer exists. `uninstall-macos` therefore removes it even without `PURGE=1`.
+- **`make install-service` points at the checkout.** It embeds the absolute
+  `daemon/bin/heimdallm` path in the plist, not the copy inside
+  `/Applications`. An install/update must migrate an existing LaunchAgent to
+  the new bundle or the UI can keep talking to an older checkout daemon. The
+  Flutter startup health gate (`main.dart:119-121` and
+  `DaemonLifecycle.ensureRunning`) reuses any healthy daemon already listening
+  on port 7842.
+- **Privilege escalation must not cover user state.** LaunchAgent operations,
+  process discovery, `~/.config`, `~/.local/share`, and Keychain all belong to
+  the invoking user. Running the complete target through `sudo` changes the
+  effective UID and can address the wrong launchd domain or home directory.
 
 ## Decision
 
-Add two inline recipes to the root `Makefile`, next to the Linux pair, reusing
-the existing `_check-macos` guard (`Makefile:233`).
+Add two thin public targets to the root `Makefile`, next to the Linux pair,
+reusing the existing `_check-macos` guard (`Makefile:233`):
 
-Rejected alternatives: a `scripts/install-macos.sh` (breaks symmetry with
-`install-linux`, which is inline, and splits install logic across two places),
-and building locally with `package-macos` instead of downloading (slower, and
-the point of the request is to get a working app without a Flutter toolchain
-run).
+- add `install-macos`, `uninstall-macos`, `test-install-macos`, and the existing
+  `_check-macos` guard to `.PHONY`;
+- `install-macos` exports `RELEASE` as a target-specific environment value and
+  invokes `scripts/macos-install.sh install`;
+- `uninstall-macos` exports `PURGE` the same way and invokes
+  `scripts/macos-install.sh uninstall`;
+- `test-install-macos` runs a small dependency-free shell harness over the
+  helper's pure validation/path/flag logic.
+
+The helper is POSIX shell and owns the transaction, traps, launchd state, and
+privilege boundary. Keeping that state machine in one normal script avoids
+Make's per-line subshells and double-dollar escaping, and lets the destructive
+paths be reviewed without Make escaping. This deliberately departs from
+`install-linux`'s inline recipe: the reviewed macOS flow coordinates an app
+bundle, a mounted volume, selective `sudo`, and a LaunchAgent, so symmetry is
+less valuable than auditable cleanup. Real launchd, mount, privilege, and swap
+behavior remains integration-tested on macOS rather than simulated in shell.
+
+Rejected alternatives: one large inline Make recipe (too fragile for the
+transaction and signal handling described below), and building locally with
+`package-macos` instead of downloading (slower, and the point of the request is
+to get a working app without a Flutter toolchain run).
 
 ```
 make install-macos                  # latest release → /Applications
 make install-macos RELEASE=v0.7.5   # pinned release
-make uninstall-macos                # remove app; config and data preserved
-make uninstall-macos PURGE=1        # also wipe config, data and logs
+make uninstall-macos                # remove app + service; user state preserved
+make uninstall-macos PURGE=1        # permanently wipe config, history and logs
 ```
 
 `/Applications` over `~/Applications`: it matches what `README.md:43` and
 `LLM-HOW-TO-INSTALL.md` already document, and it is writable without `sudo` for
-an admin user, which is the normal case on a personal Mac.
+an admin user in the common case. The targets themselves must never be invoked
+as root. When `/Applications` needs elevation, the recipe uses `sudo` only for
+the narrowly scoped bundle staging, swap, `xattr`, and removal commands; all
+LaunchAgent and home-directory work remains under the invoking user.
 
 ## Design
 
 ### `install-macos`
 
 1. `_check-macos` — fail fast on Linux with a pointer to `install-linux`.
-2. Resolve the tag: use `RELEASE` when set; otherwise `curl -fsSL` the
-   `releases/latest` endpoint and extract `tag_name` via `sed`. Fail with an
-   explicit message if resolution yields nothing.
-3. `mktemp -d`, and install a `trap` that runs `hdiutil detach` (if mounted)
-   and `rm -rf` the temp dir on every exit path.
-4. `curl -fL` the `Heimdallm-<tag>.dmg` asset. A missing asset must produce a
-   clear "this release has no macOS DMG" message rather than a `hdiutil` error.
-5. `hdiutil attach -nobrowse -quiet`, then locate `Heimdallm.app` inside the
-   mounted volume.
-6. Validate before touching `/Applications`:
-   - `Contents/MacOS/Heimdallm` and `Contents/MacOS/heimdalld` both exist.
+   Reject effective UID 0 with a clear "run `make install-macos` without
+   sudo" message, and validate the invoking user's home/UID before resolving
+   any path.
+2. Snapshot the LaunchAgent state read-only: whether the plist exists, whether
+   the job is loaded (including its PID), and whether its label is disabled in
+   the user's launchd domain. Abort before downloading anything if inspection
+   fails or a loaded job has no plist and therefore cannot be reconstructed.
+   A loaded-and-disabled job is legitimate: `launchctl disable` persists the
+   flag without stopping an already-running process, so preserve that state for
+   the migration in step 14.
+3. Inspect port 7842 before downloading anything and classify its listener:
+   - a PID running either exact executable inside
+     `/Applications/Heimdallm.app` is bundle-owned;
+   - the PID captured from the known LaunchAgent is service-owned;
+   - anything else is a foreign daemon.
+
+   Known bundle/service listeners are expected and will be stopped later. A
+   foreign daemon normally does **not** block file installation: record its PID
+   and executable and print a prominent warning before and after install that
+   it must be stopped before opening the app. If an enabled, loaded LaunchAgent
+   must be restarted, however, abort here while the operation is still
+   read-only; restarting a `KeepAlive` job against an occupied port would cause
+   a failure loop.
+4. Resolve the tag: use `RELEASE` when set; otherwise `curl -fsSL` the
+   `releases/latest` endpoint and extract `tag_name` via `sed`. Fail if the
+   result is empty or contains characters outside the release-tag-safe set
+   (`A-Z`, `a-z`, digits, `.`, `_`, and `-`).
+5. Create a private `mktemp -d` containing the DMG and a dedicated empty mount
+   directory. The helper has separate idempotent `cleanup` and `rollback`
+   functions plus explicit success/transaction flags. `EXIT` performs cleanup
+   and rolls back only an armed, unsuccessful transaction. `HUP`, `INT`, and
+   `TERM` disable their own traps, run the same idempotent rollback/cleanup,
+   then terminate with the corresponding signal status; execution must never
+   resume after a signal handler. A successful commit disarms rollback before
+   normal `EXIT` cleanup runs.
+6. `curl -fL` the exact
+   `releases/download/<tag>/Heimdallm-<tag>.dmg` asset. A missing asset must
+   produce a clear "this release has no macOS DMG" message rather than a later
+   `hdiutil` failure.
+7. Run `hdiutil verify`, then attach read-only with
+   `hdiutil attach -readonly -nobrowse -quiet -mountpoint <private-mount>`.
+   The source is exactly `<private-mount>/Heimdallm.app`; never search global
+   `/Volumes`, where a stale mount from another release could be selected.
+8. Validate the source before touching the installed app:
+   - `Contents/MacOS/Heimdallm` and `Contents/MacOS/heimdalld` both exist and
+     are executable.
    - `cmp -s` shows they differ — abort on identical binaries (fork-bomb state).
-7. Stop running instances: `pkill -f "/Applications/Heimdallm.app"`, which
-   covers both the Flutter binary and the `heimdalld` it spawned (the daemon is
-   always launched by absolute path from inside the bundle, see
-   `DaemonLifecycle.defaultBinaryPath`). Scoped to the install path, never a bare
-   `pkill -f heimdallm`, so a concurrent `make dev` survives — the same
-   reasoning documented in `uninstall-linux` (`Makefile:691-705`).
-8. `rm -rf /Applications/Heimdallm.app` then `cp -R` from the volume.
-   If `/Applications` is not writable, say so and suggest `sudo make install-macos`.
-9. `xattr -cr /Applications/Heimdallm.app`.
-10. Print the installed tag, the launch hint (`open -a Heimdallm`), and a note
-    that `~/.config/heimdallm` and `~/.local/share/heimdallm` are untouched —
-    the app picks up the existing database and config, sandbox being disabled
-    (`flutter_app/macos/Runner/Release.entitlements`).
+   - `codesign --verify --deep --strict` succeeds. The signature is ad-hoc, so
+     this detects structural corruption but does not authenticate the publisher.
+9. Copy the validated bundle with macOS `ditto` to a unique staging path on
+   the `/Applications` filesystem, apply `xattr -cr` there, and re-run the
+   binary/signature guards against the staged copy. The current installed app
+   remains untouched throughout this step. If elevation is needed, request and
+   validate the sudo ticket with one interactive `sudo -v` immediately before
+   staging; this is the only operation allowed to prompt. All subsequent
+   transactional privileged commands use non-interactive `sudo -n` so a prompt
+   can never appear halfway through rollback. Never suggest
+   `sudo make install-macos`. Do not preserve UID/GID values from the DMG:
+   explicitly run `/usr/sbin/chown -R` on the exact staging path before the
+   swap, using `sudo -n` for `root:admin` when elevated or the invoking user's
+   UID and primary GID when unprivileged.
+10. If a plist was present, back up its exact contents and permissions. If its
+    job was loaded, `bootout`, verify it is absent, and wait up to six seconds
+    for the captured PID to exit. If that process remains alive, restore the
+    original plist but leave the job unloaded and abort; bootstrapping another
+    `KeepAlive` instance while the old process lingers is unsafe. Print the
+    exact manual bootstrap command to run after the captured PID has exited.
+11. Stop bundle-owned processes with one scoped pattern:
+   `^/Applications/Heimdallm[.]app/Contents/MacOS/(Heimdallm|heimdalld)([[:space:]]|$)`.
+   Anchoring at argv[0] avoids matching diagnostics that merely mention a
+   bundle path. Signal only the invoking user's real UID with
+   `pkill -TERM -U <uid> -f <pattern>`. This one expression covers both exact
+   executables; no second daemon-specific `pkill` is needed. Wait up to six
+   seconds, then use `KILL` with the same UID/pattern only as a last resort. If
+   a matching process owned by another user remains, abort rather than
+   replacing a shared bundle that another login session is using. Never use a
+   bare Heimdallm name, so a concurrent `make dev` survives.
+12. Recheck the port classification to catch a listener that appeared after
+    preflight. A newly foreign listener follows the same policy as step 3:
+    record-and-warn when no service must be restarted. When an enabled
+    LaunchAgent was loaded, restore its original plist but deliberately leave
+    the job unloaded, then abort before swap; re-bootstrapping it against the
+    now-occupied port would create the `KeepAlive` loop preflight was designed
+    to prevent. Print the exact manual bootstrap command to run after port 7842
+    is free. This second check is only a race guard; predictable conflicts were
+    handled before download or mutation.
+13. Swap on the same filesystem: move the current bundle to a unique backup,
+    move the staged bundle to `/Applications/Heimdallm.app`, and keep the
+    backup until all remaining checks pass. Rollback first attempts to restore
+    the old bundle and service using the prevalidated `sudo -n` ticket. If that
+    recovery itself fails, never delete the backup: exit non-zero and print its
+    exact path plus explicit manual recovery commands. Do not claim success or
+    claim that rollback completed when it did not. Safety overrides exact state
+    restoration while a foreign listener owns port 7842 or the original daemon
+    has not exited: restore the plist but leave the job unloaded until the
+    process/port conflict is gone.
+14. Migrate a pre-existing plist according to its original state:
+    - **Loaded and enabled (normal `make install-service` case):** invoke
+      `/Applications/Heimdallm.app/Contents/MacOS/heimdalld install` as the
+      invoking user. `os.Executable()` regenerates the canonical plist pointing
+      at the installed daemon and bootstraps it. Verify the new path and loaded
+      PID.
+    - **Unloaded or disabled:** use system `/usr/bin/plutil` to replace only
+      `ProgramArguments[0]` (`-replace ProgramArguments.0 -string`), restore the
+      original plist permissions and persistent disabled flag, and do not
+      bootstrap it. This includes a job that was both loaded and disabled:
+      step 10 boots it out, this branch migrates its plist, and the job remains
+      disabled and unloaded.
+
+    If a foreign listener appeared before restarting the normal loaded case,
+    roll back and abort rather than starting a `KeepAlive` failure loop.
+    Restore the original plist but leave it unloaded, and print the manual
+    bootstrap command. Any other migration failure arms restoration of both the
+    old bundle and exact original plist/job state.
+15. Remove the app/service backups, detach the private mount, and print the
+    installed tag, the launch hint (`open -a Heimdallm`), and a note that
+    config, history, logs, and the Keychain credential are untouched. Repeat
+    the recorded foreign-daemon warning, including PID/executable and the
+    instruction to stop it before opening Heimdallm.
 
 ### `uninstall-macos`
 
-1. `_check-macos`.
-2. `pkill -f` the app and daemon paths, best-effort.
-3. If `/Applications/Heimdallm.app/Contents/MacOS/heimdalld` exists, run it with
-   `uninstall` to unload and remove the LaunchAgent — **before** deleting the
-   bundle, since the binary is inside it.
-4. `rm -rf /Applications/Heimdallm.app`.
-5. `PURGE=1` additionally removes `~/.config/heimdallm`,
-   `~/.local/share/heimdallm` and `~/Library/Logs/heimdallm`. Default keeps
-   them and prints where they live, mirroring `uninstall-linux`.
+1. `_check-macos`, reject effective UID 0, and resolve the invoking user's
+   absolute home and UID once. Refuse to continue if the home is empty, not
+   absolute, or `/`.
+2. Remove the LaunchAgent on every uninstall, before signaling processes.
+   Address the known `gui/<uid>/com.heimdallm.daemon` job and
+   `~/Library/LaunchAgents/com.heimdallm.daemon.plist` directly, so cleanup does
+   not depend on an intact bundle. Capture its PID when loaded, `bootout`,
+   verify the job is absent, wait up to six seconds for that PID to exit, and
+   only then remove the plist. Already-missing job/plist is success; a job or
+   process that remains alive is an error and aborts the uninstall.
+3. Stop bundle-owned UI and daemon processes with the same single
+   exact-executable pattern, invoking-user UID restriction, and bounded
+   TERM→wait→KILL sequence used by install. If another user's matching process
+   remains, abort. Verify that no match remains before removing the bundle.
+4. Clean `~/.local/share/heimdallm/ui.pid` when it is stale or belongs to the
+   installed UI. If it names a live Heimdallm UI outside `/Applications`
+   (for example `flutter run`), preserve it and print a warning instead of
+   breaking that session's single-instance tracking during a normal uninstall;
+   with `PURGE=1`, abort before deleting any user data because the purge would
+   remove that live development session's data directory.
+5. Remove `/Applications/Heimdallm.app`, elevating only this exact operation
+   when required. Running `sudo make uninstall-macos` is unsupported.
+6. Without `PURGE=1`, preserve and print the config, data/history, logs, and
+   Keychain credential locations. The LaunchAgent is still removed because it
+   is executable/autostart state, not user data.
+7. With `PURGE=1`:
+   - Print an explicit warning before deletion:
+     **"PURGE=1 permanently deletes the Heimdallm database and all review
+     history; this cannot be undone."**
+   - Verify the LaunchAgent and bundle processes are gone.
+   - If `~/.local/share/heimdallm/heimdallm.db` exists, inspect that exact file
+     with system `/usr/sbin/lsof`. A live daemon holds the main SQLite file even
+     when WAL mode is active. Abort if it is open. Fail closed if `lsof` is
+     unavailable or cannot inspect the file; only its documented "no open
+     handles" result permits deletion. Avoid `lsof +D`, which is slower and can
+     fail on unrelated files below the data directory.
+   - Remove exactly `~/.config/heimdallm`, `~/.local/share/heimdallm`, and
+     `~/Library/Logs/heimdallm`, without `sudo`.
+   - Do not follow `HEIMDALLM_CONFIG_PATH` or `HEIMDALLM_DATA_DIR` to arbitrary
+     locations. State that custom override paths are outside the purge contract.
+   - Preserve the macOS Keychain item (`service=heimdallm`,
+     `account=github-token`) to match the external credential-store behavior on
+     Linux. Print this explicitly and provide
+     `security delete-generic-password -s heimdallm -a github-token` for users
+     who also want to remove the local credential.
 
-### Integrity
+Both modes are idempotent on a never-installed machine and recover cleanly from
+partial state such as "bundle absent, plist present".
 
-The download is trusted on HTTPS alone. Publishing a DMG checksum is a change
-to the release pipeline and is deliberately out of scope; the limitation is
-recorded in #604 so it is not mistaken for an oversight.
+### Authenticity and integrity
+
+The release has no published checksum covering the DMG, and its ad-hoc
+signature carries no trusted Developer ID identity. `hdiutil verify` and
+`codesign --verify` detect accidental container/bundle corruption, but neither
+authenticates the publisher; provenance is still trusted through GitHub HTTPS.
+Publishing a DMG checksum and using a Developer ID/notarization flow are release
+pipeline changes deliberately out of scope. The limitation remains recorded in
+#604 so these structural checks are not mistaken for authenticity guarantees.
 
 ### Documentation
 
 `README.md` and `LLM-HOW-TO-INSTALL.md` lead with the target and keep the
-manual commands as the fallback for machines without a checkout.
+manual commands as the fallback for machines without a checkout. They also
+state:
+
+- run the Make targets as the normal user, never through `sudo`;
+- an existing LaunchAgent is migrated on install and removed on uninstall;
+- normal uninstall preserves config, history, logs, and Keychain;
+- `PURGE=1` irreversibly removes all review history at the three canonical
+  desktop paths, but preserves Keychain and ignores custom path overrides.
 
 ## Testing
 
-The `Makefile` has no automated coverage and this change does not introduce a
-framework for it. Verification is manual and recorded in the PR:
+### Automated pure-logic checks
 
-1. `make -n install-macos` — inspect the expanded recipe.
-2. `make install-macos` on a clean `/Applications` — app launches, version
-   matches the release, existing repos and config still present.
-3. `make install-macos RELEASE=v0.7.5` — pinned download works.
-4. `make uninstall-macos` — app gone, config and data intact.
-5. `make uninstall-macos PURGE=1` — config and data removed.
-6. `make install-macos` on Linux — guard fires.
+Add `scripts/test-macos-install.sh`, invoked by `make test-install-macos`. Keep
+it deliberately small: `sh -n` plus unit checks for release-tag validation,
+exact `PURGE=1` parsing, safe canonical-path construction, listener
+classification from supplied PID/path facts, and idempotent cleanup state when
+no external resource is armed.
+
+Do not stub a successful `hdiutil`, `launchctl`, `sudo`, process signal, or
+filesystem swap. Such tests would mostly assert that the implementation calls
+the commands encoded in the test while missing the behavior that makes an
+installer risky. Those integrations are exercised with the real macOS tools.
+
+### Required macOS verification
+
+Record these five scenarios in the PR:
+
+1. **Clean install.** No prior bundle or LaunchAgent. Confirm the release
+   version, distinct executables, signature check, expected ownership, launch,
+   `/health`, and mount/temp cleanup.
+2. **Reinstall while running.** Start the installed UI and bundle daemon, then
+   reinstall. Confirm the single UID-scoped process pattern stops both,
+   staging/swap succeeds, user state is preserved, and the replacement launches.
+3. **LaunchAgent migration.** Start with `make install-service`, then install.
+   Confirm preflight classifies the listener as known, the bundled
+   `heimdalld install` path regenerates the plist under `/Applications`, and the
+   loaded service runs the installed version.
+4. **Normal uninstall preserves history.** Seed a review row plus config/log/
+   Keychain sentinels. Confirm app and LaunchAgent disappear while the review
+   remains queryable and all user-state sentinels remain.
+5. **Purge guard and purge.** With a development daemon outside the installed
+   bundle/LaunchAgent holding `heimdallm.db`, confirm `PURGE=1` stops the known
+   installed components but aborts before deleting any user state. Stop the
+   development daemon and rerun; confirm the irreversible warning, removal of
+   the three canonical directories, and preservation of Keychain/custom
+   override paths.
+
+### Optional macOS edge checklist
+
+Exercise when the implementation or environment touches the relevant path:
+
+- pinned/invalid/missing/truncated releases and the identical-binary guard;
+- a forced swap or migration failure, including manual recovery output if
+  privileged rollback cannot complete;
+- non-writable `/Applications`, root invocation rejection, and ownership in
+  both privileged and unprivileged installs;
+- a foreign `make dev-daemon` listener: installation succeeds without killing
+  it and prints the warning before and after;
+- unloaded/disabled plist migration via `plutil`;
+- partial states (bundle/plist/job independently absent), another user's
+  bundle process, stale versus live-development `ui.pid`, repeated uninstall,
+  and values other than exact `PURGE=1`.
+
+### Linux non-regression gate
+
+This feature is macOS-only, but the Makefile change must remain additive:
+
+- do not change the recipes or variables used by `install-linux` and
+  `uninstall-linux`;
+- keep `RELEASE` and `PURGE` target-specific so they do not leak into other
+  targets;
+- run no `hdiutil`, `launchctl`, `codesign`, `ditto`, macOS `pkill`, or `lsof`
+  command at Make parse time;
+- keep `_check-macos` as the Make prerequisite and repeat the `uname -s` guard
+  as the helper's first executable check, so direct script invocation is also
+  harmless on Linux.
+
+Run the following on a Linux runner/container before merge:
+
+1. `sh -n scripts/macos-install.sh && sh -n scripts/test-macos-install.sh`.
+2. `make test-install-macos` — pure logic only, no macOS integration.
+3. `make -n install-linux` and `make -n uninstall-linux` — both existing recipes
+   still parse unchanged.
+4. Execute `make install-macos` and `make uninstall-macos` and assert that both
+   fail at `_check-macos`, before invoking the helper or changing any file.
+5. `make test-docker`, as required by `AGENTS.md`; never run daemon `go test`
+   directly on the host.

--- a/docs/superpowers/specs/2026-07-29-install-macos-target-design.md
+++ b/docs/superpowers/specs/2026-07-29-install-macos-target-design.md
@@ -1,0 +1,131 @@
+# `make install-macos` / `make uninstall-macos` (#604)
+
+**Date:** 2026-07-29
+**Issue:** [#604 — feat(makefile): add install-macos / uninstall-macos targets](https://github.com/theburrowhub/heimdallm/issues/604)
+**Status:** Approved
+
+## Problem
+
+The repo cannot install itself on macOS. `Makefile:586-754` provides
+`install-linux` / `uninstall-linux` — user-local, no sudo, driven by Docker —
+but the macOS side only has `package-macos` (build a DMG) and `release-local`
+(build, sign, notarize, publish). Neither puts an app on the machine.
+
+So the documented macOS path is manual: `curl` the release asset, `hdiutil
+attach`, `cp -R` to `/Applications`, `xattr -cr` (`README.md:38-48`,
+`LLM-HOW-TO-INSTALL.md` steps 1-3). In practice developers skip it and run
+`make dev`, which builds the daemon and launches Flutter in **debug** mode —
+a development loop, not an installation.
+
+## Context that shapes the design
+
+- **`VERSION` is already taken.** `Makefile:146` defines it as the *next*
+  auto-incremented semver, consumed by `release-local`. A target reusing it
+  would resolve to a tag that does not exist yet (today: `v0.7.8`). The new
+  targets use `RELEASE`, empty meaning "latest".
+- **The repo is public**, so `api.github.com/.../releases/latest` needs no
+  authentication and `gh` is not required. `jq` is not a dependency of this
+  repo either, so the tag is extracted with `sed`.
+- **The release DMG is ad-hoc signed, not notarized.** `release.yml:487-505`
+  runs `codesign --force --deep --sign -`. Gatekeeper therefore blocks it and
+  `xattr -cr` is mandatory; `spctl --assess` is not usable as a verification
+  step.
+- **The DMG has no published checksum.** `checksums.txt` in a release covers
+  only the GoReleaser CLI binaries, and `heimdallm_<v>_checksums.txt` only the
+  `.deb`/`.rpm`. Neither lists the DMG or the AppImage.
+- **The bundle can be born corrupt.** On case-insensitive APFS, `heimdallm`
+  resolves to the Flutter binary `Heimdallm`; if the daemon copy step in CI
+  degrades, both binaries end up identical and spawning the daemon fork-bombs
+  the machine. `install-linux` guards against exactly this
+  (`Makefile:605-608`) and `LLM-HOW-TO-INSTALL.md` repeats the check.
+- **The daemon can uninstall its own LaunchAgent.** `daemon/cmd/heimdallm/main.go:84`
+  handles the `uninstall` subcommand, calling `launchagent.Uninstall()`.
+
+## Decision
+
+Add two inline recipes to the root `Makefile`, next to the Linux pair, reusing
+the existing `_check-macos` guard (`Makefile:233`).
+
+Rejected alternatives: a `scripts/install-macos.sh` (breaks symmetry with
+`install-linux`, which is inline, and splits install logic across two places),
+and building locally with `package-macos` instead of downloading (slower, and
+the point of the request is to get a working app without a Flutter toolchain
+run).
+
+```
+make install-macos                  # latest release → /Applications
+make install-macos RELEASE=v0.7.5   # pinned release
+make uninstall-macos                # remove app; config and data preserved
+make uninstall-macos PURGE=1        # also wipe config, data and logs
+```
+
+`/Applications` over `~/Applications`: it matches what `README.md:43` and
+`LLM-HOW-TO-INSTALL.md` already document, and it is writable without `sudo` for
+an admin user, which is the normal case on a personal Mac.
+
+## Design
+
+### `install-macos`
+
+1. `_check-macos` — fail fast on Linux with a pointer to `install-linux`.
+2. Resolve the tag: use `RELEASE` when set; otherwise `curl -fsSL` the
+   `releases/latest` endpoint and extract `tag_name` via `sed`. Fail with an
+   explicit message if resolution yields nothing.
+3. `mktemp -d`, and install a `trap` that runs `hdiutil detach` (if mounted)
+   and `rm -rf` the temp dir on every exit path.
+4. `curl -fL` the `Heimdallm-<tag>.dmg` asset. A missing asset must produce a
+   clear "this release has no macOS DMG" message rather than a `hdiutil` error.
+5. `hdiutil attach -nobrowse -quiet`, then locate `Heimdallm.app` inside the
+   mounted volume.
+6. Validate before touching `/Applications`:
+   - `Contents/MacOS/Heimdallm` and `Contents/MacOS/heimdalld` both exist.
+   - `cmp -s` shows they differ — abort on identical binaries (fork-bomb state).
+7. Stop running instances: `pkill -f "/Applications/Heimdallm.app"`, which
+   covers both the Flutter binary and the `heimdalld` it spawned (the daemon is
+   always launched by absolute path from inside the bundle, see
+   `DaemonLifecycle.defaultBinaryPath`). Scoped to the install path, never a bare
+   `pkill -f heimdallm`, so a concurrent `make dev` survives — the same
+   reasoning documented in `uninstall-linux` (`Makefile:691-705`).
+8. `rm -rf /Applications/Heimdallm.app` then `cp -R` from the volume.
+   If `/Applications` is not writable, say so and suggest `sudo make install-macos`.
+9. `xattr -cr /Applications/Heimdallm.app`.
+10. Print the installed tag, the launch hint (`open -a Heimdallm`), and a note
+    that `~/.config/heimdallm` and `~/.local/share/heimdallm` are untouched —
+    the app picks up the existing database and config, sandbox being disabled
+    (`flutter_app/macos/Runner/Release.entitlements`).
+
+### `uninstall-macos`
+
+1. `_check-macos`.
+2. `pkill -f` the app and daemon paths, best-effort.
+3. If `/Applications/Heimdallm.app/Contents/MacOS/heimdalld` exists, run it with
+   `uninstall` to unload and remove the LaunchAgent — **before** deleting the
+   bundle, since the binary is inside it.
+4. `rm -rf /Applications/Heimdallm.app`.
+5. `PURGE=1` additionally removes `~/.config/heimdallm`,
+   `~/.local/share/heimdallm` and `~/Library/Logs/heimdallm`. Default keeps
+   them and prints where they live, mirroring `uninstall-linux`.
+
+### Integrity
+
+The download is trusted on HTTPS alone. Publishing a DMG checksum is a change
+to the release pipeline and is deliberately out of scope; the limitation is
+recorded in #604 so it is not mistaken for an oversight.
+
+### Documentation
+
+`README.md` and `LLM-HOW-TO-INSTALL.md` lead with the target and keep the
+manual commands as the fallback for machines without a checkout.
+
+## Testing
+
+The `Makefile` has no automated coverage and this change does not introduce a
+framework for it. Verification is manual and recorded in the PR:
+
+1. `make -n install-macos` — inspect the expanded recipe.
+2. `make install-macos` on a clean `/Applications` — app launches, version
+   matches the release, existing repos and config still present.
+3. `make install-macos RELEASE=v0.7.5` — pinned download works.
+4. `make uninstall-macos` — app gone, config and data intact.
+5. `make uninstall-macos PURGE=1` — config and data removed.
+6. `make install-macos` on Linux — guard fires.

--- a/scripts/macos-install.sh
+++ b/scripts/macos-install.sh
@@ -1,0 +1,1947 @@
+#!/bin/sh
+
+set -eu
+
+PROGRAM_NAME="macos-install.sh"
+APP_PARENT="/Applications"
+APP_PATH="$APP_PARENT/Heimdallm.app"
+APP_UI_BIN="$APP_PATH/Contents/MacOS/Heimdallm"
+APP_DAEMON_BIN="$APP_PATH/Contents/MacOS/heimdalld"
+BUNDLE_PROCESS_PATTERN='^/Applications/Heimdallm[.]app/Contents/MacOS/(Heimdallm|heimdalld)([[:space:]]|$)'
+LAUNCHAGENT_LABEL="com.heimdallm.daemon"
+PORT="7842"
+
+info() {
+  printf '%s\n' "$*"
+}
+
+warn() {
+  printf '⚠  %s\n' "$*" >&2
+}
+
+error() {
+  printf '❌  %s\n' "$*" >&2
+}
+
+die() {
+  error "$*"
+  exit 1
+}
+
+# Pure helpers ---------------------------------------------------------------
+
+validate_release_tag() {
+  if [ "$#" -ne 1 ]; then
+    return 1
+  fi
+  case "$1" in
+    ""|"."|".."|*[!A-Za-z0-9._-]*)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+purge_requested() {
+  [ "${1-}" = "1" ]
+}
+
+validate_home_path() {
+  if [ "$#" -ne 1 ]; then
+    return 1
+  fi
+  case "$1" in
+    ""|"/"|[!/]*) return 1 ;;
+    *"//"*|*"/./"*|*"/."|*"/../"*|*"/.."|*/) return 1 ;;
+    *'
+'*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+set_user_paths() {
+  if ! validate_home_path "${1-}"; then
+    return 1
+  fi
+  USER_HOME=$1
+  CONFIG_DIR="$USER_HOME/.config/heimdallm"
+  DATA_DIR="$USER_HOME/.local/share/heimdallm"
+  LOG_DIR="$USER_HOME/Library/Logs/heimdallm"
+  DB_PATH="$DATA_DIR/heimdallm.db"
+  UI_PID_PATH="$DATA_DIR/ui.pid"
+  PLIST_PATH="$USER_HOME/Library/LaunchAgents/$LAUNCHAGENT_LABEL.plist"
+  return 0
+}
+
+# Arguments: listener PID, exact executable path, captured LaunchAgent PID.
+# Service ownership wins over bundle ownership so the classes are exclusive.
+classify_listener() {
+  mi_listener_pid=${1-}
+  mi_listener_executable=${2-}
+  mi_launchagent_pid=${3-}
+
+  if [ -z "$mi_listener_pid" ]; then
+    printf '%s\n' "free"
+  elif [ -n "$mi_launchagent_pid" ] &&
+       [ "$mi_listener_pid" = "$mi_launchagent_pid" ]; then
+    printf '%s\n' "service"
+  elif [ "$mi_listener_executable" = "$APP_UI_BIN" ] ||
+       [ "$mi_listener_executable" = "$APP_DAEMON_BIN" ]; then
+    printf '%s\n' "bundle"
+  else
+    printf '%s\n' "foreign"
+  fi
+}
+
+# Encodes the reviewed LaunchAgent × port matrix. The returned token is used by
+# both the implementation and the dependency-free test harness.
+decide_install_policy() {
+  mi_plist_state=${1-}
+  mi_listener_class=${2-}
+
+  case "$mi_plist_state:$mi_listener_class" in
+    absent:free) printf '%s\n' "proceed" ;;
+    absent:bundle) printf '%s\n' "stop-bundle" ;;
+    absent:service) printf '%s\n' "abort-inconsistent" ;;
+    absent:foreign) printf '%s\n' "warn" ;;
+
+    present-unloaded:free) printf '%s\n' "migrate-unloaded" ;;
+    present-unloaded:bundle) printf '%s\n' "stop-bundle+migrate-unloaded" ;;
+    present-unloaded:service) printf '%s\n' "abort-inconsistent" ;;
+    present-unloaded:foreign) printf '%s\n' "warn+migrate-unloaded" ;;
+
+    loaded-enabled:free) printf '%s\n' "restart-service" ;;
+    loaded-enabled:bundle) printf '%s\n' "stop-bundle+restart-service" ;;
+    loaded-enabled:service) printf '%s\n' "restart-service" ;;
+    loaded-enabled:foreign) printf '%s\n' "abort-foreign" ;;
+
+    loaded-disabled:free) printf '%s\n' "migrate-disabled" ;;
+    loaded-disabled:bundle) printf '%s\n' "stop-bundle+migrate-disabled" ;;
+    loaded-disabled:service) printf '%s\n' "migrate-disabled" ;;
+    loaded-disabled:foreign) printf '%s\n' "warn+migrate-disabled" ;;
+
+    *) return 1 ;;
+  esac
+}
+
+rollback_old_move_detected() {
+  [ "${1-}" = "1" ] ||
+    { [ "${2-}" = "1" ] && [ "${3-}" = "1" ]; }
+}
+
+rollback_new_move_detected() {
+  [ "${1-}" = "1" ] ||
+    { [ "${2-}" = "1" ] &&
+      [ "${3-}" = "1" ] &&
+      [ "${4-}" = "1" ]; }
+}
+
+init_runtime_state() {
+  INSTALL_COMMITTED=0
+  ROLLBACK_ARMED=0
+  ROLLBACK_LEAVE_UNLOADED=0
+  USE_SUDO=0
+
+  TEMP_DIR=""
+  DMG_PATH=""
+  MOUNT_POINT=""
+  MOUNTED=0
+  MOUNT_ATTEMPTED=0
+
+  STAGE_ROOT=""
+  STAGED_APP=""
+  BACKUP_ROOT=""
+  BACKUP_APP=""
+  APP_MOVED_TO_BACKUP=0
+  NEW_APP_INSTALLED=0
+  OLD_MOVE_INTENDED=0
+  NEW_MOVE_INTENDED=0
+  PRESERVE_BACKUP=0
+  PRESERVE_TEMP=0
+
+  ORIGINAL_PLIST_PRESENT=0
+  ORIGINAL_PLIST_MODE=""
+  ORIGINAL_PLIST_FINGERPRINT=""
+  ORIGINAL_JOB_PLIST_PATH=""
+  ORIGINAL_LOADED=0
+  ORIGINAL_DISABLED=0
+  ORIGINAL_PID=""
+  ORIGINAL_PID_EXECUTABLE=""
+  ORIGINAL_PLIST_BACKUP=""
+  LAUNCHAGENT_STATE=""
+
+  PORT_CLASS="free"
+  PORT_FOREIGN_INFO=""
+  PREFLIGHT_FOREIGN_INFO=""
+  RESOLVED_RELEASE=""
+}
+
+# Runtime helpers ------------------------------------------------------------
+
+require_macos() {
+  if [ "$(/usr/bin/uname -s)" != "Darwin" ]; then
+    error "This installer requires macOS."
+    info "For Linux, use: make install-linux"
+    exit 1
+  fi
+}
+
+require_executable() {
+  if [ ! -x "$1" ]; then
+    die "Required system tool is unavailable: $1"
+  fi
+}
+
+require_common_commands() {
+  for mi_command in \
+    /bin/chmod \
+    /bin/cat \
+    /bin/cp \
+    /bin/launchctl \
+    /bin/mkdir \
+    /bin/mv \
+    /bin/ps \
+    /bin/rm \
+    /bin/sleep \
+    /usr/bin/awk \
+    /usr/bin/cksum \
+    /usr/bin/grep \
+    /usr/bin/id \
+    /usr/bin/mktemp \
+    /usr/bin/pgrep \
+    /usr/bin/pkill \
+    /usr/bin/plutil \
+    /usr/bin/stat \
+    /usr/sbin/lsof
+  do
+    require_executable "$mi_command"
+  done
+}
+
+require_install_commands() {
+  require_common_commands
+  for mi_command in \
+    /sbin/mount \
+    /usr/bin/cmp \
+    /usr/bin/codesign \
+    /usr/bin/curl \
+    /usr/bin/ditto \
+    /usr/bin/hdiutil \
+    /usr/bin/sed \
+    /usr/bin/xattr \
+    /usr/sbin/chown
+  do
+    require_executable "$mi_command"
+  done
+}
+
+resolve_invoking_user() {
+  USER_UID=$(/usr/bin/id -u)
+  USER_GID=$(/usr/bin/id -g)
+  USER_NAME=$(/usr/bin/id -un)
+
+  if [ "$USER_UID" = "0" ]; then
+    die "Run make install-macos/uninstall-macos as your normal user, never through sudo."
+  fi
+
+  mi_home_input=${HOME-}
+  if ! validate_home_path "$mi_home_input"; then
+    die "HOME must be an absolute, non-root path for the invoking user."
+  fi
+  if ! mi_home_resolved=$(CDPATH= cd "$mi_home_input" 2>/dev/null && /bin/pwd -P); then
+    die "Cannot resolve the invoking user's home directory: $mi_home_input"
+  fi
+  if ! set_user_paths "$mi_home_resolved"; then
+    die "Resolved home directory is unsafe: $mi_home_resolved"
+  fi
+
+  LAUNCH_DOMAIN="gui/$USER_UID"
+  SERVICE_TARGET="$LAUNCH_DOMAIN/$LAUNCHAGENT_LABEL"
+}
+
+process_executable() {
+  mi_process_pid=${1-}
+  case "$mi_process_pid" in
+    ""|*[!0-9]*) return 1 ;;
+  esac
+
+  if ! mi_process_lsof=$(
+    /usr/sbin/lsof -nP -a -p "$mi_process_pid" -d txt -Ffn 2>/dev/null
+  ); then
+    return 1
+  fi
+  mi_process_path=$(
+    printf '%s\n' "$mi_process_lsof" |
+      /usr/bin/awk '
+        /^ftxt$/ { want_path = 1; next }
+        want_path && /^n/ { sub(/^n/, ""); print; exit }
+      '
+  )
+  if [ -z "$mi_process_path" ]; then
+    return 1
+  fi
+  printf '%s\n' "$mi_process_path"
+}
+
+process_uid() {
+  mi_process_pid=${1-}
+  case "$mi_process_pid" in
+    ""|*[!0-9]*) return 1 ;;
+  esac
+
+  if ! mi_process_lsof=$(
+    /usr/sbin/lsof -nP -a -p "$mi_process_pid" -d txt -Fpu 2>/dev/null
+  ); then
+    return 1
+  fi
+  mi_process_uid=$(
+    printf '%s\n' "$mi_process_lsof" |
+      /usr/bin/awk '/^u[0-9]+$/ { sub(/^u/, ""); print; exit }'
+  )
+  if [ -z "$mi_process_uid" ]; then
+    return 1
+  fi
+  printf '%s\n' "$mi_process_uid"
+}
+
+pid_exists() {
+  mi_exists_pid=${1-}
+  case "$mi_exists_pid" in
+    ""|*[!0-9]*) return 1 ;;
+  esac
+  if mi_ps_output=$(/bin/ps -p "$mi_exists_pid" -o pid= 2>/dev/null); then
+    :
+  else
+    mi_ps_status=$?
+    if [ "$mi_ps_status" -eq 1 ]; then
+      return 1
+    fi
+    return 2
+  fi
+  mi_ps_pid=$(
+    printf '%s\n' "$mi_ps_output" |
+      /usr/bin/awk '$1 ~ /^[0-9]+$/ { print $1; exit }'
+  )
+  if [ -z "$mi_ps_pid" ]; then
+    return 2
+  fi
+  [ "$mi_ps_pid" = "$mi_exists_pid" ]
+}
+
+pid_is_same_process() {
+  mi_same_pid=${1-}
+  mi_same_executable=${2-}
+  case "$mi_same_pid" in
+    ""|*[!0-9]*) return 1 ;;
+  esac
+
+  if [ -n "$mi_same_executable" ]; then
+    if mi_current_executable=$(process_executable "$mi_same_pid" 2>/dev/null); then
+      [ "$mi_current_executable" = "$mi_same_executable" ]
+      return
+    fi
+    # Failure to resolve the executable is not proof that the process exited.
+    # If the PID still exists, fail closed and keep waiting.
+    if pid_exists "$mi_same_pid"; then
+      return 0
+    else
+      mi_pid_status=$?
+    fi
+    if [ "$mi_pid_status" -eq 1 ]; then
+      return 1
+    fi
+    return 0
+  fi
+  if pid_exists "$mi_same_pid"; then
+    return 0
+  else
+    mi_pid_status=$?
+  fi
+  if [ "$mi_pid_status" -eq 1 ]; then
+    return 1
+  fi
+  return 0
+}
+
+launchagent_job_state() {
+  if mi_state_output=$(/bin/launchctl print "$SERVICE_TARGET" 2>&1); then
+    printf '%s\n' "loaded"
+    return 0
+  else
+    mi_state_status=$?
+  fi
+  if [ "$mi_state_status" -eq 113 ] ||
+     printf '%s\n' "$mi_state_output" |
+       /usr/bin/grep -q "Could not find service"; then
+    printf '%s\n' "unloaded"
+    return 0
+  fi
+  error "Cannot inspect LaunchAgent job:"
+  printf '%s\n' "$mi_state_output" >&2
+  return 2
+}
+
+current_job_pid() {
+  if ! mi_job_output=$(/bin/launchctl print "$SERVICE_TARGET" 2>/dev/null); then
+    return 1
+  fi
+  mi_job_pid=$(
+    printf '%s\n' "$mi_job_output" |
+      /usr/bin/awk '$1 == "pid" && $2 == "=" && $3 ~ /^[0-9]+$/ { print $3; exit }'
+  )
+  if [ -z "$mi_job_pid" ]; then
+    return 1
+  fi
+  printf '%s\n' "$mi_job_pid"
+}
+
+current_job_plist_path() {
+  if ! mi_job_output=$(/bin/launchctl print "$SERVICE_TARGET" 2>/dev/null); then
+    return 1
+  fi
+  mi_job_path=$(
+    printf '%s\n' "$mi_job_output" |
+      /usr/bin/awk '$1 == "path" && $2 == "=" { sub(/^[^=]*=[[:space:]]*/, ""); print; exit }'
+  )
+  if [ -z "$mi_job_path" ]; then
+    return 1
+  fi
+  printf '%s\n' "$mi_job_path"
+}
+
+read_disabled_state() {
+  if ! mi_disabled_output=$(
+    /bin/launchctl print-disabled "$LAUNCH_DOMAIN" 2>&1
+  ); then
+    error "Cannot inspect disabled LaunchAgent state:"
+    printf '%s\n' "$mi_disabled_output" >&2
+    return 1
+  fi
+
+  mi_disabled_line=$(
+    printf '%s\n' "$mi_disabled_output" |
+      /usr/bin/awk -v label="\"$LAUNCHAGENT_LABEL\"" \
+        'index($0, label) { print; exit }'
+  )
+  case "$mi_disabled_line" in
+    "") printf '%s\n' "0" ;;
+    *"=>"*"disabled"*|*"=>"*"true"*) printf '%s\n' "1" ;;
+    *"=>"*"enabled"*|*"=>"*"false"*) printf '%s\n' "0" ;;
+    *)
+      error "Unrecognized launchctl disabled-state output: $mi_disabled_line"
+      return 1
+      ;;
+  esac
+}
+
+snapshot_launchagent() {
+  if [ -L "$PLIST_PATH" ]; then
+    die "LaunchAgent plist must not be a symlink: $PLIST_PATH"
+  fi
+  if [ -e "$PLIST_PATH" ]; then
+    if [ ! -f "$PLIST_PATH" ]; then
+      die "LaunchAgent plist is not a regular file: $PLIST_PATH"
+    fi
+    mi_plist_owner=$(/usr/bin/stat -f '%u' "$PLIST_PATH")
+    if [ "$mi_plist_owner" != "$USER_UID" ]; then
+      die "LaunchAgent plist is not owned by the invoking user: $PLIST_PATH"
+    fi
+    if [ ! -r "$PLIST_PATH" ] || [ ! -w "$PLIST_PATH" ]; then
+      die "LaunchAgent plist must be readable and writable: $PLIST_PATH"
+    fi
+    ORIGINAL_PLIST_PRESENT=1
+    ORIGINAL_PLIST_MODE=$(/usr/bin/stat -f '%Lp' "$PLIST_PATH")
+    ORIGINAL_PLIST_FINGERPRINT=$(/usr/bin/cksum < "$PLIST_PATH")
+  fi
+
+  if mi_job_output=$(/bin/launchctl print "$SERVICE_TARGET" 2>&1); then
+    ORIGINAL_LOADED=1
+    ORIGINAL_PID=$(
+      printf '%s\n' "$mi_job_output" |
+        /usr/bin/awk '$1 == "pid" && $2 == "=" && $3 ~ /^[0-9]+$/ { print $3; exit }'
+    )
+    ORIGINAL_JOB_PLIST_PATH=$(
+      printf '%s\n' "$mi_job_output" |
+        /usr/bin/awk '$1 == "path" && $2 == "=" { sub(/^[^=]*=[[:space:]]*/, ""); print; exit }'
+    )
+  else
+    mi_job_status=$?
+    if [ "$mi_job_status" -ne 113 ] &&
+       ! printf '%s\n' "$mi_job_output" |
+         /usr/bin/grep -q "Could not find service"; then
+      error "Cannot inspect LaunchAgent job:"
+      printf '%s\n' "$mi_job_output" >&2
+      exit 1
+    fi
+  fi
+
+  if ! ORIGINAL_DISABLED=$(read_disabled_state); then
+    exit 1
+  fi
+
+  if [ "$ORIGINAL_LOADED" = "1" ] &&
+     [ "$ORIGINAL_PLIST_PRESENT" != "1" ]; then
+    die "LaunchAgent is loaded but its plist is missing; refusing an unreconstructable install."
+  fi
+  if [ "$ORIGINAL_LOADED" = "1" ] &&
+     [ "$ORIGINAL_JOB_PLIST_PATH" != "$PLIST_PATH" ]; then
+    die "Loaded LaunchAgent came from '$ORIGINAL_JOB_PLIST_PATH', not the canonical plist '$PLIST_PATH'."
+  fi
+
+  # KeepAlive may respawn between launchctl calls. Refresh the captured PID once
+  # immediately before listener classification.
+  if [ "$ORIGINAL_LOADED" = "1" ]; then
+    if mi_refreshed_pid=$(current_job_pid 2>/dev/null); then
+      ORIGINAL_PID=$mi_refreshed_pid
+    fi
+    if [ -n "$ORIGINAL_PID" ]; then
+      ORIGINAL_PID_EXECUTABLE=$(process_executable "$ORIGINAL_PID" 2>/dev/null || true)
+    fi
+  fi
+
+  if [ "$ORIGINAL_PLIST_PRESENT" != "1" ]; then
+    LAUNCHAGENT_STATE="absent"
+  elif [ "$ORIGINAL_LOADED" != "1" ]; then
+    LAUNCHAGENT_STATE="present-unloaded"
+  elif [ "$ORIGINAL_DISABLED" = "1" ]; then
+    LAUNCHAGENT_STATE="loaded-disabled"
+  else
+    LAUNCHAGENT_STATE="loaded-enabled"
+  fi
+}
+
+inspect_port() {
+  PORT_CLASS="free"
+  PORT_FOREIGN_INFO=""
+
+  # KeepAlive may replace its process between the initial snapshot and this
+  # scan. Refresh only while the job is still loaded; after bootout the last
+  # captured PID remains useful for detecting a lingering service process.
+  if [ "${ORIGINAL_LOADED:-0}" = "1" ]; then
+    if ! mi_live_job_state=$(launchagent_job_state); then
+      return 1
+    fi
+    if [ "$mi_live_job_state" = "loaded" ]; then
+      if mi_live_job_pid=$(current_job_pid 2>/dev/null); then
+        ORIGINAL_PID=$mi_live_job_pid
+        ORIGINAL_PID_EXECUTABLE=$(
+          process_executable "$ORIGINAL_PID" 2>/dev/null || true
+        )
+      fi
+    fi
+  fi
+
+  mi_port_lsof_error=$(
+    /usr/bin/mktemp "/tmp/heimdallm-port-lsof.XXXXXX"
+  ) || {
+    error "Could not create a scratch file for port inspection."
+    return 1
+  }
+  if mi_port_output=$(
+    /usr/sbin/lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -Fp \
+      2>"$mi_port_lsof_error"
+  ); then
+    mi_lsof_status=0
+  else
+    mi_lsof_status=$?
+  fi
+  mi_port_lsof_error_text=""
+  if [ -s "$mi_port_lsof_error" ]; then
+    mi_port_lsof_error_text=$(/bin/cat "$mi_port_lsof_error")
+  fi
+  /bin/rm -f "$mi_port_lsof_error"
+
+  if [ "$mi_lsof_status" -eq 1 ] &&
+     [ -z "$mi_port_output" ] &&
+     [ -z "$mi_port_lsof_error_text" ]; then
+    return 0
+  fi
+  if [ "$mi_lsof_status" -ne 0 ] ||
+     [ -n "$mi_port_lsof_error_text" ]; then
+    error "Unable to inspect TCP port $PORT with lsof."
+    if [ -n "$mi_port_lsof_error_text" ]; then
+      printf '%s\n' "$mi_port_lsof_error_text" >&2
+    fi
+    return 1
+  fi
+
+  mi_port_pids=$(
+    printf '%s\n' "$mi_port_output" |
+      /usr/bin/awk '/^p[0-9]+$/ { sub(/^p/, ""); if (!seen[$0]++) print }'
+  )
+  if [ -z "$mi_port_pids" ]; then
+    return 0
+  fi
+
+  mi_saw_bundle=0
+  mi_saw_service=0
+  mi_saw_foreign=0
+  for mi_port_pid in $mi_port_pids; do
+    mi_port_executable=$(process_executable "$mi_port_pid" 2>/dev/null || true)
+    mi_listener_class=$(
+      classify_listener "$mi_port_pid" "$mi_port_executable" "$ORIGINAL_PID"
+    )
+    case "$mi_listener_class" in
+      service)
+        mi_saw_service=1
+        ;;
+      bundle)
+        mi_saw_bundle=1
+        ;;
+      foreign)
+        mi_saw_foreign=1
+        mi_display_executable=${mi_port_executable:-unknown-executable}
+        if [ -z "$PORT_FOREIGN_INFO" ]; then
+          PORT_FOREIGN_INFO="PID $mi_port_pid ($mi_display_executable)"
+        else
+          PORT_FOREIGN_INFO="$PORT_FOREIGN_INFO
+PID $mi_port_pid ($mi_display_executable)"
+        fi
+        ;;
+    esac
+  done
+
+  if [ "$mi_saw_foreign" = "1" ]; then
+    PORT_CLASS="foreign"
+  elif [ "$mi_saw_service" = "1" ]; then
+    PORT_CLASS="service"
+  elif [ "$mi_saw_bundle" = "1" ]; then
+    PORT_CLASS="bundle"
+  fi
+}
+
+print_foreign_warning() {
+  warn "A daemon outside this installation is listening on port $PORT:"
+  printf '%s\n' "$1" >&2
+  warn "Stop it before opening Heimdallm; the app reuses any healthy daemon on that port."
+}
+
+configure_application_privilege() {
+  if [ ! -d "$APP_PARENT" ]; then
+    die "Applications directory does not exist: $APP_PARENT"
+  fi
+  if [ -L "$APP_PATH" ]; then
+    die "Installed app path must not be a symlink: $APP_PATH"
+  fi
+
+  mi_need_sudo=0
+  if [ ! -w "$APP_PARENT" ]; then
+    mi_need_sudo=1
+  elif [ -e "$APP_PATH" ]; then
+    mi_existing_app_owner=$(/usr/bin/stat -f '%u' "$APP_PATH")
+    if [ "$mi_existing_app_owner" != "$USER_UID" ]; then
+      mi_need_sudo=1
+    fi
+  fi
+
+  if [ "$mi_need_sudo" != "1" ]; then
+    USE_SUDO=0
+    return 0
+  fi
+
+  require_executable /usr/bin/sudo
+  info "▶  /Applications needs administrator access."
+  info "   sudo will prompt once now; make itself continues as $USER_NAME."
+  if ! /usr/bin/sudo -v; then
+    die "Could not obtain an administrator sudo ticket."
+  fi
+  USE_SUDO=1
+}
+
+run_privileged() {
+  if [ "${USE_SUDO:-0}" = "1" ]; then
+    /usr/bin/sudo -n "$@"
+  else
+    "$@"
+  fi
+}
+
+safe_application_work_path() {
+  case "${1-}" in
+    "$APP_PARENT"/.heimdallm-staging.??????|\
+    "$APP_PARENT"/.heimdallm-backup.??????)
+      [ "$1" != "$APP_PARENT" ]
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+safe_temp_path() {
+  mi_temp_candidate=${1-}
+  case "$mi_temp_candidate" in
+    /tmp/heimdallm-install.??????|\
+    /private/tmp/heimdallm-install.??????|\
+    /var/folders/*/T/heimdallm-install.??????|\
+    /private/var/folders/*/T/heimdallm-install.??????)
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+cleanup() {
+  mi_cleanup_ok=1
+
+  if { [ "${MOUNTED:-0}" = "1" ] ||
+       [ "${MOUNT_ATTEMPTED:-0}" = "1" ]; } &&
+     [ -n "${MOUNT_POINT:-}" ]; then
+    if /usr/bin/hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 ||
+       /usr/bin/hdiutil detach -force "$MOUNT_POINT" >/dev/null 2>&1; then
+      MOUNTED=0
+      MOUNT_ATTEMPTED=0
+    else
+      warn "Could not detach private DMG mount: $MOUNT_POINT"
+      PRESERVE_TEMP=1
+      mi_cleanup_ok=0
+    fi
+  fi
+
+  if [ -n "${STAGE_ROOT:-}" ] && [ -e "$STAGE_ROOT" ]; then
+    if safe_application_work_path "$STAGE_ROOT" &&
+       run_privileged /bin/rm -rf "$STAGE_ROOT"; then
+      STAGE_ROOT=""
+      STAGED_APP=""
+    else
+      warn "Could not remove staging directory: $STAGE_ROOT"
+      mi_cleanup_ok=0
+    fi
+  fi
+
+  if [ "${PRESERVE_BACKUP:-0}" != "1" ] &&
+     [ -n "${BACKUP_ROOT:-}" ] && [ -e "$BACKUP_ROOT" ]; then
+    if safe_application_work_path "$BACKUP_ROOT" &&
+       run_privileged /bin/rm -rf "$BACKUP_ROOT"; then
+      BACKUP_ROOT=""
+      BACKUP_APP=""
+    else
+      warn "Could not remove backup directory: $BACKUP_ROOT"
+      mi_cleanup_ok=0
+    fi
+  fi
+
+  if [ "${PRESERVE_TEMP:-0}" != "1" ] &&
+     [ -n "${TEMP_DIR:-}" ] && [ -e "$TEMP_DIR" ]; then
+    if safe_temp_path "$TEMP_DIR" && /bin/rm -rf "$TEMP_DIR"; then
+      TEMP_DIR=""
+      DMG_PATH=""
+      MOUNT_POINT=""
+    else
+      warn "Could not remove installer temp directory: $TEMP_DIR"
+      mi_cleanup_ok=0
+    fi
+  fi
+
+  [ "$mi_cleanup_ok" = "1" ]
+}
+
+wait_for_pid_exit() {
+  mi_wait_pid=${1-}
+  mi_wait_executable=${2-}
+  if [ -z "$mi_wait_pid" ]; then
+    return 0
+  fi
+
+  mi_wait_count=0
+  while [ "$mi_wait_count" -lt 6 ]; do
+    if ! pid_is_same_process "$mi_wait_pid" "$mi_wait_executable"; then
+      return 0
+    fi
+    /bin/sleep 1
+    mi_wait_count=$((mi_wait_count + 1))
+  done
+  ! pid_is_same_process "$mi_wait_pid" "$mi_wait_executable"
+}
+
+wait_for_job_unloaded() {
+  mi_wait_count=0
+  while [ "$mi_wait_count" -lt 6 ]; do
+    if ! mi_wait_job_state=$(launchagent_job_state); then
+      return 1
+    fi
+    if [ "$mi_wait_job_state" = "unloaded" ]; then
+      return 0
+    fi
+    /bin/sleep 1
+    mi_wait_count=$((mi_wait_count + 1))
+  done
+  if ! mi_wait_job_state=$(launchagent_job_state); then
+    return 1
+  fi
+  [ "$mi_wait_job_state" = "unloaded" ]
+}
+
+bootout_current_job() {
+  if ! mi_bootout_state=$(launchagent_job_state); then
+    return 1
+  fi
+  if [ "$mi_bootout_state" = "unloaded" ]; then
+    return 0
+  fi
+
+  mi_bootout_pid=$(current_job_pid 2>/dev/null || true)
+  mi_bootout_executable=""
+  if [ -n "$mi_bootout_pid" ]; then
+    mi_bootout_executable=$(process_executable "$mi_bootout_pid" 2>/dev/null || true)
+  fi
+
+  if /bin/launchctl bootout "$SERVICE_TARGET" >/dev/null 2>&1; then
+    :
+  else
+    if ! mi_bootout_state=$(launchagent_job_state); then
+      return 1
+    fi
+    if [ "$mi_bootout_state" = "loaded" ]; then
+      error "launchctl bootout failed for $SERVICE_TARGET"
+      return 1
+    fi
+  fi
+
+  if ! wait_for_job_unloaded; then
+    error "LaunchAgent did not reach a verified unloaded state: $SERVICE_TARGET"
+    return 1
+  fi
+  if ! wait_for_pid_exit "$mi_bootout_pid" "$mi_bootout_executable"; then
+    error "LaunchAgent process remains alive after bootout: PID $mi_bootout_pid"
+    return 1
+  fi
+}
+
+list_bundle_pids() {
+  if mi_bundle_pids=$(/usr/bin/pgrep -f "$BUNDLE_PROCESS_PATTERN" 2>/dev/null); then
+    printf '%s\n' "$mi_bundle_pids"
+    return 0
+  else
+    mi_pgrep_status=$?
+  fi
+  if [ "$mi_pgrep_status" -eq 1 ]; then
+    return 0
+  fi
+  return "$mi_pgrep_status"
+}
+
+verify_bundle_process_owners() {
+  if ! mi_owner_pids=$(list_bundle_pids); then
+    error "Unable to inspect running Heimdallm bundle processes."
+    return 1
+  fi
+  for mi_owner_pid in $mi_owner_pids; do
+    if ! mi_owner_uid=$(process_uid "$mi_owner_pid" 2>/dev/null); then
+      if pid_exists "$mi_owner_pid"; then
+        error "Cannot determine owner of bundle process PID $mi_owner_pid."
+        return 1
+      else
+        mi_owner_pid_status=$?
+      fi
+      if [ "$mi_owner_pid_status" -eq 1 ]; then
+        continue
+      fi
+      error "Cannot determine owner of bundle process PID $mi_owner_pid."
+      return 1
+    fi
+    if [ "$mi_owner_uid" != "$USER_UID" ]; then
+      error "Another user owns running bundle process PID $mi_owner_pid; refusing to replace the shared app."
+      return 1
+    fi
+  done
+}
+
+verify_no_bundle_processes() {
+  if ! mi_remaining_bundle_pids=$(list_bundle_pids); then
+    error "Unable to verify that Heimdallm bundle processes exited."
+    return 1
+  fi
+  if [ -n "$mi_remaining_bundle_pids" ]; then
+    error "Heimdallm bundle process remains alive: $mi_remaining_bundle_pids"
+    return 1
+  fi
+}
+
+wait_for_user_bundle_exit() {
+  mi_bundle_wait=0
+  while [ "$mi_bundle_wait" -lt 6 ]; do
+    if mi_bundle_pids=$(
+      /usr/bin/pgrep -U "$USER_UID" -f "$BUNDLE_PROCESS_PATTERN" 2>/dev/null
+    ); then
+      :
+    else
+      mi_bundle_status=$?
+      if [ "$mi_bundle_status" -eq 1 ]; then
+        return 0
+      fi
+      return "$mi_bundle_status"
+    fi
+    /bin/sleep 1
+    mi_bundle_wait=$((mi_bundle_wait + 1))
+  done
+  if /usr/bin/pgrep -U "$USER_UID" -f "$BUNDLE_PROCESS_PATTERN" \
+    >/dev/null 2>&1; then
+    return 1
+  else
+    mi_bundle_status=$?
+  fi
+  [ "$mi_bundle_status" -eq 1 ]
+}
+
+stop_bundle_processes() {
+  if ! verify_bundle_process_owners; then
+    return 1
+  fi
+
+  if /usr/bin/pkill -TERM -U "$USER_UID" -f "$BUNDLE_PROCESS_PATTERN" 2>/dev/null; then
+    :
+  else
+    mi_pkill_status=$?
+    if [ "$mi_pkill_status" -ne 1 ]; then
+      error "Unable to signal Heimdallm bundle processes."
+      return 1
+    fi
+  fi
+
+  if ! wait_for_user_bundle_exit; then
+    warn "Heimdallm did not exit after TERM; sending KILL to the same exact bundle paths."
+    if /usr/bin/pkill -KILL -U "$USER_UID" -f "$BUNDLE_PROCESS_PATTERN" 2>/dev/null; then
+      :
+    else
+      mi_pkill_status=$?
+      if [ "$mi_pkill_status" -ne 1 ]; then
+        error "Unable to kill remaining Heimdallm bundle processes."
+        return 1
+      fi
+    fi
+    if ! wait_for_user_bundle_exit; then
+      error "A Heimdallm bundle process remains alive."
+      return 1
+    fi
+  fi
+
+  verify_no_bundle_processes
+}
+
+restore_plist_contents_and_flag() {
+  mi_restore_ok=1
+
+  if [ "$ORIGINAL_PLIST_PRESENT" = "1" ]; then
+    if [ -L "$PLIST_PATH" ] ||
+       [ -z "$ORIGINAL_PLIST_BACKUP" ] ||
+       [ ! -f "$ORIGINAL_PLIST_BACKUP" ] ||
+       ! /bin/cp -p "$ORIGINAL_PLIST_BACKUP" "$PLIST_PATH"; then
+      error "Could not restore original LaunchAgent plist: $PLIST_PATH"
+      mi_restore_ok=0
+    fi
+  fi
+
+  if [ "$ORIGINAL_DISABLED" = "1" ]; then
+    if ! /bin/launchctl disable "$SERVICE_TARGET"; then
+      error "Could not restore disabled LaunchAgent flag."
+      mi_restore_ok=0
+    fi
+  else
+    if ! /bin/launchctl enable "$SERVICE_TARGET"; then
+      error "Could not restore enabled LaunchAgent flag."
+      mi_restore_ok=0
+    fi
+  fi
+
+  [ "$mi_restore_ok" = "1" ]
+}
+
+print_manual_service_recovery() {
+  warn "The original LaunchAgent plist was restored but left unloaded for safety."
+  warn "After PID/port $PORT is free, run:"
+  if [ "$ORIGINAL_DISABLED" = "1" ]; then
+    printf '   /bin/launchctl enable "%s"\n' "$SERVICE_TARGET" >&2
+    printf '   /bin/launchctl bootstrap "%s" "%s"\n' \
+      "$LAUNCH_DOMAIN" "$PLIST_PATH" >&2
+    printf '   /bin/launchctl disable "%s"\n' "$SERVICE_TARGET" >&2
+  else
+    printf '   /bin/launchctl bootstrap "%s" "%s"\n' \
+      "$LAUNCH_DOMAIN" "$PLIST_PATH" >&2
+  fi
+}
+
+print_backup_recovery() {
+  if [ -n "${BACKUP_APP:-}" ] && [ -e "$BACKUP_APP" ]; then
+    warn "The previous app backup was preserved at:"
+    printf '   %s\n' "$BACKUP_APP" >&2
+    warn "Manual recovery (add sudo only if /Applications requires it):"
+    printf '   /bin/rm -rf "%s"\n' "$APP_PATH" >&2
+    printf '   /bin/mv "%s" "%s"\n' "$BACKUP_APP" "$APP_PATH" >&2
+  fi
+  if [ "${PRESERVE_TEMP:-0}" = "1" ] &&
+     [ -n "${ORIGINAL_PLIST_BACKUP:-}" ] &&
+     [ -f "$ORIGINAL_PLIST_BACKUP" ]; then
+    warn "The exact original LaunchAgent plist backup was preserved at:"
+    printf '   %s\n' "$ORIGINAL_PLIST_BACKUP" >&2
+    warn "Manual plist recovery:"
+    printf '   /bin/cp -p "%s" "%s"\n' \
+      "$ORIGINAL_PLIST_BACKUP" "$PLIST_PATH" >&2
+  fi
+}
+
+rollback_install() {
+  ROLLBACK_ARMED=0
+  mi_rollback_ok=1
+  mi_rollback_partial=0
+  info "↩  Rolling back the macOS installation..."
+
+  mi_backup_has_app=0
+  if [ -n "${BACKUP_APP:-}" ] &&
+     { [ -e "$BACKUP_APP" ] || [ -L "$BACKUP_APP" ]; }; then
+    mi_backup_has_app=1
+  fi
+  mi_old_was_moved=0
+  if rollback_old_move_detected \
+    "$APP_MOVED_TO_BACKUP" "$OLD_MOVE_INTENDED" "$mi_backup_has_app"; then
+    mi_old_was_moved=1
+  fi
+  mi_staged_app_missing=0
+  if [ -n "${STAGED_APP:-}" ] && [ ! -e "$STAGED_APP" ]; then
+    mi_staged_app_missing=1
+  fi
+  mi_final_app_present=0
+  if [ -e "$APP_PATH" ] || [ -L "$APP_PATH" ]; then
+    mi_final_app_present=1
+  fi
+  mi_new_was_installed=0
+  if rollback_new_move_detected \
+    "$NEW_APP_INSTALLED" \
+    "$NEW_MOVE_INTENDED" \
+    "$mi_staged_app_missing" \
+    "$mi_final_app_present"; then
+    mi_new_was_installed=1
+  fi
+
+  if ! bootout_current_job; then
+    PRESERVE_BACKUP=1
+    if [ -n "$ORIGINAL_PLIST_BACKUP" ]; then
+      PRESERVE_TEMP=1
+    fi
+    print_backup_recovery
+    return 1
+  fi
+  if [ "$mi_old_was_moved" = "1" ] ||
+     [ "$mi_new_was_installed" = "1" ]; then
+    if ! stop_bundle_processes; then
+      PRESERVE_BACKUP=1
+      if [ -n "$ORIGINAL_PLIST_BACKUP" ]; then
+        PRESERVE_TEMP=1
+      fi
+      print_backup_recovery
+      return 1
+    fi
+  fi
+
+  if [ "$mi_old_was_moved" = "1" ]; then
+    if [ -z "$BACKUP_APP" ] ||
+       { [ ! -e "$BACKUP_APP" ] && [ ! -L "$BACKUP_APP" ]; }; then
+      error "Previous app backup is unavailable; cannot roll back the bundle."
+      PRESERVE_BACKUP=1
+      if [ -n "$ORIGINAL_PLIST_BACKUP" ]; then
+        PRESERVE_TEMP=1
+      fi
+      print_backup_recovery
+      return 1
+    fi
+    if { [ -e "$APP_PATH" ] || [ -L "$APP_PATH" ]; } &&
+       ! run_privileged /bin/rm -rf "$APP_PATH"; then
+      error "Could not remove the replacement app during rollback."
+      PRESERVE_BACKUP=1
+      if [ -n "$ORIGINAL_PLIST_BACKUP" ]; then
+        PRESERVE_TEMP=1
+      fi
+      print_backup_recovery
+      return 1
+    fi
+    if ! run_privileged /bin/mv "$BACKUP_APP" "$APP_PATH"; then
+      error "Could not restore the previous app bundle."
+      PRESERVE_BACKUP=1
+      if [ -n "$ORIGINAL_PLIST_BACKUP" ]; then
+        PRESERVE_TEMP=1
+      fi
+      print_backup_recovery
+      return 1
+    fi
+    APP_MOVED_TO_BACKUP=0
+    NEW_APP_INSTALLED=0
+  elif [ "$mi_new_was_installed" = "1" ] &&
+       { [ -e "$APP_PATH" ] || [ -L "$APP_PATH" ]; }; then
+    if ! run_privileged /bin/rm -rf "$APP_PATH"; then
+      error "Could not remove the newly installed app during rollback."
+      mi_rollback_ok=0
+    fi
+    NEW_APP_INSTALLED=0
+  fi
+  OLD_MOVE_INTENDED=0
+  NEW_MOVE_INTENDED=0
+
+  if ! restore_plist_contents_and_flag; then
+    if [ -n "$ORIGINAL_PLIST_BACKUP" ]; then
+      PRESERVE_TEMP=1
+    fi
+    mi_rollback_ok=0
+  fi
+
+  if [ "$ORIGINAL_LOADED" = "1" ] &&
+     [ "$mi_rollback_ok" = "1" ]; then
+    if [ "$ROLLBACK_LEAVE_UNLOADED" = "1" ]; then
+      print_manual_service_recovery
+      mi_rollback_partial=1
+    elif ! inspect_port || [ "$PORT_CLASS" != "free" ]; then
+      ROLLBACK_LEAVE_UNLOADED=1
+      print_manual_service_recovery
+      mi_rollback_partial=1
+    elif [ "$ORIGINAL_DISABLED" = "1" ]; then
+      if /bin/launchctl enable "$SERVICE_TARGET" &&
+         /bin/launchctl bootstrap "$LAUNCH_DOMAIN" "$PLIST_PATH" &&
+         /bin/launchctl disable "$SERVICE_TARGET"; then
+        :
+      else
+        error "Could not restore the original loaded-and-disabled LaunchAgent state."
+        if bootout_current_job &&
+           /bin/launchctl disable "$SERVICE_TARGET"; then
+          print_manual_service_recovery
+          mi_rollback_partial=1
+        else
+          error "Could not return the LaunchAgent to a verified disabled-and-unloaded state."
+          mi_rollback_ok=0
+        fi
+      fi
+    elif ! /bin/launchctl bootstrap "$LAUNCH_DOMAIN" "$PLIST_PATH"; then
+      error "Could not reload the original LaunchAgent during rollback."
+      if bootout_current_job; then
+        print_manual_service_recovery
+        mi_rollback_partial=1
+      else
+        error "Could not verify the failed bootstrap was unloaded."
+        mi_rollback_ok=0
+      fi
+    fi
+  fi
+
+  if [ "$mi_rollback_ok" = "1" ] &&
+     [ "$mi_rollback_partial" != "1" ]; then
+    info "✓  Previous app and LaunchAgent state restored."
+    return 0
+  fi
+  if [ "$mi_rollback_ok" = "1" ]; then
+    warn "Previous app and plist were restored, but the LaunchAgent remains unloaded."
+    return 1
+  fi
+  PRESERVE_BACKUP=1
+  if [ -n "$ORIGINAL_PLIST_BACKUP" ]; then
+    PRESERVE_TEMP=1
+  fi
+  print_backup_recovery
+  return 1
+}
+
+handle_exit() {
+  mi_exit_status=$1
+  trap - 0
+  trap '' HUP INT TERM
+
+  if [ "${ROLLBACK_ARMED:-0}" = "1" ] &&
+     [ "${INSTALL_COMMITTED:-0}" != "1" ]; then
+    if ! rollback_install; then
+      mi_exit_status=1
+    fi
+  fi
+  if ! cleanup; then
+    mi_exit_status=1
+  fi
+  exit "$mi_exit_status"
+}
+
+handle_signal() {
+  mi_signal_name=$1
+  mi_signal_status=$2
+  trap - 0
+  trap '' HUP INT TERM
+  warn "Received $mi_signal_name; cleaning up."
+  if [ "${ROLLBACK_ARMED:-0}" = "1" ] &&
+     [ "${INSTALL_COMMITTED:-0}" != "1" ]; then
+    rollback_install || true
+  fi
+  cleanup || true
+  exit "$mi_signal_status"
+}
+
+resolve_release() {
+  mi_requested_release=${RELEASE-}
+  if [ -n "$mi_requested_release" ]; then
+    if ! validate_release_tag "$mi_requested_release"; then
+      die "Invalid RELEASE tag. Use only letters, digits, dots, underscores, and hyphens."
+    fi
+    RESOLVED_RELEASE=$mi_requested_release
+    return 0
+  fi
+
+  info "▶  Resolving the latest Heimdallm release..."
+  if ! mi_release_json=$(
+    /usr/bin/curl -fsSL \
+      "https://api.github.com/repos/theburrowhub/heimdallm/releases/latest"
+  ); then
+    die "Could not resolve the latest release from GitHub."
+  fi
+  RESOLVED_RELEASE=$(
+    printf '%s\n' "$mi_release_json" |
+      /usr/bin/sed -n \
+        's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+      /usr/bin/sed -n '1p'
+  )
+  if ! validate_release_tag "$RESOLVED_RELEASE"; then
+    die "GitHub returned an empty or unsafe release tag."
+  fi
+}
+
+create_private_temp() {
+  mi_tmp_base=${TMPDIR:-/tmp}
+  mi_tmp_base=${mi_tmp_base%/}
+  case "$mi_tmp_base" in
+    /tmp|/private/tmp|/var/folders/*/T|/private/var/folders/*/T) ;;
+    *) mi_tmp_base="/tmp" ;;
+  esac
+
+  trap 'handle_exit $?' 0
+  trap 'handle_signal HUP 129' HUP
+  trap 'handle_signal INT 130' INT
+  trap 'handle_signal TERM 143' TERM
+
+  TEMP_DIR=$(/usr/bin/mktemp -d "$mi_tmp_base/heimdallm-install.XXXXXX")
+  if ! mi_canonical_temp=$(
+    CDPATH= cd "$TEMP_DIR" 2>/dev/null && /bin/pwd -P
+  ); then
+    die "Could not canonicalize installer temp directory: $TEMP_DIR"
+  fi
+  TEMP_DIR=$mi_canonical_temp
+  if ! safe_temp_path "$TEMP_DIR"; then
+    die "System mktemp returned an unsafe installer path: $TEMP_DIR"
+  fi
+  /bin/chmod 700 "$TEMP_DIR"
+  DMG_PATH="$TEMP_DIR/Heimdallm-$RESOLVED_RELEASE.dmg"
+  MOUNT_POINT="$TEMP_DIR/mount"
+  /bin/mkdir "$MOUNT_POINT"
+}
+
+download_and_mount_release() {
+  mi_download_url="https://github.com/theburrowhub/heimdallm/releases/download/$RESOLVED_RELEASE/Heimdallm-$RESOLVED_RELEASE.dmg"
+  info "▶  Downloading Heimdallm $RESOLVED_RELEASE..."
+  if ! /usr/bin/curl -fL --progress-bar "$mi_download_url" -o "$DMG_PATH"; then
+    die "Release $RESOLVED_RELEASE has no downloadable macOS DMG at the expected URL."
+  fi
+
+  info "▶  Verifying and mounting the DMG..."
+  if ! /usr/bin/hdiutil verify "$DMG_PATH" >/dev/null; then
+    die "DMG verification failed; refusing to install."
+  fi
+  MOUNT_ATTEMPTED=1
+  if ! /usr/bin/hdiutil attach -readonly -nobrowse -quiet \
+    -mountpoint "$MOUNT_POINT" "$DMG_PATH"; then
+    if mi_mount_table=$(/sbin/mount 2>/dev/null); then
+      if ! printf '%s\n' "$mi_mount_table" |
+        /usr/bin/grep -F " on $MOUNT_POINT " >/dev/null 2>&1; then
+        MOUNT_ATTEMPTED=0
+      fi
+    else
+      warn "Could not inspect the mount table after attach failed; cleanup will fail closed."
+    fi
+    die "Could not mount the release DMG."
+  fi
+  MOUNTED=1
+  MOUNT_ATTEMPTED=0
+  SOURCE_APP="$MOUNT_POINT/Heimdallm.app"
+}
+
+validate_bundle() {
+  mi_bundle_path=$1
+  mi_ui_binary="$mi_bundle_path/Contents/MacOS/Heimdallm"
+  mi_daemon_binary="$mi_bundle_path/Contents/MacOS/heimdalld"
+
+  if [ ! -d "$mi_bundle_path" ] || [ -L "$mi_bundle_path" ]; then
+    error "Bundle must be a real application directory, not a symlink: $mi_bundle_path"
+    return 1
+  fi
+  if [ ! -f "$mi_ui_binary" ] || [ -L "$mi_ui_binary" ] ||
+     [ ! -f "$mi_daemon_binary" ] || [ -L "$mi_daemon_binary" ] ||
+     [ ! -x "$mi_ui_binary" ] || [ ! -x "$mi_daemon_binary" ]; then
+    error "Bundle is missing an executable UI or daemon: $mi_bundle_path"
+    return 1
+  fi
+  if /usr/bin/cmp -s "$mi_ui_binary" "$mi_daemon_binary"; then
+    error "Bundle binaries are identical (case-collision fork-bomb state)."
+    return 1
+  fi
+  if ! /usr/bin/codesign --verify --deep --strict "$mi_bundle_path"; then
+    error "Bundle signature structure is invalid: $mi_bundle_path"
+    return 1
+  fi
+}
+
+stage_bundle() {
+  configure_application_privilege
+  if ! STAGE_ROOT=$(
+    run_privileged /usr/bin/mktemp -d \
+      "$APP_PARENT/.heimdallm-staging.XXXXXX"
+  ); then
+    die "Could not create a staging directory on the /Applications filesystem."
+  fi
+  if ! safe_application_work_path "$STAGE_ROOT"; then
+    die "System mktemp returned an unsafe staging path: $STAGE_ROOT"
+  fi
+  if [ "$USE_SUDO" = "1" ] &&
+     ! run_privileged /bin/chmod 711 "$STAGE_ROOT"; then
+    die "Could not make the privileged staging root traversable for validation."
+  fi
+  STAGED_APP="$STAGE_ROOT/Heimdallm.app"
+
+  info "▶  Staging the validated app bundle..."
+  if ! run_privileged /usr/bin/ditto "$SOURCE_APP" "$STAGED_APP"; then
+    die "Could not copy the app bundle to staging."
+  fi
+  if ! run_privileged /usr/bin/xattr -cr "$STAGED_APP"; then
+    die "Could not clear quarantine attributes on the staged app."
+  fi
+  if [ "$USE_SUDO" = "1" ]; then
+    if ! run_privileged /usr/sbin/chown -R root:admin "$STAGED_APP"; then
+      die "Could not normalize staged bundle ownership to root:admin."
+    fi
+    if [ "$(/usr/bin/stat -f '%Su:%Sg' "$STAGED_APP")" != "root:admin" ]; then
+      die "Staged bundle ownership is not root:admin after normalization."
+    fi
+  elif ! /usr/sbin/chown -R "$USER_UID:$USER_GID" "$STAGED_APP"; then
+    die "Could not normalize staged bundle ownership to $USER_UID:$USER_GID."
+  elif [ "$(/usr/bin/stat -f '%u:%g' "$STAGED_APP")" != "$USER_UID:$USER_GID" ]; then
+    die "Staged bundle ownership does not match the invoking user and primary group."
+  fi
+  if ! validate_bundle "$STAGED_APP"; then
+    die "The staged app failed post-copy validation."
+  fi
+}
+
+prepare_transaction() {
+  if [ -L "$PLIST_PATH" ]; then
+    die "LaunchAgent plist became a symlink during staging; refusing to mutate state."
+  fi
+  mi_current_plist_present=0
+  if [ -e "$PLIST_PATH" ]; then
+    mi_current_plist_present=1
+  fi
+  if [ "$mi_current_plist_present" != "$ORIGINAL_PLIST_PRESENT" ]; then
+    die "LaunchAgent plist presence changed during staging; retry after the other operation finishes."
+  fi
+
+  if [ "$ORIGINAL_PLIST_PRESENT" = "1" ]; then
+    if [ ! -f "$PLIST_PATH" ] ||
+       [ "$(/usr/bin/stat -f '%u' "$PLIST_PATH")" != "$USER_UID" ] ||
+       [ "$(/usr/bin/stat -f '%Lp' "$PLIST_PATH")" != "$ORIGINAL_PLIST_MODE" ] ||
+       [ "$(/usr/bin/cksum < "$PLIST_PATH")" != "$ORIGINAL_PLIST_FINGERPRINT" ]; then
+      die "LaunchAgent plist content, owner, or mode changed during staging."
+    fi
+    ORIGINAL_PLIST_BACKUP="$TEMP_DIR/original-launchagent.plist"
+    if ! /bin/cp -p "$PLIST_PATH" "$ORIGINAL_PLIST_BACKUP"; then
+      die "Could not back up the LaunchAgent plist."
+    fi
+  fi
+
+  if ! mi_current_job_state=$(launchagent_job_state); then
+    die "Cannot revalidate LaunchAgent state before mutation."
+  fi
+  mi_current_loaded=0
+  if [ "$mi_current_job_state" = "loaded" ]; then
+    mi_current_loaded=1
+  fi
+  if [ "$mi_current_loaded" != "$ORIGINAL_LOADED" ]; then
+    die "LaunchAgent loaded state changed during staging; retry the install."
+  fi
+  if [ "$mi_current_loaded" = "1" ]; then
+    if ! mi_current_job_path=$(current_job_plist_path) ||
+       [ "$mi_current_job_path" != "$PLIST_PATH" ]; then
+      die "Loaded LaunchAgent plist identity changed during staging."
+    fi
+  fi
+  if ! mi_current_disabled=$(read_disabled_state); then
+    die "Cannot revalidate LaunchAgent disabled state before mutation."
+  fi
+  if [ "$mi_current_disabled" != "$ORIGINAL_DISABLED" ]; then
+    die "LaunchAgent disabled state changed during staging; retry the install."
+  fi
+
+  ROLLBACK_ARMED=1
+}
+
+stop_original_launchagent() {
+  if [ "$ORIGINAL_LOADED" != "1" ]; then
+    return 0
+  fi
+
+  info "▶  Stopping the existing LaunchAgent..."
+  if ! mi_current_original_path=$(current_job_plist_path) ||
+     [ "$mi_current_original_path" != "$PLIST_PATH" ]; then
+    die "LaunchAgent plist identity changed immediately before bootout."
+  fi
+  # Capture the process that launchd owns now, not the potentially stale PID
+  # seen before download/staging.
+  if mi_current_original_pid=$(current_job_pid 2>/dev/null); then
+    ORIGINAL_PID=$mi_current_original_pid
+    ORIGINAL_PID_EXECUTABLE=$(
+      process_executable "$ORIGINAL_PID" 2>/dev/null || true
+    )
+  else
+    ORIGINAL_PID=""
+    ORIGINAL_PID_EXECUTABLE=""
+  fi
+  if /bin/launchctl bootout "$SERVICE_TARGET" >/dev/null 2>&1; then
+    :
+  else
+    if ! mi_original_job_state=$(launchagent_job_state); then
+      die "Could not verify LaunchAgent state after bootout failed."
+    fi
+    if [ "$mi_original_job_state" = "loaded" ]; then
+      die "Could not boot out the existing LaunchAgent."
+    fi
+  fi
+  if ! wait_for_job_unloaded; then
+    ROLLBACK_LEAVE_UNLOADED=1
+    die "LaunchAgent remains loaded after bootout."
+  fi
+  if ! wait_for_pid_exit "$ORIGINAL_PID" "$ORIGINAL_PID_EXECUTABLE"; then
+    ROLLBACK_LEAVE_UNLOADED=1
+    die "LaunchAgent PID $ORIGINAL_PID remains alive; plist restored but service will stay unloaded."
+  fi
+}
+
+late_port_guard_before_swap() {
+  if ! inspect_port; then
+    ROLLBACK_LEAVE_UNLOADED=1
+    die "Cannot recheck port $PORT safely."
+  fi
+  if [ "$PORT_CLASS" = "free" ]; then
+    return 0
+  fi
+
+  if [ "$LAUNCHAGENT_STATE" = "loaded-enabled" ]; then
+    ROLLBACK_LEAVE_UNLOADED=1
+    die "Port $PORT became occupied after preflight; refusing to restart a KeepAlive service."
+  fi
+  if [ "$PORT_CLASS" = "foreign" ]; then
+    if [ -n "$PORT_FOREIGN_INFO" ]; then
+      if [ -z "$PREFLIGHT_FOREIGN_INFO" ]; then
+        PREFLIGHT_FOREIGN_INFO=$PORT_FOREIGN_INFO
+      elif [ "$PREFLIGHT_FOREIGN_INFO" != "$PORT_FOREIGN_INFO" ]; then
+        PREFLIGHT_FOREIGN_INFO="$PREFLIGHT_FOREIGN_INFO
+$PORT_FOREIGN_INFO"
+      fi
+      print_foreign_warning "$PORT_FOREIGN_INFO"
+    fi
+    return 0
+  fi
+  die "A known Heimdallm process appeared again after shutdown; refusing to swap the running app."
+}
+
+swap_staged_bundle() {
+  if [ -L "$APP_PATH" ]; then
+    die "Installed app path must not be a symlink: $APP_PATH"
+  fi
+  if [ -e "$APP_PATH" ]; then
+    if [ ! -d "$APP_PATH" ]; then
+      die "Installed app path is not a regular application directory: $APP_PATH"
+    fi
+    if ! BACKUP_ROOT=$(
+      run_privileged /usr/bin/mktemp -d \
+        "$APP_PARENT/.heimdallm-backup.XXXXXX"
+    ); then
+      die "Could not create the app rollback directory."
+    fi
+    if ! safe_application_work_path "$BACKUP_ROOT"; then
+      die "System mktemp returned an unsafe backup path: $BACKUP_ROOT"
+    fi
+    if [ "$USE_SUDO" = "1" ] &&
+       ! run_privileged /bin/chmod 711 "$BACKUP_ROOT"; then
+      die "Could not make the privileged rollback root traversable."
+    fi
+    BACKUP_APP="$BACKUP_ROOT/Heimdallm.app"
+    OLD_MOVE_INTENDED=1
+    if ! run_privileged /bin/mv "$APP_PATH" "$BACKUP_APP"; then
+      die "Could not move the current app into the rollback directory."
+    fi
+    APP_MOVED_TO_BACKUP=1
+    OLD_MOVE_INTENDED=0
+  fi
+
+  NEW_MOVE_INTENDED=1
+  if ! run_privileged /bin/mv "$STAGED_APP" "$APP_PATH"; then
+    die "Could not move the staged app into /Applications."
+  fi
+  NEW_APP_INSTALLED=1
+  NEW_MOVE_INTENDED=0
+  STAGED_APP=""
+}
+
+plist_program_path() {
+  /usr/bin/plutil -extract ProgramArguments.0 raw -o - "$PLIST_PATH" 2>/dev/null
+}
+
+verify_plist_program_path() {
+  if ! mi_installed_program=$(plist_program_path); then
+    return 1
+  fi
+  [ "$mi_installed_program" = "$APP_DAEMON_BIN" ]
+}
+
+wait_for_loaded_service_ready() {
+  mi_service_wait=0
+  while [ "$mi_service_wait" -lt 6 ]; do
+    if ! mi_service_state=$(launchagent_job_state); then
+      return 1
+    fi
+    if [ "$mi_service_state" = "loaded" ] &&
+       mi_service_pid=$(current_job_pid 2>/dev/null); then
+      if mi_service_executable=$(process_executable "$mi_service_pid" 2>/dev/null) &&
+         [ "$mi_service_executable" = "$APP_DAEMON_BIN" ] &&
+         inspect_port &&
+         [ "$PORT_CLASS" = "service" ]; then
+        /bin/sleep 1
+        if ! mi_service_state=$(launchagent_job_state); then
+          return 1
+        fi
+        if [ "$mi_service_state" = "loaded" ] &&
+           [ "$(current_job_pid 2>/dev/null || true)" = "$mi_service_pid" ] &&
+           [ "$(process_executable "$mi_service_pid" 2>/dev/null || true)" = "$APP_DAEMON_BIN" ] &&
+           inspect_port &&
+           [ "$PORT_CLASS" = "service" ]; then
+          return 0
+        fi
+      fi
+    fi
+    /bin/sleep 1
+    mi_service_wait=$((mi_service_wait + 1))
+  done
+  return 1
+}
+
+migrate_launchagent() {
+  if [ "$ORIGINAL_PLIST_PRESENT" != "1" ]; then
+    return 0
+  fi
+
+  if [ "$LAUNCHAGENT_STATE" = "loaded-enabled" ]; then
+    # This check is intentionally stricter than the general foreign-listener
+    # policy: any listener would make launchd spin the KeepAlive daemon.
+    if ! inspect_port || [ "$PORT_CLASS" != "free" ]; then
+      ROLLBACK_LEAVE_UNLOADED=1
+      die "Port $PORT is no longer free; refusing to bootstrap the migrated LaunchAgent."
+    fi
+    info "▶  Migrating and restarting the LaunchAgent from the installed bundle..."
+    if ! /bin/launchctl enable "$SERVICE_TARGET"; then
+      die "Could not preserve the enabled LaunchAgent state."
+    fi
+    if ! PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+      "$APP_DAEMON_BIN" install; then
+      die "The bundled daemon could not regenerate the LaunchAgent plist."
+    fi
+    if ! verify_plist_program_path; then
+      die "Migrated LaunchAgent does not point at the installed daemon."
+    fi
+    if ! wait_for_loaded_service_ready; then
+      die "Migrated LaunchAgent did not keep the installed daemon listening on port $PORT."
+    fi
+    return 0
+  fi
+
+  info "▶  Migrating the unloaded LaunchAgent plist without starting it..."
+  if ! /usr/bin/plutil -replace ProgramArguments.0 \
+    -string "$APP_DAEMON_BIN" "$PLIST_PATH"; then
+    die "Could not update ProgramArguments[0] in the LaunchAgent plist."
+  fi
+  if ! /bin/chmod "$ORIGINAL_PLIST_MODE" "$PLIST_PATH"; then
+    die "Could not restore LaunchAgent plist permissions."
+  fi
+  if [ "$ORIGINAL_DISABLED" = "1" ]; then
+    if ! /bin/launchctl disable "$SERVICE_TARGET"; then
+      die "Could not restore the disabled LaunchAgent flag."
+    fi
+  elif ! /bin/launchctl enable "$SERVICE_TARGET"; then
+    die "Could not restore the enabled LaunchAgent flag."
+  fi
+  if ! mi_migrated_job_state=$(launchagent_job_state); then
+    die "Could not verify unloaded LaunchAgent state after migration."
+  fi
+  if [ "$mi_migrated_job_state" = "loaded" ]; then
+    die "LaunchAgent was unexpectedly loaded during unloaded-state migration."
+  fi
+  if ! verify_plist_program_path; then
+    die "Migrated LaunchAgent does not point at the installed daemon."
+  fi
+}
+
+finish_install() {
+  INSTALL_COMMITTED=1
+  ROLLBACK_ARMED=0
+
+  if ! cleanup; then
+    die "Heimdallm was installed, but installer cleanup was incomplete."
+  fi
+
+  info ""
+  info "✅  Heimdallm $RESOLVED_RELEASE installed."
+  info "    App: $APP_PATH"
+  info "    Launch with: open -a Heimdallm"
+  info ""
+  info "    Preserved:"
+  info "      Config:   $CONFIG_DIR"
+  info "      History:  $DATA_DIR"
+  info "      Logs:     $LOG_DIR"
+  info "      Keychain: service=heimdallm, account=github-token"
+  if [ -n "$PREFLIGHT_FOREIGN_INFO" ]; then
+    info ""
+    print_foreign_warning "$PREFLIGHT_FOREIGN_INFO"
+  fi
+}
+
+install_macos() {
+  require_install_commands
+  resolve_invoking_user
+  snapshot_launchagent
+
+  if ! inspect_port; then
+    die "Cannot safely inspect port $PORT."
+  fi
+  if ! mi_install_policy=$(
+    decide_install_policy "$LAUNCHAGENT_STATE" "$PORT_CLASS"
+  ); then
+    die "Unsupported LaunchAgent/listener state: $LAUNCHAGENT_STATE/$PORT_CLASS"
+  fi
+  case "$mi_install_policy" in
+    abort-inconsistent)
+      die "Port ownership is inconsistent with LaunchAgent state; refusing to install."
+      ;;
+    abort-foreign)
+      print_foreign_warning "$PORT_FOREIGN_INFO"
+      die "Stop the foreign daemon before updating an enabled, loaded LaunchAgent."
+      ;;
+    *warn*)
+      PREFLIGHT_FOREIGN_INFO=$PORT_FOREIGN_INFO
+      print_foreign_warning "$PREFLIGHT_FOREIGN_INFO"
+      ;;
+  esac
+
+  resolve_release
+  create_private_temp
+  download_and_mount_release
+  if ! validate_bundle "$SOURCE_APP"; then
+    die "Downloaded app bundle failed validation."
+  fi
+  stage_bundle
+  prepare_transaction
+  stop_original_launchagent
+
+  info "▶  Stopping running app-bundle processes..."
+  if ! stop_bundle_processes; then
+    die "Could not safely stop all installed bundle processes."
+  fi
+  late_port_guard_before_swap
+  swap_staged_bundle
+  migrate_launchagent
+  finish_install
+}
+
+# Uninstall helpers ----------------------------------------------------------
+
+remove_launchagent() {
+  mi_uninstall_pid=""
+  mi_uninstall_executable=""
+  if mi_uninstall_job=$(/bin/launchctl print "$SERVICE_TARGET" 2>&1); then
+    mi_uninstall_pid=$(
+      printf '%s\n' "$mi_uninstall_job" |
+        /usr/bin/awk '$1 == "pid" && $2 == "=" && $3 ~ /^[0-9]+$/ { print $3; exit }'
+    )
+    if [ -n "$mi_uninstall_pid" ]; then
+      mi_uninstall_executable=$(
+        process_executable "$mi_uninstall_pid" 2>/dev/null || true
+      )
+    fi
+    if /bin/launchctl bootout "$SERVICE_TARGET" >/dev/null 2>&1; then
+      :
+    else
+      if ! mi_uninstall_state=$(launchagent_job_state); then
+        die "Could not verify LaunchAgent state after bootout failed."
+      fi
+      if [ "$mi_uninstall_state" = "loaded" ]; then
+        die "Could not boot out LaunchAgent $SERVICE_TARGET."
+      fi
+    fi
+    if ! wait_for_job_unloaded; then
+      die "LaunchAgent remains loaded; uninstall aborted before removing its plist."
+    fi
+    if ! wait_for_pid_exit "$mi_uninstall_pid" "$mi_uninstall_executable"; then
+      die "LaunchAgent PID $mi_uninstall_pid remains alive; uninstall aborted."
+    fi
+  else
+    mi_uninstall_job_status=$?
+    if [ "$mi_uninstall_job_status" -ne 113 ] &&
+       ! printf '%s\n' "$mi_uninstall_job" |
+         /usr/bin/grep -q "Could not find service"; then
+      error "Cannot inspect LaunchAgent job; uninstall aborted:"
+      printf '%s\n' "$mi_uninstall_job" >&2
+      exit 1
+    fi
+  fi
+
+  if ! mi_uninstall_disabled=$(read_disabled_state); then
+    die "Cannot inspect the persistent LaunchAgent disabled flag."
+  fi
+  if [ "$mi_uninstall_disabled" = "1" ]; then
+    if ! /bin/launchctl enable "$SERVICE_TARGET"; then
+      die "Could not clear the persistent disabled flag for the removed LaunchAgent."
+    fi
+    if ! mi_uninstall_disabled=$(read_disabled_state) ||
+       [ "$mi_uninstall_disabled" != "0" ]; then
+      die "LaunchAgent disabled flag remains set; uninstall aborted before removing the plist."
+    fi
+  fi
+
+  if [ -L "$PLIST_PATH" ]; then
+    die "LaunchAgent plist must not be a symlink: $PLIST_PATH"
+  fi
+  if [ -e "$PLIST_PATH" ]; then
+    if [ ! -f "$PLIST_PATH" ]; then
+      die "LaunchAgent plist is not a regular file: $PLIST_PATH"
+    fi
+    if ! /bin/rm -f "$PLIST_PATH"; then
+      die "Could not remove LaunchAgent plist: $PLIST_PATH"
+    fi
+    info "↓  Removed LaunchAgent: $PLIST_PATH"
+  fi
+}
+
+ui_pid_is_live() {
+  mi_ui_pid=${1-}
+  case "$mi_ui_pid" in
+    ""|*[!0-9]*) return 1 ;;
+  esac
+  if pid_exists "$mi_ui_pid"; then
+    return 0
+  else
+    mi_ui_pid_status=$?
+  fi
+  if [ "$mi_ui_pid_status" -eq 1 ]; then
+    return 1
+  fi
+  return 0
+}
+
+handle_ui_pid_file() {
+  if [ ! -e "$UI_PID_PATH" ]; then
+    return 0
+  fi
+  if [ ! -f "$UI_PID_PATH" ] || [ -L "$UI_PID_PATH" ]; then
+    if purge_requested "${PURGE-}"; then
+      die "PURGE=1 refuses an unsafe ui.pid path: $UI_PID_PATH"
+    fi
+    warn "Preserving non-regular ui.pid path: $UI_PID_PATH"
+    return 0
+  fi
+
+  IFS= read -r mi_ui_pid < "$UI_PID_PATH" || mi_ui_pid=""
+  if ! ui_pid_is_live "$mi_ui_pid"; then
+    /bin/rm -f "$UI_PID_PATH"
+    return 0
+  fi
+
+  mi_ui_executable=$(process_executable "$mi_ui_pid" 2>/dev/null || true)
+  case "$mi_ui_executable" in
+    "$APP_UI_BIN")
+      die "Installed UI PID $mi_ui_pid remains alive after shutdown."
+      ;;
+    */Heimdallm.app/Contents/MacOS/Heimdallm)
+      if purge_requested "${PURGE-}"; then
+        die "PURGE=1 would delete data used by live development UI PID $mi_ui_pid ($mi_ui_executable)."
+      fi
+      warn "Preserving ui.pid for live development UI PID $mi_ui_pid ($mi_ui_executable)."
+      ;;
+    *)
+      if purge_requested "${PURGE-}"; then
+        die "PURGE=1 cannot verify live ui.pid owner PID $mi_ui_pid; refusing to delete user data."
+      fi
+      warn "Preserving ui.pid for unrecognized live PID $mi_ui_pid."
+      ;;
+  esac
+}
+
+remove_installed_app() {
+  if [ -L "$APP_PATH" ]; then
+    die "Installed app path must not be a symlink: $APP_PATH"
+  fi
+  if [ ! -e "$APP_PATH" ]; then
+    return 0
+  fi
+  if [ ! -d "$APP_PATH" ]; then
+    die "Installed app path is not a regular application directory: $APP_PATH"
+  fi
+
+  configure_application_privilege
+  if ! run_privileged /bin/rm -rf "$APP_PATH"; then
+    die "Could not remove $APP_PATH"
+  fi
+  info "↓  Removed $APP_PATH"
+}
+
+verify_database_closed() {
+  if [ ! -e "$DB_PATH" ]; then
+    return 0
+  fi
+  if [ ! -f "$DB_PATH" ] || [ -L "$DB_PATH" ]; then
+    die "Database path is not a regular file: $DB_PATH"
+  fi
+
+  mi_lsof_error=$(
+    /usr/bin/mktemp "${TMPDIR:-/tmp}/heimdallm-lsof.XXXXXX"
+  )
+  if mi_lsof_output=$(
+    /usr/sbin/lsof -nP "$DB_PATH" 2>"$mi_lsof_error"
+  ); then
+    /bin/rm -f "$mi_lsof_error"
+    error "Database is still open; refusing PURGE=1:"
+    printf '%s\n' "$mi_lsof_output" >&2
+    exit 1
+  else
+    mi_lsof_status=$?
+  fi
+
+  mi_lsof_error_text=""
+  if [ -s "$mi_lsof_error" ]; then
+    mi_lsof_error_text=$(/bin/cat "$mi_lsof_error")
+  fi
+  /bin/rm -f "$mi_lsof_error"
+
+  if [ "$mi_lsof_status" -ne 1 ] || [ -n "$mi_lsof_error_text" ]; then
+    error "lsof could not prove that the database is closed; refusing PURGE=1."
+    if [ -n "$mi_lsof_error_text" ]; then
+      printf '%s\n' "$mi_lsof_error_text" >&2
+    fi
+    exit 1
+  fi
+}
+
+safe_purge_directory() {
+  mi_purge_path=$1
+  case "$mi_purge_path" in
+    "$CONFIG_DIR"|"$DATA_DIR"|"$LOG_DIR") ;;
+    *)
+      error "Refusing unexpected purge path: $mi_purge_path"
+      return 1
+      ;;
+  esac
+  if [ -e "$mi_purge_path" ] || [ -L "$mi_purge_path" ]; then
+    /bin/rm -rf "$mi_purge_path"
+    info "    Removed $mi_purge_path"
+  fi
+}
+
+purge_user_data() {
+  info ""
+  warn "PURGE=1 permanently deletes the Heimdallm database and all review history; this cannot be undone."
+
+  if ! mi_purge_job_state=$(launchagent_job_state); then
+    die "Cannot prove that the LaunchAgent is unloaded; refusing to purge."
+  fi
+  if [ "$mi_purge_job_state" = "loaded" ]; then
+    die "LaunchAgent became loaded again; refusing to purge."
+  fi
+  if ! verify_bundle_process_owners; then
+    die "Cannot prove that installed bundle processes are stopped; refusing to purge."
+  fi
+  if ! verify_no_bundle_processes; then
+    die "Cannot prove that installed bundle processes are absent; refusing to purge."
+  fi
+
+  verify_database_closed
+  safe_purge_directory "$CONFIG_DIR"
+  safe_purge_directory "$DATA_DIR"
+  safe_purge_directory "$LOG_DIR"
+
+  info ""
+  info "✅  Heimdallm fully uninstalled; canonical config, history, and logs were removed."
+  info "    Preserved Keychain item: service=heimdallm, account=github-token"
+  info "    Custom HEIMDALLM_CONFIG_PATH/HEIMDALLM_DATA_DIR locations were not followed."
+  info "    To remove the Keychain item too:"
+  info "      security delete-generic-password -s heimdallm -a github-token"
+}
+
+print_preserved_state() {
+  info ""
+  info "✅  Heimdallm uninstalled; user state was preserved."
+  info ""
+  info "    Config:   $CONFIG_DIR"
+  info "    History:  $DATA_DIR"
+  info "    Logs:     $LOG_DIR"
+  info "    Keychain: service=heimdallm, account=github-token"
+  info ""
+  info "    To remove canonical config, history, and logs:"
+  info "      make uninstall-macos PURGE=1"
+}
+
+uninstall_macos() {
+  require_common_commands
+  resolve_invoking_user
+
+  if [ -n "${PURGE-}" ] && ! purge_requested "${PURGE-}"; then
+    warn "Ignoring PURGE=${PURGE}; only exact PURGE=1 deletes user data."
+  fi
+
+  info "▶  Removing Heimdallm LaunchAgent..."
+  remove_launchagent
+  info "▶  Stopping installed Heimdallm processes..."
+  if ! stop_bundle_processes; then
+    die "Could not safely stop all installed bundle processes."
+  fi
+  handle_ui_pid_file
+  remove_installed_app
+
+  if purge_requested "${PURGE-}"; then
+    purge_user_data
+  else
+    print_preserved_state
+  fi
+}
+
+usage() {
+  printf 'Usage: %s install|uninstall\n' "$PROGRAM_NAME" >&2
+}
+
+main() {
+  # Keep this as the first runtime check. Make has its own prerequisite guard,
+  # and this second guard makes direct script invocation harmless on Linux.
+  require_macos
+  init_runtime_state
+
+  case "${1-}" in
+    install)
+      if [ "$#" -ne 1 ]; then
+        usage
+        exit 2
+      fi
+      install_macos
+      ;;
+    uninstall)
+      if [ "$#" -ne 1 ]; then
+        usage
+        exit 2
+      fi
+      uninstall_macos
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+# The test harness sources this file to exercise pure helpers. Normal direct
+# execution always enters main(), whose first runtime action is the Darwin guard.
+case "${HEIMDALLM_MACOS_INSTALL_SOURCE_ONLY:-0}" in
+  1) ;;
+  *) main "$@" ;;
+esac

--- a/scripts/macos-install.sh
+++ b/scripts/macos-install.sh
@@ -10,6 +10,7 @@ APP_DAEMON_BIN="$APP_PATH/Contents/MacOS/heimdalld"
 BUNDLE_PROCESS_PATTERN='^/Applications/Heimdallm[.]app/Contents/MacOS/(Heimdallm|heimdalld)([[:space:]]|$)'
 LAUNCHAGENT_LABEL="com.heimdallm.daemon"
 PORT="7842"
+SERVICE_READY_TIMEOUT_SECONDS="60"
 
 info() {
   printf '%s\n' "$*"
@@ -46,6 +47,16 @@ validate_release_tag() {
 
 purge_requested() {
   [ "${1-}" = "1" ]
+}
+
+validate_purge_value() {
+  if [ "$#" -gt 1 ]; then
+    return 1
+  fi
+  case "${1-}" in
+    ""|"1") return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 validate_home_path() {
@@ -95,8 +106,8 @@ classify_listener() {
   fi
 }
 
-# Encodes the reviewed LaunchAgent × port matrix. The returned token is used by
-# both the implementation and the dependency-free test harness.
+# Abort/warn drives preflight; suffixes are a docs/test oracle. Later actions
+# derive from LAUNCHAGENT_STATE. Absent/unloaded + service is defensive only.
 decide_install_policy() {
   mi_plist_state=${1-}
   mi_listener_class=${2-}
@@ -136,6 +147,33 @@ rollback_new_move_detected() {
     { [ "${2-}" = "1" ] &&
       [ "${3-}" = "1" ] &&
       [ "${4-}" = "1" ]; }
+}
+
+rollback_required() {
+  [ "${1-}" = "1" ] && [ "${2-}" != "1" ]
+}
+
+# The captured service PID or exact installed executables are controlled by
+# uninstall; every other live database/ui.pid holder blocks purge.
+classify_purge_holder() {
+  mi_holder_pid=${1-}
+  mi_holder_executable=${2-}
+  mi_holder_uid=${3-}
+  mi_known_service_pid=${4-}
+  mi_expected_uid=${5-}
+
+  if [ -z "$mi_holder_uid" ] ||
+     [ "$mi_holder_uid" != "$mi_expected_uid" ]; then
+    printf '%s\n' "foreign"
+  elif [ -n "$mi_known_service_pid" ] &&
+       [ "$mi_holder_pid" = "$mi_known_service_pid" ]; then
+    printf '%s\n' "known-service"
+  elif [ "$mi_holder_executable" = "$APP_UI_BIN" ] ||
+       [ "$mi_holder_executable" = "$APP_DAEMON_BIN" ]; then
+    printf '%s\n' "known-bundle"
+  else
+    printf '%s\n' "foreign"
+  fi
 }
 
 init_runtime_state() {
@@ -1142,8 +1180,8 @@ handle_exit() {
   trap - 0
   trap '' HUP INT TERM
 
-  if [ "${ROLLBACK_ARMED:-0}" = "1" ] &&
-     [ "${INSTALL_COMMITTED:-0}" != "1" ]; then
+  if rollback_required \
+    "${ROLLBACK_ARMED:-0}" "${INSTALL_COMMITTED:-0}"; then
     if ! rollback_install; then
       mi_exit_status=1
     fi
@@ -1160,8 +1198,8 @@ handle_signal() {
   trap - 0
   trap '' HUP INT TERM
   warn "Received $mi_signal_name; cleaning up."
-  if [ "${ROLLBACK_ARMED:-0}" = "1" ] &&
-     [ "${INSTALL_COMMITTED:-0}" != "1" ]; then
+  if rollback_required \
+    "${ROLLBACK_ARMED:-0}" "${INSTALL_COMMITTED:-0}"; then
     rollback_install || true
   fi
   cleanup || true
@@ -1492,7 +1530,7 @@ verify_plist_program_path() {
 
 wait_for_loaded_service_ready() {
   mi_service_wait=0
-  while [ "$mi_service_wait" -lt 6 ]; do
+  while [ "$mi_service_wait" -lt "$SERVICE_READY_TIMEOUT_SECONDS" ]; do
     if ! mi_service_state=$(launchagent_job_state); then
       return 1
     fi
@@ -1503,6 +1541,7 @@ wait_for_loaded_service_ready() {
          inspect_port &&
          [ "$PORT_CLASS" = "service" ]; then
         /bin/sleep 1
+        mi_service_wait=$((mi_service_wait + 1))
         if ! mi_service_state=$(launchagent_job_state); then
           return 1
         fi
@@ -1513,6 +1552,7 @@ wait_for_loaded_service_ready() {
            [ "$PORT_CLASS" = "service" ]; then
           return 0
         fi
+        continue
       fi
     fi
     /bin/sleep 1
@@ -1628,6 +1668,8 @@ install_macos() {
   esac
 
   resolve_release
+  warn "This release DMG has no published checksum and is ad-hoc signed."
+  warn "hdiutil/codesign validate structure, not publisher identity; download trust relies on GitHub HTTPS."
   create_private_temp
   download_and_mount_release
   if ! validate_bundle "$SOURCE_APP"; then
@@ -1732,6 +1774,114 @@ ui_pid_is_live() {
   return 0
 }
 
+read_pid_file() {
+  mi_pid_file_path=${1-}
+  PID_FILE_VALUE=""
+  if [ "$#" -ne 1 ] || [ -z "$mi_pid_file_path" ]; then
+    return 1
+  fi
+  if IFS= read -r PID_FILE_VALUE < "$mi_pid_file_path"; then
+    return 0
+  fi
+  # Dart omits the newline; POSIX read assigns at EOF but returns non-zero.
+  [ -n "$PID_FILE_VALUE" ] || [ -r "$mi_pid_file_path" ]
+}
+
+inspect_purge_holder() {
+  mi_purge_holder_pid=${1-}
+  mi_purge_service_pid=${2-}
+  PURGE_HOLDER_CLASS=""
+  PURGE_HOLDER_EXECUTABLE=""
+
+  if ! mi_purge_holder_uid=$(
+    process_uid "$mi_purge_holder_pid" 2>/dev/null
+  ); then
+    if pid_exists "$mi_purge_holder_pid"; then
+      error "Cannot determine owner of live purge holder PID $mi_purge_holder_pid."
+      return 2
+    else
+      mi_purge_holder_status=$?
+    fi
+    if [ "$mi_purge_holder_status" -eq 1 ]; then
+      return 1
+    fi
+    error "Cannot determine whether purge holder PID $mi_purge_holder_pid still exists."
+    return 2
+  fi
+
+  PURGE_HOLDER_EXECUTABLE=$(
+    process_executable "$mi_purge_holder_pid" 2>/dev/null || true
+  )
+  if [ -z "$PURGE_HOLDER_EXECUTABLE" ] &&
+     { [ -z "$mi_purge_service_pid" ] ||
+       [ "$mi_purge_holder_pid" != "$mi_purge_service_pid" ]; }; then
+    if pid_exists "$mi_purge_holder_pid"; then
+      error "Cannot resolve executable for live purge holder PID $mi_purge_holder_pid."
+      return 2
+    else
+      mi_purge_holder_status=$?
+    fi
+    if [ "$mi_purge_holder_status" -eq 1 ]; then
+      return 1
+    fi
+    error "Cannot determine whether purge holder PID $mi_purge_holder_pid still exists."
+    return 2
+  fi
+
+  PURGE_HOLDER_CLASS=$(
+    classify_purge_holder \
+      "$mi_purge_holder_pid" \
+      "$PURGE_HOLDER_EXECUTABLE" \
+      "$mi_purge_holder_uid" \
+      "$mi_purge_service_pid" \
+      "$USER_UID"
+  )
+  return 0
+}
+
+preflight_purge_ui_pid() {
+  mi_purge_service_pid=${1-}
+  if [ ! -e "$UI_PID_PATH" ]; then
+    return 0
+  fi
+  if [ ! -f "$UI_PID_PATH" ] || [ -L "$UI_PID_PATH" ]; then
+    die "PURGE=1 refuses an unsafe ui.pid path before uninstall: $UI_PID_PATH"
+  fi
+
+  if ! read_pid_file "$UI_PID_PATH"; then
+    die "PURGE=1 cannot read ui.pid safely before uninstall: $UI_PID_PATH"
+  fi
+  mi_preflight_ui_pid=$PID_FILE_VALUE
+  case "$mi_preflight_ui_pid" in
+    ""|*[!0-9]*) return 0 ;;
+  esac
+
+  if pid_exists "$mi_preflight_ui_pid"; then
+    :
+  else
+    mi_preflight_ui_status=$?
+    if [ "$mi_preflight_ui_status" -eq 1 ]; then
+      return 0
+    fi
+    die "PURGE=1 cannot determine whether ui.pid PID $mi_preflight_ui_pid is live."
+  fi
+
+  if inspect_purge_holder \
+    "$mi_preflight_ui_pid" "$mi_purge_service_pid"; then
+    :
+  else
+    mi_preflight_ui_status=$?
+    if [ "$mi_preflight_ui_status" -eq 1 ]; then
+      return 0
+    fi
+    die "PURGE=1 cannot verify live ui.pid PID $mi_preflight_ui_pid."
+  fi
+  if [ "$PURGE_HOLDER_CLASS" = "foreign" ]; then
+    mi_preflight_ui_executable=${PURGE_HOLDER_EXECUTABLE:-unknown-executable}
+    die "PURGE=1 would affect live external ui.pid PID $mi_preflight_ui_pid ($mi_preflight_ui_executable); close it before uninstall."
+  fi
+}
+
 handle_ui_pid_file() {
   if [ ! -e "$UI_PID_PATH" ]; then
     return 0
@@ -1744,7 +1894,11 @@ handle_ui_pid_file() {
     return 0
   fi
 
-  IFS= read -r mi_ui_pid < "$UI_PID_PATH" || mi_ui_pid=""
+  if ! read_pid_file "$UI_PID_PATH"; then
+    warn "Preserving unreadable ui.pid path: $UI_PID_PATH"
+    return 0
+  fi
+  mi_ui_pid=$PID_FILE_VALUE
   if ! ui_pid_is_live "$mi_ui_pid"; then
     /bin/rm -f "$UI_PID_PATH"
     return 0
@@ -1781,31 +1935,32 @@ remove_installed_app() {
     die "Installed app path is not a regular application directory: $APP_PATH"
   fi
 
-  configure_application_privilege
   if ! run_privileged /bin/rm -rf "$APP_PATH"; then
     die "Could not remove $APP_PATH"
   fi
   info "↓  Removed $APP_PATH"
 }
 
-verify_database_closed() {
+inspect_database_holders() {
+  DATABASE_HOLDER_PIDS=""
   if [ ! -e "$DB_PATH" ]; then
     return 0
   fi
   if [ ! -f "$DB_PATH" ] || [ -L "$DB_PATH" ]; then
-    die "Database path is not a regular file: $DB_PATH"
+    error "Database path is not a regular file: $DB_PATH"
+    return 2
   fi
 
   mi_lsof_error=$(
-    /usr/bin/mktemp "${TMPDIR:-/tmp}/heimdallm-lsof.XXXXXX"
-  )
+    /usr/bin/mktemp "/tmp/heimdallm-lsof.XXXXXX"
+  ) || {
+    error "Could not create a scratch file for database inspection."
+    return 2
+  }
   if mi_lsof_output=$(
-    /usr/sbin/lsof -nP "$DB_PATH" 2>"$mi_lsof_error"
+    /usr/sbin/lsof -nP -Fp "$DB_PATH" 2>"$mi_lsof_error"
   ); then
-    /bin/rm -f "$mi_lsof_error"
-    error "Database is still open; refusing PURGE=1:"
-    printf '%s\n' "$mi_lsof_output" >&2
-    exit 1
+    mi_lsof_status=0
   else
     mi_lsof_status=$?
   fi
@@ -1816,11 +1971,82 @@ verify_database_closed() {
   fi
   /bin/rm -f "$mi_lsof_error"
 
-  if [ "$mi_lsof_status" -ne 1 ] || [ -n "$mi_lsof_error_text" ]; then
-    error "lsof could not prove that the database is closed; refusing PURGE=1."
+  if [ "$mi_lsof_status" -eq 1 ] &&
+     [ -z "$mi_lsof_output" ] &&
+     [ -z "$mi_lsof_error_text" ]; then
+    return 0
+  fi
+  if [ "$mi_lsof_status" -ne 0 ] || [ -n "$mi_lsof_error_text" ]; then
+    error "lsof could not inspect the database safely."
     if [ -n "$mi_lsof_error_text" ]; then
       printf '%s\n' "$mi_lsof_error_text" >&2
     fi
+    return 2
+  fi
+
+  DATABASE_HOLDER_PIDS=$(
+    printf '%s\n' "$mi_lsof_output" |
+      /usr/bin/awk '/^p[0-9]+$/ { sub(/^p/, ""); if (!seen[$0]++) print }'
+  )
+  if [ -z "$DATABASE_HOLDER_PIDS" ]; then
+    error "lsof reported an open database without an inspectable PID."
+    return 2
+  fi
+}
+
+preflight_purge_database() {
+  mi_purge_service_pid=${1-}
+  if ! inspect_database_holders; then
+    die "Cannot inspect database holders before PURGE=1."
+  fi
+
+  for mi_preflight_db_pid in $DATABASE_HOLDER_PIDS; do
+    if inspect_purge_holder \
+      "$mi_preflight_db_pid" "$mi_purge_service_pid"; then
+      :
+    else
+      mi_preflight_db_status=$?
+      if [ "$mi_preflight_db_status" -eq 1 ]; then
+        continue
+      fi
+      die "PURGE=1 cannot verify database holder PID $mi_preflight_db_pid."
+    fi
+    if [ "$PURGE_HOLDER_CLASS" = "foreign" ]; then
+      mi_preflight_db_executable=${PURGE_HOLDER_EXECUTABLE:-unknown-executable}
+      die "PURGE=1 found external database holder PID $mi_preflight_db_pid ($mi_preflight_db_executable); stop it before uninstall."
+    fi
+  done
+}
+
+preflight_purge() {
+  warn "PURGE=1 permanently deletes the Heimdallm database and all review history; this cannot be undone."
+
+  if ! mi_preflight_job_state=$(launchagent_job_state); then
+    die "Cannot inspect the LaunchAgent before PURGE=1."
+  fi
+  mi_preflight_service_pid=""
+  if [ "$mi_preflight_job_state" = "loaded" ]; then
+    mi_preflight_service_pid=$(current_job_pid 2>/dev/null || true)
+  fi
+
+  preflight_purge_ui_pid "$mi_preflight_service_pid"
+  preflight_purge_database "$mi_preflight_service_pid"
+}
+
+verify_database_closed() {
+  if ! inspect_database_holders; then
+    die "lsof could not prove that the database is closed; refusing PURGE=1."
+  fi
+  if [ -n "$DATABASE_HOLDER_PIDS" ]; then
+    error "Database is still open; refusing PURGE=1:"
+    for mi_database_holder_pid in $DATABASE_HOLDER_PIDS; do
+      mi_database_holder_executable=$(
+        process_executable "$mi_database_holder_pid" 2>/dev/null || true
+      )
+      printf 'PID %s (%s)\n' \
+        "$mi_database_holder_pid" \
+        "${mi_database_holder_executable:-unknown-executable}" >&2
+    done
     exit 1
   fi
 }
@@ -1841,9 +2067,6 @@ safe_purge_directory() {
 }
 
 purge_user_data() {
-  info ""
-  warn "PURGE=1 permanently deletes the Heimdallm database and all review history; this cannot be undone."
-
   if ! mi_purge_job_state=$(launchagent_job_state); then
     die "Cannot prove that the LaunchAgent is unloaded; refusing to purge."
   fi
@@ -1858,8 +2081,8 @@ purge_user_data() {
   fi
 
   verify_database_closed
-  safe_purge_directory "$CONFIG_DIR"
   safe_purge_directory "$DATA_DIR"
+  safe_purge_directory "$CONFIG_DIR"
   safe_purge_directory "$LOG_DIR"
 
   info ""
@@ -1887,8 +2110,22 @@ uninstall_macos() {
   require_common_commands
   resolve_invoking_user
 
-  if [ -n "${PURGE-}" ] && ! purge_requested "${PURGE-}"; then
-    warn "Ignoring PURGE=${PURGE}; only exact PURGE=1 deletes user data."
+  if ! validate_purge_value "${PURGE-}"; then
+    die "Invalid PURGE value; omit PURGE to preserve data or use PURGE=1 to delete it."
+  fi
+  if purge_requested "${PURGE-}"; then
+    info ""
+    preflight_purge
+  fi
+
+  # Authenticate while uninstall is still read-only.
+  if [ -L "$APP_PATH" ]; then
+    die "Installed app path must not be a symlink: $APP_PATH"
+  elif [ -e "$APP_PATH" ]; then
+    if [ ! -d "$APP_PATH" ]; then
+      die "Installed app path is not a regular application directory: $APP_PATH"
+    fi
+    configure_application_privilege
   fi
 
   info "▶  Removing Heimdallm LaunchAgent..."

--- a/scripts/test-macos-install.sh
+++ b/scripts/test-macos-install.sh
@@ -1,0 +1,222 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && /bin/pwd -P)
+HEIMDALLM_MACOS_INSTALL_SOURCE_ONLY=1
+export HEIMDALLM_MACOS_INSTALL_SOURCE_ONLY
+. "$SCRIPT_DIR/macos-install.sh"
+unset HEIMDALLM_MACOS_INSTALL_SOURCE_ONLY
+
+TEST_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  TEST_COUNT=$((TEST_COUNT + 1))
+  printf 'ok %d - %s\n' "$TEST_COUNT" "$1"
+}
+
+fail() {
+  TEST_COUNT=$((TEST_COUNT + 1))
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'not ok %d - %s\n' "$TEST_COUNT" "$1" >&2
+  if [ "$#" -gt 1 ]; then
+    printf '  %s\n' "$2" >&2
+  fi
+}
+
+assert_accepts() {
+  mi_test_name=$1
+  shift
+  if "$@"; then
+    pass "$mi_test_name"
+  else
+    fail "$mi_test_name" "expected success"
+  fi
+}
+
+assert_rejects() {
+  mi_test_name=$1
+  shift
+  if "$@"; then
+    fail "$mi_test_name" "expected failure"
+  else
+    pass "$mi_test_name"
+  fi
+}
+
+assert_output() {
+  mi_test_name=$1
+  mi_expected=$2
+  shift 2
+  if mi_actual=$("$@" 2>&1); then
+    if [ "$mi_actual" = "$mi_expected" ]; then
+      pass "$mi_test_name"
+    else
+      fail "$mi_test_name" "expected '$mi_expected', got '$mi_actual'"
+    fi
+  else
+    fail "$mi_test_name" "command failed; expected '$mi_expected'"
+  fi
+}
+
+assert_value() {
+  mi_test_name=$1
+  mi_expected=$2
+  mi_actual=$3
+  if [ "$mi_actual" = "$mi_expected" ]; then
+    pass "$mi_test_name"
+  else
+    fail "$mi_test_name" "expected '$mi_expected', got '$mi_actual'"
+  fi
+}
+
+assert_policy() {
+  mi_state=$1
+  mi_listener=$2
+  mi_expected=$3
+  assert_output \
+    "matrix $mi_state × $mi_listener" \
+    "$mi_expected" \
+    decide_install_policy "$mi_state" "$mi_listener"
+}
+
+# Release tags: URL interpolation is allowed only after this pure validation.
+assert_accepts "accepts semver release tag" validate_release_tag "v0.7.8"
+assert_accepts "accepts safe named release tag" \
+  validate_release_tag "release_2026-07.29"
+assert_rejects "rejects empty release tag" validate_release_tag ""
+assert_rejects "rejects dot release path segment" validate_release_tag "."
+assert_rejects "rejects dot-dot release path segment" validate_release_tag ".."
+assert_rejects "rejects release path traversal" validate_release_tag "../v1"
+assert_rejects "rejects release slash" validate_release_tag "feature/v1"
+assert_rejects "rejects release spaces" validate_release_tag "v1 latest"
+assert_rejects "rejects release query characters" validate_release_tag "v1?"
+assert_rejects "rejects shell metacharacters" validate_release_tag 'v1;id'
+mi_newline_tag='v1
+v2'
+assert_rejects "rejects release newline" validate_release_tag "$mi_newline_tag"
+
+# PURGE must be exact; every other spelling preserves data.
+assert_accepts "PURGE=1 requests purge" purge_requested "1"
+assert_rejects "empty PURGE preserves data" purge_requested ""
+assert_rejects "unset-style PURGE preserves data" purge_requested
+assert_rejects "PURGE=0 preserves data" purge_requested "0"
+assert_rejects "PURGE=true preserves data" purge_requested "true"
+assert_rejects "PURGE=01 preserves data" purge_requested "01"
+assert_rejects "PURGE with trailing space preserves data" purge_requested "1 "
+
+# Canonical user paths.
+assert_accepts "accepts macOS absolute home" set_user_paths "/Users/alice"
+assert_value "derives config path" \
+  "/Users/alice/.config/heimdallm" "$CONFIG_DIR"
+assert_value "derives data path" \
+  "/Users/alice/.local/share/heimdallm" "$DATA_DIR"
+assert_value "derives database path" \
+  "/Users/alice/.local/share/heimdallm/heimdallm.db" "$DB_PATH"
+assert_value "derives ui.pid path" \
+  "/Users/alice/.local/share/heimdallm/ui.pid" "$UI_PID_PATH"
+assert_value "derives log path" \
+  "/Users/alice/Library/Logs/heimdallm" "$LOG_DIR"
+assert_value "derives LaunchAgent path" \
+  "/Users/alice/Library/LaunchAgents/com.heimdallm.daemon.plist" \
+  "$PLIST_PATH"
+assert_accepts "accepts Linux home for cross-platform pure tests" \
+  set_user_paths "/home/alice"
+assert_rejects "rejects empty home" set_user_paths ""
+assert_rejects "rejects relative home" set_user_paths "Users/alice"
+assert_rejects "rejects root home" set_user_paths "/"
+assert_rejects "rejects dot component" set_user_paths "/Users/./alice"
+assert_rejects "rejects dot-dot component" set_user_paths "/Users/bob/../alice"
+assert_rejects "rejects duplicate slash" set_user_paths "/Users//alice"
+assert_rejects "rejects trailing slash" set_user_paths "/Users/alice/"
+assert_accepts "accepts canonical /tmp installer workspace" \
+  safe_temp_path "/tmp/heimdallm-install.ABC123"
+assert_accepts "accepts macOS per-user TMPDIR workspace" \
+  safe_temp_path "/var/folders/ab/cdef/T/heimdallm-install.ABC123"
+assert_rejects "rejects arbitrary TMPDIR cleanup path" \
+  safe_temp_path "/Users/alice/tmp/heimdallm-install.ABC123"
+assert_rejects "rejects unrelated /tmp cleanup path" \
+  safe_temp_path "/tmp/unrelated.ABC123"
+assert_rejects "rejects short installer workspace suffix" \
+  safe_temp_path "/tmp/heimdallm-install.ABC"
+assert_accepts "accepts exact staging work path" \
+  safe_application_work_path "/Applications/.heimdallm-staging.ABC123"
+assert_accepts "accepts exact backup work path" \
+  safe_application_work_path "/Applications/.heimdallm-backup.ABC123"
+assert_rejects "rejects Applications root as work path" \
+  safe_application_work_path "/Applications"
+assert_rejects "rejects short staging work path suffix" \
+  safe_application_work_path "/Applications/.heimdallm-staging.ABC"
+
+# Listener classification uses exact executable paths and prioritizes the
+# captured LaunchAgent PID.
+assert_output "classifies empty listener as free" \
+  "free" classify_listener "" "" ""
+assert_output "classifies captured PID as service-owned" \
+  "service" classify_listener "42" "$APP_DAEMON_BIN" "42"
+assert_output "classifies exact UI binary as bundle-owned" \
+  "bundle" classify_listener "43" "$APP_UI_BIN" "42"
+assert_output "classifies exact daemon binary as bundle-owned" \
+  "bundle" classify_listener "43" "$APP_DAEMON_BIN" "42"
+assert_output "rejects bundle-path prefix as foreign" \
+  "foreign" classify_listener "43" "$APP_DAEMON_BIN.old" "42"
+assert_output "classifies checkout daemon as foreign" \
+  "foreign" classify_listener "43" "/work/daemon/bin/heimdallm" "42"
+
+# Reviewed 4 × 4 LaunchAgent/listener matrix.
+assert_policy "absent" "free" "proceed"
+assert_policy "absent" "bundle" "stop-bundle"
+assert_policy "absent" "service" "abort-inconsistent"
+assert_policy "absent" "foreign" "warn"
+
+assert_policy "present-unloaded" "free" "migrate-unloaded"
+assert_policy "present-unloaded" "bundle" \
+  "stop-bundle+migrate-unloaded"
+assert_policy "present-unloaded" "service" "abort-inconsistent"
+assert_policy "present-unloaded" "foreign" \
+  "warn+migrate-unloaded"
+
+assert_policy "loaded-enabled" "free" "restart-service"
+assert_policy "loaded-enabled" "bundle" \
+  "stop-bundle+restart-service"
+assert_policy "loaded-enabled" "service" "restart-service"
+assert_policy "loaded-enabled" "foreign" "abort-foreign"
+
+assert_policy "loaded-disabled" "free" "migrate-disabled"
+assert_policy "loaded-disabled" "bundle" \
+  "stop-bundle+migrate-disabled"
+assert_policy "loaded-disabled" "service" "migrate-disabled"
+assert_policy "loaded-disabled" "foreign" \
+  "warn+migrate-disabled"
+
+# Signal-safe swap detection: rollback must not touch the installed app before
+# a rename, but must recognize a rename that completed before its post-command
+# flag assignment.
+assert_rejects "pre-swap rollback does not infer an app mutation" \
+  rollback_old_move_detected "0" "0" "0"
+assert_rejects "old-move intent alone is not a completed rename" \
+  rollback_old_move_detected "0" "1" "0"
+assert_accepts "backup presence closes old-move signal window" \
+  rollback_old_move_detected "0" "1" "1"
+assert_accepts "completed old-move flag is authoritative" \
+  rollback_old_move_detected "1" "0" "0"
+assert_rejects "new-move intent before rename is not installed" \
+  rollback_new_move_detected "0" "1" "0" "0"
+assert_accepts "path evidence closes new-move signal window" \
+  rollback_new_move_detected "0" "1" "1" "1"
+assert_accepts "completed new-app flag is authoritative" \
+  rollback_new_move_detected "1" "0" "0" "0"
+
+# Cleanup is deliberately tested only with every external resource disarmed.
+# Real hdiutil/launchctl/sudo/swap behavior belongs to macOS integration tests.
+init_runtime_state
+assert_accepts "cleanup succeeds with no resources armed" cleanup
+assert_accepts "cleanup is idempotent with no resources armed" cleanup
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  printf '\n%d of %d tests failed\n' "$FAIL_COUNT" "$TEST_COUNT" >&2
+  exit 1
+fi
+
+printf '\n%d tests passed\n' "$TEST_COUNT"

--- a/scripts/test-macos-install.sh
+++ b/scripts/test-macos-install.sh
@@ -97,14 +97,19 @@ mi_newline_tag='v1
 v2'
 assert_rejects "rejects release newline" validate_release_tag "$mi_newline_tag"
 
-# PURGE must be exact; every other spelling preserves data.
+# PURGE mode is exact, and the public command accepts only empty/unset or 1.
 assert_accepts "PURGE=1 requests purge" purge_requested "1"
-assert_rejects "empty PURGE preserves data" purge_requested ""
-assert_rejects "unset-style PURGE preserves data" purge_requested
-assert_rejects "PURGE=0 preserves data" purge_requested "0"
-assert_rejects "PURGE=true preserves data" purge_requested "true"
-assert_rejects "PURGE=01 preserves data" purge_requested "01"
-assert_rejects "PURGE with trailing space preserves data" purge_requested "1 "
+assert_rejects "empty PURGE does not request purge" purge_requested ""
+assert_rejects "unset-style PURGE does not request purge" purge_requested
+assert_accepts "accepts unset PURGE value" validate_purge_value
+assert_accepts "accepts empty PURGE value" validate_purge_value ""
+assert_accepts "accepts exact PURGE=1 value" validate_purge_value "1"
+assert_rejects "rejects PURGE=0 before mutation" validate_purge_value "0"
+assert_rejects "rejects PURGE=true before mutation" \
+  validate_purge_value "true"
+assert_rejects "rejects PURGE=01 before mutation" validate_purge_value "01"
+assert_rejects "rejects PURGE with trailing space before mutation" \
+  validate_purge_value "1 "
 
 # Canonical user paths.
 assert_accepts "accepts macOS absolute home" set_user_paths "/Users/alice"
@@ -149,6 +154,15 @@ assert_rejects "rejects Applications root as work path" \
 assert_rejects "rejects short staging work path suffix" \
   safe_application_work_path "/Applications/.heimdallm-staging.ABC"
 
+# Flutter writes ui.pid without a trailing newline; retain the assigned value
+# even though POSIX read reports EOF as a non-zero status.
+mi_pid_file=$(mktemp "/tmp/heimdallm-ui-pid.XXXXXX")
+printf '%s' "12345" > "$mi_pid_file"
+assert_accepts "reads ui.pid without a trailing newline" \
+  read_pid_file "$mi_pid_file"
+assert_value "preserves ui.pid value assigned at EOF" "12345" "$PID_FILE_VALUE"
+rm -f "$mi_pid_file"
+
 # Listener classification uses exact executable paths and prioritizes the
 # captured LaunchAgent PID.
 assert_output "classifies empty listener as free" \
@@ -163,6 +177,26 @@ assert_output "rejects bundle-path prefix as foreign" \
   "foreign" classify_listener "43" "$APP_DAEMON_BIN.old" "42"
 assert_output "classifies checkout daemon as foreign" \
   "foreign" classify_listener "43" "/work/daemon/bin/heimdallm" "42"
+
+# PURGE preflight permits only the invoking user's known service or exact
+# installed-bundle executables. A checkout daemon is known only by service PID.
+assert_output "purge permits captured checkout service PID" \
+  "known-service" \
+  classify_purge_holder "42" "/work/daemon/bin/heimdallm" "501" "42" "501"
+assert_output "purge permits exact installed UI" \
+  "known-bundle" \
+  classify_purge_holder "43" "$APP_UI_BIN" "501" "42" "501"
+assert_output "purge permits exact installed daemon" \
+  "known-bundle" \
+  classify_purge_holder "44" "$APP_DAEMON_BIN" "501" "42" "501"
+assert_output "purge rejects a development daemon" \
+  "foreign" \
+  classify_purge_holder "45" "/work/daemon/bin/heimdallm" "501" "42" "501"
+assert_output "purge rejects another user's installed process" \
+  "foreign" \
+  classify_purge_holder "46" "$APP_DAEMON_BIN" "502" "42" "501"
+assert_output "purge rejects an unresolved executable" \
+  "foreign" classify_purge_holder "47" "" "501" "42" "501"
 
 # Reviewed 4 × 4 LaunchAgent/listener matrix.
 assert_policy "absent" "free" "proceed"
@@ -208,11 +242,43 @@ assert_accepts "path evidence closes new-move signal window" \
 assert_accepts "completed new-app flag is authoritative" \
   rollback_new_move_detected "1" "0" "0" "0"
 
-# Cleanup is deliberately tested only with every external resource disarmed.
-# Real hdiutil/launchctl/sudo/swap behavior belongs to macOS integration tests.
+# EXIT/signal handlers roll back only an armed, uncommitted transaction.
+assert_rejects "disarmed failed install does not roll back" \
+  rollback_required "0" "0"
+assert_accepts "armed failed install requires rollback" \
+  rollback_required "1" "0"
+assert_rejects "committed install does not roll back" \
+  rollback_required "1" "1"
+assert_rejects "disarmed committed install does not roll back" \
+  rollback_required "0" "1"
+
+# Cleanup exercises only real private /tmp state; external macOS integrations
+# (hdiutil/launchctl/sudo/swap) remain in the manual verification scenarios.
 init_runtime_state
 assert_accepts "cleanup succeeds with no resources armed" cleanup
 assert_accepts "cleanup is idempotent with no resources armed" cleanup
+
+mi_cleanup_dir=$(mktemp -d "/tmp/heimdallm-install.XXXXXX")
+init_runtime_state
+TEMP_DIR=$mi_cleanup_dir
+assert_accepts "cleanup removes an armed private temp directory" cleanup
+assert_rejects "armed private temp directory is gone" \
+  test -e "$mi_cleanup_dir"
+assert_value "cleanup disarms the private temp directory" "" "$TEMP_DIR"
+assert_accepts "cleanup stays idempotent after removing private temp" cleanup
+
+mi_preserved_dir=$(mktemp -d "/tmp/heimdallm-install.XXXXXX")
+init_runtime_state
+TEMP_DIR=$mi_preserved_dir
+PRESERVE_TEMP=1
+assert_accepts "cleanup preserves an explicitly protected temp directory" \
+  cleanup
+assert_accepts "protected temp directory remains present" \
+  test -d "$mi_preserved_dir"
+PRESERVE_TEMP=0
+assert_accepts "cleanup removes temp after protection is cleared" cleanup
+assert_rejects "formerly protected temp directory is gone" \
+  test -e "$mi_preserved_dir"
 
 if [ "$FAIL_COUNT" -ne 0 ]; then
   printf '\n%d of %d tests failed\n' "$FAIL_COUNT" "$TEST_COUNT" >&2


### PR DESCRIPTION
## Summary

- add `make install-macos`, `make uninstall-macos`, and `make test-install-macos`
- install release DMGs through a POSIX helper with validated staging, same-filesystem swap, bounded process shutdown, selective `sudo`, and rollback
- migrate existing LaunchAgents to the daemon inside `/Applications/Heimdallm.app`, including loaded-disabled and unloaded states
- remove the LaunchAgent during normal uninstall while preserving user state
- make exact `PURGE=1` delete only canonical config, review-history, and log directories while preserving Keychain and custom override paths
- document the preferred checkout workflow and add a Linux CI non-regression gate

## Why

macOS currently has packaging and release targets but no repository-driven install or uninstall flow. The manual DMG procedure does not safely migrate a service installed from a checkout and can leave `launchd` retrying a missing or stale daemon.

The new flow keeps executable service state consistent with the installed bundle, limits privilege escalation to `/Applications`, and fails closed around launchd, process, port, mount, database, and rollback inspection.

## Security-sensitive files

- [installer at ded023f](https://github.com/theburrowhub/heimdallm/blob/ded023fc4751ef11f939ad39b18f459562fc53b0/scripts/macos-install.sh) ([raw](https://raw.githubusercontent.com/theburrowhub/heimdallm/ded023fc4751ef11f939ad39b18f459562fc53b0/scripts/macos-install.sh))
- [test harness at ded023f](https://github.com/theburrowhub/heimdallm/blob/ded023fc4751ef11f939ad39b18f459562fc53b0/scripts/test-macos-install.sh) ([raw](https://raw.githubusercontent.com/theburrowhub/heimdallm/ded023fc4751ef11f939ad39b18f459562fc53b0/scripts/test-macos-install.sh))
- [concise ADR](https://github.com/theburrowhub/heimdallm/blob/ded023fc4751ef11f939ad39b18f459562fc53b0/docs/superpowers/specs/2026-07-29-install-macos-target-design.md)

GitHub's per-file API exposes both script patches completely (2,184 installer lines and 288 harness lines), even if an aggregated reviewer context truncates the PR diff.

## Validation

- `make test-install-macos` — 96/96
- `/bin/dash scripts/test-macos-install.sh` — 96/96
- Alpine Linux read-only smoke — syntax, pure tests, Make guards, direct helper guards, and unchanged Linux dry-runs passed
- `make test-docker` — daemon vet and full Go suite passed in the pinned container
- `make test-cli` — passed
- `make -n install-linux` and `make -n uninstall-linux` — existing recipes still parse unchanged
- workflow YAML parse and `git diff --check` — passed

## Manual verification

The five real macOS integration scenarios in the ADR have not been run against `/Applications` or live user data from this checkout. They remain a merge gate/checklist for clean install, running-app reinstall, LaunchAgent migration, state-preserving uninstall, and guarded purge.

Closes #604
Related to #436
Related to #437
