### PR TITLE
fix(test): isolate Compose integration runs from production volumes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,6 +109,15 @@ jobs:
         working-directory: cli
         run: go vet ./...
 
+  compose-isolation:
+    name: Docker Compose test isolation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test destructive-command guards without starting services
+        run: make test-compose-isolation
+
   flutter:
     name: Flutter
     runs-on: macos-14

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ else
   APP_BUNDLE       := $(FLUTTER_BUILD)/bundle
 endif
 
-.PHONY: build-daemon build-app build-web build-cli test test-cli lint-cli dev-cli test-docker dev dev-daemon dev-stop \
+.PHONY: build-daemon build-app build-web build-cli test test-cli lint-cli test-compose-isolation \
+        test-smoke test-github test-e2e test-web dev-cli test-docker dev dev-daemon dev-stop \
         release-local package-macos install-service verify-linux run-linux test-install-macos \
         install-macos uninstall-macos install-linux uninstall-linux \
         setup up up-build up-daemon up-build-daemon down logs logs-daemon \
@@ -55,6 +56,23 @@ test-install-macos:
 	@sh -n scripts/macos-install.sh
 	@sh -n scripts/test-macos-install.sh
 	@./scripts/test-macos-install.sh
+
+# Static/fake-Docker regression suite for the destructive Compose test wrappers.
+# It does not build images, start containers, or touch daemon data.
+test-compose-isolation:
+	./docker/scripts/tests/test-compose-isolation.sh
+
+test-smoke:
+	./docker/scripts/test-local.sh smoke
+
+test-github:
+	./docker/scripts/test-local.sh github
+
+test-e2e:
+	./docker/scripts/test-local.sh e2e
+
+test-web:
+	./docker/scripts/test-web.sh
 
 # ── Sandboxed Go tests (EDR-safe) ─────────────────────────────────────────────
 #

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,21 +1,22 @@
-# Override for local testing.
-# Usage: docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml up
+# Override for isolated local testing.
+#
+# Do not invoke this file directly. docker/scripts/test-local.sh and
+# docker/scripts/test-web.sh generate a unique Compose project and required
+# container names for every run.
 services:
   heimdallm:
-    container_name: heimdallm-test
+    container_name: "${HEIMDALLM_TEST_DAEMON_CONTAINER_NAME:?use an isolated Docker test runner}"
     restart: "no"
-    ports:
-      - "${HEIMDALLM_PORT:-7842}:${HEIMDALLM_PORT:-7842}"
     environment:
       - HEIMDALLM_POLL_INTERVAL=${HEIMDALLM_POLL_INTERVAL:-1m}
     volumes:
       - heimdallm-test-data:/data
-      - ./config:/config
+      - heimdallm-test-config:/config
       # Gemini OAuth tokens from host (uncomment for Level 3 E2E test):
       # - ~/.gemini:/home/heimdallm/.gemini:ro
 
   web:
-    container_name: heimdallm-web-test
+    container_name: "${HEIMDALLM_TEST_WEB_CONTAINER_NAME:?use an isolated Docker test runner}"
     restart: "no"
     # Set HEIMDALLM_API_TOKEN to empty (the entrypoint's `[ -n "$VAR" ]`
     # check treats empty and unset the same, falling through to the file
@@ -33,4 +34,6 @@ services:
 
 volumes:
   heimdallm-test-data:
+    driver: local
+  heimdallm-test-config:
     driver: local

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,12 @@ services:
     container_name: heimdallm
     restart: unless-stopped
     ports:
-      - "${HEIMDALLM_PORT:-7842}:${HEIMDALLM_PORT:-7842}"
+      # Compose-only host binding knobs let the isolated test runners request
+      # a loopback ephemeral port without adding a second merged port entry.
+      # When HOST_IP is unset the mapping remains exactly the original
+      # host-port:container-port form, preserving Docker's default bind
+      # semantics. Tests set it to 127.0.0.1 and the host port to 0.
+      - "${HEIMDALLM_COMPOSE_DAEMON_HOST_IP:+${HEIMDALLM_COMPOSE_DAEMON_HOST_IP}:}${HEIMDALLM_COMPOSE_DAEMON_HOST_PORT:-${HEIMDALLM_PORT:-7842}}:${HEIMDALLM_PORT:-7842}"
     environment:
       # ── Heimdallm config ───────────────────────────────────────────────
       - GITHUB_TOKEN=${GITHUB_TOKEN}
@@ -134,7 +139,7 @@ services:
     container_name: heimdallm-web
     restart: unless-stopped
     ports:
-      - "${HEIMDALLM_WEB_PORT:-3000}:3000"
+      - "${HEIMDALLM_COMPOSE_WEB_HOST_IP:+${HEIMDALLM_COMPOSE_WEB_HOST_IP}:}${HEIMDALLM_COMPOSE_WEB_HOST_PORT:-${HEIMDALLM_WEB_PORT:-3000}}:3000"
     environment:
       # Upstream daemon URL inside the compose network. Host + port line
       # up with the heimdallm service above.

