### PR TITLE
fix(web): include shared Flutter assets in the production Docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,13 +46,5 @@ jobs:
           cache-from: type=gha,scope=flutter-web
           cache-to: type=gha,mode=max,scope=flutter-web
 
-      - name: Smoke-test Flutter Web image contents
-        run: |
-          docker run --rm --entrypoint sh heimdallm-web:test -ec '
-            web_root=/usr/share/nginx/html
-            test -s "$web_root/index.html"
-            test -s "$web_root/main.dart.js"
-            test -s "$web_root/assets/assets/icon.png"
-            test -s "$web_root/assets/assets/tray_icon.png"
-            test -s "$web_root/assets/assets/tray_icon@2x.png"
-          '
+      - name: Smoke-test Flutter Web image contents and runtime
+        run: sh docker/scripts/test-web-image.sh heimdallm-web:test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Verify Flutter Web build-context exclusions
+        run: sh docker/scripts/test-web-build-context.sh
+
       - name: Build Docker image (validation only)
         uses: docker/build-push-action@v6
         with:
@@ -31,3 +34,25 @@ jobs:
           tags: heimdallm:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Build Flutter Web image (validation only)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: flutter_app/Dockerfile.web
+          push: false
+          load: true
+          tags: heimdallm-web:test
+          cache-from: type=gha,scope=flutter-web
+          cache-to: type=gha,mode=max,scope=flutter-web
+
+      - name: Smoke-test Flutter Web image contents
+        run: |
+          docker run --rm --entrypoint sh heimdallm-web:test -ec '
+            web_root=/usr/share/nginx/html
+            test -s "$web_root/index.html"
+            test -s "$web_root/main.dart.js"
+            test -s "$web_root/assets/assets/icon.png"
+            test -s "$web_root/assets/assets/tray_icon.png"
+            test -s "$web_root/assets/assets/tray_icon@2x.png"
+          '

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Verify Flutter Web tooling guards
+        run: make test-web-tooling
+
       - name: Verify Flutter Web build-context exclusions
         run: sh docker/scripts/test-web-build-context.sh
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ else
   APP_BUNDLE       := $(FLUTTER_BUILD)/bundle
 endif
 
-.PHONY: build-daemon build-app build-web build-cli test test-cli lint-cli dev-cli test-docker dev dev-daemon dev-stop \
+.PHONY: build-daemon build-app build-web build-cli test test-cli lint-cli test-web-tooling dev-cli test-docker dev dev-daemon dev-stop \
         release-local package-macos install-service verify-linux run-linux test-install-macos \
         install-macos uninstall-macos install-linux uninstall-linux \
         setup up up-build up-daemon up-build-daemon down logs logs-daemon \
@@ -56,6 +56,9 @@ test-install-macos:
 	@sh -n scripts/macos-install.sh
 	@sh -n scripts/test-macos-install.sh
 	@./scripts/test-macos-install.sh
+
+test-web-tooling:
+	@sh docker/scripts/tests/test-web-tooling.sh
 
 # ── Sandboxed Go tests (EDR-safe) ─────────────────────────────────────────────
 #
@@ -338,10 +341,16 @@ _check-docker:
 	@command -v docker >/dev/null || { echo "❌  Docker is required. Install from https://docs.docker.com/get-docker/"; exit 1; }
 
 _check-buildkit: _check-docker
-	@if [ "$${DOCKER_BUILDKIT:-1}" = "0" ]; then \
-	  echo "❌  BuildKit cannot be disabled for Flutter Web builds."; \
-	  echo "    Dockerfile.web.dockerignore is only applied by BuildKit."; \
+	@docker compose version >/dev/null 2>&1 || { \
+	  echo "❌  Docker Compose v2 is required for Flutter Web builds."; \
 	  exit 1; \
+	}
+	@docker buildx version >/dev/null 2>&1 || { \
+	  echo "❌  Docker Buildx/BuildKit is required for Flutter Web builds."; \
+	  exit 1; \
+	}
+	@if [ "$${DOCKER_BUILDKIT:-1}" = "0" ]; then \
+	  echo "⚠  DOCKER_BUILDKIT=0 is overridden with 1 for the Flutter Web build."; \
 	fi
 
 _check-env: _check-docker

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ endif
         release-local package-macos install-service verify-linux run-linux test-install-macos \
         install-macos uninstall-macos install-linux uninstall-linux \
         setup up up-build up-daemon up-build-daemon down logs logs-daemon \
-        ps restart clean clean-clones _check-docker _check-env _check-macos _check-macos-user _check-linux _post-up-hints
+        ps restart clean clean-clones _check-docker _check-buildkit _check-env \
+        _check-macos _check-macos-user _check-linux _post-up-hints
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 
@@ -336,6 +337,13 @@ setup:
 _check-docker:
 	@command -v docker >/dev/null || { echo "❌  Docker is required. Install from https://docs.docker.com/get-docker/"; exit 1; }
 
