### PR TITLE
fix(security): enforce AI execution policy at subprocess boundary

### DIFF
--- a/daemon/cmd/heimdallm/autonomous_runner.go
+++ b/daemon/cmd/heimdallm/autonomous_runner.go
@@ -78,8 +78,7 @@ func (g *coordinationCommentGen) GenerateCoordinationComment(_ context.Context, 
 		return "", err
 	}
 	prompt := buildCoordinationPrompt(c)
-	opts := executor.OptionsForSelectedCLI(primary, cli, executor.ExecOptions{})
-	raw, err := g.runner.ExecuteRaw(cli, prompt, opts)
+	raw, err := g.runner.ExecuteRaw(cli, prompt, executor.ExecOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/daemon/cmd/heimdallm/autonomous_runner.go
+++ b/daemon/cmd/heimdallm/autonomous_runner.go
@@ -78,7 +78,8 @@ func (g *coordinationCommentGen) GenerateCoordinationComment(_ context.Context, 
 		return "", err
 	}
 	prompt := buildCoordinationPrompt(c)
-	raw, err := g.runner.ExecuteRaw(cli, prompt, executor.ExecOptions{})
+	opts := executor.OptionsForSelectedCLI(primary, cli, executor.ExecOptions{})
+	raw, err := g.runner.ExecuteRaw(cli, prompt, opts)
 	if err != nil {
 		return "", err
 	}
@@ -286,7 +287,7 @@ func (r *autonomousStageRunner) RunStage(ctx context.Context, stage string, c au
 
 	extraFlags := agentCfg.ExtraFlags
 	if extraFlags != "" {
-		if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+		if err := executor.ValidateExtraFlagsForCLI(aiCfg.Primary, extraFlags); err != nil {
 			slog.Warn("autonomous: extra_flags rejected", "err", err)
 			extraFlags = ""
 		}

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -456,7 +456,7 @@ func main() {
 		cfgMu.Unlock()
 		extraFlags := agentCfg.ExtraFlags
 		if extraFlags != "" {
-			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+			if err := executor.ValidateExtraFlagsForCLI(cli, extraFlags); err != nil {
 				slog.Warn("buildRunOpts: extra_flags from config rejected", "err", err)
 				extraFlags = ""
 			}
@@ -1263,7 +1263,7 @@ func main() {
 
 		extraFlags := agentCfg.ExtraFlags
 		if extraFlags != "" {
-			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+			if err := executor.ValidateExtraFlagsForCLI(aiCfg.Primary, extraFlags); err != nil {
 				slog.Warn("triage-worker: extra_flags rejected", "err", err)
 				extraFlags = ""
 			}
@@ -1459,7 +1459,7 @@ func main() {
 
 		extraFlags := agentCfg.ExtraFlags
 		if extraFlags != "" {
-			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+			if err := executor.ValidateExtraFlagsForCLI(aiCfg.Primary, extraFlags); err != nil {
 				slog.Warn("implement-worker: extra_flags rejected", "err", err)
 				extraFlags = ""
 			}
@@ -3816,7 +3816,7 @@ func (a *tier2Adapter) ProcessRepo(ctx context.Context, repo string) (int, error
 
 		extraFlags := agentCfg.ExtraFlags
 		if extraFlags != "" {
-			if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+			if err := executor.ValidateExtraFlagsForCLI(aiCfg.Primary, extraFlags); err != nil {
 				slog.Warn("issue poll: extra_flags rejected", "err", err)
 				extraFlags = ""
 			}
@@ -4501,7 +4501,7 @@ func buildRefinementRunOptions(
 
 	extraFlags := agentCfg.ExtraFlags
 	if extraFlags != "" {
-		if err := executor.ValidateExtraFlags(extraFlags); err != nil {
+		if err := executor.ValidateExtraFlagsForCLI(aiCfg.Primary, extraFlags); err != nil {
 			slog.Warn(scope+": extra_flags rejected", "err", err)
 			extraFlags = ""
 		}

--- a/daemon/cmd/heimdallm/main_pr_review_executors.go
+++ b/daemon/cmd/heimdallm/main_pr_review_executors.go
@@ -32,6 +32,7 @@ func (p *prReviewExecutor) GenerateReviewResponse(_ context.Context, prompt stri
 	if err != nil {
 		return "", err
 	}
+	opts = executor.OptionsForSelectedCLI(primary, cli, opts)
 	raw, err := p.runner.ExecuteRaw(cli, prompt, opts)
 	if err != nil {
 		return "", err
@@ -65,12 +66,12 @@ var _ issuepipeline.ResponderExecutor = (*prReviewExecutor)(nil)
 // auto_implement (#461), so concurrent fix runs on the same repo are
 // properly isolated.
 type prFixExecutor struct {
-	pipeline   *issuepipeline.Pipeline
-	repoCtx    *repoctx.Manager
-	ghClient   *gh.Client
-	ghToken    string
-	cfg        **config.Config
-	cfgMu      *sync.Mutex
+	pipeline *issuepipeline.Pipeline
+	repoCtx  *repoctx.Manager
+	ghClient *gh.Client
+	ghToken  string
+	cfg      **config.Config
+	cfgMu    *sync.Mutex
 }
 
 func (p *prFixExecutor) RunFix(ctx context.Context, req issuepipeline.FixRequest) (issuepipeline.FixResult, error) {

--- a/daemon/internal/config/canonical_map.go
+++ b/daemon/internal/config/canonical_map.go
@@ -3,9 +3,11 @@ package config
 import (
 	"encoding"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 )
 
 var (
@@ -16,6 +18,10 @@ var (
 	tomlUnmarshalerType = reflect.TypeOf((*interface {
 		UnmarshalTOML(any) error
 	})(nil)).Elem()
+
+	configSchemaValidation = sync.OnceValue(func() error {
+		return validateKnownTOMLSchema(configSchemaType, "config", make(map[reflect.Type]bool))
+	})
 )
 
 // projectKnownConfigMap returns a canonical, schema-shaped view of raw. It is
@@ -24,7 +30,7 @@ var (
 // heterogeneous array) cannot make an otherwise valid legacy config fail to
 // load.
 func projectKnownConfigMap(raw map[string]any) (map[string]any, error) {
-	if err := validateKnownTOMLSchema(configSchemaType, "config", make(map[reflect.Type]bool)); err != nil {
+	if err := configSchemaValidation(); err != nil {
 		return nil, err
 	}
 	projected, err := walkKnownTOMLValue(raw, configSchemaType, "config")
@@ -80,6 +86,11 @@ func walkKnownTOMLValue(raw any, schema reflect.Type, path string) (any, error) 
 			projected[key] = child
 		}
 		return projected, nil
+	case reflect.Slice, reflect.Array:
+		if err := validateHomogeneousTOMLArrays(raw, path, schema); err != nil {
+			return nil, err
+		}
+		return raw, nil
 	case reflect.Interface:
 		return nil, fmt.Errorf("config schema at %q uses unsupported interface type %s", path, schema)
 	default:
@@ -112,7 +123,7 @@ func walkKnownTOMLStruct(table map[string]any, schema reflect.Type, path string)
 		}
 
 		if schema == cliAgentSchemaType && canonical == "dangerously_skip_perms" {
-			value, err := failClosedDangerousValue(table, matches)
+			value, err := resolveFailClosedBool(table, matches, canonical)
 			if err != nil {
 				return nil, fmt.Errorf("%s: %w", path, err)
 			}
@@ -127,10 +138,11 @@ func walkKnownTOMLStruct(table map[string]any, schema reflect.Type, path string)
 			)
 		}
 
-		selected, err := selectCanonicalMapKey(matches, canonical)
+		selected, discarded, err := selectCanonicalMapKey(matches, canonical)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", path, err)
 		}
+		warnDiscardedAliases(path, canonical, discarded)
 		original := table[selected]
 		child, err := walkKnownTOMLValue(original, field.Type, path+"."+canonical)
 		if err != nil {
@@ -164,33 +176,109 @@ func caseFoldedMapKeys(table map[string]any, canonical string) []string {
 	return matches
 }
 
-func selectCanonicalMapKey(matches []string, canonical string) (string, error) {
+func selectCanonicalMapKey(matches []string, canonical string) (string, []string, error) {
 	for _, key := range matches {
 		if key == canonical {
-			return canonical, nil
+			discarded := make([]string, 0, len(matches)-1)
+			for _, alias := range matches {
+				if alias != canonical {
+					discarded = append(discarded, alias)
+				}
+			}
+			return canonical, discarded, nil
 		}
 	}
 	if len(matches) == 1 {
-		return matches[0], nil
+		return matches[0], nil, nil
 	}
-	return "", fmt.Errorf(
+	return "", nil, fmt.Errorf(
 		"ambiguous aliases for %q (%s); keep a single canonical %q key",
 		canonical, strings.Join(matches, ", "), canonical,
 	)
 }
 
-func failClosedDangerousValue(table map[string]any, matches []string) (bool, error) {
+func resolveFailClosedBool(table map[string]any, matches []string, canonical string) (bool, error) {
 	value := true
 	for _, key := range matches {
 		candidate, ok := table[key].(bool)
 		if !ok {
-			return false, fmt.Errorf("dangerously_skip_perms must be a boolean")
+			return false, fmt.Errorf("%s must be a boolean", canonical)
 		}
 		if !candidate {
 			value = false
 		}
 	}
 	return value, nil
+}
+
+func warnDiscardedAliases(path, canonical string, discarded []string) {
+	if len(discarded) == 0 {
+		return
+	}
+	slog.Warn(
+		"config: ignored case-variant aliases because the canonical key is present",
+		"path", path,
+		"field", canonical,
+		"aliases", discarded,
+	)
+}
+
+func validateHomogeneousTOMLArrays(raw any, path string, schema reflect.Type) error {
+	if table, ok := raw.(map[string]any); ok {
+		for _, key := range sortedMapKeys(table) {
+			if err := validateHomogeneousTOMLArrays(
+				table[key],
+				fmt.Sprintf("%s[%q]", path, key),
+				schema,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	value := reflect.ValueOf(raw)
+	if !value.IsValid() || (value.Kind() != reflect.Slice && value.Kind() != reflect.Array) {
+		return nil
+	}
+
+	var firstType reflect.Type
+	firstIndex := -1
+	childSchema := schema
+	if schema.Kind() == reflect.Slice || schema.Kind() == reflect.Array {
+		childSchema = schema.Elem()
+	}
+	for i := 0; i < value.Len(); i++ {
+		element := value.Index(i).Interface()
+		elementType := reflect.TypeOf(element)
+		if firstIndex < 0 {
+			firstType = elementType
+			firstIndex = i
+		} else if elementType != firstType {
+			return fmt.Errorf(
+				"%s: TOML array has mixed element types %s at index %d and %s at index %d; expected %s",
+				path,
+				displayType(firstType), firstIndex,
+				displayType(elementType), i,
+				schema,
+			)
+		}
+		if err := validateHomogeneousTOMLArrays(
+			element,
+			fmt.Sprintf("%s[%d]", path, i),
+			childSchema,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func displayType(value reflect.Type) string {
+	if value == nil {
+		return "<nil>"
+	}
+	return value.String()
 }
 
 func sortedMapKeys(table map[string]any) []string {

--- a/daemon/internal/config/canonical_map.go
+++ b/daemon/internal/config/canonical_map.go
@@ -49,6 +49,13 @@ func walkKnownTOMLValue(raw any, schema reflect.Type, path string) (any, error) 
 	if schema == nil {
 		return nil, fmt.Errorf("config schema at %q has no concrete type", path)
 	}
+	rawValue := reflect.ValueOf(raw)
+	if rawValue.IsValid() &&
+		(rawValue.Kind() == reflect.Slice || rawValue.Kind() == reflect.Array) {
+		if err := validateHomogeneousTOMLArrays(raw, path, schema); err != nil {
+			return nil, err
+		}
+	}
 	if implementsTOMLScalar(schema) {
 		return raw, nil
 	}
@@ -87,9 +94,6 @@ func walkKnownTOMLValue(raw any, schema reflect.Type, path string) (any, error) 
 		}
 		return projected, nil
 	case reflect.Slice, reflect.Array:
-		if err := validateHomogeneousTOMLArrays(raw, path, schema); err != nil {
-			return nil, err
-		}
 		return raw, nil
 	case reflect.Interface:
 		return nil, fmt.Errorf("config schema at %q uses unsupported interface type %s", path, schema)
@@ -198,6 +202,9 @@ func selectCanonicalMapKey(matches []string, canonical string) (string, []string
 }
 
 func resolveFailClosedBool(table map[string]any, matches []string, canonical string) (bool, error) {
+	if len(matches) == 0 {
+		return false, fmt.Errorf("%s has no configured aliases", canonical)
+	}
 	value := true
 	for _, key := range matches {
 		candidate, ok := table[key].(bool)

--- a/daemon/internal/config/canonical_map.go
+++ b/daemon/internal/config/canonical_map.go
@@ -1,0 +1,303 @@
+package config
+
+import (
+	"encoding"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+var (
+	configSchemaType   = reflect.TypeOf(Config{})
+	cliAgentSchemaType = reflect.TypeOf(CLIAgentConfig{})
+
+	textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+	tomlUnmarshalerType = reflect.TypeOf((*interface {
+		UnmarshalTOML(any) error
+	})(nil)).Elem()
+)
+
+// projectKnownConfigMap returns a canonical, schema-shaped view of raw. It is
+// intentionally not a generic TOML round-trip: unknown keys are omitted so an
+// unrelated value that BurntSushi's encoder cannot represent (for example, a
+// heterogeneous array) cannot make an otherwise valid legacy config fail to
+// load.
+func projectKnownConfigMap(raw map[string]any) (map[string]any, error) {
+	if err := validateKnownTOMLSchema(configSchemaType, "config", make(map[reflect.Type]bool)); err != nil {
+		return nil, err
+	}
+	projected, err := walkKnownTOMLValue(raw, configSchemaType, "config")
+	if err != nil {
+		return nil, err
+	}
+	out, ok := projected.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("config schema projection returned %T, want a table", projected)
+	}
+	return out, nil
+}
+
+func walkKnownTOMLValue(raw any, schema reflect.Type, path string) (any, error) {
+	schema = indirectSchemaType(schema)
+	if schema == nil {
+		return nil, fmt.Errorf("config schema at %q has no concrete type", path)
+	}
+	if implementsTOMLScalar(schema) {
+		return raw, nil
+	}
+
+	switch schema.Kind() {
+	case reflect.Struct:
+		table, ok := raw.(map[string]any)
+		if !ok {
+			// Keep the known value in the projection. The normal typed TOML
+			// decoder will report the same useful type mismatch it did before.
+			return raw, nil
+		}
+		return walkKnownTOMLStruct(table, schema, path)
+	case reflect.Map:
+		if schema.Key().Kind() != reflect.String {
+			return nil, fmt.Errorf("config schema map at %q must use string keys", path)
+		}
+		table, ok := raw.(map[string]any)
+		if !ok {
+			return raw, nil
+		}
+		projected := make(map[string]any, len(table))
+		keys := sortedMapKeys(table)
+		for _, key := range keys {
+			// Map keys are user data (CLI names, orgs and repo slugs), not
+			// schema identifiers. Preserve their spelling exactly.
+			child, err := walkKnownTOMLValue(
+				table[key],
+				schema.Elem(),
+				fmt.Sprintf("%s[%q]", path, key),
+			)
+			if err != nil {
+				return nil, err
+			}
+			projected[key] = child
+		}
+		return projected, nil
+	case reflect.Interface:
+		return nil, fmt.Errorf("config schema at %q uses unsupported interface type %s", path, schema)
+	default:
+		return raw, nil
+	}
+}
+
+func walkKnownTOMLStruct(table map[string]any, schema reflect.Type, path string) (map[string]any, error) {
+	projected := make(map[string]any)
+	for i := 0; i < schema.NumField(); i++ {
+		field := schema.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+		if field.Anonymous {
+			return nil, fmt.Errorf("config schema at %q has unsupported anonymous field %s", path, field.Name)
+		}
+
+		canonical, include, err := canonicalTOMLFieldName(field)
+		if err != nil {
+			return nil, fmt.Errorf("config schema at %q: %w", path, err)
+		}
+		if !include {
+			continue
+		}
+
+		matches := caseFoldedMapKeys(table, canonical)
+		if len(matches) == 0 {
+			continue
+		}
+
+		if schema == cliAgentSchemaType && canonical == "dangerously_skip_perms" {
+			value, err := failClosedDangerousValue(table, matches)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", path, err)
+			}
+			projected[canonical] = value
+			continue
+		}
+
+		if isStructuralSchemaType(field.Type) && len(matches) > 1 {
+			return nil, fmt.Errorf(
+				"ambiguous structural aliases at %q for %q (%s); keep a single canonical %q key",
+				path, canonical, strings.Join(matches, ", "), canonical,
+			)
+		}
+
+		selected, err := selectCanonicalMapKey(matches, canonical)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		original := table[selected]
+		child, err := walkKnownTOMLValue(original, field.Type, path+"."+canonical)
+		if err != nil {
+			return nil, err
+		}
+		projected[canonical] = child
+	}
+	return projected, nil
+}
+
+func canonicalTOMLFieldName(field reflect.StructField) (name string, include bool, err error) {
+	tag := strings.Split(field.Tag.Get("toml"), ",")[0]
+	switch tag {
+	case "-":
+		return "", false, nil
+	case "":
+		return "", false, fmt.Errorf("exported field %s is missing a toml tag", field.Name)
+	default:
+		return tag, true, nil
+	}
+}
+
+func caseFoldedMapKeys(table map[string]any, canonical string) []string {
+	matches := make([]string, 0, 1)
+	for key := range table {
+		if strings.EqualFold(key, canonical) {
+			matches = append(matches, key)
+		}
+	}
+	sort.Strings(matches)
+	return matches
+}
+
+func selectCanonicalMapKey(matches []string, canonical string) (string, error) {
+	for _, key := range matches {
+		if key == canonical {
+			return canonical, nil
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	return "", fmt.Errorf(
+		"ambiguous aliases for %q (%s); keep a single canonical %q key",
+		canonical, strings.Join(matches, ", "), canonical,
+	)
+}
+
+func failClosedDangerousValue(table map[string]any, matches []string) (bool, error) {
+	value := true
+	for _, key := range matches {
+		candidate, ok := table[key].(bool)
+		if !ok {
+			return false, fmt.Errorf("dangerously_skip_perms must be a boolean")
+		}
+		if !candidate {
+			value = false
+		}
+	}
+	return value, nil
+}
+
+func sortedMapKeys(table map[string]any) []string {
+	keys := make([]string, 0, len(table))
+	for key := range table {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func indirectSchemaType(schema reflect.Type) reflect.Type {
+	for schema != nil && schema.Kind() == reflect.Pointer {
+		schema = schema.Elem()
+	}
+	return schema
+}
+
+func isStructuralSchemaType(schema reflect.Type) bool {
+	schema = indirectSchemaType(schema)
+	if schema == nil || implementsTOMLScalar(schema) {
+		return false
+	}
+	return schema.Kind() == reflect.Struct || schema.Kind() == reflect.Map
+}
+
+func implementsTOMLScalar(schema reflect.Type) bool {
+	if schema.Implements(textUnmarshalerType) || schema.Implements(tomlUnmarshalerType) {
+		return true
+	}
+	return schema.Kind() != reflect.Pointer &&
+		(reflect.PointerTo(schema).Implements(textUnmarshalerType) ||
+			reflect.PointerTo(schema).Implements(tomlUnmarshalerType))
+}
+
+func validateKnownTOMLSchema(schema reflect.Type, path string, visiting map[reflect.Type]bool) error {
+	schema = indirectSchemaType(schema)
+	if schema == nil {
+		return fmt.Errorf("config schema at %q has no concrete type", path)
+	}
+	if implementsTOMLScalar(schema) {
+		return nil
+	}
+
+	switch schema.Kind() {
+	case reflect.Struct:
+		if visiting[schema] {
+			return fmt.Errorf("config schema at %q contains recursive type %s", path, schema)
+		}
+		visiting[schema] = true
+		defer delete(visiting, schema)
+		fieldNames := make([]string, 0, schema.NumField())
+		for i := 0; i < schema.NumField(); i++ {
+			field := schema.Field(i)
+			if field.PkgPath != "" {
+				continue
+			}
+			if field.Anonymous {
+				return fmt.Errorf("config schema at %q has unsupported anonymous field %s", path, field.Name)
+			}
+			canonical, include, err := canonicalTOMLFieldName(field)
+			if err != nil {
+				return fmt.Errorf("config schema at %q: %w", path, err)
+			}
+			if !include {
+				continue
+			}
+			for _, existing := range fieldNames {
+				if strings.EqualFold(existing, canonical) {
+					return fmt.Errorf(
+						"config schema at %q has case-insensitive duplicate TOML fields %q and %q",
+						path, existing, canonical,
+					)
+				}
+			}
+			fieldNames = append(fieldNames, canonical)
+			if err := validateKnownTOMLSchema(field.Type, path+"."+canonical, visiting); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Map:
+		if schema.Key().Kind() != reflect.String {
+			return fmt.Errorf("config schema map at %q must use string keys", path)
+		}
+		return validateKnownTOMLSchema(schema.Elem(), path+"[*]", visiting)
+	case reflect.Slice, reflect.Array:
+		element := indirectSchemaType(schema.Elem())
+		if element == nil || implementsTOMLScalar(element) {
+			return nil
+		}
+		switch element.Kind() {
+		case reflect.Bool,
+			reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+			reflect.Float32, reflect.Float64,
+			reflect.String:
+			return nil
+		default:
+			return fmt.Errorf(
+				"config schema at %q uses unsupported composite %s elements",
+				path, element,
+			)
+		}
+	case reflect.Interface:
+		return fmt.Errorf("config schema at %q uses unsupported interface type %s", path, schema)
+	default:
+		return nil
+	}
+}

--- a/daemon/internal/config/canonical_map_test.go
+++ b/daemon/internal/config/canonical_map_test.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type projectionTextScalar struct{}
+
+func (*projectionTextScalar) UnmarshalText([]byte) error { return nil }
+
+type projectionTOMLScalar struct{}
+
+func (*projectionTOMLScalar) UnmarshalTOML(any) error { return nil }
+
+type ProjectionEmbedded struct{}
+
+func TestValidateKnownTOMLSchema_RejectsUnsupportedShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema reflect.Type
+		marker string
+	}{
+		{
+			name: "case-insensitive duplicate tags",
+			schema: reflect.TypeOf(struct {
+				First  string `toml:"field"`
+				Second string `toml:"FIELD"`
+			}{}),
+			marker: `duplicate TOML fields "field" and "FIELD"`,
+		},
+		{
+			name: "anonymous field",
+			schema: reflect.TypeOf(struct {
+				ProjectionEmbedded
+			}{}),
+			marker: "unsupported anonymous field",
+		},
+		{
+			name: "interface field",
+			schema: reflect.TypeOf(struct {
+				Value any `toml:"value"`
+			}{}),
+			marker: "unsupported interface type",
+		},
+		{
+			name: "composite slice elements",
+			schema: reflect.TypeOf(struct {
+				Values []struct {
+					Name string `toml:"name"`
+				} `toml:"values"`
+			}{}),
+			marker: "unsupported composite",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateKnownTOMLSchema(tc.schema, "test", make(map[reflect.Type]bool))
+			if err == nil || !strings.Contains(err.Error(), tc.marker) {
+				t.Fatalf("schema error = %v, want marker %q", err, tc.marker)
+			}
+		})
+	}
+}
+
+func TestValidateKnownTOMLSchema_TreatsCustomUnmarshalersAsScalars(t *testing.T) {
+	schema := reflect.TypeOf(struct {
+		Text projectionTextScalar `toml:"text"`
+		TOML projectionTOMLScalar `toml:"toml"`
+	}{})
+
+	if err := validateKnownTOMLSchema(schema, "test", make(map[reflect.Type]bool)); err != nil {
+		t.Fatalf("custom scalar schema rejected: %v", err)
+	}
+}
+
+func TestFailClosedDangerousValue_FalseWinsEveryAliasShape(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags map[string]any
+		want  bool
+	}{
+		{
+			name: "canonical true",
+			flags: map[string]any{
+				"dangerously_skip_perms": true,
+			},
+			want: true,
+		},
+		{
+			name: "canonical false beats alias true",
+			flags: map[string]any{
+				"dangerously_skip_perms": false,
+				"DANGEROUSLY_SKIP_PERMS": true,
+			},
+			want: false,
+		},
+		{
+			name: "alias false beats canonical true",
+			flags: map[string]any{
+				"dangerously_skip_perms": true,
+				"DANGEROUSLY_SKIP_PERMS": false,
+			},
+			want: false,
+		},
+		{
+			name: "alias false beats another alias",
+			flags: map[string]any{
+				"Dangerously_Skip_Perms": true,
+				"DANGEROUSLY_SKIP_PERMS": false,
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := caseFoldedMapKeys(tc.flags, "dangerously_skip_perms")
+			got, err := failClosedDangerousValue(tc.flags, matches)
+			if err != nil {
+				t.Fatalf("failClosedDangerousValue: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("dangerous value = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	flags := map[string]any{"DANGEROUSLY_SKIP_PERMS": "false"}
+	if _, err := failClosedDangerousValue(
+		flags,
+		caseFoldedMapKeys(flags, "dangerously_skip_perms"),
+	); err == nil || !strings.Contains(err.Error(), "must be a boolean") {
+		t.Fatalf("non-boolean dangerous alias error = %v", err)
+	}
+}

--- a/daemon/internal/config/canonical_map_test.go
+++ b/daemon/internal/config/canonical_map_test.go
@@ -16,6 +16,19 @@ func (*projectionTOMLScalar) UnmarshalTOML(any) error { return nil }
 
 type ProjectionEmbedded struct{}
 
+func TestValidateKnownTOMLSchema_AcceptsRealConfigSchema(t *testing.T) {
+	if err := validateKnownTOMLSchema(
+		reflect.TypeOf(Config{}),
+		"config",
+		make(map[reflect.Type]bool),
+	); err != nil {
+		t.Fatalf("real Config schema rejected: %v", err)
+	}
+	if _, err := projectKnownConfigMap(map[string]any{}); err != nil {
+		t.Fatalf("empty real Config projection failed: %v", err)
+	}
+}
+
 func TestValidateKnownTOMLSchema_RejectsUnsupportedShapes(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -118,9 +131,9 @@ func TestFailClosedDangerousValue_FalseWinsEveryAliasShape(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			matches := caseFoldedMapKeys(tc.flags, "dangerously_skip_perms")
-			got, err := failClosedDangerousValue(tc.flags, matches)
+			got, err := resolveFailClosedBool(tc.flags, matches, "dangerously_skip_perms")
 			if err != nil {
-				t.Fatalf("failClosedDangerousValue: %v", err)
+				t.Fatalf("resolveFailClosedBool: %v", err)
 			}
 			if got != tc.want {
 				t.Fatalf("dangerous value = %v, want %v", got, tc.want)
@@ -129,9 +142,10 @@ func TestFailClosedDangerousValue_FalseWinsEveryAliasShape(t *testing.T) {
 	}
 
 	flags := map[string]any{"DANGEROUSLY_SKIP_PERMS": "false"}
-	if _, err := failClosedDangerousValue(
+	if _, err := resolveFailClosedBool(
 		flags,
 		caseFoldedMapKeys(flags, "dangerously_skip_perms"),
+		"dangerously_skip_perms",
 	); err == nil || !strings.Contains(err.Error(), "must be a boolean") {
 		t.Fatalf("non-boolean dangerous alias error = %v", err)
 	}

--- a/daemon/internal/config/canonical_map_test.go
+++ b/daemon/internal/config/canonical_map_test.go
@@ -141,6 +141,14 @@ func TestFailClosedDangerousValue_FalseWinsEveryAliasShape(t *testing.T) {
 		})
 	}
 
+	if got, err := resolveFailClosedBool(
+		map[string]any{},
+		nil,
+		"dangerously_skip_perms",
+	); err == nil || got || !strings.Contains(err.Error(), "has no configured aliases") {
+		t.Fatalf("empty aliases returned value=%v error=%v", got, err)
+	}
+
 	flags := map[string]any{"DANGEROUSLY_SKIP_PERMS": "false"}
 	if _, err := resolveFailClosedBool(
 		flags,

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -377,7 +377,7 @@ func labelSetIntersects(set map[string]struct{}, list []string) bool {
 type CLIAgentConfig struct {
 	Model        string `toml:"model" json:"model,omitempty"`                 // e.g. "claude-opus-4-6"
 	MaxTurns     int    `toml:"max_turns" json:"max_turns,omitempty"`         // claude: --max-turns (0 = not set)
-	ApprovalMode string `toml:"approval_mode" json:"approval_mode,omitempty"` // codex: --ask-for-approval
+	ApprovalMode string `toml:"approval_mode" json:"approval_mode,omitempty"` // codex/gemini typed approval mode
 	ExtraFlags   string `toml:"extra_flags" json:"extra_flags,omitempty"`     // free-form additional CLI flags
 	PromptID     string `toml:"prompt" json:"prompt,omitempty"`               // agent-level prompt override
 
@@ -1286,13 +1286,24 @@ func (c *Config) Validate() error {
 	if err := ValidatePollInterval(c.GitHub.PollInterval); err != nil {
 		return fmt.Errorf("config: %w", err)
 	}
-	// Validate per-CLI agent configs: permission_mode and approval_mode must be in their allowlists.
+	// Validate every persisted execution option before it reaches Executor.
+	// This catches legacy TOML/store rows during reload; ExecuteRaw repeats the
+	// same checks at the subprocess boundary as defense in depth.
 	for name, a := range c.AI.Agents {
+		if err := executor.ValidateModel(a.Model); err != nil {
+			return fmt.Errorf("config: agents[%s].model: %w", name, err)
+		}
+		if err := executor.ValidateEffort(a.Effort); err != nil {
+			return fmt.Errorf("config: agents[%s].effort: %w", name, err)
+		}
 		if err := executor.ValidatePermissionMode(a.PermissionMode); err != nil {
 			return fmt.Errorf("config: agents[%s].permission_mode: %w", name, err)
 		}
-		if err := executor.ValidateApprovalMode(a.ApprovalMode); err != nil {
+		if err := executor.ValidateApprovalModeForCLI(name, a.ApprovalMode); err != nil {
 			return fmt.Errorf("config: agents[%s].approval_mode: %w", name, err)
+		}
+		if err := executor.ValidateExtraFlagsForCLI(name, a.ExtraFlags); err != nil {
+			return fmt.Errorf("config: agents[%s].extra_flags: %w", name, err)
 		}
 	}
 	if err := c.validateRefinementTimeouts(); err != nil {

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -1290,8 +1290,18 @@ func (c *Config) Validate() error {
 	// This catches legacy TOML/store rows during reload; ExecuteRaw repeats the
 	// same checks at the subprocess boundary as defense in depth.
 	for name, a := range c.AI.Agents {
+		// Preserve unknown legacy profiles as inert configuration. They cannot
+		// be selected by Detect/ExecuteRaw, and every HTTP write still rejects
+		// unknown CLI names, but an unused historical section must not prevent
+		// the daemon from starting after an upgrade.
+		if err := executor.ValidateCLIName(name); err != nil {
+			continue
+		}
 		if err := executor.ValidateModel(a.Model); err != nil {
 			return fmt.Errorf("config: agents[%s].model: %w", name, err)
+		}
+		if a.MaxTurns < 0 {
+			return fmt.Errorf("config: agents[%s].max_turns must be non-negative", name)
 		}
 		if err := executor.ValidateEffort(a.Effort); err != nil {
 			return fmt.Errorf("config: agents[%s].effort: %w", name, err)
@@ -1337,6 +1347,247 @@ func (c *Config) Validate() error {
 		}
 	}
 	return nil
+}
+
+// sanitizeLegacyAgentExecutionPolicy keeps trusted TOML/env configurations
+// from becoming a startup regression when Heimdallm learns about a newly
+// dangerous provider flag. HTTP writes remain strict and ExecuteRaw validates
+// again at the subprocess boundary; this compatibility path only canonicalizes
+// safe values and removes the individual unsafe field with an actionable log.
+//
+// Unknown profiles are preserved but inert. Detect and ExecuteRaw only accept
+// the four supported CLI names, while retaining the map entry avoids deleting
+// a user's dormant configuration during an upgrade.
+func (c *Config) sanitizeLegacyAgentExecutionPolicy(source string) {
+	for name, agent := range c.AI.Agents {
+		if err := executor.ValidateCLIName(name); err != nil {
+			slog.Warn("config: preserving inert legacy agent profile for unknown CLI",
+				"source", source, "agent", name, "err", err)
+			continue
+		}
+		c.AI.Agents[name] = sanitizeLegacyAgentConfig(name, agent, source)
+	}
+}
+
+func sanitizeLegacyAgentConfig(name string, agent CLIAgentConfig, source string) CLIAgentConfig {
+	agent.Model = strings.TrimSpace(agent.Model)
+	if err := executor.ValidateModel(agent.Model); err != nil {
+		slog.Warn("config: ignored unsafe legacy agent field",
+			"source", source, "agent", name, "field", "model", "err", err)
+		agent.Model = ""
+	}
+	if agent.MaxTurns < 0 {
+		slog.Warn("config: ignored invalid legacy agent field",
+			"source", source, "agent", name, "field", "max_turns",
+			"err", "value must be non-negative")
+		agent.MaxTurns = 0
+	}
+	if normalized, err := executor.NormalizeEffort(agent.Effort); err != nil {
+		slog.Warn("config: ignored unsafe legacy agent field",
+			"source", source, "agent", name, "field", "effort", "err", err)
+		agent.Effort = ""
+	} else {
+		agent.Effort = normalized
+	}
+	if normalized, err := executor.NormalizePermissionMode(agent.PermissionMode); err != nil {
+		slog.Warn("config: ignored unsafe legacy agent field",
+			"source", source, "agent", name, "field", "permission_mode", "err", err)
+		agent.PermissionMode = ""
+	} else {
+		agent.PermissionMode = normalized
+	}
+	if normalized, err := executor.NormalizeApprovalModeForCLI(name, agent.ApprovalMode); err != nil {
+		slog.Warn("config: ignored unsafe legacy agent field",
+			"source", source, "agent", name, "field", "approval_mode", "err", err)
+		agent.ApprovalMode = ""
+	} else {
+		agent.ApprovalMode = normalized
+	}
+
+	opts, migrated := executor.MigrateLegacyTypedExtraFlagsForCLI(name, executor.ExecOptions{
+		Model:        agent.Model,
+		MaxTurns:     agent.MaxTurns,
+		ExtraFlags:   agent.ExtraFlags,
+		Effort:       agent.Effort,
+		ApprovalMode: agent.ApprovalMode,
+	})
+	if len(migrated) > 0 {
+		slog.Warn("config: migrated legacy extra_flags to typed agent fields",
+			"source", source, "agent", name, "fields", migrated)
+	}
+	agent.Model = opts.Model
+	agent.MaxTurns = opts.MaxTurns
+	agent.Effort = opts.Effort
+	agent.ExtraFlags = opts.ExtraFlags
+	if err := executor.ValidateExtraFlagsForCLI(name, agent.ExtraFlags); err != nil {
+		slog.Warn("config: ignored unsafe legacy agent field",
+			"source", source, "agent", name, "field", "extra_flags", "err", err)
+		agent.ExtraFlags = ""
+	}
+	return agent
+}
+
+// SanitizeLegacyAgentExecutionPolicyMap migrates only the trusted agent
+// settings already present in a TOML map. HTTP handlers call this before
+// applying their separately validated payload, so an old local --model flag
+// cannot make an unrelated PATCH fail while a new HTTP --model flag remains a
+// strict 400. Unknown fields and the local-only dangerously_skip_perms gate are
+// left untouched.
+func SanitizeLegacyAgentExecutionPolicyMap(m map[string]any, source string) error {
+	for aiKey, rawAI := range m {
+		if !strings.EqualFold(aiKey, "ai") {
+			continue
+		}
+		ai, ok := rawAI.(map[string]any)
+		if !ok {
+			continue
+		}
+		for agentsKey, rawAgents := range ai {
+			if !strings.EqualFold(agentsKey, "agents") {
+				continue
+			}
+			agents, ok := rawAgents.(map[string]any)
+			if !ok {
+				continue
+			}
+			for name, rawAgent := range agents {
+				if err := executor.ValidateCLIName(name); err != nil {
+					continue
+				}
+				agentMap, ok := rawAgent.(map[string]any)
+				if !ok {
+					continue
+				}
+				before, rewrite, err := legacyAgentConfigFromMap(agentMap)
+				if err != nil {
+					return fmt.Errorf("config: sanitize legacy TOML agent %q: %w", name, err)
+				}
+				after := sanitizeLegacyAgentConfig(name, before, source)
+				syncLegacyAgentStringField(agentMap, "model", before.Model, after.Model, rewrite["model"])
+				syncLegacyAgentIntField(agentMap, "max_turns", before.MaxTurns, after.MaxTurns, rewrite["max_turns"])
+				syncLegacyAgentStringField(agentMap, "approval_mode", before.ApprovalMode, after.ApprovalMode, rewrite["approval_mode"])
+				syncLegacyAgentStringField(agentMap, "extra_flags", before.ExtraFlags, after.ExtraFlags, rewrite["extra_flags"])
+				syncLegacyAgentStringField(agentMap, "effort", before.Effort, after.Effort, rewrite["effort"])
+				syncLegacyAgentStringField(agentMap, "permission_mode", before.PermissionMode, after.PermissionMode, rewrite["permission_mode"])
+			}
+		}
+	}
+	return nil
+}
+
+func legacyAgentConfigFromMap(m map[string]any) (CLIAgentConfig, map[string]bool, error) {
+	var agent CLIAgentConfig
+	rewrite := make(map[string]bool, 6)
+	stringField := func(canonical string, target *string) error {
+		raw, present, canonicalize := legacyMapValue(m, canonical)
+		rewrite[canonical] = canonicalize
+		if !present {
+			return nil
+		}
+		value, ok := raw.(string)
+		if !ok {
+			return fmt.Errorf("%s must be a string", canonical)
+		}
+		*target = value
+		return nil
+	}
+	if err := stringField("model", &agent.Model); err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	if err := stringField("approval_mode", &agent.ApprovalMode); err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	if err := stringField("extra_flags", &agent.ExtraFlags); err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	if err := stringField("effort", &agent.Effort); err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	if err := stringField("permission_mode", &agent.PermissionMode); err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	if raw, present, canonicalize := legacyMapValue(m, "max_turns"); present {
+		rewrite["max_turns"] = canonicalize
+		value, err := legacyMapInt(raw)
+		if err != nil {
+			return CLIAgentConfig{}, nil, fmt.Errorf("max_turns: %w", err)
+		}
+		agent.MaxTurns = value
+	} else {
+		rewrite["max_turns"] = canonicalize
+	}
+	return agent, rewrite, nil
+}
+
+func legacyMapValue(m map[string]any, canonical string) (value any, present, canonicalize bool) {
+	if exact, ok := m[canonical]; ok {
+		value = exact
+		present = true
+	}
+	matches := 0
+	for key, candidate := range m {
+		if !strings.EqualFold(key, canonical) {
+			continue
+		}
+		matches++
+		if !present {
+			value = candidate
+			present = true
+		}
+		if key != canonical {
+			canonicalize = true
+		}
+	}
+	return value, present, canonicalize || matches > 1
+}
+
+func legacyMapInt(raw any) (int, error) {
+	switch value := raw.(type) {
+	case int:
+		return value, nil
+	case int64:
+		converted := int(value)
+		if int64(converted) != value {
+			return 0, fmt.Errorf("value is outside the supported integer range")
+		}
+		return converted, nil
+	case float64:
+		converted := int(value)
+		if float64(converted) != value {
+			return 0, fmt.Errorf("value must be an integer")
+		}
+		return converted, nil
+	default:
+		return 0, fmt.Errorf("value must be an integer")
+	}
+}
+
+func syncLegacyAgentStringField(m map[string]any, canonical, before, after string, canonicalize bool) {
+	if before == after && !canonicalize {
+		return
+	}
+	deleteLegacyAgentFieldAliases(m, canonical)
+	if after != "" {
+		m[canonical] = after
+	}
+}
+
+func syncLegacyAgentIntField(m map[string]any, canonical string, before, after int, canonicalize bool) {
+	if before == after && !canonicalize {
+		return
+	}
+	deleteLegacyAgentFieldAliases(m, canonical)
+	if after != 0 {
+		m[canonical] = int64(after)
+	}
+}
+
+func deleteLegacyAgentFieldAliases(m map[string]any, canonical string) {
+	for key := range m {
+		if strings.EqualFold(key, canonical) {
+			delete(m, key)
+		}
+	}
 }
 
 // validateNeverApproveMinSeverity bounds never_approve_min_severity to the
@@ -1553,6 +1804,7 @@ func Load(path string) (*Config, error) {
 	}
 	cfg.applyDefaults()
 	cfg.applyEnvOverrides()
+	cfg.sanitizeLegacyAgentExecutionPolicy("toml/env")
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
@@ -1583,6 +1835,7 @@ func LoadOrCreate(path string) (*Config, error) {
 	cfg := &Config{}
 	cfg.applyDefaults()
 	cfg.applyEnvOverrides()
+	cfg.sanitizeLegacyAgentExecutionPolicy("generated env")
 	if cfg.AI.Primary == "" {
 		return nil, fmt.Errorf("no config file and HEIMDALLM_AI_PRIMARY not set")
 	}

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -1371,25 +1371,7 @@ func (c *Config) sanitizeLegacyAgentExecutionPolicy(source string) {
 }
 
 func sanitizeLegacyAgentConfig(name string, agent CLIAgentConfig, source string) CLIAgentConfig {
-	agent.Model = strings.TrimSpace(agent.Model)
-	if err := executor.ValidateModel(agent.Model); err != nil {
-		slog.Warn("config: ignored unsafe legacy agent field",
-			"source", source, "agent", name, "field", "model", "err", err)
-		agent.Model = ""
-	}
-	if agent.MaxTurns < 0 {
-		slog.Warn("config: ignored invalid legacy agent field",
-			"source", source, "agent", name, "field", "max_turns",
-			"err", "value must be non-negative")
-		agent.MaxTurns = 0
-	}
-	if normalized, err := executor.NormalizeEffort(agent.Effort); err != nil {
-		slog.Warn("config: ignored unsafe legacy agent field",
-			"source", source, "agent", name, "field", "effort", "err", err)
-		agent.Effort = ""
-	} else {
-		agent.Effort = normalized
-	}
+	agent = sanitizeAgentExecutionFields(name, agent, source, "legacy")
 	if normalized, err := executor.NormalizePermissionMode(agent.PermissionMode); err != nil {
 		slog.Warn("config: ignored unsafe legacy agent field",
 			"source", source, "agent", name, "field", "permission_mode", "err", err)
@@ -1423,7 +1405,7 @@ func sanitizeLegacyAgentConfig(name string, agent CLIAgentConfig, source string)
 	// values. Keep the compatibility boundary defensive nevertheless: a
 	// future migration must not turn a formerly survivable legacy config into
 	// a startup failure by returning an unsafe typed value.
-	agent = sanitizeMigratedAgentExecutionFields(name, agent, source)
+	agent = sanitizeAgentExecutionFields(name, agent, source, "migrated")
 	if err := executor.ValidateExtraFlagsForCLI(name, agent.ExtraFlags); err != nil {
 		slog.Warn("config: ignored unsafe legacy agent field",
 			"source", source, "agent", name, "field", "extra_flags", "err", err)
@@ -1432,21 +1414,28 @@ func sanitizeLegacyAgentConfig(name string, agent CLIAgentConfig, source string)
 	return agent
 }
 
-func sanitizeMigratedAgentExecutionFields(name string, agent CLIAgentConfig, source string) CLIAgentConfig {
+func sanitizeAgentExecutionFields(
+	name string,
+	agent CLIAgentConfig,
+	source string,
+	provenance string,
+) CLIAgentConfig {
+	unsafeMessage := "config: ignored unsafe " + provenance + " agent field"
+	invalidMessage := "config: ignored invalid " + provenance + " agent field"
 	agent.Model = strings.TrimSpace(agent.Model)
 	if err := executor.ValidateModel(agent.Model); err != nil {
-		slog.Warn("config: ignored unsafe migrated agent field",
+		slog.Warn(unsafeMessage,
 			"source", source, "agent", name, "field", "model", "err", err)
 		agent.Model = ""
 	}
 	if agent.MaxTurns < 0 {
-		slog.Warn("config: ignored invalid migrated agent field",
+		slog.Warn(invalidMessage,
 			"source", source, "agent", name, "field", "max_turns",
 			"err", "value must be non-negative")
 		agent.MaxTurns = 0
 	}
 	if normalized, err := executor.NormalizeEffort(agent.Effort); err != nil {
-		slog.Warn("config: ignored unsafe migrated agent field",
+		slog.Warn(unsafeMessage,
 			"source", source, "agent", name, "field", "effort", "err", err)
 		agent.Effort = ""
 	} else {
@@ -1535,7 +1524,7 @@ func canonicalizeLegacyMapChild(m map[string]any, canonical, path string) (map[s
 
 func legacyAgentConfigFromMap(m map[string]any) (CLIAgentConfig, map[string]bool, error) {
 	var agent CLIAgentConfig
-	rewrite := make(map[string]bool, 11)
+	rewrite := make(map[string]bool)
 	stringField := func(canonical string, target *string) error {
 		raw, present, canonicalize, err := legacyMapValue(m, canonical)
 		if err != nil {
@@ -1952,19 +1941,21 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("config: read %s: %w", path, err)
 	}
 	// Decode through a generic map first. BurntSushi's struct decoder matches
-	// TOML keys case-insensitively, so legacy aliases such as Model/MODEL can
-	// otherwise race on Go map iteration and produce different configs across
-	// reloads. Canonicalize or reject them deterministically before the typed
-	// decode used by the runtime.
+	// TOML keys case-insensitively, so aliases that differ only in casing can
+	// otherwise race on Go map iteration. Project only schema-known fields
+	// under canonical names before the typed decode. Unknown TOML remains
+	// accepted and never passes through the encoder, which cannot re-emit
+	// every valid value its decoder accepts (for example mixed-type arrays).
 	var raw map[string]any
 	if err := toml.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("config: parse %s: %w", path, err)
 	}
-	if err := SanitizeLegacyAgentExecutionPolicyMap(raw, "toml load"); err != nil {
-		return nil, fmt.Errorf("config: sanitize %s: %w", path, err)
+	known, err := projectKnownConfigMap(raw)
+	if err != nil {
+		return nil, fmt.Errorf("config: canonicalize %s: %w", path, err)
 	}
 	var canonical strings.Builder
-	if err := toml.NewEncoder(&canonical).Encode(raw); err != nil {
+	if err := toml.NewEncoder(&canonical).Encode(known); err != nil {
 		return nil, fmt.Errorf("config: canonicalize %s: %w", path, err)
 	}
 	var cfg Config

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -64,6 +63,11 @@ var githubOrgPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-z
 // are rejected separately by ValidateRepoSlug to avoid path-traversal tokens.
 var repoNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
+// Config is the schema root used by the deterministic TOML projection in
+// canonical_map.go. Every exported field in this graph must have a unique
+// case-insensitive toml tag. Embedded fields, interface values and slices of
+// composite structs/maps are deliberately unsupported; the schema invariant
+// test fails before such a change can turn into a runtime Load failure.
 type Config struct {
 	Server         ServerConfig         `toml:"server"`
 	GitHub         GitHubConfig         `toml:"github"`
@@ -1457,7 +1461,7 @@ func SanitizeLegacyAgentExecutionPolicyMap(m map[string]any, source string) erro
 	if err != nil || !present {
 		return err
 	}
-	agents, present, err := canonicalizeLegacyMapChild(ai, "agents", "ai")
+	agents, present, err := canonicalizeLegacyMapChild(ai, "agents", "config.ai")
 	if err != nil || !present {
 		return err
 	}
@@ -1472,7 +1476,8 @@ func SanitizeLegacyAgentExecutionPolicyMap(m map[string]any, source string) erro
 		if !ok {
 			continue
 		}
-		before, rewrite, err := legacyAgentConfigFromMap(agentMap)
+		agentPath := fmt.Sprintf(`config.ai.agents[%q]`, name)
+		before, rewrite, err := legacyAgentConfigFromMap(agentMap, agentPath)
 		if err != nil {
 			return fmt.Errorf("config: sanitize legacy TOML agent %q: %w", name, err)
 		}
@@ -1493,13 +1498,7 @@ func SanitizeLegacyAgentExecutionPolicyMap(m map[string]any, source string) erro
 }
 
 func canonicalizeLegacyMapChild(m map[string]any, canonical, path string) (map[string]any, bool, error) {
-	aliases := make([]string, 0, 1)
-	for key := range m {
-		if strings.EqualFold(key, canonical) {
-			aliases = append(aliases, key)
-		}
-	}
-	sort.Strings(aliases)
+	aliases := caseFoldedMapKeys(m, canonical)
 	switch len(aliases) {
 	case 0:
 		return nil, false, nil
@@ -1522,11 +1521,11 @@ func canonicalizeLegacyMapChild(m map[string]any, canonical, path string) (map[s
 	}
 }
 
-func legacyAgentConfigFromMap(m map[string]any) (CLIAgentConfig, map[string]bool, error) {
+func legacyAgentConfigFromMap(m map[string]any, path string) (CLIAgentConfig, map[string]bool, error) {
 	var agent CLIAgentConfig
 	rewrite := make(map[string]bool)
 	stringField := func(canonical string, target *string) error {
-		raw, present, canonicalize, err := legacyMapValue(m, canonical)
+		raw, present, canonicalize, err := legacyMapValue(m, canonical, path)
 		if err != nil {
 			return err
 		}
@@ -1542,7 +1541,7 @@ func legacyAgentConfigFromMap(m map[string]any) (CLIAgentConfig, map[string]bool
 		return nil
 	}
 	boolField := func(canonical string, target *bool) error {
-		raw, present, canonicalize, err := legacyMapValue(m, canonical)
+		raw, present, canonicalize, err := legacyMapValue(m, canonical, path)
 		if err != nil {
 			return err
 		}
@@ -1584,7 +1583,7 @@ func legacyAgentConfigFromMap(m map[string]any) (CLIAgentConfig, map[string]bool
 	if err := boolField("no_session_persistence", &agent.NoSessionPersistence); err != nil {
 		return CLIAgentConfig{}, nil, err
 	}
-	raw, present, canonicalize, err := legacyMapValue(m, "max_turns")
+	raw, present, canonicalize, err := legacyMapValue(m, "max_turns", path)
 	if err != nil {
 		return CLIAgentConfig{}, nil, err
 	}
@@ -1614,57 +1613,28 @@ func legacyAgentConfigFromMap(m map[string]any) (CLIAgentConfig, map[string]bool
 
 func legacyDangerousBoolValue(m map[string]any) (value bool, present, canonicalize bool, err error) {
 	const canonical = "dangerously_skip_perms"
-	aliases := make([]string, 0, 1)
-	for key := range m {
-		if strings.EqualFold(key, canonical) {
-			aliases = append(aliases, key)
-		}
-	}
-	sort.Strings(aliases)
+	aliases := caseFoldedMapKeys(m, canonical)
 	if len(aliases) == 0 {
 		return false, false, false, nil
 	}
-	value = true
-	for _, key := range aliases {
-		candidate, ok := m[key].(bool)
-		if !ok {
-			return false, false, false, fmt.Errorf("%s must be a boolean", canonical)
-		}
-		if !candidate {
-			value = false
-		}
+	value, err = resolveFailClosedBool(m, aliases, canonical)
+	if err != nil {
+		return false, false, false, err
 	}
 	return value, true, len(aliases) != 1 || aliases[0] != canonical, nil
 }
 
-func legacyMapValue(m map[string]any, canonical string) (value any, present, canonicalize bool, err error) {
-	if exact, ok := m[canonical]; ok {
-		aliases := 0
-		for key := range m {
-			if key != canonical && strings.EqualFold(key, canonical) {
-				aliases++
-			}
-		}
-		return exact, true, aliases > 0, nil
-	}
-	aliases := make([]string, 0, 1)
-	for key := range m {
-		if strings.EqualFold(key, canonical) {
-			aliases = append(aliases, key)
-		}
-	}
-	sort.Strings(aliases)
-	switch len(aliases) {
-	case 0:
+func legacyMapValue(m map[string]any, canonical, path string) (value any, present, canonicalize bool, err error) {
+	aliases := caseFoldedMapKeys(m, canonical)
+	if len(aliases) == 0 {
 		return nil, false, false, nil
-	case 1:
-		return m[aliases[0]], true, true, nil
-	default:
-		return nil, false, false, fmt.Errorf(
-			"ambiguous aliases for %q (%s); keep a single canonical %q key",
-			canonical, strings.Join(aliases, ", "), canonical,
-		)
 	}
+	selected, discarded, err := selectCanonicalMapKey(aliases, canonical)
+	if err != nil {
+		return nil, false, false, err
+	}
+	warnDiscardedAliases(path, canonical, discarded)
+	return m[selected], true, selected != canonical || len(discarded) > 0, nil
 }
 
 func legacyMapInt(raw any) (int, error) {
@@ -1725,10 +1695,8 @@ func syncLegacyAgentBoolField(m map[string]any, canonical string, before, after 
 }
 
 func deleteLegacyAgentFieldAliases(m map[string]any, canonical string) {
-	for key := range m {
-		if strings.EqualFold(key, canonical) {
-			delete(m, key)
-		}
+	for _, key := range caseFoldedMapKeys(m, canonical) {
+		delete(m, key)
 	}
 }
 

--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -385,7 +386,7 @@ type CLIAgentConfig struct {
 	Effort               string `toml:"effort" json:"effort,omitempty"`                       // low|medium|high|max
 	PermissionMode       string `toml:"permission_mode" json:"permission_mode,omitempty"`     // default|auto|acceptEdits|dontAsk (bypassPermissions is explicitly forbidden)
 	Bare                 bool   `toml:"bare" json:"bare"`                                     // --bare
-	DangerouslySkipPerms bool   `toml:"dangerously_skip_perms" json:"dangerously_skip_perms"` // --dangerously-skip-permissions (cannot be set via HTTP API, see M-5)
+	DangerouslySkipPerms bool   `toml:"dangerously_skip_perms" json:"dangerously_skip_perms"` // --dangerously-skip-permissions (HTTP may only disable it, see M-5)
 	NoSessionPersistence bool   `toml:"no_session_persistence" json:"no_session_persistence"` // --no-session-persistence
 	ExecutionTimeout     string `toml:"execution_timeout" json:"execution_timeout,omitempty"` // per-agent override, e.g. "20m"
 }
@@ -1405,11 +1406,10 @@ func sanitizeLegacyAgentConfig(name string, agent CLIAgentConfig, source string)
 	}
 
 	opts, migrated := executor.MigrateLegacyTypedExtraFlagsForCLI(name, executor.ExecOptions{
-		Model:        agent.Model,
-		MaxTurns:     agent.MaxTurns,
-		ExtraFlags:   agent.ExtraFlags,
-		Effort:       agent.Effort,
-		ApprovalMode: agent.ApprovalMode,
+		Model:      agent.Model,
+		MaxTurns:   agent.MaxTurns,
+		ExtraFlags: agent.ExtraFlags,
+		Effort:     agent.Effort,
 	})
 	if len(migrated) > 0 {
 		slog.Warn("config: migrated legacy extra_flags to typed agent fields",
@@ -1419,6 +1419,11 @@ func sanitizeLegacyAgentConfig(name string, agent CLIAgentConfig, source string)
 	agent.MaxTurns = opts.MaxTurns
 	agent.Effort = opts.Effort
 	agent.ExtraFlags = opts.ExtraFlags
+	// MigrateLegacyTypedExtraFlagsForCLI currently emits only validated
+	// values. Keep the compatibility boundary defensive nevertheless: a
+	// future migration must not turn a formerly survivable legacy config into
+	// a startup failure by returning an unsafe typed value.
+	agent = sanitizeMigratedAgentExecutionFields(name, agent, source)
 	if err := executor.ValidateExtraFlagsForCLI(name, agent.ExtraFlags); err != nil {
 		slog.Warn("config: ignored unsafe legacy agent field",
 			"source", source, "agent", name, "field", "extra_flags", "err", err)
@@ -1427,59 +1432,115 @@ func sanitizeLegacyAgentConfig(name string, agent CLIAgentConfig, source string)
 	return agent
 }
 
+func sanitizeMigratedAgentExecutionFields(name string, agent CLIAgentConfig, source string) CLIAgentConfig {
+	agent.Model = strings.TrimSpace(agent.Model)
+	if err := executor.ValidateModel(agent.Model); err != nil {
+		slog.Warn("config: ignored unsafe migrated agent field",
+			"source", source, "agent", name, "field", "model", "err", err)
+		agent.Model = ""
+	}
+	if agent.MaxTurns < 0 {
+		slog.Warn("config: ignored invalid migrated agent field",
+			"source", source, "agent", name, "field", "max_turns",
+			"err", "value must be non-negative")
+		agent.MaxTurns = 0
+	}
+	if normalized, err := executor.NormalizeEffort(agent.Effort); err != nil {
+		slog.Warn("config: ignored unsafe migrated agent field",
+			"source", source, "agent", name, "field", "effort", "err", err)
+		agent.Effort = ""
+	} else {
+		agent.Effort = normalized
+	}
+	return agent
+}
+
 // SanitizeLegacyAgentExecutionPolicyMap migrates only the trusted agent
 // settings already present in a TOML map. HTTP handlers call this before
 // applying their separately validated payload, so an old local --model flag
 // cannot make an unrelated PATCH fail while a new HTTP --model flag remains a
-// strict 400. Unknown fields and the local-only dangerously_skip_perms gate are
-// left untouched.
+// strict 400. Known CLIAgentConfig leaves for supported providers are
+// canonicalized before any typed decode; unknown fields and inert provider
+// profiles remain untouched. Trusted dangerously_skip_perms values are
+// preserved, with conflicting aliases resolved fail-closed.
 func SanitizeLegacyAgentExecutionPolicyMap(m map[string]any, source string) error {
-	for aiKey, rawAI := range m {
-		if !strings.EqualFold(aiKey, "ai") {
+	ai, present, err := canonicalizeLegacyMapChild(m, "ai", "config")
+	if err != nil || !present {
+		return err
+	}
+	agents, present, err := canonicalizeLegacyMapChild(ai, "agents", "ai")
+	if err != nil || !present {
+		return err
+	}
+	for name, rawAgent := range agents {
+		if err := executor.ValidateCLIName(name); err != nil {
+			// Unknown profiles are intentionally inert and preserved exactly.
+			// Do not let newly introduced validation for supported providers
+			// turn a dormant future/legacy profile into a startup regression.
 			continue
 		}
-		ai, ok := rawAI.(map[string]any)
+		agentMap, ok := rawAgent.(map[string]any)
 		if !ok {
 			continue
 		}
-		for agentsKey, rawAgents := range ai {
-			if !strings.EqualFold(agentsKey, "agents") {
-				continue
-			}
-			agents, ok := rawAgents.(map[string]any)
-			if !ok {
-				continue
-			}
-			for name, rawAgent := range agents {
-				if err := executor.ValidateCLIName(name); err != nil {
-					continue
-				}
-				agentMap, ok := rawAgent.(map[string]any)
-				if !ok {
-					continue
-				}
-				before, rewrite, err := legacyAgentConfigFromMap(agentMap)
-				if err != nil {
-					return fmt.Errorf("config: sanitize legacy TOML agent %q: %w", name, err)
-				}
-				after := sanitizeLegacyAgentConfig(name, before, source)
-				syncLegacyAgentStringField(agentMap, "model", before.Model, after.Model, rewrite["model"])
-				syncLegacyAgentIntField(agentMap, "max_turns", before.MaxTurns, after.MaxTurns, rewrite["max_turns"])
-				syncLegacyAgentStringField(agentMap, "approval_mode", before.ApprovalMode, after.ApprovalMode, rewrite["approval_mode"])
-				syncLegacyAgentStringField(agentMap, "extra_flags", before.ExtraFlags, after.ExtraFlags, rewrite["extra_flags"])
-				syncLegacyAgentStringField(agentMap, "effort", before.Effort, after.Effort, rewrite["effort"])
-				syncLegacyAgentStringField(agentMap, "permission_mode", before.PermissionMode, after.PermissionMode, rewrite["permission_mode"])
-			}
+		before, rewrite, err := legacyAgentConfigFromMap(agentMap)
+		if err != nil {
+			return fmt.Errorf("config: sanitize legacy TOML agent %q: %w", name, err)
 		}
+		after := sanitizeLegacyAgentConfig(name, before, source)
+		syncLegacyAgentStringField(agentMap, "model", before.Model, after.Model, rewrite["model"])
+		syncLegacyAgentIntField(agentMap, "max_turns", before.MaxTurns, after.MaxTurns, rewrite["max_turns"])
+		syncLegacyAgentStringField(agentMap, "approval_mode", before.ApprovalMode, after.ApprovalMode, rewrite["approval_mode"])
+		syncLegacyAgentStringField(agentMap, "extra_flags", before.ExtraFlags, after.ExtraFlags, rewrite["extra_flags"])
+		syncLegacyAgentStringField(agentMap, "effort", before.Effort, after.Effort, rewrite["effort"])
+		syncLegacyAgentStringField(agentMap, "permission_mode", before.PermissionMode, after.PermissionMode, rewrite["permission_mode"])
+		syncLegacyAgentTrustedStringField(agentMap, "prompt", before.PromptID, after.PromptID, rewrite["prompt"])
+		syncLegacyAgentTrustedStringField(agentMap, "execution_timeout", before.ExecutionTimeout, after.ExecutionTimeout, rewrite["execution_timeout"])
+		syncLegacyAgentBoolField(agentMap, "bare", before.Bare, after.Bare, rewrite["bare"])
+		syncLegacyAgentBoolField(agentMap, "dangerously_skip_perms", before.DangerouslySkipPerms, after.DangerouslySkipPerms, rewrite["dangerously_skip_perms"])
+		syncLegacyAgentBoolField(agentMap, "no_session_persistence", before.NoSessionPersistence, after.NoSessionPersistence, rewrite["no_session_persistence"])
 	}
 	return nil
 }
 
+func canonicalizeLegacyMapChild(m map[string]any, canonical, path string) (map[string]any, bool, error) {
+	aliases := make([]string, 0, 1)
+	for key := range m {
+		if strings.EqualFold(key, canonical) {
+			aliases = append(aliases, key)
+		}
+	}
+	sort.Strings(aliases)
+	switch len(aliases) {
+	case 0:
+		return nil, false, nil
+	case 1:
+		key := aliases[0]
+		child, ok := m[key].(map[string]any)
+		if !ok {
+			return nil, false, fmt.Errorf("legacy TOML key %q must be a table", path+"."+key)
+		}
+		if key != canonical {
+			delete(m, key)
+			m[canonical] = child
+		}
+		return child, true, nil
+	default:
+		return nil, false, fmt.Errorf(
+			"ambiguous structural aliases at %q for %q (%s); keep a single canonical %q key",
+			path, canonical, strings.Join(aliases, ", "), canonical,
+		)
+	}
+}
+
 func legacyAgentConfigFromMap(m map[string]any) (CLIAgentConfig, map[string]bool, error) {
 	var agent CLIAgentConfig
-	rewrite := make(map[string]bool, 6)
+	rewrite := make(map[string]bool, 11)
 	stringField := func(canonical string, target *string) error {
-		raw, present, canonicalize := legacyMapValue(m, canonical)
+		raw, present, canonicalize, err := legacyMapValue(m, canonical)
+		if err != nil {
+			return err
+		}
 		rewrite[canonical] = canonicalize
 		if !present {
 			return nil
@@ -1487,6 +1548,22 @@ func legacyAgentConfigFromMap(m map[string]any) (CLIAgentConfig, map[string]bool
 		value, ok := raw.(string)
 		if !ok {
 			return fmt.Errorf("%s must be a string", canonical)
+		}
+		*target = value
+		return nil
+	}
+	boolField := func(canonical string, target *bool) error {
+		raw, present, canonicalize, err := legacyMapValue(m, canonical)
+		if err != nil {
+			return err
+		}
+		rewrite[canonical] = canonicalize
+		if !present {
+			return nil
+		}
+		value, ok := raw.(bool)
+		if !ok {
+			return fmt.Errorf("%s must be a boolean", canonical)
 		}
 		*target = value
 		return nil
@@ -1506,7 +1583,23 @@ func legacyAgentConfigFromMap(m map[string]any) (CLIAgentConfig, map[string]bool
 	if err := stringField("permission_mode", &agent.PermissionMode); err != nil {
 		return CLIAgentConfig{}, nil, err
 	}
-	if raw, present, canonicalize := legacyMapValue(m, "max_turns"); present {
+	if err := stringField("prompt", &agent.PromptID); err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	if err := stringField("execution_timeout", &agent.ExecutionTimeout); err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	if err := boolField("bare", &agent.Bare); err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	if err := boolField("no_session_persistence", &agent.NoSessionPersistence); err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	raw, present, canonicalize, err := legacyMapValue(m, "max_turns")
+	if err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	if present {
 		rewrite["max_turns"] = canonicalize
 		value, err := legacyMapInt(raw)
 		if err != nil {
@@ -1516,29 +1609,73 @@ func legacyAgentConfigFromMap(m map[string]any) (CLIAgentConfig, map[string]bool
 	} else {
 		rewrite["max_turns"] = canonicalize
 	}
+	dangerous, present, canonicalize, err := legacyDangerousBoolValue(m)
+	if err != nil {
+		return CLIAgentConfig{}, nil, err
+	}
+	rewrite["dangerously_skip_perms"] = canonicalize
+	if present {
+		// This is trusted TOML state. Preserve true exactly; the HTTP boundary
+		// separately prevents untrusted callers from granting the capability.
+		// Conflicting trusted aliases resolve fail-closed: any false wins.
+		agent.DangerouslySkipPerms = dangerous
+	}
 	return agent, rewrite, nil
 }
 
-func legacyMapValue(m map[string]any, canonical string) (value any, present, canonicalize bool) {
+func legacyDangerousBoolValue(m map[string]any) (value bool, present, canonicalize bool, err error) {
+	const canonical = "dangerously_skip_perms"
+	aliases := make([]string, 0, 1)
+	for key := range m {
+		if strings.EqualFold(key, canonical) {
+			aliases = append(aliases, key)
+		}
+	}
+	sort.Strings(aliases)
+	if len(aliases) == 0 {
+		return false, false, false, nil
+	}
+	value = true
+	for _, key := range aliases {
+		candidate, ok := m[key].(bool)
+		if !ok {
+			return false, false, false, fmt.Errorf("%s must be a boolean", canonical)
+		}
+		if !candidate {
+			value = false
+		}
+	}
+	return value, true, len(aliases) != 1 || aliases[0] != canonical, nil
+}
+
+func legacyMapValue(m map[string]any, canonical string) (value any, present, canonicalize bool, err error) {
 	if exact, ok := m[canonical]; ok {
-		value = exact
-		present = true
+		aliases := 0
+		for key := range m {
+			if key != canonical && strings.EqualFold(key, canonical) {
+				aliases++
+			}
+		}
+		return exact, true, aliases > 0, nil
 	}
-	matches := 0
-	for key, candidate := range m {
-		if !strings.EqualFold(key, canonical) {
-			continue
-		}
-		matches++
-		if !present {
-			value = candidate
-			present = true
-		}
-		if key != canonical {
-			canonicalize = true
+	aliases := make([]string, 0, 1)
+	for key := range m {
+		if strings.EqualFold(key, canonical) {
+			aliases = append(aliases, key)
 		}
 	}
-	return value, present, canonicalize || matches > 1
+	sort.Strings(aliases)
+	switch len(aliases) {
+	case 0:
+		return nil, false, false, nil
+	case 1:
+		return m[aliases[0]], true, true, nil
+	default:
+		return nil, false, false, fmt.Errorf(
+			"ambiguous aliases for %q (%s); keep a single canonical %q key",
+			canonical, strings.Join(aliases, ", "), canonical,
+		)
+	}
 }
 
 func legacyMapInt(raw any) (int, error) {
@@ -1572,6 +1709,14 @@ func syncLegacyAgentStringField(m map[string]any, canonical, before, after strin
 	}
 }
 
+func syncLegacyAgentTrustedStringField(m map[string]any, canonical, before, after string, canonicalize bool) {
+	if before == after && !canonicalize {
+		return
+	}
+	deleteLegacyAgentFieldAliases(m, canonical)
+	m[canonical] = after
+}
+
 func syncLegacyAgentIntField(m map[string]any, canonical string, before, after int, canonicalize bool) {
 	if before == after && !canonicalize {
 		return
@@ -1580,6 +1725,14 @@ func syncLegacyAgentIntField(m map[string]any, canonical string, before, after i
 	if after != 0 {
 		m[canonical] = int64(after)
 	}
+}
+
+func syncLegacyAgentBoolField(m map[string]any, canonical string, before, after bool, canonicalize bool) {
+	if before == after && !canonicalize {
+		return
+	}
+	deleteLegacyAgentFieldAliases(m, canonical)
+	m[canonical] = after
 }
 
 func deleteLegacyAgentFieldAliases(m map[string]any, canonical string) {
@@ -1798,8 +1951,24 @@ func Load(path string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("config: read %s: %w", path, err)
 	}
+	// Decode through a generic map first. BurntSushi's struct decoder matches
+	// TOML keys case-insensitively, so legacy aliases such as Model/MODEL can
+	// otherwise race on Go map iteration and produce different configs across
+	// reloads. Canonicalize or reject them deterministically before the typed
+	// decode used by the runtime.
+	var raw map[string]any
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("config: parse %s: %w", path, err)
+	}
+	if err := SanitizeLegacyAgentExecutionPolicyMap(raw, "toml load"); err != nil {
+		return nil, fmt.Errorf("config: sanitize %s: %w", path, err)
+	}
+	var canonical strings.Builder
+	if err := toml.NewEncoder(&canonical).Encode(raw); err != nil {
+		return nil, fmt.Errorf("config: canonicalize %s: %w", path, err)
+	}
 	var cfg Config
-	if err := toml.Unmarshal(data, &cfg); err != nil {
+	if err := toml.Unmarshal([]byte(canonical.String()), &cfg); err != nil {
 		return nil, fmt.Errorf("config: parse %s: %w", path, err)
 	}
 	cfg.applyDefaults()

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -2341,6 +2341,288 @@ model = "preserve-inert-profile"
 	}
 }
 
+func TestLoad_CanonicalizesAgentAliasesBeforeTypedDecode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `
+[AI]
+primary = "claude"
+
+[AI.Agents.codex]
+model = "canonical-model"
+Model = "first-alias"
+MODEL = "second-alias"
+Prompt = "trusted-profile"
+BARE = true
+DANGEROUSLY_SKIP_PERMS = true
+NO_SESSION_PERSISTENCE = true
+EXECUTION_TIMEOUT = "20m"
+
+[AI.Agents.Claude]
+model = "--sandbox"
+permission_mode = "bypassPermissions"
+DANGEROUSLY_SKIP_PERMS = true
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HEIMDALLM_AI_PRIMARY", "gemini")
+
+	for i := 0; i < 64; i++ {
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load iteration %d: %v", i, err)
+		}
+		if cfg.AI.Primary != "gemini" {
+			t.Fatalf("iteration %d: env precedence changed, primary = %q", i, cfg.AI.Primary)
+		}
+		if cfg.GitHub.PollInterval != "5m" {
+			t.Fatalf("iteration %d: default precedence changed, poll_interval = %q", i, cfg.GitHub.PollInterval)
+		}
+		got := cfg.AI.Agents["codex"]
+		if got.Model != "canonical-model" ||
+			got.PromptID != "trusted-profile" ||
+			!got.Bare ||
+			!got.DangerouslySkipPerms ||
+			!got.NoSessionPersistence ||
+			got.ExecutionTimeout != "20m" {
+			t.Fatalf("iteration %d: aliases decoded inconsistently: %+v", i, got)
+		}
+		inert, ok := cfg.AI.Agents["Claude"]
+		if !ok ||
+			inert.Model != "--sandbox" ||
+			inert.PermissionMode != "bypassPermissions" ||
+			!inert.DangerouslySkipPerms {
+			t.Fatalf("iteration %d: case-variant CLI profile was not preserved inert: %+v", i, inert)
+		}
+		if _, active := cfg.AI.Agents["claude"]; active {
+			t.Fatalf("iteration %d: inert Claude profile was activated as canonical claude", i)
+		}
+	}
+	gotContent, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotContent) != content {
+		t.Fatalf("Load rewrote inert profile:\n%s", gotContent)
+	}
+}
+
+func TestLoad_RejectsAmbiguousAliasesDeterministically(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		marker  string
+	}{
+		{
+			name: "agent leaf aliases",
+			content: `
+[ai]
+primary = "codex"
+[ai.agents.codex]
+Model = "first"
+MODEL = "second"
+`,
+			marker: `ambiguous aliases for "model" (MODEL, Model)`,
+		},
+		{
+			name: "structural aliases",
+			content: `
+[ai]
+primary = "codex"
+[AI]
+fallback = "gemini"
+`,
+			marker: `ambiguous structural aliases at "config" for "ai" (AI, ai)`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			var first string
+			for i := 0; i < 64; i++ {
+				_, err := Load(path)
+				if err == nil {
+					t.Fatalf("Load iteration %d unexpectedly accepted ambiguous aliases", i)
+				}
+				if !strings.Contains(err.Error(), tc.marker) {
+					t.Fatalf("iteration %d: error %q missing %q", i, err, tc.marker)
+				}
+				if i == 0 {
+					first = err.Error()
+				} else if err.Error() != first {
+					t.Fatalf("nondeterministic errors:\nfirst: %s\niteration %d: %s", first, i, err)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeMigratedAgentExecutionFields_RevalidatesOutputs(t *testing.T) {
+	got := sanitizeMigratedAgentExecutionFields("claude", CLIAgentConfig{
+		Model:        " --sandbox ",
+		MaxTurns:     -1,
+		Effort:       "impossible",
+		ApprovalMode: "default",
+	}, "test migration")
+
+	if got.Model != "" || got.MaxTurns != 0 || got.Effort != "" {
+		t.Fatalf("unsafe migrated typed outputs survived: %+v", got)
+	}
+	if got.ApprovalMode != "default" {
+		t.Fatalf("unrelated typed field changed: %+v", got)
+	}
+
+	safe := sanitizeMigratedAgentExecutionFields("claude", CLIAgentConfig{
+		Model:    " safe-model ",
+		MaxTurns: 7,
+		Effort:   "HIGH",
+	}, "test migration")
+	if safe.Model != "safe-model" || safe.MaxTurns != 7 || safe.Effort != "high" {
+		t.Fatalf("safe migrated typed outputs were not canonicalized: %+v", safe)
+	}
+}
+
+func TestSanitizeLegacyAgentExecutionPolicyMap_CanonicalExactWinsAliases(t *testing.T) {
+	agent := map[string]any{
+		"model":                  "canonical-model",
+		"Model":                  "first-alias",
+		"MODEL":                  "second-alias",
+		"prompt":                 "canonical-prompt",
+		"Prompt":                 "alias-prompt",
+		"bare":                   true,
+		"Bare":                   false,
+		"no_session_persistence": false,
+		"No_Session_Persistence": true,
+		"execution_timeout":      "20m",
+		"Execution_Timeout":      "1m",
+	}
+	m := map[string]any{
+		"ai": map[string]any{
+			"agents": map[string]any{"codex": agent},
+		},
+	}
+
+	if err := SanitizeLegacyAgentExecutionPolicyMap(m, "test TOML"); err != nil {
+		t.Fatalf("sanitize canonical plus aliases: %v", err)
+	}
+	if got := agent["model"]; got != "canonical-model" {
+		t.Fatalf("canonical exact key did not win: %v", agent)
+	}
+	if _, present := agent["Model"]; present {
+		t.Fatalf("mixed-case alias was not removed: %v", agent)
+	}
+	if _, present := agent["MODEL"]; present {
+		t.Fatalf("uppercase alias was not removed: %v", agent)
+	}
+	if agent["prompt"] != "canonical-prompt" ||
+		agent["bare"] != true ||
+		agent["no_session_persistence"] != false ||
+		agent["execution_timeout"] != "20m" {
+		t.Fatalf("pass-through canonical leaves did not win: %v", agent)
+	}
+	for _, alias := range []string{"Prompt", "Bare", "No_Session_Persistence", "Execution_Timeout"} {
+		if _, present := agent[alias]; present {
+			t.Fatalf("pass-through alias %q was not removed: %v", alias, agent)
+		}
+	}
+}
+
+func TestSanitizeLegacyAgentExecutionPolicyMap_DangerousAliasesFailClosed(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags map[string]any
+		want  bool
+	}{
+		{
+			name:  "single canonical true",
+			flags: map[string]any{"dangerously_skip_perms": true},
+			want:  true,
+		},
+		{
+			name:  "single alias true",
+			flags: map[string]any{"DANGEROUSLY_SKIP_PERMS": true},
+			want:  true,
+		},
+		{
+			name: "canonical true plus alias false",
+			flags: map[string]any{
+				"dangerously_skip_perms": true,
+				"DANGEROUSLY_SKIP_PERMS": false,
+			},
+			want: false,
+		},
+		{
+			name: "aliases all true",
+			flags: map[string]any{
+				"Dangerously_Skip_Perms": true,
+				"DANGEROUSLY_SKIP_PERMS": true,
+			},
+			want: true,
+		},
+		{
+			name: "aliases mixed",
+			flags: map[string]any{
+				"Dangerously_Skip_Perms": true,
+				"DANGEROUSLY_SKIP_PERMS": false,
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := make(map[string]any, len(tc.flags))
+			for key, value := range tc.flags {
+				agent[key] = value
+			}
+			m := map[string]any{
+				"ai": map[string]any{
+					"agents": map[string]any{"claude": agent},
+				},
+			}
+			if err := SanitizeLegacyAgentExecutionPolicyMap(m, "test TOML"); err != nil {
+				t.Fatalf("sanitize dangerous aliases: %v", err)
+			}
+			if got, ok := agent["dangerously_skip_perms"].(bool); !ok || got != tc.want {
+				t.Fatalf("canonical dangerous value = %v, want %v (map: %v)", got, tc.want, agent)
+			}
+			for key := range agent {
+				if key != "dangerously_skip_perms" && strings.EqualFold(key, "dangerously_skip_perms") {
+					t.Fatalf("dangerous alias %q survived: %v", key, agent)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeLegacyAgentExecutionPolicyMap_RejectsAmbiguousAliases(t *testing.T) {
+	agent := map[string]any{
+		"Model": "first-alias",
+		"MODEL": "second-alias",
+	}
+	m := map[string]any{
+		"ai": map[string]any{
+			"agents": map[string]any{"codex": agent},
+		},
+	}
+
+	err := SanitizeLegacyAgentExecutionPolicyMap(m, "test TOML")
+	if err == nil {
+		t.Fatal("ambiguous aliases unexpectedly accepted")
+	}
+	got := err.Error()
+	for _, want := range []string{`ambiguous aliases for "model"`, "MODEL, Model", `canonical "model"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error %q does not contain actionable detail %q", got, want)
+		}
+	}
+}
+
 // ── LoadOrCreate ─────────────────────────────────────────────────────────────
 
 func TestLoadOrCreate_Creates(t *testing.T) {

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -2319,6 +2319,69 @@ unknown_mixed = [3, "repo"]
 	}
 }
 
+func TestLoad_KnownMixedArrayReportsFieldPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[github]
+repositories = ["org/repo", 1]
+
+[ai]
+primary = "claude"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load accepted a mixed array for github.repositories")
+	}
+	for _, marker := range []string{
+		"config.github.repositories",
+		"TOML array has mixed element types",
+		"expected []string",
+	} {
+		if !strings.Contains(err.Error(), marker) {
+			t.Fatalf("Load error %q missing %q", err, marker)
+		}
+	}
+}
+
+func TestLoad_WarnsWhenCanonicalKeyDiscardsAliases(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[ai]
+primary = "claude"
+PRIMARY = "codex"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load canonical plus alias: %v", err)
+	}
+	if cfg.AI.Primary != "claude" {
+		t.Fatalf("canonical primary did not win: %q", cfg.AI.Primary)
+	}
+	for _, marker := range []string{
+		"ignored case-variant aliases",
+		"path=config.ai",
+		"field=primary",
+		"PRIMARY",
+	} {
+		if !strings.Contains(logs.String(), marker) {
+			t.Fatalf("alias warning %q missing %q", logs.String(), marker)
+		}
+	}
+}
+
 func TestLoad_CanonicalizesSchemaFieldsWithoutFoldingDynamicMapKeys(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	content := `
@@ -2447,12 +2510,6 @@ model = "--sandbox"
 	}
 	if got := strings.Count(logs.String(), "field=model"); got != 1 {
 		t.Fatalf("model sanitation warnings = %d, want 1:\n%s", got, logs.String())
-	}
-}
-
-func TestProjectKnownConfigMap_CurrentSchemaIsSupported(t *testing.T) {
-	if _, err := projectKnownConfigMap(map[string]any{}); err != nil {
-		t.Fatalf("Config schema is unsupported by canonical projection: %v", err)
 	}
 }
 
@@ -2676,6 +2733,11 @@ func TestSanitizeAgentExecutionFields_RevalidatesMigratedOutputs(t *testing.T) {
 }
 
 func TestSanitizeLegacyAgentExecutionPolicyMap_CanonicalExactWinsAliases(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
 	agent := map[string]any{
 		"model":                  "canonical-model",
 		"Model":                  "first-alias",
@@ -2716,6 +2778,17 @@ func TestSanitizeLegacyAgentExecutionPolicyMap_CanonicalExactWinsAliases(t *test
 	for _, alias := range []string{"Prompt", "Bare", "No_Session_Persistence", "Execution_Timeout"} {
 		if _, present := agent[alias]; present {
 			t.Fatalf("pass-through alias %q was not removed: %v", alias, agent)
+		}
+	}
+	for _, marker := range []string{
+		"ignored case-variant aliases",
+		"config.ai.agents",
+		"field=model",
+		"MODEL",
+		"Model",
+	} {
+		if !strings.Contains(logs.String(), marker) {
+			t.Fatalf("legacy alias warning %q missing %q", logs.String(), marker)
 		}
 	}
 }

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -2288,6 +2288,59 @@ primary = "claude"
 	}
 }
 
+func TestLoad_SanitizesLegacyAgentPolicyWithoutBlockingStartup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `
+[github]
+poll_interval = "10m"
+
+[ai]
+primary = "codex"
+
+[ai.agents.codex]
+approval_mode = "ON-REQUEST"
+extra_flags = "--model gpt-5 --json"
+
+[ai.agents.gemini]
+approval_mode = "YOLO"
+extra_flags = "--sandbox"
+
+[ai.agents.claude]
+effort = "HIGH"
+permission_mode = "ACCEPTEDITS"
+
+[ai.agents.future_cli]
+model = "preserve-inert-profile"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load legacy config: %v", err)
+	}
+	if cfg.GitHub.PollInterval != "10m" {
+		t.Fatalf("unrelated config lost: poll_interval = %q", cfg.GitHub.PollInterval)
+	}
+	codex := cfg.AI.Agents["codex"]
+	if codex.Model != "gpt-5" || codex.ApprovalMode != "on-request" || codex.ExtraFlags != "--json" {
+		t.Fatalf("Codex legacy policy was not migrated safely: %+v", codex)
+	}
+	gemini := cfg.AI.Agents["gemini"]
+	if gemini.ApprovalMode != "" || gemini.ExtraFlags != "" {
+		t.Fatalf("unsafe Gemini legacy policy survived: %+v", gemini)
+	}
+	claude := cfg.AI.Agents["claude"]
+	if claude.Effort != "high" || claude.PermissionMode != "acceptEdits" {
+		t.Fatalf("safe casing was not canonicalized: %+v", claude)
+	}
+	if got := cfg.AI.Agents["future_cli"].Model; got != "preserve-inert-profile" {
+		t.Fatalf("unknown inert profile was not preserved: %q", got)
+	}
+}
+
 // ── LoadOrCreate ─────────────────────────────────────────────────────────────
 
 func TestLoadOrCreate_Creates(t *testing.T) {
@@ -2895,7 +2948,7 @@ func TestValidateAgentExecutionPolicy(t *testing.T) {
 		{
 			name: "safe provider flags and typed modes",
 			agents: map[string]CLIAgentConfig{
-				"claude": {ExtraFlags: "--model opus --max-turns 5", PermissionMode: "acceptEdits"},
+				"claude": {Model: "opus", MaxTurns: 5, ExtraFlags: "--verbose", PermissionMode: "ACCEPTEDITS", Effort: "HIGH"},
 				"codex":  {ExtraFlags: "--json --color never", ApprovalMode: "on-request"},
 				"gemini": {ExtraFlags: "--output-format json", ApprovalMode: "auto_edit"},
 			},
@@ -2939,6 +2992,12 @@ func TestValidateAgentExecutionPolicy(t *testing.T) {
 			name: "unknown CLI config",
 			agents: map[string]CLIAgentConfig{
 				"other": {},
+			},
+		},
+		{
+			name: "negative max turns",
+			agents: map[string]CLIAgentConfig{
+				"claude": {MaxTurns: -1},
 			},
 			wantErr: true,
 		},

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -2877,3 +2877,84 @@ func TestNeverApproveMinSeverity_Validate(t *testing.T) {
 		t.Errorf("invalid repo value accepted")
 	}
 }
+
+func TestValidateAgentExecutionPolicy(t *testing.T) {
+	base := func() *Config {
+		c := &Config{}
+		c.applyDefaults()
+		c.AI.Primary = "claude"
+		c.GitHub.PollInterval = "1m"
+		return c
+	}
+
+	tests := []struct {
+		name    string
+		agents  map[string]CLIAgentConfig
+		wantErr bool
+	}{
+		{
+			name: "safe provider flags and typed modes",
+			agents: map[string]CLIAgentConfig{
+				"claude": {ExtraFlags: "--model opus --max-turns 5", PermissionMode: "acceptEdits"},
+				"codex":  {ExtraFlags: "--json --color never", ApprovalMode: "on-request"},
+				"gemini": {ExtraFlags: "--output-format json", ApprovalMode: "auto_edit"},
+			},
+		},
+		{
+			name: "legacy Codex sandbox override",
+			agents: map[string]CLIAgentConfig{
+				"codex": {ExtraFlags: "--sandbox danger-full-access"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "legacy Gemini approval override",
+			agents: map[string]CLIAgentConfig{
+				"gemini": {ExtraFlags: "--approval-mode=yolo"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsafe typed Gemini approval",
+			agents: map[string]CLIAgentConfig{
+				"gemini": {ApprovalMode: "yolo"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "option-shaped typed model",
+			agents: map[string]CLIAgentConfig{
+				"claude": {Model: "--dangerously-skip-permissions"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid typed effort",
+			agents: map[string]CLIAgentConfig{
+				"claude": {Effort: "--dangerously-skip-permissions"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown CLI config",
+			agents: map[string]CLIAgentConfig{
+				"other": {},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := base()
+			c.AI.Agents = tc.agents
+			err := c.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("expected agent execution policy error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected agent execution policy error: %v", err)
+			}
+		})
+	}
+}

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2288,6 +2290,172 @@ primary = "claude"
 	}
 }
 
+func TestLoad_IgnoresUnknownMixedArraysOutsideTypedSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := `
+unknown_mixed = [1, "top-level"]
+
+[ai]
+primary = "claude"
+unknown_mixed = [2, "ai"]
+
+[ai.repos."Org/Repo"]
+primary = "codex"
+unknown_mixed = [3, "repo"]
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load with unknown mixed arrays: %v", err)
+	}
+	if cfg.AI.Primary != "claude" {
+		t.Fatalf("known sibling ai.primary = %q, want claude", cfg.AI.Primary)
+	}
+	if got := cfg.AI.Repos["Org/Repo"].Primary; got != "codex" {
+		t.Fatalf("known nested repo primary = %q, want codex", got)
+	}
+}
+
+func TestLoad_CanonicalizesSchemaFieldsWithoutFoldingDynamicMapKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[GITHUB]
+POLL_INTERVAL = "10m"
+
+[AI]
+primary = "claude"
+PRIMARY = "codex"
+
+[AI.AGENTS.Claude]
+MODEL = "preserve-inert"
+
+[AI.AGENTS.claude]
+MODEL = "active-model"
+
+[AI.REPOS."Org/Repo"]
+PRIMARY = "codex"
+
+[AI.REPOS."org/repo"]
+PRIMARY = "gemini"
+
+[AI.REPOS."Org/Repo".ISSUE_TRACKING]
+ENABLED = true
+unknown_mixed = [4, "pointer"]
+
+[AUTONOMOUS.REPOS."Org/Repo"]
+ENABLED = true
+
+[AUTONOMOUS.REPOS."org/repo"]
+ENABLED = false
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load aliases: %v", err)
+	}
+	if cfg.AI.Primary != "claude" {
+		t.Fatalf("exact canonical primary did not win its alias: %q", cfg.AI.Primary)
+	}
+	if cfg.GitHub.PollInterval != "10m" {
+		t.Fatalf("generic GitHub alias was not canonicalized: %q", cfg.GitHub.PollInterval)
+	}
+	if got := cfg.AI.Agents["Claude"].Model; got != "preserve-inert" {
+		t.Fatalf("case-sensitive inert agent key was changed: %q", got)
+	}
+	if got := cfg.AI.Agents["claude"].Model; got != "active-model" {
+		t.Fatalf("supported agent key or aliased field was lost: %q", got)
+	}
+	if len(cfg.AI.Agents) != 2 {
+		t.Fatalf("case-distinct agent keys collapsed: %#v", cfg.AI.Agents)
+	}
+	upperRepo, upperOK := cfg.AI.Repos["Org/Repo"]
+	lowerRepo, lowerOK := cfg.AI.Repos["org/repo"]
+	if !upperOK || !lowerOK || len(cfg.AI.Repos) != 2 {
+		t.Fatalf("case-distinct repo keys collapsed: %#v", cfg.AI.Repos)
+	}
+	if upperRepo.Primary != "codex" || upperRepo.IssueTracking == nil ||
+		upperRepo.IssueTracking.Enabled == nil || !*upperRepo.IssueTracking.Enabled {
+		t.Fatalf("upper-case repo fields/pointer were not decoded: %+v", upperRepo)
+	}
+	if lowerRepo.Primary != "gemini" {
+		t.Fatalf("lower-case repo primary = %q, want gemini", lowerRepo.Primary)
+	}
+	upperAuto, upperAutoOK := cfg.Autonomous.Repos["Org/Repo"]
+	lowerAuto, lowerAutoOK := cfg.Autonomous.Repos["org/repo"]
+	if !upperAutoOK || !lowerAutoOK || len(cfg.Autonomous.Repos) != 2 {
+		t.Fatalf("case-distinct autonomous repo keys collapsed: %#v", cfg.Autonomous.Repos)
+	}
+	if upperAuto.Enabled == nil || !*upperAuto.Enabled ||
+		lowerAuto.Enabled == nil || *lowerAuto.Enabled {
+		t.Fatalf("autonomous pointer aliases were not decoded: %#v", cfg.Autonomous.Repos)
+	}
+}
+
+func TestLoad_DangerousAliasesRemainFailClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[ai]
+primary = "claude"
+
+[ai.agents.claude]
+dangerously_skip_perms = true
+DANGEROUSLY_SKIP_PERMS = false
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load dangerous aliases: %v", err)
+	}
+	if cfg.AI.Agents["claude"].DangerouslySkipPerms {
+		t.Fatal("false dangerous alias did not override canonical true")
+	}
+}
+
+func TestLoad_SanitizesLegacyAgentFieldOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[ai]
+primary = "claude"
+
+[ai.agents.claude]
+model = "--sandbox"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load unsafe legacy field: %v", err)
+	}
+	if cfg.AI.Agents["claude"].Model != "" {
+		t.Fatalf("unsafe model survived: %+v", cfg.AI.Agents["claude"])
+	}
+	if got := strings.Count(logs.String(), "field=model"); got != 1 {
+		t.Fatalf("model sanitation warnings = %d, want 1:\n%s", got, logs.String())
+	}
+}
+
+func TestProjectKnownConfigMap_CurrentSchemaIsSupported(t *testing.T) {
+	if _, err := projectKnownConfigMap(map[string]any{}); err != nil {
+		t.Fatalf("Config schema is unsupported by canonical projection: %v", err)
+	}
+}
+
 func TestLoad_SanitizesLegacyAgentPolicyWithoutBlockingStartup(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
@@ -2426,6 +2594,26 @@ MODEL = "second"
 			marker: `ambiguous aliases for "model" (MODEL, Model)`,
 		},
 		{
+			name: "generic leaf aliases",
+			content: `
+[ai]
+Primary = "claude"
+PRIMARY = "codex"
+`,
+			marker: `ambiguous aliases for "primary" (PRIMARY, Primary)`,
+		},
+		{
+			name: "nested dynamic map leaf aliases",
+			content: `
+[ai]
+primary = "claude"
+[ai.repos."Org/Repo"]
+Primary = "codex"
+PRIMARY = "gemini"
+`,
+			marker: `config.ai.repos["Org/Repo"]: ambiguous aliases for "primary" (PRIMARY, Primary)`,
+		},
+		{
 			name: "structural aliases",
 			content: `
 [ai]
@@ -2462,13 +2650,13 @@ fallback = "gemini"
 	}
 }
 
-func TestSanitizeMigratedAgentExecutionFields_RevalidatesOutputs(t *testing.T) {
-	got := sanitizeMigratedAgentExecutionFields("claude", CLIAgentConfig{
+func TestSanitizeAgentExecutionFields_RevalidatesMigratedOutputs(t *testing.T) {
+	got := sanitizeAgentExecutionFields("claude", CLIAgentConfig{
 		Model:        " --sandbox ",
 		MaxTurns:     -1,
 		Effort:       "impossible",
 		ApprovalMode: "default",
-	}, "test migration")
+	}, "test migration", "migrated")
 
 	if got.Model != "" || got.MaxTurns != 0 || got.Effort != "" {
 		t.Fatalf("unsafe migrated typed outputs survived: %+v", got)
@@ -2477,11 +2665,11 @@ func TestSanitizeMigratedAgentExecutionFields_RevalidatesOutputs(t *testing.T) {
 		t.Fatalf("unrelated typed field changed: %+v", got)
 	}
 
-	safe := sanitizeMigratedAgentExecutionFields("claude", CLIAgentConfig{
+	safe := sanitizeAgentExecutionFields("claude", CLIAgentConfig{
 		Model:    " safe-model ",
 		MaxTurns: 7,
 		Effort:   "HIGH",
-	}, "test migration")
+	}, "test migration", "migrated")
 	if safe.Model != "safe-model" || safe.MaxTurns != 7 || safe.Effort != "high" {
 		t.Fatalf("safe migrated typed outputs were not canonicalized: %+v", safe)
 	}

--- a/daemon/internal/config/config_test.go
+++ b/daemon/internal/config/config_test.go
@@ -2320,30 +2320,59 @@ unknown_mixed = [3, "repo"]
 }
 
 func TestLoad_KnownMixedArrayReportsFieldPath(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "config.toml")
-	content := `
+	tests := []struct {
+		name     string
+		content  string
+		path     string
+		expected string
+	}{
+		{
+			name: "slice field",
+			content: `
 [github]
 repositories = ["org/repo", 1]
 
 [ai]
 primary = "claude"
-`
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
+`,
+			path:     "config.github.repositories",
+			expected: "[]string",
+		},
+		{
+			name: "scalar field",
+			content: `
+[ai]
+primary = "claude"
+
+[ai.agents.claude]
+model = ["safe-model", 1]
+`,
+			path:     `config.ai.agents["claude"].model`,
+			expected: "string",
+		},
 	}
 
-	_, err := Load(path)
-	if err == nil {
-		t.Fatal("Load accepted a mixed array for github.repositories")
-	}
-	for _, marker := range []string{
-		"config.github.repositories",
-		"TOML array has mixed element types",
-		"expected []string",
-	} {
-		if !strings.Contains(err.Error(), marker) {
-			t.Fatalf("Load error %q missing %q", err, marker)
-		}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("Load accepted a mixed array for a known field")
+			}
+			for _, marker := range []string{
+				tc.path,
+				"TOML array has mixed element types",
+				"expected " + tc.expected,
+			} {
+				if !strings.Contains(err.Error(), marker) {
+					t.Fatalf("Load error %q missing %q", err, marker)
+				}
+			}
+		})
 	}
 }
 

--- a/daemon/internal/config/store.go
+++ b/daemon/internal/config/store.go
@@ -198,15 +198,38 @@ func mergeStoredAgentConfig(cli string, base CLIAgentConfig, payload json.RawMes
 		return base, false, err
 	}
 
-	for field := range fields {
-		if strings.EqualFold(field, "dangerously_skip_perms") {
-			slog.Warn("config: ignoring HTTP/store override of dangerously_skip_perms (M-5 gate)",
-				"agent", cli)
+	dangerousPresent := false
+	disableDangerous := false
+	for field, raw := range fields {
+		if !strings.EqualFold(field, "dangerously_skip_perms") {
+			continue
+		}
+		dangerousPresent = true
+		var requested bool
+		if err := json.Unmarshal(raw, &requested); err != nil {
+			return base, false, fmt.Errorf("dangerously_skip_perms must be a boolean: %w", err)
+		}
+		if !requested {
+			disableDangerous = true
 		}
 	}
-	// Store rows originate from the HTTP API and are never trusted to alter
-	// this filesystem-only gate, including through a case-variant alias.
-	candidate.DangerouslySkipPerms = base.DangerouslySkipPerms
+	switch {
+	case disableDangerous:
+		// HTTP/store is allowed to reduce privilege even when trusted TOML/env
+		// enabled the bypass. If a malformed legacy row contains conflicting
+		// aliases, the safer false value wins deterministically.
+		candidate.DangerouslySkipPerms = false
+		slog.Info("config: applied HTTP/store disable of dangerously_skip_perms (M-5 gate)",
+			"agent", cli)
+	case dangerousPresent:
+		// A stored true must never grant the filesystem-only capability. Keep
+		// a trusted base true if one already exists, otherwise remain false.
+		candidate.DangerouslySkipPerms = base.DangerouslySkipPerms
+		slog.Warn("config: ignored HTTP/store attempt to enable dangerously_skip_perms (M-5 gate)",
+			"agent", cli)
+	default:
+		candidate.DangerouslySkipPerms = base.DangerouslySkipPerms
+	}
 
 	if storeAgentFieldPresent(fields, "model") {
 		candidate.Model = strings.TrimSpace(candidate.Model)
@@ -248,11 +271,10 @@ func mergeStoredAgentConfig(cli string, base CLIAgentConfig, payload json.RawMes
 		maxTurnsPresent := storeAgentFieldPresent(fields, "max_turns")
 		effortPresent := storeAgentFieldPresent(fields, "effort")
 		migrationInput := executor.ExecOptions{
-			Model:        candidate.Model,
-			MaxTurns:     candidate.MaxTurns,
-			ApprovalMode: candidate.ApprovalMode,
-			ExtraFlags:   candidate.ExtraFlags,
-			Effort:       candidate.Effort,
+			Model:      candidate.Model,
+			MaxTurns:   candidate.MaxTurns,
+			ExtraFlags: candidate.ExtraFlags,
+			Effort:     candidate.Effort,
 		}
 		// A legacy typed flag belongs to the store layer. When the same stored
 		// payload does not contain the corresponding typed field, let the
@@ -275,11 +297,27 @@ func mergeStoredAgentConfig(cli string, base CLIAgentConfig, payload json.RawMes
 		for _, field := range migrated {
 			switch field {
 			case "model":
-				candidate.Model = opts.Model
+				model := strings.TrimSpace(opts.Model)
+				if err := executor.ValidateModel(model); err != nil {
+					warnIgnoredStoreAgentField(cli, "model", err)
+					candidate.Model = base.Model
+				} else {
+					candidate.Model = model
+				}
 			case "max_turns":
-				candidate.MaxTurns = opts.MaxTurns
+				if opts.MaxTurns < 0 {
+					warnIgnoredStoreAgentField(cli, "max_turns", fmt.Errorf("value must be non-negative"))
+					candidate.MaxTurns = base.MaxTurns
+				} else {
+					candidate.MaxTurns = opts.MaxTurns
+				}
 			case "effort":
-				candidate.Effort = opts.Effort
+				if normalized, err := executor.NormalizeEffort(opts.Effort); err != nil {
+					warnIgnoredStoreAgentField(cli, "effort", err)
+					candidate.Effort = base.Effort
+				} else {
+					candidate.Effort = normalized
+				}
 			}
 		}
 		candidate.ExtraFlags = opts.ExtraFlags

--- a/daemon/internal/config/store.go
+++ b/daemon/internal/config/store.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+
+	"github.com/heimdallm/daemon/internal/executor"
 )
 
 // StoreLister is the subset of *store.Store that ApplyStore needs. Kept as a
@@ -59,11 +61,12 @@ func (c *Config) MergeStoreLayer(s StoreLister) error {
 // single malformed row therefore leaves the receiver untouched, so the
 // caller's error-path ("continuing with TOML+env") is truthful.
 //
-// cloneStoreMergeConfig copies the mutable slices touched below, and the
-// agent_configs branch replaces its map wholesale. If a future store key
-// mutates another map/slice in place, add it to that helper first.
+// cloneStoreMergeConfig copies the mutable slices and agents map touched below.
+// If a future store key mutates another map/slice in place, add it to that
+// helper first.
 func (c *Config) ApplyStore(rows map[string]string) error {
 	shadow := cloneStoreMergeConfig(c)
+	shadow.sanitizeLegacyAgentExecutionPolicy("pre-store config")
 	var storeRepos []string
 	var storeNonMonitored []string
 	var sawStoreRepos bool
@@ -148,26 +151,16 @@ func (c *Config) ApplyStore(rows map[string]string) error {
 				merged[k] = v
 			}
 			for cli, payload := range perCLI {
-				existing := merged[cli]
-				trustedDangerouslySkipPerms := existing.DangerouslySkipPerms
-				var fields map[string]json.RawMessage
-				if err := json.Unmarshal(payload, &fields); err != nil {
+				base, existed := merged[cli]
+				candidate, apply, err := mergeStoredAgentConfig(cli, base, payload)
+				if err != nil {
 					return fmt.Errorf("config: apply store key %q: agent %q: %w", key, cli, err)
 				}
-				for field := range fields {
-					if strings.EqualFold(field, "dangerously_skip_perms") {
-						slog.Warn("config: ignoring HTTP/store override of dangerously_skip_perms (M-5 gate)",
-							"agent", cli)
-					}
+				if apply {
+					merged[cli] = candidate
+				} else if !existed {
+					delete(merged, cli)
 				}
-				if err := json.Unmarshal(payload, &existing); err != nil {
-					return fmt.Errorf("config: apply store key %q: agent %q: %w", key, cli, err)
-				}
-				// Store rows originate from the HTTP API and are never trusted
-				// to alter this filesystem-only gate. Preserve the TOML/env
-				// value even when a legacy row contains a case-variant alias.
-				existing.DangerouslySkipPerms = trustedDangerouslySkipPerms
-				merged[cli] = existing
 			}
 			shadow.AI.Agents = merged
 		case "server_port":
@@ -186,11 +179,143 @@ func (c *Config) ApplyStore(rows map[string]string) error {
 	return nil
 }
 
+func mergeStoredAgentConfig(cli string, base CLIAgentConfig, payload json.RawMessage) (CLIAgentConfig, bool, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return base, false, err
+	}
+	if fields == nil {
+		return base, false, fmt.Errorf("agent config must be an object")
+	}
+	if err := executor.ValidateCLIName(cli); err != nil {
+		slog.Warn("config: ignoring store override for unknown CLI",
+			"agent", cli, "err", err)
+		return base, false, nil
+	}
+
+	candidate := base
+	if err := json.Unmarshal(payload, &candidate); err != nil {
+		return base, false, err
+	}
+
+	for field := range fields {
+		if strings.EqualFold(field, "dangerously_skip_perms") {
+			slog.Warn("config: ignoring HTTP/store override of dangerously_skip_perms (M-5 gate)",
+				"agent", cli)
+		}
+	}
+	// Store rows originate from the HTTP API and are never trusted to alter
+	// this filesystem-only gate, including through a case-variant alias.
+	candidate.DangerouslySkipPerms = base.DangerouslySkipPerms
+
+	if storeAgentFieldPresent(fields, "model") {
+		candidate.Model = strings.TrimSpace(candidate.Model)
+		if err := executor.ValidateModel(candidate.Model); err != nil {
+			warnIgnoredStoreAgentField(cli, "model", err)
+			candidate.Model = base.Model
+		}
+	}
+	if storeAgentFieldPresent(fields, "max_turns") && candidate.MaxTurns < 0 {
+		warnIgnoredStoreAgentField(cli, "max_turns", fmt.Errorf("value must be non-negative"))
+		candidate.MaxTurns = base.MaxTurns
+	}
+	if storeAgentFieldPresent(fields, "effort") {
+		if normalized, err := executor.NormalizeEffort(candidate.Effort); err != nil {
+			warnIgnoredStoreAgentField(cli, "effort", err)
+			candidate.Effort = base.Effort
+		} else {
+			candidate.Effort = normalized
+		}
+	}
+	if storeAgentFieldPresent(fields, "permission_mode") {
+		if normalized, err := executor.NormalizePermissionMode(candidate.PermissionMode); err != nil {
+			warnIgnoredStoreAgentField(cli, "permission_mode", err)
+			candidate.PermissionMode = base.PermissionMode
+		} else {
+			candidate.PermissionMode = normalized
+		}
+	}
+	if storeAgentFieldPresent(fields, "approval_mode") {
+		if normalized, err := executor.NormalizeApprovalModeForCLI(cli, candidate.ApprovalMode); err != nil {
+			warnIgnoredStoreAgentField(cli, "approval_mode", err)
+			candidate.ApprovalMode = base.ApprovalMode
+		} else {
+			candidate.ApprovalMode = normalized
+		}
+	}
+	if storeAgentFieldPresent(fields, "extra_flags") {
+		modelPresent := storeAgentFieldPresent(fields, "model")
+		maxTurnsPresent := storeAgentFieldPresent(fields, "max_turns")
+		effortPresent := storeAgentFieldPresent(fields, "effort")
+		migrationInput := executor.ExecOptions{
+			Model:        candidate.Model,
+			MaxTurns:     candidate.MaxTurns,
+			ApprovalMode: candidate.ApprovalMode,
+			ExtraFlags:   candidate.ExtraFlags,
+			Effort:       candidate.Effort,
+		}
+		// A legacy typed flag belongs to the store layer. When the same stored
+		// payload does not contain the corresponding typed field, let the
+		// migrated value override the lower-precedence TOML/env base exactly as
+		// the trailing argv flag did before this migration.
+		if !modelPresent {
+			migrationInput.Model = ""
+		}
+		if !maxTurnsPresent {
+			migrationInput.MaxTurns = 0
+		}
+		if !effortPresent {
+			migrationInput.Effort = ""
+		}
+		opts, migrated := executor.MigrateLegacyTypedExtraFlagsForCLI(cli, migrationInput)
+		if len(migrated) > 0 {
+			slog.Warn("config: migrated stored legacy extra_flags to typed agent fields",
+				"agent", cli, "fields", migrated)
+		}
+		for _, field := range migrated {
+			switch field {
+			case "model":
+				candidate.Model = opts.Model
+			case "max_turns":
+				candidate.MaxTurns = opts.MaxTurns
+			case "effort":
+				candidate.Effort = opts.Effort
+			}
+		}
+		candidate.ExtraFlags = opts.ExtraFlags
+		if err := executor.ValidateExtraFlagsForCLI(cli, candidate.ExtraFlags); err != nil {
+			warnIgnoredStoreAgentField(cli, "extra_flags", err)
+			candidate.ExtraFlags = base.ExtraFlags
+		}
+	}
+	return candidate, true, nil
+}
+
+func storeAgentFieldPresent(fields map[string]json.RawMessage, canonical string) bool {
+	for field := range fields {
+		if strings.EqualFold(field, canonical) {
+			return true
+		}
+	}
+	return false
+}
+
+func warnIgnoredStoreAgentField(cli, field string, err error) {
+	slog.Warn("config: ignored unsafe legacy store agent field",
+		"agent", cli, "field", field, "err", err)
+}
+
 func cloneStoreMergeConfig(c *Config) Config {
 	shadow := *c
 	shadow.GitHub.Repositories = cloneStrings(c.GitHub.Repositories)
 	shadow.GitHub.NonMonitored = cloneStrings(c.GitHub.NonMonitored)
 	shadow.GitHub.IssueTracking = cloneIssueTrackingConfig(c.GitHub.IssueTracking)
+	if c.AI.Agents != nil {
+		shadow.AI.Agents = make(map[string]CLIAgentConfig, len(c.AI.Agents))
+		for cli, agent := range c.AI.Agents {
+			shadow.AI.Agents[cli] = agent
+		}
+	}
 	return shadow
 }
 

--- a/daemon/internal/config/store.go
+++ b/daemon/internal/config/store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 )
 
 // StoreLister is the subset of *store.Store that ApplyStore needs. Kept as a
@@ -19,20 +20,22 @@ type StoreLister interface {
 // the poller also writes them as runtime discovery state, so ApplyStore merges
 // those rows below explicit TOML/env values.
 //
-// Returns the first error encountered. On error the receiver is untouched
-// (ApplyStore is atomic and Validate is a read-only check), so the caller is
-// free to keep serving the previous Config on reload failure.
+// Returns the first error encountered. The complete apply+validate operation
+// happens on a shadow copy, so a row that decodes successfully but makes the
+// resulting config invalid cannot leak into the receiver.
 func (c *Config) MergeStoreLayer(s StoreLister) error {
 	rows, err := s.ListConfigs()
 	if err != nil {
 		return fmt.Errorf("config: list store: %w", err)
 	}
-	if err := c.ApplyStore(rows); err != nil {
+	shadow := cloneStoreMergeConfig(c)
+	if err := shadow.ApplyStore(rows); err != nil {
 		return fmt.Errorf("config: apply store: %w", err)
 	}
-	if err := c.Validate(); err != nil {
+	if err := shadow.Validate(); err != nil {
 		return fmt.Errorf("config: validate after store: %w", err)
 	}
+	*c = shadow
 	return nil
 }
 
@@ -56,16 +59,11 @@ func (c *Config) MergeStoreLayer(s StoreLister) error {
 // single malformed row therefore leaves the receiver untouched, so the
 // caller's error-path ("continuing with TOML+env") is truthful.
 //
-// INVARIANT — shallow copy + wholesale replacement: `shadow := *c` is a
-// shallow copy, so `shadow.AI.Agents` and `shadow.AI.Repos` (both maps)
-// still share backing storage with the receiver. Today every case below
-// *replaces the whole field* (slice/struct/string assignment) rather than
-// mutating it in place, so the atomicity guarantee holds. If you ever add
-// a case that writes into an existing map (e.g. `shadow.AI.Agents[k] = v`)
-// you MUST deep-copy that map into the shadow first, or the mutation will
-// leak through to the receiver even when a later row fails.
+// cloneStoreMergeConfig copies the mutable slices touched below, and the
+// agent_configs branch replaces its map wholesale. If a future store key
+// mutates another map/slice in place, add it to that helper first.
 func (c *Config) ApplyStore(rows map[string]string) error {
-	shadow := *c
+	shadow := cloneStoreMergeConfig(c)
 	var storeRepos []string
 	var storeNonMonitored []string
 	var sawStoreRepos bool
@@ -151,9 +149,24 @@ func (c *Config) ApplyStore(rows map[string]string) error {
 			}
 			for cli, payload := range perCLI {
 				existing := merged[cli]
+				trustedDangerouslySkipPerms := existing.DangerouslySkipPerms
+				var fields map[string]json.RawMessage
+				if err := json.Unmarshal(payload, &fields); err != nil {
+					return fmt.Errorf("config: apply store key %q: agent %q: %w", key, cli, err)
+				}
+				for field := range fields {
+					if strings.EqualFold(field, "dangerously_skip_perms") {
+						slog.Warn("config: ignoring HTTP/store override of dangerously_skip_perms (M-5 gate)",
+							"agent", cli)
+					}
+				}
 				if err := json.Unmarshal(payload, &existing); err != nil {
 					return fmt.Errorf("config: apply store key %q: agent %q: %w", key, cli, err)
 				}
+				// Store rows originate from the HTTP API and are never trusted
+				// to alter this filesystem-only gate. Preserve the TOML/env
+				// value even when a legacy row contains a case-variant alias.
+				existing.DangerouslySkipPerms = trustedDangerouslySkipPerms
 				merged[cli] = existing
 			}
 			shadow.AI.Agents = merged
@@ -171,6 +184,33 @@ func (c *Config) ApplyStore(rows map[string]string) error {
 	}
 	*c = shadow
 	return nil
+}
+
+func cloneStoreMergeConfig(c *Config) Config {
+	shadow := *c
+	shadow.GitHub.Repositories = cloneStrings(c.GitHub.Repositories)
+	shadow.GitHub.NonMonitored = cloneStrings(c.GitHub.NonMonitored)
+	shadow.GitHub.IssueTracking = cloneIssueTrackingConfig(c.GitHub.IssueTracking)
+	return shadow
+}
+
+func cloneIssueTrackingConfig(in IssueTrackingConfig) IssueTrackingConfig {
+	out := in
+	out.Organizations = cloneStrings(in.Organizations)
+	out.Assignees = cloneStrings(in.Assignees)
+	out.DevelopLabels = cloneStrings(in.DevelopLabels)
+	out.RefinementLabels = cloneStrings(in.RefinementLabels)
+	out.ReviewOnlyLabels = cloneStrings(in.ReviewOnlyLabels)
+	out.SkipLabels = cloneStrings(in.SkipLabels)
+	out.BlockedLabels = cloneStrings(in.BlockedLabels)
+	return out
+}
+
+func cloneStrings(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	return append([]string{}, in...)
 }
 
 func mergeStoreRepoLists(c *Config, storeRepos, storeNonMonitored []string) {

--- a/daemon/internal/config/store_test.go
+++ b/daemon/internal/config/store_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -61,12 +62,13 @@ func TestApplyStore_AgentConfigs_MergesOverTOML(t *testing.T) {
 	}
 }
 
-func TestApplyStore_AgentConfigs_FalseBoolOverridesTOMLTrue(t *testing.T) {
+func TestApplyStore_AgentConfigs_SafeFalseBoolsOverrideTOMLTrue(t *testing.T) {
 	// Regression for the omitempty foot-gun the bot review flagged on #432:
 	// an operator who flips bare=false in the UI must override a TOML
 	// bare=true. With omitempty on the bool tag, a direct Marshal of
-	// CLIAgentConfig would drop the false and ApplyStore's merge-into-
-	// existing-struct path would preserve the TOML true.
+	// CLIAgentConfig would drop the false and ApplyStore's merge-into-existing
+	// path would preserve the TOML true. dangerously_skip_perms is different:
+	// it is filesystem-trusted and a legacy HTTP/store row must not alter it.
 	cfg := &Config{}
 	cfg.applyDefaults()
 	cfg.AI.Agents = map[string]CLIAgentConfig{
@@ -83,11 +85,33 @@ func TestApplyStore_AgentConfigs_FalseBoolOverridesTOMLTrue(t *testing.T) {
 	if got.Bare {
 		t.Errorf("Bare: stored false did not override TOML true")
 	}
-	if got.DangerouslySkipPerms {
-		t.Errorf("DangerouslySkipPerms: stored false did not override TOML true")
+	if !got.DangerouslySkipPerms {
+		t.Errorf("DangerouslySkipPerms: legacy store row overrode trusted TOML true")
 	}
 	if got.NoSessionPersistence {
 		t.Errorf("NoSessionPersistence: stored false did not override TOML true")
+	}
+}
+
+func TestApplyStore_AgentConfigs_CannotEnableDangerouslySkipPerms(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.AI.Agents = map[string]CLIAgentConfig{
+		"claude": {DangerouslySkipPerms: false},
+	}
+
+	rows := map[string]string{
+		"agent_configs": `{"claude":{"DANGEROUSLY_SKIP_PERMS":true,"model":"safe-model"}}`,
+	}
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+	got := cfg.AI.Agents["claude"]
+	if got.DangerouslySkipPerms {
+		t.Errorf("DangerouslySkipPerms enabled by legacy store row")
+	}
+	if got.Model != "safe-model" {
+		t.Errorf("safe sibling field was not applied: %v", got)
 	}
 }
 
@@ -364,13 +388,47 @@ func TestMergeStoreLayer_FailsValidationOnBadMergedCfg(t *testing.T) {
 	cfg := &Config{}
 	cfg.applyDefaults()
 	cfg.AI.Primary = "claude"
+	originalPollInterval := cfg.GitHub.PollInterval
+	cfg.GitHub.IssueTracking.Assignees = []string{"original"}
 
 	store := &fakeStoreLister{rows: map[string]string{
-		"poll_interval": "48h", // parseable string, but above the 24h ceiling
+		"poll_interval":  "48h", // parseable string, but above the 24h ceiling
+		"issue_tracking": `{"assignees":["mutated"]}`,
 	}}
 
 	if err := cfg.MergeStoreLayer(store); err == nil {
 		t.Fatal("MergeStoreLayer with invalid merged cfg: expected error, got nil")
+	}
+	if cfg.GitHub.PollInterval != originalPollInterval {
+		t.Fatalf("PollInterval mutated to %q after failed validation; want %q",
+			cfg.GitHub.PollInterval, originalPollInterval)
+	}
+	if got := cfg.GitHub.IssueTracking.Assignees; len(got) != 1 || got[0] != "original" {
+		t.Fatalf("nested issue-tracking slice mutated after failed validation: %v", got)
+	}
+}
+
+func TestMergeStoreLayer_RejectsLegacyUnsafeAgentFlags(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.AI.Primary = "codex"
+	cfg.AI.Agents = map[string]CLIAgentConfig{
+		"codex": {ExtraFlags: "--json"},
+	}
+
+	store := &fakeStoreLister{rows: map[string]string{
+		"agent_configs": `{"codex":{"extra_flags":"--sandbox danger-full-access"}}`,
+	}}
+
+	err := cfg.MergeStoreLayer(store)
+	if err == nil {
+		t.Fatal("expected legacy unsafe extra_flags to fail store-layer validation")
+	}
+	if !strings.Contains(err.Error(), "extra_flags") || !strings.Contains(err.Error(), "--sandbox") {
+		t.Fatalf("error is not actionable: %v", err)
+	}
+	if got := cfg.AI.Agents["codex"].ExtraFlags; got != "--json" {
+		t.Fatalf("unsafe store row mutated ExtraFlags to %q after failed validation", got)
 	}
 }
 
@@ -405,6 +463,26 @@ func TestApplyStore_PartialFailure_LeavesCfgUnchanged(t *testing.T) {
 	}
 	if len(cfg.GitHub.Repositories) != 1 || cfg.GitHub.Repositories[0] != "original/repo" {
 		t.Errorf("Repositories = %v, want [original/repo]", cfg.GitHub.Repositories)
+	}
+}
+
+func TestApplyStore_PartialIssueTrackingDecodeLeavesNestedSlicesUnchanged(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.AI.Primary = "claude"
+	// Spare capacity makes encoding/json reuse the backing array while
+	// decoding, which exposes shallow-copy rollback bugs deterministically.
+	cfg.GitHub.IssueTracking.Assignees = make([]string, 1, 4)
+	cfg.GitHub.IssueTracking.Assignees[0] = "original"
+
+	err := cfg.ApplyStore(map[string]string{
+		"issue_tracking": `{"assignees":["mutated"],"enabled":"not-a-bool"}`,
+	})
+	if err == nil {
+		t.Fatal("expected malformed issue_tracking row to fail")
+	}
+	if got := cfg.GitHub.IssueTracking.Assignees; len(got) != 1 || got[0] != "original" {
+		t.Fatalf("nested issue-tracking slice mutated after failed decode: %v", got)
 	}
 }
 

--- a/daemon/internal/config/store_test.go
+++ b/daemon/internal/config/store_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -408,27 +407,102 @@ func TestMergeStoreLayer_FailsValidationOnBadMergedCfg(t *testing.T) {
 	}
 }
 
-func TestMergeStoreLayer_RejectsLegacyUnsafeAgentFlags(t *testing.T) {
+func TestMergeStoreLayer_SanitizesLegacyUnsafeAgentFieldWithoutDroppingLayer(t *testing.T) {
 	cfg := &Config{}
 	cfg.applyDefaults()
 	cfg.AI.Primary = "codex"
 	cfg.AI.Agents = map[string]CLIAgentConfig{
 		"codex": {ExtraFlags: "--json"},
 	}
+	cfg.GitHub.IssueTracking.Assignees = []string{"toml-user"}
 
 	store := &fakeStoreLister{rows: map[string]string{
-		"agent_configs": `{"codex":{"extra_flags":"--sandbox danger-full-access"}}`,
+		"agent_configs":  `{"codex":{"extra_flags":"--sandbox danger-full-access"}}`,
+		"poll_interval":  "30m",
+		"issue_tracking": `{"assignees":["store-user"]}`,
 	}}
 
-	err := cfg.MergeStoreLayer(store)
-	if err == nil {
-		t.Fatal("expected legacy unsafe extra_flags to fail store-layer validation")
-	}
-	if !strings.Contains(err.Error(), "extra_flags") || !strings.Contains(err.Error(), "--sandbox") {
-		t.Fatalf("error is not actionable: %v", err)
+	if err := cfg.MergeStoreLayer(store); err != nil {
+		t.Fatalf("legacy semantic policy error must not discard the store layer: %v", err)
 	}
 	if got := cfg.AI.Agents["codex"].ExtraFlags; got != "--json" {
-		t.Fatalf("unsafe store row mutated ExtraFlags to %q after failed validation", got)
+		t.Fatalf("unsafe store field replaced trusted base ExtraFlags with %q", got)
+	}
+	if cfg.GitHub.PollInterval != "30m" {
+		t.Fatalf("valid store poll_interval was discarded: %q", cfg.GitHub.PollInterval)
+	}
+	if got := cfg.GitHub.IssueTracking.Assignees; len(got) != 1 || got[0] != "store-user" {
+		t.Fatalf("valid issue_tracking row was discarded: %v", got)
+	}
+}
+
+func TestApplyStore_MigratesLegacyTypedFlagsAndRestoresOnlyInvalidFields(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.AI.Primary = "claude"
+	cfg.AI.Agents = map[string]CLIAgentConfig{
+		"claude": {
+			Model:          "toml-model",
+			Effort:         "low",
+			PermissionMode: "default",
+			ExtraFlags:     "--verbose",
+		},
+	}
+
+	rows := map[string]string{
+		"agent_configs": `{"claude":{"model":"--sandbox","effort":"HIGH","permission_mode":"bypassPermissions","extra_flags":"--model legacy --output-format json"}}`,
+	}
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+
+	got := cfg.AI.Agents["claude"]
+	if got.Model != "toml-model" {
+		t.Fatalf("invalid stored model replaced trusted base: %+v", got)
+	}
+	if got.Effort != "high" {
+		t.Fatalf("safe stored effort was not canonicalized: %+v", got)
+	}
+	if got.PermissionMode != "default" {
+		t.Fatalf("invalid stored permission mode replaced trusted base: %+v", got)
+	}
+	if got.ExtraFlags != "--output-format json" {
+		t.Fatalf("legacy typed flag was not removed while safe sibling survived: %+v", got)
+	}
+}
+
+func TestApplyStore_LegacyTypedFlagsPreserveStorePrecedence(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	cfg.AI.Primary = "claude"
+	cfg.AI.Agents = map[string]CLIAgentConfig{
+		"claude": {
+			Model:      "toml-model",
+			MaxTurns:   3,
+			Effort:     "low",
+			ExtraFlags: "--debug",
+		},
+	}
+
+	rows := map[string]string{
+		"agent_configs": `{"claude":{"extra_flags":"--model store-model --max-turns 9 --effort HIGH --verbose"}}`,
+	}
+	if err := cfg.ApplyStore(rows); err != nil {
+		t.Fatalf("ApplyStore: %v", err)
+	}
+
+	got := cfg.AI.Agents["claude"]
+	if got.Model != "store-model" {
+		t.Fatalf("legacy store model did not override lower-precedence TOML value: %+v", got)
+	}
+	if got.MaxTurns != 9 {
+		t.Fatalf("legacy store max_turns did not override lower-precedence TOML value: %+v", got)
+	}
+	if got.Effort != "high" {
+		t.Fatalf("legacy store effort did not override lower-precedence TOML value: %+v", got)
+	}
+	if got.ExtraFlags != "--verbose" {
+		t.Fatalf("legacy typed flags were not removed while the safe sibling survived: %+v", got)
 	}
 }
 
@@ -448,6 +522,9 @@ func TestApplyStore_PartialFailure_LeavesCfgUnchanged(t *testing.T) {
 	cfg.GitHub.PollInterval = "5m"
 	cfg.GitHub.Repositories = []string{"original/repo"}
 	cfg.AI.Primary = "claude"
+	cfg.AI.Agents = map[string]CLIAgentConfig{
+		"claude": {ExtraFlags: "--sandbox"},
+	}
 
 	rows := map[string]string{
 		"poll_interval": "30m",            // valid — would apply on its own
@@ -463,6 +540,9 @@ func TestApplyStore_PartialFailure_LeavesCfgUnchanged(t *testing.T) {
 	}
 	if len(cfg.GitHub.Repositories) != 1 || cfg.GitHub.Repositories[0] != "original/repo" {
 		t.Errorf("Repositories = %v, want [original/repo]", cfg.GitHub.Repositories)
+	}
+	if got := cfg.AI.Agents["claude"].ExtraFlags; got != "--sandbox" {
+		t.Errorf("legacy sanitizer leaked through failed atomic merge: %q", got)
 	}
 }
 

--- a/daemon/internal/config/store_test.go
+++ b/daemon/internal/config/store_test.go
@@ -66,8 +66,9 @@ func TestApplyStore_AgentConfigs_SafeFalseBoolsOverrideTOMLTrue(t *testing.T) {
 	// an operator who flips bare=false in the UI must override a TOML
 	// bare=true. With omitempty on the bool tag, a direct Marshal of
 	// CLIAgentConfig would drop the false and ApplyStore's merge-into-existing
-	// path would preserve the TOML true. dangerously_skip_perms is different:
-	// it is filesystem-trusted and a legacy HTTP/store row must not alter it.
+	// path would preserve the TOML true. dangerously_skip_perms deliberately
+	// uses asymmetric security semantics: a stored false may reduce privilege,
+	// while a stored true may never grant it.
 	cfg := &Config{}
 	cfg.applyDefaults()
 	cfg.AI.Agents = map[string]CLIAgentConfig{
@@ -84,8 +85,8 @@ func TestApplyStore_AgentConfigs_SafeFalseBoolsOverrideTOMLTrue(t *testing.T) {
 	if got.Bare {
 		t.Errorf("Bare: stored false did not override TOML true")
 	}
-	if !got.DangerouslySkipPerms {
-		t.Errorf("DangerouslySkipPerms: legacy store row overrode trusted TOML true")
+	if got.DangerouslySkipPerms {
+		t.Errorf("DangerouslySkipPerms: stored false did not disable TOML true")
 	}
 	if got.NoSessionPersistence {
 		t.Errorf("NoSessionPersistence: stored false did not override TOML true")
@@ -111,6 +112,62 @@ func TestApplyStore_AgentConfigs_CannotEnableDangerouslySkipPerms(t *testing.T) 
 	}
 	if got.Model != "safe-model" {
 		t.Errorf("safe sibling field was not applied: %v", got)
+	}
+}
+
+func TestApplyStore_AgentConfigs_DangerouslySkipPermsAsymmetricMatrix(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    bool
+		payload string
+		want    bool
+	}{
+		{
+			name:    "omitted preserves trusted true",
+			base:    true,
+			payload: `{"claude":{"model":"safe"}}`,
+			want:    true,
+		},
+		{
+			name:    "false disables trusted true",
+			base:    true,
+			payload: `{"claude":{"dangerously_skip_perms":false}}`,
+			want:    false,
+		},
+		{
+			name:    "true cannot elevate false",
+			base:    false,
+			payload: `{"claude":{"dangerously_skip_perms":true}}`,
+			want:    false,
+		},
+		{
+			name:    "true cannot replace trusted source",
+			base:    true,
+			payload: `{"claude":{"dangerously_skip_perms":true}}`,
+			want:    true,
+		},
+		{
+			name:    "false wins conflicting legacy aliases",
+			base:    true,
+			payload: `{"claude":{"DANGEROUSLY_SKIP_PERMS":true,"dangerously_skip_perms":false}}`,
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{}
+			cfg.applyDefaults()
+			cfg.AI.Agents = map[string]CLIAgentConfig{
+				"claude": {DangerouslySkipPerms: tc.base},
+			}
+			if err := cfg.ApplyStore(map[string]string{"agent_configs": tc.payload}); err != nil {
+				t.Fatalf("ApplyStore: %v", err)
+			}
+			if got := cfg.AI.Agents["claude"].DangerouslySkipPerms; got != tc.want {
+				t.Fatalf("DangerouslySkipPerms = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -130,11 +131,11 @@ var allowedCLIs = map[string]struct{}{
 // allowedPermissionModes is the strict allowlist for the --permission-mode flag.
 // "bypassPermissions" is intentionally excluded — it grants unrestricted filesystem
 // access and must never be passed to the claude CLI from Heimdallm config.
-var allowedPermissionModes = map[string]struct{}{
-	"default":     {},
-	"auto":        {},
-	"acceptEdits": {},
-	"dontAsk":     {},
+var canonicalPermissionModes = map[string]string{
+	"default":     "default",
+	"auto":        "auto",
+	"acceptedits": "acceptEdits",
+	"dontask":     "dontAsk",
 }
 
 var allowedEfforts = map[string]struct{}{
@@ -158,16 +159,25 @@ func ValidateModel(model string) error {
 	return nil
 }
 
+// NormalizeEffort returns the canonical lowercase spelling of a safe effort
+// value. Accepting harmless case variants keeps older hand-written TOML files
+// working without widening the enum.
+func NormalizeEffort(effort string) (string, error) {
+	effort = strings.ToLower(strings.TrimSpace(effort))
+	if effort == "" {
+		return "", nil
+	}
+	if _, ok := allowedEfforts[effort]; !ok {
+		return "", fmt.Errorf("executor: effort %q is not allowed — valid values: low, medium, high, max", effort)
+	}
+	return effort, nil
+}
+
 // ValidateEffort validates Claude's typed --effort value. Keeping this field
 // enum-shaped prevents it from being interpreted as another CLI option.
 func ValidateEffort(effort string) error {
-	if effort == "" {
-		return nil
-	}
-	if _, ok := allowedEfforts[effort]; !ok {
-		return fmt.Errorf("executor: effort %q is not allowed — valid values: low, medium, high, max", effort)
-	}
-	return nil
+	_, err := NormalizeEffort(effort)
+	return err
 }
 
 // allowedApprovalModes is the allowlist for the Codex approval mode config.
@@ -195,20 +205,27 @@ var allowedGeminiApprovalModes = map[string]struct{}{
 
 // ValidatePermissionMode returns an error if mode is not in the allowlist.
 // An empty string is accepted (means "not set").
+func NormalizePermissionMode(mode string) (string, error) {
+	trimmed := strings.TrimSpace(mode)
+	if trimmed == "" {
+		return "", nil
+	}
+	normalized, ok := canonicalPermissionModes[strings.ToLower(trimmed)]
+	if !ok {
+		return "", fmt.Errorf("executor: permission_mode %q is not allowed — valid values: default, auto, acceptEdits, dontAsk", mode)
+	}
+	return normalized, nil
+}
+
 func ValidatePermissionMode(mode string) error {
-	if mode == "" {
-		return nil
-	}
-	if _, ok := allowedPermissionModes[mode]; !ok {
-		return fmt.Errorf("executor: permission_mode %q is not allowed — valid values: default, auto, acceptEdits, dontAsk", mode)
-	}
-	return nil
+	_, err := NormalizePermissionMode(mode)
+	return err
 }
 
 // ValidateApprovalMode returns an error if mode is not in the allowlist.
 // An empty string is accepted (means "not set").
 func ValidateApprovalMode(mode string) error {
-	mode = strings.TrimSpace(mode)
+	mode = strings.ToLower(strings.TrimSpace(mode))
 	if mode == "" {
 		return nil
 	}
@@ -218,47 +235,58 @@ func ValidateApprovalMode(mode string) error {
 	return nil
 }
 
-// ValidateApprovalModeForCLI validates the typed approval mode using the
-// vocabulary of the CLI that will consume it. Codex keeps accepting its legacy
-// values for backwards compatibility. Gemini accepts auto-edit as a friendly
-// spelling but emits auto_edit, and intentionally rejects yolo.
+// NormalizeApprovalModeForCLI validates a typed approval mode and returns the
+// canonical value emitted for the selected provider. Codex keeps accepting its
+// legacy values for backwards compatibility. Gemini accepts auto-edit as a
+// friendly spelling but emits auto_edit, and intentionally rejects yolo.
 //
 // Claude and OpenCode do not consume ApprovalMode today. We still validate a
 // non-empty value against the safe Codex/Gemini union so a primary-to-fallback
 // transition does not fail merely because the selected fallback ignores a
 // setting belonging to the primary CLI.
-func ValidateApprovalModeForCLI(cli, mode string) error {
+func NormalizeApprovalModeForCLI(cli, mode string) (string, error) {
 	if err := ValidateCLIName(cli); err != nil {
-		return err
+		return "", err
 	}
 
-	mode = strings.TrimSpace(mode)
+	mode = strings.ToLower(strings.TrimSpace(mode))
 	if mode == "" {
-		return nil
+		return "", nil
 	}
 
 	switch cli {
 	case "codex":
-		return ValidateApprovalMode(mode)
+		if err := ValidateApprovalMode(mode); err != nil {
+			return "", err
+		}
+		return normalizeCodexApprovalMode(mode), nil
 	case "gemini":
 		normalized := normalizeGeminiApprovalMode(mode)
 		if _, ok := allowedGeminiApprovalModes[normalized]; !ok {
-			return fmt.Errorf("executor: approval_mode %q is not allowed for gemini — valid values: default, auto_edit, auto-edit, plan", mode)
+			return "", fmt.Errorf("executor: approval_mode %q is not allowed for gemini — valid values: default, auto_edit, auto-edit, plan", mode)
 		}
-		return nil
+		return normalized, nil
 	default:
 		if _, ok := allowedApprovalModes[mode]; ok {
-			return nil
+			return normalizeCodexApprovalMode(mode), nil
 		}
-		if _, ok := allowedGeminiApprovalModes[normalizeGeminiApprovalMode(mode)]; ok {
-			return nil
+		normalized := normalizeGeminiApprovalMode(mode)
+		if _, ok := allowedGeminiApprovalModes[normalized]; ok {
+			return normalized, nil
 		}
-		return fmt.Errorf("executor: approval_mode %q is not a known safe mode for %s", mode, cli)
+		return "", fmt.Errorf("executor: approval_mode %q is not a known safe mode for %s", mode, cli)
 	}
 }
 
+// ValidateApprovalModeForCLI is the validation-only wrapper used by callers
+// that do not need the canonical spelling.
+func ValidateApprovalModeForCLI(cli, mode string) error {
+	_, err := NormalizeApprovalModeForCLI(cli, mode)
+	return err
+}
+
 func normalizeCodexApprovalMode(mode string) string {
-	switch strings.TrimSpace(mode) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
 	case "full-auto":
 		return "never"
 	case "auto-edit":
@@ -271,12 +299,157 @@ func normalizeCodexApprovalMode(mode string) string {
 }
 
 func normalizeGeminiApprovalMode(mode string) string {
-	switch strings.TrimSpace(mode) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
 	case "auto-edit":
 		return "auto_edit"
 	default:
-		return strings.TrimSpace(mode)
+		return strings.ToLower(strings.TrimSpace(mode))
 	}
+}
+
+// MigrateLegacyTypedExtraFlagsForCLI promotes the model/effort/turn-limit
+// flags that older releases allowed in ExtraFlags into their typed fields.
+// It exists only for trusted TOML/env/store compatibility. New HTTP writes and
+// the subprocess boundary reject these aliases in ExtraFlags so a trailing
+// free-form option can never override a validated typed value.
+//
+// Explicit typed values win over their legacy duplicates. The returned field
+// names describe the aliases removed from ExtraFlags so callers can emit an
+// actionable migration warning.
+func MigrateLegacyTypedExtraFlagsForCLI(cli string, opts ExecOptions) (ExecOptions, []string) {
+	if err := ValidateCLIName(cli); err != nil || strings.TrimSpace(opts.ExtraFlags) == "" {
+		return opts, nil
+	}
+
+	parts := strings.Fields(opts.ExtraFlags)
+	kept := make([]string, 0, len(parts))
+	var migrated []string
+	modelFromLegacy := strings.TrimSpace(opts.Model) == ""
+	effortFromLegacy := strings.TrimSpace(opts.Effort) == ""
+	maxTurnsFromLegacy := opts.MaxTurns == 0
+
+	recordMigration := func(field string) {
+		for _, existing := range migrated {
+			if existing == field {
+				return
+			}
+		}
+		migrated = append(migrated, field)
+	}
+
+	for i := 0; i < len(parts); i++ {
+		field, value, consumed, matched := legacyTypedExtraFlag(cli, parts, i)
+		if !matched {
+			kept = append(kept, parts[i])
+			continue
+		}
+
+		valid := false
+		switch field {
+		case "model":
+			value = strings.TrimSpace(value)
+			if err := ValidateModel(value); err == nil && value != "" {
+				if modelFromLegacy {
+					opts.Model = value // last legacy occurrence keeps CLI precedence
+				}
+				valid = true
+			}
+		case "effort":
+			if normalized, err := NormalizeEffort(value); err == nil && normalized != "" {
+				if effortFromLegacy {
+					opts.Effort = normalized
+				}
+				valid = true
+			}
+		case "max_turns":
+			if turns, err := strconv.Atoi(strings.TrimSpace(value)); err == nil && turns >= 0 {
+				if maxTurnsFromLegacy {
+					opts.MaxTurns = turns
+				}
+				valid = true
+			}
+		}
+		if !valid {
+			// Preserve the invalid spelling so the strict policy below can
+			// reject it and the compatibility sanitizer can report it.
+			kept = append(kept, parts[i])
+			continue
+		}
+
+		recordMigration(field)
+		i += consumed
+	}
+
+	opts.ExtraFlags = strings.Join(kept, " ")
+	return opts, migrated
+}
+
+// NormalizeLegacyCLIFlagsForCLI converts the typed aliases historically
+// accepted by stored prompt profiles into ExecOptions, then validates the
+// remaining free-form flags with the current provider policy. Callers must pass
+// the returned ExtraFlags rather than the original string so typed aliases
+// never reach the subprocess twice or override typed options by argv order.
+//
+// This compatibility helper is intentionally narrower than the general config
+// sanitizer: prompt profiles only have a CLIFlags string today, so model,
+// effort and max-turns have no other persisted representation there.
+func NormalizeLegacyCLIFlagsForCLI(cli, flags string) (ExecOptions, []string, error) {
+	opts, migrated := MigrateLegacyTypedExtraFlagsForCLI(cli, ExecOptions{ExtraFlags: flags})
+	if err := ValidateCLIName(cli); err != nil {
+		return ExecOptions{}, nil, err
+	}
+	if err := ValidateModel(opts.Model); err != nil {
+		return ExecOptions{}, nil, err
+	}
+	if opts.MaxTurns < 0 {
+		return ExecOptions{}, nil, fmt.Errorf("executor: max_turns must be non-negative")
+	}
+	if err := ValidateEffort(opts.Effort); err != nil {
+		return ExecOptions{}, nil, err
+	}
+	if err := ValidateExtraFlagsForCLI(cli, opts.ExtraFlags); err != nil {
+		return ExecOptions{}, nil, err
+	}
+	return opts, migrated, nil
+}
+
+func legacyTypedExtraFlag(cli string, parts []string, index int) (field, value string, consumed int, matched bool) {
+	token := parts[index]
+	name := canonicalFlagName(token)
+
+	if strings.HasPrefix(name, "--") {
+		switch comparableLongFlag(name) {
+		case "model":
+			field = "model"
+		case "effort":
+			if cli != "claude" {
+				return "", "", 0, false
+			}
+			field = "effort"
+		case "maxturns":
+			if cli != "claude" {
+				return "", "", 0, false
+			}
+			field = "max_turns"
+		default:
+			return "", "", 0, false
+		}
+	} else if strings.HasPrefix(name, "-m") {
+		field = "model"
+	} else {
+		return "", "", 0, false
+	}
+
+	if equals := strings.IndexByte(token, '='); equals >= 0 {
+		return field, token[equals+1:], 0, true
+	}
+	if strings.HasPrefix(name, "-m") && name != "-m" {
+		return field, token[2:], 0, true
+	}
+	if index+1 < len(parts) && !strings.HasPrefix(parts[index+1], "-") {
+		return field, parts[index+1], 1, true
+	}
+	return field, "", 0, true
 }
 
 // forbiddenExtraFlagsByCLI defines the policy-changing aliases understood by
@@ -291,6 +464,7 @@ func normalizeGeminiApprovalMode(mode string) string {
 var forbiddenExtraFlagsByCLI = map[string]map[string]string{
 	"claude": {
 		"-c":                                   "session state",
+		"-m":                                   "typed model configuration",
 		"-r":                                   "session state",
 		"-w":                                   "working-directory access",
 		"--add-dir":                            "working-directory access",
@@ -318,7 +492,9 @@ var forbiddenExtraFlagsByCLI = map[string]map[string]string{
 		"--init":                                  "hook execution",
 		"--init-only":                             "hook execution",
 		"--maintenance":                           "hook execution",
+		"--max-turns":                             "typed turn-limit configuration",
 		"--mcp-config":                            "runtime configuration",
+		"--model":                                 "typed model configuration",
 		"--no-sandbox":                            "sandbox policy",
 		"--permission-mode":                       "permission policy",
 		"--permission-prompt-tool":                "permission policy",
@@ -335,11 +511,13 @@ var forbiddenExtraFlagsByCLI = map[string]map[string]string{
 		"--system-prompt-file":                    "working-directory file access",
 		"--teleport":                              "execution boundary",
 		"--worktree":                              "working-directory access",
+		"--effort":                                "typed effort configuration",
 	},
 	"codex": {
 		"-a":                 "approval policy",
 		"-c":                 "runtime configuration or working directory",
 		"-i":                 "working-directory file access",
+		"-m":                 "typed model configuration",
 		"-o":                 "working-directory file access",
 		"-p":                 "runtime configuration",
 		"-s":                 "sandbox policy",
@@ -359,6 +537,7 @@ var forbiddenExtraFlagsByCLI = map[string]map[string]string{
 		"--image":                                    "working-directory file access",
 		"--include-managed-config":                   "runtime configuration",
 		"--local-provider":                           "execution boundary",
+		"--model":                                    "typed model configuration",
 		"--no-sandbox":                               "sandbox policy",
 		"--oss":                                      "execution boundary",
 		"--output-last-message":                      "working-directory file access",
@@ -375,6 +554,7 @@ var forbiddenExtraFlagsByCLI = map[string]map[string]string{
 	"gemini": {
 		"-r":                         "session state",
 		"-e":                         "runtime configuration",
+		"-m":                         "typed model configuration",
 		"-s":                         "sandbox policy",
 		"-w":                         "working-directory access",
 		"-y":                         "approval policy",
@@ -390,6 +570,7 @@ var forbiddenExtraFlagsByCLI = map[string]map[string]string{
 		"--fake-responses":           "working-directory file access",
 		"--include-directories":      "working-directory access",
 		"--include-directory":        "working-directory access",
+		"--model":                    "typed model configuration",
 		"--no-sandbox":               "sandbox policy",
 		"--policy":                   "permission policy",
 		"--record-responses":         "working-directory file access",
@@ -403,6 +584,7 @@ var forbiddenExtraFlagsByCLI = map[string]map[string]string{
 	},
 	"opencode": {
 		"-c":            "session state",
+		"-m":            "typed model configuration",
 		"--agent":       "agent and permission configuration",
 		"--attach":      "execution boundary",
 		"--auto":        "approval policy",
@@ -413,6 +595,7 @@ var forbiddenExtraFlagsByCLI = map[string]map[string]string{
 		"--file":        "working-directory access",
 		"--fork":        "session state",
 		"--interactive": "execution boundary",
+		"--model":       "typed model configuration",
 		"--no-sandbox":  "sandbox policy",
 		"--password":    "execution boundary",
 		"--permission":  "permission policy",
@@ -451,18 +634,14 @@ const (
 var allowedExtraFlagsByCLI = map[string]map[string]extraFlagArity{
 	"claude": {
 		"-d":                         extraFlagBoolean,
-		"-m":                         extraFlagValue,
 		"--debug":                    extraFlagOptionalValue,
 		"--disable-slash-commands":   extraFlagBoolean,
 		"--disallowed-tools":         extraFlagVariadicValue,
-		"--effort":                   extraFlagValue,
 		"--fallback-model":           extraFlagValue,
 		"--include-partial-messages": extraFlagBoolean,
 		"--input-format":             extraFlagValue,
 		"--json-schema":              extraFlagValue,
 		"--max-budget-usd":           extraFlagValue,
-		"--max-turns":                extraFlagValue,
-		"--model":                    extraFlagValue,
 		"--no-session-persistence":   extraFlagBoolean,
 		"--output-format":            extraFlagValue,
 		"--replay-user-messages":     extraFlagBoolean,
@@ -470,26 +649,20 @@ var allowedExtraFlagsByCLI = map[string]map[string]extraFlagArity{
 		"--verbose":                  extraFlagBoolean,
 	},
 	"codex": {
-		"-m":              extraFlagValue,
 		"--color":         extraFlagValue,
 		"--ephemeral":     extraFlagBoolean,
 		"--json":          extraFlagBoolean,
-		"--model":         extraFlagValue,
 		"--strict-config": extraFlagBoolean,
 	},
 	"gemini": {
 		"-d":              extraFlagBoolean,
-		"-m":              extraFlagValue,
 		"-o":              extraFlagValue,
 		"--debug":         extraFlagBoolean,
-		"--model":         extraFlagValue,
 		"--output-format": extraFlagValue,
 		"--screen-reader": extraFlagBoolean,
 	},
 	"opencode": {
-		"-m":         extraFlagValue,
 		"--format":   extraFlagValue,
-		"--model":    extraFlagValue,
 		"--pure":     extraFlagBoolean,
 		"--thinking": extraFlagBoolean,
 		"--variant":  extraFlagValue,
@@ -1039,22 +1212,22 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
 		// positional message args are given.
 		args = append(args, "run")
 		if opts.Model != "" {
-			args = append(args, "-m", opts.Model)
+			args = append(args, "-m", strings.TrimSpace(opts.Model))
 		}
 	case "codex":
 		// Codex's top-level command is interactive and requires a TTY. The
 		// daemon must use the non-interactive subcommand and feed the prompt on
 		// stdin, otherwise Codex exits with "stdin is not a terminal".
 		if mode := strings.TrimSpace(opts.ApprovalMode); mode != "" {
-			if err := ValidateApprovalMode(mode); err != nil {
+			if normalized, err := NormalizeApprovalModeForCLI(cli, mode); err != nil {
 				slog.Warn("buildArgs: ApprovalMode rejected, ignoring", "mode", mode, "err", err)
 			} else {
-				args = append(args, "--ask-for-approval", normalizeCodexApprovalMode(mode))
+				args = append(args, "--ask-for-approval", normalized)
 			}
 		}
 		args = append(args, "exec")
 		if opts.Model != "" {
-			args = append(args, "--model", opts.Model)
+			args = append(args, "--model", strings.TrimSpace(opts.Model))
 		}
 	default:
 		// claude, gemini: stdin mode
@@ -1064,14 +1237,14 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
 			args = append(args, "-p", "-")
 		}
 		if opts.Model != "" {
-			args = append(args, "--model", opts.Model)
+			args = append(args, "--model", strings.TrimSpace(opts.Model))
 		}
 		if cli == "gemini" {
 			if mode := strings.TrimSpace(opts.ApprovalMode); mode != "" {
-				if err := ValidateApprovalModeForCLI(cli, mode); err != nil {
+				if normalized, err := NormalizeApprovalModeForCLI(cli, mode); err != nil {
 					slog.Warn("buildArgs: ApprovalMode rejected, ignoring", "cli", cli, "mode", mode, "err", err)
 				} else {
-					args = append(args, "--approval-mode", normalizeGeminiApprovalMode(mode))
+					args = append(args, "--approval-mode", normalized)
 				}
 			}
 		}
@@ -1080,13 +1253,15 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
 				args = append(args, "--max-turns", fmt.Sprintf("%d", opts.MaxTurns))
 			}
 			if opts.Effort != "" {
-				args = append(args, "--effort", opts.Effort)
+				if effort, err := NormalizeEffort(opts.Effort); err == nil {
+					args = append(args, "--effort", effort)
+				}
 			}
 			if opts.PermissionMode != "" {
-				if err := ValidatePermissionMode(opts.PermissionMode); err != nil {
+				if mode, err := NormalizePermissionMode(opts.PermissionMode); err != nil {
 					slog.Warn("buildArgs: PermissionMode rejected, ignoring", "mode", opts.PermissionMode, "err", err)
 				} else {
-					args = append(args, "--permission-mode", opts.PermissionMode)
+					args = append(args, "--permission-mode", mode)
 				}
 			}
 			if opts.Bare {

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -38,7 +38,7 @@ type ExecOptions struct {
 	Model string
 	// MaxTurns sets --max-turns <n> for Claude (0 = not set).
 	MaxTurns int
-	// ApprovalMode sets Codex --ask-for-approval <value>.
+	// ApprovalMode sets the typed Codex/Gemini approval option.
 	// Legacy values from older Codex CLIs are still accepted and normalized.
 	ApprovalMode string
 	// ExtraFlags is a free-form string of additional CLI flags (split on spaces).
@@ -62,6 +62,29 @@ type ExecOptions struct {
 	// Timeout overrides the default execution timeout for the CLI process.
 	// Zero = use default (5 minutes).
 	Timeout time.Duration
+}
+
+// OptionsForSelectedCLI removes provider-specific options when Detect falls
+// back to a different CLI. The options were resolved from the configured
+// primary agent, so forwarding its model, approval mode or free-form flags to
+// another provider is both unreliable and unsafe. WorkDir and Timeout are
+// provider-independent and remain in force.
+func OptionsForSelectedCLI(primary, selected string, opts ExecOptions) ExecOptions {
+	primary = strings.TrimSpace(primary)
+	selected = strings.TrimSpace(selected)
+	if primary == "" || selected == "" || primary == selected {
+		return opts
+	}
+	opts.Model = ""
+	opts.MaxTurns = 0
+	opts.ApprovalMode = ""
+	opts.ExtraFlags = ""
+	opts.Effort = ""
+	opts.PermissionMode = ""
+	opts.Bare = false
+	opts.DangerouslySkipPerms = false
+	opts.NoSessionPersistence = false
+	return opts
 }
 
 // Executor runs AI CLI tools for code review.
@@ -114,6 +137,39 @@ var allowedPermissionModes = map[string]struct{}{
 	"dontAsk":     {},
 }
 
+var allowedEfforts = map[string]struct{}{
+	"low":    {},
+	"medium": {},
+	"high":   {},
+	"max":    {},
+}
+
+// ValidateModel rejects option-shaped model identifiers. ExecOptions values
+// are passed as separate argv entries, but many CLI parsers reinterpret a
+// value beginning with "-" as the next option when the preceding flag expects
+// a value. That would turn a typed model field into another policy bypass.
+func ValidateModel(model string) error {
+	if model == "" {
+		return nil
+	}
+	if strings.HasPrefix(strings.TrimSpace(model), "-") {
+		return fmt.Errorf("executor: model %q must not begin with '-'", model)
+	}
+	return nil
+}
+
+// ValidateEffort validates Claude's typed --effort value. Keeping this field
+// enum-shaped prevents it from being interpreted as another CLI option.
+func ValidateEffort(effort string) error {
+	if effort == "" {
+		return nil
+	}
+	if _, ok := allowedEfforts[effort]; !ok {
+		return fmt.Errorf("executor: effort %q is not allowed — valid values: low, medium, high, max", effort)
+	}
+	return nil
+}
+
 // allowedApprovalModes is the allowlist for the Codex approval mode config.
 // The first group is the current Codex --ask-for-approval vocabulary; the
 // second group is kept for existing config.toml files created before Codex
@@ -126,6 +182,15 @@ var allowedApprovalModes = map[string]struct{}{
 	"auto-edit":  {},
 	"full-auto":  {},
 	"suggest":    {},
+}
+
+// allowedGeminiApprovalModes is deliberately narrower than Gemini's full
+// --approval-mode vocabulary: yolo removes every approval prompt and therefore
+// must never be reachable through Heimdallm's typed agent configuration.
+var allowedGeminiApprovalModes = map[string]struct{}{
+	"default":   {},
+	"auto_edit": {},
+	"plan":      {},
 }
 
 // ValidatePermissionMode returns an error if mode is not in the allowlist.
@@ -153,6 +218,45 @@ func ValidateApprovalMode(mode string) error {
 	return nil
 }
 
+// ValidateApprovalModeForCLI validates the typed approval mode using the
+// vocabulary of the CLI that will consume it. Codex keeps accepting its legacy
+// values for backwards compatibility. Gemini accepts auto-edit as a friendly
+// spelling but emits auto_edit, and intentionally rejects yolo.
+//
+// Claude and OpenCode do not consume ApprovalMode today. We still validate a
+// non-empty value against the safe Codex/Gemini union so a primary-to-fallback
+// transition does not fail merely because the selected fallback ignores a
+// setting belonging to the primary CLI.
+func ValidateApprovalModeForCLI(cli, mode string) error {
+	if err := ValidateCLIName(cli); err != nil {
+		return err
+	}
+
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		return nil
+	}
+
+	switch cli {
+	case "codex":
+		return ValidateApprovalMode(mode)
+	case "gemini":
+		normalized := normalizeGeminiApprovalMode(mode)
+		if _, ok := allowedGeminiApprovalModes[normalized]; !ok {
+			return fmt.Errorf("executor: approval_mode %q is not allowed for gemini — valid values: default, auto_edit, auto-edit, plan", mode)
+		}
+		return nil
+	default:
+		if _, ok := allowedApprovalModes[mode]; ok {
+			return nil
+		}
+		if _, ok := allowedGeminiApprovalModes[normalizeGeminiApprovalMode(mode)]; ok {
+			return nil
+		}
+		return fmt.Errorf("executor: approval_mode %q is not a known safe mode for %s", mode, cli)
+	}
+}
+
 func normalizeCodexApprovalMode(mode string) string {
 	switch strings.TrimSpace(mode) {
 	case "full-auto":
@@ -166,51 +270,490 @@ func normalizeCodexApprovalMode(mode string) string {
 	}
 }
 
-// dangerousFlagPrefixes is the denylist for ValidateExtraFlags.
-var dangerousFlagPrefixes = []string{
-	"--dangerously-skip-permissions",
-	"--allow-dangerously",
-	"--danger",
-	"--permission-mode", // has a dedicated typed field (PermissionMode); must not appear in free-form flags
+func normalizeGeminiApprovalMode(mode string) string {
+	switch strings.TrimSpace(mode) {
+	case "auto-edit":
+		return "auto_edit"
+	default:
+		return strings.TrimSpace(mode)
+	}
+}
+
+// forbiddenExtraFlagsByCLI defines the policy-changing aliases understood by
+// each supported provider. ExtraFlags is appended after Heimdallm's typed
+// options, so allowing any of these names would let legacy config or a stored
+// agent replace the validated approval, sandbox, permission, config, or
+// workspace policy at the last possible moment.
+//
+// Long names are stored lowercase because validation is case-insensitive.
+// Short names are lowercase too: this intentionally treats Codex -C (workdir)
+// and -c (config override) as the same forbidden class.
+var forbiddenExtraFlagsByCLI = map[string]map[string]string{
+	"claude": {
+		"-c":                                   "session state",
+		"-r":                                   "session state",
+		"-w":                                   "working-directory access",
+		"--add-dir":                            "working-directory access",
+		"--agent":                              "agent configuration",
+		"--agents":                             "agent configuration",
+		"--allow-dangerously-skip-permissions": "permission policy",
+		"--allowed-tools":                      "permission policy",
+		"--allowedtools":                       "permission policy",
+		"--append-system-prompt":               "system instructions",
+		"--append-system-prompt-file":          "working-directory file access",
+		"--background":                         "execution boundary",
+		"--bg":                                 "execution boundary",
+		"--channels":                           "runtime configuration",
+		"--chrome":                             "execution boundary",
+		"--cloud":                              "execution boundary",
+		"--continue":                           "session state",
+		"--dangerously-load-development-channels": "permission policy",
+		"--dangerously-skip-permissions":          "permission policy",
+		"--debug-file":                            "working-directory file access",
+		"--directory":                             "working-directory access",
+		"--enable-auto-mode":                      "permission policy",
+		"--exec":                                  "execution boundary",
+		"--from-pr":                               "session state",
+		"--ide":                                   "execution boundary",
+		"--init":                                  "hook execution",
+		"--init-only":                             "hook execution",
+		"--maintenance":                           "hook execution",
+		"--mcp-config":                            "runtime configuration",
+		"--no-sandbox":                            "sandbox policy",
+		"--permission-mode":                       "permission policy",
+		"--permission-prompt-tool":                "permission policy",
+		"--plugin-dir":                            "runtime configuration",
+		"--plugin-url":                            "runtime configuration",
+		"--rc":                                    "execution boundary",
+		"--remote":                                "execution boundary",
+		"--remote-control":                        "execution boundary",
+		"--resume":                                "session state",
+		"--session-id":                            "session state",
+		"--setting-sources":                       "runtime configuration",
+		"--settings":                              "runtime configuration",
+		"--system-prompt":                         "system instructions",
+		"--system-prompt-file":                    "working-directory file access",
+		"--teleport":                              "execution boundary",
+		"--worktree":                              "working-directory access",
+	},
+	"codex": {
+		"-a":                 "approval policy",
+		"-c":                 "runtime configuration or working directory",
+		"-i":                 "working-directory file access",
+		"-o":                 "working-directory file access",
+		"-p":                 "runtime configuration",
+		"-s":                 "sandbox policy",
+		"--add-dir":          "working-directory access",
+		"--approval-mode":    "approval policy",
+		"--ask-for-approval": "approval policy",
+		"--cd":               "working-directory access",
+		"--config":           "runtime configuration",
+		"--cwd":              "working-directory access",
+		"--dangerously-bypass-approvals-and-sandbox": "approval and sandbox policy",
+		"--dangerously-bypass-hook-trust":            "permission policy",
+		"--disable":                                  "runtime configuration",
+		"--enable":                                   "runtime configuration",
+		"--full-auto":                                "approval and sandbox policy",
+		"--ignore-rules":                             "permission policy",
+		"--ignore-user-config":                       "runtime configuration",
+		"--image":                                    "working-directory file access",
+		"--include-managed-config":                   "runtime configuration",
+		"--local-provider":                           "execution boundary",
+		"--no-sandbox":                               "sandbox policy",
+		"--oss":                                      "execution boundary",
+		"--output-last-message":                      "working-directory file access",
+		"--output-schema":                            "working-directory file access",
+		"--permission-profile":                       "permission policy",
+		"--profile":                                  "runtime configuration",
+		"--remote":                                   "execution boundary",
+		"--remote-auth-token-env":                    "execution boundary",
+		"--sandbox":                                  "sandbox policy",
+		"--search":                                   "permission policy",
+		"--skip-git-repo-check":                      "workspace trust policy",
+		"--yolo":                                     "approval and sandbox policy",
+	},
+	"gemini": {
+		"-r":                         "session state",
+		"-e":                         "runtime configuration",
+		"-s":                         "sandbox policy",
+		"-w":                         "working-directory access",
+		"-y":                         "approval policy",
+		"--acp":                      "execution boundary",
+		"--admin-policy":             "permission policy",
+		"--allowed-mcp-server-names": "permission policy",
+		"--allowed-tools":            "permission policy",
+		"--approval-mode":            "approval policy",
+		"--config":                   "runtime configuration",
+		"--cwd":                      "working-directory access",
+		"--extensions":               "runtime configuration",
+		"--experimental-acp":         "execution boundary",
+		"--fake-responses":           "working-directory file access",
+		"--include-directories":      "working-directory access",
+		"--include-directory":        "working-directory access",
+		"--no-sandbox":               "sandbox policy",
+		"--policy":                   "permission policy",
+		"--record-responses":         "working-directory file access",
+		"--resume":                   "session state",
+		"--sandbox":                  "sandbox policy",
+		"--session-file":             "working-directory file access",
+		"--settings":                 "runtime configuration",
+		"--skip-trust":               "workspace trust policy",
+		"--worktree":                 "working-directory access",
+		"--yolo":                     "approval policy",
+	},
+	"opencode": {
+		"-c":            "session state",
+		"--agent":       "agent and permission configuration",
+		"--attach":      "execution boundary",
+		"--auto":        "approval policy",
+		"--command":     "runtime configuration",
+		"--continue":    "session state",
+		"--config":      "runtime configuration",
+		"--dir":         "working-directory access",
+		"--file":        "working-directory access",
+		"--fork":        "session state",
+		"--interactive": "execution boundary",
+		"--no-sandbox":  "sandbox policy",
+		"--password":    "execution boundary",
+		"--permission":  "permission policy",
+		"--permissions": "permission policy",
+		"--port":        "execution boundary",
+		"--sandbox":     "sandbox policy",
+		"--session":     "session state",
+		"--settings":    "runtime configuration",
+		"--share":       "external data sharing",
+		"--username":    "execution boundary",
+		"-f":            "working-directory access",
+		"-i":            "execution boundary",
+		"-p":            "execution boundary",
+		"-s":            "session state",
+		"-u":            "execution boundary",
+	},
+}
+
+type extraFlagArity uint8
+
+const (
+	extraFlagBoolean extraFlagArity = iota
+	extraFlagValue
+	extraFlagOptionalValue
+	extraFlagVariadicValue
+)
+
+// allowedExtraFlagsByCLI is the deliberate compatibility surface for the
+// free-form field. Unknown flags fail closed: upstream CLIs regularly add
+// options that can load files, select agents/config, resume sessions, or move
+// execution outside Heimdallm's validated workspace.
+//
+// Keep this list limited to output, model/resource tuning, accessibility, and
+// options that only remove capabilities. Security-sensitive behavior belongs
+// in typed ExecOptions fields instead.
+var allowedExtraFlagsByCLI = map[string]map[string]extraFlagArity{
+	"claude": {
+		"-d":                         extraFlagBoolean,
+		"-m":                         extraFlagValue,
+		"--debug":                    extraFlagOptionalValue,
+		"--disable-slash-commands":   extraFlagBoolean,
+		"--disallowed-tools":         extraFlagVariadicValue,
+		"--effort":                   extraFlagValue,
+		"--fallback-model":           extraFlagValue,
+		"--include-partial-messages": extraFlagBoolean,
+		"--input-format":             extraFlagValue,
+		"--json-schema":              extraFlagValue,
+		"--max-budget-usd":           extraFlagValue,
+		"--max-turns":                extraFlagValue,
+		"--model":                    extraFlagValue,
+		"--no-session-persistence":   extraFlagBoolean,
+		"--output-format":            extraFlagValue,
+		"--replay-user-messages":     extraFlagBoolean,
+		"--strict-mcp-config":        extraFlagBoolean,
+		"--verbose":                  extraFlagBoolean,
+	},
+	"codex": {
+		"-m":              extraFlagValue,
+		"--color":         extraFlagValue,
+		"--ephemeral":     extraFlagBoolean,
+		"--json":          extraFlagBoolean,
+		"--model":         extraFlagValue,
+		"--strict-config": extraFlagBoolean,
+	},
+	"gemini": {
+		"-d":              extraFlagBoolean,
+		"-m":              extraFlagValue,
+		"-o":              extraFlagValue,
+		"--debug":         extraFlagBoolean,
+		"--model":         extraFlagValue,
+		"--output-format": extraFlagValue,
+		"--screen-reader": extraFlagBoolean,
+	},
+	"opencode": {
+		"-m":         extraFlagValue,
+		"--format":   extraFlagValue,
+		"--model":    extraFlagValue,
+		"--pure":     extraFlagBoolean,
+		"--thinking": extraFlagBoolean,
+		"--variant":  extraFlagValue,
+	},
 }
 
 // dangerousFlagValues are flag values that must never appear regardless of position.
 var dangerousFlagValues = []string{"bypassPermissions"}
 
-// ValidateExtraFlags rejects free-form flag strings that contain dangerous flags.
-// These flags are already modelled as explicit typed fields (DangerouslySkipPerms,
-// PermissionMode, etc.) — the free-form field must not be able to re-set them or
-// bypass the CLI agent config guards (security issue #5).
+// ValidateExtraFlags rejects provider-independent dangerous free-form flags.
+// It is kept for callers that do not yet have a CLI name. Long aliases from
+// every provider are rejected, while provider-specific short aliases are left
+// to ValidateExtraFlagsForCLI.
 func ValidateExtraFlags(flags string) error {
+	return validateExtraFlags("", flags)
+}
+
+// ValidateExtraFlagsForCLI applies the provider-aware ExtraFlags policy. This
+// is the validation used at the ExecuteRaw process boundary.
+func ValidateExtraFlagsForCLI(cli, flags string) error {
+	if err := ValidateCLIName(cli); err != nil {
+		return err
+	}
+	return validateExtraFlags(cli, flags)
+}
+
+func validateExtraFlags(cli, flags string) error {
 	parts := strings.Fields(flags)
-	for _, part := range parts {
-		lower := strings.ToLower(part)
-		for _, bad := range dangerousFlagPrefixes {
-			if strings.HasPrefix(lower, bad) {
-				slog.Warn("executor: ExtraFlags validation failed",
-					"err", fmt.Sprintf("flag %q is forbidden in ExtraFlags/CLIFlags — use the dedicated config field instead", part))
-				return fmt.Errorf("executor: flag %q is forbidden in ExtraFlags/CLIFlags — use the dedicated config field instead", part)
+	for i := 0; i < len(parts); i++ {
+		part := parts[i]
+		flag := canonicalFlagName(part)
+		if flag != "" {
+			if strings.HasPrefix(flag, "--danger") || strings.HasPrefix(flag, "--allow-dangerously") {
+				return forbiddenExtraFlagError(cli, part, "permission or sandbox policy")
+			}
+			if category, forbidden := forbiddenExtraFlagCategory(cli, flag); forbidden {
+				return forbiddenExtraFlagError(cli, part, category)
 			}
 		}
+		if err := validateExtraFlagValue(part); err != nil {
+			return err
+		}
+
+		// The legacy provider-independent helper can only reject the union of
+		// known dangerous long flags. Every execution path supplies a CLI and
+		// therefore reaches the fail-closed parser below.
+		if cli == "" {
+			continue
+		}
+		if flag == "" {
+			return fmt.Errorf("executor: unexpected positional value %q in ExtraFlags/CLIFlags for %s", part, cli)
+		}
+
+		consumed, err := validateAllowedExtraFlag(cli, parts, i)
+		if err != nil {
+			return err
+		}
+		i += consumed
+	}
+	return nil
+}
+
+func validateExtraFlagValue(part string) error {
+	values := []string{part}
+	if idx := strings.IndexByte(part, '='); idx >= 0 {
+		values = append(values, part[idx+1:])
+	}
+	for _, value := range values {
 		for _, badVal := range dangerousFlagValues {
-			if strings.EqualFold(part, badVal) {
+			if strings.EqualFold(value, badVal) {
 				return fmt.Errorf("executor: value %q is forbidden in ExtraFlags/CLIFlags", part)
-			}
-		}
-		// Also catch --flag=value form (e.g. --permission-mode=bypassPermissions).
-		// Without this check a single token like "--permission-mode=bypassPermissions"
-		// passes the prefix loop (which only matches the exact flag prefix, not the
-		// joined form) and passes the value loop (which only matches bare values).
-		if idx := strings.Index(lower, "="); idx >= 0 {
-			val := lower[idx+1:]
-			for _, badVal := range dangerousFlagValues {
-				if strings.EqualFold(val, badVal) {
-					return fmt.Errorf("executor: value %q is forbidden in ExtraFlags/CLIFlags", part)
-				}
 			}
 		}
 	}
 	return nil
+}
+
+func canonicalFlagName(token string) string {
+	if len(token) < 2 || token[0] != '-' {
+		return ""
+	}
+	if idx := strings.IndexByte(token, '='); idx >= 0 {
+		token = token[:idx]
+	}
+	return strings.ToLower(token)
+}
+
+func validateAllowedExtraFlag(cli string, parts []string, index int) (int, error) {
+	token := parts[index]
+	name := canonicalFlagName(token)
+	if strings.HasPrefix(name, "--") {
+		arity, ok := allowedLongExtraFlag(cli, name)
+		if !ok {
+			return 0, unsupportedExtraFlagError(cli, token)
+		}
+		hasInlineValue := strings.Contains(token, "=")
+		return consumeExtraFlagValues(cli, token, arity, hasInlineValue, parts, index)
+	}
+
+	return validateAllowedShortExtraFlags(cli, token, parts, index)
+}
+
+func allowedLongExtraFlag(cli, flag string) (extraFlagArity, bool) {
+	policy := allowedExtraFlagsByCLI[cli]
+	if arity, ok := policy[flag]; ok {
+		return arity, true
+	}
+	comparable := comparableLongFlag(flag)
+	for alias, arity := range policy {
+		if strings.HasPrefix(alias, "--") && comparableLongFlag(alias) == comparable {
+			return arity, true
+		}
+	}
+	return 0, false
+}
+
+func validateAllowedShortExtraFlags(cli, token string, parts []string, index int) (int, error) {
+	nameAndValue := token
+	hasEqualsValue := false
+	if equals := strings.IndexByte(nameAndValue, '='); equals >= 0 {
+		nameAndValue = nameAndValue[:equals]
+		hasEqualsValue = true
+	}
+	if len(nameAndValue) < 2 {
+		return 0, unsupportedExtraFlagError(cli, token)
+	}
+
+	policy := allowedExtraFlagsByCLI[cli]
+	for pos := 1; pos < len(nameAndValue); pos++ {
+		alias := "-" + strings.ToLower(nameAndValue[pos:pos+1])
+		if category, forbidden := forbiddenExtraFlagCategory(cli, alias); forbidden {
+			return 0, forbiddenExtraFlagError(cli, token, category)
+		}
+		arity, allowed := policy[alias]
+		if !allowed {
+			return 0, unsupportedExtraFlagError(cli, token)
+		}
+		if arity == extraFlagBoolean {
+			if hasEqualsValue {
+				return 0, fmt.Errorf("executor: boolean flag %q cannot use an attached value in ExtraFlags/CLIFlags for %s", token, cli)
+			}
+			continue
+		}
+
+		hasAttachedValue := pos+1 < len(nameAndValue) || hasEqualsValue
+		return consumeExtraFlagValues(cli, token, arity, hasAttachedValue, parts, index)
+	}
+	return 0, nil
+}
+
+func consumeExtraFlagValues(cli, token string, arity extraFlagArity, hasInlineValue bool, parts []string, index int) (int, error) {
+	if arity == extraFlagBoolean {
+		if hasInlineValue {
+			return 0, fmt.Errorf("executor: boolean flag %q cannot use an attached value in ExtraFlags/CLIFlags for %s", token, cli)
+		}
+		return 0, nil
+	}
+	if hasInlineValue {
+		return 0, nil
+	}
+
+	switch arity {
+	case extraFlagValue:
+		if index+1 >= len(parts) || strings.HasPrefix(parts[index+1], "-") {
+			return 0, fmt.Errorf("executor: flag %q requires a value in ExtraFlags/CLIFlags for %s", token, cli)
+		}
+		if err := validateExtraFlagValue(parts[index+1]); err != nil {
+			return 0, err
+		}
+		return 1, nil
+	case extraFlagOptionalValue:
+		if index+1 < len(parts) && !strings.HasPrefix(parts[index+1], "-") {
+			if err := validateExtraFlagValue(parts[index+1]); err != nil {
+				return 0, err
+			}
+			return 1, nil
+		}
+		return 0, nil
+	case extraFlagVariadicValue:
+		consumed := 0
+		for index+consumed+1 < len(parts) && !strings.HasPrefix(parts[index+consumed+1], "-") {
+			consumed++
+			if err := validateExtraFlagValue(parts[index+consumed]); err != nil {
+				return 0, err
+			}
+		}
+		if consumed == 0 {
+			return 0, fmt.Errorf("executor: flag %q requires at least one value in ExtraFlags/CLIFlags for %s", token, cli)
+		}
+		return consumed, nil
+	default:
+		return 0, unsupportedExtraFlagError(cli, token)
+	}
+}
+
+func unsupportedExtraFlagError(cli, flag string) error {
+	err := fmt.Errorf(
+		"executor: flag %q is not in the safe ExtraFlags/CLIFlags allowlist for %s; use a typed configuration field or update Heimdallm's provider policy",
+		flag, cli)
+	slog.Warn("executor: ExtraFlags validation failed", "cli", cli, "flag", flag, "err", err)
+	return err
+}
+
+func forbiddenExtraFlagCategory(cli, flag string) (string, bool) {
+	if cli != "" {
+		policy := forbiddenExtraFlagsByCLI[cli]
+		if category, ok := policy[flag]; ok {
+			return category, true
+		}
+		// Yargs accepts camelCase/snake_case aliases for kebab-case options
+		// (for example --approvalMode=yolo). Compare long options with
+		// separators removed so alternate spellings reach the same policy.
+		if strings.HasPrefix(flag, "--") {
+			comparable := comparableLongFlag(flag)
+			for alias, category := range policy {
+				if strings.HasPrefix(alias, "--") && comparableLongFlag(alias) == comparable {
+					return category, true
+				}
+			}
+		}
+		// Clap/yargs accept attached short-option values in forms such as
+		// -sdanger-full-access, -C/etc, and -f/etc. Match only aliases that
+		// belong to this provider so an alias from one CLI cannot change the
+		// interpretation of another CLI's flags.
+		if strings.HasPrefix(flag, "-") && !strings.HasPrefix(flag, "--") {
+			for alias, category := range policy {
+				if len(alias) == 2 && alias[0] == '-' && strings.HasPrefix(flag, alias) {
+					return category, true
+				}
+			}
+		}
+		return "", false
+	}
+	if !strings.HasPrefix(flag, "--") {
+		return "", false
+	}
+	comparable := comparableLongFlag(flag)
+	for _, policy := range forbiddenExtraFlagsByCLI {
+		for alias, category := range policy {
+			if strings.HasPrefix(alias, "--") && comparableLongFlag(alias) == comparable {
+				return category, true
+			}
+		}
+	}
+	return "", false
+}
+
+func comparableLongFlag(flag string) string {
+	flag = strings.TrimPrefix(strings.ToLower(flag), "--")
+	flag = strings.ReplaceAll(flag, "-", "")
+	flag = strings.ReplaceAll(flag, "_", "")
+	return flag
+}
+
+func forbiddenExtraFlagError(cli, flag, category string) error {
+	scope := ""
+	if cli != "" {
+		scope = " for " + cli
+	}
+	err := fmt.Errorf(
+		"executor: flag %q is forbidden in ExtraFlags/CLIFlags%s because it can override %s; use the dedicated typed configuration instead",
+		flag, scope, category)
+	slog.Warn("executor: ExtraFlags validation failed", "cli", cli, "flag", flag, "err", err)
+	return err
 }
 
 // ValidateCLIName returns an error if name is not in the known-safe allowlist.
@@ -408,6 +951,13 @@ func (e *Executor) Execute(cli, prompt string, opts ExecOptions) (*ReviewResult,
 // output, etc.). Callers should pass the bytes through StripToJSON before
 // json.Unmarshal — CLIs routinely wrap JSON in code fences or surrounding text.
 func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, error) {
+	// This is the final trust boundary before creating a subprocess. Callers
+	// validate configuration on ingress too, but legacy rows, direct TOML edits,
+	// and future call paths must not be able to bypass the execution policy.
+	if err := validateExecutionRequest(cli, opts); err != nil {
+		return nil, err
+	}
+
 	timeout := executionTimeout
 	if opts.Timeout > 0 {
 		timeout = opts.Timeout
@@ -423,9 +973,6 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 
 	var workDirFlags []string
 	if opts.WorkDir != "" {
-		if err := ValidateWorkDir(opts.WorkDir); err != nil {
-			return nil, err
-		}
 		workDirFlags = detectWorkDirFlags(cli, cliPath, opts.WorkDir)
 	}
 
@@ -458,6 +1005,28 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	}
 
 	return stdout.Bytes(), nil
+}
+
+func validateExecutionRequest(cli string, opts ExecOptions) error {
+	if err := ValidateCLIName(cli); err != nil {
+		return err
+	}
+	if err := ValidateModel(opts.Model); err != nil {
+		return err
+	}
+	if err := ValidateEffort(opts.Effort); err != nil {
+		return err
+	}
+	if err := ValidatePermissionMode(opts.PermissionMode); err != nil {
+		return err
+	}
+	if err := ValidateApprovalModeForCLI(cli, opts.ApprovalMode); err != nil {
+		return err
+	}
+	if err := validateExtraFlags(cli, opts.ExtraFlags); err != nil {
+		return err
+	}
+	return ValidateWorkDir(opts.WorkDir)
 }
 
 // buildArgs constructs the CLI argument list based on the CLI name and options.
@@ -496,6 +1065,15 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
 		}
 		if opts.Model != "" {
 			args = append(args, "--model", opts.Model)
+		}
+		if cli == "gemini" {
+			if mode := strings.TrimSpace(opts.ApprovalMode); mode != "" {
+				if err := ValidateApprovalModeForCLI(cli, mode); err != nil {
+					slog.Warn("buildArgs: ApprovalMode rejected, ignoring", "cli", cli, "mode", mode, "err", err)
+				} else {
+					args = append(args, "--approval-mode", normalizeGeminiApprovalMode(mode))
+				}
+			}
 		}
 		if cli == "claude" {
 			if opts.MaxTurns > 0 {

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -148,6 +148,18 @@ func TestMigrateLegacyTypedExtraFlagsForCLI(t *testing.T) {
 				ExtraFlags: "--model --sandbox danger-full-access",
 			},
 		},
+		{
+			name: "approval flags are deliberately not migrated",
+			cli:  "codex",
+			opts: executor.ExecOptions{
+				ApprovalMode: "never",
+				ExtraFlags:   "--ask-for-approval on-request --json",
+			},
+			want: executor.ExecOptions{
+				ApprovalMode: "never",
+				ExtraFlags:   "--ask-for-approval on-request --json",
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -189,6 +201,12 @@ func TestNormalizeLegacyCLIFlagsForCLI(t *testing.T) {
 		"--model gpt-5 --sandbox danger-full-access",
 	); err == nil {
 		t.Fatal("unsafe sibling flag was accepted after typed model migration")
+	}
+	if _, _, err := executor.NormalizeLegacyCLIFlagsForCLI(
+		"codex",
+		"--ask-for-approval on-request --json",
+	); err == nil {
+		t.Fatal("legacy approval flag unexpectedly migrated or accepted")
 	}
 }
 

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -3,9 +3,11 @@ package executor_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/heimdallm/daemon/internal/executor"
 )
@@ -54,6 +56,35 @@ func TestDetect_NoneAvailable(t *testing.T) {
 	_, err := e.Detect("nonexistent", "also_nonexistent")
 	if err == nil {
 		t.Error("expected error when no CLI available")
+	}
+}
+
+func TestOptionsForSelectedCLI(t *testing.T) {
+	original := executor.ExecOptions{
+		Model:                "primary-model",
+		MaxTurns:             7,
+		ApprovalMode:         "never",
+		ExtraFlags:           "--json",
+		WorkDir:              "/tmp/repo",
+		Effort:               "high",
+		PermissionMode:       "acceptEdits",
+		Bare:                 true,
+		DangerouslySkipPerms: true,
+		NoSessionPersistence: true,
+		Timeout:              9 * time.Minute,
+	}
+
+	if got := executor.OptionsForSelectedCLI("codex", "codex", original); !reflect.DeepEqual(got, original) {
+		t.Fatalf("same provider changed options:\n got: %+v\nwant: %+v", got, original)
+	}
+
+	got := executor.OptionsForSelectedCLI("codex", "gemini", original)
+	want := executor.ExecOptions{
+		WorkDir: "/tmp/repo",
+		Timeout: 9 * time.Minute,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fallback options:\n got: %+v\nwant: %+v", got, want)
 	}
 }
 
@@ -237,6 +268,159 @@ func TestValidateApprovalModeAcceptsCurrentAndLegacyCodexValues(t *testing.T) {
 	}
 }
 
+func TestValidateApprovalModeForCLI(t *testing.T) {
+	tests := []struct {
+		name    string
+		cli     string
+		mode    string
+		wantErr bool
+	}{
+		{name: "codex current", cli: "codex", mode: "on-request"},
+		{name: "codex legacy", cli: "codex", mode: "auto-edit"},
+		{name: "codex rejects gemini plan", cli: "codex", mode: "plan", wantErr: true},
+		{name: "gemini default", cli: "gemini", mode: "default"},
+		{name: "gemini underscore auto edit", cli: "gemini", mode: "auto_edit"},
+		{name: "gemini hyphen auto edit", cli: "gemini", mode: "auto-edit"},
+		{name: "gemini plan", cli: "gemini", mode: "plan"},
+		{name: "gemini rejects yolo", cli: "gemini", mode: "yolo", wantErr: true},
+		{name: "gemini rejects codex never", cli: "gemini", mode: "never", wantErr: true},
+		{name: "ignored codex mode remains safe on claude fallback", cli: "claude", mode: "on-request"},
+		{name: "ignored gemini mode remains safe on opencode fallback", cli: "opencode", mode: "auto_edit"},
+		{name: "fallback still rejects unknown mode", cli: "claude", mode: "bypassPermissions", wantErr: true},
+		{name: "unknown CLI", cli: "other", mode: "default", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := executor.ValidateApprovalModeForCLI(tc.cli, tc.mode)
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateApprovalModeForCLI(%q, %q) unexpectedly succeeded", tc.cli, tc.mode)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateApprovalModeForCLI(%q, %q): %v", tc.cli, tc.mode, err)
+			}
+		})
+	}
+}
+
+func TestExecuteRawGeminiAddsTypedApprovalBeforeSafeExtraFlags(t *testing.T) {
+	binDir := t.TempDir()
+	captureArgs := filepath.Join(t.TempDir(), "args.txt")
+	captureCWD := filepath.Join(t.TempDir(), "cwd.txt")
+	path := filepath.Join(binDir, "gemini")
+	if err := os.WriteFile(path, []byte(fakeCLIScript("Usage: gemini\n", captureArgs, captureCWD)), 0o755); err != nil {
+		t.Fatalf("write fake Gemini: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	e := executor.New()
+	opts := executor.ExecOptions{
+		ApprovalMode: "auto-edit",
+		ExtraFlags:   "--output-format json --debug --output-format text",
+	}
+	if _, err := e.ExecuteRaw("gemini", "prompt", opts); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+
+	argsBytes, err := os.ReadFile(captureArgs)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	args := strings.Fields(string(argsBytes))
+	if !containsInOrder(args, "--approval-mode", "auto_edit") {
+		t.Fatalf("args = %v, want normalized Gemini approval mode", args)
+	}
+	approvalIdx := indexOf(args, "--approval-mode")
+	outputIdx := indexOf(args, "--output-format")
+	if outputIdx < 0 || approvalIdx > outputIdx {
+		t.Fatalf("args = %v, typed approval must precede safe ExtraFlags", args)
+	}
+	if strings.Count(string(argsBytes), "--output-format") != 2 {
+		t.Fatalf("args = %v, repeated safe flags must be preserved", args)
+	}
+}
+
+func TestExecuteRawRejectsUnsafeRequestBeforeStartingCLI(t *testing.T) {
+	tests := []struct {
+		name string
+		cli  string
+		opts executor.ExecOptions
+	}{
+		{name: "unknown CLI", cli: "other"},
+		{
+			name: "invalid typed Claude permission mode",
+			cli:  "claude",
+			opts: executor.ExecOptions{PermissionMode: "bypassPermissions"},
+		},
+		{
+			name: "option-shaped typed model",
+			cli:  "claude",
+			opts: executor.ExecOptions{Model: "--dangerously-skip-permissions"},
+		},
+		{
+			name: "option-shaped typed effort",
+			cli:  "claude",
+			opts: executor.ExecOptions{Effort: "--dangerously-skip-permissions"},
+		},
+		{
+			name: "invalid typed Codex approval mode",
+			cli:  "codex",
+			opts: executor.ExecOptions{ApprovalMode: "danger-full-access"},
+		},
+		{
+			name: "unsafe typed Gemini approval mode",
+			cli:  "gemini",
+			opts: executor.ExecOptions{ApprovalMode: "yolo"},
+		},
+		{
+			name: "legacy Claude extra flags",
+			cli:  "claude",
+			opts: executor.ExecOptions{ExtraFlags: "--permission-mode=bypassPermissions"},
+		},
+		{
+			name: "legacy Codex extra flags",
+			cli:  "codex",
+			opts: executor.ExecOptions{ExtraFlags: "--sandbox danger-full-access"},
+		},
+		{
+			name: "legacy Gemini extra flags",
+			cli:  "gemini",
+			opts: executor.ExecOptions{ExtraFlags: "--approval-mode=yolo"},
+		},
+		{
+			name: "bundled Gemini yolo alias",
+			cli:  "gemini",
+			opts: executor.ExecOptions{ExtraFlags: "-dy"},
+		},
+		{
+			name: "legacy OpenCode extra flags",
+			cli:  "opencode",
+			opts: executor.ExecOptions{ExtraFlags: "--auto"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			started := filepath.Join(t.TempDir(), "started")
+			if tc.cli != "other" {
+				script := "#!/bin/sh\nprintf started > " + shellQuote(started) + "\nprintf ok\n"
+				if err := os.WriteFile(filepath.Join(binDir, tc.cli), []byte(script), 0o755); err != nil {
+					t.Fatalf("write fake CLI: %v", err)
+				}
+			}
+			t.Setenv("PATH", binDir)
+
+			if _, err := executor.New().ExecuteRaw(tc.cli, "prompt", tc.opts); err == nil {
+				t.Fatal("ExecuteRaw unexpectedly accepted an unsafe request")
+			}
+			if _, err := os.Stat(started); !os.IsNotExist(err) {
+				t.Fatalf("CLI subprocess was started before validation: stat error = %v", err)
+			}
+		})
+	}
+}
+
 func containsInOrder(args []string, first, second string) bool {
 	for i := 0; i+1 < len(args); i++ {
 		if args[i] == first && args[i+1] == second {
@@ -410,6 +594,26 @@ func TestValidateExtraFlags(t *testing.T) {
 			flags:   "--model claude-opus-4-6 --max-turns 5",
 			wantErr: false,
 		},
+		{
+			name:    "ambiguous short aliases remain compatible without a CLI",
+			flags:   "-s session-id -p password",
+			wantErr: false,
+		},
+		{
+			name:    "Codex sandbox long alias rejected without a CLI",
+			flags:   "--sandbox danger-full-access",
+			wantErr: true,
+		},
+		{
+			name:    "Gemini camel-case approval alias rejected without a CLI",
+			flags:   "--approvalMode=yolo",
+			wantErr: true,
+		},
+		{
+			name:    "OpenCode auto long alias rejected without a CLI",
+			flags:   "--auto",
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -420,6 +624,181 @@ func TestValidateExtraFlags(t *testing.T) {
 			}
 			if !tc.wantErr && err != nil {
 				t.Errorf("unexpected error for flags %q: %v", tc.flags, err)
+			}
+		})
+	}
+}
+
+func TestValidateExtraFlagsForCLIRejectsPolicyAliases(t *testing.T) {
+	tests := []struct {
+		name  string
+		cli   string
+		flags string
+	}{
+		{name: "Claude dangerous skip", cli: "claude", flags: "--dangerously-skip-permissions"},
+		{name: "Claude allow later bypass", cli: "claude", flags: "--allow-dangerously-skip-permissions"},
+		{name: "Claude permission mode", cli: "claude", flags: "--permission-mode default"},
+		{name: "Claude permission camel case", cli: "claude", flags: "--PeRmIsSiOn-MoDe=bypassPermissions"},
+		{name: "Claude permission separator alias", cli: "claude", flags: "--permissionMode=acceptEdits"},
+		{name: "Claude allowedTools spelling", cli: "claude", flags: "--allowedTools Bash"},
+		{name: "Claude allowed-tools spelling", cli: "claude", flags: "--allowed-tools=Bash"},
+		{name: "Claude permission prompt tool", cli: "claude", flags: "--permission-prompt-tool=mcp__approval"},
+		{name: "Claude add dir", cli: "claude", flags: "--add-dir /etc"},
+		{name: "Claude legacy directory", cli: "claude", flags: "--directory=/"},
+		{name: "Claude sandbox negation", cli: "claude", flags: "--no-sandbox"},
+		{name: "Claude settings", cli: "claude", flags: "--settings unsafe.json"},
+		{name: "Claude setting sources", cli: "claude", flags: "--setting-sources=user"},
+		{name: "Claude MCP config", cli: "claude", flags: "--mcp-config mcp.json"},
+		{name: "Claude plugin config", cli: "claude", flags: "--plugin-dir ./plugin"},
+		{name: "Claude dynamic agent", cli: "claude", flags: "--agents={}"},
+		{name: "Claude system prompt replacement", cli: "claude", flags: "--system-prompt ignore-policy"},
+		{name: "Claude system prompt file", cli: "claude", flags: "--system-prompt-file /etc/passwd"},
+		{name: "Claude appended system prompt file", cli: "claude", flags: "--append-system-prompt-file=/etc/passwd"},
+		{name: "Claude debug file", cli: "claude", flags: "--debug-file /tmp/claude.log"},
+		{name: "Claude shell exec", cli: "claude", flags: "--exec 'touch /tmp/pwned'"},
+		{name: "Claude background mode", cli: "claude", flags: "--bg"},
+		{name: "Claude worktree", cli: "claude", flags: "--worktree unsafe"},
+		{name: "Claude worktree short attached", cli: "claude", flags: "-wunsafe"},
+		{name: "Claude cloud execution", cli: "claude", flags: "--cloud"},
+		{name: "Claude remote control", cli: "claude", flags: "--remote-control"},
+		{name: "Claude channels", cli: "claude", flags: "--channels plugin:channel"},
+		{name: "Claude browser tooling", cli: "claude", flags: "--chrome"},
+		{name: "Claude IDE integration", cli: "claude", flags: "--ide"},
+		{name: "Claude setup hooks", cli: "claude", flags: "--init-only"},
+		{name: "Claude resumed session", cli: "claude", flags: "--resume session-id"},
+		{name: "Claude resume hidden in legacy debug bundle", cli: "claude", flags: "-dr00000000-0000-4000-8000-000000000000"},
+		{name: "Claude PR session", cli: "claude", flags: "--from-pr 42"},
+		{name: "Claude tool availability", cli: "claude", flags: "--tools Read"},
+
+		{name: "Codex approval", cli: "codex", flags: "--ask-for-approval never"},
+		{name: "Codex approval camel case", cli: "codex", flags: "--askForApproval=never"},
+		{name: "Codex approval short", cli: "codex", flags: "-a=never"},
+		{name: "Codex legacy approval", cli: "codex", flags: "--approval-mode=yolo"},
+		{name: "Codex sandbox", cli: "codex", flags: "--sandbox danger-full-access"},
+		{name: "Codex sandbox short", cli: "codex", flags: "-s=danger-full-access"},
+		{name: "Codex sandbox short attached", cli: "codex", flags: "-sdanger-full-access"},
+		{name: "Codex sandbox negation", cli: "codex", flags: "--no-sandbox"},
+		{name: "Codex yolo alias", cli: "codex", flags: "--yolo"},
+		{name: "Codex full auto alias", cli: "codex", flags: "--full-auto"},
+		{name: "Codex bypass alias", cli: "codex", flags: "--dangerously-bypass-approvals-and-sandbox"},
+		{name: "Codex hook trust bypass", cli: "codex", flags: "--dangerously-bypass-hook-trust"},
+		{name: "Codex cd", cli: "codex", flags: "--cd /etc"},
+		{name: "Codex uppercase C", cli: "codex", flags: "-C /etc"},
+		{name: "Codex uppercase C attached", cli: "codex", flags: "-C/etc"},
+		{name: "Codex config lowercase c", cli: "codex", flags: "-c sandbox_mode=danger-full-access"},
+		{name: "Codex config lowercase c attached", cli: "codex", flags: "-capproval_policy=never"},
+		{name: "Codex config", cli: "codex", flags: "--config=approval_policy=\"never\""},
+		{name: "Codex add dir", cli: "codex", flags: "--add-dir /etc"},
+		{name: "Codex image outside workdir", cli: "codex", flags: "--image /etc/passwd"},
+		{name: "Codex image short attached", cli: "codex", flags: "-i/etc/passwd"},
+		{name: "Codex output file", cli: "codex", flags: "--output-last-message /tmp/result"},
+		{name: "Codex output schema", cli: "codex", flags: "--output-schema=/etc/schema.json"},
+		{name: "Codex output short", cli: "codex", flags: "-o/tmp/result"},
+		{name: "Codex remote auth token env", cli: "codex", flags: "--remote-auth-token-env SECRET"},
+		{name: "Codex search permission", cli: "codex", flags: "--search"},
+		{name: "Codex profile", cli: "codex", flags: "--profile unsafe"},
+		{name: "Codex permission profile", cli: "codex", flags: "--permission-profile unsafe"},
+		{name: "Codex OSS provider", cli: "codex", flags: "--oss"},
+		{name: "Codex local provider", cli: "codex", flags: "--local-provider ollama"},
+		{name: "Codex repeated override", cli: "codex", flags: "--color never --sandbox read-only --SaNdBoX=danger-full-access"},
+
+		{name: "Gemini sandbox", cli: "gemini", flags: "--sandbox"},
+		{name: "Gemini sandbox short", cli: "gemini", flags: "-s"},
+		{name: "Gemini sandbox negation", cli: "gemini", flags: "--no-sandbox"},
+		{name: "Gemini approval", cli: "gemini", flags: "--approval-mode auto_edit"},
+		{name: "Gemini approval casing", cli: "gemini", flags: "--ApPrOvAl-MoDe=yolo"},
+		{name: "Gemini approval camel case", cli: "gemini", flags: "--approvalMode=yolo"},
+		{name: "Gemini approval snake case", cli: "gemini", flags: "--approval_mode=yolo"},
+		{name: "Gemini yolo", cli: "gemini", flags: "--yolo"},
+		{name: "Gemini yolo short", cli: "gemini", flags: "-y"},
+		{name: "Gemini yolo short bundle", cli: "gemini", flags: "-dy"},
+		{name: "Gemini sandbox and yolo short bundle", cli: "gemini", flags: "-dsy"},
+		{name: "Gemini skip trust", cli: "gemini", flags: "--skip-trust"},
+		{name: "Gemini allowed tools", cli: "gemini", flags: "--allowed-tools shell"},
+		{name: "Gemini policy", cli: "gemini", flags: "--policy allow-all.toml"},
+		{name: "Gemini admin policy", cli: "gemini", flags: "--admin-policy=allow-all.toml"},
+		{name: "Gemini extension", cli: "gemini", flags: "--extensions unsafe-extension"},
+		{name: "Gemini extension short", cli: "gemini", flags: "-e unsafe-extension"},
+		{name: "Gemini ACP mode", cli: "gemini", flags: "--experimental-acp"},
+		{name: "Gemini fake responses file", cli: "gemini", flags: "--fake-responses=/etc/responses.json"},
+		{name: "Gemini record responses file", cli: "gemini", flags: "--recordResponses=/etc/responses.json"},
+		{name: "Gemini session file", cli: "gemini", flags: "--session-file=/etc/session.json"},
+		{name: "Gemini resumed session", cli: "gemini", flags: "-r5"},
+		{name: "Gemini include directories", cli: "gemini", flags: "--include-directories=/etc"},
+		{name: "Gemini include directories camel case", cli: "gemini", flags: "--includeDirectories=/etc"},
+		{name: "Gemini no sandbox camel case", cli: "gemini", flags: "--noSandbox"},
+		{name: "Gemini worktree", cli: "gemini", flags: "-w unsafe"},
+		{name: "Gemini worktree short attached", cli: "gemini", flags: "-wunsafe"},
+
+		{name: "OpenCode auto", cli: "opencode", flags: "--auto"},
+		{name: "OpenCode agent", cli: "opencode", flags: "--agent build"},
+		{name: "OpenCode directory", cli: "opencode", flags: "--dir=/etc"},
+		{name: "OpenCode attach", cli: "opencode", flags: "--attach http://localhost:4096"},
+		{name: "OpenCode file", cli: "opencode", flags: "--file /etc/passwd"},
+		{name: "OpenCode file short", cli: "opencode", flags: "-f=/etc/passwd"},
+		{name: "OpenCode file short attached", cli: "opencode", flags: "-f/etc/passwd"},
+		{name: "OpenCode bundled file alias", cli: "opencode", flags: "-if/etc/passwd"},
+		{name: "OpenCode command config", cli: "opencode", flags: "--command unsafe"},
+		{name: "OpenCode future permission alias", cli: "opencode", flags: "--permission=allow"},
+		{name: "OpenCode external share", cli: "opencode", flags: "--share"},
+		{name: "OpenCode sandbox negation", cli: "opencode", flags: "--no-sandbox"},
+		{name: "OpenCode resumed session", cli: "opencode", flags: "-sSESSION"},
+		{name: "OpenCode continued session", cli: "opencode", flags: "--continue"},
+		{name: "OpenCode interactive mode", cli: "opencode", flags: "-i"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := executor.ValidateExtraFlagsForCLI(tc.cli, tc.flags); err == nil {
+				t.Fatalf("ValidateExtraFlagsForCLI(%q, %q) unexpectedly succeeded", tc.cli, tc.flags)
+			}
+		})
+	}
+}
+
+func TestValidateExtraFlagsForCLIAllowsSafeFlagsInOrder(t *testing.T) {
+	tests := []struct {
+		cli   string
+		flags string
+	}{
+		{cli: "claude", flags: "--model opus --max-turns 5 --output-format json --verbose --disallowed-tools Bash --strict-mcp-config"},
+		{cli: "codex", flags: "-mgpt-5 --json --color never --ephemeral"},
+		{cli: "gemini", flags: "-mpro --output-format json -d --screen-reader"},
+		{cli: "opencode", flags: "-mopenai/gpt-5 --format json --thinking --variant high --pure"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.cli, func(t *testing.T) {
+			if err := executor.ValidateExtraFlagsForCLI(tc.cli, tc.flags); err != nil {
+				t.Fatalf("ValidateExtraFlagsForCLI(%q, %q): %v", tc.cli, tc.flags, err)
+			}
+		})
+	}
+}
+
+func TestValidateExtraFlagsForCLIFailsClosed(t *testing.T) {
+	tests := []struct {
+		name  string
+		cli   string
+		flags string
+	}{
+		{name: "Claude future flag", cli: "claude", flags: "--future-auto-approve"},
+		{name: "Codex future flag", cli: "codex", flags: "--future-config /tmp/config"},
+		{name: "Gemini future short alias", cli: "gemini", flags: "-z"},
+		{name: "OpenCode future flag", cli: "opencode", flags: "--future-attach"},
+		{name: "Claude bare can omit project policy", cli: "claude", flags: "--bare"},
+		{name: "Claude restrictive bool disabled inline", cli: "claude", flags: "--no-session-persistence=false"},
+		{name: "Codex restrictive bool disabled inline", cli: "codex", flags: "--ephemeral=false"},
+		{name: "Gemini bool uses inline value", cli: "gemini", flags: "--debug=false"},
+		{name: "Codex positional subcommand", cli: "codex", flags: "--json resume deadbeef"},
+		{name: "bare positional argument", cli: "gemini", flags: "resume"},
+		{name: "missing required value", cli: "codex", flags: "--color"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := executor.ValidateExtraFlagsForCLI(tc.cli, tc.flags); err == nil {
+				t.Fatalf("ValidateExtraFlagsForCLI(%q, %q) unexpectedly succeeded", tc.cli, tc.flags)
 			}
 		})
 	}

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -88,6 +88,110 @@ func TestOptionsForSelectedCLI(t *testing.T) {
 	}
 }
 
+func TestNormalizeTypedModesAcceptsHarmlessCaseVariants(t *testing.T) {
+	if got, err := executor.NormalizeEffort(" HIGH "); err != nil || got != "high" {
+		t.Fatalf("NormalizeEffort = %q, %v; want high", got, err)
+	}
+	if got, err := executor.NormalizePermissionMode("ACCEPTEDITS"); err != nil || got != "acceptEdits" {
+		t.Fatalf("NormalizePermissionMode = %q, %v; want acceptEdits", got, err)
+	}
+	if got, err := executor.NormalizeApprovalModeForCLI("codex", "FULL-AUTO"); err != nil || got != "never" {
+		t.Fatalf("NormalizeApprovalModeForCLI(codex) = %q, %v; want never", got, err)
+	}
+	if got, err := executor.NormalizeApprovalModeForCLI("gemini", "Auto-Edit"); err != nil || got != "auto_edit" {
+		t.Fatalf("NormalizeApprovalModeForCLI(gemini) = %q, %v; want auto_edit", got, err)
+	}
+}
+
+func TestMigrateLegacyTypedExtraFlagsForCLI(t *testing.T) {
+	tests := []struct {
+		name       string
+		cli        string
+		opts       executor.ExecOptions
+		want       executor.ExecOptions
+		wantFields []string
+	}{
+		{
+			name: "Claude promotes legacy typed fields and preserves safe flags",
+			cli:  "claude",
+			opts: executor.ExecOptions{
+				ExtraFlags: "--model opus --maxTurns=8 --effort HIGH --verbose",
+			},
+			want: executor.ExecOptions{
+				Model:      "opus",
+				MaxTurns:   8,
+				Effort:     "high",
+				ExtraFlags: "--verbose",
+			},
+			wantFields: []string{"model", "max_turns", "effort"},
+		},
+		{
+			name: "explicit typed model wins over legacy duplicate",
+			cli:  "codex",
+			opts: executor.ExecOptions{
+				Model:      "typed",
+				ExtraFlags: "-mlegacy --json",
+			},
+			want: executor.ExecOptions{
+				Model:      "typed",
+				ExtraFlags: "--json",
+			},
+			wantFields: []string{"model"},
+		},
+		{
+			name: "invalid legacy typed value remains for strict rejection",
+			cli:  "claude",
+			opts: executor.ExecOptions{
+				ExtraFlags: "--model --sandbox danger-full-access",
+			},
+			want: executor.ExecOptions{
+				ExtraFlags: "--model --sandbox danger-full-access",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, fields := executor.MigrateLegacyTypedExtraFlagsForCLI(tc.cli, tc.opts)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("migrated options:\n got: %+v\nwant: %+v", got, tc.want)
+			}
+			if !reflect.DeepEqual(fields, tc.wantFields) {
+				t.Fatalf("migrated fields = %v, want %v", fields, tc.wantFields)
+			}
+		})
+	}
+}
+
+func TestNormalizeLegacyCLIFlagsForCLI(t *testing.T) {
+	got, fields, err := executor.NormalizeLegacyCLIFlagsForCLI(
+		"claude",
+		"--model profile-model --max-turns 7 --effort HIGH --verbose",
+	)
+	if err != nil {
+		t.Fatalf("NormalizeLegacyCLIFlagsForCLI: %v", err)
+	}
+	want := executor.ExecOptions{
+		Model:      "profile-model",
+		MaxTurns:   7,
+		Effort:     "high",
+		ExtraFlags: "--verbose",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalized profile options:\n got: %+v\nwant: %+v", got, want)
+	}
+	if wantFields := []string{"model", "max_turns", "effort"}; !reflect.DeepEqual(fields, wantFields) {
+		t.Fatalf("migrated fields = %v, want %v", fields, wantFields)
+	}
+
+	if _, _, err := executor.NormalizeLegacyCLIFlagsForCLI(
+		"codex",
+		"--model gpt-5 --sandbox danger-full-access",
+	); err == nil {
+		t.Fatal("unsafe sibling flag was accepted after typed model migration")
+	}
+}
+
 func TestExecute(t *testing.T) {
 	_, file, _, _ := runtime.Caller(0)
 	binDir := filepath.Join(filepath.Dir(file), "testdata", "bin")
@@ -276,11 +380,13 @@ func TestValidateApprovalModeForCLI(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "codex current", cli: "codex", mode: "on-request"},
+		{name: "codex harmless casing", cli: "codex", mode: "On-Request"},
 		{name: "codex legacy", cli: "codex", mode: "auto-edit"},
 		{name: "codex rejects gemini plan", cli: "codex", mode: "plan", wantErr: true},
 		{name: "gemini default", cli: "gemini", mode: "default"},
 		{name: "gemini underscore auto edit", cli: "gemini", mode: "auto_edit"},
 		{name: "gemini hyphen auto edit", cli: "gemini", mode: "auto-edit"},
+		{name: "gemini harmless casing", cli: "gemini", mode: "AUTO-EDIT"},
 		{name: "gemini plan", cli: "gemini", mode: "plan"},
 		{name: "gemini rejects yolo", cli: "gemini", mode: "yolo", wantErr: true},
 		{name: "gemini rejects codex never", cli: "gemini", mode: "never", wantErr: true},
@@ -315,7 +421,7 @@ func TestExecuteRawGeminiAddsTypedApprovalBeforeSafeExtraFlags(t *testing.T) {
 
 	e := executor.New()
 	opts := executor.ExecOptions{
-		ApprovalMode: "auto-edit",
+		ApprovalMode: "AUTO-EDIT",
 		ExtraFlags:   "--output-format json --debug --output-format text",
 	}
 	if _, err := e.ExecuteRaw("gemini", "prompt", opts); err != nil {
@@ -376,6 +482,11 @@ func TestExecuteRawRejectsUnsafeRequestBeforeStartingCLI(t *testing.T) {
 			name: "legacy Claude extra flags",
 			cli:  "claude",
 			opts: executor.ExecOptions{ExtraFlags: "--permission-mode=bypassPermissions"},
+		},
+		{
+			name: "free-form model cannot override typed model",
+			cli:  "claude",
+			opts: executor.ExecOptions{Model: "typed", ExtraFlags: "--model other"},
 		},
 		{
 			name: "legacy Codex extra flags",
@@ -565,8 +676,8 @@ func TestValidateExtraFlags(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "safe model flag — allowed",
-			flags:   "--model claude-opus-4-6",
+			name:    "safe output flag — allowed",
+			flags:   "--output-format json",
 			wantErr: false,
 		},
 		{
@@ -591,7 +702,7 @@ func TestValidateExtraFlags(t *testing.T) {
 		},
 		{
 			name:    "mixed safe flags — allowed",
-			flags:   "--model claude-opus-4-6 --max-turns 5",
+			flags:   "--output-format json --verbose",
 			wantErr: false,
 		},
 		{
@@ -669,6 +780,10 @@ func TestValidateExtraFlagsForCLIRejectsPolicyAliases(t *testing.T) {
 		{name: "Claude resume hidden in legacy debug bundle", cli: "claude", flags: "-dr00000000-0000-4000-8000-000000000000"},
 		{name: "Claude PR session", cli: "claude", flags: "--from-pr 42"},
 		{name: "Claude tool availability", cli: "claude", flags: "--tools Read"},
+		{name: "Claude typed model long", cli: "claude", flags: "--model opus"},
+		{name: "Claude typed model short attached", cli: "claude", flags: "-mopus"},
+		{name: "Claude typed effort", cli: "claude", flags: "--effort high"},
+		{name: "Claude typed max turns casing alias", cli: "claude", flags: "--maxTurns=5"},
 
 		{name: "Codex approval", cli: "codex", flags: "--ask-for-approval never"},
 		{name: "Codex approval camel case", cli: "codex", flags: "--askForApproval=never"},
@@ -701,6 +816,7 @@ func TestValidateExtraFlagsForCLIRejectsPolicyAliases(t *testing.T) {
 		{name: "Codex OSS provider", cli: "codex", flags: "--oss"},
 		{name: "Codex local provider", cli: "codex", flags: "--local-provider ollama"},
 		{name: "Codex repeated override", cli: "codex", flags: "--color never --sandbox read-only --SaNdBoX=danger-full-access"},
+		{name: "Codex typed model short", cli: "codex", flags: "-m gpt-5"},
 
 		{name: "Gemini sandbox", cli: "gemini", flags: "--sandbox"},
 		{name: "Gemini sandbox short", cli: "gemini", flags: "-s"},
@@ -729,6 +845,7 @@ func TestValidateExtraFlagsForCLIRejectsPolicyAliases(t *testing.T) {
 		{name: "Gemini no sandbox camel case", cli: "gemini", flags: "--noSandbox"},
 		{name: "Gemini worktree", cli: "gemini", flags: "-w unsafe"},
 		{name: "Gemini worktree short attached", cli: "gemini", flags: "-wunsafe"},
+		{name: "Gemini typed model", cli: "gemini", flags: "--model pro"},
 
 		{name: "OpenCode auto", cli: "opencode", flags: "--auto"},
 		{name: "OpenCode agent", cli: "opencode", flags: "--agent build"},
@@ -745,6 +862,7 @@ func TestValidateExtraFlagsForCLIRejectsPolicyAliases(t *testing.T) {
 		{name: "OpenCode resumed session", cli: "opencode", flags: "-sSESSION"},
 		{name: "OpenCode continued session", cli: "opencode", flags: "--continue"},
 		{name: "OpenCode interactive mode", cli: "opencode", flags: "-i"},
+		{name: "OpenCode typed model attached", cli: "opencode", flags: "-mopenai/gpt-5"},
 	}
 
 	for _, tc := range tests {
@@ -761,10 +879,10 @@ func TestValidateExtraFlagsForCLIAllowsSafeFlagsInOrder(t *testing.T) {
 		cli   string
 		flags string
 	}{
-		{cli: "claude", flags: "--model opus --max-turns 5 --output-format json --verbose --disallowed-tools Bash --strict-mcp-config"},
-		{cli: "codex", flags: "-mgpt-5 --json --color never --ephemeral"},
-		{cli: "gemini", flags: "-mpro --output-format json -d --screen-reader"},
-		{cli: "opencode", flags: "-mopenai/gpt-5 --format json --thinking --variant high --pure"},
+		{cli: "claude", flags: "--fallback-model sonnet --output-format json --verbose --disallowed-tools Bash --strict-mcp-config"},
+		{cli: "codex", flags: "--json --color never --ephemeral"},
+		{cli: "gemini", flags: "--output-format json -d --screen-reader"},
+		{cli: "opencode", flags: "--format json --thinking --variant high --pure"},
 	}
 
 	for _, tc := range tests {

--- a/daemon/internal/issues/pipeline.go
+++ b/daemon/internal/issues/pipeline.go
@@ -607,7 +607,8 @@ func (p *Pipeline) runReviewOnly(ctx context.Context, issue *github.Issue, issue
 		p.publishError(issueID, issue, fmt.Errorf("detect CLI: %w", err))
 		return nil, fmt.Errorf("issues pipeline: detect CLI: %w", err)
 	}
-	raw, err := p.executor.ExecuteRaw(cli, prompt, opts.ExecOpts)
+	execOpts := executor.OptionsForSelectedCLI(opts.Primary, cli, opts.ExecOpts)
+	raw, err := p.executor.ExecuteRaw(cli, prompt, execOpts)
 	if err != nil {
 		p.publishError(issueID, issue, fmt.Errorf("execute %s: %w", cli, err))
 		return nil, fmt.Errorf("issues pipeline: execute %s: %w", cli, err)
@@ -723,6 +724,7 @@ func (p *Pipeline) runAutoImplement(ctx context.Context, issue *github.Issue, is
 		p.publishError(issueID, issue, fmt.Errorf("detect CLI: %w", err))
 		return nil, fmt.Errorf("issues pipeline: detect CLI: %w", err)
 	}
+	opts.ExecOpts = executor.OptionsForSelectedCLI(opts.Primary, cli, opts.ExecOpts)
 
 	// Auto_implement requires the CLI to be allowed to write files. When the
 	// operator has not configured a permission/approval flag explicitly, fall
@@ -1008,10 +1010,6 @@ func (p *Pipeline) autoImplementNoChangesFallback(issue *github.Issue, issueID i
 // every issue degrades to the no-changes fallback comment (#433). Any
 // explicit operator setting wins; this only fills the gap when *nothing* is
 // configured.
-//
-// gemini has no equivalent non-interactive write flag today: callers must
-// configure --include-directories plus an approval bypass in extra_flags
-// themselves. We log a warn so the operator sees why writes are no-op.
 func ensureAutoImplementWritePerms(cli string, opts executor.ExecOptions) executor.ExecOptions {
 	switch cli {
 	case "claude":
@@ -1027,9 +1025,11 @@ func ensureAutoImplementWritePerms(cli string, opts executor.ExecOptions) execut
 				"cli", cli)
 		}
 	case "gemini":
-		slog.Warn("issues pipeline: gemini has no built-in write-permission default; "+
-			"configure approval bypass via extra_flags or expect no-changes runs",
-			"cli", cli)
+		if strings.TrimSpace(opts.ApprovalMode) == "" {
+			opts.ApprovalMode = "auto_edit"
+			slog.Info("issues pipeline: defaulting gemini approval_mode to auto_edit for auto_implement",
+				"cli", cli)
+		}
 	}
 	return opts
 }

--- a/daemon/internal/issues/pipeline_test.go
+++ b/daemon/internal/issues/pipeline_test.go
@@ -1008,6 +1008,61 @@ func TestPipeline_AutoImplementDefaultsCodexApprovalMode(t *testing.T) {
 	}
 }
 
+func TestPipeline_AutoImplementDefaultsGeminiApprovalMode(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{defaultBranch: "main"}
+	exec := &fakeExec{detectCLI: "gemini", rawOutput: []byte("ok")}
+	git := &fakeGit{hasChanges: true}
+	p := issues.New(s, gh, exec, git, &fakeBroker{}, nil)
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), autoImplementRunOptions()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if exec.lastOpts.ApprovalMode != "auto_edit" {
+		t.Errorf("ApprovalMode = %q, want auto_edit (safe default for gemini auto_implement)", exec.lastOpts.ApprovalMode)
+	}
+}
+
+func TestPipeline_AutoImplementFallbackDropsPrimaryProviderOptions(t *testing.T) {
+	s := &fakeStore{}
+	gh := &fakeGH{defaultBranch: "main"}
+	exec := &fakeExec{detectCLI: "gemini", rawOutput: []byte("ok")}
+	git := &fakeGit{hasChanges: true}
+	p := issues.New(s, gh, exec, git, &fakeBroker{}, nil)
+
+	opts := autoImplementRunOptions()
+	opts.Primary = "codex"
+	opts.Fallback = "gemini"
+	opts.ExecOpts.Model = "codex-only-model"
+	opts.ExecOpts.MaxTurns = 9
+	opts.ExecOpts.ApprovalMode = "never"
+	opts.ExecOpts.ExtraFlags = "--json"
+	opts.ExecOpts.Effort = "high"
+	opts.ExecOpts.PermissionMode = "acceptEdits"
+	opts.ExecOpts.Bare = true
+	opts.ExecOpts.DangerouslySkipPerms = true
+	opts.ExecOpts.NoSessionPersistence = true
+	opts.ExecOpts.Timeout = 17 * time.Minute
+
+	if _, err := p.Run(context.Background(), newIssue(config.IssueModeDevelop), opts); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if exec.lastCLI != "gemini" {
+		t.Fatalf("CLI = %q, want gemini fallback", exec.lastCLI)
+	}
+	if exec.lastOpts.Model != "" || exec.lastOpts.MaxTurns != 0 || exec.lastOpts.ExtraFlags != "" ||
+		exec.lastOpts.Effort != "" || exec.lastOpts.PermissionMode != "" || exec.lastOpts.Bare ||
+		exec.lastOpts.DangerouslySkipPerms || exec.lastOpts.NoSessionPersistence {
+		t.Fatalf("primary provider options leaked to fallback: %+v", exec.lastOpts)
+	}
+	if exec.lastOpts.ApprovalMode != "auto_edit" {
+		t.Fatalf("ApprovalMode = %q, want fallback-specific Gemini write default", exec.lastOpts.ApprovalMode)
+	}
+	if exec.lastOpts.WorkDir != "/tmp/repo" || exec.lastOpts.Timeout != 17*time.Minute {
+		t.Fatalf("provider-independent options were not preserved: %+v", exec.lastOpts)
+	}
+}
+
 func TestPipeline_AutoImplementNoChangesRecordsTerminalNoChanges(t *testing.T) {
 	// Agent escape hatch fired; the working tree is untouched. The pipeline
 	// must degrade to a review_only-style comment rather than open an empty PR.

--- a/daemon/internal/issues/refinement.go
+++ b/daemon/internal/issues/refinement.go
@@ -79,7 +79,8 @@ func (p *Pipeline) runRefinement(ctx context.Context, issue *github.Issue, issue
 		p.publishError(issueID, issue, fmt.Errorf("detect CLI: %w", err))
 		return nil, fmt.Errorf("issues pipeline: detect CLI: %w", err)
 	}
-	raw, err := p.executor.ExecuteRaw(cli, prompt, opts.ExecOpts)
+	execOpts := executor.OptionsForSelectedCLI(opts.Primary, cli, opts.ExecOpts)
+	raw, err := p.executor.ExecuteRaw(cli, prompt, execOpts)
 	if err != nil {
 		p.publishError(issueID, issue, fmt.Errorf("execute %s: %w", cli, err))
 		return nil, fmt.Errorf("issues pipeline: execute %s: %w", cli, err)

--- a/daemon/internal/issues/runfix.go
+++ b/daemon/internal/issues/runfix.go
@@ -110,7 +110,8 @@ func (p *Pipeline) RunFix(ctx context.Context, req FixRequest) (FixResult, error
 
 	// Promote CLI flags into write mode — same posture as
 	// runAutoImplement so the agent can actually edit files.
-	execOpts := ensureAutoImplementWritePerms(cli, req.ExecOpts)
+	execOpts := executor.OptionsForSelectedCLI(req.CLIPrimary, cli, req.ExecOpts)
+	execOpts = ensureAutoImplementWritePerms(cli, execOpts)
 
 	prompt := buildFixAgentPrompt(req)
 	if _, err := p.executor.ExecuteRaw(cli, prompt, execOpts); err != nil {

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -362,6 +362,25 @@ func (p *Pipeline) applyPrompt(repoPromptID, agentPromptID string, tmpl *string,
 	*flags = a.CLIFlags
 }
 
+func applyStoredProfileCLIFlags(cli, raw string, opts executor.ExecOptions) (executor.ExecOptions, error) {
+	profileOpts, migrated, err := executor.NormalizeLegacyCLIFlagsForCLI(cli, raw)
+	if err != nil {
+		return opts, err
+	}
+	for _, field := range migrated {
+		switch field {
+		case "model":
+			opts.Model = profileOpts.Model
+		case "effort":
+			opts.Effort = profileOpts.Effort
+		case "max_turns":
+			opts.MaxTurns = profileOpts.MaxTurns
+		}
+	}
+	opts.ExtraFlags = profileOpts.ExtraFlags
+	return opts, nil
+}
+
 // RunOptions carries per-execution settings derived from global + repo + agent config.
 type RunOptions struct {
 	Primary        string
@@ -742,11 +761,12 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	// permission or workspace guards.
 	execOpts := executor.OptionsForSelectedCLI(primary, cli, opts.ExecOpts)
 	if cliFlags != "" && execOpts.ExtraFlags == "" {
-		if err := executor.ValidateExtraFlagsForCLI(cli, cliFlags); err != nil {
+		migratedOpts, err := applyStoredProfileCLIFlags(cli, cliFlags, execOpts)
+		if err != nil {
 			slog.Warn("pipeline: prompt cli_flags rejected by execution policy, ignoring", "err", err)
 			// Don't abort the review — just skip the unsafe flags
 		} else {
-			execOpts.ExtraFlags = cliFlags
+			execOpts = migratedOpts
 		}
 	}
 	result, err := p.executor.Execute(cli, prompt, execOpts)

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -737,13 +737,13 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	})
 
 	// 5. Execute review (merge cliFlags from prompt into ExecOptions.ExtraFlags)
-	// Validate cliFlags from the prompt profile against the same denylist as
-	// ExtraFlags — a stored prompt can otherwise carry forbidden flags like
-	// --dangerously-skip-permissions that bypass the CLI agent config guards.
-	execOpts := opts.ExecOpts
+	// Validate cliFlags from the prompt profile against the selected provider's
+	// execution policy — a stored prompt must not override sandbox, approval,
+	// permission or workspace guards.
+	execOpts := executor.OptionsForSelectedCLI(primary, cli, opts.ExecOpts)
 	if cliFlags != "" && execOpts.ExtraFlags == "" {
-		if err := executor.ValidateExtraFlags(cliFlags); err != nil {
-			slog.Warn("pipeline: prompt cli_flags rejected by denylist, ignoring", "err", err)
+		if err := executor.ValidateExtraFlagsForCLI(cli, cliFlags); err != nil {
+			slog.Warn("pipeline: prompt cli_flags rejected by execution policy, ignoring", "err", err)
 			// Don't abort the review — just skip the unsafe flags
 		} else {
 			execOpts.ExtraFlags = cliFlags

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -177,7 +177,7 @@ func TestPipeline_Run(t *testing.T) {
 		ID: 1, Number: 1, Title: "Fix bug", Repo: "org/repo",
 		User: github.User{Login: "alice"}, State: "open",
 		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/1",
-		Head:      github.Branch{SHA: "sha1"},
+		Head: github.Branch{SHA: "sha1"},
 	}
 
 	rev, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini", ReviewMode: "single"})
@@ -205,15 +205,23 @@ func TestPipeline_Run(t *testing.T) {
 // fakeExecCapture captures the prompt passed to Execute for assertion in tests.
 type fakeExecCapture struct {
 	capturePrompt *string
+	captureOpts   *executor.ExecOptions
+	detectCLI     string
 }
 
 func (f *fakeExecCapture) Detect(primary, fallback string) (string, error) {
+	if f.detectCLI != "" {
+		return f.detectCLI, nil
+	}
 	return "fake_claude", nil
 }
 
-func (f *fakeExecCapture) Execute(cli, prompt string, _ executor.ExecOptions) (*executor.ReviewResult, error) {
+func (f *fakeExecCapture) Execute(cli, prompt string, opts executor.ExecOptions) (*executor.ReviewResult, error) {
 	if f.capturePrompt != nil {
 		*f.capturePrompt = prompt
+	}
+	if f.captureOpts != nil {
+		*f.captureOpts = opts
 	}
 	return &executor.ReviewResult{Summary: "ok", Severity: "low"}, nil
 }
@@ -260,7 +268,7 @@ func TestPipeline_Run_CommentsInjectedIntoPrompt(t *testing.T) {
 		ID: 2, Number: 2, Title: "Add feature", Repo: "org/repo",
 		User: github.User{Login: "alice"}, State: "open",
 		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/2",
-		Head:      github.Branch{SHA: "sha2"},
+		Head: github.Branch{SHA: "sha2"},
 	}
 	_, err = p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
 	if err != nil {
@@ -271,6 +279,47 @@ func TestPipeline_Run_CommentsInjectedIntoPrompt(t *testing.T) {
 	}
 	if !strings.Contains(capturedPrompt, "Please add error handling here") {
 		t.Errorf("expected comment body in prompt, got: %s", capturedPrompt)
+	}
+}
+
+func TestPipeline_RunFallbackDropsPrimaryProviderOptions(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	var captured executor.ExecOptions
+	exec := &fakeExecCapture{captureOpts: &captured, detectCLI: "gemini"}
+	p := pipeline.New(s, &fakeGH{diff: "+new line"}, exec, &fakeNotify{})
+	pr := &github.PullRequest{
+		ID: 22, Number: 22, Title: "Fallback", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/22",
+		Head: github.Branch{SHA: "sha22"},
+	}
+	opts := executor.ExecOptions{
+		Model:                "codex-only",
+		MaxTurns:             4,
+		ApprovalMode:         "never",
+		ExtraFlags:           "--json",
+		WorkDir:              "/tmp/repo",
+		Effort:               "high",
+		PermissionMode:       "acceptEdits",
+		Bare:                 true,
+		DangerouslySkipPerms: true,
+		NoSessionPersistence: true,
+		Timeout:              11 * time.Minute,
+	}
+
+	if _, err := p.Run(pr, pipeline.RunOptions{
+		Primary: "codex", Fallback: "gemini", ReviewMode: "single", ExecOpts: opts,
+	}); err != nil {
+		t.Fatalf("pipeline run: %v", err)
+	}
+	want := executor.ExecOptions{WorkDir: "/tmp/repo", Timeout: 11 * time.Minute}
+	if captured != want {
+		t.Fatalf("fallback options:\n got: %+v\nwant: %+v", captured, want)
 	}
 }
 
@@ -287,7 +336,7 @@ func TestPipeline_Run_CommentsFetchErrorIsNonFatal(t *testing.T) {
 		ID: 3, Number: 3, Title: "Fix", Repo: "org/repo",
 		User: github.User{Login: "alice"}, State: "open",
 		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/3",
-		Head:      github.Branch{SHA: "sha3"},
+		Head: github.Branch{SHA: "sha3"},
 	}
 	_, err = p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
 	if err != nil {
@@ -794,7 +843,7 @@ func TestPipeline_Run_FailsClosedOnEmptyResolvedSHA(t *testing.T) {
 		ID: 88, Number: 88, Title: "t", Repo: "org/repo",
 		User: github.User{Login: "alice"}, State: "open",
 		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/88",
-		Head:      github.Branch{SHA: ""}, // forces the resolver path
+		Head: github.Branch{SHA: ""}, // forces the resolver path
 	}
 	_, err = p.Run(pr, pipeline.RunOptions{Primary: "claude", Force: true})
 	if err == nil {
@@ -845,7 +894,7 @@ func TestPipeline_Run_ForceBackfillsLegacyRowAndReviews(t *testing.T) {
 		ID: 77, Number: 77, Title: "t", Repo: "org/repo",
 		User: github.User{Login: "alice"}, State: "open",
 		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/77",
-		Head:      github.Branch{SHA: "newsha"},
+		Head: github.Branch{SHA: "newsha"},
 	}
 	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Force: true}); err != nil {
 		t.Fatalf("forced run: %v", err)

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -323,6 +323,61 @@ func TestPipeline_RunFallbackDropsPrimaryProviderOptions(t *testing.T) {
 	}
 }
 
+func TestPipeline_RunMigratesStoredProfileCLIFlagsBeforeExecution(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	if err := s.UpsertAgent(&store.Agent{
+		ID:           "legacy-profile",
+		Name:         "Legacy profile",
+		CLI:          "claude",
+		Instructions: "Review carefully",
+		CLIFlags:     "--model profile-model --max-turns 7 --effort HIGH --verbose",
+		IsDefaultPR:  true,
+		CreatedAt:    time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("upsert profile: %v", err)
+	}
+
+	var captured executor.ExecOptions
+	exec := &fakeExecCapture{captureOpts: &captured, detectCLI: "claude"}
+	p := pipeline.New(s, &fakeGH{diff: "+new line"}, exec, &fakeNotify{})
+	pr := &github.PullRequest{
+		ID: 23, Number: 23, Title: "Legacy profile", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/23",
+		Head: github.Branch{SHA: "sha23"},
+	}
+
+	if _, err := p.Run(pr, pipeline.RunOptions{
+		Primary: "claude",
+		ExecOpts: executor.ExecOptions{
+			Model:    "global-model",
+			MaxTurns: 2,
+			Effort:   "low",
+			WorkDir:  "/tmp/repo",
+			Timeout:  3 * time.Minute,
+		},
+	}); err != nil {
+		t.Fatalf("pipeline run: %v", err)
+	}
+
+	want := executor.ExecOptions{
+		Model:      "profile-model",
+		MaxTurns:   7,
+		Effort:     "high",
+		ExtraFlags: "--verbose",
+		WorkDir:    "/tmp/repo",
+		Timeout:    3 * time.Minute,
+	}
+	if captured != want {
+		t.Fatalf("stored profile options:\n got: %+v\nwant: %+v", captured, want)
+	}
+}
+
 func TestPipeline_Run_CommentsFetchErrorIsNonFatal(t *testing.T) {
 	s, err := store.Open(":memory:")
 	if err != nil {

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -296,6 +296,13 @@ func (srv *Server) writeTOMLUnderLock(mutateFn func(m map[string]any) error) (ma
 	if err != nil {
 		return nil, err
 	}
+	// Migrate only the trusted TOML base before applying the request. Every
+	// PATCH payload has already passed the strict HTTP policy, so legacy typed
+	// flags can no longer block an unrelated edit without creating a path for a
+	// new payload to smuggle those flags into ExtraFlags.
+	if err := config.SanitizeLegacyAgentExecutionPolicyMap(m, "toml PATCH base"); err != nil {
+		return nil, err
+	}
 	if err := mutateFn(m); err != nil {
 		return nil, err
 	}
@@ -1384,7 +1391,7 @@ func (srv *Server) handleUpsertAgent(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "cli is required when cli_flags is set", http.StatusBadRequest)
 			return
 		}
-		if err := executor.ValidateExtraFlagsForCLI(a.CLI, a.CLIFlags); err != nil {
+		if _, _, err := executor.NormalizeLegacyCLIFlagsForCLI(a.CLI, a.CLIFlags); err != nil {
 			http.Error(w, fmt.Sprintf("invalid cli_flags: %v", err), http.StatusBadRequest)
 			return
 		}
@@ -2208,17 +2215,21 @@ func validateCanonicalAgentConfigKeys(cli string, agent map[string]any, path str
 			if !ok {
 				return fmt.Errorf("config PATCH key %q must be a string", path+"."+key)
 			}
+			model = strings.TrimSpace(model)
 			if err := executor.ValidateModel(model); err != nil {
 				return fmt.Errorf("config PATCH key %q: %w", path+"."+key, err)
 			}
+			agent[key] = model
 		case "effort":
 			effort, ok := value.(string)
 			if !ok {
 				return fmt.Errorf("config PATCH key %q must be a string", path+"."+key)
 			}
-			if err := executor.ValidateEffort(effort); err != nil {
+			canonicalValue, err := executor.NormalizeEffort(effort)
+			if err != nil {
 				return fmt.Errorf("config PATCH key %q: %w", path+"."+key, err)
 			}
+			agent[key] = canonicalValue
 		case "extra_flags":
 			flags, ok := value.(string)
 			if !ok {
@@ -2232,17 +2243,21 @@ func validateCanonicalAgentConfigKeys(cli string, agent map[string]any, path str
 			if !ok {
 				return fmt.Errorf("config PATCH key %q must be a string", path+"."+key)
 			}
-			if err := executor.ValidatePermissionMode(mode); err != nil {
+			canonicalValue, err := executor.NormalizePermissionMode(mode)
+			if err != nil {
 				return fmt.Errorf("config PATCH key %q: %w", path+"."+key, err)
 			}
+			agent[key] = canonicalValue
 		case "approval_mode":
 			mode, ok := value.(string)
 			if !ok {
 				return fmt.Errorf("config PATCH key %q must be a string", path+"."+key)
 			}
-			if err := executor.ValidateApprovalModeForCLI(cli, mode); err != nil {
+			canonicalValue, err := executor.NormalizeApprovalModeForCLI(cli, mode)
+			if err != nil {
 				return fmt.Errorf("config PATCH key %q: %w", path+"."+key, err)
 			}
+			agent[key] = canonicalValue
 		}
 	}
 	return nil
@@ -2475,14 +2490,17 @@ func normalizeAgentConfigsForPut(v any) (map[string]map[string]any, error) {
 					return nil, fmt.Errorf("agent_configs[%q].%s must be a string", cli, k)
 				}
 				if k == "model" {
+					s = strings.TrimSpace(s)
 					if err := executor.ValidateModel(s); err != nil {
 						return nil, fmt.Errorf("agent_configs[%q].model: %v", cli, err)
 					}
 				}
 				if k == "effort" {
-					if err := executor.ValidateEffort(s); err != nil {
+					canonicalValue, err := executor.NormalizeEffort(s)
+					if err != nil {
 						return nil, fmt.Errorf("agent_configs[%q].effort: %v", cli, err)
 					}
+					s = canonicalValue
 				}
 				if k == "extra_flags" && s != "" {
 					if err := executor.ValidateExtraFlagsForCLI(cli, s); err != nil {
@@ -2500,19 +2518,21 @@ func normalizeAgentConfigsForPut(v any) (map[string]map[string]any, error) {
 				if !isStr {
 					return nil, fmt.Errorf("agent_configs[%q].permission_mode must be a string", cli)
 				}
-				if err := executor.ValidatePermissionMode(s); err != nil {
+				canonicalValue, err := executor.NormalizePermissionMode(s)
+				if err != nil {
 					return nil, fmt.Errorf("agent_configs[%q].permission_mode: %v", cli, err)
 				}
-				normalized[k] = s
+				normalized[k] = canonicalValue
 			case "approval_mode":
 				s, isStr := val.(string)
 				if !isStr {
 					return nil, fmt.Errorf("agent_configs[%q].approval_mode must be a string", cli)
 				}
-				if err := executor.ValidateApprovalModeForCLI(cli, s); err != nil {
+				canonicalValue, err := executor.NormalizeApprovalModeForCLI(cli, s)
+				if err != nil {
 					return nil, fmt.Errorf("agent_configs[%q].approval_mode: %v", cli, err)
 				}
-				normalized[k] = s
+				normalized[k] = canonicalValue
 			case "max_turns":
 				n, isNum := val.(float64) // JSON numbers decode as float64
 				if !isNum || n < 0 || n != float64(int(n)) {

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -299,18 +299,6 @@ func (srv *Server) writeTOMLUnderLock(mutateFn func(m map[string]any) error) (ma
 	if err := mutateFn(m); err != nil {
 		return nil, err
 	}
-	// Defense-in-depth (security gate M-5): every PATCH path that
-	// touches ai.agents.* must drop dangerously_skip_perms before the
-	// merged map is validated and persisted. PUT rejects the key with
-	// a 400 via normalizeAgentConfigsForPut, but PATCH deep-merges
-	// arbitrary JSON, so the gate has to be enforced here regardless
-	// of which handler invoked patchTOML. Audit-log non-zero strips so
-	// operators can detect bypass attempts even though they're now
-	// neutralized.
-	if stripped := stripDangerousAgentFlags(m); stripped > 0 {
-		slog.Warn("config: PATCH attempted to set dangerously_skip_perms; stripped (M-5 gate)",
-			"count", stripped)
-	}
 	if err := config.ValidateMap(m); err != nil {
 		return nil, err
 	}
@@ -855,6 +843,11 @@ func (srv *Server) handlePatchConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
 		return
 	}
+	if err := validateCanonicalConfigPatchKeys(patch); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	stripHTTPDangerousAgentFlags(patch)
 	if err := config.ContainsNull(patch); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
 			"error": "null values not allowed in PATCH — use DELETE to remove fields",
@@ -908,6 +901,10 @@ func (srv *Server) handlePatchRepoConfig(w http.ResponseWriter, r *http.Request)
 		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
 		return
 	}
+	if err := validateCanonicalScopedAgentPatchKeys(patch, "ai.repos"); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
 	if err := config.ContainsNull(patch); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
 			"error": "null values not allowed in PATCH — use DELETE to remove fields",
@@ -923,6 +920,7 @@ func (srv *Server) handlePatchRepoConfig(w http.ResponseWriter, r *http.Request)
 			},
 		},
 	}
+	stripHTTPDangerousAgentFlags(globalPatch)
 
 	result, err := srv.patchTOML(func(m map[string]any) error {
 		merged := config.DeepMerge(m, globalPatch)
@@ -969,6 +967,10 @@ func (srv *Server) handlePatchOrgConfig(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
 		return
 	}
+	if err := validateCanonicalScopedAgentPatchKeys(patch, "ai.orgs"); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
 	if err := config.ContainsNull(patch); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
 			"error": "null values not allowed in PATCH — use DELETE to remove fields",
@@ -984,6 +986,7 @@ func (srv *Server) handlePatchOrgConfig(w http.ResponseWriter, r *http.Request) 
 			},
 		},
 	}
+	stripHTTPDangerousAgentFlags(globalPatch)
 
 	result, err := srv.patchTOML(func(m map[string]any) error {
 		merged := config.DeepMerge(m, globalPatch)
@@ -1045,6 +1048,10 @@ func (srv *Server) patchAutonomousSubKey(w http.ResponseWriter, r *http.Request,
 	var patch map[string]any
 	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	if err := rejectAutonomousAgentPatch(patch, "autonomous."+subKey+"."+id); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
 	if err := config.ContainsNull(patch); err != nil {
@@ -1373,7 +1380,11 @@ func (srv *Server) handleUpsertAgent(w http.ResponseWriter, r *http.Request) {
 	}
 	// Validate CLIFlags to reject dangerous flags before persisting.
 	if a.CLIFlags != "" {
-		if err := executor.ValidateExtraFlags(a.CLIFlags); err != nil {
+		if a.CLI == "" {
+			http.Error(w, "cli is required when cli_flags is set", http.StatusBadRequest)
+			return
+		}
+		if err := executor.ValidateExtraFlagsForCLI(a.CLI, a.CLIFlags); err != nil {
 			http.Error(w, fmt.Sprintf("invalid cli_flags: %v", err), http.StatusBadRequest)
 			return
 		}
@@ -2132,6 +2143,227 @@ func tailLines(f *os.File, n int) []string {
 // this constant so the M-5 denylist has a single source of truth.
 const dangerousAgentFlagKey = "dangerously_skip_perms"
 
+var canonicalAgentConfigKeys = []string{
+	"model",
+	"max_turns",
+	"approval_mode",
+	"extra_flags",
+	"prompt",
+	"effort",
+	"permission_mode",
+	"bare",
+	"no_session_persistence",
+	"execution_timeout",
+}
+
+// canonicalMapChild returns a map stored at canonicalKey and rejects aliases
+// that differ only by case. JSON object keys are case-sensitive, while the
+// downstream config decoder is not; accepting both spellings would let an
+// HTTP PATCH bypass validation performed against the canonical tree.
+func canonicalMapChild(m map[string]any, canonicalKey, path string) (map[string]any, bool, error) {
+	var raw any
+	found := false
+	for key, value := range m {
+		if !strings.EqualFold(key, canonicalKey) {
+			continue
+		}
+		if key != canonicalKey {
+			return nil, false, fmt.Errorf(
+				"config PATCH key %q must use canonical casing %q",
+				path+"."+key, path+"."+canonicalKey,
+			)
+		}
+		raw = value
+		found = true
+	}
+	if !found {
+		return nil, false, nil
+	}
+	child, ok := raw.(map[string]any)
+	if !ok {
+		return nil, false, fmt.Errorf("config PATCH key %q must be an object", path+"."+canonicalKey)
+	}
+	return child, true, nil
+}
+
+func validateCanonicalAgentConfigKeys(cli string, agent map[string]any, path string) error {
+	for key, value := range agent {
+		// Keep the existing case-insensitive scrub semantics for
+		// dangerously_skip_perms: every spelling is removed and audit-logged
+		// later by stripDangerousAgentFlags.
+		if strings.EqualFold(key, dangerousAgentFlagKey) {
+			continue
+		}
+		for _, canonical := range canonicalAgentConfigKeys {
+			if strings.EqualFold(key, canonical) && key != canonical {
+				return fmt.Errorf(
+					"config PATCH key %q must use canonical casing %q",
+					path+"."+key, path+"."+canonical,
+				)
+			}
+		}
+		switch key {
+		case "model":
+			model, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("config PATCH key %q must be a string", path+"."+key)
+			}
+			if err := executor.ValidateModel(model); err != nil {
+				return fmt.Errorf("config PATCH key %q: %w", path+"."+key, err)
+			}
+		case "effort":
+			effort, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("config PATCH key %q must be a string", path+"."+key)
+			}
+			if err := executor.ValidateEffort(effort); err != nil {
+				return fmt.Errorf("config PATCH key %q: %w", path+"."+key, err)
+			}
+		case "extra_flags":
+			flags, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("config PATCH key %q must be a string", path+"."+key)
+			}
+			if err := executor.ValidateExtraFlagsForCLI(cli, flags); err != nil {
+				return fmt.Errorf("config PATCH key %q: %w", path+"."+key, err)
+			}
+		case "permission_mode":
+			mode, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("config PATCH key %q must be a string", path+"."+key)
+			}
+			if err := executor.ValidatePermissionMode(mode); err != nil {
+				return fmt.Errorf("config PATCH key %q: %w", path+"."+key, err)
+			}
+		case "approval_mode":
+			mode, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("config PATCH key %q must be a string", path+"."+key)
+			}
+			if err := executor.ValidateApprovalModeForCLI(cli, mode); err != nil {
+				return fmt.Errorf("config PATCH key %q: %w", path+"."+key, err)
+			}
+		}
+	}
+	return nil
+}
+
+func validateCanonicalAgentCollection(agents map[string]any, path string) error {
+	for cli, raw := range agents {
+		for _, canonical := range []string{"claude", "gemini", "codex", "opencode"} {
+			if strings.EqualFold(cli, canonical) && cli != canonical {
+				return fmt.Errorf(
+					"config PATCH key %q must use canonical casing %q",
+					path+"."+cli, path+"."+canonical,
+				)
+			}
+		}
+		if err := executor.ValidateCLIName(cli); err != nil {
+			return fmt.Errorf("config PATCH key %q: %w", path+"."+cli, err)
+		}
+		agent, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("config PATCH key %q must be an object", path+"."+cli)
+		}
+		if err := validateCanonicalAgentConfigKeys(cli, agent, path+"."+cli); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCanonicalScopedAgentPatchKeys(patch map[string]any, path string) error {
+	agents, ok, err := canonicalMapChild(patch, "agents", path)
+	if err != nil || !ok {
+		return err
+	}
+	return validateCanonicalAgentCollection(agents, path+".agents")
+}
+
+// validateCanonicalConfigPatchKeys rejects case-variant structural aliases
+// before DeepMerge. This makes the HTTP policy operate on exactly the same
+// tree that is persisted and decoded, including global, repo and org agents.
+func validateCanonicalConfigPatchKeys(patch map[string]any) error {
+	ai, ok, err := canonicalMapChild(patch, "ai", "config")
+	if err != nil {
+		return err
+	}
+	if ok {
+		if err := validateCanonicalScopedAgentPatchKeys(ai, "ai"); err != nil {
+			return err
+		}
+		for _, scope := range []string{"repos", "orgs"} {
+			overrides, present, childErr := canonicalMapChild(ai, scope, "ai")
+			if childErr != nil {
+				return childErr
+			}
+			if !present {
+				continue
+			}
+			for id, raw := range overrides {
+				override, mapOK := raw.(map[string]any)
+				if !mapOK {
+					continue
+				}
+				if err := validateCanonicalScopedAgentPatchKeys(override, "ai."+scope+"."+id); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return validateCanonicalAutonomousPatchKeys(patch)
+}
+
+func validateCanonicalAutonomousPatchKeys(patch map[string]any) error {
+	autonomous, present, err := canonicalMapChild(patch, "autonomous", "config")
+	if err != nil || !present {
+		return err
+	}
+	if err := rejectAutonomousAgentPatch(autonomous, "autonomous"); err != nil {
+		return err
+	}
+	for _, scope := range []string{"repos", "orgs"} {
+		overrides, scoped, childErr := canonicalMapChild(autonomous, scope, "autonomous")
+		if childErr != nil {
+			return childErr
+		}
+		if !scoped {
+			continue
+		}
+		for id, raw := range overrides {
+			override, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if err := rejectAutonomousAgentPatch(override, "autonomous."+scope+"."+id); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func rejectAutonomousAgentPatch(patch map[string]any, path string) error {
+	agents, present, err := canonicalMapChild(patch, "agents", path)
+	if err != nil || !present {
+		return err
+	}
+	if err := validateCanonicalAgentCollection(agents, path+".agents"); err != nil {
+		return err
+	}
+	return fmt.Errorf(
+		"config PATCH key %q is not supported; configure execution options under ai.agents",
+		path+".agents",
+	)
+}
+
+func stripHTTPDangerousAgentFlags(patch map[string]any) {
+	if stripped := stripDangerousAgentFlags(patch); stripped > 0 {
+		slog.Warn("config: PATCH attempted to set dangerously_skip_perms; stripped (M-5 gate)",
+			"count", stripped)
+	}
+}
+
 // stripDangerousAgentFlags removes the HTTP-forbidden
 // dangerously_skip_perms flag from every agent map reachable in the
 // merged config: top-level ai.agents.<cli>, per-repo
@@ -2147,9 +2379,9 @@ const dangerousAgentFlagKey = "dangerously_skip_perms"
 // match would leave Dangerously_Skip_Perms / DANGEROUSLY_SKIP_PERMS
 // shaped payloads as a live bypass.
 //
-// Invoked from patchTOML so every PATCH endpoint (global, per-repo,
-// per-org) inherits the gate without each handler having to remember
-// to call it.
+// Invoked on the canonicalized HTTP payload before DeepMerge. Scrubbing the
+// merged config would also erase a trusted value set directly in config.toml
+// whenever an unrelated PATCH is applied.
 func stripDangerousAgentFlags(m map[string]any) int {
 	if m == nil {
 		return 0
@@ -2242,8 +2474,18 @@ func normalizeAgentConfigsForPut(v any) (map[string]map[string]any, error) {
 				if !isStr {
 					return nil, fmt.Errorf("agent_configs[%q].%s must be a string", cli, k)
 				}
+				if k == "model" {
+					if err := executor.ValidateModel(s); err != nil {
+						return nil, fmt.Errorf("agent_configs[%q].model: %v", cli, err)
+					}
+				}
+				if k == "effort" {
+					if err := executor.ValidateEffort(s); err != nil {
+						return nil, fmt.Errorf("agent_configs[%q].effort: %v", cli, err)
+					}
+				}
 				if k == "extra_flags" && s != "" {
-					if err := executor.ValidateExtraFlags(s); err != nil {
+					if err := executor.ValidateExtraFlagsForCLI(cli, s); err != nil {
 						return nil, fmt.Errorf("agent_configs[%q].extra_flags: %v", cli, err)
 					}
 				}
@@ -2267,7 +2509,7 @@ func normalizeAgentConfigsForPut(v any) (map[string]map[string]any, error) {
 				if !isStr {
 					return nil, fmt.Errorf("agent_configs[%q].approval_mode must be a string", cli)
 				}
-				if err := executor.ValidateApprovalMode(s); err != nil {
+				if err := executor.ValidateApprovalModeForCLI(cli, s); err != nil {
 					return nil, fmt.Errorf("agent_configs[%q].approval_mode: %v", cli, err)
 				}
 				normalized[k] = s

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -301,7 +301,7 @@ func (srv *Server) writeTOMLUnderLock(mutateFn func(m map[string]any) error) (ma
 	// flags can no longer block an unrelated edit without creating a path for a
 	// new payload to smuggle those flags into ExtraFlags.
 	if err := config.SanitizeLegacyAgentExecutionPolicyMap(m, "toml PATCH base"); err != nil {
-		return nil, err
+		return nil, &config.ValidationError{Err: err}
 	}
 	if err := mutateFn(m); err != nil {
 		return nil, err
@@ -675,10 +675,9 @@ var readOnlyConfigKeys = map[string]struct{}{
 }
 
 // allowedAgentConfigSubkeys is the per-agent allowlist for PUT /config.
-// Mirrors CLIAgentConfig fields exposed via the Flutter UI. Note the deliberate
-// omission of dangerously_skip_perms (M-5): toggling --dangerously-skip-permissions
-// at runtime over HTTP would let an attacker with API access escalate the
-// agent's effective permissions. That field stays TOML/env-only.
+// Mirrors CLIAgentConfig fields exposed via the Flutter UI. The asymmetric
+// dangerously_skip_perms gate is handled separately: HTTP may persist false
+// to reduce privilege, but true remains TOML/env-only.
 var allowedAgentConfigSubkeys = map[string]struct{}{
 	"model":                  {},
 	"max_turns":              {},
@@ -854,7 +853,6 @@ func (srv *Server) handlePatchConfig(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
-	stripHTTPDangerousAgentFlags(patch)
 	if err := config.ContainsNull(patch); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
 			"error": "null values not allowed in PATCH — use DELETE to remove fields",
@@ -908,7 +906,7 @@ func (srv *Server) handlePatchRepoConfig(w http.ResponseWriter, r *http.Request)
 		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
 		return
 	}
-	if err := validateCanonicalScopedAgentPatchKeys(patch, "ai.repos"); err != nil {
+	if err := rejectUnsupportedScopedAgentPatchKeys(patch, "ai.repos"); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
@@ -927,7 +925,6 @@ func (srv *Server) handlePatchRepoConfig(w http.ResponseWriter, r *http.Request)
 			},
 		},
 	}
-	stripHTTPDangerousAgentFlags(globalPatch)
 
 	result, err := srv.patchTOML(func(m map[string]any) error {
 		merged := config.DeepMerge(m, globalPatch)
@@ -974,7 +971,7 @@ func (srv *Server) handlePatchOrgConfig(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
 		return
 	}
-	if err := validateCanonicalScopedAgentPatchKeys(patch, "ai.orgs"); err != nil {
+	if err := rejectUnsupportedScopedAgentPatchKeys(patch, "ai.orgs"); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
@@ -993,7 +990,6 @@ func (srv *Server) handlePatchOrgConfig(w http.ResponseWriter, r *http.Request) 
 			},
 		},
 	}
-	stripHTTPDangerousAgentFlags(globalPatch)
 
 	result, err := srv.patchTOML(func(m map[string]any) error {
 		merged := config.DeepMerge(m, globalPatch)
@@ -2145,9 +2141,8 @@ func tailLines(f *os.File, n int) []string {
 }
 
 // dangerousAgentFlagKey names the security-gated flag that grants
-// `--dangerously-skip-permissions` to the AI CLI. Both
-// normalizeAgentConfigsForPut and stripDangerousAgentFlags reference
-// this constant so the M-5 denylist has a single source of truth.
+// `--dangerously-skip-permissions` to the AI CLI. HTTP callers may explicitly
+// disable it, but enabling it requires trusted TOML/env access.
 const dangerousAgentFlagKey = "dangerously_skip_perms"
 
 var canonicalAgentConfigKeys = []string{
@@ -2195,10 +2190,24 @@ func canonicalMapChild(m map[string]any, canonicalKey, path string) (map[string]
 
 func validateCanonicalAgentConfigKeys(cli string, agent map[string]any, path string) error {
 	for key, value := range agent {
-		// Keep the existing case-insensitive scrub semantics for
-		// dangerously_skip_perms: every spelling is removed and audit-logged
-		// later by stripDangerousAgentFlags.
 		if strings.EqualFold(key, dangerousAgentFlagKey) {
+			if key != dangerousAgentFlagKey {
+				return fmt.Errorf(
+					"config PATCH key %q must use canonical casing %q",
+					path+"."+key, path+"."+dangerousAgentFlagKey,
+				)
+			}
+			requested, ok := value.(bool)
+			if !ok {
+				return fmt.Errorf("config PATCH key %q must be a boolean", path+"."+key)
+			}
+			if requested {
+				return fmt.Errorf(
+					"config PATCH key %q cannot be enabled via HTTP API; "+
+						"configure it directly in config.toml (security gate M-5)",
+					path+"."+key,
+				)
+			}
 			continue
 		}
 		for _, canonical := range canonicalAgentConfigKeys {
@@ -2287,12 +2296,30 @@ func validateCanonicalAgentCollection(agents map[string]any, path string) error 
 	return nil
 }
 
-func validateCanonicalScopedAgentPatchKeys(patch map[string]any, path string) error {
+func validateCanonicalAgentPatchKeysAtPath(patch map[string]any, path string) error {
 	agents, ok, err := canonicalMapChild(patch, "agents", path)
 	if err != nil || !ok {
 		return err
 	}
 	return validateCanonicalAgentCollection(agents, path+".agents")
+}
+
+func rejectUnsupportedScopedAgentPatchKeys(patch map[string]any, path string) error {
+	agents, present, err := canonicalMapChild(patch, "agents", path)
+	if err != nil || !present {
+		return err
+	}
+	// Validate first so attempts to enable the dangerous gate and casing
+	// aliases retain their precise security error. A valid-looking false is
+	// still rejected: repo/org agent execution profiles are not consumed by
+	// AgentConfigFor, so persisting one would falsely imply a safety downgrade.
+	if err := validateCanonicalAgentCollection(agents, path+".agents"); err != nil {
+		return err
+	}
+	return fmt.Errorf(
+		"config PATCH key %q is not supported; configure execution options under ai.agents",
+		path+".agents",
+	)
 }
 
 // validateCanonicalConfigPatchKeys rejects case-variant structural aliases
@@ -2304,7 +2331,7 @@ func validateCanonicalConfigPatchKeys(patch map[string]any) error {
 		return err
 	}
 	if ok {
-		if err := validateCanonicalScopedAgentPatchKeys(ai, "ai"); err != nil {
+		if err := validateCanonicalAgentPatchKeysAtPath(ai, "ai"); err != nil {
 			return err
 		}
 		for _, scope := range []string{"repos", "orgs"} {
@@ -2320,7 +2347,7 @@ func validateCanonicalConfigPatchKeys(patch map[string]any) error {
 				if !mapOK {
 					continue
 				}
-				if err := validateCanonicalScopedAgentPatchKeys(override, "ai."+scope+"."+id); err != nil {
+				if err := rejectUnsupportedScopedAgentPatchKeys(override, "ai."+scope+"."+id); err != nil {
 					return err
 				}
 			}
@@ -2372,89 +2399,13 @@ func rejectAutonomousAgentPatch(patch map[string]any, path string) error {
 	)
 }
 
-func stripHTTPDangerousAgentFlags(patch map[string]any) {
-	if stripped := stripDangerousAgentFlags(patch); stripped > 0 {
-		slog.Warn("config: PATCH attempted to set dangerously_skip_perms; stripped (M-5 gate)",
-			"count", stripped)
-	}
-}
-
-// stripDangerousAgentFlags removes the HTTP-forbidden
-// dangerously_skip_perms flag from every agent map reachable in the
-// merged config: top-level ai.agents.<cli>, per-repo
-// ai.repos.<repo>.agents.<cli>, and per-org ai.orgs.<org>.agents.<cli>.
-// The flag is still settable via direct edits to config.toml
-// (security gate M-5: only filesystem-trusted inputs can grant the
-// permission-sandbox bypass), but never via the HTTP API.
-//
-// Returns the number of entries stripped so callers can audit-log
-// bypass attempts. Key comparison is case-insensitive because the
-// downstream koanf/mapstructure decoder is case-insensitive when
-// mapping into CLIAgentConfig.DangerouslySkipPerms — an exact-case
-// match would leave Dangerously_Skip_Perms / DANGEROUSLY_SKIP_PERMS
-// shaped payloads as a live bypass.
-//
-// Invoked on the canonicalized HTTP payload before DeepMerge. Scrubbing the
-// merged config would also erase a trusted value set directly in config.toml
-// whenever an unrelated PATCH is applied.
-func stripDangerousAgentFlags(m map[string]any) int {
-	if m == nil {
-		return 0
-	}
-	stripped := 0
-	scrub := func(agents map[string]any) {
-		for _, raw := range agents {
-			inner, ok := raw.(map[string]any)
-			if !ok {
-				continue
-			}
-			for k := range inner {
-				if strings.EqualFold(k, dangerousAgentFlagKey) {
-					delete(inner, k)
-					stripped++
-				}
-			}
-		}
-	}
-	ai, ok := m["ai"].(map[string]any)
-	if !ok {
-		return 0
-	}
-	if agents, ok := ai["agents"].(map[string]any); ok {
-		scrub(agents)
-	}
-	if repos, ok := ai["repos"].(map[string]any); ok {
-		for _, raw := range repos {
-			repo, ok := raw.(map[string]any)
-			if !ok {
-				continue
-			}
-			if agents, ok := repo["agents"].(map[string]any); ok {
-				scrub(agents)
-			}
-		}
-	}
-	if orgs, ok := ai["orgs"].(map[string]any); ok {
-		for _, raw := range orgs {
-			org, ok := raw.(map[string]any)
-			if !ok {
-				continue
-			}
-			if agents, ok := org["agents"].(map[string]any); ok {
-				scrub(agents)
-			}
-		}
-	}
-	return stripped
-}
-
 // normalizeAgentConfigsForPut validates the agent_configs payload from PUT
 // /config. The payload must be a JSON object keyed by CLI name (claude, gemini,
 // codex, opencode), where each value is itself an object whose keys are in
-// allowedAgentConfigSubkeys. Subkeys outside that set — including the
-// security-gated dangerously_skip_perms — return a 400 with a descriptive
-// message. permission_mode / approval_mode / extra_flags get value validation
-// against the executor allowlists.
+// allowedAgentConfigSubkeys. dangerously_skip_perms is the sole asymmetric
+// exception: false is accepted to reduce privilege, while true returns a 400.
+// permission_mode / approval_mode / extra_flags get value validation against
+// the executor allowlists.
 //
 // The returned map is shaped for json.Marshal so the persisted row deserializes
 // cleanly into map[string]CLIAgentConfig in ApplyStore.
@@ -2475,10 +2426,25 @@ func normalizeAgentConfigsForPut(v any) (map[string]map[string]any, error) {
 		normalized := make(map[string]any, len(inner))
 		for k, val := range inner {
 			if strings.EqualFold(k, dangerousAgentFlagKey) {
-				return nil, fmt.Errorf(
-					"agent_configs[%q].%s cannot be set via HTTP API; "+
-						"configure it in config.toml under [ai.agents.%s] (security gate M-5)",
-					cli, dangerousAgentFlagKey, cli)
+				if k != dangerousAgentFlagKey {
+					return nil, fmt.Errorf(
+						"agent_configs[%q].%s must use canonical casing %q",
+						cli, k, dangerousAgentFlagKey)
+				}
+				requested, isBool := val.(bool)
+				if !isBool {
+					return nil, fmt.Errorf(
+						"agent_configs[%q].%s must be a boolean",
+						cli, dangerousAgentFlagKey)
+				}
+				if requested {
+					return nil, fmt.Errorf(
+						"agent_configs[%q].%s cannot be enabled via HTTP API; "+
+							"configure it in config.toml under [ai.agents.%s] (security gate M-5)",
+						cli, dangerousAgentFlagKey, cli)
+				}
+				normalized[dangerousAgentFlagKey] = false
+				continue
 			}
 			if _, allowed := allowedAgentConfigSubkeys[k]; !allowed {
 				return nil, fmt.Errorf("agent_configs[%q]: unknown key %q", cli, k)

--- a/daemon/internal/server/handlers_internal_test.go
+++ b/daemon/internal/server/handlers_internal_test.go
@@ -146,6 +146,265 @@ func TestStripDangerousAgentFlags_ReportsCount(t *testing.T) {
 	}
 }
 
+func TestValidateCanonicalConfigPatchKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		patch   map[string]any
+		wantErr bool
+	}{
+		{
+			name: "canonical global agent tree",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"agents": map[string]any{
+						"claude": map[string]any{"extra_flags": "--verbose"},
+					},
+				},
+			},
+		},
+		{
+			name: "canonical repo and org agent trees",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"repos": map[string]any{
+						"org/repo": map[string]any{
+							"agents": map[string]any{
+								"codex": map[string]any{"approval_mode": "on-request"},
+							},
+						},
+					},
+					"orgs": map[string]any{
+						"org": map[string]any{
+							"agents": map[string]any{
+								"gemini": map[string]any{"model": "gemini-2.5-pro"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "dangerous leaf aliases remain eligible for the scrubber",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"agents": map[string]any{
+						"claude": map[string]any{"DANGEROUSLY_SKIP_PERMS": true},
+					},
+				},
+			},
+		},
+		{
+			name: "unsafe extra flags rejected in otherwise schema-ignored repo tree",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"repos": map[string]any{
+						"org/repo": map[string]any{
+							"agents": map[string]any{
+								"codex": map[string]any{"extra_flags": "--sandbox danger-full-access"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsafe approval rejected in otherwise schema-ignored org tree",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"orgs": map[string]any{
+						"org": map[string]any{
+							"agents": map[string]any{
+								"gemini": map[string]any{"approval_mode": "yolo"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown CLI rejected",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"agents": map[string]any{
+						"future-cli": map[string]any{"extra_flags": "--model safe"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-object agent rejected",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"agents": map[string]any{
+						"claude": "not-an-object",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-object structural node rejected",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"agents": "not-an-object",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "top-level AI alias rejected",
+			patch: map[string]any{
+				"AI": map[string]any{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Agents alias rejected",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"Agents": map[string]any{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Repos alias rejected",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"Repos": map[string]any{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nested Agents alias rejected",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"orgs": map[string]any{
+						"org": map[string]any{
+							"Agents": map[string]any{},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "CLI alias rejected",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"agents": map[string]any{
+						"Codex": map[string]any{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "agent field alias rejected",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"agents": map[string]any{
+						"codex": map[string]any{"Extra_Flags": "--quiet"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "autonomous repo agents rejected",
+			patch: map[string]any{
+				"autonomous": map[string]any{
+					"repos": map[string]any{
+						"org/repo": map[string]any{
+							"agents": map[string]any{
+								"codex": map[string]any{
+									"extra_flags": "--sandbox danger-full-access",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "autonomous agents alias rejected",
+			patch: map[string]any{
+				"autonomous": map[string]any{
+					"orgs": map[string]any{
+						"org": map[string]any{
+							"Agents": map[string]any{},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCanonicalConfigPatchKeys(tc.patch)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected casing validation error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected casing validation error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateCanonicalScopedAgentPatchKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		patch   map[string]any
+		wantErr bool
+	}{
+		{
+			name: "canonical",
+			patch: map[string]any{
+				"agents": map[string]any{
+					"claude": map[string]any{"permission_mode": "acceptEdits"},
+				},
+			},
+		},
+		{
+			name: "case variant",
+			patch: map[string]any{
+				"Agents": map[string]any{
+					"claude": map[string]any{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsafe extra flags",
+			patch: map[string]any{
+				"agents": map[string]any{
+					"opencode": map[string]any{"extra_flags": "--auto"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCanonicalScopedAgentPatchKeys(tc.patch, "ai.repos.org/repo")
+			if tc.wantErr && err == nil {
+				t.Fatal("expected casing validation error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected casing validation error: %v", err)
+			}
+		})
+	}
+}
+
 func TestDaemonLogPath_XDGStateHomeUsedWhenSet(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip("XDG path only used on non-darwin when HEIMDALLM_DATA_DIR is unset")

--- a/daemon/internal/server/handlers_internal_test.go
+++ b/daemon/internal/server/handlers_internal_test.go
@@ -85,67 +85,6 @@ func TestDaemonLogPath_FallsBackToNativeWhenDataDirUnset(t *testing.T) {
 	}
 }
 
-// TestStripDangerousAgentFlags_HandlesUnexpectedShapes pins the
-// type-assertion guards: callers feed the scrubber a merged config
-// map whose interior types come from JSON decoding plus a TOML round
-// trip, and weird shapes (nil, scalars where maps are expected)
-// must never panic. PATCH validation enforces shape strictly today,
-// but the scrubber must remain safe even if a future ValidateMap
-// becomes more permissive.
-func TestStripDangerousAgentFlags_HandlesUnexpectedShapes(t *testing.T) {
-	cases := []map[string]any{
-		nil,
-		{},
-		{"ai": "not a map"},
-		{"ai": map[string]any{"agents": nil}},
-		{"ai": map[string]any{"agents": "string"}},
-		{"ai": map[string]any{"agents": map[string]any{"claude": nil}}},
-		{"ai": map[string]any{"agents": map[string]any{"claude": "string"}}},
-		{"ai": map[string]any{"repos": "string"}},
-		{"ai": map[string]any{"repos": map[string]any{"org/r": "string"}}},
-		{"ai": map[string]any{"repos": map[string]any{"org/r": map[string]any{"agents": "string"}}}},
-		{"ai": map[string]any{"orgs": map[string]any{"org": map[string]any{"agents": map[string]any{"claude": nil}}}}},
-	}
-	for _, m := range cases {
-		stripDangerousAgentFlags(m) // must not panic
-	}
-}
-
-func TestStripDangerousAgentFlags_ReportsCount(t *testing.T) {
-	m := map[string]any{
-		"ai": map[string]any{
-			"agents": map[string]any{
-				"claude": map[string]any{"dangerously_skip_perms": true, "permission_mode": "acceptEdits"},
-				"gemini": map[string]any{"DANGEROUSLY_SKIP_PERMS": true},
-			},
-			"repos": map[string]any{
-				"org/r": map[string]any{
-					"agents": map[string]any{
-						"claude": map[string]any{"Dangerously_Skip_Perms": true},
-					},
-				},
-			},
-			"orgs": map[string]any{
-				"org": map[string]any{
-					"agents": map[string]any{
-						"claude": map[string]any{"dangerously_skip_perms": true},
-					},
-				},
-			},
-		},
-	}
-	n := stripDangerousAgentFlags(m)
-	if n != 4 {
-		t.Fatalf("stripped count = %d, want 4 (global x2 + repo + org)", n)
-	}
-	ai := m["ai"].(map[string]any)
-	agents := ai["agents"].(map[string]any)
-	claude := agents["claude"].(map[string]any)
-	if claude["permission_mode"] != "acceptEdits" {
-		t.Errorf("permission_mode lost: %v", claude)
-	}
-}
-
 func TestValidateCanonicalConfigPatchKeys(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -163,7 +102,7 @@ func TestValidateCanonicalConfigPatchKeys(t *testing.T) {
 			},
 		},
 		{
-			name: "canonical repo and org agent trees",
+			name: "repo and org agent trees are unsupported",
 			patch: map[string]any{
 				"ai": map[string]any{
 					"repos": map[string]any{
@@ -182,9 +121,31 @@ func TestValidateCanonicalConfigPatchKeys(t *testing.T) {
 					},
 				},
 			},
+			wantErr: true,
 		},
 		{
-			name: "dangerous leaf aliases remain eligible for the scrubber",
+			name: "dangerous false reduces privilege",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"agents": map[string]any{
+						"claude": map[string]any{"dangerously_skip_perms": false},
+					},
+				},
+			},
+		},
+		{
+			name: "dangerous true cannot enable privilege",
+			patch: map[string]any{
+				"ai": map[string]any{
+					"agents": map[string]any{
+						"claude": map[string]any{"dangerously_skip_perms": true},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "dangerous leaf alias rejected",
 			patch: map[string]any{
 				"ai": map[string]any{
 					"agents": map[string]any{
@@ -192,6 +153,7 @@ func TestValidateCanonicalConfigPatchKeys(t *testing.T) {
 					},
 				},
 			},
+			wantErr: true,
 		},
 		{
 			name: "unsafe extra flags rejected in otherwise schema-ignored repo tree",
@@ -359,19 +321,26 @@ func TestValidateCanonicalConfigPatchKeys(t *testing.T) {
 	}
 }
 
-func TestValidateCanonicalScopedAgentPatchKeys(t *testing.T) {
+func TestRejectUnsupportedScopedAgentPatchKeys(t *testing.T) {
 	tests := []struct {
 		name    string
 		patch   map[string]any
 		wantErr bool
 	}{
 		{
-			name: "canonical",
+			name: "no agent tree",
+			patch: map[string]any{
+				"primary": "codex",
+			},
+		},
+		{
+			name: "canonical but unsupported",
 			patch: map[string]any{
 				"agents": map[string]any{
 					"claude": map[string]any{"permission_mode": "acceptEdits"},
 				},
 			},
+			wantErr: true,
 		},
 		{
 			name: "case variant",
@@ -394,12 +363,12 @@ func TestValidateCanonicalScopedAgentPatchKeys(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateCanonicalScopedAgentPatchKeys(tc.patch, "ai.repos.org/repo")
+			err := rejectUnsupportedScopedAgentPatchKeys(tc.patch, "ai.repos.org/repo")
 			if tc.wantErr && err == nil {
-				t.Fatal("expected casing validation error")
+				t.Fatal("expected scoped agent rejection")
 			}
 			if !tc.wantErr && err != nil {
-				t.Fatalf("unexpected casing validation error: %v", err)
+				t.Fatalf("unexpected scoped rejection: %v", err)
 			}
 		})
 	}

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1189,9 +1189,9 @@ func TestHandlerPutConfig_WritableAndReadOnly_Mixed(t *testing.T) {
 }
 
 func TestHandlerPutConfig_AgentConfigs_RejectsDangerouslySkipPerms(t *testing.T) {
-	// Security gate M-5: --dangerously-skip-permissions cannot be flipped
+	// Security gate M-5: --dangerously-skip-permissions cannot be enabled
 	// over HTTP. The handler must 400 with a message that points the
-	// operator at config.toml so the toggle never lands in sqlite.
+	// operator at config.toml so true never lands in sqlite.
 	srv, _ := setupServer(t)
 	body := `{"agent_configs":{"claude":{"dangerously_skip_perms":true}}}`
 	w := httptest.NewRecorder()
@@ -1201,6 +1201,23 @@ func TestHandlerPutConfig_AgentConfigs_RejectsDangerouslySkipPerms(t *testing.T)
 	}
 	if !strings.Contains(w.Body.String(), "dangerously_skip_perms") {
 		t.Errorf("error message must name the rejected key, got: %s", w.Body.String())
+	}
+}
+
+func TestHandlerPutConfig_AgentConfigs_AllowsDisablingDangerouslySkipPerms(t *testing.T) {
+	srv, s := setupServer(t)
+	body := `{"agent_configs":{"claude":{"dangerously_skip_perms":false}}}`
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, putConfigRequest(body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	rows, err := s.ListConfigs()
+	if err != nil {
+		t.Fatalf("ListConfigs: %v", err)
+	}
+	if got := rows["agent_configs"]; !strings.Contains(got, `"dangerously_skip_perms":false`) {
+		t.Fatalf("explicit safety downgrade was not persisted: %q", got)
 	}
 }
 
@@ -1809,13 +1826,9 @@ func TestHandlePatchConfig_RepoListsWriteTOML(t *testing.T) {
 	}
 }
 
-func TestHandlePatchConfig_StripsDangerouslySkipPerms(t *testing.T) {
-	// Security gate M-5: PUT /config rejects dangerously_skip_perms with
-	// a 400. PATCH /config deep-merges arbitrary JSON; before this fix it
-	// silently persisted the flag, granting AI runs --dangerously-skip-
-	// permissions on the next reload. The PATCH path must scrub the flag
-	// out of every agent under ai.agents before validating + writing TOML
-	// so HTTP can never flip the toggle.
+func TestHandlePatchConfig_RejectsDangerouslySkipPermsEnable(t *testing.T) {
+	// Security gate M-5 must be explicit: HTTP callers cannot enable the
+	// bypass, and a rejected payload must not partially apply safe siblings.
 	tomlContent := "[ai]\nprimary = \"claude\"\n"
 	tomlPath := writeTempTOML(t, tomlContent)
 
@@ -1829,43 +1842,34 @@ func TestHandlePatchConfig_StripsDangerouslySkipPerms(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH should succeed (other fields land), got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("PATCH enable = %d, want 400 (body: %s)", w.Code, w.Body.String())
 	}
-
-	m, err := config.ReadTOMLMap(tomlPath)
+	if !strings.Contains(w.Body.String(), "cannot be enabled") {
+		t.Fatalf("PATCH error is not actionable: %s", w.Body.String())
+	}
+	got, err := os.ReadFile(tomlPath)
 	if err != nil {
-		t.Fatalf("read TOML after PATCH: %v", err)
+		t.Fatalf("read TOML after rejected PATCH: %v", err)
 	}
-	ai, _ := m["ai"].(map[string]any)
-	agents, _ := ai["agents"].(map[string]any)
-	claude, ok := agents["claude"].(map[string]any)
-	if !ok {
-		t.Fatalf("ai.agents.claude missing after PATCH: %v", agents)
-	}
-	if _, present := claude["dangerously_skip_perms"]; present {
-		t.Fatalf("dangerously_skip_perms persisted via PATCH (M-5 bypass): %v", claude)
-	}
-	// Sanity: other legal fields landed so the strip is targeted, not nuking the whole section.
-	if claude["permission_mode"] != "acceptEdits" {
-		t.Errorf("permission_mode = %v, want acceptEdits (legal fields must still land)", claude["permission_mode"])
+	if string(got) != tomlContent {
+		t.Fatalf("rejected PATCH partially changed TOML:\n%s", got)
 	}
 }
 
-func TestHandlePatchConfig_PreservesTrustedDangerousFlag(t *testing.T) {
-	tomlContent := "[ai]\n" +
+func TestHandlePatchConfig_DisablesAndCanonicalizesTrustedDangerousAlias(t *testing.T) {
+	tomlContent := "[AI]\n" +
 		"primary = \"claude\"\n" +
-		"[ai.agents.claude]\n" +
-		"dangerously_skip_perms = true\n" +
+		"[AI.Agents.claude]\n" +
+		"DANGEROUSLY_SKIP_PERMS = true\n" +
 		"permission_mode = \"default\"\n"
 	tomlPath := writeTempTOML(t, tomlContent)
 
 	srv := setupServerWithToken(t, "test-token")
 	srv.SetConfigPath(tomlPath)
 
-	// HTTP cannot enable or disable the filesystem-trusted gate. The attempted
-	// false value is removed from the payload before merge, while legal sibling
-	// fields still apply.
+	// HTTP may reduce privilege. False must persist rather than being silently
+	// stripped, while legal sibling fields still apply atomically.
 	body := `{"ai":{"agents":{"claude":{"dangerously_skip_perms":false,"permission_mode":"acceptEdits"}}}}`
 	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -1881,14 +1885,38 @@ func TestHandlePatchConfig_PreservesTrustedDangerousFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read TOML after PATCH: %v", err)
 	}
+	for key := range m {
+		if strings.EqualFold(key, "ai") && key != "ai" {
+			t.Fatalf("legacy structural alias %q survived PATCH: %v", key, m)
+		}
+	}
 	ai, _ := m["ai"].(map[string]any)
+	for key := range ai {
+		if strings.EqualFold(key, "agents") && key != "agents" {
+			t.Fatalf("legacy agents alias %q survived PATCH: %v", key, ai)
+		}
+	}
 	agents, _ := ai["agents"].(map[string]any)
 	claude, _ := agents["claude"].(map[string]any)
-	if got, ok := claude["dangerously_skip_perms"].(bool); !ok || !got {
-		t.Fatalf("trusted dangerously_skip_perms was changed by HTTP PATCH: %v", claude)
+	if got, ok := claude["dangerously_skip_perms"].(bool); !ok || got {
+		t.Fatalf("dangerously_skip_perms was not disabled by HTTP PATCH: %v", claude)
+	}
+	for key := range claude {
+		if strings.EqualFold(key, "dangerously_skip_perms") && key != "dangerously_skip_perms" {
+			t.Fatalf("legacy dangerous alias %q survived PATCH: %v", key, claude)
+		}
 	}
 	if claude["permission_mode"] != "acceptEdits" {
 		t.Fatalf("legal sibling field did not land: %v", claude)
+	}
+	for i := 0; i < 32; i++ {
+		loaded, err := config.Load(tomlPath)
+		if err != nil {
+			t.Fatalf("Load iteration %d after PATCH: %v", i, err)
+		}
+		if loaded.AI.Agents["claude"].DangerouslySkipPerms {
+			t.Fatalf("Load iteration %d re-enabled dangerously_skip_perms", i)
+		}
 	}
 }
 
@@ -1929,6 +1957,41 @@ func TestHandlePatchConfig_MigratesLegacyTOMLBaseBeforeInnocuousPatch(t *testing
 	}
 }
 
+func TestHandlePatchConfig_ReportsAmbiguousTrustedAliases(t *testing.T) {
+	tomlContent := "[ai]\n" +
+		"primary = \"codex\"\n" +
+		"[ai.agents.codex]\n" +
+		"Model = \"first\"\n" +
+		"MODEL = \"second\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+	req := httptest.NewRequest(
+		"PATCH",
+		"/config",
+		strings.NewReader(`{"github":{"poll_interval":"10m"}}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("ambiguous trusted base PATCH = %d, want 400 (body: %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "ambiguous aliases") {
+		t.Fatalf("ambiguous trusted base error is not actionable: %s", w.Body.String())
+	}
+	got, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != tomlContent {
+		t.Fatalf("rejected PATCH changed ambiguous TOML:\n%s", got)
+	}
+}
+
 func TestHandlePatchConfig_RejectsNewLegacyTypedFlagWithoutChangingTOML(t *testing.T) {
 	tomlContent := "[ai]\nprimary = \"codex\"\n"
 	tomlPath := writeTempTOML(t, tomlContent)
@@ -1955,11 +2018,9 @@ func TestHandlePatchConfig_RejectsNewLegacyTypedFlagWithoutChangingTOML(t *testi
 	}
 }
 
-func TestHandlePatchConfig_StripsDangerouslySkipPermsCaseInsensitive(t *testing.T) {
-	// JSON preserves key casing; the merged map then feeds into a
-	// Go struct via mapstructure/koanf, which is case-insensitive
-	// by default — so a payload using mixed/upper casing would
-	// otherwise bypass an exact-match strip.
+func TestHandlePatchConfig_RejectsDangerouslySkipPermsCaseAliases(t *testing.T) {
+	// JSON preserves key casing while downstream decoding is case-insensitive.
+	// Reject aliases explicitly instead of relying on a silent scrub.
 	tomlContent := "[ai]\nprimary = \"claude\"\n"
 	tomlPath := writeTempTOML(t, tomlContent)
 
@@ -1977,23 +2038,15 @@ func TestHandlePatchConfig_StripsDangerouslySkipPermsCaseInsensitive(t *testing.
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH should succeed, got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("PATCH aliases = %d, want 400 (body: %s)", w.Code, w.Body.String())
 	}
-
-	m, _ := config.ReadTOMLMap(tomlPath)
-	ai, _ := m["ai"].(map[string]any)
-	agents, _ := ai["agents"].(map[string]any)
-	for _, name := range []string{"claude", "gemini", "codex"} {
-		inner, ok := agents[name].(map[string]any)
-		if !ok {
-			continue
-		}
-		for k := range inner {
-			if strings.EqualFold(k, "dangerously_skip_perms") {
-				t.Errorf("case-variant %q persisted for %s (M-5 bypass)", k, name)
-			}
-		}
+	got, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != tomlContent {
+		t.Fatalf("rejected alias PATCH changed TOML:\n%s", got)
 	}
 }
 
@@ -2089,11 +2142,65 @@ func TestHandleScopedPatchConfig_RejectsCaseVariantAgentTree(t *testing.T) {
 	}
 }
 
-func TestHandlePatchConfig_StripsDangerouslySkipPermsInRepoOverride(t *testing.T) {
-	// Per-repo overrides land at ai.repos.<repo>.agents.<cli>.* in
-	// the merged map. The scrubber must walk those too so a buggy
-	// future schema or a koanf-style alias can't grant the flag via
-	// a non-top-level path.
+func TestHandlePatchConfig_RejectsUnsupportedScopedAgentSafetyDowngrade(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "repo endpoint",
+			path: "/config/repos/" + url.PathEscape("org/repo"),
+			body: `{"agents":{"claude":{"dangerously_skip_perms":false}}}`,
+		},
+		{
+			name: "org endpoint",
+			path: "/config/orgs/" + url.PathEscape("org"),
+			body: `{"agents":{"claude":{"dangerously_skip_perms":false}}}`,
+		},
+		{
+			name: "repo in global endpoint",
+			path: "/config",
+			body: `{"ai":{"repos":{"org/repo":{"agents":{"claude":{"dangerously_skip_perms":false}}}}}}`,
+		},
+		{
+			name: "org in global endpoint",
+			path: "/config",
+			body: `{"ai":{"orgs":{"org":{"agents":{"claude":{"dangerously_skip_perms":false}}}}}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tomlContent := "[ai]\nprimary = \"claude\"\n"
+			tomlPath := writeTempTOML(t, tomlContent)
+			srv := setupServerWithToken(t, "test-token")
+			srv.SetConfigPath(tomlPath)
+
+			req := httptest.NewRequest("PATCH", tc.path, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Heimdallm-Token", "test-token")
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("scoped agent PATCH = %d, want 400 (body: %s)", w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "not supported") {
+				t.Fatalf("scoped rejection is not actionable: %s", w.Body.String())
+			}
+			got, err := os.ReadFile(tomlPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tomlContent {
+				t.Fatalf("rejected scoped PATCH changed TOML:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestHandlePatchConfig_RejectsDangerouslySkipPermsInRepoOverride(t *testing.T) {
 	tomlContent := "[ai]\nprimary = \"claude\"\n"
 	tomlPath := writeTempTOML(t, tomlContent)
 
@@ -2107,31 +2214,19 @@ func TestHandlePatchConfig_StripsDangerouslySkipPermsInRepoOverride(t *testing.T
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH should succeed, got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("repo PATCH enable = %d, want 400 (body: %s)", w.Code, w.Body.String())
 	}
-
-	m, _ := config.ReadTOMLMap(tomlPath)
-	ai, _ := m["ai"].(map[string]any)
-	repos, _ := ai["repos"].(map[string]any)
-	repo, ok := repos["org/repo"].(map[string]any)
-	if !ok {
-		return
+	got, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
 	}
-	agents, ok := repo["agents"].(map[string]any)
-	if !ok {
-		return
-	}
-	claude, ok := agents["claude"].(map[string]any)
-	if !ok {
-		return
-	}
-	if _, present := claude["dangerously_skip_perms"]; present {
-		t.Fatalf("repo-level dangerously_skip_perms persisted (M-5 bypass): %v", claude)
+	if string(got) != tomlContent {
+		t.Fatalf("rejected repo PATCH changed TOML:\n%s", got)
 	}
 }
 
-func TestHandlePatchConfig_StripsDangerouslySkipPermsInOrgOverride(t *testing.T) {
+func TestHandlePatchConfig_RejectsDangerouslySkipPermsInOrgOverride(t *testing.T) {
 	tomlContent := "[ai]\nprimary = \"claude\"\n"
 	tomlPath := writeTempTOML(t, tomlContent)
 
@@ -2145,31 +2240,19 @@ func TestHandlePatchConfig_StripsDangerouslySkipPermsInOrgOverride(t *testing.T)
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH should succeed, got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("org PATCH enable = %d, want 400 (body: %s)", w.Code, w.Body.String())
 	}
-
-	m, _ := config.ReadTOMLMap(tomlPath)
-	ai, _ := m["ai"].(map[string]any)
-	orgs, _ := ai["orgs"].(map[string]any)
-	org, ok := orgs["org"].(map[string]any)
-	if !ok {
-		return
+	got, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
 	}
-	agents, ok := org["agents"].(map[string]any)
-	if !ok {
-		return
-	}
-	claude, ok := agents["claude"].(map[string]any)
-	if !ok {
-		return
-	}
-	if _, present := claude["dangerously_skip_perms"]; present {
-		t.Fatalf("org-level dangerously_skip_perms persisted (M-5 bypass): %v", claude)
+	if string(got) != tomlContent {
+		t.Fatalf("rejected org PATCH changed TOML:\n%s", got)
 	}
 }
 
-func TestHandlePatchConfig_StripsDangerouslySkipPermsAcrossAllAgents(t *testing.T) {
+func TestHandlePatchConfig_RejectsDangerouslySkipPermsAcrossAllAgents(t *testing.T) {
 	// Same gate applied to every CLI under ai.agents — an attacker may
 	// try flipping the flag on a less-watched agent.
 	tomlContent := "[ai]\nprimary = \"claude\"\n"
@@ -2190,21 +2273,15 @@ func TestHandlePatchConfig_StripsDangerouslySkipPermsAcrossAllAgents(t *testing.
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH failed: %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("multi-agent PATCH enable = %d, want 400 (body: %s)", w.Code, w.Body.String())
 	}
-
-	m, _ := config.ReadTOMLMap(tomlPath)
-	ai, _ := m["ai"].(map[string]any)
-	agents, _ := ai["agents"].(map[string]any)
-	for _, name := range []string{"claude", "gemini", "codex", "opencode"} {
-		inner, ok := agents[name].(map[string]any)
-		if !ok {
-			continue
-		}
-		if _, present := inner["dangerously_skip_perms"]; present {
-			t.Errorf("dangerously_skip_perms persisted for %s (M-5 bypass)", name)
-		}
+	got, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != tomlContent {
+		t.Fatalf("rejected multi-agent PATCH changed TOML:\n%s", got)
 	}
 }
 

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1245,6 +1245,11 @@ func TestHandlerPutConfig_AgentConfigs_EnforcesProviderPolicy(t *testing.T) {
 			body:       `{"agent_configs":{"claude":{"effort":"--dangerously-skip-permissions"}}}`,
 			wantStatus: http.StatusBadRequest,
 		},
+		{
+			name:       "Legacy free-form model rejected in new config writes",
+			body:       `{"agent_configs":{"claude":{"extra_flags":"--model opus"}}}`,
+			wantStatus: http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1272,6 +1277,26 @@ func TestHandlerUpsertAgent_RejectsProviderPolicyFlags(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "--sandbox") {
 		t.Fatalf("error must identify rejected flag, got: %s", w.Body.String())
+	}
+}
+
+func TestHandlerUpsertAgent_AcceptsSafeLegacyTypedProfileFlags(t *testing.T) {
+	srv, s := setupServer(t)
+	body := `{"id":"legacy-claude","name":"Legacy Claude","cli":"claude","cli_flags":"--model opus --max-turns 5 --effort HIGH --verbose"}`
+	req := httptest.NewRequest("POST", "/agents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	agents, err := s.ListAgents()
+	if err != nil {
+		t.Fatalf("list agents: %v", err)
+	}
+	if len(agents) != 1 || agents[0].CLIFlags != "--model opus --max-turns 5 --effort HIGH --verbose" {
+		t.Fatalf("legacy profile flags were not preserved for runtime migration: %+v", agents)
 	}
 }
 
@@ -1864,6 +1889,69 @@ func TestHandlePatchConfig_PreservesTrustedDangerousFlag(t *testing.T) {
 	}
 	if claude["permission_mode"] != "acceptEdits" {
 		t.Fatalf("legal sibling field did not land: %v", claude)
+	}
+}
+
+func TestHandlePatchConfig_MigratesLegacyTOMLBaseBeforeInnocuousPatch(t *testing.T) {
+	tomlContent := "[github]\n" +
+		"poll_interval = \"5m\"\n\n" +
+		"[ai]\n" +
+		"primary = \"codex\"\n\n" +
+		"[ai.agents.codex]\n" +
+		"extra_flags = \"--model gpt-5 --json\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(`{"github":{"poll_interval":"10m"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("innocuous PATCH over legacy TOML = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	m, err := config.ReadTOMLMap(tomlPath)
+	if err != nil {
+		t.Fatalf("read migrated TOML: %v", err)
+	}
+	githubConfig, _ := m["github"].(map[string]any)
+	if githubConfig["poll_interval"] != "10m" {
+		t.Fatalf("innocuous PATCH did not land: %v", githubConfig)
+	}
+	ai, _ := m["ai"].(map[string]any)
+	agents, _ := ai["agents"].(map[string]any)
+	codex, _ := agents["codex"].(map[string]any)
+	if codex["model"] != "gpt-5" || codex["extra_flags"] != "--json" {
+		t.Fatalf("legacy TOML base was not migrated safely: %v", codex)
+	}
+}
+
+func TestHandlePatchConfig_RejectsNewLegacyTypedFlagWithoutChangingTOML(t *testing.T) {
+	tomlContent := "[ai]\nprimary = \"codex\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	body := `{"ai":{"agents":{"codex":{"extra_flags":"--model gpt-5"}}}}`
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("new legacy typed flag PATCH = %d, want 400 (body: %s)", w.Code, w.Body.String())
+	}
+	got, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatalf("read TOML after rejected PATCH: %v", err)
+	}
+	if string(got) != tomlContent {
+		t.Fatalf("rejected PATCH changed TOML:\n%s", got)
 	}
 }
 

--- a/daemon/internal/server/handlers_test.go
+++ b/daemon/internal/server/handlers_test.go
@@ -1214,6 +1214,83 @@ func TestHandlerPutConfig_AgentConfigs_RejectsBadPermissionMode(t *testing.T) {
 	}
 }
 
+func TestHandlerPutConfig_AgentConfigs_EnforcesProviderPolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{
+			name:       "Codex sandbox override rejected",
+			body:       `{"agent_configs":{"codex":{"extra_flags":"--sandbox danger-full-access"}}}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "Gemini yolo approval rejected",
+			body:       `{"agent_configs":{"gemini":{"approval_mode":"yolo"}}}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "Gemini typed auto edit accepted",
+			body:       `{"agent_configs":{"gemini":{"approval_mode":"auto_edit"}}}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "Option-shaped model rejected",
+			body:       `{"agent_configs":{"claude":{"model":"--dangerously-skip-permissions"}}}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "Option-shaped effort rejected",
+			body:       `{"agent_configs":{"claude":{"effort":"--dangerously-skip-permissions"}}}`,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := setupServer(t)
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, putConfigRequest(tc.body))
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %s)", w.Code, tc.wantStatus, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandlerUpsertAgent_RejectsProviderPolicyFlags(t *testing.T) {
+	srv, _ := setupServer(t)
+	body := `{"id":"unsafe-codex","name":"Unsafe Codex","cli":"codex","cli_flags":"--sandbox=danger-full-access"}`
+	req := httptest.NewRequest("POST", "/agents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "--sandbox") {
+		t.Fatalf("error must identify rejected flag, got: %s", w.Body.String())
+	}
+}
+
+func TestHandlerUpsertAgent_RequiresCLIForFlags(t *testing.T) {
+	srv, _ := setupServer(t)
+	body := `{"id":"missing-cli","name":"Missing CLI","cli_flags":"--model safe-model"}`
+	req := httptest.NewRequest("POST", "/agents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "cli is required") {
+		t.Fatalf("error must explain the effective-provider requirement, got: %s", w.Body.String())
+	}
+}
+
 func TestHandlerPutConfig_AgentConfigs_RejectsUnknownSubkey(t *testing.T) {
 	srv, _ := setupServer(t)
 	body := `{"agent_configs":{"claude":{"new_secret_field":true}}}`
@@ -1750,6 +1827,46 @@ func TestHandlePatchConfig_StripsDangerouslySkipPerms(t *testing.T) {
 	}
 }
 
+func TestHandlePatchConfig_PreservesTrustedDangerousFlag(t *testing.T) {
+	tomlContent := "[ai]\n" +
+		"primary = \"claude\"\n" +
+		"[ai.agents.claude]\n" +
+		"dangerously_skip_perms = true\n" +
+		"permission_mode = \"default\"\n"
+	tomlPath := writeTempTOML(t, tomlContent)
+
+	srv := setupServerWithToken(t, "test-token")
+	srv.SetConfigPath(tomlPath)
+
+	// HTTP cannot enable or disable the filesystem-trusted gate. The attempted
+	// false value is removed from the payload before merge, while legal sibling
+	// fields still apply.
+	body := `{"ai":{"agents":{"claude":{"dangerously_skip_perms":false,"permission_mode":"acceptEdits"}}}}`
+	req := httptest.NewRequest("PATCH", "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Heimdallm-Token", "test-token")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH should succeed, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	m, err := config.ReadTOMLMap(tomlPath)
+	if err != nil {
+		t.Fatalf("read TOML after PATCH: %v", err)
+	}
+	ai, _ := m["ai"].(map[string]any)
+	agents, _ := ai["agents"].(map[string]any)
+	claude, _ := agents["claude"].(map[string]any)
+	if got, ok := claude["dangerously_skip_perms"].(bool); !ok || !got {
+		t.Fatalf("trusted dangerously_skip_perms was changed by HTTP PATCH: %v", claude)
+	}
+	if claude["permission_mode"] != "acceptEdits" {
+		t.Fatalf("legal sibling field did not land: %v", claude)
+	}
+}
+
 func TestHandlePatchConfig_StripsDangerouslySkipPermsCaseInsensitive(t *testing.T) {
 	// JSON preserves key casing; the merged map then feeds into a
 	// Go struct via mapstructure/koanf, which is case-insensitive
@@ -1789,6 +1906,98 @@ func TestHandlePatchConfig_StripsDangerouslySkipPermsCaseInsensitive(t *testing.
 				t.Errorf("case-variant %q persisted for %s (M-5 bypass)", k, name)
 			}
 		}
+	}
+}
+
+func TestHandlePatchConfig_RejectsCaseVariantAgentTree(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "top-level AI",
+			body: `{"AI":{"agents":{"claude":{"dangerously_skip_perms":true}}}}`,
+		},
+		{
+			name: "global Agents",
+			body: `{"ai":{"Agents":{"claude":{"dangerously_skip_perms":true}}}}`,
+		},
+		{
+			name: "repo Agents",
+			body: `{"ai":{"repos":{"org/repo":{"Agents":{"claude":{"dangerously_skip_perms":true}}}}}}`,
+		},
+		{
+			name: "org Agents",
+			body: `{"ai":{"orgs":{"org":{"Agents":{"claude":{"dangerously_skip_perms":true}}}}}}`,
+		},
+		{
+			name: "CLI name",
+			body: `{"ai":{"agents":{"Codex":{"extra_flags":"--sandbox danger-full-access"}}}}`,
+		},
+		{
+			name: "agent field",
+			body: `{"ai":{"agents":{"codex":{"Extra_Flags":"--sandbox danger-full-access"}}}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tomlPath := writeTempTOML(t, "[ai]\nprimary = \"claude\"\n")
+			srv := setupServerWithToken(t, "test-token")
+			srv.SetConfigPath(tomlPath)
+
+			req := httptest.NewRequest("PATCH", "/config", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Heimdallm-Token", "test-token")
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for case-variant config tree, got %d (body: %s)", w.Code, w.Body.String())
+			}
+			got, err := os.ReadFile(tomlPath)
+			if err != nil {
+				t.Fatalf("read config after rejected PATCH: %v", err)
+			}
+			if string(got) != "[ai]\nprimary = \"claude\"\n" {
+				t.Fatalf("rejected PATCH changed config:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestHandleScopedPatchConfig_RejectsCaseVariantAgentTree(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "repo",
+			path: "/config/repos/" + url.PathEscape("org/repo"),
+		},
+		{
+			name: "org",
+			path: "/config/orgs/" + url.PathEscape("org"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tomlPath := writeTempTOML(t, "[ai]\nprimary = \"claude\"\n")
+			srv := setupServerWithToken(t, "test-token")
+			srv.SetConfigPath(tomlPath)
+
+			body := `{"Agents":{"claude":{"dangerously_skip_perms":true}}}`
+			req := httptest.NewRequest("PATCH", tc.path, strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Heimdallm-Token", "test-token")
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for case-variant scoped tree, got %d (body: %s)", w.Code, w.Body.String())
+			}
+		})
 	}
 }
 
@@ -2695,5 +2904,55 @@ func TestHandlePatchAutonomousOrgConfig(t *testing.T) {
 	}
 	if myorg["dev_max_turns"] != int64(10) {
 		t.Errorf("autonomous.orgs[myorg].dev_max_turns = %v (%T), want 10", myorg["dev_max_turns"], myorg["dev_max_turns"])
+	}
+}
+
+func TestHandlePatchAutonomousConfigRejectsAgentsWithoutPersisting(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "global config repo override",
+			path: "/config",
+			body: `{"autonomous":{"repos":{"org/repo":{"agents":{"codex":{"extra_flags":"--sandbox danger-full-access"}}}}}}`,
+		},
+		{
+			name: "repo endpoint",
+			path: "/config/autonomous/repos/" + url.PathEscape("org/repo"),
+			body: `{"agents":{"codex":{"extra_flags":"--sandbox danger-full-access"}}}`,
+		},
+		{
+			name: "org endpoint",
+			path: "/config/autonomous/orgs/org",
+			body: `{"agents":{"codex":{"extra_flags":"--sandbox danger-full-access"}}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const tomlContent = "[ai]\nprimary = \"claude\"\n\n[autonomous]\nenabled = true\n"
+			tomlPath := writeTempTOML(t, tomlContent)
+			srv := setupServerWithToken(t, "test-token")
+			srv.SetConfigPath(tomlPath)
+
+			req := httptest.NewRequest(http.MethodPatch, tc.path, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Heimdallm-Token", "test-token")
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d (body: %s)", w.Code, http.StatusBadRequest, w.Body.String())
+			}
+			got, err := os.ReadFile(tomlPath)
+			if err != nil {
+				t.Fatalf("read TOML after rejected PATCH: %v", err)
+			}
+			if string(got) != tomlContent {
+				t.Fatalf("rejected PATCH changed TOML:\n%s", got)
+			}
+		})
 	}
 }

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -582,13 +582,16 @@ model = "anthropic/claude-sonnet-4"
 `dangerously_skip_perms` cannot be set via the HTTP API for security reasons — it must be set in `config.toml` directly.
 
 `extra_flags` uses a fail-closed allowlist per CLI. Only reviewed presentation,
-model, output and restrictive options are accepted; unknown flags and options
+output, resource-tuning and restrictive options are accepted; unknown flags and options
 that can alter approval, sandbox, permissions, sessions, trusted directories,
 files, tools, policy or external configuration are rejected. Heimdallm validates
 the list while loading configuration and again immediately before creating the
-subprocess. Use the typed `permission_mode` / `approval_mode` fields for
-supported safe modes instead. When execution falls back to a different CLI,
-provider-specific options from the unavailable primary are not forwarded.
+subprocess. Model, effort, turn-limit, permission and approval settings must use
+their typed fields; legacy model/effort/turn flags are migrated on load with a
+warning. Unsafe legacy fields are ignored individually rather than preventing
+startup or discarding unrelated stored settings. When execution falls back to a
+different CLI, provider-specific options from the unavailable primary are not
+forwarded.
 
 ### Prompt categories
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -579,7 +579,9 @@ model = "anthropic/claude-sonnet-4"
 
 **Important:** `bare = true` disables OAuth authentication. Use it only when authenticating via `ANTHROPIC_API_KEY`, never with `CLAUDE_CODE_OAUTH_TOKEN`.
 
-`dangerously_skip_perms` cannot be set via the HTTP API for security reasons — it must be set in `config.toml` directly.
+For security reasons, the HTTP API can only set `dangerously_skip_perms` to
+`false` (reducing privilege). Enabling it requires a direct edit to
+`config.toml`.
 
 `extra_flags` uses a fail-closed allowlist per CLI. Only reviewed presentation,
 output, resource-tuning and restrictive options are accepted; unknown flags and options
@@ -1323,7 +1325,7 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # effort                 = "high"         # low | medium | high | max
 # permission_mode        = "auto"         # default | auto | acceptEdits | dontAsk
 # bare                   = false          # WARNING: disables OAuth — use ANTHROPIC_API_KEY
-# dangerously_skip_perms = false          # cannot be set via HTTP API
+# dangerously_skip_perms = false          # HTTP may disable; enable only in config.toml
 # no_session_persistence = false
 # execution_timeout      = "20m"          # per-agent override (overrides [ai].execution_timeout)
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -566,7 +566,8 @@ no_session_persistence = false          # --no-session-persistence
 execution_timeout      = "20m"          # per-agent override
 
 [ai.agents.gemini]
-model = "gemini-2.5-pro"
+model         = "gemini-2.5-pro"
+approval_mode = "auto_edit"    # default | auto_edit | plan (yolo is forbidden)
 
 [ai.agents.codex]
 model         = "codex-mini"
@@ -579,6 +580,15 @@ model = "anthropic/claude-sonnet-4"
 **Important:** `bare = true` disables OAuth authentication. Use it only when authenticating via `ANTHROPIC_API_KEY`, never with `CLAUDE_CODE_OAUTH_TOKEN`.
 
 `dangerously_skip_perms` cannot be set via the HTTP API for security reasons — it must be set in `config.toml` directly.
+
+`extra_flags` uses a fail-closed allowlist per CLI. Only reviewed presentation,
+model, output and restrictive options are accepted; unknown flags and options
+that can alter approval, sandbox, permissions, sessions, trusted directories,
+files, tools, policy or external configuration are rejected. Heimdallm validates
+the list while loading configuration and again immediately before creating the
+subprocess. Use the typed `permission_mode` / `approval_mode` fields for
+supported safe modes instead. When execution falls back to a different CLI,
+provider-specific options from the unavailable primary are not forwarded.
 
 ### Prompt categories
 
@@ -1315,7 +1325,8 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # execution_timeout      = "20m"          # per-agent override (overrides [ai].execution_timeout)
 
 # [ai.agents.gemini]
-# model = "gemini-2.5-pro"
+# model         = "gemini-2.5-pro"
+# approval_mode = "auto_edit"    # default | auto_edit | plan (yolo is forbidden)
 
 # [ai.agents.codex]
 # model         = "codex-mini"

--- a/flutter_app/lib/features/cli_agents/cli_agents_screen.dart
+++ b/flutter_app/lib/features/cli_agents/cli_agents_screen.dart
@@ -483,12 +483,18 @@ class _AgentSectionState extends State<_AgentSection> {
               onChanged: (v) { setState(() => s.noSessionPersistence = v); widget.onChanged(s); },
             ),
             _tipToggle(
+              switchKey: ValueKey('dangerously-skip-permissions-${widget.name}'),
               label: '--dangerously-skip-permissions',
               value: s.dangerouslySkipPerms,
               tooltip: '⚠️ Bypasses ALL permission checks.\n'
-                  'Only use in sandboxed or trusted environments '
-                  'where security is handled externally.',
-              onChanged: (v) { setState(() => s.dangerouslySkipPerms = v); widget.onChanged(s); },
+                  'This screen can only disable it. To enable it, edit '
+                  'config.toml directly in a sandboxed or trusted environment.',
+              onChanged: s.dangerouslySkipPerms
+                  ? (v) {
+                      setState(() => s.dangerouslySkipPerms = v);
+                      widget.onChanged(s);
+                    }
+                  : null,
               danger: true,
             ),
           ],
@@ -522,10 +528,11 @@ class _AgentSectionState extends State<_AgentSection> {
   }
 
   Widget _tipToggle({
+    Key? switchKey,
     required String label,
     required bool value,
     required String tooltip,
-    required ValueChanged<bool> onChanged,
+    required ValueChanged<bool>? onChanged,
     bool danger = false,
   }) {
     return Tooltip(
@@ -533,6 +540,7 @@ class _AgentSectionState extends State<_AgentSection> {
       waitDuration: const Duration(milliseconds: 600),
       child: Row(mainAxisSize: MainAxisSize.min, children: [
         Switch(
+          key: switchKey,
           value: value,
           onChanged: onChanged,
           // ignore: deprecated_member_use

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -385,8 +385,16 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
       ad['permission_mode'] = n.permissionMode;
     }
     if (o.bare != n.bare) ad['bare'] = n.bare;
-    if (o.dangerouslySkipPerms != n.dangerouslySkipPerms) {
-      ad['dangerously_skip_perms'] = n.dangerouslySkipPerms;
+    // HTTP is deliberately asymmetric for this capability: the UI may reduce
+    // privilege, but enabling it requires a trusted config.toml edit.
+    if (!o.dangerouslySkipPerms && n.dangerouslySkipPerms) {
+      throw StateError(
+        'dangerously_skip_perms cannot be enabled via the HTTP API; '
+        'edit config.toml directly',
+      );
+    }
+    if (o.dangerouslySkipPerms && !n.dangerouslySkipPerms) {
+      ad['dangerously_skip_perms'] = false;
     }
     if (o.noSessionPersistence != n.noSessionPersistence) {
       ad['no_session_persistence'] = n.noSessionPersistence;

--- a/flutter_app/test/features/cli_agents_screen_test.dart
+++ b/flutter_app/test/features/cli_agents_screen_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:heimdallm/core/api/api_client.dart';
+import 'package:heimdallm/core/models/agent.dart';
+import 'package:heimdallm/core/models/config_model.dart';
+import 'package:heimdallm/features/agents/agents_screen.dart';
+import 'package:heimdallm/features/cli_agents/cli_agents_screen.dart';
+import 'package:heimdallm/features/config/config_providers.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    required bool dangerouslySkipPerms,
+  }) async {
+    // Keep only the first (Claude) card in the ListView build/cache extent.
+    // The pre-existing fixed-width Codex approval dropdown overflows under
+    // Flutter's synthetic test font metrics and is unrelated to this switch.
+    tester.view.physicalSize = const Size(1400, 600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final config = AppConfig(
+      agentConfigs: {
+        'claude': CLIAgentConfig(dangerouslySkipPerms: dangerouslySkipPerms),
+      },
+    );
+    final configJson = {
+      ...config.toJson(),
+      'agent_configs': {
+        'claude': {'dangerously_skip_perms': dangerouslySkipPerms},
+      },
+    };
+    final api = _MockApiClient();
+    when(api.fetchConfig).thenAnswer((_) async => configJson);
+    when(() => api.patchConfig(any())).thenAnswer((_) async => configJson);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiClientProvider.overrideWithValue(api),
+          configNotifierProvider.overrideWith(ConfigNotifier.new),
+          agentsProvider.overrideWith(
+            (ref) => Future.value(const <ReviewPrompt>[]),
+          ),
+        ],
+        child: const MaterialApp(home: Scaffold(body: CLIAgentsScreen())),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('dangerous switch cannot enable an inactive bypass', (
+    tester,
+  ) async {
+    await pumpScreen(tester, dangerouslySkipPerms: false);
+
+    final finder = find.byKey(
+      const ValueKey('dangerously-skip-permissions-claude'),
+    );
+    final toggle = tester.widget<Switch>(finder);
+    expect(toggle.value, isFalse);
+    expect(toggle.onChanged, isNull);
+  });
+
+  testWidgets('dangerous switch only allows true to false', (tester) async {
+    await pumpScreen(tester, dangerouslySkipPerms: true);
+
+    final finder = find.byKey(
+      const ValueKey('dangerously-skip-permissions-claude'),
+    );
+    expect(tester.widget<Switch>(finder).onChanged, isNotNull);
+
+    await tester.tap(finder);
+    await tester.pump();
+
+    final disabled = tester.widget<Switch>(finder);
+    expect(disabled.value, isFalse);
+    expect(disabled.onChanged, isNull);
+  });
+}

--- a/flutter_app/test/features/config_dangerous_flag_test.dart
+++ b/flutter_app/test/features/config_dangerous_flag_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:heimdallm/core/api/api_client.dart';
+import 'package:heimdallm/core/models/config_model.dart';
+import 'package:heimdallm/features/config/config_providers.dart';
+import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+Map<String, dynamic> _configJson(bool dangerouslySkipPerms) => {
+  ...const AppConfig().toJson(),
+  'agent_configs': {
+    'claude': {'dangerously_skip_perms': dangerouslySkipPerms},
+  },
+};
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  test('config diff emits a dangerous safety downgrade', () async {
+    final api = _MockApiClient();
+    Map<String, dynamic>? capturedPatch;
+    when(api.fetchConfig).thenAnswer((_) async => _configJson(true));
+    when(() => api.patchConfig(any())).thenAnswer((invocation) async {
+      capturedPatch = invocation.positionalArguments[0] as Map<String, dynamic>;
+      return _configJson(false);
+    });
+
+    final container = ProviderContainer(
+      overrides: [apiClientProvider.overrideWithValue(api)],
+    );
+    addTearDown(container.dispose);
+    final initial = await container.read(configNotifierProvider.future);
+
+    await container
+        .read(configNotifierProvider.notifier)
+        .save(
+          initial.copyWith(
+            agentConfigs: {
+              'claude': initial.agentConfigs['claude']!.copyWith(
+                dangerouslySkipPerms: false,
+              ),
+            },
+          ),
+        );
+
+    expect(
+      capturedPatch!['ai']['agents']['claude']['dangerously_skip_perms'],
+      isFalse,
+    );
+  });
+
+  test('config diff rejects a dangerous privilege elevation', () async {
+    final api = _MockApiClient();
+    when(api.fetchConfig).thenAnswer((_) async => _configJson(false));
+
+    final container = ProviderContainer(
+      overrides: [apiClientProvider.overrideWithValue(api)],
+    );
+    addTearDown(container.dispose);
+    final initial = await container.read(configNotifierProvider.future);
+
+    expect(
+      () => container
+          .read(configNotifierProvider.notifier)
+          .save(
+            initial.copyWith(
+              agentConfigs: {
+                'claude': initial.agentConfigs['claude']!.copyWith(
+                  dangerouslySkipPerms: true,
+                ),
+              },
+            ),
+          ),
+      throwsStateError,
+    );
+    verifyNever(() => api.patchConfig(any()));
+  });
+}


### PR DESCRIPTION
## Resumen

- Centraliza la política fail-closed por proveedor en ExecuteRaw y bloquea aliases, flags adjuntos, valores inline y opciones que cambian permisos, sandbox, sesiones, archivos o configuración.
- Evita trasladar opciones del proveedor primario cuando Detect usa el fallback y mantiene Gemini auto-implement en el modo tipado auto_edit.
- Endurece PUT, PATCH global/repo/org/autonomous y el store legacy con claves canónicas, saneado del gate trusted-only y merge atómico.
- Añade cobertura de no regresión para Claude, Codex, Gemini y OpenCode, incluida la comprobación de que un rechazo no inicia procesos ni persiste TOML parcial.

## Validación

- make test-docker GO_TEST_ARGS="./internal/executor/... ./internal/config/... ./internal/server/... ./internal/issues/... ./internal/pipeline/... ./cmd/heimdallm/..."
- make test-docker
- git diff --check y gofmt limpios
- revisión independiente de seguridad y regresiones sin bloqueantes

## Puerta humana

Ready for review para el equipo. Esta PR no debe considerarse validada ni fusionarse hasta recibir el visto bueno explícito de Muriano.

Closes #609