--- a/docker/scripts/lib/compose-test.sh
+++ b/docker/scripts/lib/compose-test.sh
@@ -1,0 +1,280 @@
+#!/bin/sh
+#
+# Shared Docker Compose isolation helpers for integration-test runners.
+#
+# This file is sourced by both test-local.sh (bash) and test-web.sh (POSIX sh),
+# so keep it portable and do not enable shell options here.
+
+compose_test_error() {
+    printf 'compose-test: %s\n' "$*" >&2
+}
+
+compose_test_init() {
+    if [ "${COMPOSE_TEST_INITIALIZED:-0}" = "1" ]; then
+        compose_test_error "isolation is already initialized"
+        return 1
+    fi
+
+    COMPOSE_TEST_KIND="${1:-}"
+    COMPOSE_TEST_REPO_ROOT="${2:-}"
+
+    case "$COMPOSE_TEST_KIND" in
+        ''|*[!a-z0-9-]*)
+            compose_test_error "invalid test kind '$COMPOSE_TEST_KIND'"
+            return 1
+            ;;
+    esac
+
+    if [ ! -d "$COMPOSE_TEST_REPO_ROOT" ]; then
+        compose_test_error "repository root does not exist: $COMPOSE_TEST_REPO_ROOT"
+        return 1
+    fi
+
+    COMPOSE_TEST_BASE_FILE="$COMPOSE_TEST_REPO_ROOT/docker/docker-compose.yml"
+    COMPOSE_TEST_OVERRIDE_FILE="$COMPOSE_TEST_REPO_ROOT/docker/docker-compose.test.yml"
+    if [ ! -f "$COMPOSE_TEST_BASE_FILE" ] || [ ! -f "$COMPOSE_TEST_OVERRIDE_FILE" ]; then
+        compose_test_error "Compose files were not found under $COMPOSE_TEST_REPO_ROOT/docker"
+        return 1
+    fi
+
+    COMPOSE_TEST_STATE_DIR="$(
+        mktemp -d "${TMPDIR:-/tmp}/heimdallm-compose-test-${COMPOSE_TEST_KIND}.XXXXXX"
+    )" || {
+        compose_test_error "could not allocate an isolated run directory"
+        return 1
+    }
+
+    _compose_test_token=${COMPOSE_TEST_STATE_DIR##*.}
+    case "$_compose_test_token" in
+        ''|*[!A-Za-z0-9]*)
+            compose_test_error "mktemp returned an unsafe run token"
+            rmdir "$COMPOSE_TEST_STATE_DIR" 2>/dev/null || true
+            return 1
+            ;;
+    esac
+    _compose_test_token=$(printf '%s' "$_compose_test_token" | tr '[:upper:]' '[:lower:]')
+
+    COMPOSE_TEST_PROJECT_NAME="heimdallm-test-${COMPOSE_TEST_KIND}-$$-${_compose_test_token}"
+    COMPOSE_TEST_MARKER="$COMPOSE_TEST_STATE_DIR/project"
+    if ! (
+        umask 077
+        printf '%s\n%s\n' "$COMPOSE_TEST_PROJECT_NAME" "$$" >"$COMPOSE_TEST_MARKER"
+    ); then
+        compose_test_error "could not write the isolation marker"
+        rmdir "$COMPOSE_TEST_STATE_DIR" 2>/dev/null || true
+        return 1
+    fi
+
+    # docker-compose.test.yml requires these names. They retain the normal
+    # stack's stable container names while making every test run collision-free.
+    HEIMDALLM_TEST_DAEMON_CONTAINER_NAME="${COMPOSE_TEST_PROJECT_NAME}-daemon"
+    HEIMDALLM_TEST_WEB_CONTAINER_NAME="${COMPOSE_TEST_PROJECT_NAME}-web"
+    # Reuse the base Compose port entries instead of appending override entries.
+    # Port 0 asks Docker to allocate a free port for each independent project.
+    HEIMDALLM_COMPOSE_DAEMON_HOST_IP=127.0.0.1
+    HEIMDALLM_COMPOSE_DAEMON_HOST_PORT=0
+    HEIMDALLM_COMPOSE_WEB_HOST_IP=127.0.0.1
+    HEIMDALLM_COMPOSE_WEB_HOST_PORT=0
+    export HEIMDALLM_TEST_DAEMON_CONTAINER_NAME
+    export HEIMDALLM_TEST_WEB_CONTAINER_NAME
+    export HEIMDALLM_COMPOSE_DAEMON_HOST_IP
+    export HEIMDALLM_COMPOSE_DAEMON_HOST_PORT
+    export HEIMDALLM_COMPOSE_WEB_HOST_IP
+    export HEIMDALLM_COMPOSE_WEB_HOST_PORT
+    export COMPOSE_TEST_PROJECT_NAME
+
+    COMPOSE_TEST_INITIALIZED=1
+}
+
+compose_test_assert_identity() {
+    if [ "${COMPOSE_TEST_INITIALIZED:-0}" != "1" ]; then
+        compose_test_error "isolation is not initialized"
+        return 1
+    fi
+    if [ -z "${COMPOSE_TEST_PROJECT_NAME:-}" ] ||
+       [ -z "${COMPOSE_TEST_KIND:-}" ] ||
+       [ -z "${COMPOSE_TEST_MARKER:-}" ]; then
+        compose_test_error "run identity is incomplete"
+        return 1
+    fi
+    if [ "$COMPOSE_TEST_MARKER" != "${COMPOSE_TEST_STATE_DIR:-}/project" ]; then
+        compose_test_error "run marker path does not match the private state directory"
+        return 1
+    fi
+    if [ ! -f "$COMPOSE_TEST_MARKER" ] || [ -L "$COMPOSE_TEST_MARKER" ]; then
+        compose_test_error "run marker is missing or unsafe"
+        return 1
+    fi
+
+    _compose_test_expected_project=$(sed -n '1p' "$COMPOSE_TEST_MARKER")
+    _compose_test_expected_pid=$(sed -n '2p' "$COMPOSE_TEST_MARKER")
+    if [ "$_compose_test_expected_project" != "$COMPOSE_TEST_PROJECT_NAME" ] ||
+       [ "$_compose_test_expected_pid" != "$$" ]; then
+        compose_test_error "run marker does not match this process"
+        return 1
+    fi
+
+    _compose_test_prefix="heimdallm-test-${COMPOSE_TEST_KIND}-"
+    case "$COMPOSE_TEST_PROJECT_NAME" in
+        "$_compose_test_prefix"*) ;;
+        *)
+            compose_test_error "project is not test-scoped"
+            return 1
+            ;;
+    esac
+    case "$COMPOSE_TEST_PROJECT_NAME" in
+        *[!a-z0-9_-]*)
+            compose_test_error "project contains unsafe characters"
+            return 1
+            ;;
+    esac
+    if [ "$COMPOSE_TEST_PROJECT_NAME" = "$_compose_test_prefix" ]; then
+        compose_test_error "project identity is incomplete"
+        return 1
+    fi
+
+    if [ "${COMPOSE_TEST_BASE_FILE:-}" != "${COMPOSE_TEST_REPO_ROOT:-}/docker/docker-compose.yml" ] ||
+       [ "${COMPOSE_TEST_OVERRIDE_FILE:-}" != "${COMPOSE_TEST_REPO_ROOT:-}/docker/docker-compose.test.yml" ]; then
+        compose_test_error "Compose file identity changed after initialization"
+        return 1
+    fi
+    if [ "${HEIMDALLM_TEST_DAEMON_CONTAINER_NAME:-}" != "${COMPOSE_TEST_PROJECT_NAME}-daemon" ] ||
+       [ "${HEIMDALLM_TEST_WEB_CONTAINER_NAME:-}" != "${COMPOSE_TEST_PROJECT_NAME}-web" ]; then
+        compose_test_error "container identity changed after initialization"
+        return 1
+    fi
+    if [ "${HEIMDALLM_COMPOSE_DAEMON_HOST_IP:-}" != "127.0.0.1" ] ||
+       [ "${HEIMDALLM_COMPOSE_DAEMON_HOST_PORT:-}" != "0" ] ||
+       [ "${HEIMDALLM_COMPOSE_WEB_HOST_IP:-}" != "127.0.0.1" ] ||
+       [ "${HEIMDALLM_COMPOSE_WEB_HOST_PORT:-}" != "0" ]; then
+        compose_test_error "test port isolation changed after initialization"
+        return 1
+    fi
+}
+
+compose_test_assert_safe() {
+    if ! compose_test_assert_identity; then
+        compose_test_error "refusing destructive Compose command"
+        return 1
+    fi
+}
+
+compose_test() {
+    case "${1:-}" in
+        '')
+            compose_test_error "a Compose subcommand is required"
+            return 1
+            ;;
+        -*)
+            compose_test_error "the first argument must be a Compose subcommand"
+            return 1
+            ;;
+    esac
+
+    if [ "${1:-}" = "down" ]; then
+        compose_test_assert_safe || return $?
+    else
+        compose_test_assert_identity || return $?
+    fi
+
+    command docker compose \
+        --project-name "$COMPOSE_TEST_PROJECT_NAME" \
+        -f "$COMPOSE_TEST_BASE_FILE" \
+        -f "$COMPOSE_TEST_OVERRIDE_FILE" \
+        "$@"
+}
+
+compose_test_down() {
+    compose_test down -v --remove-orphans
+}
+
+compose_test_cleanup() {
+    if [ -z "${COMPOSE_TEST_STATE_DIR:-}" ] ||
+       [ ! -d "$COMPOSE_TEST_STATE_DIR" ] ||
+       [ "${COMPOSE_TEST_MARKER:-}" != "$COMPOSE_TEST_STATE_DIR/project" ]; then
+        compose_test_error "cleanup state is invalid; refusing to invoke Docker"
+        return 1
+    fi
+
+    COMPOSE_TEST_CLEANUP_LOG="$COMPOSE_TEST_STATE_DIR/cleanup.log"
+    if compose_test_down >"$COMPOSE_TEST_CLEANUP_LOG" 2>&1; then
+        rm -f "$COMPOSE_TEST_CLEANUP_LOG"
+        compose_test_release
+        return 0
+    fi
+
+    compose_test_error "cleanup failed; isolated Docker resources may remain"
+    if compose_test_assert_identity >/dev/null 2>&1; then
+        compose_test_error "project: $COMPOSE_TEST_PROJECT_NAME"
+        compose_test_error "inspect: $(compose_test_display) ps -a"
+    fi
+    compose_test_error "marker preserved: $COMPOSE_TEST_MARKER"
+    compose_test_error "cleanup log: $COMPOSE_TEST_CLEANUP_LOG"
+    return 1
+}
+
+compose_test_run_path() {
+    _compose_test_run_file="${1:-}"
+    case "$_compose_test_run_file" in
+        ''|*[!a-z0-9-]*)
+            compose_test_error "invalid per-run file name '$_compose_test_run_file'"
+            return 1
+            ;;
+    esac
+    compose_test_assert_identity || return $?
+    printf '%s/%s\n' "$COMPOSE_TEST_STATE_DIR" "$_compose_test_run_file"
+}
+
+compose_test_published_port() {
+    _compose_test_service="${1:-}"
+    _compose_test_container_port="${2:-}"
+    if [ -z "$_compose_test_service" ] || [ -z "$_compose_test_container_port" ]; then
+        compose_test_error "service and container port are required"
+        return 1
+    fi
+
+    _compose_test_binding=$(compose_test port "$_compose_test_service" "$_compose_test_container_port" | tail -n 1)
+    _compose_test_host_port=${_compose_test_binding##*:}
+    case "$_compose_test_host_port" in
+        ''|*[!0-9]*)
+            compose_test_error "could not resolve published port for ${_compose_test_service}:${_compose_test_container_port}"
+            return 1
+            ;;
+    esac
+    printf '%s\n' "$_compose_test_host_port"
+}
+
+compose_test_display() {
+    printf 'env HEIMDALLM_TEST_DAEMON_CONTAINER_NAME=%s HEIMDALLM_TEST_WEB_CONTAINER_NAME=%s HEIMDALLM_COMPOSE_DAEMON_HOST_IP=127.0.0.1 HEIMDALLM_COMPOSE_DAEMON_HOST_PORT=0 HEIMDALLM_COMPOSE_WEB_HOST_IP=127.0.0.1 HEIMDALLM_COMPOSE_WEB_HOST_PORT=0 docker compose --project-name %s -f "%s" -f "%s"' \
+        "$HEIMDALLM_TEST_DAEMON_CONTAINER_NAME" \
+        "$HEIMDALLM_TEST_WEB_CONTAINER_NAME" \
+        "$COMPOSE_TEST_PROJECT_NAME" \
+        "$COMPOSE_TEST_BASE_FILE" \
+        "$COMPOSE_TEST_OVERRIDE_FILE"
+}
+
+compose_test_release() {
+    if [ -n "${COMPOSE_TEST_MARKER:-}" ] &&
+       [ "$COMPOSE_TEST_MARKER" = "${COMPOSE_TEST_STATE_DIR:-}/project" ]; then
+        rm -f "$COMPOSE_TEST_MARKER"
+    fi
+    if [ -n "${COMPOSE_TEST_STATE_DIR:-}" ]; then
+        rmdir "$COMPOSE_TEST_STATE_DIR" 2>/dev/null || true
+    fi
+
+    unset HEIMDALLM_TEST_DAEMON_CONTAINER_NAME
+    unset HEIMDALLM_TEST_WEB_CONTAINER_NAME
+    unset HEIMDALLM_COMPOSE_DAEMON_HOST_IP
+    unset HEIMDALLM_COMPOSE_DAEMON_HOST_PORT
+    unset HEIMDALLM_COMPOSE_WEB_HOST_IP
+    unset HEIMDALLM_COMPOSE_WEB_HOST_PORT
+    unset COMPOSE_TEST_PROJECT_NAME
+    unset COMPOSE_TEST_KIND
+    unset COMPOSE_TEST_REPO_ROOT
+    unset COMPOSE_TEST_BASE_FILE
+    unset COMPOSE_TEST_OVERRIDE_FILE
+    unset COMPOSE_TEST_STATE_DIR
+    unset COMPOSE_TEST_MARKER
+    unset COMPOSE_TEST_CLEANUP_LOG
+    COMPOSE_TEST_INITIALIZED=0
+}