+_check-buildkit: _check-docker
+	@if [ "$${DOCKER_BUILDKIT:-1}" = "0" ]; then \
+	  echo "❌  BuildKit cannot be disabled for Flutter Web builds."; \
+	  echo "    Dockerfile.web.dockerignore is only applied by BuildKit."; \
+	  exit 1; \
+	fi
+
 _check-env: _check-docker
 	@test -f $(DOCKER_ENV) || { \
 	  echo "❌  $(DOCKER_ENV) missing."; \
@@ -381,13 +389,13 @@ _post-up-hints:
 	@echo ""
 	@echo "Next: open http://localhost:$${HEIMDALLM_WEB_PORT:-3000}  ·  logs: \`make logs\`  ·  stop: \`make down\`"
 
-up: _check-env
-	docker compose -f $(COMPOSE_FILE) up -d
+up: _check-env _check-buildkit
+	DOCKER_BUILDKIT=1 docker compose -f $(COMPOSE_FILE) up -d
 	@$(MAKE) --no-print-directory _post-up-hints
 
 # Like `up` but rebuilds images from local source (use after `git pull` on main).
-up-build: _check-env
-	docker compose -f $(COMPOSE_FILE) up -d --build --pull always
+up-build: _check-env _check-buildkit
+	DOCKER_BUILDKIT=1 docker compose -f $(COMPOSE_FILE) up -d --build --pull always
 	@$(MAKE) --no-print-directory _post-up-hints
 
 up-daemon: _check-env

--- a/README.md
+++ b/README.md
@@ -457,6 +457,13 @@ For iterating on the Flutter Web bundle against a running daemon:
 ```bash
 make build-web    # compile Flutter → web/; then `make up-build` to bake into the Nginx image
 ```
+To validate the production image directly, run both commands from the
+repository root. The root context is required because `flutter_app/assets`
+links to the shared `assets/` directory:
+```bash
+docker build --target build -f flutter_app/Dockerfile.web .
+docker compose -f docker/docker-compose.yml build web
+```
 
 **CLI / TUI** — terminal client against a running daemon:
 ```bash

--- a/README.md
+++ b/README.md
@@ -457,13 +457,19 @@ For iterating on the Flutter Web bundle against a running daemon:
 ```bash
 make build-web    # compile Flutter → web/; then `make up-build` to bake into the Nginx image
 ```
-To validate the production image directly, run both commands from the
-repository root. The root context is required because `flutter_app/assets`
-links to the shared `assets/` directory:
+The production web image requires BuildKit: its Dockerfile-specific
+`.dockerignore` is what keeps the repository-root context minimal. The Make
+wrappers enforce this requirement. For direct validation, run these commands
+from the repository root (`flutter_app/assets` links to the shared `assets/`
+directory):
 ```bash
-docker build --target build -f flutter_app/Dockerfile.web .
-docker compose -f docker/docker-compose.yml build web
+sh docker/scripts/test-web-build-context.sh
+docker buildx build --load --target build -t heimdallm-web-build:test -f flutter_app/Dockerfile.web .
+DOCKER_BUILDKIT=1 docker compose -f docker/docker-compose.yml build web
 ```
+Do not use the legacy `docker build` backend for this Dockerfile: it ignores
+`flutter_app/Dockerfile.web.dockerignore` and can transfer unrelated repository
+files to the builder.
 
 **CLI / TUI** — terminal client against a running daemon:
 ```bash

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,5 +1,7 @@
 # Override for local testing.
-# Usage: docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml up
+# Usage:
+#   DOCKER_BUILDKIT=1 docker compose \
+#     -f docker/docker-compose.yml -f docker/docker-compose.test.yml up
 services:
   heimdallm:
     container_name: heimdallm-test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -78,9 +78,10 @@ services:
       # this version, otherwise the daemon will regenerate from env vars
       # and your manual edits are lost silently:
       #
-      #   docker compose up --no-start heimdallm     # create container
+      #   DOCKER_BUILDKIT=1 docker compose up --no-start heimdallm
+      #                                                   # create container
       #   docker cp docker/config/config.toml heimdallm:/config/config.toml
-      #   docker compose up -d                        # start with the file in place
+      #   DOCKER_BUILDKIT=1 docker compose up -d     # start with the file in place
       #
       # Env-driven setups (HEIMDALLM_* in docker/.env) and saves you made
       # via the web UI Configuration screen are unaffected; both flow
@@ -131,7 +132,8 @@ services:
     build:
       # The Flutter project shares the repository-root assets directory via
       # flutter_app/assets -> ../assets. Use the repo root as context; the
-      # Dockerfile-specific ignore file keeps the transferred context minimal.
+      # BuildKit-only Dockerfile-specific ignore file keeps the transferred
+      # context minimal. Make wrappers set DOCKER_BUILDKIT=1 explicitly.
       context: ..
       dockerfile: flutter_app/Dockerfile.web
     container_name: heimdallm-web

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -129,8 +129,11 @@ services:
   # it into proxied /api/* requests so the browser never handles it.
   web:
     build:
-      context: ../flutter_app
-      dockerfile: Dockerfile.web
+      # The Flutter project shares the repository-root assets directory via
+      # flutter_app/assets -> ../assets. Use the repo root as context; the
+      # Dockerfile-specific ignore file keeps the transferred context minimal.
+      context: ..
+      dockerfile: flutter_app/Dockerfile.web
     container_name: heimdallm-web
     restart: unless-stopped
     ports:

--- a/docker/scripts/lib/compose-test.sh
+++ b/docker/scripts/lib/compose-test.sh
@@ -9,6 +9,17 @@ compose_test_error() {
     printf 'compose-test: %s\n' "$*" >&2
 }
 
+compose_test_require_build_tools() {
+    if ! command docker compose version >/dev/null 2>&1; then
+        compose_test_error "Docker Compose v2 is required for Flutter Web builds."
+        return 1
+    fi
+    if ! command docker buildx version >/dev/null 2>&1; then
+        compose_test_error "Docker Buildx/BuildKit is required for Flutter Web builds."
+        return 1
+    fi
+}
+
 compose_test_init() {
     if [ "${COMPOSE_TEST_INITIALIZED:-0}" = "1" ]; then
         compose_test_error "isolation is already initialized"

--- a/docker/scripts/list-flutter-assets.sh
+++ b/docker/scripts/list-flutter-assets.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+# Print the file assets declared under flutter.assets in pubspec.yaml.
+#
+# The web Docker context and image smoke tests both consume this output so
+# pubspec.yaml remains the source of truth. Directory entries and complex YAML
+# values are rejected deliberately: supporting either requires updating the
+# Docker context contract rather than silently widening it.
+set -eu
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+pubspec="${1:-$script_dir/../../flutter_app/pubspec.yaml}"
+
+if [ ! -f "$pubspec" ]; then
+  printf 'Flutter pubspec not found: %s\n' "$pubspec" >&2
+  exit 1
+fi
+
+awk '
+function indentation(line, stripped) {
+  stripped = line
+  sub(/^[ \t]*/, "", stripped)
+  return length(line) - length(stripped)
+}
+
+function trim(value) {
+  sub(/^[ \t]+/, "", value)
+  sub(/[ \t]+$/, "", value)
+  return value
+}
+
+function invalid(message) {
+  print "invalid flutter.assets entry: " message > "/dev/stderr"
+  failed = 1
+  exit 1
+}
+
+BEGIN {
+  in_flutter = 0
+  in_assets = 0
+  found_flutter = 0
+  found_assets = 0
+  asset_count = 0
+  failed = 0
+}
+
+/^[ \t]*(#|$)/ {
+  next
+}
+
+{
+  line = $0
+  current_indent = indentation(line)
+
+  if (!in_flutter) {
+    if (line ~ /^flutter:[ \t]*(#.*)?$/) {
+      in_flutter = 1
+      found_flutter = 1
+      flutter_indent = current_indent
+    }
+    next
+  }
+
+  if (current_indent <= flutter_indent) {
+    in_flutter = 0
+    in_assets = 0
+    next
+  }
+
+  if (!in_assets) {
+    if (line ~ /^[ \t]+assets:[ \t]*(#.*)?$/) {
+      in_assets = 1
+      found_assets = 1
+      assets_indent = current_indent
+    }
+    next
+  }
+
+  if (current_indent <= assets_indent) {
+    in_assets = 0
+    next
+  }
+
+  if (line !~ /^[ \t]*-[ \t]+/) {
+    invalid("expected a scalar list item in " FILENAME ":" FNR)
+  }
+
+  value = line
+  sub(/^[ \t]*-[ \t]+/, "", value)
+  value = trim(value)
+  quote = substr(value, 1, 1)
+
+  if (quote == "\"" || quote == "\047") {
+    if (length(value) < 2 || substr(value, length(value), 1) != quote) {
+      invalid("unterminated quoted value in " FILENAME ":" FNR)
+    }
+    value = substr(value, 2, length(value) - 2)
+  } else {
+    sub(/[ \t]+#.*/, "", value)
+    value = trim(value)
+  }
+
+  if (value !~ /^assets\//) {
+    invalid("\047" value "\047 must be under assets/")
+  }
+  if (value ~ /(^|\/)\.\.(\/|$)/) {
+    invalid("\047" value "\047 must not traverse parent directories")
+  }
+  if (value ~ /\/$/) {
+    invalid("\047" value "\047 is a directory; declare individual files")
+  }
+  if (seen[value]++) {
+    invalid("\047" value "\047 is declared more than once")
+  }
+
+  print value
+  asset_count++
+}
+
+END {
+  if (failed) {
+    exit 1
+  }
+  if (!found_flutter) {
+    print "pubspec has no top-level flutter section: " FILENAME > "/dev/stderr"
+    exit 1
+  }
+  if (!found_assets || asset_count == 0) {
+    print "pubspec has no flutter.assets file entries: " FILENAME > "/dev/stderr"
+    exit 1
+  }
+}
+' "$pubspec"

--- a/docker/scripts/list-flutter-assets.sh
+++ b/docker/scripts/list-flutter-assets.sh
@@ -2,36 +2,135 @@
 # Print file resources declared by flutter.assets, flutter.fonts and
 # flutter.shaders in pubspec.yaml.
 #
-# Default output uses Flutter-relative paths, one per line. With
-# --dockerignore, output the exact negation rules required by the repository-
-# root Docker context. The context check and image smoke both consume this
-# parser so pubspec.yaml remains the single source of truth.
+# Default output uses Flutter-relative paths, one per line. --context-paths
+# maps those resources to repository-root Docker context paths, while
+# --dockerignore emits the exact resource rules for that context.
 #
 # Directory entries and complex YAML values are rejected deliberately. Resource
 # paths must be simple, safe relative file names so they cannot turn a literal
-# Docker ignore allowlist into a glob.
+# Docker ignore allowlist into a glob. Secret-like names remain denied unless
+# their exact public context path is audited in Dockerfile.web.dockerignore.
 set -eu
 
 script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 output_mode=paths
+output_mode_set=0
+pubspec="$script_dir/../../flutter_app/pubspec.yaml"
+pubspec_set=0
+dockerignore_file="$script_dir/../../flutter_app/Dockerfile.web.dockerignore"
+public_allowlist_begin="# BEGIN flutter-public-secret-like-resource-allowlist"
+public_allowlist_end="# END flutter-public-secret-like-resource-allowlist"
 
-if [ "${1:-}" = "--dockerignore" ]; then
-  output_mode=dockerignore
-  shift
-fi
-if [ "$#" -gt 1 ]; then
-  printf 'Usage: %s [--dockerignore] [pubspec.yaml]\n' "$0" >&2
+usage() {
+  printf '%s\n' \
+    "Usage: $0 [--dockerignore|--context-paths]" \
+    "       [--dockerignore-file Dockerfile.web.dockerignore] [pubspec.yaml]" >&2
   exit 1
-fi
+}
 
-pubspec="${1:-$script_dir/../../flutter_app/pubspec.yaml}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dockerignore)
+      [ "$output_mode_set" -eq 0 ] || usage
+      output_mode=dockerignore
+      output_mode_set=1
+      shift
+      ;;
+    --context-paths)
+      [ "$output_mode_set" -eq 0 ] || usage
+      output_mode=context-paths
+      output_mode_set=1
+      shift
+      ;;
+    --dockerignore-file)
+      [ "$#" -ge 2 ] || usage
+      dockerignore_file="$2"
+      shift 2
+      ;;
+    -*)
+      usage
+      ;;
+    *)
+      [ "$pubspec_set" -eq 0 ] || usage
+      pubspec="$1"
+      pubspec_set=1
+      shift
+      ;;
+  esac
+done
 
 if [ ! -f "$pubspec" ]; then
   printf 'Flutter pubspec not found: %s\n' "$pubspec" >&2
   exit 1
 fi
+if [ ! -f "$dockerignore_file" ]; then
+  printf 'Flutter Web Docker ignore policy not found: %s\n' \
+    "$dockerignore_file" >&2
+  exit 1
+fi
 
-awk -v output_mode="$output_mode" '
+if ! public_secret_like_context_paths="$(
+  awk \
+    -v begin_marker="$public_allowlist_begin" \
+    -v end_marker="$public_allowlist_end" '
+function invalid(message) {
+  print "invalid Flutter public-resource exception block: " message \
+    > "/dev/stderr"
+  failed = 1
+  exit 1
+}
+
+$0 == begin_marker {
+  if (inside || ++begin_count != 1) {
+    invalid("duplicate or nested begin marker")
+  }
+  inside = 1
+  next
+}
+
+$0 == end_marker {
+  if (!inside || ++end_count != 1) {
+    invalid("end marker has no matching begin marker")
+  }
+  inside = 0
+  next
+}
+
+inside {
+  value = $0
+  sub(/^[ \t]+/, "", value)
+  sub(/[ \t]+$/, "", value)
+  if (value == "" || value ~ /^#/) {
+    next
+  }
+  if (value !~ /^!/) {
+    invalid("entries must be exact Docker negation rules beginning with !")
+  }
+  sub(/^!/, "", value)
+  print value
+}
+
+END {
+  if (failed) {
+    exit 1
+  }
+  if (begin_count != 1 || end_count != 1 || inside) {
+    print "invalid Flutter public-resource exception block: expected exactly " \
+      "one matched marker pair" > "/dev/stderr"
+    exit 1
+  }
+}
+' "$dockerignore_file"
+)"; then
+  exit 1
+fi
+
+awk \
+  -v output_mode="$output_mode" \
+  -v public_exception_paths="$public_secret_like_context_paths" \
+  -v exception_source="$dockerignore_file" \
+  -v public_begin="$public_allowlist_begin" \
+  -v public_end="$public_allowlist_end" '
 function indentation(line, stripped) {
   stripped = line
   sub(/^[ \t]*/, "", stripped)
@@ -68,7 +167,7 @@ function scalar_value(raw, location, value, quote) {
   return value
 }
 
-function validate_path(value, kind, location) {
+function validate_literal_path(value, kind, location) {
   if (value == "") {
     invalid(kind " path is empty at " location)
   }
@@ -84,9 +183,44 @@ function validate_path(value, kind, location) {
   if (value ~ /[^A-Za-z0-9_@.+\/-]/) {
     invalid("\047" value "\047 contains characters unsafe for a literal Docker allowlist")
   }
-  if (value ~ /(^|\/)\.env([.]|$)/ ||
-      value ~ /[.](pem|key|crt|p12|pfx)$/) {
-    invalid("\047" value "\047 matches a protected secret-file pattern")
+}
+
+function is_secret_like(value) {
+  return value ~ /(^|\/)\.env([.]|$)/ ||
+    value ~ /[.](pem|key|crt|p12|pfx)$/
+}
+
+function to_context_path(path) {
+  if (path ~ /^assets\//) {
+    return path
+  }
+  return "flutter_app/" path
+}
+
+function validate_public_exception(value) {
+  validate_literal_path(value, "public exception", exception_source)
+  if (value !~ /^(assets|flutter_app)\//) {
+    invalid("\047" value "\047 must be under assets/ or flutter_app/ in " exception_source)
+  }
+  if (!is_secret_like(value)) {
+    invalid("\047" value "\047 is not secret-like and must not be in the public exception block")
+  }
+  if (public_exception[value]++) {
+    invalid("\047" value "\047 is duplicated in the public exception block")
+  }
+}
+
+function validate_path(value, kind, location, mapped) {
+  validate_literal_path(value, kind, location)
+  if (is_secret_like(value)) {
+    mapped = to_context_path(value)
+    if (!(mapped in public_exception)) {
+      invalid("\047" value "\047 matches a protected secret-file pattern. " \
+        "If it is intentionally public, add the exact rule \047!" mapped \
+        "\047 between \047" public_begin "\047 and \047" public_end \
+        "\047 in " exception_source)
+    }
+    used_public_exception[mapped] = 1
   }
 }
 
@@ -116,13 +250,9 @@ function finish_font_family(location) {
   font_family_location = ""
 }
 
-function emit_dockerignore(path, context_path, count, pieces, parent, i, rule) {
-  context_path = path
-  if (path !~ /^assets\//) {
-    context_path = "flutter_app/" path
-  }
-
-  count = split(context_path, pieces, "/")
+function emit_dockerignore(path, mapped_path, count, pieces, parent, i, rule) {
+  mapped_path = to_context_path(path)
+  count = split(mapped_path, pieces, "/")
   parent = pieces[1]
   for (i = 2; i < count; i++) {
     parent = parent "/" pieces[i]
@@ -133,7 +263,7 @@ function emit_dockerignore(path, context_path, count, pieces, parent, i, rule) {
     }
   }
 
-  rule = "!" context_path
+  rule = "!" mapped_path
   if (!emitted_rule[rule]++) {
     print rule
   }
@@ -154,6 +284,15 @@ BEGIN {
   font_family_seen = 0
   current_family_asset_count = 0
   failed = 0
+
+  if (public_exception_paths != "") {
+    public_exception_count = split(public_exception_paths, public_exception_entries, "\n")
+    for (public_exception_index = 1;
+         public_exception_index <= public_exception_count;
+         public_exception_index++) {
+      validate_public_exception(public_exception_entries[public_exception_index])
+    }
+  }
 }
 
 /^[ \t]*(#|$)/ {
@@ -295,10 +434,18 @@ END {
     print "pubspec has no supported Flutter file resources: " FILENAME > "/dev/stderr"
     exit 1
   }
+  for (public_exception_path in public_exception) {
+    if (!(public_exception_path in used_public_exception)) {
+      invalid("\047" public_exception_path "\047 in " exception_source \
+        " does not match a declared protected Flutter resource")
+    }
+  }
 
   for (i = 1; i <= resource_count; i++) {
     if (output_mode == "dockerignore") {
       emit_dockerignore(resources[i])
+    } else if (output_mode == "context-paths") {
+      print to_context_path(resources[i])
     } else {
       print resources[i]
     }

--- a/docker/scripts/list-flutter-assets.sh
+++ b/docker/scripts/list-flutter-assets.sh
@@ -1,13 +1,29 @@
 #!/bin/sh
-# Print the file assets declared under flutter.assets in pubspec.yaml.
+# Print file resources declared by flutter.assets, flutter.fonts and
+# flutter.shaders in pubspec.yaml.
 #
-# The web Docker context and image smoke tests both consume this output so
-# pubspec.yaml remains the source of truth. Directory entries and complex YAML
-# values are rejected deliberately: supporting either requires updating the
-# Docker context contract rather than silently widening it.
+# Default output uses Flutter-relative paths, one per line. With
+# --dockerignore, output the exact negation rules required by the repository-
+# root Docker context. The context check and image smoke both consume this
+# parser so pubspec.yaml remains the single source of truth.
+#
+# Directory entries and complex YAML values are rejected deliberately. Resource
+# paths must be simple, safe relative file names so they cannot turn a literal
+# Docker ignore allowlist into a glob.
 set -eu
 
 script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+output_mode=paths
+
+if [ "${1:-}" = "--dockerignore" ]; then
+  output_mode=dockerignore
+  shift
+fi
+if [ "$#" -gt 1 ]; then
+  printf 'Usage: %s [--dockerignore] [pubspec.yaml]\n' "$0" >&2
+  exit 1
+fi
+
 pubspec="${1:-$script_dir/../../flutter_app/pubspec.yaml}"
 
 if [ ! -f "$pubspec" ]; then
@@ -15,7 +31,7 @@ if [ ! -f "$pubspec" ]; then
   exit 1
 fi
 
-awk '
+awk -v output_mode="$output_mode" '
 function indentation(line, stripped) {
   stripped = line
   sub(/^[ \t]*/, "", stripped)
@@ -29,17 +45,114 @@ function trim(value) {
 }
 
 function invalid(message) {
-  print "invalid flutter.assets entry: " message > "/dev/stderr"
+  print "invalid Flutter resource declaration: " message > "/dev/stderr"
   failed = 1
   exit 1
 }
 
+function scalar_value(raw, location, value, quote) {
+  value = trim(raw)
+  quote = substr(value, 1, 1)
+
+  if (quote == "\"" || quote == "\047") {
+    sub(/[ \t]+#.*/, "", value)
+    value = trim(value)
+    if (length(value) < 2 || substr(value, length(value), 1) != quote) {
+      invalid("unterminated quoted value at " location)
+    }
+    value = substr(value, 2, length(value) - 2)
+  } else {
+    sub(/[ \t]+#.*/, "", value)
+    value = trim(value)
+  }
+  return value
+}
+
+function validate_path(value, kind, location) {
+  if (value == "") {
+    invalid(kind " path is empty at " location)
+  }
+  if (value ~ /^\//) {
+    invalid("\047" value "\047 must be relative at " location)
+  }
+  if (value ~ /(^|\/)\.\.?($|\/)/) {
+    invalid("\047" value "\047 must not contain dot path segments at " location)
+  }
+  if (value ~ /\/$/) {
+    invalid("\047" value "\047 is a directory; declare individual files")
+  }
+  if (value ~ /[^A-Za-z0-9_@.+\/-]/) {
+    invalid("\047" value "\047 contains characters unsafe for a literal Docker allowlist")
+  }
+  if (value ~ /(^|\/)\.env([.]|$)/ ||
+      value ~ /[.](pem|key|crt|p12|pfx)$/) {
+    invalid("\047" value "\047 matches a protected secret-file pattern")
+  }
+}
+
+function add_resource(raw, kind, location, value) {
+  value = scalar_value(raw, location)
+  validate_path(value, kind, location)
+  if (seen[value]++) {
+    invalid("\047" value "\047 is declared more than once")
+  }
+  resources[++resource_count] = value
+  if (kind == "asset") {
+    asset_count++
+  } else if (kind == "font") {
+    font_count++
+  } else if (kind == "shader") {
+    shader_count++
+  }
+}
+
+function finish_font_family(location) {
+  if (font_family_seen && current_family_asset_count == 0) {
+    invalid("font family declared at " font_family_location \
+      " has no supported asset entries before " location)
+  }
+  font_family_seen = 0
+  current_family_asset_count = 0
+  font_family_location = ""
+}
+
+function emit_dockerignore(path, context_path, count, pieces, parent, i, rule) {
+  context_path = path
+  if (path !~ /^assets\//) {
+    context_path = "flutter_app/" path
+  }
+
+  count = split(context_path, pieces, "/")
+  parent = pieces[1]
+  for (i = 2; i < count; i++) {
+    parent = parent "/" pieces[i]
+    rule = "!" parent "/"
+    if (!emitted_rule[rule]++) {
+      print rule
+      print parent "/**"
+    }
+  }
+
+  rule = "!" context_path
+  if (!emitted_rule[rule]++) {
+    print rule
+  }
+}
+
 BEGIN {
   in_flutter = 0
-  in_assets = 0
+  child_indent_set = 0
+  section = ""
   found_flutter = 0
   found_assets = 0
+  found_fonts = 0
+  found_shaders = 0
   asset_count = 0
+  font_count = 0
+  shader_count = 0
+  resource_count = 0
+  font_family_seen = 0
+  current_family_asset_count = 0
   failed = 0
 }
 
@@ -50,10 +163,14 @@ BEGIN {
 {
   line = $0
   current_indent = indentation(line)
+  stripped = line
+  sub(/^[ \t]*/, "", stripped)
 
   if (!in_flutter) {
-    if (line ~ /^flutter:[ \t]*(#.*)?$/) {
+    if (current_indent == 0 && line ~ /^flutter:[ \t]*(#.*)?$/) {
       in_flutter = 1
+      child_indent_set = 0
+      section = ""
       found_flutter = 1
       flutter_indent = current_indent
     }
@@ -61,72 +178,130 @@ BEGIN {
   }
 
   if (current_indent <= flutter_indent) {
+    if (section == "fonts" && !failed) {
+      finish_font_family(FILENAME ":" FNR)
+    }
     in_flutter = 0
-    in_assets = 0
+    section = ""
     next
   }
 
-  if (!in_assets) {
-    if (line ~ /^[ \t]+assets:[ \t]*(#.*)?$/) {
-      in_assets = 1
+  if (!child_indent_set) {
+    child_indent = current_indent
+    child_indent_set = 1
+  }
+  if (current_indent < child_indent) {
+    invalid("inconsistent indentation at " FILENAME ":" FNR)
+  }
+
+  if (current_indent == child_indent) {
+    if (section == "fonts" && !failed) {
+      finish_font_family(FILENAME ":" FNR)
+    }
+    section = ""
+
+    if (stripped ~ /^assets[ \t]*:/) {
+      if (stripped !~ /^assets[ \t]*:[ \t]*(#.*)?$/) {
+        invalid("inline flutter.assets values are unsupported at " FILENAME ":" FNR)
+      }
+      section = "assets"
       found_assets = 1
-      assets_indent = current_indent
+    } else if (stripped ~ /^fonts[ \t]*:/) {
+      if (stripped !~ /^fonts[ \t]*:[ \t]*(#.*)?$/) {
+        invalid("inline flutter.fonts values are unsupported at " FILENAME ":" FNR)
+      }
+      section = "fonts"
+      found_fonts = 1
+      font_family_seen = 0
+      current_family_asset_count = 0
+    } else if (stripped ~ /^shaders[ \t]*:/) {
+      if (stripped !~ /^shaders[ \t]*:[ \t]*(#.*)?$/) {
+        invalid("inline flutter.shaders values are unsupported at " FILENAME ":" FNR)
+      }
+      section = "shaders"
+      found_shaders = 1
     }
     next
   }
 
-  if (current_indent <= assets_indent) {
-    in_assets = 0
+  if (section == "assets" || section == "shaders") {
+    if (stripped !~ /^-[ \t]+/) {
+      invalid("expected a scalar flutter." section " list item at " FILENAME ":" FNR)
+    }
+    value = stripped
+    sub(/^-[ \t]+/, "", value)
+    kind = section == "assets" ? "asset" : "shader"
+    add_resource(value, kind, FILENAME ":" FNR)
     next
   }
 
-  if (line !~ /^[ \t]*-[ \t]+/) {
-    invalid("expected a scalar list item in " FILENAME ":" FNR)
-  }
-
-  value = line
-  sub(/^[ \t]*-[ \t]+/, "", value)
-  value = trim(value)
-  quote = substr(value, 1, 1)
-
-  if (quote == "\"" || quote == "\047") {
-    if (length(value) < 2 || substr(value, length(value), 1) != quote) {
-      invalid("unterminated quoted value in " FILENAME ":" FNR)
+  if (section == "fonts") {
+    if (stripped ~ /^-[ \t]+family[ \t]*:/) {
+      if (font_family_seen) {
+        finish_font_family(FILENAME ":" FNR)
+      }
+      font_family_seen = 1
+      current_family_asset_count = 0
+      font_family_location = FILENAME ":" FNR
+    } else if (stripped ~ /^fonts[ \t]*:/) {
+      if (!font_family_seen) {
+        invalid("font asset list has no family at " FILENAME ":" FNR)
+      }
+      if (stripped !~ /^fonts[ \t]*:[ \t]*(#.*)?$/) {
+        invalid("inline font asset lists are unsupported at " FILENAME ":" FNR)
+      }
+    } else if (stripped ~ /^-[ \t]+asset[ \t]*:/) {
+      if (!font_family_seen) {
+        invalid("font asset has no family at " FILENAME ":" FNR)
+      }
+      value = stripped
+      sub(/^-[ \t]+asset[ \t]*:[ \t]*/, "", value)
+      add_resource(value, "font", FILENAME ":" FNR)
+      current_family_asset_count++
+    } else if (stripped ~ /^asset[ \t]*:/) {
+      invalid("font asset must be a list item at " FILENAME ":" FNR)
+    } else if (stripped ~ /^(style|weight)[ \t]*:/) {
+      next
+    } else {
+      invalid("unsupported flutter.fonts entry at " FILENAME ":" FNR)
     }
-    value = substr(value, 2, length(value) - 2)
-  } else {
-    sub(/[ \t]+#.*/, "", value)
-    value = trim(value)
   }
-
-  if (value !~ /^assets\//) {
-    invalid("\047" value "\047 must be under assets/")
-  }
-  if (value ~ /(^|\/)\.\.(\/|$)/) {
-    invalid("\047" value "\047 must not traverse parent directories")
-  }
-  if (value ~ /\/$/) {
-    invalid("\047" value "\047 is a directory; declare individual files")
-  }
-  if (seen[value]++) {
-    invalid("\047" value "\047 is declared more than once")
-  }
-
-  print value
-  asset_count++
 }
 
 END {
   if (failed) {
     exit 1
   }
+  if (section == "fonts") {
+    finish_font_family("end of file")
+  }
   if (!found_flutter) {
     print "pubspec has no top-level flutter section: " FILENAME > "/dev/stderr"
     exit 1
   }
-  if (!found_assets || asset_count == 0) {
-    print "pubspec has no flutter.assets file entries: " FILENAME > "/dev/stderr"
+  if (found_assets && asset_count == 0) {
+    print "pubspec has flutter.assets but no scalar file entries: " FILENAME > "/dev/stderr"
     exit 1
+  }
+  if (found_fonts && font_count == 0) {
+    print "pubspec has flutter.fonts but no supported font asset entries: " FILENAME > "/dev/stderr"
+    exit 1
+  }
+  if (found_shaders && shader_count == 0) {
+    print "pubspec has flutter.shaders but no scalar file entries: " FILENAME > "/dev/stderr"
+    exit 1
+  }
+  if (resource_count == 0) {
+    print "pubspec has no supported Flutter file resources: " FILENAME > "/dev/stderr"
+    exit 1
+  }
+
+  for (i = 1; i <= resource_count; i++) {
+    if (output_mode == "dockerignore") {
+      emit_dockerignore(resources[i])
+    } else {
+      print resources[i]
+    }
   }
 }
 ' "$pubspec"

--- a/docker/scripts/test-local.sh
+++ b/docker/scripts/test-local.sh
@@ -22,6 +22,10 @@ BASE_URL="http://localhost:${HEIMDALLM_PORT:-7842}"
 HEALTH_TIMEOUT=60   # seconds to wait for /health
 HEALTH_INTERVAL=2   # seconds between retries
 
+# The web service uses Dockerfile.web.dockerignore with a repository-root
+# context. The legacy builder ignores that file and must never be used here.
+export DOCKER_BUILDKIT=1
+
 # ─── Colors ───────────────────────────────────────────────────────────────────
 
 RED='\033[0;31m'

--- a/docker/scripts/test-local.sh
+++ b/docker/scripts/test-local.sh
@@ -19,6 +19,12 @@ cd "$REPO_ROOT"
 # shellcheck source=lib/compose-test.sh
 source "$SCRIPT_DIR/lib/compose-test.sh"
 
+# Keep every isolated Compose build on the same supported backend as the
+# production wrappers. Verify both plugins before allocating run state because
+# no cleanup is needed when the local Docker toolchain is incomplete.
+export DOCKER_BUILDKIT=1
+compose_test_require_build_tools
+
 cleanup_initialization() {
     local exit_code=$?
     trap - EXIT
@@ -45,10 +51,6 @@ BASE_URL=""
 HTTP_BODY_FILE=$(compose_test_run_path http-body)
 HEALTH_TIMEOUT=60   # seconds to wait for /health
 HEALTH_INTERVAL=2   # seconds between retries
-
-# The web service uses Dockerfile.web.dockerignore with a repository-root
-# context. The legacy builder ignores that file and must never be used here.
-export DOCKER_BUILDKIT=1
 
 # ─── Colors ───────────────────────────────────────────────────────────────────
 

--- a/docker/scripts/test-web-build-context.sh
+++ b/docker/scripts/test-web-build-context.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Verify that Dockerfile.web's allow-listed context cannot re-include secrets.
+# Verify Dockerfile.web's BuildKit-only allowlist with synthetic canaries.
 # All fixtures are dummy files created in a temporary build context.
 set -eu
 
@@ -8,6 +8,14 @@ repo_root="$(CDPATH= cd "$script_dir/../.." && pwd)"
 temp_root="$(mktemp -d)"
 context_dir="$temp_root/context"
 output_dir="$temp_root/output"
+declared_assets="$temp_root/declared-assets"
+allowlisted_assets="$temp_root/allowlisted-assets"
+undeclared_asset="assets/heimdallm-undeclared-context-canary-$$.txt"
+
+fail() {
+  printf 'Flutter Web build-context check failed: %s\n' "$1" >&2
+  exit 1
+}
 
 cleanup() {
   if [ -n "${temp_root:-}" ] && [ -d "$temp_root" ]; then
@@ -16,36 +24,77 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p \
-  "$context_dir/assets" \
-  "$context_dir/flutter_app/lib/nested" \
-  "$context_dir/flutter_app/web/nested" \
-  "$context_dir/flutter_app/docker-entrypoint.d/nested" \
-  "$output_dir"
+write_fixture() {
+  fixture="$1"
+  mkdir -p "$(dirname "$context_dir/$fixture")"
+  printf '%s\n' 'dummy build-context fixture' >"$context_dir/$fixture"
+}
 
+command -v docker >/dev/null 2>&1 || fail "Docker is required"
+docker buildx version >/dev/null 2>&1 \
+  || fail "Docker Buildx/BuildKit is required for Dockerfile-specific ignore rules"
+
+# pubspec.yaml is the source of truth. Require the checked-in allowlist to be
+# an exact mirror so additions and removals both fail CI until synchronized.
+sh "$script_dir/list-flutter-assets.sh" \
+  "$repo_root/flutter_app/pubspec.yaml" >"$temp_root/declared-assets-raw"
+LC_ALL=C sort -u "$temp_root/declared-assets-raw" >"$declared_assets"
+
+sed -n '/^!assets\/./ { s/^!//; p; }' \
+  "$repo_root/flutter_app/Dockerfile.web.dockerignore" \
+  >"$temp_root/allowlisted-assets-raw"
+LC_ALL=C sort -u "$temp_root/allowlisted-assets-raw" >"$allowlisted_assets"
+
+if ! cmp -s "$declared_assets" "$allowlisted_assets"; then
+  printf '%s\n' \
+    'flutter.assets and Dockerfile.web.dockerignore are out of sync:' >&2
+  diff -u "$declared_assets" "$allowlisted_assets" >&2 || true
+  exit 1
+fi
+
+mkdir -p "$context_dir/flutter_app" "$output_dir"
 cp "$repo_root/flutter_app/Dockerfile.web.dockerignore" \
   "$context_dir/Dockerfile.web.dockerignore"
+cp "$repo_root/flutter_app/pubspec.yaml" \
+  "$context_dir/flutter_app/pubspec.yaml"
+cp "$repo_root/flutter_app/pubspec.lock" \
+  "$context_dir/flutter_app/pubspec.lock"
 printf '%s\n' 'FROM scratch' 'COPY . /context' \
   >"$context_dir/Dockerfile.web"
 
-# Allowed canaries prove that the temporary context exercises re-included
-# source paths rather than passing because the whole directory stayed ignored.
-printf '%s\n' 'dummy public asset' >"$context_dir/assets/icon.png"
-printf '%s\n' 'dummy source' >"$context_dir/flutter_app/lib/allowed.txt"
-printf '%s\n' 'dummy example config' \
-  >"$context_dir/flutter_app/lib/.env.example"
+# Every declared asset must survive the allowlist. The undeclared canary below
+# proves this is exact inclusion rather than a broad assets/** exception.
+while IFS= read -r asset; do
+  write_fixture "$asset"
+done <"$declared_assets"
 
-# These names contain no credentials; they only exercise the exclusion rules.
-for fixture in \
+for allowed in \
+  flutter_app/.metadata \
+  flutter_app/lib/allowed.txt \
+  flutter_app/web/nested/allowed.txt \
+  flutter_app/nginx.conf.template \
+  flutter_app/docker-entrypoint.d/nested/allowed.sh
+do
+  write_fixture "$allowed"
+done
+ln -s ../assets "$context_dir/flutter_app/assets"
+
+# These names contain no credentials; they only exercise exclusion rules.
+for excluded in \
+  "$undeclared_asset" \
+  flutter_app/build/blocked.txt \
+  flutter_app/macos/blocked.txt \
+  flutter_app/test/blocked.txt \
   flutter_app/lib/.env \
   flutter_app/lib/.env.local \
+  flutter_app/lib/.env.example \
   flutter_app/lib/nested/dummy.pem \
   flutter_app/lib/nested/dummy.key \
   flutter_app/web/nested/dummy.crt \
   flutter_app/web/nested/dummy.p12 \
   flutter_app/docker-entrypoint.d/nested/dummy.pfx
 do
-  printf '%s\n' 'dummy excluded fixture' >"$context_dir/$fixture"
+  write_fixture "$excluded"
 done
 
 docker buildx build \
@@ -54,20 +103,35 @@ docker buildx build \
   --file "$context_dir/Dockerfile.web" \
   "$context_dir" >/dev/null
 
+while IFS= read -r asset; do
+  if [ ! -f "$output_dir/context/$asset" ]; then
+    fail "declared asset missing from context: $asset"
+  fi
+done <"$declared_assets"
+
 for allowed in \
-  assets/icon.png \
+  flutter_app/.metadata \
+  flutter_app/pubspec.yaml \
+  flutter_app/pubspec.lock \
   flutter_app/lib/allowed.txt \
-  flutter_app/lib/.env.example
+  flutter_app/web/nested/allowed.txt \
+  flutter_app/assets \
+  flutter_app/nginx.conf.template \
+  flutter_app/docker-entrypoint.d/nested/allowed.sh
 do
-  if [ ! -f "$output_dir/context/$allowed" ]; then
-    printf 'missing allowed build-context fixture: %s\n' "$allowed" >&2
-    exit 1
+  if [ ! -e "$output_dir/context/$allowed" ]; then
+    fail "allowed fixture missing from context: $allowed"
   fi
 done
 
 for excluded in \
+  "$undeclared_asset" \
+  flutter_app/build/blocked.txt \
+  flutter_app/macos/blocked.txt \
+  flutter_app/test/blocked.txt \
   flutter_app/lib/.env \
   flutter_app/lib/.env.local \
+  flutter_app/lib/.env.example \
   flutter_app/lib/nested/dummy.pem \
   flutter_app/lib/nested/dummy.key \
   flutter_app/web/nested/dummy.crt \
@@ -75,9 +139,8 @@ for excluded in \
   flutter_app/docker-entrypoint.d/nested/dummy.pfx
 do
   if [ -e "$output_dir/context/$excluded" ]; then
-    printf 'sensitive build-context fixture was included: %s\n' "$excluded" >&2
-    exit 1
+    fail "excluded fixture was included: $excluded"
   fi
 done
 
-printf 'Flutter Web build-context exclusions verified\n'
+printf 'Flutter Web BuildKit context and asset allowlist verified\n'

--- a/docker/scripts/test-web-build-context.sh
+++ b/docker/scripts/test-web-build-context.sh
@@ -16,6 +16,9 @@ checked_in_allowlist="$temp_root/checked-in-resource-allowlist"
 public_resource_rules_file="$temp_root/public-resource-rules"
 production_policy_skeleton="$temp_root/production-policy-skeleton"
 public_policy_skeleton="$temp_root/public-policy-skeleton"
+empty_resource_rules_file="$temp_root/empty-resource-rules"
+empty_policy_output="$temp_root/empty-policy-output"
+empty_policy_error="$temp_root/empty-policy-error"
 pubspec="$repo_root/flutter_app/pubspec.yaml"
 resource_policy="$repo_root/flutter_app/Dockerfile.web.dockerignore"
 undeclared_asset="assets/heimdallm-undeclared-context-canary-$$.txt"
@@ -56,11 +59,18 @@ function invalid(message) {
   exit 1
 }
 
-function emit_resource_rules(line) {
-  while ((getline line < resource_rules_file) > 0) {
+function emit_resource_rules(line, result, emitted) {
+  while ((result = getline line < resource_rules_file) > 0) {
     print line
+    emitted++
   }
   close(resource_rules_file)
+  if (result < 0) {
+    invalid("cannot read resource rules file " resource_rules_file)
+  }
+  if (emitted == 0) {
+    invalid("resource rules file is empty: " resource_rules_file)
+  }
 }
 
 $0 == "# BEGIN flutter-resource-allowlist" {
@@ -143,6 +153,17 @@ $0 == "# END flutter-public-secret-like-resource-allowlist" {
 }
 ' "$1" >"$2"
 }
+
+: >"$empty_resource_rules_file"
+if write_policy_variant \
+  "$resource_policy" \
+  "$empty_policy_output" \
+  "$empty_resource_rules_file" \
+  "!$public_certificate" 2>"$empty_policy_error"; then
+  fail "policy generator accepted an empty resource rules file"
+fi
+grep -F "resource rules file is empty:" "$empty_policy_error" >/dev/null \
+  || fail "policy generator did not explain an empty resource rules file"
 
 command -v docker >/dev/null 2>&1 || fail "Docker is required"
 docker buildx version >/dev/null 2>&1 \

--- a/docker/scripts/test-web-build-context.sh
+++ b/docker/scripts/test-web-build-context.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Verify that Dockerfile.web's allow-listed context cannot re-include secrets.
+# All fixtures are dummy files created in a temporary build context.
+set -eu
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+repo_root="$(CDPATH= cd "$script_dir/../.." && pwd)"
+temp_root="$(mktemp -d)"
+context_dir="$temp_root/context"
+output_dir="$temp_root/output"
+
+cleanup() {
+  if [ -n "${temp_root:-}" ] && [ -d "$temp_root" ]; then
+    rm -rf "$temp_root"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p \
+  "$context_dir/assets" \
+  "$context_dir/flutter_app/lib/nested" \
+  "$context_dir/flutter_app/web/nested" \
+  "$context_dir/flutter_app/docker-entrypoint.d/nested" \
+  "$output_dir"
+
+cp "$repo_root/flutter_app/Dockerfile.web.dockerignore" \
+  "$context_dir/Dockerfile.web.dockerignore"
+printf '%s\n' 'FROM scratch' 'COPY . /context' \
+  >"$context_dir/Dockerfile.web"
+
+# Allowed canaries prove that the temporary context exercises re-included
+# source paths rather than passing because the whole directory stayed ignored.
+printf '%s\n' 'dummy public asset' >"$context_dir/assets/icon.png"
+printf '%s\n' 'dummy source' >"$context_dir/flutter_app/lib/allowed.txt"
+printf '%s\n' 'dummy example config' \
+  >"$context_dir/flutter_app/lib/.env.example"
+
+# These names contain no credentials; they only exercise the exclusion rules.
+for fixture in \
+  flutter_app/lib/.env \
+  flutter_app/lib/.env.local \
+  flutter_app/lib/nested/dummy.pem \
+  flutter_app/lib/nested/dummy.key \
+  flutter_app/web/nested/dummy.crt \
+  flutter_app/web/nested/dummy.p12 \
+  flutter_app/docker-entrypoint.d/nested/dummy.pfx
+do
+  printf '%s\n' 'dummy excluded fixture' >"$context_dir/$fixture"
+done
+
+docker buildx build \
+  --quiet \
+  --output "type=local,dest=$output_dir" \
+  --file "$context_dir/Dockerfile.web" \
+  "$context_dir" >/dev/null
+
+for allowed in \
+  assets/icon.png \
+  flutter_app/lib/allowed.txt \
+  flutter_app/lib/.env.example
+do
+  if [ ! -f "$output_dir/context/$allowed" ]; then
+    printf 'missing allowed build-context fixture: %s\n' "$allowed" >&2
+    exit 1
+  fi
+done
+
+for excluded in \
+  flutter_app/lib/.env \
+  flutter_app/lib/.env.local \
+  flutter_app/lib/nested/dummy.pem \
+  flutter_app/lib/nested/dummy.key \
+  flutter_app/web/nested/dummy.crt \
+  flutter_app/web/nested/dummy.p12 \
+  flutter_app/docker-entrypoint.d/nested/dummy.pfx
+do
+  if [ -e "$output_dir/context/$excluded" ]; then
+    printf 'sensitive build-context fixture was included: %s\n' "$excluded" >&2
+    exit 1
+  fi
+done
+
+printf 'Flutter Web build-context exclusions verified\n'

--- a/docker/scripts/test-web-build-context.sh
+++ b/docker/scripts/test-web-build-context.sh
@@ -13,6 +13,9 @@ public_output_dir="$temp_root/public-output"
 declared_context_resources="$temp_root/declared-context-resources"
 generated_allowlist="$temp_root/generated-resource-allowlist"
 checked_in_allowlist="$temp_root/checked-in-resource-allowlist"
+public_resource_rules_file="$temp_root/public-resource-rules"
+production_policy_skeleton="$temp_root/production-policy-skeleton"
+public_policy_skeleton="$temp_root/public-policy-skeleton"
 pubspec="$repo_root/flutter_app/pubspec.yaml"
 resource_policy="$repo_root/flutter_app/Dockerfile.web.dockerignore"
 undeclared_asset="assets/heimdallm-undeclared-context-canary-$$.txt"
@@ -36,6 +39,109 @@ write_fixture() {
   fixture="$1"
   mkdir -p "$(dirname "$context_dir/$fixture")"
   printf '%s\n' 'dummy build-context fixture' >"$context_dir/$fixture"
+}
+
+write_policy_variant() {
+  source_policy="$1"
+  destination_policy="$2"
+  resource_rules_file="$3"
+  public_exception_rule="$4"
+
+  awk \
+    -v resource_rules_file="$resource_rules_file" \
+    -v public_exception_rule="$public_exception_rule" '
+function invalid(message) {
+  print "invalid production Docker ignore policy: " message > "/dev/stderr"
+  failed = 1
+  exit 1
+}
+
+function emit_resource_rules(line) {
+  while ((getline line < resource_rules_file) > 0) {
+    print line
+  }
+  close(resource_rules_file)
+}
+
+$0 == "# BEGIN flutter-resource-allowlist" {
+  if (inside || ++resource_begin_count != 1) {
+    invalid("duplicate or nested Flutter resource begin marker")
+  }
+  print
+  emit_resource_rules()
+  inside = "resource"
+  next
+}
+
+$0 == "# END flutter-resource-allowlist" {
+  if (inside != "resource" || ++resource_end_count != 1) {
+    invalid("Flutter resource end marker has no matching begin marker")
+  }
+  inside = ""
+  print
+  next
+}
+
+$0 == "# BEGIN flutter-public-secret-like-resource-allowlist" {
+  if (inside || ++public_begin_count != 1) {
+    invalid("duplicate or nested public-resource begin marker")
+  }
+  print
+  print public_exception_rule
+  inside = "public"
+  next
+}
+
+$0 == "# END flutter-public-secret-like-resource-allowlist" {
+  if (inside != "public" || ++public_end_count != 1) {
+    invalid("public-resource end marker has no matching begin marker")
+  }
+  inside = ""
+  print
+  next
+}
+
+inside {
+  next
+}
+
+{
+  print
+}
+
+END {
+  if (failed) {
+    exit 1
+  }
+  if (inside ||
+      resource_begin_count != 1 || resource_end_count != 1 ||
+      public_begin_count != 1 || public_end_count != 1) {
+    print "invalid production Docker ignore policy: expected one matched " \
+      "pair for each generated block" > "/dev/stderr"
+    exit 1
+  }
+}
+' "$source_policy" >"$destination_policy"
+}
+
+write_policy_skeleton() {
+  awk '
+$0 == "# BEGIN flutter-resource-allowlist" ||
+$0 == "# BEGIN flutter-public-secret-like-resource-allowlist" {
+  print
+  inside = 1
+  next
+}
+$0 == "# END flutter-resource-allowlist" ||
+$0 == "# END flutter-public-secret-like-resource-allowlist" {
+  inside = 0
+  print
+  next
+}
+!inside {
+  print
+}
+' "$1" >"$2"
 }
 
 command -v docker >/dev/null 2>&1 || fail "Docker is required"
@@ -201,21 +307,14 @@ printf '%s\n' \
   '  assets:' \
   "    - $public_certificate" >"$public_pubspec"
 
-# Seed the exception policy so the parser can validate and generate the normal
-# resource rules from the synthetic pubspec. The final policy below keeps that
-# exact exception after the broad deny, matching the production contract.
-printf '%s\n' \
-  '**' \
-  '!assets/' \
-  'assets/**' \
-  '!flutter_app/' \
-  'flutter_app/**' \
-  '# BEGIN flutter-resource-allowlist' \
-  '# END flutter-resource-allowlist' \
-  '**/*.crt' \
-  '# BEGIN flutter-public-secret-like-resource-allowlist' \
-  "!$public_certificate" \
-  '# END flutter-public-secret-like-resource-allowlist' >"$public_policy"
+# Derive the synthetic policy from production and replace only generated block
+# contents. This keeps every base allow/deny rule and their ordering coupled to
+# Dockerfile.web.dockerignore instead of maintaining a second policy by hand.
+write_policy_variant \
+  "$resource_policy" \
+  "$public_policy" \
+  "$checked_in_allowlist" \
+  "!$public_certificate"
 
 public_resource_rules="$(
   sh "$script_dir/list-flutter-assets.sh" \
@@ -232,19 +331,22 @@ public_context_paths="$(
 [ "$public_context_paths" = "$public_certificate" ] \
   || fail "public certificate mapped to an unexpected context path"
 
+# Give the neighbouring certificate a normal resource exception as a canary:
+# the production-derived broad .crt deny must still remove it, while the exact
+# public block below re-includes only the audited certificate.
 printf '%s\n' \
-  '**' \
-  '!assets/' \
-  'assets/**' \
-  '!flutter_app/' \
-  'flutter_app/**' \
-  '# BEGIN flutter-resource-allowlist' \
   "$public_resource_rules" \
-  '# END flutter-resource-allowlist' \
-  '**/*.crt' \
-  '# BEGIN flutter-public-secret-like-resource-allowlist' \
-  "!$public_certificate" \
-  '# END flutter-public-secret-like-resource-allowlist' >"$public_policy"
+  "!$blocked_certificate" >"$public_resource_rules_file"
+write_policy_variant \
+  "$resource_policy" \
+  "$public_policy" \
+  "$public_resource_rules_file" \
+  "!$public_certificate"
+
+write_policy_skeleton "$resource_policy" "$production_policy_skeleton"
+write_policy_skeleton "$public_policy" "$public_policy_skeleton"
+cmp -s "$production_policy_skeleton" "$public_policy_skeleton" \
+  || fail "synthetic policy changed production rules outside generated blocks"
 
 printf '%s\n' 'FROM scratch' 'COPY . /context' \
   >"$public_context_dir/flutter_app/Dockerfile.web"

--- a/docker/scripts/test-web-build-context.sh
+++ b/docker/scripts/test-web-build-context.sh
@@ -8,11 +8,17 @@ repo_root="$(CDPATH= cd "$script_dir/../.." && pwd)"
 temp_root="$(mktemp -d)"
 context_dir="$temp_root/context"
 output_dir="$temp_root/output"
-declared_resources="$temp_root/declared-resources"
+public_context_dir="$temp_root/public-context"
+public_output_dir="$temp_root/public-output"
+declared_context_resources="$temp_root/declared-context-resources"
 generated_allowlist="$temp_root/generated-resource-allowlist"
 checked_in_allowlist="$temp_root/checked-in-resource-allowlist"
+pubspec="$repo_root/flutter_app/pubspec.yaml"
+resource_policy="$repo_root/flutter_app/Dockerfile.web.dockerignore"
 undeclared_asset="assets/heimdallm-undeclared-context-canary-$$.txt"
 undeclared_flutter_resource="flutter_app/fonts/heimdallm-undeclared-context-canary-$$.ttf"
+public_certificate="assets/certs/heimdallm-public-ca.crt"
+blocked_certificate="assets/certs/heimdallm-unlisted-ca.crt"
 
 fail() {
   printf 'Flutter Web build-context check failed: %s\n' "$1" >&2
@@ -32,13 +38,6 @@ write_fixture() {
   printf '%s\n' 'dummy build-context fixture' >"$context_dir/$fixture"
 }
 
-resource_context_path() {
-  case "$1" in
-    assets/*) printf '%s\n' "$1" ;;
-    *) printf 'flutter_app/%s\n' "$1" ;;
-  esac
-}
-
 command -v docker >/dev/null 2>&1 || fail "Docker is required"
 docker buildx version >/dev/null 2>&1 \
   || fail "Docker Buildx/BuildKit is required for Dockerfile-specific ignore rules"
@@ -46,10 +45,13 @@ docker buildx version >/dev/null 2>&1 \
 # pubspec.yaml is the source of truth. Require the checked-in allowlist to be
 # an exact mirror so additions and removals both fail CI until synchronized.
 sh "$script_dir/list-flutter-assets.sh" \
-  "$repo_root/flutter_app/pubspec.yaml" >"$declared_resources"
+  --context-paths \
+  --dockerignore-file "$resource_policy" \
+  "$pubspec" >"$declared_context_resources"
 sh "$script_dir/list-flutter-assets.sh" \
   --dockerignore \
-  "$repo_root/flutter_app/pubspec.yaml" >"$generated_allowlist"
+  --dockerignore-file "$resource_policy" \
+  "$pubspec" >"$generated_allowlist"
 
 if ! awk '
   $0 == "# BEGIN flutter-resource-allowlist" {
@@ -70,7 +72,7 @@ if ! awk '
       exit 2
     }
   }
-' "$repo_root/flutter_app/Dockerfile.web.dockerignore" \
+' "$resource_policy" \
   >"$checked_in_allowlist"; then
   fail "Dockerfile.web.dockerignore has an invalid resource allowlist block"
 fi
@@ -84,7 +86,7 @@ fi
 
 mkdir -p "$context_dir/flutter_app" "$output_dir"
 cp "$repo_root/.dockerignore" "$context_dir/.dockerignore"
-cp "$repo_root/flutter_app/Dockerfile.web.dockerignore" \
+cp "$resource_policy" \
   "$context_dir/flutter_app/Dockerfile.web.dockerignore"
 cp "$repo_root/flutter_app/pubspec.yaml" \
   "$context_dir/flutter_app/pubspec.yaml"
@@ -101,8 +103,8 @@ printf '%s\n' 'FROM scratch' 'COPY . /context' \
 # prove this is exact inclusion rather than a broad assets/** or fonts/**
 # exception.
 while IFS= read -r resource; do
-  write_fixture "$(resource_context_path "$resource")"
-done <"$declared_resources"
+  write_fixture "$resource"
+done <"$declared_context_resources"
 
 for allowed in \
   flutter_app/.metadata \
@@ -141,11 +143,10 @@ docker buildx build \
   "$context_dir" >/dev/null
 
 while IFS= read -r resource; do
-  context_resource="$(resource_context_path "$resource")"
-  if [ ! -f "$output_dir/context/$context_resource" ]; then
-    fail "declared resource missing from context: $context_resource"
+  if [ ! -f "$output_dir/context/$resource" ]; then
+    fail "declared resource missing from context: $resource"
   fi
-done <"$declared_resources"
+done <"$declared_context_resources"
 
 for allowed in \
   flutter_app/.metadata \
@@ -182,4 +183,86 @@ do
   fi
 done
 
-printf 'Flutter Web BuildKit context and resource allowlist verified\n'
+# Exercise the public secret-like exception end to end. This second context
+# deliberately places an exact public .crt exception after the broad .crt deny;
+# a neighbouring certificate without an exception must remain excluded.
+mkdir -p \
+  "$public_context_dir/flutter_app" \
+  "$public_context_dir/assets/certs" \
+  "$public_output_dir"
+cp "$repo_root/.dockerignore" "$public_context_dir/.dockerignore"
+
+public_pubspec="$public_context_dir/flutter_app/pubspec.yaml"
+public_policy="$public_context_dir/flutter_app/Dockerfile.web.dockerignore"
+printf '%s\n' \
+  'name: public_secret_like_context_fixture' \
+  '' \
+  'flutter:' \
+  '  assets:' \
+  "    - $public_certificate" >"$public_pubspec"
+
+# Seed the exception policy so the parser can validate and generate the normal
+# resource rules from the synthetic pubspec. The final policy below keeps that
+# exact exception after the broad deny, matching the production contract.
+printf '%s\n' \
+  '**' \
+  '!assets/' \
+  'assets/**' \
+  '!flutter_app/' \
+  'flutter_app/**' \
+  '# BEGIN flutter-resource-allowlist' \
+  '# END flutter-resource-allowlist' \
+  '**/*.crt' \
+  '# BEGIN flutter-public-secret-like-resource-allowlist' \
+  "!$public_certificate" \
+  '# END flutter-public-secret-like-resource-allowlist' >"$public_policy"
+
+public_resource_rules="$(
+  sh "$script_dir/list-flutter-assets.sh" \
+    --dockerignore \
+    --dockerignore-file "$public_policy" \
+    "$public_pubspec"
+)"
+public_context_paths="$(
+  sh "$script_dir/list-flutter-assets.sh" \
+    --context-paths \
+    --dockerignore-file "$public_policy" \
+    "$public_pubspec"
+)"
+[ "$public_context_paths" = "$public_certificate" ] \
+  || fail "public certificate mapped to an unexpected context path"
+
+printf '%s\n' \
+  '**' \
+  '!assets/' \
+  'assets/**' \
+  '!flutter_app/' \
+  'flutter_app/**' \
+  '# BEGIN flutter-resource-allowlist' \
+  "$public_resource_rules" \
+  '# END flutter-resource-allowlist' \
+  '**/*.crt' \
+  '# BEGIN flutter-public-secret-like-resource-allowlist' \
+  "!$public_certificate" \
+  '# END flutter-public-secret-like-resource-allowlist' >"$public_policy"
+
+printf '%s\n' 'FROM scratch' 'COPY . /context' \
+  >"$public_context_dir/flutter_app/Dockerfile.web"
+printf '%s\n' 'public certificate fixture' \
+  >"$public_context_dir/$public_certificate"
+printf '%s\n' 'blocked certificate fixture' \
+  >"$public_context_dir/$blocked_certificate"
+
+docker buildx build \
+  --quiet \
+  --output "type=local,dest=$public_output_dir" \
+  --file "$public_context_dir/flutter_app/Dockerfile.web" \
+  "$public_context_dir" >/dev/null
+
+[ -f "$public_output_dir/context/$public_certificate" ] \
+  || fail "exact public secret-like exception did not survive the broad deny"
+[ ! -e "$public_output_dir/context/$blocked_certificate" ] \
+  || fail "unlisted secret-like certificate was included in the context"
+
+printf '%s\n' \
+  'Flutter Web BuildKit context, resource allowlist and public exceptions verified'

--- a/docker/scripts/test-web-build-context.sh
+++ b/docker/scripts/test-web-build-context.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Verify Dockerfile.web's BuildKit-only allowlist with synthetic canaries.
-# All fixtures are dummy files created in a temporary build context.
+# All fixtures are dummy files created in a temporary repository-root context.
 set -eu
 
 script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
@@ -8,9 +8,11 @@ repo_root="$(CDPATH= cd "$script_dir/../.." && pwd)"
 temp_root="$(mktemp -d)"
 context_dir="$temp_root/context"
 output_dir="$temp_root/output"
-declared_assets="$temp_root/declared-assets"
-allowlisted_assets="$temp_root/allowlisted-assets"
+declared_resources="$temp_root/declared-resources"
+generated_allowlist="$temp_root/generated-resource-allowlist"
+checked_in_allowlist="$temp_root/checked-in-resource-allowlist"
 undeclared_asset="assets/heimdallm-undeclared-context-canary-$$.txt"
+undeclared_flutter_resource="flutter_app/fonts/heimdallm-undeclared-context-canary-$$.ttf"
 
 fail() {
   printf 'Flutter Web build-context check failed: %s\n' "$1" >&2
@@ -30,6 +32,13 @@ write_fixture() {
   printf '%s\n' 'dummy build-context fixture' >"$context_dir/$fixture"
 }
 
+resource_context_path() {
+  case "$1" in
+    assets/*) printf '%s\n' "$1" ;;
+    *) printf 'flutter_app/%s\n' "$1" ;;
+  esac
+}
+
 command -v docker >/dev/null 2>&1 || fail "Docker is required"
 docker buildx version >/dev/null 2>&1 \
   || fail "Docker Buildx/BuildKit is required for Dockerfile-specific ignore rules"
@@ -37,36 +46,63 @@ docker buildx version >/dev/null 2>&1 \
 # pubspec.yaml is the source of truth. Require the checked-in allowlist to be
 # an exact mirror so additions and removals both fail CI until synchronized.
 sh "$script_dir/list-flutter-assets.sh" \
-  "$repo_root/flutter_app/pubspec.yaml" >"$temp_root/declared-assets-raw"
-LC_ALL=C sort -u "$temp_root/declared-assets-raw" >"$declared_assets"
+  "$repo_root/flutter_app/pubspec.yaml" >"$declared_resources"
+sh "$script_dir/list-flutter-assets.sh" \
+  --dockerignore \
+  "$repo_root/flutter_app/pubspec.yaml" >"$generated_allowlist"
 
-sed -n '/^!assets\/./ { s/^!//; p; }' \
-  "$repo_root/flutter_app/Dockerfile.web.dockerignore" \
-  >"$temp_root/allowlisted-assets-raw"
-LC_ALL=C sort -u "$temp_root/allowlisted-assets-raw" >"$allowlisted_assets"
+if ! awk '
+  $0 == "# BEGIN flutter-resource-allowlist" {
+    start_count++
+    inside = 1
+    next
+  }
+  $0 == "# END flutter-resource-allowlist" {
+    end_count++
+    inside = 0
+    next
+  }
+  inside && $0 !~ /^[[:space:]]*(#|$)/ {
+    print
+  }
+  END {
+    if (start_count != 1 || end_count != 1 || inside) {
+      exit 2
+    }
+  }
+' "$repo_root/flutter_app/Dockerfile.web.dockerignore" \
+  >"$checked_in_allowlist"; then
+  fail "Dockerfile.web.dockerignore has an invalid resource allowlist block"
+fi
 
-if ! cmp -s "$declared_assets" "$allowlisted_assets"; then
+if ! cmp -s "$generated_allowlist" "$checked_in_allowlist"; then
   printf '%s\n' \
-    'flutter.assets and Dockerfile.web.dockerignore are out of sync:' >&2
-  diff -u "$declared_assets" "$allowlisted_assets" >&2 || true
+    'Flutter resources and Dockerfile.web.dockerignore are out of sync:' >&2
+  diff -u "$generated_allowlist" "$checked_in_allowlist" >&2 || true
   exit 1
 fi
 
 mkdir -p "$context_dir/flutter_app" "$output_dir"
+cp "$repo_root/.dockerignore" "$context_dir/.dockerignore"
 cp "$repo_root/flutter_app/Dockerfile.web.dockerignore" \
-  "$context_dir/Dockerfile.web.dockerignore"
+  "$context_dir/flutter_app/Dockerfile.web.dockerignore"
 cp "$repo_root/flutter_app/pubspec.yaml" \
   "$context_dir/flutter_app/pubspec.yaml"
 cp "$repo_root/flutter_app/pubspec.lock" \
   "$context_dir/flutter_app/pubspec.lock"
-printf '%s\n' 'FROM scratch' 'COPY . /context' \
-  >"$context_dir/Dockerfile.web"
 
-# Every declared asset must survive the allowlist. The undeclared canary below
-# proves this is exact inclusion rather than a broad assets/** exception.
-while IFS= read -r asset; do
-  write_fixture "$asset"
-done <"$declared_assets"
+# Keep the synthetic Dockerfile body tiny, but place it at the same path and
+# name as the production Dockerfile. This is what makes BuildKit discover the
+# adjacent Dockerfile.web.dockerignore instead of falling back to .dockerignore.
+printf '%s\n' 'FROM scratch' 'COPY . /context' \
+  >"$context_dir/flutter_app/Dockerfile.web"
+
+# Every declared resource must survive the allowlist. Undeclared canaries below
+# prove this is exact inclusion rather than a broad assets/** or fonts/**
+# exception.
+while IFS= read -r resource; do
+  write_fixture "$(resource_context_path "$resource")"
+done <"$declared_resources"
 
 for allowed in \
   flutter_app/.metadata \
@@ -82,6 +118,7 @@ ln -s ../assets "$context_dir/flutter_app/assets"
 # These names contain no credentials; they only exercise exclusion rules.
 for excluded in \
   "$undeclared_asset" \
+  "$undeclared_flutter_resource" \
   flutter_app/build/blocked.txt \
   flutter_app/macos/blocked.txt \
   flutter_app/test/blocked.txt \
@@ -100,14 +137,15 @@ done
 docker buildx build \
   --quiet \
   --output "type=local,dest=$output_dir" \
-  --file "$context_dir/Dockerfile.web" \
+  --file "$context_dir/flutter_app/Dockerfile.web" \
   "$context_dir" >/dev/null
 
-while IFS= read -r asset; do
-  if [ ! -f "$output_dir/context/$asset" ]; then
-    fail "declared asset missing from context: $asset"
+while IFS= read -r resource; do
+  context_resource="$(resource_context_path "$resource")"
+  if [ ! -f "$output_dir/context/$context_resource" ]; then
+    fail "declared resource missing from context: $context_resource"
   fi
-done <"$declared_assets"
+done <"$declared_resources"
 
 for allowed in \
   flutter_app/.metadata \
@@ -126,6 +164,7 @@ done
 
 for excluded in \
   "$undeclared_asset" \
+  "$undeclared_flutter_resource" \
   flutter_app/build/blocked.txt \
   flutter_app/macos/blocked.txt \
   flutter_app/test/blocked.txt \
@@ -143,4 +182,4 @@ do
   fi
 done
 
-printf 'Flutter Web BuildKit context and asset allowlist verified\n'
+printf 'Flutter Web BuildKit context and resource allowlist verified\n'

--- a/docker/scripts/test-web-image.sh
+++ b/docker/scripts/test-web-image.sh
@@ -13,7 +13,21 @@ fail() {
 }
 
 cleanup() {
+  exit_code=$?
+  trap - EXIT
+
+  if [ "$exit_code" -ne 0 ] &&
+     docker inspect "$container_name" >/dev/null 2>&1; then
+    printf '%s\n' \
+      "Flutter Web smoke container logs (${container_name}):" >&2
+    docker logs "$container_name" >&2 || true
+    printf '%s\n' \
+      "Flutter Web smoke container inspect (${container_name}):" >&2
+    docker inspect "$container_name" >&2 || true
+  fi
+
   docker rm -f "$container_name" >/dev/null 2>&1 || true
+  exit "$exit_code"
 }
 trap cleanup EXIT
 
@@ -21,16 +35,16 @@ command -v docker >/dev/null 2>&1 || fail "Docker is required"
 docker image inspect "$image" >/dev/null 2>&1 \
   || fail "image '$image' does not exist locally"
 
-flutter_assets="$(
+flutter_resources="$(
   sh "$script_dir/list-flutter-assets.sh" \
     "$repo_root/flutter_app/pubspec.yaml"
 )"
 
-# Validate immutable image contents. Asset paths come directly from pubspec,
-# so adding or removing an asset cannot leave this smoke list stale.
+# Validate immutable image contents. Resource paths come directly from pubspec,
+# so adding or removing an asset, font or shader cannot leave this list stale.
 docker run --rm \
   --entrypoint sh \
-  --env "FLUTTER_ASSETS=$flutter_assets" \
+  --env "FLUTTER_RESOURCES=$flutter_resources" \
   "$image" -ec '
     web_root=/usr/share/nginx/html
     test -s "$web_root/index.html"
@@ -38,12 +52,12 @@ docker run --rm \
     test -s /etc/nginx/heimdallm.conf.template
     test -x /docker-entrypoint.d/10-heimdallm-token.sh
 
-    printf "%s\n" "$FLUTTER_ASSETS" |
-      while IFS= read -r asset; do
-        test -n "$asset"
-        test -s "$web_root/assets/$asset"
+    printf "%s\n" "$FLUTTER_RESOURCES" |
+      while IFS= read -r resource; do
+        test -n "$resource"
+        test -s "$web_root/assets/$resource"
       done
-  ' || fail "required bundle, asset, template, or executable is missing"
+  ' || fail "required bundle, resource, template, or executable is missing"
 
 # Start the image with its stock entrypoint/CMD. This catches failures that
 # static file checks miss, including template rendering and Nginx startup.

--- a/docker/scripts/test-web-image.sh
+++ b/docker/scripts/test-web-image.sh
@@ -37,6 +37,8 @@ docker image inspect "$image" >/dev/null 2>&1 \
 
 flutter_resources="$(
   sh "$script_dir/list-flutter-assets.sh" \
+    --dockerignore-file \
+    "$repo_root/flutter_app/Dockerfile.web.dockerignore" \
     "$repo_root/flutter_app/pubspec.yaml"
 )"
 

--- a/docker/scripts/test-web-image.sh
+++ b/docker/scripts/test-web-image.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Smoke-test the built Flutter Web image, including its real Nginx entrypoint.
+set -eu
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+repo_root="$(CDPATH= cd "$script_dir/../.." && pwd)"
+image="${1:-heimdallm-web:test}"
+container_name="heimdallm-web-smoke-$$"
+
+fail() {
+  printf 'Flutter Web image smoke failed: %s\n' "$1" >&2
+  exit 1
+}
+
+cleanup() {
+  docker rm -f "$container_name" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+command -v docker >/dev/null 2>&1 || fail "Docker is required"
+docker image inspect "$image" >/dev/null 2>&1 \
+  || fail "image '$image' does not exist locally"
+
+flutter_assets="$(
+  sh "$script_dir/list-flutter-assets.sh" \
+    "$repo_root/flutter_app/pubspec.yaml"
+)"
+
+# Validate immutable image contents. Asset paths come directly from pubspec,
+# so adding or removing an asset cannot leave this smoke list stale.
+docker run --rm \
+  --entrypoint sh \
+  --env "FLUTTER_ASSETS=$flutter_assets" \
+  "$image" -ec '
+    web_root=/usr/share/nginx/html
+    test -s "$web_root/index.html"
+    test -s "$web_root/main.dart.js"
+    test -s /etc/nginx/heimdallm.conf.template
+    test -x /docker-entrypoint.d/10-heimdallm-token.sh
+
+    printf "%s\n" "$FLUTTER_ASSETS" |
+      while IFS= read -r asset; do
+        test -n "$asset"
+        test -s "$web_root/assets/$asset"
+      done
+  ' || fail "required bundle, asset, template, or executable is missing"
+
+# Start the image with its stock entrypoint/CMD. This catches failures that
+# static file checks miss, including template rendering and Nginx startup.
+docker rm -f "$container_name" >/dev/null 2>&1 || true
+docker run -d \
+  --name "$container_name" \
+  --env HEIMDALLM_API_TOKEN=smoke-token \
+  --env DAEMON_URL=http://127.0.0.1:9 \
+  "$image" >/dev/null \
+  || fail "container did not start"
+
+attempt=0
+health_body=""
+while [ "$attempt" -lt 30 ]; do
+  if health_body="$(
+    docker exec "$container_name" \
+      wget -qO- http://127.0.0.1:3000/healthz 2>/dev/null
+  )"; then
+    break
+  fi
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+[ "$health_body" = "ok" ] || fail "Nginx did not become healthy"
+
+docker exec "$container_name" sh -ec '
+  test -s /etc/nginx/conf.d/default.conf
+  grep -Fq "proxy_pass http://127.0.0.1:9/;" \
+    /etc/nginx/conf.d/default.conf
+  grep -Fq "proxy_set_header X-Heimdallm-Token \"smoke-token\";" \
+    /etc/nginx/conf.d/default.conf
+  wget -qO- http://127.0.0.1:3000/ |
+    grep -q Heimdallm
+' || fail "entrypoint output or served Flutter shell is invalid"
+
+printf 'Flutter Web image contents and runtime verified\n'

--- a/docker/scripts/test-web.sh
+++ b/docker/scripts/test-web.sh
@@ -20,14 +20,15 @@ cd "$REPO_ROOT"
 
 # shellcheck source=lib/compose-test.sh
 . "$SCRIPT_DIR/lib/compose-test.sh"
+
+# Verify the supported build backend before allocating isolated run state.
+export DOCKER_BUILDKIT=1
+compose_test_require_build_tools
 compose_test_init web "$REPO_ROOT"
 
 BASE=""
-
 log() { printf '▶  %s\n' "$1"; }
 fail() { printf '✗  %s\n' "$1" >&2; exit 1; }
-
-export DOCKER_BUILDKIT=1
 
 cleanup() {
   exit_code=$?

--- a/docker/scripts/test-web.sh
+++ b/docker/scripts/test-web.sh
@@ -21,6 +21,8 @@ COMPOSE="docker compose -f docker/docker-compose.yml -f docker/docker-compose.te
 log() { printf '▶  %s\n' "$1"; }
 fail() { printf '✗  %s\n' "$1" >&2; exit 1; }
 
+export DOCKER_BUILDKIT=1
+
 cleanup() {
   $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
   rm -f "${INDEX_HTML:-}" "${DEEP_HTML:-}" "${SSE_HDR:-}"

--- a/docker/scripts/tests/fixtures/docker
+++ b/docker/scripts/tests/fixtures/docker
@@ -11,6 +11,20 @@ set -eu
     printf '\n'
 } >>"$FAKE_DOCKER_LOG"
 
+if [ "$*" = "compose version" ]; then
+    if [ "${FAKE_DOCKER_FAIL_COMPOSE:-0}" = "1" ]; then
+        exit 45
+    fi
+    exit 0
+fi
+
+if [ "$*" = "buildx version" ]; then
+    if [ "${FAKE_DOCKER_FAIL_BUILDX:-0}" = "1" ]; then
+        exit 46
+    fi
+    exit 0
+fi
+
 case "$*" in
     *" ps -q web")
         printf 'fake-web-container\n'

--- a/docker/scripts/tests/fixtures/web-tooling/allow-public-secret.dockerignore
+++ b/docker/scripts/tests/fixtures/web-tooling/allow-public-secret.dockerignore
@@ -1,0 +1,3 @@
+# BEGIN flutter-public-secret-like-resource-allowlist
+!assets/certs/public-ca.crt
+# END flutter-public-secret-like-resource-allowlist

--- a/docker/scripts/tests/fixtures/web-tooling/broad-public-secret-exception.dockerignore
+++ b/docker/scripts/tests/fixtures/web-tooling/broad-public-secret-exception.dockerignore
@@ -1,0 +1,3 @@
+# BEGIN flutter-public-secret-like-resource-allowlist
+!assets/certs/*.crt
+# END flutter-public-secret-like-resource-allowlist

--- a/docker/scripts/tests/fixtures/web-tooling/directory-asset.yaml
+++ b/docker/scripts/tests/fixtures/web-tooling/directory-asset.yaml
@@ -1,0 +1,5 @@
+name: web_tooling_directory_asset_fixture
+
+flutter:
+  assets:
+    - assets/images/

--- a/docker/scripts/tests/fixtures/web-tooling/docker
+++ b/docker/scripts/tests/fixtures/web-tooling/docker
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+log_args() {
+  [ -n "${FAKE_WEB_DOCKER_LOG:-}" ] || return 0
+
+  separator=
+  for argument in "$@"; do
+    printf '%s%s' "$separator" "$argument" >>"$FAKE_WEB_DOCKER_LOG"
+    separator='	'
+  done
+  printf '\n' >>"$FAKE_WEB_DOCKER_LOG"
+}
+
+log_args "$@"
+
+case "${1:-}" in
+  compose)
+    [ "${2:-}" = "version" ] || exit 64
+    [ "${FAKE_DOCKER_COMPOSE_FAIL:-0}" != "1" ]
+    ;;
+  buildx)
+    [ "${2:-}" = "version" ] || exit 64
+    [ "${FAKE_DOCKER_BUILDX_FAIL:-0}" != "1" ]
+    ;;
+  image)
+    [ "${2:-}" = "inspect" ] || exit 64
+    ;;
+  run)
+    for argument in "$@"; do
+      if [ "$argument" = "-d" ]; then
+        printf '%s\n' 'fake-container-id'
+        break
+      fi
+    done
+    ;;
+  exec)
+    # The image-smoke regression test deliberately exercises its unhealthy
+    # container path. A fake sleep binary makes all 30 attempts instantaneous.
+    exit 1
+    ;;
+  logs)
+    printf '%s\n' 'fake nginx startup failure'
+    ;;
+  inspect)
+    printf '%s\n' '[{"State":{"Status":"exited","ExitCode":42}}]'
+    ;;
+  rm)
+    ;;
+  *)
+    printf 'unexpected fake docker command: %s\n' "${1:-<empty>}" >&2
+    exit 64
+    ;;
+esac

--- a/docker/scripts/tests/fixtures/web-tooling/duplicate-resource.yaml
+++ b/docker/scripts/tests/fixtures/web-tooling/duplicate-resource.yaml
@@ -1,0 +1,7 @@
+name: web_tooling_duplicate_resource_fixture
+
+flutter:
+  assets:
+    - assets/icon.png
+  shaders:
+    - assets/icon.png

--- a/docker/scripts/tests/fixtures/web-tooling/empty-public-exceptions.dockerignore
+++ b/docker/scripts/tests/fixtures/web-tooling/empty-public-exceptions.dockerignore
@@ -1,0 +1,3 @@
+# BEGIN flutter-public-secret-like-resource-allowlist
+# Intentionally empty.
+# END flutter-public-secret-like-resource-allowlist

--- a/docker/scripts/tests/fixtures/web-tooling/inline-fonts.yaml
+++ b/docker/scripts/tests/fixtures/web-tooling/inline-fonts.yaml
@@ -1,0 +1,6 @@
+name: web_tooling_inline_fonts_fixture
+
+flutter:
+  assets:
+    - assets/icon.png
+  fonts: []

--- a/docker/scripts/tests/fixtures/web-tooling/missing-font-assets.yaml
+++ b/docker/scripts/tests/fixtures/web-tooling/missing-font-assets.yaml
@@ -1,0 +1,7 @@
+name: web_tooling_missing_font_assets_fixture
+
+flutter:
+  assets:
+    - assets/icon.png
+  fonts:
+    - family: MissingAssets

--- a/docker/scripts/tests/fixtures/web-tooling/partial-fonts.yaml
+++ b/docker/scripts/tests/fixtures/web-tooling/partial-fonts.yaml
@@ -1,0 +1,10 @@
+name: web_tooling_partial_fonts_fixture
+
+flutter:
+  assets:
+    - assets/icon.png
+  fonts:
+    - family: PartiallySupported
+      fonts:
+        - asset: fonts/Supported.ttf
+        - path: fonts/SilentlySkippedBefore.ttf

--- a/docker/scripts/tests/fixtures/web-tooling/public-secret-resource.yaml
+++ b/docker/scripts/tests/fixtures/web-tooling/public-secret-resource.yaml
@@ -1,0 +1,6 @@
+name: web_tooling_public_secret_resource_fixture
+
+flutter:
+  assets:
+    - assets/certs/public-ca.crt
+    - assets/icon.png

--- a/docker/scripts/tests/fixtures/web-tooling/resources.yaml
+++ b/docker/scripts/tests/fixtures/web-tooling/resources.yaml
@@ -1,0 +1,18 @@
+name: web_tooling_fixture
+
+flutter:
+  uses-material-design: true
+
+  # Resource comments and blank lines are deliberately part of this fixture.
+  assets:
+    - assets/icon.png # unquoted trailing comments are supported
+
+  fonts:
+    - family: HeimdallmFixture
+      fonts:
+        - asset: fonts/Fixture-Regular.ttf
+        - asset: "fonts/Fixture-Bold.ttf" # quoted trailing comments work too
+          weight: 700
+
+  shaders:
+    - shaders/fixture.frag

--- a/docker/scripts/tests/fixtures/web-tooling/secret-resource.yaml
+++ b/docker/scripts/tests/fixtures/web-tooling/secret-resource.yaml
@@ -1,0 +1,5 @@
+name: web_tooling_secret_resource_fixture
+
+flutter:
+  assets:
+    - assets/private-signing.key

--- a/docker/scripts/tests/fixtures/web-tooling/sleep
+++ b/docker/scripts/tests/fixtures/web-tooling/sleep
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/docker/scripts/tests/fixtures/web-tooling/unsafe-asset.yaml
+++ b/docker/scripts/tests/fixtures/web-tooling/unsafe-asset.yaml
@@ -1,0 +1,5 @@
+name: web_tooling_unsafe_asset_fixture
+
+flutter:
+  assets:
+    - assets/images/*.png

--- a/docker/scripts/tests/test-compose-isolation.sh
+++ b/docker/scripts/tests/test-compose-isolation.sh
@@ -27,6 +27,9 @@ cleanup_test_files() {
         "$TEST_TMP/config.json" \
         "$TEST_TMP/production-config.json" \
         "$TEST_TMP/runner-cleanup-failure.out" \
+        "$TEST_TMP/runner-compose-failure.out" \
+        "$TEST_TMP/runner-buildkit-failure.out" \
+        "$TEST_TMP/web-buildkit-failure.out" \
         "$TEST_TMP/runner-port-failure.out" \
         "$TEST_TMP/runner-token-failure.out" \
         "$TEST_TMP/outside-http-body"
@@ -287,6 +290,37 @@ awk -F '\t' '
     fail "local runner built or started services beyond heimdallm"
 assert_log_has_safe_down "$local_project"
 
+printf '    missing Compose v2 fails before run-state allocation\n'
+: >"$FAKE_DOCKER_LOG"
+if FAKE_DOCKER_FAIL_COMPOSE=1 TMPDIR="$TEST_TMP" \
+    "$SCRIPT_DIR/test-local.sh" smoke >"$TEST_TMP/runner-compose-failure.out" 2>&1; then
+    fail "local runner accepted a missing Docker Compose v2 plugin"
+fi
+grep -F "Docker Compose v2 is required for Flutter Web builds." \
+    "$TEST_TMP/runner-compose-failure.out" >/dev/null ||
+    fail "local runner did not report the shared Compose v2 requirement"
+if awk -F '\t' '$0 ~ /\t(build|up|down)\t/ { found = 1 } END { exit !found }' \
+    "$FAKE_DOCKER_LOG"; then
+    fail "local runner allocated Docker work before its Compose v2 preflight"
+fi
+
+printf '    missing Buildx fails before any image build or startup\n'
+: >"$FAKE_DOCKER_LOG"
+if FAKE_DOCKER_FAIL_BUILDX=1 TMPDIR="$TEST_TMP" \
+    "$SCRIPT_DIR/test-local.sh" smoke >"$TEST_TMP/runner-buildkit-failure.out" 2>&1; then
+    fail "local runner accepted a missing Docker Buildx plugin"
+fi
+grep -F "Docker Buildx/BuildKit is required for Flutter Web builds." \
+    "$TEST_TMP/runner-buildkit-failure.out" >/dev/null ||
+    fail "local runner did not report the shared Buildx requirement"
+if awk -F '\t' '$0 ~ /\t(build|up)\t/ { found = 1 } END { exit !found }' \
+    "$FAKE_DOCKER_LOG"; then
+    fail "local runner built or started services after the Buildx preflight failed"
+fi
+if grep -F "	down	" "$FAKE_DOCKER_LOG" >/dev/null; then
+    fail "local runner allocated cleanup work before its Buildx preflight"
+fi
+
 printf '    startup port failures retain Compose diagnostics\n'
 : >"$FAKE_DOCKER_LOG"
 if FAKE_DOCKER_FAIL_PORT=1 TMPDIR="$TEST_TMP" \
@@ -349,6 +383,23 @@ esac
 [ "$web_up_project" = "$web_down_project" ] ||
     fail "web runner startup and cleanup used different projects"
 assert_log_has_safe_down "$web_down_project"
+
+printf '    web runner shares the same Buildx preflight\n'
+: >"$FAKE_DOCKER_LOG"
+if FAKE_DOCKER_FAIL_BUILDX=1 TMPDIR="$TEST_TMP" \
+    "$SCRIPT_DIR/test-web.sh" >"$TEST_TMP/web-buildkit-failure.out" 2>&1; then
+    fail "web runner accepted a missing Docker Buildx plugin"
+fi
+grep -F "Docker Buildx/BuildKit is required for Flutter Web builds." \
+    "$TEST_TMP/web-buildkit-failure.out" >/dev/null ||
+    fail "web runner did not report the shared Buildx requirement"
+if awk -F '\t' '$0 ~ /\tup\t/ { found = 1 } END { exit !found }' \
+    "$FAKE_DOCKER_LOG"; then
+    fail "web runner started services after the Buildx preflight failed"
+fi
+if grep -F "	down	" "$FAKE_DOCKER_LOG" >/dev/null; then
+    fail "web runner allocated cleanup work before its Buildx preflight"
+fi
 
 printf '8/8 merged Compose config has per-run names, volumes, and ephemeral ports\n'
 if [ -n "$REAL_DOCKER" ] && "$REAL_DOCKER" compose version >/dev/null 2>&1; then

--- a/docker/scripts/tests/test-web-tooling.sh
+++ b/docker/scripts/tests/test-web-tooling.sh
@@ -6,6 +6,8 @@ script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 repo_root="$(CDPATH= cd "$script_dir/../../.." && pwd)"
 fixture_dir="$script_dir/fixtures/web-tooling"
 parser="$repo_root/docker/scripts/list-flutter-assets.sh"
+empty_public_policy="$fixture_dir/empty-public-exceptions.dockerignore"
+allowed_public_policy="$fixture_dir/allow-public-secret.dockerignore"
 temp_root="$(mktemp -d)"
 fake_log="$temp_root/fake-docker.log"
 
@@ -34,8 +36,13 @@ assert_contains() {
 assert_parser_fails() {
   fixture="$1"
   expected_error="$2"
+  public_policy="${3:-$empty_public_policy}"
 
-  if parser_error="$(sh "$parser" "$fixture" 2>&1)"; then
+  if parser_error="$(
+    sh "$parser" \
+      --dockerignore-file "$public_policy" \
+      "$fixture" 2>&1
+  )"; then
     fail "parser accepted unsupported fixture: $(basename "$fixture")"
   fi
   assert_contains \
@@ -49,10 +56,25 @@ fonts/Fixture-Regular.ttf
 fonts/Fixture-Bold.ttf
 shaders/fixture.frag'
 actual_resources="$(
-  sh "$parser" "$fixture_dir/resources.yaml"
+  sh "$parser" \
+    --dockerignore-file "$empty_public_policy" \
+    "$fixture_dir/resources.yaml"
 )"
 [ "$actual_resources" = "$expected_resources" ] \
   || fail "assets, font assets and shaders were not parsed in declaration order"
+
+expected_context_paths='assets/icon.png
+flutter_app/fonts/Fixture-Regular.ttf
+flutter_app/fonts/Fixture-Bold.ttf
+flutter_app/shaders/fixture.frag'
+actual_context_paths="$(
+  sh "$parser" \
+    --context-paths \
+    --dockerignore-file "$empty_public_policy" \
+    "$fixture_dir/resources.yaml"
+)"
+[ "$actual_context_paths" = "$expected_context_paths" ] \
+  || fail "--context-paths did not apply the parser's repository-root mapping"
 
 expected_allowlist='!assets/icon.png
 !flutter_app/fonts/
@@ -63,10 +85,36 @@ flutter_app/fonts/**
 flutter_app/shaders/**
 !flutter_app/shaders/fixture.frag'
 actual_allowlist="$(
-  sh "$parser" --dockerignore "$fixture_dir/resources.yaml"
+  sh "$parser" \
+    --dockerignore \
+    --dockerignore-file "$empty_public_policy" \
+    "$fixture_dir/resources.yaml"
 )"
 [ "$actual_allowlist" = "$expected_allowlist" ] \
   || fail "repository-root Docker paths were not generated literally"
+
+expected_public_resources='assets/certs/public-ca.crt
+assets/icon.png'
+actual_public_resources="$(
+  sh "$parser" \
+    --dockerignore-file "$allowed_public_policy" \
+    "$fixture_dir/public-secret-resource.yaml"
+)"
+[ "$actual_public_resources" = "$expected_public_resources" ] \
+  || fail "an exact audited public secret-like resource was not accepted"
+
+expected_public_allowlist='!assets/certs/
+assets/certs/**
+!assets/certs/public-ca.crt
+!assets/icon.png'
+actual_public_allowlist="$(
+  sh "$parser" \
+    --dockerignore \
+    --dockerignore-file "$allowed_public_policy" \
+    "$fixture_dir/public-secret-resource.yaml"
+)"
+[ "$actual_public_allowlist" = "$expected_public_allowlist" ] \
+  || fail "audited public resource did not produce literal Docker rules"
 
 assert_parser_fails \
   "$fixture_dir/inline-fonts.yaml" \
@@ -85,7 +133,15 @@ assert_parser_fails \
   "is declared more than once"
 assert_parser_fails \
   "$fixture_dir/secret-resource.yaml" \
-  "matches a protected secret-file pattern"
+  "add the exact rule '!assets/private-signing.key'"
+assert_parser_fails \
+  "$fixture_dir/public-secret-resource.yaml" \
+  "unsafe for a literal Docker allowlist" \
+  "$fixture_dir/broad-public-secret-exception.dockerignore"
+assert_parser_fails \
+  "$fixture_dir/resources.yaml" \
+  "does not match a declared protected Flutter resource" \
+  "$allowed_public_policy"
 assert_parser_fails \
   "$fixture_dir/partial-fonts.yaml" \
   "unsupported flutter.fonts entry"

--- a/docker/scripts/tests/test-web-tooling.sh
+++ b/docker/scripts/tests/test-web-tooling.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# Deterministic regression tests for the Flutter Web shell tooling.
+set -eu
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+repo_root="$(CDPATH= cd "$script_dir/../../.." && pwd)"
+fixture_dir="$script_dir/fixtures/web-tooling"
+parser="$repo_root/docker/scripts/list-flutter-assets.sh"
+temp_root="$(mktemp -d)"
+fake_log="$temp_root/fake-docker.log"
+
+fail() {
+  printf 'Flutter Web tooling test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+cleanup() {
+  if [ -n "${temp_root:-}" ] && [ -d "$temp_root" ]; then
+    rm -rf "$temp_root"
+  fi
+}
+trap cleanup EXIT
+
+assert_contains() {
+  haystack="$1"
+  needle="$2"
+  description="$3"
+  case "$haystack" in
+    *"$needle"*) ;;
+    *) fail "$description (missing: $needle)" ;;
+  esac
+}
+
+assert_parser_fails() {
+  fixture="$1"
+  expected_error="$2"
+
+  if parser_error="$(sh "$parser" "$fixture" 2>&1)"; then
+    fail "parser accepted unsupported fixture: $(basename "$fixture")"
+  fi
+  assert_contains \
+    "$parser_error" \
+    "$expected_error" \
+    "parser did not explain why $(basename "$fixture") is unsupported"
+}
+
+expected_resources='assets/icon.png
+fonts/Fixture-Regular.ttf
+fonts/Fixture-Bold.ttf
+shaders/fixture.frag'
+actual_resources="$(
+  sh "$parser" "$fixture_dir/resources.yaml"
+)"
+[ "$actual_resources" = "$expected_resources" ] \
+  || fail "assets, font assets and shaders were not parsed in declaration order"
+
+expected_allowlist='!assets/icon.png
+!flutter_app/fonts/
+flutter_app/fonts/**
+!flutter_app/fonts/Fixture-Regular.ttf
+!flutter_app/fonts/Fixture-Bold.ttf
+!flutter_app/shaders/
+flutter_app/shaders/**
+!flutter_app/shaders/fixture.frag'
+actual_allowlist="$(
+  sh "$parser" --dockerignore "$fixture_dir/resources.yaml"
+)"
+[ "$actual_allowlist" = "$expected_allowlist" ] \
+  || fail "repository-root Docker paths were not generated literally"
+
+assert_parser_fails \
+  "$fixture_dir/inline-fonts.yaml" \
+  "inline flutter.fonts values are unsupported"
+assert_parser_fails \
+  "$fixture_dir/missing-font-assets.yaml" \
+  "has no supported asset entries"
+assert_parser_fails \
+  "$fixture_dir/unsafe-asset.yaml" \
+  "unsafe for a literal Docker allowlist"
+assert_parser_fails \
+  "$fixture_dir/directory-asset.yaml" \
+  "is a directory; declare individual files"
+assert_parser_fails \
+  "$fixture_dir/duplicate-resource.yaml" \
+  "is declared more than once"
+assert_parser_fails \
+  "$fixture_dir/secret-resource.yaml" \
+  "matches a protected secret-file pattern"
+assert_parser_fails \
+  "$fixture_dir/partial-fonts.yaml" \
+  "unsupported flutter.fonts entry"
+
+fake_path="$fixture_dir:$PATH"
+
+if ! buildkit_output="$(
+  PATH="$fake_path" \
+    DOCKER_BUILDKIT=0 \
+    make --no-print-directory -C "$repo_root" _check-buildkit 2>&1
+)"; then
+  fail "_check-buildkit rejected DOCKER_BUILDKIT=0 even though wrappers override it"
+fi
+assert_contains \
+  "$buildkit_output" \
+  "DOCKER_BUILDKIT=0 is overridden with 1" \
+  "_check-buildkit did not explain its environment override"
+
+if compose_error="$(
+  PATH="$fake_path" \
+    FAKE_DOCKER_COMPOSE_FAIL=1 \
+    make --no-print-directory -C "$repo_root" _check-buildkit 2>&1
+)"; then
+  fail "_check-buildkit accepted a missing Docker Compose v2 plugin"
+fi
+assert_contains \
+  "$compose_error" \
+  "Docker Compose v2 is required" \
+  "_check-buildkit did not report the missing Compose v2 plugin"
+
+if buildx_error="$(
+  PATH="$fake_path" \
+    FAKE_DOCKER_BUILDX_FAIL=1 \
+    make --no-print-directory -C "$repo_root" _check-buildkit 2>&1
+)"; then
+  fail "_check-buildkit accepted missing Docker Buildx"
+fi
+assert_contains \
+  "$buildx_error" \
+  "Docker Buildx/BuildKit is required" \
+  "_check-buildkit did not report missing Buildx"
+
+: >"$fake_log"
+if smoke_error="$(
+  PATH="$fake_path" \
+    FAKE_WEB_DOCKER_LOG="$fake_log" \
+    sh "$repo_root/docker/scripts/test-web-image.sh" fake-web:test 2>&1
+)"; then
+  fail "image smoke unexpectedly passed with an unhealthy fake container"
+fi
+assert_contains \
+  "$smoke_error" \
+  "fake nginx startup failure" \
+  "image smoke did not print container logs on failure"
+assert_contains \
+  "$smoke_error" \
+  '"ExitCode":42' \
+  "image smoke did not print docker inspect output on failure"
+
+logs_line="$(
+  awk -F '	' '$1 == "logs" { print NR; exit }' "$fake_log"
+)"
+inspect_after_logs_line="$(
+  awk -F '	' -v logs_line="$logs_line" \
+    '$1 == "inspect" && NR > logs_line { print NR; exit }' \
+    "$fake_log"
+)"
+final_remove_line="$(
+  awk -F '	' '$1 == "rm" && $2 == "-f" { line = NR } END { print line + 0 }' \
+    "$fake_log"
+)"
+
+[ -n "$logs_line" ] \
+  || fail "image smoke did not call docker logs"
+[ -n "$inspect_after_logs_line" ] \
+  || fail "image smoke did not inspect the container after collecting logs"
+[ "$logs_line" -lt "$inspect_after_logs_line" ] \
+  || fail "image smoke inspected the container before collecting logs"
+[ "$inspect_after_logs_line" -lt "$final_remove_line" ] \
+  || fail "image smoke destroyed the container before collecting diagnostics"
+
+printf 'Flutter Web parser, tooling guards and failure diagnostics verified\n'

--- a/docs/e2e-test-guide.md
+++ b/docs/e2e-test-guide.md
@@ -74,7 +74,7 @@ Or use CODEOWNERS/branch protection to auto-assign reviewers.
 
 ```bash
 # With test compose overlay (no auto-restart, mapped ports)
-docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml up --build
+DOCKER_BUILDKIT=1 docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml up --build
 ```
 
 Or use the Makefile shortcut:

--- a/flutter_app/.dockerignore
+++ b/flutter_app/.dockerignore
@@ -1,9 +1,0 @@
-build/
-.dart_tool/
-.idea/
-.vscode/
-ios/
-android/
-macos/
-linux/
-test/

--- a/flutter_app/Dockerfile.web
+++ b/flutter_app/Dockerfile.web
@@ -1,3 +1,6 @@
+# BuildKit is required so Docker applies Dockerfile.web.dockerignore to the
+# repository-root context. Supported commands enforce this requirement.
+#
 # ── Stage 1: build the Flutter Web bundle ────────────────────────────────
 #
 # ghcr.io/cirruslabs/flutter ships a working Flutter SDK (Dart, Flutter,

--- a/flutter_app/Dockerfile.web
+++ b/flutter_app/Dockerfile.web
@@ -6,13 +6,17 @@
 # bundle size / renderer.
 FROM ghcr.io/cirruslabs/flutter:stable AS build
 
-WORKDIR /src
+WORKDIR /src/flutter_app
 # Copy manifests first so pub get is cacheable on dependency-free changes.
-COPY pubspec.yaml pubspec.lock ./
+COPY flutter_app/pubspec.yaml flutter_app/pubspec.lock ./
 RUN flutter pub get
 
-# Now the rest of the source. .dockerignore keeps this cheap.
-COPY . .
+# The Flutter project deliberately shares the repository-root assets directory
+# through `flutter_app/assets -> ../assets`. The build context therefore has to
+# be the repository root; the Dockerfile-specific ignore file keeps that context
+# limited to the web sources and shared assets.
+COPY flutter_app/ ./
+COPY assets/ /src/assets/
 RUN flutter build web --release --base-href=/
 
 # ── Stage 2: Nginx runtime ───────────────────────────────────────────────
@@ -25,15 +29,15 @@ FROM nginx:1.27-alpine
 # gettext provides envsubst for the entrypoint rendering step.
 RUN apk add --no-cache gettext
 
-COPY --from=build /src/build/web /usr/share/nginx/html
+COPY --from=build /src/flutter_app/build/web /usr/share/nginx/html
 # NOTE: template lives OUTSIDE /etc/nginx/templates/ on purpose. The stock
 # nginx:alpine entrypoint auto-renders every *.template under that path
 # with an unrestricted envsubst invocation that (a) runs after our script
 # in a fresh shell where our exports no longer exist and (b) would write
 # a second server{} block into conf.d/. Keeping the template at a custom
 # path makes our entrypoint the single renderer.
-COPY nginx.conf.template /etc/nginx/heimdallm.conf.template
-COPY docker-entrypoint.d/10-heimdallm-token.sh /docker-entrypoint.d/10-heimdallm-token.sh
+COPY flutter_app/nginx.conf.template /etc/nginx/heimdallm.conf.template
+COPY flutter_app/docker-entrypoint.d/10-heimdallm-token.sh /docker-entrypoint.d/10-heimdallm-token.sh
 
 # The default conf.d entry shipped with the image would listen on 80 and
 # 404 everything we care about — remove it.

--- a/flutter_app/Dockerfile.web.dockerignore
+++ b/flutter_app/Dockerfile.web.dockerignore
@@ -42,3 +42,11 @@ flutter_app/**
 **/*.crt
 **/*.p12
 **/*.pfx
+
+# Public resources whose exact names intentionally match the secret-like deny
+# rules above must be declared here as literal negation rules. The shared
+# parser rejects globs, directories, non-secret-like paths, duplicates and
+# entries not declared in pubspec.yaml.
+# BEGIN flutter-public-secret-like-resource-allowlist
+# No public secret-like resources are declared.
+# END flutter-public-secret-like-resource-allowlist

--- a/flutter_app/Dockerfile.web.dockerignore
+++ b/flutter_app/Dockerfile.web.dockerignore
@@ -3,17 +3,22 @@
 # BuildKit uses this file instead of the root .dockerignore whenever
 # flutter_app/Dockerfile.web is selected; the legacy builder does not. Supported
 # Make targets, tests, and documented direct builds therefore require BuildKit.
-# Keep only the Flutter Web inputs, runtime Nginx files, and the shared asset
-# source reached by flutter_app/assets -> ../assets. CI verifies that the
-# literal asset entries below exactly match flutter.assets in pubspec.yaml.
+# Keep only the Flutter Web inputs, runtime Nginx files, and the resources
+# declared by Flutter. CI verifies that the generated resource block below
+# exactly matches flutter.assets, flutter.fonts and flutter.shaders in
+# pubspec.yaml.
 **
 !assets/
 assets/**
+!flutter_app/
+flutter_app/**
+
+# BEGIN flutter-resource-allowlist
 !assets/icon.png
 !assets/tray_icon.png
 !assets/tray_icon@2x.png
-!flutter_app/
-flutter_app/**
+# END flutter-resource-allowlist
+
 !flutter_app/.metadata
 !flutter_app/pubspec.yaml
 !flutter_app/pubspec.lock

--- a/flutter_app/Dockerfile.web.dockerignore
+++ b/flutter_app/Dockerfile.web.dockerignore
@@ -1,0 +1,36 @@
+# Dockerfile-specific ignore rules for repository-root web builds.
+#
+# Docker uses this file instead of the root .dockerignore whenever
+# flutter_app/Dockerfile.web is selected. Keep only the Flutter Web inputs,
+# runtime Nginx files, and the shared asset source reached by
+# flutter_app/assets -> ../assets.
+**
+!assets/
+assets/**
+!assets/icon.png
+!assets/tray_icon.png
+!assets/tray_icon@2x.png
+!flutter_app/
+flutter_app/**
+!flutter_app/.metadata
+!flutter_app/pubspec.yaml
+!flutter_app/pubspec.lock
+!flutter_app/lib/
+!flutter_app/lib/**
+!flutter_app/web/
+!flutter_app/web/**
+!flutter_app/assets
+!flutter_app/nginx.conf.template
+!flutter_app/docker-entrypoint.d/
+!flutter_app/docker-entrypoint.d/**
+
+# Defense in depth: a future source-directory exception must not leak local
+# credentials or private key material into the Docker build context.
+**/.env
+**/.env.*
+!**/.env.example
+**/*.pem
+**/*.key
+**/*.crt
+**/*.p12
+**/*.pfx

--- a/flutter_app/Dockerfile.web.dockerignore
+++ b/flutter_app/Dockerfile.web.dockerignore
@@ -1,9 +1,11 @@
 # Dockerfile-specific ignore rules for repository-root web builds.
 #
-# Docker uses this file instead of the root .dockerignore whenever
-# flutter_app/Dockerfile.web is selected. Keep only the Flutter Web inputs,
-# runtime Nginx files, and the shared asset source reached by
-# flutter_app/assets -> ../assets.
+# BuildKit uses this file instead of the root .dockerignore whenever
+# flutter_app/Dockerfile.web is selected; the legacy builder does not. Supported
+# Make targets, tests, and documented direct builds therefore require BuildKit.
+# Keep only the Flutter Web inputs, runtime Nginx files, and the shared asset
+# source reached by flutter_app/assets -> ../assets. CI verifies that the
+# literal asset entries below exactly match flutter.assets in pubspec.yaml.
 **
 !assets/
 assets/**
@@ -25,10 +27,11 @@ flutter_app/**
 !flutter_app/docker-entrypoint.d/**
 
 # Defense in depth: a future source-directory exception must not leak local
-# credentials or private key material into the Docker build context.
+# credentials or private key material into the Docker build context. No
+# .env.example file is a web build input, so there is intentionally no global
+# exception for that name.
 **/.env
 **/.env.*
-!**/.env.example
 **/*.pem
 **/*.key
 **/*.crt


### PR DESCRIPTION
## Qué cambia

- Construye la imagen web desde el contexto raíz para que los tres assets compartidos entren realmente en el bundle Flutter.
- Mantiene `flutter_app/assets -> ../assets` como única fuente y corrige las rutas del Dockerfile y de Compose.
- Añade un `Dockerfile.web.dockerignore` de allowlist estricta con exclusiones finales para secretos, claves y certificados.
- Añade una prueba BuildKit del contexto y smoke checks de `index.html`, `main.dart.js` y los tres assets en CI.
- Documenta los comandos directos de build de producción.

## Causa raíz e impacto

El contexto anterior era `flutter_app/`, por lo que Docker no podía seguir el symlink hacia `../assets`. El build de producción podía completarse sin incluir los recursos compartidos. El nuevo contexto los incluye sin copiar archivos sensibles al contexto de BuildKit.

## Validación

- `cd flutter_app && flutter test` — 216 tests.
- `cd flutter_app && flutter analyze`.
- `make build-web`.
- `sh docker/scripts/test-web-build-context.sh`, incluyendo siete canarios sensibles excluidos.
- Build Docker directo y `docker compose config --quiet` / `docker compose build web`.
- Smoke del stage Flutter y de la imagen final para HTML, JavaScript y los tres assets.
- `make test-docker`, `make test-cli` y `make lint-cli`.
- `sh -n` y `git diff --check`.
- Revisión independiente final sin hallazgos nuevos.

Closes #607