--- a/docker/scripts/lib/compose-test.sh
+++ b/docker/scripts/lib/compose-test.sh
@@ -199,14 +199,22 @@ compose_test_cleanup() {
     COMPOSE_TEST_CLEANUP_LOG="$COMPOSE_TEST_STATE_DIR/cleanup.log"
     if compose_test_down >"$COMPOSE_TEST_CLEANUP_LOG" 2>&1; then
         rm -f "$COMPOSE_TEST_CLEANUP_LOG"
-        compose_test_release
-        return 0
+        if compose_test_release; then
+            return 0
+        fi
+
+        compose_test_error "Docker cleanup succeeded, but the private state directory could not be released"
+        compose_test_error "inspect state directory: $COMPOSE_TEST_STATE_DIR"
+        compose_test_error "after inspecting unexpected files, remove the preserved state explicitly"
+        return 1
     fi
 
     compose_test_error "cleanup failed; isolated Docker resources may remain"
     if compose_test_assert_identity >/dev/null 2>&1; then
         compose_test_error "project: $COMPOSE_TEST_PROJECT_NAME"
         compose_test_error "inspect: $(compose_test_display) ps -a"
+        compose_test_error "retry cleanup: $(compose_test_display) down -v --remove-orphans"
+        compose_test_error "after Docker cleanup succeeds, remove state: $(compose_test_display_state_cleanup)"
     fi
     compose_test_error "marker preserved: $COMPOSE_TEST_MARKER"
     compose_test_error "cleanup log: $COMPOSE_TEST_CLEANUP_LOG"
@@ -223,6 +231,32 @@ compose_test_run_path() {
     esac
     compose_test_assert_identity || return $?
     printf '%s/%s\n' "$COMPOSE_TEST_STATE_DIR" "$_compose_test_run_file"
+}
+
+compose_test_remove_run_file() {
+    _compose_test_remove_name="${1:-}"
+    _compose_test_remove_candidate="${2:-}"
+    _compose_test_remove_mismatch=0
+
+    # Derive the deletion target from the validated run identity. Never use the
+    # caller-provided candidate as an rm target: test-local.sh sources
+    # docker/.env, which can overwrite otherwise internal shell variables.
+    if ! _compose_test_remove_expected=$(compose_test_run_path "$_compose_test_remove_name"); then
+        compose_test_error "could not validate the per-run file; refusing deletion"
+        return 1
+    fi
+
+    if [ "$_compose_test_remove_candidate" != "$_compose_test_remove_expected" ]; then
+        compose_test_error "per-run file identity changed; deleting only the validated state file"
+        _compose_test_remove_mismatch=1
+    fi
+
+    if ! rm -f "$_compose_test_remove_expected"; then
+        compose_test_error "could not remove the validated per-run file"
+        return 1
+    fi
+
+    [ "$_compose_test_remove_mismatch" -eq 0 ]
 }
 
 compose_test_published_port() {
@@ -245,21 +279,61 @@ compose_test_published_port() {
 }
 
 compose_test_display() {
-    printf 'env HEIMDALLM_TEST_DAEMON_CONTAINER_NAME=%s HEIMDALLM_TEST_WEB_CONTAINER_NAME=%s HEIMDALLM_COMPOSE_DAEMON_HOST_IP=127.0.0.1 HEIMDALLM_COMPOSE_DAEMON_HOST_PORT=0 HEIMDALLM_COMPOSE_WEB_HOST_IP=127.0.0.1 HEIMDALLM_COMPOSE_WEB_HOST_PORT=0 docker compose --project-name %s -f "%s" -f "%s"' \
-        "$HEIMDALLM_TEST_DAEMON_CONTAINER_NAME" \
-        "$HEIMDALLM_TEST_WEB_CONTAINER_NAME" \
-        "$COMPOSE_TEST_PROJECT_NAME" \
-        "$COMPOSE_TEST_BASE_FILE" \
-        "$COMPOSE_TEST_OVERRIDE_FILE"
+    _compose_test_daemon_name=$(compose_test_shell_quote "$HEIMDALLM_TEST_DAEMON_CONTAINER_NAME")
+    _compose_test_web_name=$(compose_test_shell_quote "$HEIMDALLM_TEST_WEB_CONTAINER_NAME")
+    _compose_test_project=$(compose_test_shell_quote "$COMPOSE_TEST_PROJECT_NAME")
+    _compose_test_base_file=$(compose_test_shell_quote "$COMPOSE_TEST_BASE_FILE")
+    _compose_test_override_file=$(compose_test_shell_quote "$COMPOSE_TEST_OVERRIDE_FILE")
+
+    printf 'env HEIMDALLM_TEST_DAEMON_CONTAINER_NAME=%s HEIMDALLM_TEST_WEB_CONTAINER_NAME=%s HEIMDALLM_COMPOSE_DAEMON_HOST_IP=127.0.0.1 HEIMDALLM_COMPOSE_DAEMON_HOST_PORT=0 HEIMDALLM_COMPOSE_WEB_HOST_IP=127.0.0.1 HEIMDALLM_COMPOSE_WEB_HOST_PORT=0 docker compose --project-name %s -f %s -f %s' \
+        "$_compose_test_daemon_name" \
+        "$_compose_test_web_name" \
+        "$_compose_test_project" \
+        "$_compose_test_base_file" \
+        "$_compose_test_override_file"
+}
+
+compose_test_shell_quote() {
+    printf "'"
+    printf '%s' "$1" | sed "s/'/'\\\\''/g"
+    printf "'"
+}
+
+compose_test_display_state_cleanup() {
+    _compose_test_cleanup_log=${COMPOSE_TEST_CLEANUP_LOG:-"$COMPOSE_TEST_STATE_DIR/cleanup.log"}
+    _compose_test_quoted_log=$(compose_test_shell_quote "$_compose_test_cleanup_log")
+    _compose_test_quoted_marker=$(compose_test_shell_quote "$COMPOSE_TEST_MARKER")
+    _compose_test_quoted_state=$(compose_test_shell_quote "$COMPOSE_TEST_STATE_DIR")
+
+    # Deliberately avoid rm -rf. Removing only the two helper-owned files and
+    # then using rmdir makes recovery fail safely if anything unexpected is
+    # still present in the private directory.
+    printf 'rm -f %s %s && rmdir %s' \
+        "$_compose_test_quoted_log" \
+        "$_compose_test_quoted_marker" \
+        "$_compose_test_quoted_state"
 }
 
 compose_test_release() {
-    if [ -n "${COMPOSE_TEST_MARKER:-}" ] &&
-       [ "$COMPOSE_TEST_MARKER" = "${COMPOSE_TEST_STATE_DIR:-}/project" ]; then
-        rm -f "$COMPOSE_TEST_MARKER"
+    compose_test_assert_identity || return $?
+
+    if ! rm -f "$COMPOSE_TEST_MARKER"; then
+        compose_test_error "could not remove the private run marker"
+        return 1
     fi
-    if [ -n "${COMPOSE_TEST_STATE_DIR:-}" ]; then
-        rmdir "$COMPOSE_TEST_STATE_DIR" 2>/dev/null || true
+
+    if ! rmdir "$COMPOSE_TEST_STATE_DIR" 2>/dev/null; then
+        # Keep the identity recoverable when an unexpected per-run file stops
+        # the non-recursive directory removal.
+        if ! (
+            umask 077
+            printf '%s\n%s\n' "$COMPOSE_TEST_PROJECT_NAME" "$$" >"$COMPOSE_TEST_MARKER"
+        ); then
+            compose_test_error "could not restore the private run marker"
+            return 1
+        fi
+        compose_test_error "private state directory is not empty: $COMPOSE_TEST_STATE_DIR"
+        return 1
     fi
 
     unset HEIMDALLM_TEST_DAEMON_CONTAINER_NAME

--- a/docker/scripts/test-local.sh
+++ b/docker/scripts/test-local.sh
@@ -16,9 +16,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
-COMPOSE_TEST="docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml"
+# shellcheck source=lib/compose-test.sh
+source "$SCRIPT_DIR/lib/compose-test.sh"
+compose_test_init local "$REPO_ROOT"
+
 SERVICE="heimdallm"
-BASE_URL="http://localhost:${HEIMDALLM_PORT:-7842}"
+BASE_URL=""
+HTTP_BODY_FILE=$(compose_test_run_path http-body)
 HEALTH_TIMEOUT=60   # seconds to wait for /health
 HEALTH_INTERVAL=2   # seconds between retries
 
@@ -46,10 +50,30 @@ info() { echo -e "${CYAN}==>${NC} ${BOLD}$1${NC}"; }
 warn() { echo -e "${YELLOW}WARNING:${NC} $1"; }
 
 cleanup() {
+    local exit_code=$?
+    trap - EXIT
+    trap '' HUP INT TERM
     info "Cleaning up..."
-    $COMPOSE_TEST down -v --remove-orphans >/dev/null 2>&1 || true
+    rm -f "$HTTP_BODY_FILE" 2>/dev/null || true
+    if ! compose_test_cleanup; then
+        if [ "$exit_code" -eq 0 ]; then
+            exit_code=1
+        fi
+    fi
+    exit "$exit_code"
 }
 trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+resolve_daemon_url() {
+    local container_port="${HEIMDALLM_PORT:-7842}"
+    local host_port
+    host_port=$(compose_test_published_port "$SERVICE" "$container_port")
+    BASE_URL="http://127.0.0.1:${host_port}"
+    info "Isolated project: ${COMPOSE_TEST_PROJECT_NAME} (${BASE_URL})"
+}
 
 wait_for_health() {
     local elapsed=0
@@ -70,7 +94,7 @@ check_http() {
     local desc="$1" method="$2" path="$3" expected="$4" body_check="${5:-}"
     local extra_headers="${6:-}"
     local url="${BASE_URL}${path}"
-    local args=(-s -o /tmp/heimdallm_test_body -w "%{http_code}" -X "$method")
+    local args=(-s -o "$HTTP_BODY_FILE" -w "%{http_code}" -X "$method")
 
     if [ -n "$extra_headers" ]; then
         args+=(-H "$extra_headers")
@@ -86,7 +110,7 @@ check_http() {
 
     if [ -n "$body_check" ]; then
         local result
-        result=$(jq -r "$body_check" /tmp/heimdallm_test_body 2>/dev/null) || result="false"
+        result=$(jq -r "$body_check" "$HTTP_BODY_FILE" 2>/dev/null) || result="false"
         if [ "$result" != "true" ]; then
             fail "$desc" "body check failed: $body_check"
             return
@@ -99,9 +123,14 @@ check_http() {
 # check_http_header <description> <method> <path> <header_name> <header_contains>
 check_http_header() {
     local desc="$1" method="$2" path="$3" header="$4" contains="$5"
+    local extra_headers="${6:-}"
     local url="${BASE_URL}${path}"
+    local args=(-sI -X "$method")
+    if [ -n "$extra_headers" ]; then
+        args+=(-H "$extra_headers")
+    fi
     local headers
-    headers=$(curl -sI -X "$method" "$url" 2>/dev/null) || headers=""
+    headers=$(curl "${args[@]}" "$url" 2>/dev/null) || headers=""
 
     if echo "$headers" | grep -qi "${header}:.*${contains}"; then
         pass "$desc"
@@ -114,7 +143,7 @@ check_http_header() {
 check_exec() {
     local desc="$1"
     shift
-    if $COMPOSE_TEST exec -T "$SERVICE" "$@" >/dev/null 2>&1; then
+    if compose_test exec -T "$SERVICE" "$@" >/dev/null 2>&1; then
         pass "$desc"
     else
         fail "$desc"
@@ -124,7 +153,7 @@ check_exec() {
 # check_logs <description> <grep pattern>
 check_logs() {
     local desc="$1" pattern="$2"
-    if $COMPOSE_TEST logs 2>&1 | grep -qiE "$pattern"; then
+    if compose_test logs 2>&1 | grep -qiE "$pattern"; then
         pass "$desc"
     else
         fail "$desc" "pattern '$pattern' not found in logs"
@@ -159,7 +188,7 @@ test_smoke() {
 
     # Build
     info "Building Docker image..."
-    if $COMPOSE_TEST build --quiet 2>&1; then
+    if compose_test build --quiet "$SERVICE" 2>&1; then
         pass "Docker image builds"
     else
         fail "Docker image builds"
@@ -169,7 +198,8 @@ test_smoke() {
 
     # Start with dummy credentials
     info "Starting container with dummy credentials..."
-    $COMPOSE_TEST up -d 2>&1
+    compose_test up -d "$SERVICE" 2>&1
+    resolve_daemon_url
 
     if wait_for_health; then
         pass "Container starts and /health responds"
@@ -177,9 +207,15 @@ test_smoke() {
         fail "Container starts and /health responds" "timeout after ${HEALTH_TIMEOUT}s"
         echo ""
         info "Container logs:"
-        $COMPOSE_TEST logs --tail=30 2>&1
+        compose_test logs --tail=30 2>&1
         return 1
     fi
+
+    # Every endpoint except /health is authenticated. Read the generated token
+    # once and use it for the positive endpoint checks below.
+    local api_token
+    api_token=$(compose_test exec -T "$SERVICE" cat /data/api_token 2>/dev/null | tr -d '[:space:]') || api_token=""
+    local api_header="X-Heimdallm-Token: ${api_token}"
 
     echo ""
     info "Checking HTTP endpoints..."
@@ -190,23 +226,23 @@ test_smoke() {
 
     # Config
     check_http "GET /config returns valid JSON with ai_primary" \
-        GET /config 200 '.ai_primary == "gemini"'
+        GET /config 200 '.ai_primary == "gemini"' "$api_header"
 
     # PRs
     check_http "GET /prs returns JSON array" \
-        GET /prs 200 'type == "array"'
+        GET /prs 200 'type == "array"' "$api_header"
 
     # Stats
     check_http "GET /stats returns valid JSON" \
-        GET /stats 200 'type == "object"'
+        GET /stats 200 'type == "object"' "$api_header"
 
     # Agents
     check_http "GET /agents returns JSON array" \
-        GET /agents 200 'type == "array"'
+        GET /agents 200 'type == "array"' "$api_header"
 
     # SSE endpoint
     check_http_header "GET /events returns SSE content type" \
-        GET /events "Content-Type" "text/event-stream"
+        GET /events "Content-Type" "text/event-stream" "$api_header"
 
     echo ""
     info "Checking authentication..."
@@ -214,10 +250,6 @@ test_smoke() {
     # Auth rejection (POST without token)
     check_http "POST /reload without token returns 401" \
         POST /reload 401
-
-    # Read API token from container
-    local api_token
-    api_token=$($COMPOSE_TEST exec -T "$SERVICE" cat /data/api_token 2>/dev/null | tr -d '[:space:]') || api_token=""
 
     if [ ${#api_token} -ge 32 ]; then
         pass "API token exists and is >= 32 chars"
@@ -229,7 +261,7 @@ test_smoke() {
     if [ -n "$api_token" ]; then
         check_http "POST /reload with valid token returns 200" \
             POST /reload 200 '.status == "reloaded"' \
-            "X-Heimdallm-Token: ${api_token}"
+            "$api_header"
     else
         skip "POST /reload with valid token" "no API token available"
     fi
@@ -284,7 +316,7 @@ test_github() {
 
     # Build
     info "Building Docker image..."
-    if $COMPOSE_TEST build --quiet 2>&1; then
+    if compose_test build --quiet "$SERVICE" 2>&1; then
         pass "Docker image builds"
     else
         fail "Docker image builds"
@@ -293,13 +325,14 @@ test_github() {
 
     # Start with real .env
     info "Starting container with real credentials..."
-    $COMPOSE_TEST up -d 2>&1
+    compose_test up -d "$SERVICE" 2>&1
+    resolve_daemon_url
 
     if wait_for_health; then
         pass "Container starts and /health responds"
     else
         fail "Container starts and /health responds"
-        $COMPOSE_TEST logs --tail=30 2>&1
+        compose_test logs --tail=30 2>&1
         return 1
     fi
 
@@ -401,20 +434,21 @@ test_e2e() {
 
     # Build & start
     info "Building Docker image..."
-    $COMPOSE_TEST build --quiet 2>&1
+    compose_test build --quiet "$SERVICE" 2>&1
 
     info "Starting container..."
-    $COMPOSE_TEST up -d 2>&1
+    compose_test up -d "$SERVICE" 2>&1
+    resolve_daemon_url
 
     if ! wait_for_health; then
         fail "Container health check"
-        $COMPOSE_TEST logs --tail=30 2>&1
+        compose_test logs --tail=30 2>&1
         return 1
     fi
     pass "Container is healthy"
 
     local api_token
-    api_token=$($COMPOSE_TEST exec -T "$SERVICE" cat /data/api_token 2>/dev/null | tr -d '[:space:]') || api_token=""
+    api_token=$(compose_test exec -T "$SERVICE" cat /data/api_token 2>/dev/null | tr -d '[:space:]') || api_token=""
 
     echo ""
     echo -e "${BOLD}Container is running. Use the commands below to verify:${NC}"
@@ -442,7 +476,7 @@ test_e2e() {
     echo "  curl -X POST ${BASE_URL}/reload -H 'X-Heimdallm-Token: ${api_token}'"
     echo ""
     echo -e "${BOLD}Follow logs:${NC}"
-    echo "  $COMPOSE_TEST logs -f"
+    echo "  $(compose_test_display) logs -f"
     echo ""
     echo -e "${BOLD}What to look for in logs:${NC}"
     echo "  1. 'daemon started'              — service is up"
@@ -455,7 +489,7 @@ test_e2e() {
     echo -e "${YELLOW}Press Ctrl+C to stop and clean up.${NC}"
 
     # Follow logs until interrupted (cleanup trap handles shutdown)
-    $COMPOSE_TEST logs -f 2>&1 || true
+    compose_test logs -f 2>&1 || true
 }
 
 # ─── Main ─────────────────────────────────────────────────────────────────────

--- a/docker/scripts/test-local.sh
+++ b/docker/scripts/test-local.sh
@@ -18,7 +18,27 @@ cd "$REPO_ROOT"
 
 # shellcheck source=lib/compose-test.sh
 source "$SCRIPT_DIR/lib/compose-test.sh"
+
+cleanup_initialization() {
+    local exit_code=$?
+    trap - EXIT
+    trap '' HUP INT TERM
+    if ! compose_test_release; then
+        if [ "$exit_code" -eq 0 ]; then
+            exit_code=1
+        fi
+    fi
+    exit "$exit_code"
+}
+
 compose_test_init local "$REPO_ROOT"
+# Cover the initialization window before the full Docker-aware cleanup handler
+# is defined. No Compose command can have run yet, so only the private marker
+# and state directory need releasing here.
+trap cleanup_initialization EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 SERVICE="heimdallm"
 BASE_URL=""
@@ -66,6 +86,8 @@ cleanup() {
     fi
     exit "$exit_code"
 }
+# Replace the initialization-only handler once all runtime state and helpers
+# required by the full cleanup path exist.
 trap cleanup EXIT
 trap 'exit 129' HUP
 trap 'exit 130' INT

--- a/docker/scripts/test-local.sh
+++ b/docker/scripts/test-local.sh
@@ -54,7 +54,11 @@ cleanup() {
     trap - EXIT
     trap '' HUP INT TERM
     info "Cleaning up..."
-    rm -f "$HTTP_BODY_FILE" 2>/dev/null || true
+    if ! compose_test_remove_run_file http-body "${HTTP_BODY_FILE:-}"; then
+        if [ "$exit_code" -eq 0 ]; then
+            exit_code=1
+        fi
+    fi
     if ! compose_test_cleanup; then
         if [ "$exit_code" -eq 0 ]; then
             exit_code=1
@@ -70,9 +74,29 @@ trap 'exit 143' TERM
 resolve_daemon_url() {
     local container_port="${HEIMDALLM_PORT:-7842}"
     local host_port
-    host_port=$(compose_test_published_port "$SERVICE" "$container_port")
+    if ! host_port=$(compose_test_published_port "$SERVICE" "$container_port"); then
+        return 1
+    fi
     BASE_URL="http://127.0.0.1:${host_port}"
     info "Isolated project: ${COMPOSE_TEST_PROJECT_NAME} (${BASE_URL})"
+}
+
+show_container_logs() {
+    echo ""
+    info "Container logs:"
+    compose_test logs --tail=30 2>&1 || true
+}
+
+read_api_token() {
+    local api_token
+    if ! api_token=$(compose_test exec -T "$SERVICE" cat /data/api_token 2>/dev/null); then
+        return 1
+    fi
+    api_token=$(printf '%s' "$api_token" | tr -d '[:space:]')
+    if [ -z "$api_token" ]; then
+        return 1
+    fi
+    printf '%s\n' "$api_token"
 }
 
 wait_for_health() {
@@ -94,7 +118,12 @@ check_http() {
     local desc="$1" method="$2" path="$3" expected="$4" body_check="${5:-}"
     local extra_headers="${6:-}"
     local url="${BASE_URL}${path}"
-    local args=(-s -o "$HTTP_BODY_FILE" -w "%{http_code}" -X "$method")
+    local response_file
+    if ! response_file=$(compose_test_run_path http-body); then
+        fail "$desc" "HTTP response file identity is invalid"
+        return
+    fi
+    local args=(-s -o "$response_file" -w "%{http_code}" -X "$method")
 
     if [ -n "$extra_headers" ]; then
         args+=(-H "$extra_headers")
@@ -110,7 +139,7 @@ check_http() {
 
     if [ -n "$body_check" ]; then
         local result
-        result=$(jq -r "$body_check" "$HTTP_BODY_FILE" 2>/dev/null) || result="false"
+        result=$(jq -r "$body_check" "$response_file" 2>/dev/null) || result="false"
         if [ "$result" != "true" ]; then
             fail "$desc" "body check failed: $body_check"
             return
@@ -199,23 +228,36 @@ test_smoke() {
     # Start with dummy credentials
     info "Starting container with dummy credentials..."
     compose_test up -d "$SERVICE" 2>&1
-    resolve_daemon_url
+    if ! resolve_daemon_url; then
+        fail "Container starts and /health responds" "published API port is unavailable"
+        show_container_logs
+        return 1
+    fi
 
     if wait_for_health; then
         pass "Container starts and /health responds"
     else
         fail "Container starts and /health responds" "timeout after ${HEALTH_TIMEOUT}s"
-        echo ""
-        info "Container logs:"
-        compose_test logs --tail=30 2>&1
+        show_container_logs
         return 1
     fi
 
     # Every endpoint except /health is authenticated. Read the generated token
-    # once and use it for the positive endpoint checks below.
-    local api_token
-    api_token=$(compose_test exec -T "$SERVICE" cat /data/api_token 2>/dev/null | tr -d '[:space:]') || api_token=""
-    local api_header="X-Heimdallm-Token: ${api_token}"
+    # once and run authenticated checks only when it is present and valid.
+    local api_token=""
+    local api_header=""
+    local api_token_ready=false
+    if api_token=$(read_api_token); then
+        if [ ${#api_token} -ge 32 ]; then
+            api_header="X-Heimdallm-Token: ${api_token}"
+            api_token_ready=true
+            pass "API token exists and is >= 32 chars"
+        else
+            fail "API token exists and is >= 32 chars" "got ${#api_token} chars"
+        fi
+    else
+        fail "Read generated API token" "could not read a non-empty /data/api_token"
+    fi
 
     echo ""
     info "Checking HTTP endpoints..."
@@ -224,25 +266,33 @@ test_smoke() {
     check_http "GET /health returns ok" \
         GET /health 200 '.status == "ok"'
 
-    # Config
-    check_http "GET /config returns valid JSON with ai_primary" \
-        GET /config 200 '.ai_primary == "gemini"' "$api_header"
+    if [ "$api_token_ready" = true ]; then
+        # Config
+        check_http "GET /config returns valid JSON with ai_primary" \
+            GET /config 200 '.ai_primary == "gemini"' "$api_header"
 
-    # PRs
-    check_http "GET /prs returns JSON array" \
-        GET /prs 200 'type == "array"' "$api_header"
+        # PRs
+        check_http "GET /prs returns JSON array" \
+            GET /prs 200 'type == "array"' "$api_header"
 
-    # Stats
-    check_http "GET /stats returns valid JSON" \
-        GET /stats 200 'type == "object"' "$api_header"
+        # Stats
+        check_http "GET /stats returns valid JSON" \
+            GET /stats 200 'type == "object"' "$api_header"
 
-    # Agents
-    check_http "GET /agents returns JSON array" \
-        GET /agents 200 'type == "array"' "$api_header"
+        # Agents
+        check_http "GET /agents returns JSON array" \
+            GET /agents 200 'type == "array"' "$api_header"
 
-    # SSE endpoint
-    check_http_header "GET /events returns SSE content type" \
-        GET /events "Content-Type" "text/event-stream" "$api_header"
+        # SSE endpoint
+        check_http_header "GET /events returns SSE content type" \
+            GET /events "Content-Type" "text/event-stream" "$api_header"
+    else
+        skip "GET /config returns valid JSON with ai_primary" "no valid API token available"
+        skip "GET /prs returns JSON array" "no valid API token available"
+        skip "GET /stats returns valid JSON" "no valid API token available"
+        skip "GET /agents returns JSON array" "no valid API token available"
+        skip "GET /events returns SSE content type" "no valid API token available"
+    fi
 
     echo ""
     info "Checking authentication..."
@@ -251,19 +301,13 @@ test_smoke() {
     check_http "POST /reload without token returns 401" \
         POST /reload 401
 
-    if [ ${#api_token} -ge 32 ]; then
-        pass "API token exists and is >= 32 chars"
-    else
-        fail "API token exists and is >= 32 chars" "got ${#api_token} chars"
-    fi
-
     # Auth acceptance (POST with valid token)
-    if [ -n "$api_token" ]; then
+    if [ "$api_token_ready" = true ]; then
         check_http "POST /reload with valid token returns 200" \
             POST /reload 200 '.status == "reloaded"' \
             "$api_header"
     else
-        skip "POST /reload with valid token" "no API token available"
+        skip "POST /reload with valid token" "no valid API token available"
     fi
 
     echo ""
@@ -326,15 +370,32 @@ test_github() {
     # Start with real .env
     info "Starting container with real credentials..."
     compose_test up -d "$SERVICE" 2>&1
-    resolve_daemon_url
+    if ! resolve_daemon_url; then
+        fail "Container starts and /health responds" "published API port is unavailable"
+        show_container_logs
+        return 1
+    fi
 
     if wait_for_health; then
         pass "Container starts and /health responds"
     else
         fail "Container starts and /health responds"
-        compose_test logs --tail=30 2>&1
+        show_container_logs
         return 1
     fi
+
+    local api_token
+    if ! api_token=$(read_api_token); then
+        fail "Read generated API token" "could not read a non-empty /data/api_token"
+        show_container_logs
+        return 1
+    fi
+    if [ ${#api_token} -lt 32 ]; then
+        fail "API token exists and is >= 32 chars" "got ${#api_token} chars"
+        return 1
+    fi
+    local api_header="X-Heimdallm-Token: ${api_token}"
+    pass "API token exists and is >= 32 chars"
 
     # Wait for first poll to complete
     info "Waiting for first poll cycle..."
@@ -345,7 +406,7 @@ test_github() {
 
     # /me should return a real login
     local me_body
-    me_body=$(curl -sf "${BASE_URL}/me" 2>/dev/null) || me_body="{}"
+    me_body=$(curl -sf -H "$api_header" "${BASE_URL}/me" 2>/dev/null) || me_body="{}"
     local login
     login=$(echo "$me_body" | jq -r '.login // empty' 2>/dev/null) || login=""
 
@@ -357,7 +418,7 @@ test_github() {
 
     # Config should have repositories
     local config_body
-    config_body=$(curl -sf "${BASE_URL}/config" 2>/dev/null) || config_body="{}"
+    config_body=$(curl -sf -H "$api_header" "${BASE_URL}/config" 2>/dev/null) || config_body="{}"
     local repo_count
     repo_count=$(echo "$config_body" | jq '.repositories | length' 2>/dev/null) || repo_count=0
 
@@ -373,7 +434,7 @@ test_github() {
 
     # Check if any PRs were detected
     local prs_body
-    prs_body=$(curl -sf "${BASE_URL}/prs" 2>/dev/null) || prs_body="[]"
+    prs_body=$(curl -sf -H "$api_header" "${BASE_URL}/prs" 2>/dev/null) || prs_body="[]"
     local pr_count
     pr_count=$(echo "$prs_body" | jq 'length' 2>/dev/null) || pr_count=0
 
@@ -438,32 +499,45 @@ test_e2e() {
 
     info "Starting container..."
     compose_test up -d "$SERVICE" 2>&1
-    resolve_daemon_url
+    if ! resolve_daemon_url; then
+        fail "Container health check" "published API port is unavailable"
+        show_container_logs
+        return 1
+    fi
 
     if ! wait_for_health; then
         fail "Container health check"
-        compose_test logs --tail=30 2>&1
+        show_container_logs
         return 1
     fi
     pass "Container is healthy"
 
     local api_token
-    api_token=$(compose_test exec -T "$SERVICE" cat /data/api_token 2>/dev/null | tr -d '[:space:]') || api_token=""
+    if ! api_token=$(read_api_token); then
+        fail "Read generated API token" "could not read a non-empty /data/api_token"
+        show_container_logs
+        return 1
+    fi
+    if [ ${#api_token} -lt 32 ]; then
+        fail "API token exists and is >= 32 chars" "got ${#api_token} chars"
+        return 1
+    fi
+    pass "API token exists and is >= 32 chars"
 
     echo ""
     echo -e "${BOLD}Container is running. Use the commands below to verify:${NC}"
     echo ""
     echo "  # Check authenticated user"
-    echo "  curl -s ${BASE_URL}/me | jq"
+    echo "  curl -s ${BASE_URL}/me -H 'X-Heimdallm-Token: ${api_token}' | jq"
     echo ""
     echo "  # List detected PRs"
-    echo "  curl -s ${BASE_URL}/prs | jq"
+    echo "  curl -s ${BASE_URL}/prs -H 'X-Heimdallm-Token: ${api_token}' | jq"
     echo ""
     echo "  # View stats"
-    echo "  curl -s ${BASE_URL}/stats | jq"
+    echo "  curl -s ${BASE_URL}/stats -H 'X-Heimdallm-Token: ${api_token}' | jq"
     echo ""
     echo "  # Follow SSE events (in another terminal)"
-    echo "  curl -N ${BASE_URL}/events"
+    echo "  curl -N ${BASE_URL}/events -H 'X-Heimdallm-Token: ${api_token}'"
     echo ""
     echo "  # Trigger manual review (replace <id> with PR ID from /prs)"
     echo "  curl -X POST ${BASE_URL}/prs/<id>/review -H 'X-Heimdallm-Token: ${api_token}'"

--- a/docker/scripts/test-web.sh
+++ b/docker/scripts/test-web.sh
@@ -31,7 +31,7 @@ cleanup() {
   exit_code=$?
   trap - EXIT
   trap '' HUP INT TERM
-  rm -f "${INDEX_HTML:-}" "${DEEP_HTML:-}" "${SSE_HDR:-}"
+  rm -f "${INDEX_HTML:-}" "${DEEP_HTML:-}" "${SSE_HDR:-}" 2>/dev/null || true
   if ! compose_test_cleanup; then
     if [ "$exit_code" -eq 0 ]; then
       exit_code=1
@@ -52,7 +52,11 @@ SSE_HDR="$(mktemp)"
 log "starting isolated Compose project ${COMPOSE_TEST_PROJECT_NAME}"
 compose_test up -d --build
 
-web_host_port=$(compose_test_published_port web 3000)
+if ! web_host_port=$(compose_test_published_port web 3000); then
+  log "container logs after published-port resolution failed"
+  compose_test logs --tail=30 2>&1 || true
+  fail "could not resolve the isolated web endpoint"
+fi
 BASE="http://127.0.0.1:${web_host_port}"
 log "web endpoint: ${BASE}"
 

--- a/docker/scripts/test-web.sh
+++ b/docker/scripts/test-web.sh
@@ -10,33 +10,54 @@
 #   5. GET /api/events (SSE)     — stream opens with text/event-stream
 #   6. GET /prs/123              — SPA deep-link fallback (returns HTML)
 #
-# Assumptions: docker compose is installed; HEIMDALLM_PORT + HEIMDALLM_WEB_PORT
-# default to 7842 / 3000. Override via env.
+# Assumptions: docker compose is installed. Docker assigns free loopback host
+# ports by default so concurrent invocations remain independent.
 set -eu
 
-HEIMDALLM_WEB_PORT="${HEIMDALLM_WEB_PORT:-3000}"
-BASE="http://localhost:${HEIMDALLM_WEB_PORT}"
-COMPOSE="docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml"
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+cd "$REPO_ROOT"
+
+# shellcheck source=lib/compose-test.sh
+. "$SCRIPT_DIR/lib/compose-test.sh"
+compose_test_init web "$REPO_ROOT"
+
+BASE=""
 
 log() { printf '▶  %s\n' "$1"; }
 fail() { printf '✗  %s\n' "$1" >&2; exit 1; }
 
 cleanup() {
-  $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
+  exit_code=$?
+  trap - EXIT
+  trap '' HUP INT TERM
   rm -f "${INDEX_HTML:-}" "${DEEP_HTML:-}" "${SSE_HDR:-}"
+  if ! compose_test_cleanup; then
+    if [ "$exit_code" -eq 0 ]; then
+      exit_code=1
+    fi
+  fi
+  exit "$exit_code"
 }
 trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # Temp files for response bodies/headers. mktemp is parallel-safe on CI.
 INDEX_HTML="$(mktemp)"
 DEEP_HTML="$(mktemp)"
 SSE_HDR="$(mktemp)"
 
-log "docker compose up -d --build"
-$COMPOSE up -d --build
+log "starting isolated Compose project ${COMPOSE_TEST_PROJECT_NAME}"
+compose_test up -d --build
+
+web_host_port=$(compose_test_published_port web 3000)
+BASE="http://127.0.0.1:${web_host_port}"
+log "web endpoint: ${BASE}"
 
 log "waiting for heimdallm-web healthcheck"
-web_container="$($COMPOSE ps -q web)"
+web_container="$(compose_test ps -q web)"
 for i in $(seq 1 60); do
   status="$(docker inspect -f '{{.State.Health.Status}}' "$web_container" 2>/dev/null || echo starting)"
   [ "$status" = "healthy" ] && break

--- a/docker/scripts/tests/fixtures/curl
+++ b/docker/scripts/tests/fixtures/curl
@@ -24,7 +24,10 @@ while [ "$#" -gt 0 ]; do
             ;;
         -H)
             case "$2" in
-                X-Heimdallm-Token:*) has_token=true ;;
+                X-Heimdallm-Token:*)
+                    token_value=${2#X-Heimdallm-Token: }
+                    [ -n "$token_value" ] && has_token=true
+                    ;;
             esac
             shift 2
             ;;

--- a/docker/scripts/tests/fixtures/curl
+++ b/docker/scripts/tests/fixtures/curl
@@ -1,0 +1,104 @@
+#!/bin/sh
+set -eu
+
+output_file=
+method=GET
+url=
+write_status=false
+headers_only=false
+has_token=false
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            output_file=$2
+            shift 2
+            ;;
+        -w)
+            write_status=true
+            shift 2
+            ;;
+        -X)
+            method=$2
+            shift 2
+            ;;
+        -H)
+            case "$2" in
+                X-Heimdallm-Token:*) has_token=true ;;
+            esac
+            shift 2
+            ;;
+        -sI|-Is|-I)
+            headers_only=true
+            shift
+            ;;
+        --max-time|-D)
+            shift 2
+            ;;
+        -*)
+            shift
+            ;;
+        *)
+            url=$1
+            shift
+            ;;
+    esac
+done
+
+if [ "$headers_only" = "true" ]; then
+    if [ "$has_token" = "true" ]; then
+        printf 'HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n'
+    else
+        printf 'HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\n\r\n'
+    fi
+    exit 0
+fi
+
+status=200
+body='{}'
+case "$url" in
+    */health)
+        body='{"status":"ok"}'
+        ;;
+    */config)
+        if [ "$has_token" = "true" ]; then
+            body='{"ai_primary":"gemini"}'
+        else
+            status=401
+            body='{"error":"unauthorized"}'
+        fi
+        ;;
+    */prs|*/agents)
+        if [ "$has_token" = "true" ]; then
+            body='[]'
+        else
+            status=401
+            body='{"error":"unauthorized"}'
+        fi
+        ;;
+    */stats)
+        if [ "$has_token" = "true" ]; then
+            body='{}'
+        else
+            status=401
+            body='{"error":"unauthorized"}'
+        fi
+        ;;
+    */reload)
+        if [ "$method" = "POST" ] && [ "$has_token" = "false" ]; then
+            status=401
+            body='{"error":"unauthorized"}'
+        else
+            body='{"status":"reloaded"}'
+        fi
+        ;;
+esac
+
+if [ -n "$output_file" ]; then
+    printf '%s' "$body" >"$output_file"
+else
+    printf '%s' "$body"
+fi
+if [ "$write_status" = "true" ]; then
+    printf '%s' "$status"
+fi

--- a/docker/scripts/tests/fixtures/docker
+++ b/docker/scripts/tests/fixtures/docker
@@ -16,13 +16,23 @@ case "$*" in
         printf 'fake-web-container\n'
         ;;
     *" port web 3000")
+        if [ "${FAKE_DOCKER_FAIL_PORT:-0}" = "1" ]; then
+            printf 'simulated published-port lookup failure\n' >&2
+            exit 43
+        fi
         printf '127.0.0.1:1\n'
         ;;
     *" port heimdallm "*)
+        if [ "${FAKE_DOCKER_FAIL_PORT:-0}" = "1" ]; then
+            printf 'simulated published-port lookup failure\n' >&2
+            exit 43
+        fi
         printf '127.0.0.1:1\n'
         ;;
     *" exec -T heimdallm cat /data/api_token")
-        printf '0123456789abcdef0123456789abcdef\n'
+        if [ "${FAKE_DOCKER_EMPTY_TOKEN:-0}" != "1" ]; then
+            printf '0123456789abcdef0123456789abcdef\n'
+        fi
         ;;
     *" logs"*)
         printf 'daemon started\n'

--- a/docker/scripts/tests/fixtures/docker
+++ b/docker/scripts/tests/fixtures/docker
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+: "${FAKE_DOCKER_LOG:?FAKE_DOCKER_LOG must point to the test log}"
+
+{
+    printf 'docker'
+    for arg in "$@"; do
+        printf '\t%s' "$arg"
+    done
+    printf '\n'
+} >>"$FAKE_DOCKER_LOG"
+
+case "$*" in
+    *" ps -q web")
+        printf 'fake-web-container\n'
+        ;;
+    *" port web 3000")
+        printf '127.0.0.1:1\n'
+        ;;
+    *" port heimdallm "*)
+        printf '127.0.0.1:1\n'
+        ;;
+    *" exec -T heimdallm cat /data/api_token")
+        printf '0123456789abcdef0123456789abcdef\n'
+        ;;
+    *" logs"*)
+        printf 'daemon started\n'
+        printf 'github poll fetch\n'
+        ;;
+esac
+
+if [ "${1:-}" = "inspect" ]; then
+    printf 'healthy\n'
+fi
+
+case "$*" in
+    *" down -v --remove-orphans")
+        if [ "${FAKE_DOCKER_FAIL_DOWN:-0}" = "1" ]; then
+            printf 'simulated Compose cleanup failure\n' >&2
+            exit 42
+        fi
+        ;;
+esac

--- a/docker/scripts/tests/fixtures/sleep
+++ b/docker/scripts/tests/fixtures/sleep
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/docker/scripts/tests/test-compose-isolation.sh
+++ b/docker/scripts/tests/test-compose-isolation.sh
@@ -1,0 +1,311 @@
+#!/bin/sh
+set -eu
+
+TEST_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT_DIR=$(CDPATH= cd -- "$TEST_DIR/.." && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+COMPOSE_LIB="$SCRIPT_DIR/lib/compose-test.sh"
+ORIGINAL_PATH=$PATH
+REAL_DOCKER=$(command -v docker || true)
+
+TEST_TMP=$(mktemp -d "${TMPDIR:-/tmp}/heimdallm-compose-isolation-tests.XXXXXX")
+FAKE_BIN="$TEST_TMP/bin"
+FAKE_DOCKER_LOG="$TEST_TMP/docker.log"
+mkdir "$FAKE_BIN"
+ln -s "$TEST_DIR/fixtures/docker" "$FAKE_BIN/docker"
+ln -s "$TEST_DIR/fixtures/curl" "$FAKE_BIN/curl"
+ln -s "$TEST_DIR/fixtures/sleep" "$FAKE_BIN/sleep"
+export FAKE_DOCKER_LOG
+
+cleanup_test_files() {
+    rm -f "$FAKE_BIN/curl" \
+        "$FAKE_BIN/docker" \
+        "$FAKE_BIN/sleep" \
+        "$FAKE_DOCKER_LOG" \
+        "$TEST_TMP/parallel-a" \
+        "$TEST_TMP/parallel-b" \
+        "$TEST_TMP/config.json" \
+        "$TEST_TMP/production-config.json" \
+        "$TEST_TMP/runner-cleanup-failure.out"
+    rmdir "$FAKE_BIN" 2>/dev/null || true
+    rmdir "$TEST_TMP" 2>/dev/null || true
+}
+trap cleanup_test_files EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+assert_log_has_safe_down() {
+    _expected_project=$1
+    _matching_line=$(awk -F '\t' '$0 ~ /\tdown\t-v\t--remove-orphans$/ { print }' "$FAKE_DOCKER_LOG")
+    [ -n "$_matching_line" ] || fail "fake Docker did not receive guarded down -v --remove-orphans"
+    printf '%s\n' "$_matching_line" | grep -F "	--project-name	${_expected_project}	" >/dev/null ||
+        fail "destructive command did not carry the exact isolated project name"
+}
+
+# shellcheck disable=SC1090
+. "$COMPOSE_LIB"
+
+PATH="$FAKE_BIN:$ORIGINAL_PATH"
+export PATH
+
+printf '1/8 unique project identity and destructive wrapper arguments\n'
+: >"$FAKE_DOCKER_LOG"
+compose_test_init local "$REPO_ROOT"
+first_project=$COMPOSE_TEST_PROJECT_NAME
+case "$first_project" in
+    heimdallm-test-local-*) ;;
+    *) fail "unexpected project name: $first_project" ;;
+esac
+[ "$HEIMDALLM_TEST_DAEMON_CONTAINER_NAME" = "${first_project}-daemon" ] ||
+    fail "daemon container name is not run-scoped"
+[ "$HEIMDALLM_TEST_WEB_CONTAINER_NAME" = "${first_project}-web" ] ||
+    fail "web container name is not run-scoped"
+compose_test_down
+assert_log_has_safe_down "$first_project"
+compose_test_release
+
+printf '2/8 guard fails closed when the project identity is changed\n'
+: >"$FAKE_DOCKER_LOG"
+compose_test_init local "$REPO_ROOT"
+safe_project=$COMPOSE_TEST_PROJECT_NAME
+COMPOSE_TEST_PROJECT_NAME=heimdallm
+if compose_test_down 2>/dev/null; then
+    fail "cleanup accepted a non-test project"
+fi
+[ ! -s "$FAKE_DOCKER_LOG" ] || fail "Docker ran after the project guard failed"
+COMPOSE_TEST_PROJECT_NAME=$safe_project
+printf '%s\n%s\n' "heimdallm-test-forged" "$$" >"$COMPOSE_TEST_MARKER"
+if compose_test_down 2>/dev/null; then
+    fail "cleanup accepted a forged marker"
+fi
+[ ! -s "$FAKE_DOCKER_LOG" ] || fail "Docker ran after the marker guard failed"
+printf '%s\n%s\n' "$safe_project" "$$" >"$COMPOSE_TEST_MARKER"
+compose_test_release
+
+printf '3/8 failed cleanup is non-successful and preserves recovery identity\n'
+: >"$FAKE_DOCKER_LOG"
+compose_test_init cleanup "$REPO_ROOT"
+failed_project=$COMPOSE_TEST_PROJECT_NAME
+failed_marker=$COMPOSE_TEST_MARKER
+failed_state_dir=$COMPOSE_TEST_STATE_DIR
+FAKE_DOCKER_FAIL_DOWN=1
+export FAKE_DOCKER_FAIL_DOWN
+if compose_test_cleanup 2>/dev/null; then
+    fail "simulated cleanup failure was reported as successful"
+fi
+[ "$COMPOSE_TEST_INITIALIZED" = "1" ] ||
+    fail "failed cleanup released the run identity"
+[ -f "$failed_marker" ] ||
+    fail "failed cleanup deleted the recovery marker"
+[ -s "$failed_state_dir/cleanup.log" ] ||
+    fail "failed cleanup did not preserve diagnostics"
+[ "$COMPOSE_TEST_PROJECT_NAME" = "$failed_project" ] ||
+    fail "failed cleanup changed the recovery project"
+unset FAKE_DOCKER_FAIL_DOWN
+compose_test_cleanup
+[ ! -e "$failed_marker" ] ||
+    fail "successful retry left the recovery marker behind"
+[ ! -d "$failed_state_dir" ] ||
+    fail "successful retry left the private state directory behind"
+
+runner_failure_tmp="$TEST_TMP/runner-failure"
+mkdir "$runner_failure_tmp"
+if FAKE_DOCKER_FAIL_DOWN=1 TMPDIR="$runner_failure_tmp" \
+    "$SCRIPT_DIR/test-local.sh" smoke >"$TEST_TMP/runner-cleanup-failure.out" 2>&1; then
+    fail "local runner reported success after Compose cleanup failed"
+fi
+grep -F "cleanup failed; isolated Docker resources may remain" \
+    "$TEST_TMP/runner-cleanup-failure.out" >/dev/null ||
+    fail "local runner did not report failed cleanup"
+grep -F "marker preserved:" "$TEST_TMP/runner-cleanup-failure.out" >/dev/null ||
+    fail "local runner did not report its recovery marker"
+set -- "$runner_failure_tmp"/heimdallm-compose-test-local.*
+[ "$#" -eq 1 ] && [ -d "$1" ] ||
+    fail "local runner did not preserve exactly one failed-run directory"
+runner_failure_state=$1
+[ -f "$runner_failure_state/project" ] &&
+    [ -s "$runner_failure_state/cleanup.log" ] ||
+    fail "local runner removed failed-cleanup recovery files"
+rm -f "$runner_failure_state/http-body" \
+    "$runner_failure_state/cleanup.log" \
+    "$runner_failure_state/project"
+rmdir "$runner_failure_state"
+rmdir "$runner_failure_tmp"
+
+printf '4/8 concurrent initializations never share project, container, or body-file names\n'
+run_parallel_init() (
+    # shellcheck disable=SC1090
+    . "$COMPOSE_LIB"
+    compose_test_init web "$REPO_ROOT"
+    printf '%s|%s|%s|%s\n' \
+        "$COMPOSE_TEST_PROJECT_NAME" \
+        "$HEIMDALLM_TEST_DAEMON_CONTAINER_NAME" \
+        "$HEIMDALLM_TEST_WEB_CONTAINER_NAME" \
+        "$(compose_test_run_path http-body)" >"$1"
+    compose_test_release
+)
+run_parallel_init "$TEST_TMP/parallel-a" &
+parallel_a_pid=$!
+run_parallel_init "$TEST_TMP/parallel-b" &
+parallel_b_pid=$!
+wait "$parallel_a_pid"
+wait "$parallel_b_pid"
+parallel_a=$(sed -n '1p' "$TEST_TMP/parallel-a")
+parallel_b=$(sed -n '1p' "$TEST_TMP/parallel-b")
+[ "$parallel_a" != "$parallel_b" ] || fail "parallel runs received identical identities"
+parallel_a_body=${parallel_a##*|}
+parallel_b_body=${parallel_b##*|}
+[ "$parallel_a_body" != "$parallel_b_body" ] ||
+    fail "parallel runs shared the HTTP response body file"
+
+printf '5/8 signal-driven exit cleans only its own isolated project\n'
+: >"$FAKE_DOCKER_LOG"
+if sh -c '
+    set -eu
+    . "$1"
+    compose_test_init signal "$2"
+    cleanup() {
+        status=$?
+        trap - EXIT
+        if ! compose_test_cleanup; then
+            [ "$status" -ne 0 ] || status=1
+        fi
+        exit "$status"
+    }
+    trap cleanup EXIT
+    trap "exit 143" TERM
+    kill -TERM "$$"
+' signal-cleanup "$COMPOSE_LIB" "$REPO_ROOT"; then
+    fail "signal harness unexpectedly exited successfully"
+fi
+signal_project=$(awk -F '\t' '$0 ~ /\tdown\t-v\t--remove-orphans$/ {
+    for (i = 1; i <= NF; i++) if ($i == "--project-name") print $(i + 1)
+}' "$FAKE_DOCKER_LOG")
+case "$signal_project" in
+    heimdallm-test-signal-*) ;;
+    *) fail "signal cleanup used an unsafe project: $signal_project" ;;
+esac
+assert_log_has_safe_down "$signal_project"
+
+printf '6/8 local runner scopes build/start to the daemon and cleans its project\n'
+: >"$FAKE_DOCKER_LOG"
+if ! "$SCRIPT_DIR/test-local.sh" smoke >/dev/null 2>&1; then
+    fail "fake local smoke did not complete successfully"
+fi
+local_project=$(awk -F '\t' '$0 ~ /\tdown\t-v\t--remove-orphans$/ {
+    for (i = 1; i <= NF; i++) if ($i == "--project-name") print $(i + 1)
+}' "$FAKE_DOCKER_LOG")
+case "$local_project" in
+    heimdallm-test-local-*) ;;
+    *) fail "local runner used an unsafe cleanup project: $local_project" ;;
+esac
+awk -F '\t' '
+    $0 ~ /\tbuild\t/ {
+        builds++
+        if ($NF != "heimdallm") bad = 1
+        for (i = 1; i <= NF; i++) if ($i == "web") bad = 1
+    }
+    $0 ~ /\tup\t/ {
+        starts++
+        if ($NF != "heimdallm") bad = 1
+        for (i = 1; i <= NF; i++) if ($i == "web") bad = 1
+    }
+    END { exit !(builds == 1 && starts == 1 && bad != 1) }
+' "$FAKE_DOCKER_LOG" ||
+    fail "local runner built or started services beyond heimdallm"
+assert_log_has_safe_down "$local_project"
+
+printf '7/8 web runner uses one isolated project for startup and cleanup\n'
+: >"$FAKE_DOCKER_LOG"
+if "$SCRIPT_DIR/test-web.sh" >/dev/null 2>&1; then
+    fail "fake web smoke unexpectedly reached a live HTTP endpoint"
+fi
+web_up_project=$(awk -F '\t' '$0 ~ /\tup\t-d\t--build$/ {
+    for (i = 1; i <= NF; i++) if ($i == "--project-name") print $(i + 1)
+}' "$FAKE_DOCKER_LOG")
+web_down_project=$(awk -F '\t' '$0 ~ /\tdown\t-v\t--remove-orphans$/ {
+    for (i = 1; i <= NF; i++) if ($i == "--project-name") print $(i + 1)
+}' "$FAKE_DOCKER_LOG")
+case "$web_up_project" in
+    heimdallm-test-web-*) ;;
+    *) fail "web runner used an unsafe startup project: $web_up_project" ;;
+esac
+[ "$web_up_project" = "$web_down_project" ] ||
+    fail "web runner startup and cleanup used different projects"
+assert_log_has_safe_down "$web_down_project"
+
+printf '8/8 merged Compose config has per-run names, volumes, and ephemeral ports\n'
+if [ -n "$REAL_DOCKER" ] && "$REAL_DOCKER" compose version >/dev/null 2>&1; then
+    PATH=$ORIGINAL_PATH
+    export PATH
+    (
+        unset HEIMDALLM_COMPOSE_DAEMON_HOST_IP
+        unset HEIMDALLM_COMPOSE_DAEMON_HOST_PORT
+        unset HEIMDALLM_COMPOSE_WEB_HOST_IP
+        unset HEIMDALLM_COMPOSE_WEB_HOST_PORT
+        GITHUB_TOKEN=dummy \
+        HEIMDALLM_AI_PRIMARY=gemini \
+        HEIMDALLM_REPOSITORIES=test/repo \
+        HEIMDALLM_PORT=7842 \
+        HEIMDALLM_WEB_PORT=3000 \
+            "$REAL_DOCKER" compose \
+                -f "$REPO_ROOT/docker/docker-compose.yml" \
+                config --format json
+    ) >"$TEST_TMP/production-config.json"
+
+    jq -e \
+        '.services.heimdallm.ports | length == 1 and
+         .[0].target == 7842 and .[0].published == "7842" and
+         (.[0] | has("host_ip") | not)' \
+        "$TEST_TMP/production-config.json" >/dev/null ||
+        fail "normal daemon port binding changed"
+    jq -e \
+        '.services.web.ports | length == 1 and
+         .[0].target == 3000 and .[0].published == "3000" and
+         (.[0] | has("host_ip") | not)' \
+        "$TEST_TMP/production-config.json" >/dev/null ||
+        fail "normal web port binding changed"
+
+    compose_test_init config "$REPO_ROOT"
+    GITHUB_TOKEN=dummy \
+    HEIMDALLM_AI_PRIMARY=gemini \
+    HEIMDALLM_REPOSITORIES=test/repo \
+    HEIMDALLM_PORT=7842 \
+        compose_test config --format json >"$TEST_TMP/config.json"
+
+    jq -e --arg project "$COMPOSE_TEST_PROJECT_NAME" \
+        '.name == $project' "$TEST_TMP/config.json" >/dev/null ||
+        fail "Compose config did not retain the isolated project"
+    jq -e --arg name "$HEIMDALLM_TEST_DAEMON_CONTAINER_NAME" \
+        '.services.heimdallm.container_name == $name' "$TEST_TMP/config.json" >/dev/null ||
+        fail "daemon container name is not unique"
+    jq -e --arg name "$HEIMDALLM_TEST_WEB_CONTAINER_NAME" \
+        '.services.web.container_name == $name' "$TEST_TMP/config.json" >/dev/null ||
+        fail "web container name is not unique"
+    jq -e \
+        '.services.heimdallm.ports | length == 1 and
+         .[0].target == 7842 and .[0].published == "0" and .[0].host_ip == "127.0.0.1"' \
+        "$TEST_TMP/config.json" >/dev/null ||
+        fail "daemon test port is not loopback-only and ephemeral"
+    jq -e \
+        '.services.web.ports | length == 1 and
+         .[0].target == 3000 and .[0].published == "0" and .[0].host_ip == "127.0.0.1"' \
+        "$TEST_TMP/config.json" >/dev/null ||
+        fail "web test port is not loopback-only and ephemeral"
+    jq -e \
+        '[.services.heimdallm.volumes[] | select(.target == "/data" and .source == "heimdallm-test-data")] | length == 1' \
+        "$TEST_TMP/config.json" >/dev/null ||
+        fail "daemon data volume is not test-scoped"
+    jq -e \
+        '[.services.heimdallm.volumes[] | select(.target == "/config" and .source == "heimdallm-test-config")] | length == 1' \
+        "$TEST_TMP/config.json" >/dev/null ||
+        fail "daemon config volume is not test-scoped"
+    compose_test_release
+else
+    printf 'SKIP: Docker Compose is not installed; fake-binary checks still passed\n'
+fi
+
+printf 'PASS: Compose test isolation regression suite\n'

--- a/docker/scripts/tests/test-compose-isolation.sh
+++ b/docker/scripts/tests/test-compose-isolation.sh
@@ -54,6 +54,19 @@ assert_log_has_safe_down() {
 PATH="$FAKE_BIN:$ORIGINAL_PATH"
 export PATH
 
+early_trap_line=$(awk '/^trap cleanup_initialization EXIT$/ { print NR; exit }' \
+    "$SCRIPT_DIR/test-local.sh")
+run_path_line=$(awk '/^HTTP_BODY_FILE=.*compose_test_run_path/ { print NR; exit }' \
+    "$SCRIPT_DIR/test-local.sh")
+full_trap_line=$(awk '/^trap cleanup EXIT$/ { print NR; exit }' \
+    "$SCRIPT_DIR/test-local.sh")
+[ -n "$early_trap_line" ] &&
+    [ -n "$run_path_line" ] &&
+    [ -n "$full_trap_line" ] &&
+    [ "$early_trap_line" -lt "$run_path_line" ] &&
+    [ "$run_path_line" -lt "$full_trap_line" ] ||
+    fail "local runner does not protect the initialization window with an early cleanup trap"
+
 printf '1/8 unique project identity and destructive wrapper arguments\n'
 : >"$FAKE_DOCKER_LOG"
 compose_test_init local "$REPO_ROOT"

--- a/docker/scripts/tests/test-compose-isolation.sh
+++ b/docker/scripts/tests/test-compose-isolation.sh
@@ -26,7 +26,10 @@ cleanup_test_files() {
         "$TEST_TMP/parallel-b" \
         "$TEST_TMP/config.json" \
         "$TEST_TMP/production-config.json" \
-        "$TEST_TMP/runner-cleanup-failure.out"
+        "$TEST_TMP/runner-cleanup-failure.out" \
+        "$TEST_TMP/runner-port-failure.out" \
+        "$TEST_TMP/runner-token-failure.out" \
+        "$TEST_TMP/outside-http-body"
     rmdir "$FAKE_BIN" 2>/dev/null || true
     rmdir "$TEST_TMP" 2>/dev/null || true
 }
@@ -122,6 +125,12 @@ grep -F "cleanup failed; isolated Docker resources may remain" \
     fail "local runner did not report failed cleanup"
 grep -F "marker preserved:" "$TEST_TMP/runner-cleanup-failure.out" >/dev/null ||
     fail "local runner did not report its recovery marker"
+grep -F "retry cleanup:" "$TEST_TMP/runner-cleanup-failure.out" |
+    grep -F " down -v --remove-orphans" >/dev/null ||
+    fail "local runner did not print the exact run-scoped cleanup retry"
+grep -F "after Docker cleanup succeeds, remove state: rm -f " \
+    "$TEST_TMP/runner-cleanup-failure.out" >/dev/null ||
+    fail "local runner did not print explicit private-state recovery"
 set -- "$runner_failure_tmp"/heimdallm-compose-test-local.*
 [ "$#" -eq 1 ] && [ -d "$1" ] ||
     fail "local runner did not preserve exactly one failed-run directory"
@@ -129,11 +138,58 @@ runner_failure_state=$1
 [ -f "$runner_failure_state/project" ] &&
     [ -s "$runner_failure_state/cleanup.log" ] ||
     fail "local runner removed failed-cleanup recovery files"
-rm -f "$runner_failure_state/http-body" \
-    "$runner_failure_state/cleanup.log" \
-    "$runner_failure_state/project"
-rmdir "$runner_failure_state"
+grep -F "rmdir '$runner_failure_state'" \
+    "$TEST_TMP/runner-cleanup-failure.out" >/dev/null ||
+    fail "private-state recovery did not identify the exact run directory"
+if grep -F "rm -rf" "$TEST_TMP/runner-cleanup-failure.out" >/dev/null; then
+    fail "private-state recovery suggested an unsafe recursive deletion"
+fi
+
+recovery_down=$(sed -n 's/^compose-test: retry cleanup: //p' \
+    "$TEST_TMP/runner-cleanup-failure.out")
+[ -n "$recovery_down" ] || fail "could not extract the printed cleanup retry"
+sh -c "$recovery_down"
+recovery_state=$(sed -n \
+    's/^compose-test: after Docker cleanup succeeds, remove state: //p' \
+    "$TEST_TMP/runner-cleanup-failure.out")
+[ -n "$recovery_state" ] || fail "could not extract the printed state cleanup"
+sh -c "$recovery_state"
+[ ! -d "$runner_failure_state" ] ||
+    fail "printed recovery commands did not reclaim the private state directory"
 rmdir "$runner_failure_tmp"
+
+compose_test_init release "$REPO_ROOT"
+release_marker=$COMPOSE_TEST_MARKER
+release_state_dir=$COMPOSE_TEST_STATE_DIR
+release_extra=$(compose_test_run_path unexpected)
+: >"$release_extra"
+if compose_test_release 2>/dev/null; then
+    fail "release silently accepted an unexpected private-state file"
+fi
+[ -f "$release_marker" ] ||
+    fail "failed release did not restore its recovery marker"
+rm -f "$release_extra"
+compose_test_release
+[ ! -d "$release_state_dir" ] ||
+    fail "release retry left the private state directory behind"
+
+printf '    overwritten run-file variables never delete outside private state\n'
+compose_test_init run-file "$REPO_ROOT"
+expected_http_body=$(compose_test_run_path http-body)
+outside_http_body="$TEST_TMP/outside-http-body"
+printf '%s\n' 'private state response' >"$expected_http_body"
+printf '%s\n' 'must survive cleanup' >"$outside_http_body"
+HTTP_BODY_FILE=$outside_http_body
+if compose_test_remove_run_file http-body "$HTTP_BODY_FILE" 2>/dev/null; then
+    fail "run-file cleanup accepted an overwritten candidate path"
+fi
+[ ! -e "$expected_http_body" ] ||
+    fail "run-file cleanup did not remove its validated private-state file"
+[ "$(sed -n '1p' "$outside_http_body")" = "must survive cleanup" ] ||
+    fail "run-file cleanup modified a file outside the private state directory"
+rm -f "$outside_http_body"
+unset HTTP_BODY_FILE
+compose_test_release
 
 printf '4/8 concurrent initializations never share project, container, or body-file names\n'
 run_parallel_init() (
@@ -217,6 +273,50 @@ awk -F '\t' '
 ' "$FAKE_DOCKER_LOG" ||
     fail "local runner built or started services beyond heimdallm"
 assert_log_has_safe_down "$local_project"
+
+printf '    startup port failures retain Compose diagnostics\n'
+: >"$FAKE_DOCKER_LOG"
+if FAKE_DOCKER_FAIL_PORT=1 TMPDIR="$TEST_TMP" \
+    "$SCRIPT_DIR/test-local.sh" smoke >"$TEST_TMP/runner-port-failure.out" 2>&1; then
+    fail "local runner reported success without a published daemon port"
+fi
+grep -F "published API port is unavailable" \
+    "$TEST_TMP/runner-port-failure.out" >/dev/null ||
+    fail "local runner did not explain the published-port failure"
+grep -F "Container logs:" "$TEST_TMP/runner-port-failure.out" >/dev/null ||
+    fail "local runner omitted its log heading after port resolution failed"
+grep -F "daemon started" "$TEST_TMP/runner-port-failure.out" >/dev/null ||
+    fail "local runner omitted Compose logs after port resolution failed"
+port_failure_project=$(awk -F '\t' '$0 ~ /\tdown\t-v\t--remove-orphans$/ {
+    for (i = 1; i <= NF; i++) if ($i == "--project-name") print $(i + 1)
+}' "$FAKE_DOCKER_LOG")
+assert_log_has_safe_down "$port_failure_project"
+
+printf '    empty API tokens fail once and skip authenticated checks\n'
+: >"$FAKE_DOCKER_LOG"
+if FAKE_DOCKER_EMPTY_TOKEN=1 TMPDIR="$TEST_TMP" \
+    "$SCRIPT_DIR/test-local.sh" smoke >"$TEST_TMP/runner-token-failure.out" 2>&1; then
+    fail "local runner reported success with an empty API token"
+fi
+grep -F "could not read a non-empty /data/api_token" \
+    "$TEST_TMP/runner-token-failure.out" >/dev/null ||
+    fail "local runner did not identify the empty API token"
+grep -F "FAIL: 1" "$TEST_TMP/runner-token-failure.out" >/dev/null ||
+    fail "empty API token caused more than one hard failure"
+grep -F "SKIP: 6" "$TEST_TMP/runner-token-failure.out" >/dev/null ||
+    fail "authenticated checks were not skipped after an empty API token"
+token_skip_count=$(grep -c "no valid API token available" \
+    "$TEST_TMP/runner-token-failure.out")
+[ "$token_skip_count" -eq 6 ] ||
+    fail "expected six explicit authenticated-check skips, got $token_skip_count"
+if grep -F "expected HTTP 200, got 401" \
+    "$TEST_TMP/runner-token-failure.out" >/dev/null; then
+    fail "empty API token cascaded into opaque endpoint failures"
+fi
+token_failure_project=$(awk -F '\t' '$0 ~ /\tdown\t-v\t--remove-orphans$/ {
+    for (i = 1; i <= NF; i++) if ($i == "--project-name") print $(i + 1)
+}' "$FAKE_DOCKER_LOG")
+assert_log_has_safe_down "$token_failure_project"
 
 printf '7/8 web runner uses one isolated project for startup and cleanup\n'
 : >"$FAKE_DOCKER_LOG"

--- a/docs/e2e-test-guide.md
+++ b/docs/e2e-test-guide.md
@@ -73,15 +73,18 @@ Or use CODEOWNERS/branch protection to auto-assign reviewers.
 ### 4. Start the Daemon
 
 ```bash
-# With test compose overlay (no auto-restart, mapped ports)
-docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml up --build
-```
-
-Or use the Makefile shortcut:
-
-```bash
+# Creates a unique, isolated Compose project for this invocation.
 make test-e2e
 ```
+
+Do not invoke `docker-compose.test.yml` directly. The runner generates a
+project name such as `heimdallm-test-local-<pid>-<random>`, unique container
+names, per-project data and config volumes, and free loopback-only host ports.
+This means a normal `make up` stack and other test runs can stay active without
+sharing containers, networks, ports, or persistent data.
+
+The runner prints the exact project name and daemon URL after startup. Keep it
+running while following the remaining steps; press Ctrl+C when finished.
 
 ### 5. Observe the Pipeline
 
@@ -102,7 +105,8 @@ Watch the logs for these stages in order:
 While the daemon is running, in another terminal:
 
 ```bash
-BASE=http://localhost:7842
+# Copy the per-run URL printed by make test-e2e.
+BASE='http://127.0.0.1:<printed-port>'
 
 # Health check
 curl -s $BASE/health | jq
@@ -134,7 +138,10 @@ Check the PR on GitHub — you should see a review comment from the token user w
 Read the API token from the container:
 
 ```bash
-API_TOKEN=$(docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml exec heimdallm cat /data/api_token)
+# The runner prints its exact `docker compose --project-name ...` command.
+# Copy it into this terminal and append the exec arguments:
+<printed-compose-command> exec -T heimdallm cat /data/api_token
+API_TOKEN='<output from the previous command>'
 
 # Get PR ID from /prs
 PR_ID=$(curl -s $BASE/prs | jq '.[0].id')
@@ -151,11 +158,20 @@ curl -X POST $BASE/prs/$PR_ID/undismiss -H "X-Heimdallm-Token: $API_TOKEN"
 
 ### 9. Clean Up
 
-```bash
-# Stop the daemon
-docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml down -v
+Press Ctrl+C in the runner terminal. Its EXIT trap verifies the private marker
+created for that process before it can call `down -v`; if the project name or
+marker does not match, cleanup fails closed and Docker is not invoked. The
+verified cleanup removes only that run's containers, network, and named
+volumes. The normal development/production project is never targeted.
 
-# Close the test PR
+If the process is killed with SIGKILL, Docker resources can remain because no
+shell trap can run. Their project and container names retain the
+`heimdallm-test-*` prefix for inspection; confirm the exact Compose project
+labels before removing only that run. Do not use an unscoped `down -v`.
+
+Finally, close the test PR:
+
+```bash
 gh pr close <PR_NUMBER> -d  # -d deletes the branch too
 ```
 

--- a/docs/e2e-test-guide.md
+++ b/docs/e2e-test-guide.md
@@ -108,20 +108,26 @@ While the daemon is running, in another terminal:
 # Copy the per-run URL printed by make test-e2e.
 BASE='http://127.0.0.1:<printed-port>'
 
+# The runner also prints its exact `docker compose --project-name ...` command.
+# Copy it into this terminal and append the exec arguments:
+<printed-compose-command> exec -T heimdallm cat /data/api_token
+API_TOKEN='<trimmed output from the previous command>'
+AUTH_HEADER="X-Heimdallm-Token: $API_TOKEN"
+
 # Health check
-curl -s $BASE/health | jq
+curl -s "$BASE/health" | jq
 
 # Authenticated user
-curl -s $BASE/me | jq
+curl -s -H "$AUTH_HEADER" "$BASE/me" | jq
 
 # Detected PRs
-curl -s $BASE/prs | jq
+curl -s -H "$AUTH_HEADER" "$BASE/prs" | jq
 
 # Review stats
-curl -s $BASE/stats | jq
+curl -s -H "$AUTH_HEADER" "$BASE/stats" | jq
 
 # Stream SSE events (Ctrl+C to stop)
-curl -N $BASE/events
+curl -N -H "$AUTH_HEADER" "$BASE/events"
 ```
 
 ### 7. Verify on GitHub
@@ -135,16 +141,11 @@ Check the PR on GitHub — you should see a review comment from the token user w
 
 ### 8. Advanced: Manual Review Trigger
 
-Read the API token from the container:
+Reuse the per-run `BASE`, `API_TOKEN`, and `AUTH_HEADER` values from step 6:
 
 ```bash
-# The runner prints its exact `docker compose --project-name ...` command.
-# Copy it into this terminal and append the exec arguments:
-<printed-compose-command> exec -T heimdallm cat /data/api_token
-API_TOKEN='<output from the previous command>'
-
 # Get PR ID from /prs
-PR_ID=$(curl -s $BASE/prs | jq '.[0].id')
+PR_ID=$(curl -s -H "$AUTH_HEADER" "$BASE/prs" | jq '.[0].id')
 
 # Trigger manual review
 curl -X POST $BASE/prs/$PR_ID/review -H "X-Heimdallm-Token: $API_TOKEN"
@@ -163,6 +164,13 @@ created for that process before it can call `down -v`; if the project name or
 marker does not match, cleanup fails closed and Docker is not invoked. The
 verified cleanup removes only that run's containers, network, and named
 volumes. The normal development/production project is never targeted.
+
+If cleanup fails, the runner preserves its private marker and cleanup log and
+prints two copyable, run-scoped commands: one to retry the exact
+`down -v --remove-orphans`, and another to remove the marker, log, and private
+state directory **after** Docker cleanup succeeds. The latter deliberately
+uses `rm -f` for the two known files followed by `rmdir`, rather than a
+recursive delete, so unexpected contents are never removed silently.
 
 If the process is killed with SIGKILL, Docker resources can remain because no
 shell trap can run. Their project and container names retain the


### PR DESCRIPTION
## Qué cambia

- Aísla cada ejecución de pruebas Compose con un nombre de proyecto, contenedores, red, volúmenes y puertos efímeros propios.
- Centraliza el ciclo de vida en un helper con marcador fail-closed y cleanup protegido.
- Evita que los scripts de smoke reutilicen o eliminen los recursos del stack normal.
- Añade pruebas de aislamiento, wiring en CI y documentación de recuperación.
- Conserva el flujo macOS introducido en #604.

## Causa raíz e impacto

Los scripts compartían los nombres, puertos y volúmenes por defecto de Compose. Una prueba podía colisionar con una instalación activa o ejecutar un `down -v` sobre sus datos. Ahora el ámbito destructivo queda limitado al proyecto efímero creado por esa ejecución.

## Validación

- `make test-compose-isolation` — 8/8 casos.
- `make test-install-macos` — 98/98 casos.
- Comprobaciones de sintaxis POSIX/Bash y `git diff --check`.
- Dos ejecuciones reales del smoke Docker con cleanup verificado: 16/17 checks funcionales; el único fallo es la instalación preexistente de OpenCode en arm64/musl, registrada en #631 y relacionada con #621.
- Revisión independiente sin hallazgos bloqueantes, altos ni medios.

## Riesgo residual

`SIGKILL` no permite ejecutar traps; el proyecto efímero queda identificado para limpieza manual. La concurrencia se cubre con el harness determinista y la configuración Compose, además de dos ejecuciones Docker reales secuenciales.

Closes #606
