### PR TITLE
fix(security): isolate AI and Git subprocess credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,12 +374,12 @@ _check-buildkit: _check-docker
 _check-env: _check-docker
 	@test -f $(DOCKER_ENV) || { \
 	  echo "❌  $(DOCKER_ENV) missing."; \
-	  echo "    Copy the template and fill in GITHUB_TOKEN + your AI API key:"; \
+	  echo "    Copy the template and fill in GITHUB_TOKEN + AI authentication:"; \
 	  echo "    cp docker/.env.example $(DOCKER_ENV)"; \
 	  exit 1; \
 	}
 
-# Prints a short post-up summary: the web URL, which AI keys are set, and
+# Prints a short post-up summary: the web URL, which AI auth routes are set, and
 # hints for the opt-in knobs operators most often miss (full-repo analysis,
 # topic discovery, issue tracking). Called after `up` / `up-build`.
 _post-up-hints:
@@ -389,13 +389,19 @@ _post-up-hints:
 	@echo ""
 	@set -a; . $(DOCKER_ENV); set +a; \
 	 _set=; _unset=; \
-	 for k in ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN OPENAI_API_KEY CODEX_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY; do \
+	 for k in ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_OAUTH_TOKEN \
+	          OPENAI_API_KEY CODEX_API_KEY GEMINI_API_KEY GOOGLE_API_KEY OPENROUTER_API_KEY; do \
 	   v=$$(eval "printf %s \"\$${$$k:-}\""); \
 	   if [ -n "$$v" ]; then _set="$$_set $$k"; fi; \
 	 done; \
-	 if [ -n "$$_set" ]; then echo "AI credentials present:$$_set"; \
-	 else echo "⚠  No AI credentials set — reviews will fail. Set one in $(DOCKER_ENV):"; \
-	      echo "     ANTHROPIC_API_KEY  CLAUDE_CODE_OAUTH_TOKEN  OPENAI_API_KEY  GEMINI_API_KEY"; fi
+	 for k in CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX; do \
+	   v=$$(eval "printf %s \"\$${$$k:-}\"" | tr '[:upper:]' '[:lower:]'); \
+	   if [ "$$v" = "1" ] || [ "$$v" = "true" ] || \
+	      [ "$$v" = "yes" ] || [ "$$v" = "on" ]; then _set="$$_set $$k"; fi; \
+	 done; \
+	 if [ -n "$$_set" ]; then echo "AI authentication configured:$$_set"; \
+	 else echo "⚠  No AI authentication set — reviews will fail. Configure one in $(DOCKER_ENV):"; \
+	      echo "     API/OAuth key, Anthropic gateway, Claude Bedrock, or Claude Vertex"; fi
 	@echo ""
 	@set -a; . $(DOCKER_ENV); set +a; \
 	 if [ -z "$${HEIMDALLM_LOCAL_DIR_BASE:-}" ]; then \
@@ -565,9 +571,18 @@ run-linux:
 	    echo "GITHUB_TOKEN=$$GH_TOK" >> "$$ENV_FILE" ; \
 	  fi ; \
 	fi ; \
-	for var in ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN \
+	for var in ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN ANTHROPIC_BASE_URL \
+	           ANTHROPIC_BEDROCK_BASE_URL ANTHROPIC_VERTEX_BASE_URL \
+	           ANTHROPIC_VERTEX_PROJECT_ID \
+	           AWS_ACCESS_KEY_ID AWS_BEARER_TOKEN_BEDROCK AWS_DEFAULT_REGION \
+	           AWS_REGION AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
+	           CLAUDE_CODE_OAUTH_TOKEN CLAUDE_CODE_SKIP_BEDROCK_AUTH \
+	           CLAUDE_CODE_SKIP_VERTEX_AUTH CLAUDE_CODE_USE_BEDROCK \
+	           CLAUDE_CODE_USE_VERTEX CLOUD_ML_REGION GCLOUD_PROJECT \
 	           OPENAI_API_KEY CODEX_API_KEY \
-	           GEMINI_API_KEY OPENROUTER_API_KEY ; do \
+	           GEMINI_API_KEY GOOGLE_API_KEY GOOGLE_APPLICATION_CREDENTIALS \
+	           GOOGLE_CLOUD_PROJECT GOOGLE_CLOUD_LOCATION \
+	           GOOGLE_GENAI_USE_VERTEXAI OPENROUTER_API_KEY ; do \
 	  val=$$(printenv "$$var" 2>/dev/null || true) ; \
 	  if [ -z "$$val" ] && [ -f docker/.env ]; then \
 	    val=$$(grep "^$$var=" docker/.env 2>/dev/null | head -1 | cut -d= -f2-) ; \

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For headless/server deployment, Heimdallm runs as a Docker container with all fo
 - **Credentials for your chosen AI provider** (at least one):
   - **Claude — subscription (Max / Pro / Team)**: run `claude setup-token` on your host (interactive — opens a browser) and copy the `sk-ant-oat…` token it prints. This becomes `CLAUDE_CODE_OAUTH_TOKEN`. No billing setup required if your Anthropic subscription covers Claude Code.
   - **Claude — pay-as-you-go API key**: create one at https://console.anthropic.com/settings/keys. This becomes `ANTHROPIC_API_KEY`.
-  - **Gemini**: https://aistudio.google.com/apikey → `GEMINI_API_KEY`. Or reuse your host's browser OAuth — see [Reusing your host's AI authentication](#reusing-your-hosts-ai-authentication).
+  - **Gemini**: https://aistudio.google.com/apikey → `GEMINI_API_KEY` or `GOOGLE_API_KEY`. Browser OAuth and Vertex AI are also supported — see [Reusing your host's AI authentication](#reusing-your-hosts-ai-authentication) and the [Configuration Guide](docs/configuration-guide.md#other-ai-clis).
   - **OpenAI / Codex**: https://platform.openai.com/api-keys → `OPENAI_API_KEY` or `CODEX_API_KEY`.
   - **OpenRouter** (for OpenCode): https://openrouter.ai/keys → `OPENROUTER_API_KEY`.
 
@@ -176,6 +176,13 @@ Then open `docker/.env` in your editor and set at minimum:
 For non-Claude providers see [Reusing your host's AI authentication](#reusing-your-hosts-ai-authentication) (Gemini OAuth reuse) or just set the relevant `*_API_KEY` variable from the Prerequisites list.
 
 See [`docker/.env.example`](docker/.env.example) for every supported variable including issue-tracking, topic-based discovery, and web UI settings.
+
+AI CLIs do not inherit the daemon environment. Each launch starts from an
+empty environment and a mode-`0700` temporary home, then receives only the
+selected provider's credentials and state. Additional variables require an
+explicit per-provider allowlist; GitHub, Heimdallm, Git, and process-injection
+variables remain blocked. See [AI subprocess security](docs/subprocess-security.md)
+for the exact contract, SSH opt-in, and residual threat model.
 
 #### 3. Start the stack
 
@@ -269,7 +276,8 @@ If you already authenticate the AI CLIs on your host, you can reuse those
 credentials inside Docker instead of pasting an API key into `.env`. The
 daemon runs its **own** bundled CLIs inside the container — it never shells
 out to the binaries on your host — but the container can read the same
-OAuth tokens the host CLIs wrote.
+OAuth tokens the host CLIs wrote. At execution time Heimdallm bridges only the
+selected provider's state into that process's isolated temporary home.
 
 **Claude Code (Max / Pro / Team subscription):**
 
@@ -297,11 +305,15 @@ OAuth tokens the host CLIs wrote.
    - ~/.gemini:/home/heimdallm/.gemini:ro
    ```
    The mount is read-only, so the container cannot clobber your host
-   credentials.
+   credentials; the Gemini-only home bridge preserves that restriction.
 3. Leave `GEMINI_API_KEY` empty in `docker/.env`.
 
-**Codex / OpenCode:** host-auth reuse is not wired up yet — use API keys
-(`OPENAI_API_KEY`, `CODEX_API_KEY`, `OPENROUTER_API_KEY`) in `docker/.env`.
+**Codex / OpenCode:** host-auth reuse is not wired up yet. Codex accepts
+`OPENAI_API_KEY` or `CODEX_API_KEY`. OpenCode receives
+`OPENROUTER_API_KEY` by default; when configured for Anthropic, OpenAI, or
+Gemini, explicitly name that backend key in
+`HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST`. Set the matching values in
+`docker/.env`.
 
 `make up` picks up the changes on the next start. Full reference (including
 Vertex AI service-account mode for Gemini) in
@@ -563,7 +575,10 @@ heimdallm/
 
 ## Configuration
 
-See the [Configuration Guide](docs/configuration-guide.md) for full reference of all settings, environment variables, and deployment options.
+See the [Configuration Guide](docs/configuration-guide.md) for full reference
+of all settings, environment variables, and deployment options. The
+[AI subprocess security guide](docs/subprocess-security.md) documents provider
+credential boundaries and the optional SSH-agent overlay.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,9 @@ selected provider's state into that process's isolated temporary home.
    - ~/.gemini:/home/heimdallm/.gemini:ro
    ```
    The mount is read-only, so the container cannot clobber your host
-   credentials; the Gemini-only home bridge preserves that restriction.
+   credentials; the Gemini-only home bridge preserves that restriction. OAuth
+   refreshes remain usable for the current review but are ephemeral because the
+   source cannot be updated.
 3. Leave `GEMINI_API_KEY` empty in `docker/.env`.
 
 **Codex / OpenCode:** host-auth reuse is not wired up yet. Codex accepts

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ For headless/server deployment, Heimdallm runs as a Docker container with all fo
 - **Credentials for your chosen AI provider** (at least one):
   - **Claude — subscription (Max / Pro / Team)**: run `claude setup-token` on your host (interactive — opens a browser) and copy the `sk-ant-oat…` token it prints. This becomes `CLAUDE_CODE_OAUTH_TOKEN`. No billing setup required if your Anthropic subscription covers Claude Code.
   - **Claude — pay-as-you-go API key**: create one at https://console.anthropic.com/settings/keys. This becomes `ANTHROPIC_API_KEY`.
+  - **Claude — enterprise gateway, Bedrock, or Vertex AI**: the corresponding routing and cloud credentials are supported conditionally; see [Claude Code authentication](docs/configuration-guide.md#claude-code).
   - **Gemini**: https://aistudio.google.com/apikey → `GEMINI_API_KEY` or `GOOGLE_API_KEY`. Browser OAuth and Vertex AI are also supported — see [Reusing your host's AI authentication](#reusing-your-hosts-ai-authentication) and the [Configuration Guide](docs/configuration-guide.md#other-ai-clis).
   - **OpenAI / Codex**: https://platform.openai.com/api-keys → `OPENAI_API_KEY` or `CODEX_API_KEY`.
   - **OpenRouter** (for OpenCode): https://openrouter.ai/keys → `OPENROUTER_API_KEY`.
@@ -174,6 +175,10 @@ Then open `docker/.env` in your editor and set at minimum:
   Leave `CLAUDE_CODE_OAUTH_TOKEN` empty.
 
 For non-Claude providers see [Reusing your host's AI authentication](#reusing-your-hosts-ai-authentication) (Gemini OAuth reuse) or just set the relevant `*_API_KEY` variable from the Prerequisites list.
+For Claude enterprise deployments, use the exact gateway, Bedrock, or Vertex
+variables in the [Configuration Guide](docs/configuration-guide.md#claude-code);
+AWS credentials are not exposed unless Bedrock is selected, and
+`CLAUDE_CODE_SKIP_*_AUTH` keeps client credentials out of gateway-backed runs.
 
 See [`docker/.env.example`](docker/.env.example) for every supported variable including issue-tracking, topic-based discovery, and web UI settings.
 
@@ -182,7 +187,8 @@ empty environment and a mode-`0700` temporary home, then receives only the
 selected provider's credentials and state. Additional variables require an
 explicit per-provider allowlist; GitHub, Heimdallm, Git, and process-injection
 variables remain blocked. See [AI subprocess security](docs/subprocess-security.md)
-for the exact contract, SSH opt-in, and residual threat model.
+for the exact conditional Bedrock/Vertex contract, SSH opt-in, and residual
+threat model.
 
 #### 3. Start the stack
 
@@ -222,7 +228,10 @@ Then open the web UI:
 
 The `web` container reads the daemon's API token from the shared `heimdallm-data` volume automatically — no manual copy needed.
 
-After `make up` completes, the target prints a summary of which AI credentials were picked up from `docker/.env` and flags the optional knobs (full-repo analysis, topic discovery) that are currently off. Use it as a checklist before opening the UI.
+After `make up` completes, the target prints a summary of which AI
+authentication routes were picked up from `docker/.env` and flags the optional
+knobs (full-repo analysis, topic discovery) that are currently off. Use it as a
+checklist before opening the UI.
 
 #### 4b. Opt-in: full-repo analysis
 

--- a/daemon/internal/executor/environment.go
+++ b/daemon/internal/executor/environment.go
@@ -1,18 +1,25 @@
 package executor
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
+	"sync"
+	"syscall"
+	"unicode/utf8"
 )
 
 const environmentAllowlistPrefix = "HEIMDALLM_AI_"
 
-var providerCredentialNames = map[string][]string{
+var providerEnvironmentNames = map[string][]string{
 	"claude": {
 		"ANTHROPIC_API_KEY",
 		"CLAUDE_CODE_OAUTH_TOKEN",
@@ -38,6 +45,16 @@ var providerRuntimeNames = map[string][]string{
 	"opencode": {
 		"OPENCODE_DISABLE_AUTOUPDATE",
 	},
+}
+
+var providerSecretNames = map[string]struct{}{
+	"ANTHROPIC_API_KEY":       {},
+	"CLAUDE_CODE_OAUTH_TOKEN": {},
+	"CODEX_API_KEY":           {},
+	"GEMINI_API_KEY":          {},
+	"GOOGLE_API_KEY":          {},
+	"OPENAI_API_KEY":          {},
+	"OPENROUTER_API_KEY":      {},
 }
 
 var commonEnvironmentNames = map[string]struct{}{
@@ -77,10 +94,6 @@ var commonEnvironmentNames = map[string]struct{}{
 	"TZ":                  {},
 	"USER":                {},
 	"WINDIR":              {},
-	"all_proxy":           {},
-	"http_proxy":          {},
-	"https_proxy":         {},
-	"no_proxy":            {},
 }
 
 var managedEnvironmentNames = map[string]struct{}{
@@ -97,31 +110,54 @@ var managedEnvironmentNames = map[string]struct{}{
 }
 
 var dangerousEnvironmentNames = map[string]struct{}{
-	"BASH_ENV":                         {},
-	"CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": {},
-	"CDPATH":                           {},
-	"CLAUDE_CONFIG_DIR":                {},
-	"CODEX_HOME":                       {},
-	"ENV":                              {},
-	"GH_TOKEN":                         {},
-	"GITHUB_TOKEN":                     {},
-	"GIT_ASKPASS":                      {},
-	"GEMINI_CLI_SYSTEM_SETTINGS_PATH":  {},
-	"IFS":                              {},
-	"NODE_OPTIONS":                     {},
-	"NODE_PATH":                        {},
-	"NPM_CONFIG_USERCONFIG":            {},
-	"OPENCODE_DISABLE_PROJECT_CONFIG":  {},
-	"OPENCODE_PURE":                    {},
-	"PERL5LIB":                         {},
-	"PERL5OPT":                         {},
-	"PROMPT_COMMAND":                   {},
-	"PYTHONHOME":                       {},
-	"PYTHONPATH":                       {},
-	"PYTHONSTARTUP":                    {},
-	"RUBYOPT":                          {},
-	"SSH_ASKPASS":                      {},
-	"ZDOTDIR":                          {},
+	"_JAVA_OPTIONS":                       {},
+	"BASH_ENV":                            {},
+	"CLAUDE_CODE_SAFE_MODE":               {},
+	"CLAUDE_CODE_SUBPROCESS_ENV_SCRUB":    {},
+	"CDPATH":                              {},
+	"CLAUDE_CONFIG_DIR":                   {},
+	"CODEX_HOME":                          {},
+	"DOTNET_STARTUP_HOOKS":                {},
+	"ENV":                                 {},
+	"GIO_EXTRA_MODULES":                   {},
+	"GIO_MODULE_DIR":                      {},
+	"GEMINI_CLI_HOME":                     {},
+	"GEMINI_CLI_IDE_SERVER_STDIO_COMMAND": {},
+	"GEMINI_CLI_SYSTEM_DEFAULTS_PATH":     {},
+	"GH_TOKEN":                            {},
+	"GITHUB_TOKEN":                        {},
+	"GIT_ASKPASS":                         {},
+	"GTK3_MODULES":                        {},
+	"GTK_MODULES":                         {},
+	"GTK_PATH":                            {},
+	"GEMINI_CLI_SYSTEM_SETTINGS_PATH":     {},
+	"GEMINI_CLI_TRUSTED_FOLDERS_PATH":     {},
+	"GEMINI_CLI_TRUST_WORKSPACE":          {},
+	"GEMINI_SANDBOX":                      {},
+	"GEMINI_SANDBOX_PROXY_COMMAND":        {},
+	"GEMINI_SYSTEM_MD":                    {},
+	"GEMINI_WRITE_SYSTEM_MD":              {},
+	"IFS":                                 {},
+	"JAVA_TOOL_OPTIONS":                   {},
+	"JDK_JAVA_OPTIONS":                    {},
+	"NODE_OPTIONS":                        {},
+	"NODE_PATH":                           {},
+	"NPM_CONFIG_USERCONFIG":               {},
+	"OPENCODE_CONFIG":                     {},
+	"OPENCODE_CONFIG_CONTENT":             {},
+	"OPENCODE_CONFIG_DIR":                 {},
+	"OPENCODE_DISABLE_PROJECT_CONFIG":     {},
+	"OPENCODE_PURE":                       {},
+	"PERL5LIB":                            {},
+	"PERL5OPT":                            {},
+	"PROMPT_COMMAND":                      {},
+	"PYTHONHOME":                          {},
+	"PYTHONPATH":                          {},
+	"PYTHONSTARTUP":                       {},
+	"PYTHONWARNINGS":                      {},
+	"RUBYOPT":                             {},
+	"SSH_ASKPASS":                         {},
+	"ZDOTDIR":                             {},
 }
 
 type capturedEnvironment struct {
@@ -133,13 +169,17 @@ type preparedEnvironment struct {
 	codexToolEnv map[string]string
 	runDir       string
 	redact       func(string) string
-	cleanup      func()
+	cleanup      func() error
 }
 
 type providerStateMount struct {
-	source string
-	dest   string
+	source   string
+	dest     string
+	copyBack bool
 }
+
+var providerMutableStateMu sync.Mutex
+var providerStateAbsenceLogged sync.Map
 
 func captureEnvironment() capturedEnvironment {
 	values := make(map[string]string)
@@ -176,28 +216,35 @@ func (c capturedEnvironment) prepare(cli string) (*preparedEnvironment, error) {
 	if err != nil {
 		return nil, fmt.Errorf("executor: create isolated home for %s: %w", cli, err)
 	}
-	cleanup := func() { _ = os.RemoveAll(root) }
+	cleanupRoot := func() { _ = os.RemoveAll(root) }
 	if err := os.Chmod(root, 0o700); err != nil {
-		cleanup()
+		cleanupRoot()
 		return nil, fmt.Errorf("executor: secure isolated home for %s: %w", cli, err)
 	}
 
 	base, err := c.base(root)
 	if err != nil {
-		cleanup()
-		return nil, err
-	}
-	if err := c.bridgeProviderState(cli, root); err != nil {
-		cleanup()
+		cleanupRoot()
 		return nil, err
 	}
 
+	stateCleanup, err := c.bridgeProviderState(cli, root)
+	if err != nil {
+		cleanupRoot()
+		return nil, err
+	}
+	cleanup := func() error {
+		return errors.Join(stateCleanup(), os.RemoveAll(root))
+	}
+
 	env := cloneEnvironment(base)
-	redactions := make([]string, 0, len(providerCredentialNames[cli])+len(extraNames))
-	for _, name := range providerCredentialNames[cli] {
+	redactions := make([]string, 0, len(providerEnvironmentNames[cli])+len(extraNames))
+	for _, name := range providerEnvironmentNames[cli] {
 		if value := c.values[name]; value != "" {
 			env[name] = value
-			redactions = append(redactions, value)
+			if _, secret := providerSecretNames[name]; secret {
+				redactions = append(redactions, value)
+			}
 		}
 	}
 	for _, name := range providerRuntimeNames[cli] {
@@ -209,8 +256,17 @@ func (c capturedEnvironment) prepare(cli string) (*preparedEnvironment, error) {
 		if value, ok := c.values[name]; ok {
 			env[name] = value
 			if value != "" {
-				redactions = append(redactions, value)
+				redactions = append(
+					redactions,
+					additionalEnvironmentRedactionValues(name, value)...,
+				)
 			}
+		} else {
+			slog.Warn(
+				"executor: allowlisted environment variable is not set",
+				"cli", cli,
+				"name", name,
+			)
 		}
 	}
 	if cli == "claude" {
@@ -223,7 +279,7 @@ func (c capturedEnvironment) prepare(cli string) (*preparedEnvironment, error) {
 		settingsPath := filepath.Join(root, "gemini-system-settings.json")
 		const settings = "{\n  \"advanced\": {\n    \"ignoreLocalEnv\": true\n  }\n}\n"
 		if err := os.WriteFile(settingsPath, []byte(settings), 0o600); err != nil {
-			cleanup()
+			_ = cleanup()
 			return nil, fmt.Errorf("executor: write Gemini system settings: %w", err)
 		}
 		// System settings override user and project settings. This managed
@@ -265,14 +321,14 @@ func (c capturedEnvironment) prepareProbe() (*preparedEnvironment, error) {
 	if err != nil {
 		return nil, fmt.Errorf("executor: create isolated CLI probe home: %w", err)
 	}
-	cleanup := func() { _ = os.RemoveAll(root) }
+	cleanupRoot := func() { _ = os.RemoveAll(root) }
 	if err := os.Chmod(root, 0o700); err != nil {
-		cleanup()
+		cleanupRoot()
 		return nil, fmt.Errorf("executor: secure isolated CLI probe home: %w", err)
 	}
 	base, err := c.base(root)
 	if err != nil {
-		cleanup()
+		cleanupRoot()
 		return nil, err
 	}
 	for name := range base {
@@ -285,7 +341,7 @@ func (c capturedEnvironment) prepareProbe() (*preparedEnvironment, error) {
 		codexToolEnv: cloneEnvironment(base),
 		runDir:       filepath.Join(root, "tmp"),
 		redact:       func(value string) string { return value },
-		cleanup:      cleanup,
+		cleanup:      func() error { return os.RemoveAll(root) },
 	}, nil
 }
 
@@ -308,6 +364,8 @@ func (c capturedEnvironment) base(root string) (map[string]string, error) {
 
 	env := make(map[string]string, len(commonEnvironmentNames)+12)
 	for name, value := range c.values {
+		// Environment names are matched case-insensitively while preserving
+		// the spelling supplied by the parent process.
 		if _, allowed := commonEnvironmentNames[strings.ToUpper(name)]; allowed {
 			env[name] = value
 		}
@@ -336,6 +394,9 @@ func (c capturedEnvironment) additionalNames(cli string) ([]string, error) {
 	var names []string
 	for _, item := range strings.Split(raw, ",") {
 		name := strings.TrimSpace(item)
+		if name == "" {
+			continue
+		}
 		if !validEnvironmentName(name) {
 			return nil, fmt.Errorf("executor: %s contains invalid environment name %q", controlName, name)
 		}
@@ -368,12 +429,12 @@ func validateAdditionalEnvironmentName(cli, name string) error {
 			return fmt.Errorf("%s is permanently blocked", name)
 		}
 	}
-	for provider, credentialNames := range providerCredentialNames {
+	for provider, providerNames := range providerEnvironmentNames {
 		if provider == cli {
 			continue
 		}
-		for _, credentialName := range credentialNames {
-			if upper == credentialName {
+		for _, providerName := range providerNames {
+			if upper == providerName {
 				if cli == "opencode" {
 					// OpenCode is a multi-provider client. Naming a backend
 					// credential in its exact allowlist is the operator's
@@ -400,63 +461,616 @@ func validEnvironmentName(name string) bool {
 	return true
 }
 
-func (c capturedEnvironment) bridgeProviderState(cli, root string) error {
+func (c capturedEnvironment) bridgeProviderState(cli, root string) (func() error, error) {
+	var stateSyncs []func() error
 	for _, mount := range c.providerStateMounts(cli, root) {
 		if mount.source == "" {
 			continue
 		}
 		if !filepath.IsAbs(mount.source) {
-			return fmt.Errorf("executor: %s credential state path %q must be absolute", cli, mount.source)
+			return nil, fmt.Errorf("executor: %s credential state path %q must be absolute", cli, mount.source)
+		}
+		if cli == "gemini" {
+			syncState, err := bridgeGeminiState(mount.source, mount.dest)
+			if err != nil {
+				return nil, err
+			}
+			stateSyncs = append(stateSyncs, syncState)
+			continue
+		}
+		if mount.copyBack {
+			if _, err := os.Lstat(mount.source); os.IsNotExist(err) {
+				logProviderStateAbsent(cli, mount.source)
+			}
+			syncState, err := bridgeMutableJSONState(mount.source, mount.dest)
+			if err != nil {
+				return nil, fmt.Errorf("executor: bridge %s mutable credential state: %w", cli, err)
+			}
+			stateSyncs = append(stateSyncs, syncState)
+			continue
 		}
 		if _, err := os.Lstat(mount.source); err != nil {
 			if os.IsNotExist(err) {
+				logProviderStateAbsent(cli, mount.source)
 				continue
 			}
-			return fmt.Errorf("executor: inspect %s credential state: %w", cli, err)
-		}
-		if cli == "gemini" {
-			if err := bridgeGeminiState(mount.source, mount.dest); err != nil {
-				return err
-			}
-			continue
+			return nil, fmt.Errorf("executor: inspect %s credential state: %w", cli, err)
 		}
 		if err := os.MkdirAll(filepath.Dir(mount.dest), 0o700); err != nil {
-			return fmt.Errorf("executor: prepare %s credential state bridge: %w", cli, err)
+			return nil, fmt.Errorf("executor: prepare %s credential state bridge: %w", cli, err)
 		}
 		if err := os.Symlink(mount.source, mount.dest); err != nil {
-			return fmt.Errorf("executor: bridge %s credential state: %w", cli, err)
+			return nil, fmt.Errorf("executor: bridge %s credential state: %w", cli, err)
 		}
+	}
+	return func() error {
+		var syncErr error
+		for _, syncState := range stateSyncs {
+			syncErr = errors.Join(syncErr, syncState())
+		}
+		return syncErr
+	}, nil
+}
+
+func logProviderStateAbsent(cli, path string) {
+	key := cli + "\x00" + path
+	if _, loaded := providerStateAbsenceLogged.LoadOrStore(key, struct{}{}); loaded {
+		return
+	}
+	slog.Info(
+		"executor: provider state path is absent; starting without persisted state",
+		"cli", cli,
+		"path", path,
+	)
+}
+
+type mutableStatePolicy struct {
+	seedWhenMissing          []byte
+	projectInitial           func([]byte) ([]byte, error)
+	persistUpdated           func(initial, updated []byte) ([]byte, error)
+	readOnly                 bool
+	allowEphemeralOnReadOnly bool
+}
+
+type statePathAnchor struct {
+	lexicalPath  string
+	resolvedPath string
+	info         os.FileInfo
+}
+
+// bridgeMutableJSONState copies a provider-owned JSON state file into the
+// isolated home and safely copies a changed version back after the CLI exits,
+// normally with an atomic replace. A file symlink is insufficient: CLIs
+// commonly rotate OAuth state with write-temp-then-rename, which replaces the
+// isolated symlink and silently loses the refreshed token when that home is
+// removed.
+func bridgeMutableJSONState(source, dest string) (func() error, error) {
+	return bridgeMutableState(source, dest, mutableStatePolicy{
+		projectInitial: projectMutableJSONState,
+		persistUpdated: persistMutableJSONState,
+	})
+}
+
+func bridgeGeminiMutableJSONState(source, dest string) (func() error, error) {
+	return bridgeMutableState(source, dest, mutableStatePolicy{
+		projectInitial:           projectMutableJSONState,
+		persistUpdated:           persistMutableJSONState,
+		allowEphemeralOnReadOnly: true,
+	})
+}
+
+func bridgeGeminiMutableOpaqueState(source, dest string) (func() error, error) {
+	return bridgeMutableState(source, dest, mutableStatePolicy{
+		projectInitial: func(initial []byte) ([]byte, error) {
+			return bytes.Clone(initial), nil
+		},
+		persistUpdated: func(_ []byte, updated []byte) ([]byte, error) {
+			if len(updated) > 4*1024 {
+				return nil, fmt.Errorf("opaque provider state exceeds 4 KiB")
+			}
+			if bytes.IndexByte(updated, 0) >= 0 {
+				return nil, fmt.Errorf("opaque provider state contains a NUL byte")
+			}
+			return bytes.Clone(updated), nil
+		},
+		allowEphemeralOnReadOnly: true,
+	})
+}
+
+func bridgeGeminiSettingsState(source, dest string) (func() error, error) {
+	return bridgeMutableState(source, dest, mutableStatePolicy{
+		seedWhenMissing: []byte("{}\n"),
+		projectInitial:  projectGeminiAuthSettings,
+		readOnly:        true,
+	})
+}
+
+func bridgeMutableState(source, dest string, policy mutableStatePolicy) (func() error, error) {
+	providerMutableStateMu.Lock()
+	defer providerMutableStateMu.Unlock()
+
+	resolvedSource := source
+	initialExists := false
+	var initial, initialProjection []byte
+	var initialFileInfo os.FileInfo
+	initialSourceMode := os.FileMode(0)
+	var absentSourceAnchor statePathAnchor
+	sourceInfo, err := os.Lstat(source)
+	switch {
+	case err == nil:
+		initialSourceMode = sourceInfo.Mode()
+		resolvedSource, err = filepath.EvalSymlinks(source)
+		if err != nil {
+			return nil, fmt.Errorf("resolve source %q: %w", source, err)
+		}
+		initial, initialFileInfo, err = readRegularStateFile(resolvedSource)
+		if err != nil {
+			return nil, fmt.Errorf("read source %q: %w", source, err)
+		}
+		initialProjection, err = policy.projectInitial(initial)
+		if err != nil {
+			return nil, fmt.Errorf("project source %q into isolated home: %w", source, err)
+		}
+		initialExists = true
+		if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+			return nil, fmt.Errorf("prepare isolated state directory: %w", err)
+		}
+		if err := os.WriteFile(dest, initialProjection, 0o600); err != nil {
+			return nil, fmt.Errorf("copy source %q into isolated home: %w", source, err)
+		}
+	case os.IsNotExist(err):
+		// Register copy-back even when no state exists yet. Provider CLIs can
+		// create their first login/session file during this execution.
+		resolvedSource, absentSourceAnchor, err = resolveAbsentStatePath(source)
+		if err != nil {
+			return nil, fmt.Errorf("pin absent source path %q: %w", source, err)
+		}
+		if policy.seedWhenMissing != nil {
+			initialProjection = bytes.Clone(policy.seedWhenMissing)
+			if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+				return nil, fmt.Errorf("prepare isolated state directory: %w", err)
+			}
+			if err := os.WriteFile(dest, initialProjection, 0o600); err != nil {
+				return nil, fmt.Errorf("seed isolated state %q: %w", dest, err)
+			}
+		}
+	case err != nil:
+		return nil, fmt.Errorf("inspect source %q: %w", source, err)
+	}
+	if policy.readOnly {
+		// Gemini settings are input-only. The auth selector is needed to start
+		// a headless OAuth session, but persisting any settings written by the
+		// subprocess would reopen a configuration channel for future runs.
+		return func() error { return nil }, nil
+	}
+
+	return func() error {
+		providerMutableStateMu.Lock()
+		defer providerMutableStateMu.Unlock()
+
+		destInfo, err := os.Lstat(dest)
+		if os.IsNotExist(err) {
+			if initialExists {
+				return fmt.Errorf("isolated state %q disappeared before synchronization", dest)
+			}
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("inspect isolated state %q: %w", dest, err)
+		}
+		if !destInfo.Mode().IsRegular() {
+			return fmt.Errorf("isolated state %q is not a regular file", dest)
+		}
+		updated, openedDestInfo, err := readRegularStateFile(dest)
+		if err != nil {
+			return fmt.Errorf("read isolated state %q: %w", dest, err)
+		}
+		if !os.SameFile(destInfo, openedDestInfo) {
+			return fmt.Errorf("isolated state %q changed during synchronization", dest)
+		}
+		// Unchanged provider-owned bytes are accepted even when an older CLI
+		// left an empty or malformed state file. This preserves the CLI's own
+		// recovery path while validating every changed value before copy-out.
+		if bytes.Equal(updated, initialProjection) {
+			return nil
+		}
+		persisted, err := policy.persistUpdated(initial, updated)
+		if err != nil {
+			return fmt.Errorf("validate changed isolated state %q: %w", dest, err)
+		}
+		if bytes.Equal(persisted, initial) {
+			return nil
+		}
+
+		currentExists := false
+		var current []byte
+		currentInfo, err := os.Lstat(source)
+		switch {
+		case err == nil:
+			currentExists = true
+			if initialExists {
+				if currentInfo.Mode().Type() != initialSourceMode.Type() {
+					return fmt.Errorf("source %q changed file type during execution", source)
+				}
+				currentResolved, resolveErr := filepath.EvalSymlinks(source)
+				if resolveErr != nil {
+					return fmt.Errorf("resolve current source %q: %w", source, resolveErr)
+				}
+				if currentResolved != resolvedSource {
+					return fmt.Errorf("source %q changed target during execution", source)
+				}
+			} else {
+				if !currentInfo.Mode().IsRegular() {
+					return fmt.Errorf("source %q was created as a non-regular file", source)
+				}
+				currentResolved, resolveErr := filepath.EvalSymlinks(source)
+				if resolveErr != nil {
+					return fmt.Errorf("resolve newly created source %q: %w", source, resolveErr)
+				}
+				if currentResolved != resolvedSource {
+					return fmt.Errorf("source %q changed target during execution", source)
+				}
+			}
+			currentPath := resolvedSource
+			var currentFileInfo os.FileInfo
+			current, currentFileInfo, err = readRegularStateFile(currentPath)
+			if err != nil {
+				return fmt.Errorf("read current source %q: %w", source, err)
+			}
+			if initialExists && !os.SameFile(initialFileInfo, currentFileInfo) {
+				return fmt.Errorf(
+					"source %q changed concurrently (file was replaced); refusing to overwrite provider state",
+					source,
+				)
+			}
+		case os.IsNotExist(err):
+		case err != nil:
+			return fmt.Errorf("inspect current source %q: %w", source, err)
+		}
+
+		if currentExists && bytes.Equal(current, persisted) {
+			return nil
+		}
+		if currentExists != initialExists || (initialExists && !bytes.Equal(current, initial)) {
+			return fmt.Errorf("source %q changed concurrently; refusing to overwrite provider state", source)
+		}
+		if !initialExists {
+			currentResolved, err := resolveAndValidateAbsentStatePath(source, absentSourceAnchor)
+			if err != nil {
+				return fmt.Errorf("validate absent source path %q before creation: %w", source, err)
+			}
+			if currentResolved != resolvedSource {
+				return fmt.Errorf("source %q changed target during execution", source)
+			}
+		}
+		if err := atomicWritePrivateState(resolvedSource, persisted); err != nil {
+			if policy.allowEphemeralOnReadOnly &&
+				(errors.Is(err, syscall.EROFS) || errors.Is(err, syscall.EACCES) ||
+					errors.Is(err, syscall.EPERM)) {
+				// Docker examples deliberately mount provider OAuth state
+				// read-only. Preserve the successful review and make the
+				// non-persistent refresh explicit instead of discarding output.
+				slog.Warn(
+					"executor: provider state source is read-only; refreshed state is ephemeral",
+					"path", source,
+					"err", err,
+				)
+				return nil
+			}
+			return err
+		}
+		return nil
+	}, nil
+}
+
+func resolveAbsentStatePath(path string) (string, statePathAnchor, error) {
+	candidate := filepath.Dir(path)
+	for {
+		_, err := os.Lstat(candidate)
+		switch {
+		case err == nil:
+			resolved, err := filepath.EvalSymlinks(candidate)
+			if err != nil {
+				return "", statePathAnchor{}, err
+			}
+			info, err := readDirectoryIdentity(resolved)
+			if err != nil {
+				return "", statePathAnchor{}, err
+			}
+			relative, err := filepath.Rel(candidate, path)
+			if err != nil {
+				return "", statePathAnchor{}, err
+			}
+			return filepath.Join(resolved, relative), statePathAnchor{
+				lexicalPath:  candidate,
+				resolvedPath: resolved,
+				info:         info,
+			}, nil
+		case os.IsNotExist(err):
+			parent := filepath.Dir(candidate)
+			if parent == candidate {
+				return "", statePathAnchor{}, fmt.Errorf("no existing parent directory")
+			}
+			candidate = parent
+		default:
+			return "", statePathAnchor{}, err
+		}
+	}
+}
+
+func resolveAndValidateAbsentStatePath(path string, anchor statePathAnchor) (string, error) {
+	resolvedAnchor, err := filepath.EvalSymlinks(anchor.lexicalPath)
+	if err != nil {
+		return "", err
+	}
+	if resolvedAnchor != anchor.resolvedPath {
+		return "", fmt.Errorf("existing parent changed target")
+	}
+	currentAnchorInfo, err := readDirectoryIdentity(resolvedAnchor)
+	if err != nil {
+		return "", err
+	}
+	if !os.SameFile(anchor.info, currentAnchorInfo) {
+		return "", fmt.Errorf("existing parent was replaced")
+	}
+	currentResolved, _, err := resolveAbsentStatePath(path)
+	return currentResolved, err
+}
+
+func readDirectoryIdentity(path string) (_ os.FileInfo, returnErr error) {
+	directory, err := os.OpenFile(
+		path,
+		os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, directory.Close())
+	}()
+	info, err := directory.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%q is not a directory", path)
+	}
+	return info, nil
+}
+
+func readRegularStateFile(path string) (_ []byte, _ os.FileInfo, returnErr error) {
+	file, err := os.OpenFile(
+		path,
+		os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, file.Close())
+	}()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("%q is not a regular file", path)
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, info, nil
+}
+
+func projectMutableJSONState(initial []byte) ([]byte, error) {
+	if len(bytes.TrimSpace(initial)) == 0 {
+		return []byte("{}\n"), nil
+	}
+	// Do not reject a pre-existing malformed file before the provider gets a
+	// chance to repair it. Any changed copy is validated before persistence.
+	return bytes.Clone(initial), nil
+}
+
+func persistMutableJSONState(_ []byte, updated []byte) ([]byte, error) {
+	if !json.Valid(updated) {
+		return nil, fmt.Errorf("provider state is not valid JSON")
+	}
+	return bytes.Clone(updated), nil
+}
+
+func projectGeminiAuthSettings(initial []byte) ([]byte, error) {
+	settings, err := decodeJSONObject(initial)
+	if err != nil {
+		// A malformed user settings file must not block isolated authentication
+		// or be copied into the execution environment. Settings are input-only,
+		// so changes made in the isolated home are always discarded.
+		slog.Debug("executor: ignoring malformed Gemini settings during auth projection", "err", err)
+		settings = make(map[string]any)
+	}
+	return marshalJSONObject(geminiAuthProjection(settings))
+}
+
+func decodeJSONObject(data []byte) (map[string]any, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return make(map[string]any), nil
+	}
+	var object map[string]any
+	if err := json.Unmarshal(data, &object); err != nil {
+		return nil, err
+	}
+	if object == nil {
+		return nil, fmt.Errorf("expected JSON object")
+	}
+	return object, nil
+}
+
+func marshalJSONObject(object map[string]any) ([]byte, error) {
+	encoded, err := json.MarshalIndent(object, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode JSON object: %w", err)
+	}
+	return append(encoded, '\n'), nil
+}
+
+func geminiAuthProjection(settings map[string]any) map[string]any {
+	projected := make(map[string]any)
+	if selected, ok := settings["selectedAuthType"].(string); ok {
+		projected["selectedAuthType"] = selected
+	}
+	security, ok := settings["security"].(map[string]any)
+	if !ok {
+		return projected
+	}
+	auth, ok := security["auth"].(map[string]any)
+	if !ok {
+		return projected
+	}
+	projectedAuth := make(map[string]any)
+	if selected, ok := auth["selectedType"].(string); ok {
+		projectedAuth["selectedType"] = selected
+	}
+	if len(projectedAuth) != 0 {
+		projected["security"] = map[string]any{"auth": projectedAuth}
+	}
+	return projected
+}
+
+func atomicWritePrivateState(path string, data []byte) error {
+	return atomicWritePrivateStateWithRename(path, data, os.Rename)
+}
+
+func atomicWritePrivateStateWithRename(
+	path string,
+	data []byte,
+	rename func(string, string) error,
+) (returnErr error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("prepare state directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".heimdallm-*")
+	if err != nil {
+		return fmt.Errorf("create temporary state file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("secure temporary state file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temporary state file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temporary state file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary state file: %w", err)
+	}
+	if err := rename(tmpPath, path); err != nil {
+		if errors.Is(err, syscall.EBUSY) {
+			// Linux rejects rename over an individually bind-mounted file.
+			// Fall back only for EBUSY, and write through an already verified
+			// descriptor so the host mount keeps its identity.
+			if fallbackErr := overwriteBusyMountedState(path, data); fallbackErr != nil {
+				return fmt.Errorf("replace busy mounted provider state: %w", fallbackErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("replace provider state atomically: %w", err)
 	}
 	return nil
 }
 
-// bridgeGeminiState projects Gemini's top-level state entries individually so
-// its special ~/.gemini/.env file is absent. Gemini intentionally loads that
-// file even when --ignore-env or advanced.ignoreLocalEnv is set. Other state,
-// including browser OAuth credentials, remains available through symlinks.
-func bridgeGeminiState(source, dest string) error {
-	entries, err := os.ReadDir(source)
+func overwriteBusyMountedState(path string, data []byte) (returnErr error) {
+	before, err := os.Lstat(path)
 	if err != nil {
-		return fmt.Errorf("executor: read Gemini credential state: %w", err)
+		return fmt.Errorf("inspect busy mounted state: %w", err)
 	}
-	if err := os.MkdirAll(dest, 0o700); err != nil {
-		return fmt.Errorf("executor: prepare Gemini credential state bridge: %w", err)
+	if !before.Mode().IsRegular() {
+		return fmt.Errorf("busy mounted state is not a regular file")
 	}
-	if err := os.Chmod(dest, 0o700); err != nil {
-		return fmt.Errorf("executor: secure Gemini credential state bridge: %w", err)
+	file, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open busy mounted state: %w", err)
 	}
-	for _, entry := range entries {
-		if strings.EqualFold(entry.Name(), ".env") {
-			continue
-		}
-		if err := os.Symlink(
-			filepath.Join(source, entry.Name()),
-			filepath.Join(dest, entry.Name()),
-		); err != nil {
-			return fmt.Errorf("executor: bridge Gemini credential state entry %q: %w", entry.Name(), err)
-		}
+	defer func() {
+		returnErr = errors.Join(returnErr, file.Close())
+	}()
+	after, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("inspect opened busy mounted state: %w", err)
+	}
+	if !after.Mode().IsRegular() || !os.SameFile(before, after) {
+		return fmt.Errorf("busy mounted state changed before overwrite")
+	}
+	if err := file.Chmod(0o600); err != nil {
+		return fmt.Errorf("secure busy mounted state: %w", err)
+	}
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("truncate busy mounted state: %w", err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		return fmt.Errorf("seek busy mounted state: %w", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("write busy mounted state: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync busy mounted state: %w", err)
 	}
 	return nil
+}
+
+// bridgeGeminiState projects only Gemini's mutable authentication identifiers
+// and a sanitized authentication selection. User settings, .env files, MCP
+// tokens, extensions, commands, skills and policies never enter the isolated
+// home. Mutable tokens and identifiers are copied back safely so atomic
+// rotations and first-run creation survive removal of the temporary home;
+// settings are an input-only projection and are never persisted.
+func bridgeGeminiState(source, dest string) (func() error, error) {
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		return nil, fmt.Errorf("executor: prepare Gemini credential state bridge: %w", err)
+	}
+	if err := os.Chmod(dest, 0o700); err != nil {
+		return nil, fmt.Errorf("executor: secure Gemini credential state bridge: %w", err)
+	}
+
+	var syncs []func() error
+	for _, state := range []struct {
+		name   string
+		bridge func(string, string) (func() error, error)
+	}{
+		{name: "oauth_creds.json", bridge: bridgeGeminiMutableJSONState},
+		{name: "google_accounts.json", bridge: bridgeGeminiMutableJSONState},
+		{name: "installation_id", bridge: bridgeGeminiMutableOpaqueState},
+		{name: "user_id", bridge: bridgeGeminiMutableOpaqueState},
+		{name: "settings.json", bridge: bridgeGeminiSettingsState},
+	} {
+		sourcePath := filepath.Join(source, state.name)
+		destPath := filepath.Join(dest, state.name)
+		if _, err := os.Lstat(sourcePath); os.IsNotExist(err) {
+			logProviderStateAbsent("gemini", sourcePath)
+		}
+		syncState, err := state.bridge(sourcePath, destPath)
+		if err != nil {
+			return nil, fmt.Errorf("executor: bridge Gemini state %q: %w", state.name, err)
+		}
+		syncs = append(syncs, syncState)
+	}
+	return func() error {
+		var syncErr error
+		for _, syncState := range syncs {
+			syncErr = errors.Join(syncErr, syncState())
+		}
+		return syncErr
+	}, nil
 }
 
 func (c capturedEnvironment) providerStateMounts(cli, root string) []providerStateMount {
@@ -479,9 +1093,21 @@ func (c capturedEnvironment) providerStateMounts(cli, root string) []providerSta
 		if claudeDir == "" {
 			claudeDir = homePath(".claude")
 		}
+		credentialsPath := ""
+		if claudeDir != "" {
+			credentialsPath = filepath.Join(claudeDir, ".credentials.json")
+		}
 		return []providerStateMount{
-			{source: claudeDir, dest: filepath.Join(root, ".claude")},
-			{source: homePath(".claude.json"), dest: filepath.Join(root, ".claude.json")},
+			{
+				source:   credentialsPath,
+				dest:     filepath.Join(root, ".claude", ".credentials.json"),
+				copyBack: true,
+			},
+			{
+				source:   homePath(".claude.json"),
+				dest:     filepath.Join(root, ".claude.json"),
+				copyBack: true,
+			},
 		}
 	case "codex":
 		codexHome := c.values["CODEX_HOME"]
@@ -531,7 +1157,7 @@ func codexNestedEnvironment(source map[string]string) map[string]string {
 	env := make(map[string]string, len(source))
 	for name, value := range source {
 		switch strings.ToUpper(name) {
-		case "ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY":
+		case "ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY":
 			// Proxy URLs often embed credentials. Codex itself receives the
 			// proxy through its allowlisted parent environment, but values
 			// must never be serialized into command-line config overrides.
@@ -645,6 +1271,64 @@ func proxyRedactionValues(value string) []string {
 	return values
 }
 
+func secretEnvironmentName(name string) bool {
+	upper := strings.ToUpper(name)
+	for _, providerNames := range providerEnvironmentNames {
+		for _, providerName := range providerNames {
+			if upper == providerName {
+				_, secret := providerSecretNames[upper]
+				return secret
+			}
+		}
+	}
+	switch upper {
+	case "AUTH", "CONNECTION_STRING", "COOKIE", "CREDENTIAL", "DATABASE_URL",
+		"DB_URI", "DSN", "PASSWORD", "PASSWD", "PRIVATE_KEY", "SECRET", "TOKEN":
+		return true
+	}
+	for _, suffix := range []string{
+		"_API_KEY",
+		"_AUTH",
+		"_AUTH_SECRET",
+		"_AUTH_TOKEN",
+		"_CONNECTION_STRING",
+		"_COOKIE",
+		"_CREDENTIAL",
+		"_CREDENTIALS",
+		"_DATABASE_URL",
+		"_DB_URI",
+		"_DSN",
+		"_PASSWORD",
+		"_PASSWD",
+		"_PRIVATE_KEY",
+		"_SECRET",
+		"_TOKEN",
+	} {
+		if strings.HasSuffix(upper, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func additionalEnvironmentRedactionValues(name, value string) []string {
+	var values []string
+	if secretEnvironmentName(name) {
+		values = append(values, value)
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.User == nil {
+		return values
+	}
+	if len(values) == 0 {
+		values = append(values, value)
+	}
+	if password, ok := parsed.User.Password(); ok && password != "" {
+		values = append(values, password)
+	}
+	return values
+}
+
 func environmentRedactor(values []string) func(string) string {
 	unique := make(map[string]struct{}, len(values)*2)
 	for _, value := range values {
@@ -670,7 +1354,7 @@ func environmentRedactor(values []string) func(string) string {
 	}
 }
 
-func codexShellEnvironmentPolicy(values map[string]string) string {
+func codexShellEnvironmentPolicy(values map[string]string) (string, error) {
 	names := make([]string, 0, len(values))
 	for name := range values {
 		names = append(names, name)
@@ -680,9 +1364,53 @@ func codexShellEnvironmentPolicy(values map[string]string) string {
 	includes := make([]string, 0, len(names))
 	settings := make([]string, 0, len(names))
 	for _, name := range names {
-		includes = append(includes, strconv.Quote(name))
-		settings = append(settings, strconv.Quote(name)+"="+strconv.Quote(values[name]))
+		quotedName, err := tomlBasicString(name)
+		if err != nil {
+			return "", fmt.Errorf("environment name cannot be represented in TOML: %w", err)
+		}
+		quotedValue, err := tomlBasicString(values[name])
+		if err != nil {
+			return "", fmt.Errorf("environment value for %s cannot be represented in TOML: %w", name, err)
+		}
+		includes = append(includes, quotedName)
+		settings = append(settings, quotedName+"="+quotedValue)
 	}
 	return "{inherit=\"none\",experimental_use_profile=false,ignore_default_excludes=false,include_only=[" +
-		strings.Join(includes, ",") + "],set={" + strings.Join(settings, ",") + "}}"
+		strings.Join(includes, ",") + "],set={" + strings.Join(settings, ",") + "}}", nil
+}
+
+func tomlBasicString(value string) (string, error) {
+	if !utf8.ValidString(value) {
+		return "", fmt.Errorf("invalid UTF-8")
+	}
+
+	var quoted strings.Builder
+	quoted.Grow(len(value) + 2)
+	quoted.WriteByte('"')
+	for _, r := range value {
+		switch r {
+		case '\b':
+			quoted.WriteString(`\b`)
+		case '\t':
+			quoted.WriteString(`\t`)
+		case '\n':
+			quoted.WriteString(`\n`)
+		case '\f':
+			quoted.WriteString(`\f`)
+		case '\r':
+			quoted.WriteString(`\r`)
+		case '"':
+			quoted.WriteString(`\"`)
+		case '\\':
+			quoted.WriteString(`\\`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				_, _ = fmt.Fprintf(&quoted, `\u%04X`, r)
+				continue
+			}
+			quoted.WriteRune(r)
+		}
+	}
+	quoted.WriteByte('"')
+	return quoted.String(), nil
 }

--- a/daemon/internal/executor/environment.go
+++ b/daemon/internal/executor/environment.go
@@ -22,7 +22,26 @@ const environmentAllowlistPrefix = "HEIMDALLM_AI_"
 var providerEnvironmentNames = map[string][]string{
 	"claude": {
 		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_AUTH_TOKEN",
+		"ANTHROPIC_BASE_URL",
+		"ANTHROPIC_BEDROCK_BASE_URL",
+		"ANTHROPIC_VERTEX_BASE_URL",
+		"ANTHROPIC_VERTEX_PROJECT_ID",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_BEARER_TOKEN_BEDROCK",
+		"AWS_DEFAULT_REGION",
+		"AWS_REGION",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
 		"CLAUDE_CODE_OAUTH_TOKEN",
+		"CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+		"CLAUDE_CODE_SKIP_VERTEX_AUTH",
+		"CLAUDE_CODE_USE_BEDROCK",
+		"CLAUDE_CODE_USE_VERTEX",
+		"CLOUD_ML_REGION",
+		"GCLOUD_PROJECT",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"GOOGLE_CLOUD_PROJECT",
 	},
 	"codex": {
 		"OPENAI_API_KEY",
@@ -48,13 +67,50 @@ var providerRuntimeNames = map[string][]string{
 }
 
 var providerSecretNames = map[string]struct{}{
-	"ANTHROPIC_API_KEY":       {},
-	"CLAUDE_CODE_OAUTH_TOKEN": {},
-	"CODEX_API_KEY":           {},
-	"GEMINI_API_KEY":          {},
-	"GOOGLE_API_KEY":          {},
-	"OPENAI_API_KEY":          {},
-	"OPENROUTER_API_KEY":      {},
+	"ANTHROPIC_API_KEY":        {},
+	"ANTHROPIC_AUTH_TOKEN":     {},
+	"AWS_ACCESS_KEY_ID":        {},
+	"AWS_BEARER_TOKEN_BEDROCK": {},
+	"AWS_SECRET_ACCESS_KEY":    {},
+	"AWS_SESSION_TOKEN":        {},
+	"CLAUDE_CODE_OAUTH_TOKEN":  {},
+	"CODEX_API_KEY":            {},
+	"GEMINI_API_KEY":           {},
+	"GOOGLE_API_KEY":           {},
+	"OPENAI_API_KEY":           {},
+	"OPENROUTER_API_KEY":       {},
+}
+
+var claudeBedrockEnvironmentNames = map[string]struct{}{
+	"ANTHROPIC_BEDROCK_BASE_URL":    {},
+	"AWS_ACCESS_KEY_ID":             {},
+	"AWS_BEARER_TOKEN_BEDROCK":      {},
+	"AWS_DEFAULT_REGION":            {},
+	"AWS_REGION":                    {},
+	"AWS_SECRET_ACCESS_KEY":         {},
+	"AWS_SESSION_TOKEN":             {},
+	"CLAUDE_CODE_SKIP_BEDROCK_AUTH": {},
+}
+
+var claudeBedrockCredentialNames = map[string]struct{}{
+	"AWS_ACCESS_KEY_ID":        {},
+	"AWS_BEARER_TOKEN_BEDROCK": {},
+	"AWS_SECRET_ACCESS_KEY":    {},
+	"AWS_SESSION_TOKEN":        {},
+}
+
+var claudeVertexEnvironmentNames = map[string]struct{}{
+	"ANTHROPIC_VERTEX_BASE_URL":      {},
+	"ANTHROPIC_VERTEX_PROJECT_ID":    {},
+	"CLAUDE_CODE_SKIP_VERTEX_AUTH":   {},
+	"CLOUD_ML_REGION":                {},
+	"GCLOUD_PROJECT":                 {},
+	"GOOGLE_APPLICATION_CREDENTIALS": {},
+	"GOOGLE_CLOUD_PROJECT":           {},
+}
+
+var claudeVertexCredentialNames = map[string]struct{}{
+	"GOOGLE_APPLICATION_CREDENTIALS": {},
 }
 
 var commonEnvironmentNames = map[string]struct{}{
@@ -110,26 +166,17 @@ var managedEnvironmentNames = map[string]struct{}{
 }
 
 var dangerousEnvironmentNames = map[string]struct{}{
-	"_JAVA_OPTIONS":                       {},
 	"BASH_ENV":                            {},
+	"CDPATH":                              {},
 	"CLAUDE_CODE_SAFE_MODE":               {},
 	"CLAUDE_CODE_SUBPROCESS_ENV_SCRUB":    {},
-	"CDPATH":                              {},
 	"CLAUDE_CONFIG_DIR":                   {},
 	"CODEX_HOME":                          {},
 	"DOTNET_STARTUP_HOOKS":                {},
 	"ENV":                                 {},
-	"GIO_EXTRA_MODULES":                   {},
-	"GIO_MODULE_DIR":                      {},
 	"GEMINI_CLI_HOME":                     {},
 	"GEMINI_CLI_IDE_SERVER_STDIO_COMMAND": {},
 	"GEMINI_CLI_SYSTEM_DEFAULTS_PATH":     {},
-	"GH_TOKEN":                            {},
-	"GITHUB_TOKEN":                        {},
-	"GIT_ASKPASS":                         {},
-	"GTK3_MODULES":                        {},
-	"GTK_MODULES":                         {},
-	"GTK_PATH":                            {},
 	"GEMINI_CLI_SYSTEM_SETTINGS_PATH":     {},
 	"GEMINI_CLI_TRUSTED_FOLDERS_PATH":     {},
 	"GEMINI_CLI_TRUST_WORKSPACE":          {},
@@ -137,6 +184,14 @@ var dangerousEnvironmentNames = map[string]struct{}{
 	"GEMINI_SANDBOX_PROXY_COMMAND":        {},
 	"GEMINI_SYSTEM_MD":                    {},
 	"GEMINI_WRITE_SYSTEM_MD":              {},
+	"GH_TOKEN":                            {},
+	"GIO_EXTRA_MODULES":                   {},
+	"GIO_MODULE_DIR":                      {},
+	"GITHUB_TOKEN":                        {},
+	"GIT_ASKPASS":                         {},
+	"GTK3_MODULES":                        {},
+	"GTK_MODULES":                         {},
+	"GTK_PATH":                            {},
 	"IFS":                                 {},
 	"JAVA_TOOL_OPTIONS":                   {},
 	"JDK_JAVA_OPTIONS":                    {},
@@ -158,6 +213,7 @@ var dangerousEnvironmentNames = map[string]struct{}{
 	"RUBYOPT":                             {},
 	"SSH_ASKPASS":                         {},
 	"ZDOTDIR":                             {},
+	"_JAVA_OPTIONS":                       {},
 }
 
 type capturedEnvironment struct {
@@ -207,6 +263,9 @@ func (c capturedEnvironment) loginProbeEnvironment() []string {
 }
 
 func (c capturedEnvironment) prepare(cli string) (*preparedEnvironment, error) {
+	if err := validateProviderEnvironmentSelection(cli, c.values); err != nil {
+		return nil, err
+	}
 	extraNames, err := c.additionalNames(cli)
 	if err != nil {
 		return nil, err
@@ -240,25 +299,30 @@ func (c capturedEnvironment) prepare(cli string) (*preparedEnvironment, error) {
 	env := cloneEnvironment(base)
 	redactions := make([]string, 0, len(providerEnvironmentNames[cli])+len(extraNames))
 	for _, name := range providerEnvironmentNames[cli] {
+		if !providerEnvironmentEnabled(cli, name, c.values) {
+			continue
+		}
 		if value := c.values[name]; value != "" {
 			env[name] = value
-			if _, secret := providerSecretNames[name]; secret {
-				redactions = append(redactions, value)
-			}
+			redactions = append(redactions, environmentRedactionValues(name, value)...)
 		}
 	}
 	for _, name := range providerRuntimeNames[cli] {
-		if value, ok := c.values[name]; ok {
+		if value, ok := c.additionalEnvironmentValue(name); ok {
 			env[name] = value
 		}
 	}
 	for _, name := range extraNames {
-		if value, ok := c.values[name]; ok {
+		if providerHasEnvironmentName(cli, name) &&
+			!providerEnvironmentEnabled(cli, name, c.values) {
+			continue
+		}
+		if value, ok := c.additionalEnvironmentValue(name); ok {
 			env[name] = value
 			if value != "" {
 				redactions = append(
 					redactions,
-					additionalEnvironmentRedactionValues(name, value)...,
+					environmentRedactionValues(name, value)...,
 				)
 			}
 		} else {
@@ -403,6 +467,13 @@ func (c capturedEnvironment) additionalNames(cli string) ([]string, error) {
 		if err := validateAdditionalEnvironmentName(cli, name); err != nil {
 			return nil, fmt.Errorf("executor: %s: %w", controlName, err)
 		}
+		// Environment names remain case-sensitive on Unix, except for this
+		// explicit cross-platform capability. Canonicalizing only the SSH
+		// socket keeps the allowlist and Codex's nested-tool forwarding aligned
+		// without changing the spelling of operator-defined variables.
+		if strings.EqualFold(name, "SSH_AUTH_SOCK") {
+			name = "SSH_AUTH_SOCK"
+		}
 		if _, ok := seen[name]; ok {
 			continue
 		}
@@ -411,6 +482,28 @@ func (c capturedEnvironment) additionalNames(cli string) ([]string, error) {
 	}
 	sort.Strings(names)
 	return names, nil
+}
+
+func (c capturedEnvironment) additionalEnvironmentValue(name string) (string, bool) {
+	if value, ok := c.values[name]; ok {
+		return value, true
+	}
+	if name != "SSH_AUTH_SOCK" {
+		return "", false
+	}
+	// The opt-in capability is canonicalized even if a Unix parent process
+	// used non-standard casing. Exact uppercase wins when both spellings exist.
+	var candidates []string
+	for capturedName := range c.values {
+		if strings.EqualFold(capturedName, name) {
+			candidates = append(candidates, capturedName)
+		}
+	}
+	sort.Strings(candidates)
+	if len(candidates) == 0 {
+		return "", false
+	}
+	return c.values[candidates[0]], true
 }
 
 func validateAdditionalEnvironmentName(cli, name string) error {
@@ -429,12 +522,22 @@ func validateAdditionalEnvironmentName(cli, name string) error {
 			return fmt.Errorf("%s is permanently blocked", name)
 		}
 	}
+	if providerHasEnvironmentName(cli, upper) {
+		return nil
+	}
 	for provider, providerNames := range providerEnvironmentNames {
 		if provider == cli {
 			continue
 		}
 		for _, providerName := range providerNames {
 			if upper == providerName {
+				if !providerCredentialBoundaryName(upper) {
+					// Non-secret routing selectors such as AWS_REGION may be
+					// useful to another CLI when the operator explicitly
+					// allowlists them. Only credential-bearing names form the
+					// permanent cross-provider boundary.
+					continue
+				}
 				if cli == "opencode" {
 					// OpenCode is a multi-provider client. Naming a backend
 					// credential in its exact allowlist is the operator's
@@ -446,6 +549,79 @@ func validateAdditionalEnvironmentName(cli, name string) error {
 		}
 	}
 	return nil
+}
+
+func providerCredentialBoundaryName(name string) bool {
+	if _, secret := providerSecretNames[name]; secret {
+		return true
+	}
+	// This is a path rather than secret bytes, so it must remain visible in
+	// diagnostics. It still grants access to another provider's credential
+	// file and therefore remains a cross-provider boundary.
+	return name == "GOOGLE_APPLICATION_CREDENTIALS"
+}
+
+func providerHasEnvironmentName(cli, name string) bool {
+	name = strings.ToUpper(name)
+	for _, providerName := range providerEnvironmentNames[cli] {
+		if name == providerName {
+			return true
+		}
+	}
+	return false
+}
+
+func validateProviderEnvironmentSelection(cli string, values map[string]string) error {
+	if cli == "claude" &&
+		environmentFlagEnabled(values["CLAUDE_CODE_USE_BEDROCK"]) &&
+		environmentFlagEnabled(values["CLAUDE_CODE_USE_VERTEX"]) {
+		return fmt.Errorf(
+			"executor: CLAUDE_CODE_USE_BEDROCK and CLAUDE_CODE_USE_VERTEX cannot both be enabled",
+		)
+	}
+	return nil
+}
+
+func providerEnvironmentEnabled(cli, name string, values map[string]string) bool {
+	if cli != "claude" {
+		return true
+	}
+	name = strings.ToUpper(name)
+	switch name {
+	case "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX":
+		// Preserve explicit false values as well as enabled selectors. Claude
+		// Code treats an empty value as unset.
+		return true
+	}
+	if _, bedrock := claudeBedrockEnvironmentNames[name]; bedrock {
+		if !environmentFlagEnabled(values["CLAUDE_CODE_USE_BEDROCK"]) {
+			return false
+		}
+		if _, credential := claudeBedrockCredentialNames[name]; credential &&
+			environmentFlagEnabled(values["CLAUDE_CODE_SKIP_BEDROCK_AUTH"]) {
+			return false
+		}
+	}
+	if _, vertex := claudeVertexEnvironmentNames[name]; vertex {
+		if !environmentFlagEnabled(values["CLAUDE_CODE_USE_VERTEX"]) {
+			return false
+		}
+		if _, credential := claudeVertexCredentialNames[name]; credential &&
+			environmentFlagEnabled(values["CLAUDE_CODE_SKIP_VERTEX_AUTH"]) {
+			return false
+		}
+	}
+	return true
+}
+
+func environmentFlagEnabled(value string) bool {
+	value = strings.TrimSpace(value)
+	switch strings.ToLower(value) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func validEnvironmentName(name string) bool {
@@ -482,7 +658,7 @@ func (c capturedEnvironment) bridgeProviderState(cli, root string) (func() error
 			if _, err := os.Lstat(mount.source); os.IsNotExist(err) {
 				logProviderStateAbsent(cli, mount.source)
 			}
-			syncState, err := bridgeMutableJSONState(mount.source, mount.dest)
+			syncState, err := bridgeClaudeMutableJSONState(mount.source, mount.dest)
 			if err != nil {
 				return nil, fmt.Errorf("executor: bridge %s mutable credential state: %w", cli, err)
 			}
@@ -525,11 +701,17 @@ func logProviderStateAbsent(cli, path string) {
 }
 
 type mutableStatePolicy struct {
-	seedWhenMissing          []byte
-	projectInitial           func([]byte) ([]byte, error)
-	persistUpdated           func(initial, updated []byte) ([]byte, error)
-	readOnly                 bool
-	allowEphemeralOnReadOnly bool
+	provider        string
+	seedWhenMissing []byte
+	projectInitial  func([]byte) ([]byte, error)
+	persistUpdated  func(initial, updated []byte) ([]byte, error)
+
+	// inputOnly projects state into the isolated home but never copies
+	// subprocess changes back. tolerateUnwritableSource still attempts
+	// copy-back, but treats EROFS/EACCES/EPERM as an explicit ephemeral
+	// refresh. The flags are orthogonal.
+	inputOnly                bool
+	tolerateUnwritableSource bool
 }
 
 type statePathAnchor struct {
@@ -551,16 +733,27 @@ func bridgeMutableJSONState(source, dest string) (func() error, error) {
 	})
 }
 
-func bridgeGeminiMutableJSONState(source, dest string) (func() error, error) {
+func bridgeClaudeMutableJSONState(source, dest string) (func() error, error) {
 	return bridgeMutableState(source, dest, mutableStatePolicy{
+		provider:                 "claude",
 		projectInitial:           projectMutableJSONState,
 		persistUpdated:           persistMutableJSONState,
-		allowEphemeralOnReadOnly: true,
+		tolerateUnwritableSource: true,
+	})
+}
+
+func bridgeGeminiMutableJSONState(source, dest string) (func() error, error) {
+	return bridgeMutableState(source, dest, mutableStatePolicy{
+		provider:                 "gemini",
+		projectInitial:           projectMutableJSONState,
+		persistUpdated:           persistMutableJSONState,
+		tolerateUnwritableSource: true,
 	})
 }
 
 func bridgeGeminiMutableOpaqueState(source, dest string) (func() error, error) {
 	return bridgeMutableState(source, dest, mutableStatePolicy{
+		provider: "gemini",
 		projectInitial: func(initial []byte) ([]byte, error) {
 			return bytes.Clone(initial), nil
 		},
@@ -573,15 +766,16 @@ func bridgeGeminiMutableOpaqueState(source, dest string) (func() error, error) {
 			}
 			return bytes.Clone(updated), nil
 		},
-		allowEphemeralOnReadOnly: true,
+		tolerateUnwritableSource: true,
 	})
 }
 
 func bridgeGeminiSettingsState(source, dest string) (func() error, error) {
 	return bridgeMutableState(source, dest, mutableStatePolicy{
+		provider:        "gemini",
 		seedWhenMissing: []byte("{}\n"),
 		projectInitial:  projectGeminiAuthSettings,
-		readOnly:        true,
+		inputOnly:       true,
 	})
 }
 
@@ -637,7 +831,7 @@ func bridgeMutableState(source, dest string, policy mutableStatePolicy) (func() 
 	case err != nil:
 		return nil, fmt.Errorf("inspect source %q: %w", source, err)
 	}
-	if policy.readOnly {
+	if policy.inputOnly {
 		// Gemini settings are input-only. The auth selector is needed to start
 		// a headless OAuth session, but persisting any settings written by the
 		// subprocess would reopen a configuration channel for future runs.
@@ -744,14 +938,13 @@ func bridgeMutableState(source, dest string, policy mutableStatePolicy) (func() 
 			}
 		}
 		if err := atomicWritePrivateState(resolvedSource, persisted); err != nil {
-			if policy.allowEphemeralOnReadOnly &&
-				(errors.Is(err, syscall.EROFS) || errors.Is(err, syscall.EACCES) ||
-					errors.Is(err, syscall.EPERM)) {
+			if policy.tolerateUnwritableSource && unwritableStateSourceError(err) {
 				// Docker examples deliberately mount provider OAuth state
 				// read-only. Preserve the successful review and make the
 				// non-persistent refresh explicit instead of discarding output.
 				slog.Warn(
 					"executor: provider state source is read-only; refreshed state is ephemeral",
+					"cli", policy.provider,
 					"path", source,
 					"err", err,
 				)
@@ -761,6 +954,12 @@ func bridgeMutableState(source, dest string, policy mutableStatePolicy) (func() 
 		}
 		return nil
 	}, nil
+}
+
+func unwritableStateSourceError(err error) bool {
+	return errors.Is(err, syscall.EROFS) ||
+		errors.Is(err, syscall.EACCES) ||
+		errors.Is(err, syscall.EPERM)
 }
 
 func resolveAbsentStatePath(path string) (string, statePathAnchor, error) {
@@ -1282,7 +1481,7 @@ func secretEnvironmentName(name string) bool {
 		}
 	}
 	switch upper {
-	case "AUTH", "CONNECTION_STRING", "COOKIE", "CREDENTIAL", "DATABASE_URL",
+	case "ANTHROPIC_CUSTOM_HEADERS", "AUTH", "CONNECTION_STRING", "COOKIE", "CREDENTIAL", "DATABASE_URL",
 		"DB_URI", "DSN", "PASSWORD", "PASSWD", "PRIVATE_KEY", "SECRET", "TOKEN":
 		return true
 	}
@@ -1311,7 +1510,7 @@ func secretEnvironmentName(name string) bool {
 	return false
 }
 
-func additionalEnvironmentRedactionValues(name, value string) []string {
+func environmentRedactionValues(name, value string) []string {
 	var values []string
 	if secretEnvironmentName(name) {
 		values = append(values, value)

--- a/daemon/internal/executor/environment.go
+++ b/daemon/internal/executor/environment.go
@@ -1,0 +1,688 @@
+package executor
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const environmentAllowlistPrefix = "HEIMDALLM_AI_"
+
+var providerCredentialNames = map[string][]string{
+	"claude": {
+		"ANTHROPIC_API_KEY",
+		"CLAUDE_CODE_OAUTH_TOKEN",
+	},
+	"codex": {
+		"OPENAI_API_KEY",
+		"CODEX_API_KEY",
+	},
+	"gemini": {
+		"GEMINI_API_KEY",
+		"GOOGLE_API_KEY",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"GOOGLE_CLOUD_PROJECT",
+		"GOOGLE_CLOUD_LOCATION",
+		"GOOGLE_GENAI_USE_VERTEXAI",
+	},
+	"opencode": {
+		"OPENROUTER_API_KEY",
+	},
+}
+
+var providerRuntimeNames = map[string][]string{
+	"opencode": {
+		"OPENCODE_DISABLE_AUTOUPDATE",
+	},
+}
+
+var commonEnvironmentNames = map[string]struct{}{
+	"ALL_PROXY":           {},
+	"CI":                  {},
+	"COLORTERM":           {},
+	"COMSPEC":             {},
+	"CURL_CA_BUNDLE":      {},
+	"HTTPS_PROXY":         {},
+	"HTTP_PROXY":          {},
+	"LANG":                {},
+	"LANGUAGE":            {},
+	"LC_ADDRESS":          {},
+	"LC_ALL":              {},
+	"LC_COLLATE":          {},
+	"LC_CTYPE":            {},
+	"LC_IDENTIFICATION":   {},
+	"LC_MEASUREMENT":      {},
+	"LC_MESSAGES":         {},
+	"LC_MONETARY":         {},
+	"LC_NAME":             {},
+	"LC_NUMERIC":          {},
+	"LC_PAPER":            {},
+	"LC_TELEPHONE":        {},
+	"LC_TIME":             {},
+	"LOGNAME":             {},
+	"NODE_EXTRA_CA_CERTS": {},
+	"NO_COLOR":            {},
+	"NO_PROXY":            {},
+	"PATHEXT":             {},
+	"REQUESTS_CA_BUNDLE":  {},
+	"SHELL":               {},
+	"SSL_CERT_DIR":        {},
+	"SSL_CERT_FILE":       {},
+	"SYSTEMROOT":          {},
+	"TERM":                {},
+	"TZ":                  {},
+	"USER":                {},
+	"WINDIR":              {},
+	"all_proxy":           {},
+	"http_proxy":          {},
+	"https_proxy":         {},
+	"no_proxy":            {},
+}
+
+var managedEnvironmentNames = map[string]struct{}{
+	"HOME":            {},
+	"PATH":            {},
+	"PWD":             {},
+	"TEMP":            {},
+	"TMP":             {},
+	"TMPDIR":          {},
+	"XDG_CACHE_HOME":  {},
+	"XDG_CONFIG_HOME": {},
+	"XDG_DATA_HOME":   {},
+	"XDG_STATE_HOME":  {},
+}
+
+var dangerousEnvironmentNames = map[string]struct{}{
+	"BASH_ENV":                         {},
+	"CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": {},
+	"CDPATH":                           {},
+	"CLAUDE_CONFIG_DIR":                {},
+	"CODEX_HOME":                       {},
+	"ENV":                              {},
+	"GH_TOKEN":                         {},
+	"GITHUB_TOKEN":                     {},
+	"GIT_ASKPASS":                      {},
+	"GEMINI_CLI_SYSTEM_SETTINGS_PATH":  {},
+	"IFS":                              {},
+	"NODE_OPTIONS":                     {},
+	"NODE_PATH":                        {},
+	"NPM_CONFIG_USERCONFIG":            {},
+	"OPENCODE_DISABLE_PROJECT_CONFIG":  {},
+	"OPENCODE_PURE":                    {},
+	"PERL5LIB":                         {},
+	"PERL5OPT":                         {},
+	"PROMPT_COMMAND":                   {},
+	"PYTHONHOME":                       {},
+	"PYTHONPATH":                       {},
+	"PYTHONSTARTUP":                    {},
+	"RUBYOPT":                          {},
+	"SSH_ASKPASS":                      {},
+	"ZDOTDIR":                          {},
+}
+
+type capturedEnvironment struct {
+	values map[string]string
+}
+
+type preparedEnvironment struct {
+	env          []string
+	codexToolEnv map[string]string
+	runDir       string
+	redact       func(string) string
+	cleanup      func()
+}
+
+type providerStateMount struct {
+	source string
+	dest   string
+}
+
+func captureEnvironment() capturedEnvironment {
+	values := make(map[string]string)
+	for _, entry := range os.Environ() {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[name] = value
+		}
+	}
+	return capturedEnvironment{values: values}
+}
+
+func (c capturedEnvironment) loginProbeEnvironment() []string {
+	env := make(map[string]string)
+	for name, value := range c.values {
+		if probeEnvironmentName(name) {
+			env[name] = value
+		}
+	}
+	if home := c.values["HOME"]; home != "" {
+		env["HOME"] = home
+	}
+	env["PATH"] = sanitizePath(c.values["PATH"])
+	return environmentSlice(env)
+}
+
+func (c capturedEnvironment) prepare(cli string) (*preparedEnvironment, error) {
+	extraNames, err := c.additionalNames(cli)
+	if err != nil {
+		return nil, err
+	}
+
+	root, err := os.MkdirTemp("", "heimdallm-"+cli+"-")
+	if err != nil {
+		return nil, fmt.Errorf("executor: create isolated home for %s: %w", cli, err)
+	}
+	cleanup := func() { _ = os.RemoveAll(root) }
+	if err := os.Chmod(root, 0o700); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("executor: secure isolated home for %s: %w", cli, err)
+	}
+
+	base, err := c.base(root)
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+	if err := c.bridgeProviderState(cli, root); err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	env := cloneEnvironment(base)
+	redactions := make([]string, 0, len(providerCredentialNames[cli])+len(extraNames))
+	for _, name := range providerCredentialNames[cli] {
+		if value := c.values[name]; value != "" {
+			env[name] = value
+			redactions = append(redactions, value)
+		}
+	}
+	for _, name := range providerRuntimeNames[cli] {
+		if value, ok := c.values[name]; ok {
+			env[name] = value
+		}
+	}
+	for _, name := range extraNames {
+		if value, ok := c.values[name]; ok {
+			env[name] = value
+			if value != "" {
+				redactions = append(redactions, value)
+			}
+		}
+	}
+	if cli == "claude" {
+		// Claude Code additionally scrubs provider credentials from Bash,
+		// hooks and MCP children. This managed value is assigned after all
+		// operator extras so an allowlist can never weaken the boundary.
+		env["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "1"
+	}
+	if cli == "gemini" {
+		settingsPath := filepath.Join(root, "gemini-system-settings.json")
+		const settings = "{\n  \"advanced\": {\n    \"ignoreLocalEnv\": true\n  }\n}\n"
+		if err := os.WriteFile(settingsPath, []byte(settings), 0o600); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("executor: write Gemini system settings: %w", err)
+		}
+		// System settings override user and project settings. This managed
+		// path cannot be replaced through the operator extra-env allowlist.
+		env["GEMINI_CLI_SYSTEM_SETTINGS_PATH"] = settingsPath
+	}
+	if cli == "opencode" {
+		// OpenCode otherwise discovers project opencode.json/.opencode
+		// configuration after applying --dir. Those files can declare MCP
+		// servers and trigger dependency installation. Assign these managed
+		// values after operator extras so an allowlist cannot weaken them.
+		env["OPENCODE_DISABLE_PROJECT_CONFIG"] = "1"
+		env["OPENCODE_PURE"] = "1"
+	}
+	for name, value := range env {
+		if proxyEnvironmentName(name) {
+			redactions = append(redactions, proxyRedactionValues(value)...)
+		}
+	}
+
+	codexToolEnv := codexNestedEnvironment(base)
+	if value, ok := env["SSH_AUTH_SOCK"]; ok {
+		// The agent socket is only forwarded when the operator explicitly
+		// opted this provider in. It is a path, not the private key material.
+		codexToolEnv["SSH_AUTH_SOCK"] = value
+	}
+
+	return &preparedEnvironment{
+		env:          environmentSlice(env),
+		codexToolEnv: codexToolEnv,
+		runDir:       filepath.Join(root, "tmp"),
+		redact:       environmentRedactor(redactions),
+		cleanup:      cleanup,
+	}, nil
+}
+
+func (c capturedEnvironment) prepareProbe() (*preparedEnvironment, error) {
+	root, err := os.MkdirTemp("", "heimdallm-cli-probe-")
+	if err != nil {
+		return nil, fmt.Errorf("executor: create isolated CLI probe home: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(root) }
+	if err := os.Chmod(root, 0o700); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("executor: secure isolated CLI probe home: %w", err)
+	}
+	base, err := c.base(root)
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+	for name := range base {
+		if !probeEnvironmentName(name) && !managedProbeEnvironmentName(name) {
+			delete(base, name)
+		}
+	}
+	return &preparedEnvironment{
+		env:          environmentSlice(base),
+		codexToolEnv: cloneEnvironment(base),
+		runDir:       filepath.Join(root, "tmp"),
+		redact:       func(value string) string { return value },
+		cleanup:      cleanup,
+	}, nil
+}
+
+func (c capturedEnvironment) base(root string) (map[string]string, error) {
+	dirs := []string{
+		filepath.Join(root, ".cache"),
+		filepath.Join(root, ".config"),
+		filepath.Join(root, ".local", "share"),
+		filepath.Join(root, ".local", "state"),
+		filepath.Join(root, "tmp"),
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("executor: create isolated environment directory: %w", err)
+		}
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("executor: secure isolated environment directory: %w", err)
+		}
+	}
+
+	env := make(map[string]string, len(commonEnvironmentNames)+12)
+	for name, value := range c.values {
+		if _, allowed := commonEnvironmentNames[strings.ToUpper(name)]; allowed {
+			env[name] = value
+		}
+	}
+	env["CI"] = "true"
+	env["HOME"] = root
+	env["PATH"] = enrichedPath(c.values)
+	env["TEMP"] = filepath.Join(root, "tmp")
+	env["TMP"] = filepath.Join(root, "tmp")
+	env["TMPDIR"] = filepath.Join(root, "tmp")
+	env["XDG_CACHE_HOME"] = filepath.Join(root, ".cache")
+	env["XDG_CONFIG_HOME"] = filepath.Join(root, ".config")
+	env["XDG_DATA_HOME"] = filepath.Join(root, ".local", "share")
+	env["XDG_STATE_HOME"] = filepath.Join(root, ".local", "state")
+	return env, nil
+}
+
+func (c capturedEnvironment) additionalNames(cli string) ([]string, error) {
+	controlName := environmentAllowlistPrefix + strings.ToUpper(cli) + "_ENV_ALLOWLIST"
+	raw := strings.TrimSpace(c.values[controlName])
+	if raw == "" {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	var names []string
+	for _, item := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(item)
+		if !validEnvironmentName(name) {
+			return nil, fmt.Errorf("executor: %s contains invalid environment name %q", controlName, name)
+		}
+		if err := validateAdditionalEnvironmentName(cli, name); err != nil {
+			return nil, fmt.Errorf("executor: %s: %w", controlName, err)
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func validateAdditionalEnvironmentName(cli, name string) error {
+	upper := strings.ToUpper(name)
+	if upper == "SSH_AUTH_SOCK" {
+		return nil
+	}
+	if _, managed := managedEnvironmentNames[upper]; managed {
+		return fmt.Errorf("%s is managed by Heimdallm and cannot be overridden", name)
+	}
+	if _, dangerous := dangerousEnvironmentNames[upper]; dangerous {
+		return fmt.Errorf("%s is permanently blocked", name)
+	}
+	for _, prefix := range []string{"DYLD_", "GIT_", "HEIMDALLM_", "LD_"} {
+		if strings.HasPrefix(upper, prefix) {
+			return fmt.Errorf("%s is permanently blocked", name)
+		}
+	}
+	for provider, credentialNames := range providerCredentialNames {
+		if provider == cli {
+			continue
+		}
+		for _, credentialName := range credentialNames {
+			if upper == credentialName {
+				if cli == "opencode" {
+					// OpenCode is a multi-provider client. Naming a backend
+					// credential in its exact allowlist is the operator's
+					// explicit authorization for that configured backend.
+					return nil
+				}
+				return fmt.Errorf("%s belongs to another provider and is permanently blocked", name)
+			}
+		}
+	}
+	return nil
+}
+
+func validEnvironmentName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || (i > 0 && r >= '0' && r <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func (c capturedEnvironment) bridgeProviderState(cli, root string) error {
+	for _, mount := range c.providerStateMounts(cli, root) {
+		if mount.source == "" {
+			continue
+		}
+		if !filepath.IsAbs(mount.source) {
+			return fmt.Errorf("executor: %s credential state path %q must be absolute", cli, mount.source)
+		}
+		if _, err := os.Lstat(mount.source); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("executor: inspect %s credential state: %w", cli, err)
+		}
+		if cli == "gemini" {
+			if err := bridgeGeminiState(mount.source, mount.dest); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(mount.dest), 0o700); err != nil {
+			return fmt.Errorf("executor: prepare %s credential state bridge: %w", cli, err)
+		}
+		if err := os.Symlink(mount.source, mount.dest); err != nil {
+			return fmt.Errorf("executor: bridge %s credential state: %w", cli, err)
+		}
+	}
+	return nil
+}
+
+// bridgeGeminiState projects Gemini's top-level state entries individually so
+// its special ~/.gemini/.env file is absent. Gemini intentionally loads that
+// file even when --ignore-env or advanced.ignoreLocalEnv is set. Other state,
+// including browser OAuth credentials, remains available through symlinks.
+func bridgeGeminiState(source, dest string) error {
+	entries, err := os.ReadDir(source)
+	if err != nil {
+		return fmt.Errorf("executor: read Gemini credential state: %w", err)
+	}
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		return fmt.Errorf("executor: prepare Gemini credential state bridge: %w", err)
+	}
+	if err := os.Chmod(dest, 0o700); err != nil {
+		return fmt.Errorf("executor: secure Gemini credential state bridge: %w", err)
+	}
+	for _, entry := range entries {
+		if strings.EqualFold(entry.Name(), ".env") {
+			continue
+		}
+		if err := os.Symlink(
+			filepath.Join(source, entry.Name()),
+			filepath.Join(dest, entry.Name()),
+		); err != nil {
+			return fmt.Errorf("executor: bridge Gemini credential state entry %q: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (c capturedEnvironment) providerStateMounts(cli, root string) []providerStateMount {
+	home := c.values["HOME"]
+	if home == "" {
+		if resolved, err := os.UserHomeDir(); err == nil {
+			home = resolved
+		}
+	}
+	homePath := func(parts ...string) string {
+		if home == "" {
+			return ""
+		}
+		return filepath.Join(append([]string{home}, parts...)...)
+	}
+
+	switch cli {
+	case "claude":
+		claudeDir := c.values["CLAUDE_CONFIG_DIR"]
+		if claudeDir == "" {
+			claudeDir = homePath(".claude")
+		}
+		return []providerStateMount{
+			{source: claudeDir, dest: filepath.Join(root, ".claude")},
+			{source: homePath(".claude.json"), dest: filepath.Join(root, ".claude.json")},
+		}
+	case "codex":
+		codexHome := c.values["CODEX_HOME"]
+		if codexHome == "" {
+			codexHome = homePath(".codex")
+		}
+		return []providerStateMount{{source: codexHome, dest: filepath.Join(root, ".codex")}}
+	case "gemini":
+		return []providerStateMount{{source: homePath(".gemini"), dest: filepath.Join(root, ".gemini")}}
+	case "opencode":
+		configHome := c.values["XDG_CONFIG_HOME"]
+		if configHome == "" {
+			configHome = homePath(".config")
+		}
+		dataHome := c.values["XDG_DATA_HOME"]
+		if dataHome == "" {
+			dataHome = homePath(".local", "share")
+		}
+		var mounts []providerStateMount
+		if configHome != "" {
+			mounts = append(mounts, providerStateMount{
+				source: filepath.Join(configHome, "opencode"),
+				dest:   filepath.Join(root, ".config", "opencode"),
+			})
+		}
+		if dataHome != "" {
+			mounts = append(mounts, providerStateMount{
+				source: filepath.Join(dataHome, "opencode"),
+				dest:   filepath.Join(root, ".local", "share", "opencode"),
+			})
+		}
+		return mounts
+	default:
+		return nil
+	}
+}
+
+func cloneEnvironment(source map[string]string) map[string]string {
+	cloned := make(map[string]string, len(source))
+	for name, value := range source {
+		cloned[name] = value
+	}
+	return cloned
+}
+
+func codexNestedEnvironment(source map[string]string) map[string]string {
+	env := make(map[string]string, len(source))
+	for name, value := range source {
+		switch strings.ToUpper(name) {
+		case "ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY":
+			// Proxy URLs often embed credentials. Codex itself receives the
+			// proxy through its allowlisted parent environment, but values
+			// must never be serialized into command-line config overrides.
+			continue
+		default:
+			env[name] = value
+		}
+	}
+	return env
+}
+
+func probeEnvironmentName(name string) bool {
+	switch strings.ToUpper(name) {
+	case "CI",
+		"COLORTERM",
+		"COMSPEC",
+		"LANG",
+		"LANGUAGE",
+		"LC_ADDRESS",
+		"LC_ALL",
+		"LC_COLLATE",
+		"LC_CTYPE",
+		"LC_IDENTIFICATION",
+		"LC_MEASUREMENT",
+		"LC_MESSAGES",
+		"LC_MONETARY",
+		"LC_NAME",
+		"LC_NUMERIC",
+		"LC_PAPER",
+		"LC_TELEPHONE",
+		"LC_TIME",
+		"LOGNAME",
+		"NO_COLOR",
+		"PATHEXT",
+		"SHELL",
+		"SYSTEMROOT",
+		"TERM",
+		"TZ",
+		"USER",
+		"WINDIR":
+		return true
+	default:
+		return false
+	}
+}
+
+func managedProbeEnvironmentName(name string) bool {
+	_, ok := managedEnvironmentNames[strings.ToUpper(name)]
+	return ok
+}
+
+func environmentSlice(values map[string]string) []string {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	env := make([]string, 0, len(names))
+	for _, name := range names {
+		env = append(env, name+"="+values[name])
+	}
+	return env
+}
+
+func sanitizePath(paths ...string) string {
+	seen := make(map[string]struct{})
+	entries := make([]string, 0, 16)
+	add := func(path string) {
+		path = filepath.Clean(strings.TrimSpace(path))
+		if path == "." || !filepath.IsAbs(path) {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		entries = append(entries, path)
+	}
+	for _, value := range paths {
+		for _, path := range filepath.SplitList(value) {
+			add(path)
+		}
+	}
+	for _, path := range []string{"/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"} {
+		add(path)
+	}
+	return strings.Join(entries, string(os.PathListSeparator))
+}
+
+func proxyEnvironmentName(name string) bool {
+	switch strings.ToUpper(name) {
+	case "ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY":
+		return true
+	default:
+		return false
+	}
+}
+
+func proxyRedactionValues(value string) []string {
+	if value == "" {
+		return nil
+	}
+	values := []string{value}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.User == nil {
+		return values
+	}
+	if password, ok := parsed.User.Password(); ok && password != "" {
+		values = append(values, password)
+	}
+	return values
+}
+
+func environmentRedactor(values []string) func(string) string {
+	unique := make(map[string]struct{}, len(values)*2)
+	for _, value := range values {
+		if len(value) < 4 {
+			continue
+		}
+		unique[value] = struct{}{}
+		if escaped := url.QueryEscape(value); escaped != value {
+			unique[escaped] = struct{}{}
+		}
+	}
+	ordered := make([]string, 0, len(unique))
+	for value := range unique {
+		ordered = append(ordered, value)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return len(ordered[i]) > len(ordered[j]) })
+
+	return func(message string) string {
+		for _, value := range ordered {
+			message = strings.ReplaceAll(message, value, "[REDACTED]")
+		}
+		return message
+	}
+}
+
+func codexShellEnvironmentPolicy(values map[string]string) string {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	includes := make([]string, 0, len(names))
+	settings := make([]string, 0, len(names))
+	for _, name := range names {
+		includes = append(includes, strconv.Quote(name))
+		settings = append(settings, strconv.Quote(name)+"="+strconv.Quote(values[name]))
+	}
+	return "{inherit=\"none\",experimental_use_profile=false,ignore_default_excludes=false,include_only=[" +
+		strings.Join(includes, ",") + "],set={" + strings.Join(settings, ",") + "}}"
+}

--- a/daemon/internal/executor/environment_internal_test.go
+++ b/daemon/internal/executor/environment_internal_test.go
@@ -1,0 +1,36 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoginProbeEnvironmentExcludesCredentialBearingNetworkSettings(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("HOME", "/tmp/login-probe-home")
+	t.Setenv("LANG", "C.UTF-8")
+	t.Setenv("HTTPS_PROXY", "https://user:secret@example.invalid")
+	t.Setenv("ALL_PROXY", "socks5://user:secret@example.invalid")
+	t.Setenv("SSL_CERT_FILE", "/private/daemon/ca.pem")
+	t.Setenv("NODE_EXTRA_CA_CERTS", "/private/daemon/node-ca.pem")
+	t.Setenv("GITHUB_TOKEN", "daemon-secret")
+
+	env := captureEnvironment().loginProbeEnvironment()
+	joined := strings.Join(env, "\n")
+	for _, name := range []string{
+		"HTTPS_PROXY=",
+		"ALL_PROXY=",
+		"SSL_CERT_FILE=",
+		"NODE_EXTRA_CA_CERTS=",
+		"GITHUB_TOKEN=",
+	} {
+		if strings.Contains(joined, name) {
+			t.Errorf("login-shell probe received %s", name)
+		}
+	}
+	for _, name := range []string{"PATH=", "HOME=", "LANG="} {
+		if !strings.Contains(joined, name) {
+			t.Errorf("login-shell probe lost required %s", name)
+		}
+	}
+}

--- a/daemon/internal/executor/environment_internal_test.go
+++ b/daemon/internal/executor/environment_internal_test.go
@@ -1,8 +1,13 @@
 package executor
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+
+	"github.com/BurntSushi/toml"
 )
 
 func TestLoginProbeEnvironmentExcludesCredentialBearingNetworkSettings(t *testing.T) {
@@ -33,4 +38,266 @@ func TestLoginProbeEnvironmentExcludesCredentialBearingNetworkSettings(t *testin
 			t.Errorf("login-shell probe lost required %s", name)
 		}
 	}
+}
+
+func TestCodexShellEnvironmentPolicyRoundTripsTOMLControls(t *testing.T) {
+	const value = "\x00\a\v\x1b\x7f quote=\" slash=\\ newline=\n emoji=😀"
+	policy, err := codexShellEnvironmentPolicy(map[string]string{"CONTROL": value})
+	if err != nil {
+		t.Fatalf("codexShellEnvironmentPolicy: %v", err)
+	}
+
+	var decoded struct {
+		Policy struct {
+			Inherit     string            `toml:"inherit"`
+			IncludeOnly []string          `toml:"include_only"`
+			Set         map[string]string `toml:"set"`
+		} `toml:"policy"`
+	}
+	if _, err := toml.Decode("policy = "+policy+"\n", &decoded); err != nil {
+		t.Fatalf("decode generated policy %q: %v", policy, err)
+	}
+	if decoded.Policy.Inherit != "none" {
+		t.Fatalf("inherit = %q, want none", decoded.Policy.Inherit)
+	}
+	if len(decoded.Policy.IncludeOnly) != 1 || decoded.Policy.IncludeOnly[0] != "CONTROL" {
+		t.Fatalf("include_only = %v, want CONTROL", decoded.Policy.IncludeOnly)
+	}
+	if got := decoded.Policy.Set["CONTROL"]; got != value {
+		t.Fatalf("round-trip value = %q, want %q", got, value)
+	}
+}
+
+func TestCodexShellEnvironmentPolicyRejectsInvalidUTF8(t *testing.T) {
+	_, err := codexShellEnvironmentPolicy(map[string]string{
+		"INVALID": string([]byte{0xff}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid UTF-8") {
+		t.Fatalf("codexShellEnvironmentPolicy error = %v, want invalid UTF-8", err)
+	}
+}
+
+func TestMutableJSONStateRejectsConcurrentRotation(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.json")
+	if err := os.WriteFile(source, []byte(`{"token":"old"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	firstDest := filepath.Join(root, "first", "state.json")
+	secondDest := filepath.Join(root, "second", "state.json")
+	firstSync, err := bridgeMutableJSONState(source, firstDest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondSync, err := bridgeMutableJSONState(source, secondDest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(firstDest, []byte(`{"token":"first"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secondDest, []byte(`{"token":"second"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := firstSync(); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if err := secondSync(); err == nil || !strings.Contains(err.Error(), "changed concurrently") {
+		t.Fatalf("second sync error = %v, want concurrent-change rejection", err)
+	}
+	got, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != `{"token":"first"}` {
+		t.Fatalf("source = %q, want first rotation preserved", got)
+	}
+}
+
+func TestMutableJSONStateRejectsSourceFIFOReplacementWithoutBlocking(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.json")
+	if err := os.WriteFile(source, []byte(`{"token":"old"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(root, "isolated", "state.json")
+	syncState, err := bridgeMutableJSONState(source, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(`{"token":"rotated"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(source); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncState(); err == nil || !strings.Contains(err.Error(), "changed file type") {
+		t.Fatalf("sync after FIFO replacement error = %v, want file-type rejection", err)
+	}
+	info, err := os.Lstat(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeNamedPipe == 0 {
+		t.Fatalf("source mode = %v, FIFO was unexpectedly replaced", info.Mode())
+	}
+}
+
+func TestMutableJSONStateRejectsAbsentParentSymlinkRetarget(t *testing.T) {
+	root := t.TempDir()
+	firstTarget := filepath.Join(root, "first")
+	secondTarget := filepath.Join(root, "second")
+	if err := os.Mkdir(firstTarget, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(secondTarget, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	parentLink := filepath.Join(root, "provider-home")
+	if err := os.Symlink(firstTarget, parentLink); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(parentLink, "state.json")
+	dest := filepath.Join(root, "isolated", "state.json")
+	syncState, err := bridgeMutableJSONState(source, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(`{"token":"new"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(parentLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secondTarget, parentLink); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncState(); err == nil || !strings.Contains(err.Error(), "existing parent changed target") {
+		t.Fatalf("sync after parent symlink retarget error = %v", err)
+	}
+	for _, target := range []string{firstTarget, secondTarget} {
+		if _, err := os.Lstat(filepath.Join(target, "state.json")); !os.IsNotExist(err) {
+			t.Fatalf("state was unexpectedly created under %s: %v", target, err)
+		}
+	}
+}
+
+func TestMutableJSONStateAcceptsEmptyFirstRunFile(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.json")
+	if err := os.WriteFile(source, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(root, "isolated", "state.json")
+	syncState, err := bridgeMutableJSONState(source, dest)
+	if err != nil {
+		t.Fatalf("bridge empty state: %v", err)
+	}
+	if got := string(mustReadInternalFile(t, dest)); got != "{}\n" {
+		t.Fatalf("isolated seed = %q, want empty JSON object", got)
+	}
+	if err := syncState(); err != nil {
+		t.Fatalf("sync unchanged empty state: %v", err)
+	}
+	if got := mustReadInternalFile(t, source); len(got) != 0 {
+		t.Fatalf("unchanged first-run source = %q, want original empty bytes", got)
+	}
+}
+
+func TestMutableJSONStateLetsProviderRepairMalformedState(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.json")
+	if err := os.WriteFile(source, []byte("{broken"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(root, "isolated", "state.json")
+	syncState, err := bridgeMutableJSONState(source, dest)
+	if err != nil {
+		t.Fatalf("bridge malformed state: %v", err)
+	}
+	if err := os.WriteFile(dest, []byte(`{"repaired":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncState(); err != nil {
+		t.Fatalf("sync repaired state: %v", err)
+	}
+	if got := string(mustReadInternalFile(t, source)); got != `{"repaired":true}` {
+		t.Fatalf("repaired source = %q", got)
+	}
+}
+
+func TestAtomicWritePrivateStateFallsBackForBusyBindMount(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mounted.json")
+	if err := os.WriteFile(path, []byte(`{"token":"old"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	renameBusy := func(oldPath, newPath string) error {
+		return &os.LinkError{
+			Op:  "rename",
+			Old: oldPath,
+			New: newPath,
+			Err: syscall.EBUSY,
+		}
+	}
+	const updated = `{"token":"rotated"}`
+	if err := atomicWritePrivateStateWithRename(path, []byte(updated), renameBusy); err != nil {
+		t.Fatalf("write busy bind-mounted state: %v", err)
+	}
+	if got := string(mustReadInternalFile(t, path)); got != updated {
+		t.Fatalf("busy mounted state = %q, want %q", got, updated)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("busy mounted state mode = %o, want 600", got)
+	}
+}
+
+func TestMutableJSONStateReportsReadOnlyPersistence(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	if err := os.Mkdir(sourceDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(sourceDir, "state.json")
+	if err := os.WriteFile(source, []byte(`{"token":"old"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(root, "isolated", "state.json")
+	syncState, err := bridgeMutableJSONState(source, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(`{"token":"rotated"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(sourceDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(sourceDir, 0o700) }()
+	if err := syncState(); err == nil {
+		t.Fatal("read-only generic state persistence unexpectedly succeeded")
+	}
+	if got := string(mustReadInternalFile(t, source)); got != `{"token":"old"}` {
+		t.Fatalf("read-only source changed to %q", got)
+	}
+}
+
+func mustReadInternalFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
 }

--- a/daemon/internal/executor/environment_internal_test.go
+++ b/daemon/internal/executor/environment_internal_test.go
@@ -1,6 +1,10 @@
 package executor
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,6 +78,125 @@ func TestCodexShellEnvironmentPolicyRejectsInvalidUTF8(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "invalid UTF-8") {
 		t.Fatalf("codexShellEnvironmentPolicy error = %v, want invalid UTF-8", err)
+	}
+}
+
+func TestAdditionalEnvironmentValueCanonicalizesOnlySSHAuthSock(t *testing.T) {
+	captured := capturedEnvironment{values: map[string]string{
+		"SSH_AUTH_SOCK": "/tmp/canonical.sock",
+		"ssh_auth_sock": "/tmp/lower.sock",
+		"Mixed_Case":    "exact",
+	}}
+
+	if got, ok := captured.additionalEnvironmentValue("SSH_AUTH_SOCK"); !ok || got != "/tmp/canonical.sock" {
+		t.Fatalf("SSH_AUTH_SOCK = %q, %t, want canonical value", got, ok)
+	}
+	if got, ok := captured.additionalEnvironmentValue("Mixed_Case"); !ok || got != "exact" {
+		t.Fatalf("Mixed_Case = %q, %t, want exact value", got, ok)
+	}
+	if got, ok := captured.additionalEnvironmentValue("MIXED_CASE"); ok {
+		t.Fatalf("MIXED_CASE = %q, %t, want case-sensitive miss", got, ok)
+	}
+
+	delete(captured.values, "SSH_AUTH_SOCK")
+	if got, ok := captured.additionalEnvironmentValue("SSH_AUTH_SOCK"); !ok || got != "/tmp/lower.sock" {
+		t.Fatalf("lowercase SSH socket = %q, %t, want canonicalized fallback", got, ok)
+	}
+}
+
+func TestEnvironmentFlagEnabledMatchesClaudeBooleanValues(t *testing.T) {
+	for _, value := range []string{"1", "true", "TRUE", " yes ", "ON"} {
+		if !environmentFlagEnabled(value) {
+			t.Errorf("environmentFlagEnabled(%q) = false, want true", value)
+		}
+	}
+	for _, value := range []string{"", "0", "false", "no", "off", "unexpected"} {
+		if environmentFlagEnabled(value) {
+			t.Errorf("environmentFlagEnabled(%q) = true, want false", value)
+		}
+	}
+}
+
+func TestPrepareRejectsConflictingClaudeBackendsBeforeCreatingHome(t *testing.T) {
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot)
+	captured := capturedEnvironment{values: map[string]string{
+		"CLAUDE_CODE_USE_BEDROCK": "yes",
+		"CLAUDE_CODE_USE_VERTEX":  "ON",
+	}}
+
+	prepared, err := captured.prepare("claude")
+	if prepared != nil {
+		_ = prepared.cleanup()
+		t.Fatal("prepare returned an environment for conflicting Claude backends")
+	}
+	if err == nil ||
+		!strings.Contains(err.Error(), "CLAUDE_CODE_USE_BEDROCK") ||
+		!strings.Contains(err.Error(), "CLAUDE_CODE_USE_VERTEX") {
+		t.Fatalf("prepare error = %v, want both conflicting selectors", err)
+	}
+	entries, readErr := os.ReadDir(tmpRoot)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("prepare created isolated state before rejecting conflict: %v", entries)
+	}
+}
+
+func TestKnownProviderPolicyEnvironmentNamesRemainBlocked(t *testing.T) {
+	names := []string{
+		"CLAUDE_CODE_SAFE_MODE",
+		"CLAUDE_CODE_SUBPROCESS_ENV_SCRUB",
+		"CLAUDE_CONFIG_DIR",
+		"CODEX_HOME",
+		"GEMINI_CLI_HOME",
+		"GEMINI_CLI_IDE_SERVER_STDIO_COMMAND",
+		"GEMINI_CLI_SYSTEM_DEFAULTS_PATH",
+		"GEMINI_CLI_SYSTEM_SETTINGS_PATH",
+		"GEMINI_CLI_TRUSTED_FOLDERS_PATH",
+		"GEMINI_CLI_TRUST_WORKSPACE",
+		"GEMINI_SANDBOX",
+		"GEMINI_SANDBOX_PROXY_COMMAND",
+		"GEMINI_SYSTEM_MD",
+		"GEMINI_WRITE_SYSTEM_MD",
+		"OPENCODE_CONFIG",
+		"OPENCODE_CONFIG_CONTENT",
+		"OPENCODE_CONFIG_DIR",
+		"OPENCODE_DISABLE_PROJECT_CONFIG",
+		"OPENCODE_PURE",
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			if err := validateAdditionalEnvironmentName("codex", strings.ToLower(name)); err == nil {
+				t.Fatalf("%s is no longer blocked case-insensitively", name)
+			}
+		})
+	}
+}
+
+func TestUnwritableStateSourceErrorIsNarrow(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "read-only filesystem", err: syscall.EROFS, want: true},
+		{name: "permission denied", err: syscall.EACCES, want: true},
+		{name: "operation not permitted", err: syscall.EPERM, want: true},
+		{name: "wrapped permission error", err: fmt.Errorf("persist: %w", syscall.EACCES), want: true},
+		{name: "disk full", err: syscall.ENOSPC},
+		{name: "I/O error", err: syscall.EIO},
+		{name: "invalid argument", err: syscall.EINVAL},
+		{name: "unresolved busy mount", err: syscall.EBUSY},
+		{name: "unrelated wrapped error", err: fmt.Errorf("persist: %w", errors.New("boom"))},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := unwritableStateSourceError(tc.err); got != tc.want {
+				t.Fatalf("unwritableStateSourceError(%v) = %t, want %t", tc.err, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -263,7 +386,79 @@ func TestAtomicWritePrivateStateFallsBackForBusyBindMount(t *testing.T) {
 	}
 }
 
-func TestMutableJSONStateReportsReadOnlyPersistence(t *testing.T) {
+func TestClaudeMutableJSONStateKeepsUnwritableSourceEphemeral(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	if err := os.Mkdir(sourceDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(sourceDir, "state.json")
+	if err := os.WriteFile(source, []byte(`{"token":"old"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(root, "isolated", "state.json")
+	syncState, err := bridgeClaudeMutableJSONState(source, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(`{"token":"rotated"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(sourceDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(sourceDir, 0o700) }()
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(
+		&logs,
+		&slog.HandlerOptions{Level: slog.LevelWarn},
+	)))
+	defer slog.SetDefault(previousLogger)
+
+	if err := syncState(); err != nil {
+		t.Fatalf("unwritable provider state should remain ephemeral: %v", err)
+	}
+	if got := string(mustReadInternalFile(t, source)); got != `{"token":"old"}` {
+		t.Fatalf("unwritable source changed to %q", got)
+	}
+	if got := logs.String(); !strings.Contains(got, "refreshed state is ephemeral") {
+		t.Fatalf("operator warning missing from logs:\n%s", got)
+	}
+}
+
+func TestClaudeMutableJSONStateKeepsUnwritableFirstRunEphemeral(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	if err := os.Mkdir(sourceDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(sourceDir, "state.json")
+	dest := filepath.Join(root, "isolated", "state.json")
+	syncState, err := bridgeClaudeMutableJSONState(source, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(`{"token":"first-login"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(sourceDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(sourceDir, 0o700) }()
+	if err := syncState(); err != nil {
+		t.Fatalf("unwritable first-run state should remain ephemeral: %v", err)
+	}
+	if _, err := os.Lstat(source); !os.IsNotExist(err) {
+		t.Fatalf("first-run source was unexpectedly created: %v", err)
+	}
+}
+
+func TestMutableJSONStateReportsUnwritableSourceByDefault(t *testing.T) {
 	root := t.TempDir()
 	sourceDir := filepath.Join(root, "source")
 	if err := os.Mkdir(sourceDir, 0o700); err != nil {
@@ -286,10 +481,10 @@ func TestMutableJSONStateReportsReadOnlyPersistence(t *testing.T) {
 	}
 	defer func() { _ = os.Chmod(sourceDir, 0o700) }()
 	if err := syncState(); err == nil {
-		t.Fatal("read-only generic state persistence unexpectedly succeeded")
+		t.Fatal("generic state bridge unexpectedly hid an unwritable source")
 	}
 	if got := string(mustReadInternalFile(t, source)); got != `{"token":"old"}` {
-		t.Fatalf("read-only source changed to %q", got)
+		t.Fatalf("unwritable source changed to %q", got)
 	}
 }
 

--- a/daemon/internal/executor/environment_test.go
+++ b/daemon/internal/executor/environment_test.go
@@ -1,0 +1,560 @@
+package executor_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/executor"
+)
+
+var testProviderCredentials = map[string][]string{
+	"claude": {
+		"ANTHROPIC_API_KEY",
+		"CLAUDE_CODE_OAUTH_TOKEN",
+	},
+	"codex": {
+		"OPENAI_API_KEY",
+		"CODEX_API_KEY",
+	},
+	"gemini": {
+		"GEMINI_API_KEY",
+		"GOOGLE_API_KEY",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"GOOGLE_CLOUD_PROJECT",
+		"GOOGLE_CLOUD_LOCATION",
+		"GOOGLE_GENAI_USE_VERTEXAI",
+	},
+	"opencode": {
+		"OPENROUTER_API_KEY",
+	},
+}
+
+func TestExecuteRawUsesProviderSpecificEnvironment(t *testing.T) {
+	for cli, selectedNames := range testProviderCredentials {
+		t.Run(cli, func(t *testing.T) {
+			originalHome := t.TempDir()
+			t.Setenv("HOME", originalHome)
+			t.Setenv("LANG", "es_ES.UTF-8")
+			t.Setenv("GITHUB_TOKEN", "github-daemon-secret")
+			t.Setenv("GH_TOKEN", "gh-daemon-secret")
+			t.Setenv("HEIMDALLM_API_TOKEN", "heimdallm-daemon-secret")
+			t.Setenv("GIT_CONFIG_COUNT", "1")
+			t.Setenv("GIT_CONFIG_KEY_0", "credential.helper")
+			t.Setenv("GIT_CONFIG_VALUE_0", "!steal")
+			t.Setenv("SSH_AUTH_SOCK", "/tmp/daemon-agent.sock")
+			t.Setenv("LD_PRELOAD", "/tmp/evil.so")
+			t.Setenv("LC_GITHUB_TOKEN", "locale-shaped-secret")
+			t.Setenv("OPENCODE_DISABLE_AUTOUPDATE", "true")
+			t.Setenv("OPENCODE_DISABLE_PROJECT_CONFIG", "0")
+			t.Setenv("OPENCODE_PURE", "0")
+			for provider, names := range testProviderCredentials {
+				for _, name := range names {
+					t.Setenv(name, provider+"-"+strings.ToLower(name)+"-secret")
+				}
+			}
+
+			envCapture := filepath.Join(t.TempDir(), "environment")
+			homeCapture := filepath.Join(t.TempDir(), "home")
+			binDir := installEnvironmentCLI(t, cli, envCapture, homeCapture, "")
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			if _, err := executor.New().ExecuteRaw(cli, "prompt", executor.ExecOptions{}); err != nil {
+				t.Fatalf("ExecuteRaw: %v", err)
+			}
+
+			env := readEnvironmentCapture(t, envCapture)
+			for provider, names := range testProviderCredentials {
+				for _, name := range names {
+					_, present := env[name]
+					if provider == cli && !present {
+						t.Errorf("%s credential %s was not forwarded", cli, name)
+					}
+					if provider != cli && present {
+						t.Errorf("%s received %s credential %s", cli, provider, name)
+					}
+				}
+			}
+			for _, name := range []string{
+				"GITHUB_TOKEN", "GH_TOKEN", "HEIMDALLM_API_TOKEN",
+				"GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
+				"SSH_AUTH_SOCK", "LD_PRELOAD", "LC_GITHUB_TOKEN",
+			} {
+				if _, present := env[name]; present {
+					t.Errorf("%s unexpectedly received blocked variable %s", cli, name)
+				}
+			}
+			if cli == "claude" && env["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] != "1" {
+				t.Error("Claude subprocess credential scrub was not enabled")
+			}
+			if cli == "opencode" && env["OPENCODE_DISABLE_AUTOUPDATE"] != "true" {
+				t.Error("OpenCode auto-update suppression was not preserved")
+			}
+			if cli == "opencode" && env["OPENCODE_DISABLE_PROJECT_CONFIG"] != "1" {
+				t.Error("OpenCode project config was not disabled")
+			}
+			if cli == "opencode" && env["OPENCODE_PURE"] != "1" {
+				t.Error("OpenCode pure mode was not enforced in the environment")
+			}
+			if cli != "opencode" {
+				if _, present := env["OPENCODE_DISABLE_AUTOUPDATE"]; present {
+					t.Errorf("%s unexpectedly received an OpenCode runtime variable", cli)
+				}
+				if _, present := env["OPENCODE_DISABLE_PROJECT_CONFIG"]; present {
+					t.Errorf("%s unexpectedly received OpenCode project-config policy", cli)
+				}
+				if _, present := env["OPENCODE_PURE"]; present {
+					t.Errorf("%s unexpectedly received OpenCode pure-mode policy", cli)
+				}
+			}
+			if env["LANG"] != "es_ES.UTF-8" {
+				t.Errorf("LANG = %q, want preserved locale", env["LANG"])
+			}
+			if env["CI"] != "true" {
+				t.Errorf("CI = %q, want true", env["CI"])
+			}
+			if !strings.Contains(env["PATH"], binDir) {
+				t.Errorf("PATH = %q, want fake CLI directory preserved", env["PATH"])
+			}
+
+			isolatedHome := strings.TrimSpace(string(mustReadFile(t, homeCapture)))
+			if isolatedHome == "" || isolatedHome == originalHome {
+				t.Fatalf("HOME = %q, want a new isolated directory", isolatedHome)
+			}
+			if _, err := os.Stat(isolatedHome); !os.IsNotExist(err) {
+				t.Fatalf("isolated HOME was not removed after execution: %v", err)
+			}
+			for _, selectedName := range selectedNames {
+				if env[selectedName] == "" {
+					t.Errorf("%s selected credential is empty", selectedName)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteRawBridgesOnlySelectedProviderState(t *testing.T) {
+	statePaths := map[string][]string{
+		"claude":   {".claude", ".claude.json"},
+		"codex":    {".codex"},
+		"gemini":   {".gemini"},
+		"opencode": {".config/opencode", ".local/share/opencode"},
+	}
+
+	for cli := range testProviderCredentials {
+		t.Run(cli, func(t *testing.T) {
+			sourceHome := t.TempDir()
+			t.Setenv("HOME", sourceHome)
+			for provider, paths := range statePaths {
+				for _, rel := range paths {
+					path := filepath.Join(sourceHome, filepath.FromSlash(rel))
+					if strings.HasSuffix(rel, ".json") {
+						if err := os.WriteFile(path, []byte(provider), 0o600); err != nil {
+							t.Fatalf("write state file: %v", err)
+						}
+						continue
+					}
+					if err := os.MkdirAll(path, 0o700); err != nil {
+						t.Fatalf("create state dir: %v", err)
+					}
+				}
+			}
+
+			stateCapture := filepath.Join(t.TempDir(), "state")
+			homeCapture := filepath.Join(t.TempDir(), "home")
+			scriptBody := "for path in .claude .claude.json .codex .gemini .config/opencode .local/share/opencode; do\n" +
+				"  if [ -e \"$HOME/$path\" ]; then printf '%s\\n' \"$path\"; fi\n" +
+				"done > " + shellQuote(stateCapture) + "\n"
+			binDir := installEnvironmentCLI(t, cli, filepath.Join(t.TempDir(), "env"), homeCapture, scriptBody)
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			if _, err := executor.New().ExecuteRaw(cli, "prompt", executor.ExecOptions{}); err != nil {
+				t.Fatalf("ExecuteRaw: %v", err)
+			}
+			got := strings.Fields(string(mustReadFile(t, stateCapture)))
+			want := statePaths[cli]
+			if strings.Join(got, ",") != strings.Join(want, ",") {
+				t.Fatalf("bridged state = %v, want only %v", got, want)
+			}
+		})
+	}
+}
+
+func TestGeminiStateBridgeExcludesDotEnvButPreservesOAuth(t *testing.T) {
+	sourceHome := t.TempDir()
+	stateDir := filepath.Join(sourceHome, ".gemini")
+	if err := os.Mkdir(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(stateDir, ".env"),
+		[]byte("GITHUB_TOKEN=must-not-load\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	const oauth = `{"refresh_token":"selected-provider-state"}`
+	if err := os.WriteFile(filepath.Join(stateDir, "oauth_creds.json"), []byte(oauth), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", sourceHome)
+
+	stateCapture := filepath.Join(t.TempDir(), "state")
+	argsCapture := filepath.Join(t.TempDir(), "args")
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then printf '%s\\n' '--include-directories'; exit 0; fi\n" +
+		"if [ -e \"$HOME/.gemini/.env\" ]; then printf dot-env-visible > " + shellQuote(stateCapture) + "; exit 8; fi\n" +
+		"cat \"$HOME/.gemini/oauth_creds.json\" > " + shellQuote(stateCapture) + "\n" +
+		"printf '%s\\n' \"$@\" > " + shellQuote(argsCapture) + "\n" +
+		"printf ok\n"
+	if err := os.WriteFile(filepath.Join(binDir, "gemini"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake Gemini: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if _, err := executor.New().ExecuteRaw(
+		"gemini",
+		"prompt",
+		executor.ExecOptions{WorkDir: t.TempDir()},
+	); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	if got := string(mustReadFile(t, stateCapture)); got != oauth {
+		t.Fatalf("Gemini state capture = %q, want OAuth state only", got)
+	}
+	args := strings.Fields(string(mustReadFile(t, argsCapture)))
+	ignoreIndex := indexOf(args, "--ignore-env")
+	trustIndex := indexOf(args, "--skip-trust")
+	promptIndex := indexOf(args, "-p")
+	if ignoreIndex < 0 || trustIndex < 0 || promptIndex < 0 ||
+		ignoreIndex > promptIndex || trustIndex > promptIndex {
+		t.Fatalf("Gemini args = %v, want managed isolation flags before prompt mode", args)
+	}
+}
+
+func TestExecuteRawAdditionalEnvironmentRequiresSafeExplicitOptIn(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CUSTOM_REGION", "eu-test-1")
+	t.Setenv("SSH_AUTH_SOCK", "/tmp/operator-selected-agent.sock")
+	t.Setenv("HEIMDALLM_AI_CODEX_ENV_ALLOWLIST", " CUSTOM_REGION, SSH_AUTH_SOCK ")
+
+	envCapture := filepath.Join(t.TempDir(), "environment")
+	binDir := installEnvironmentCLI(t, "codex", envCapture, filepath.Join(t.TempDir(), "home"), "")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if _, err := executor.New().ExecuteRaw("codex", "prompt", executor.ExecOptions{}); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	env := readEnvironmentCapture(t, envCapture)
+	if env["CUSTOM_REGION"] != "eu-test-1" {
+		t.Errorf("CUSTOM_REGION = %q, want explicit value", env["CUSTOM_REGION"])
+	}
+	if env["SSH_AUTH_SOCK"] != "/tmp/operator-selected-agent.sock" {
+		t.Errorf("SSH_AUTH_SOCK = %q, want explicit socket", env["SSH_AUTH_SOCK"])
+	}
+}
+
+func TestOpenCodeExplicitlyAuthorizesOnlyNamedBackendCredential(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENROUTER_API_KEY", "default-openrouter")
+	t.Setenv("ANTHROPIC_API_KEY", "authorized-anthropic")
+	t.Setenv("OPENAI_API_KEY", "unselected-openai")
+	t.Setenv("HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST", "ANTHROPIC_API_KEY")
+
+	envCapture := filepath.Join(t.TempDir(), "environment")
+	binDir := installEnvironmentCLI(t, "opencode", envCapture, filepath.Join(t.TempDir(), "home"), "")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if _, err := executor.New().ExecuteRaw("opencode", "prompt", executor.ExecOptions{}); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	env := readEnvironmentCapture(t, envCapture)
+	if env["OPENROUTER_API_KEY"] != "default-openrouter" {
+		t.Error("OpenCode default credential was not preserved")
+	}
+	if env["ANTHROPIC_API_KEY"] != "authorized-anthropic" {
+		t.Error("OpenCode explicitly selected backend credential was not forwarded")
+	}
+	if _, present := env["OPENAI_API_KEY"]; present {
+		t.Error("OpenCode received an unselected backend credential")
+	}
+}
+
+func TestExecuteRawRejectsDangerousAdditionalEnvironmentBeforeCLI(t *testing.T) {
+	tests := []struct {
+		name      string
+		allowlist string
+	}{
+		{name: "daemon GitHub token", allowlist: "GITHUB_TOKEN"},
+		{name: "other provider token", allowlist: "ANTHROPIC_API_KEY"},
+		{name: "Claude nested credential scrub", allowlist: "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"},
+		{name: "OpenCode project config policy", allowlist: "OPENCODE_DISABLE_PROJECT_CONFIG"},
+		{name: "OpenCode pure-mode policy", allowlist: "OPENCODE_PURE"},
+		{name: "Git config injection", allowlist: "GIT_CONFIG_COUNT"},
+		{name: "loader injection", allowlist: "LD_PRELOAD"},
+		{name: "managed home", allowlist: "HOME"},
+		{name: "invalid name", allowlist: "VALID,NOT-VALID"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("HEIMDALLM_AI_CODEX_ENV_ALLOWLIST", tc.allowlist)
+			started := filepath.Join(t.TempDir(), "started")
+			binDir := t.TempDir()
+			script := "#!/bin/sh\nprintf started > " + shellQuote(started) + "\nprintf ok\n"
+			if err := os.WriteFile(filepath.Join(binDir, "codex"), []byte(script), 0o755); err != nil {
+				t.Fatalf("write fake CLI: %v", err)
+			}
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			if _, err := executor.New().ExecuteRaw("codex", "prompt", executor.ExecOptions{}); err == nil {
+				t.Fatal("ExecuteRaw accepted a dangerous environment opt-in")
+			}
+			if _, err := os.Stat(started); !os.IsNotExist(err) {
+				t.Fatalf("CLI started before environment policy rejection: %v", err)
+			}
+		})
+	}
+}
+
+func TestCLIHelpProbeReceivesNoProviderOrDaemonCredential(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENAI_API_KEY", "codex-help-secret")
+	t.Setenv("GITHUB_TOKEN", "github-help-secret")
+	t.Setenv("HEIMDALLM_API_TOKEN", "daemon-help-secret")
+	t.Setenv("HTTPS_PROXY", "https://proxy-user:proxy-help-secret@example.invalid")
+	t.Setenv("SSL_CERT_FILE", "/private/daemon/ca.pem")
+
+	helpCapture := filepath.Join(t.TempDir(), "help-environment")
+	helpCWDCapture := filepath.Join(t.TempDir(), "help-cwd")
+	runCapture := filepath.Join(t.TempDir(), "run-environment")
+	homeCapture := filepath.Join(t.TempDir(), "home")
+	binDir := installEnvironmentCLI(t, "codex", runCapture, homeCapture,
+		"if [ \"$1\" = \"--help\" ]; then env > "+shellQuote(helpCapture)+
+			"; pwd > "+shellQuote(helpCWDCapture)+"; printf '%s\\n' '--cd'; exit 0; fi\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	workDir := t.TempDir()
+	if _, err := executor.New().ExecuteRaw("codex", "prompt", executor.ExecOptions{WorkDir: workDir}); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	helpEnv := readEnvironmentCapture(t, helpCapture)
+	for _, name := range []string{
+		"OPENAI_API_KEY", "GITHUB_TOKEN", "HEIMDALLM_API_TOKEN",
+		"HTTPS_PROXY", "SSL_CERT_FILE",
+	} {
+		if _, present := helpEnv[name]; present {
+			t.Errorf("CLI help probe received %s", name)
+		}
+	}
+	helpCWD := strings.TrimSpace(string(mustReadFile(t, helpCWDCapture)))
+	if cleanResolvedPath(helpCWD) == cleanResolvedPath(workDir) {
+		t.Fatal("CLI help probe ran inside the repository")
+	}
+	if _, err := os.Stat(helpCWD); !os.IsNotExist(err) {
+		t.Fatalf("isolated CLI help cwd was not removed: %v", err)
+	}
+	if runEnv := readEnvironmentCapture(t, runCapture); runEnv["OPENAI_API_KEY"] != "codex-help-secret" {
+		t.Error("selected credential was not available to the real CLI execution")
+	}
+}
+
+func TestGeminiRepositoryAnalysisUsesIsolatedCWDAndSystemEnvironmentPolicy(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GEMINI_API_KEY", "gemini-selected-secret")
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, ".env"), []byte("GITHUB_TOKEN=repo-controlled\n"), 0o600); err != nil {
+		t.Fatalf("write hostile .env: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(workDir, ".gemini"), 0o700); err != nil {
+		t.Fatalf("create project settings dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(workDir, ".gemini", "settings.json"),
+		[]byte(`{"advanced":{"ignoreLocalEnv":false}}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write hostile project settings: %v", err)
+	}
+
+	cwdCapture := filepath.Join(t.TempDir(), "cwd")
+	argsCapture := filepath.Join(t.TempDir(), "args")
+	settingsCapture := filepath.Join(t.TempDir(), "settings")
+	envCapture := filepath.Join(t.TempDir(), "environment")
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then printf '%s\\n' '--include-directories'; exit 0; fi\n" +
+		"printf '%s\\n' \"$PWD\" > " + shellQuote(cwdCapture) + "\n" +
+		"printf '%s\\n' \"$*\" > " + shellQuote(argsCapture) + "\n" +
+		"cat \"$GEMINI_CLI_SYSTEM_SETTINGS_PATH\" > " + shellQuote(settingsCapture) + "\n" +
+		"env > " + shellQuote(envCapture) + "\n" +
+		"printf ok\n"
+	if err := os.WriteFile(filepath.Join(binDir, "gemini"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake Gemini: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if _, err := executor.New().ExecuteRaw("gemini", "prompt", executor.ExecOptions{WorkDir: workDir}); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	capturedCWD := strings.TrimSpace(string(mustReadFile(t, cwdCapture)))
+	if cleanResolvedPath(capturedCWD) == cleanResolvedPath(workDir) {
+		t.Fatal("Gemini loaded the repository as its process cwd")
+	}
+	if _, err := os.Stat(capturedCWD); !os.IsNotExist(err) {
+		t.Fatalf("isolated Gemini cwd was not removed: %v", err)
+	}
+	args := strings.Fields(string(mustReadFile(t, argsCapture)))
+	if !containsInOrder(args, "--include-directories", workDir) {
+		t.Fatalf("Gemini args = %v, want isolated absolute repository include", args)
+	}
+	settings := string(mustReadFile(t, settingsCapture))
+	if !strings.Contains(settings, `"ignoreLocalEnv": true`) {
+		t.Fatalf("Gemini system settings did not disable local env loading: %s", settings)
+	}
+	env := readEnvironmentCapture(t, envCapture)
+	if env["GEMINI_CLI_SYSTEM_SETTINGS_PATH"] == "" {
+		t.Error("Gemini did not receive the managed system settings path")
+	}
+	if _, present := env["GITHUB_TOKEN"]; present {
+		t.Error("hostile repository .env reached the Gemini parent process")
+	}
+}
+
+func TestGeminiRepositoryAnalysisRejectsCWDOnlyCLI(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	started := filepath.Join(t.TempDir(), "started")
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then printf '%s\\n' '--cwd'; exit 0; fi\n" +
+		"printf started > " + shellQuote(started) + "\n"
+	if err := os.WriteFile(filepath.Join(binDir, "gemini"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake Gemini: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := executor.New().ExecuteRaw(
+		"gemini",
+		"prompt",
+		executor.ExecOptions{WorkDir: t.TempDir()},
+	)
+	if err == nil || !strings.Contains(err.Error(), "include-directory") {
+		t.Fatalf("ExecuteRaw error = %v, want fail-closed include-directory error", err)
+	}
+	if _, statErr := os.Stat(started); !os.IsNotExist(statErr) {
+		t.Fatalf("Gemini executed after unsafe --cwd-only detection: %v", statErr)
+	}
+}
+
+func TestExecuteRawRedactsCredentialFromCLIError(t *testing.T) {
+	secret := "openai-error-secret-123"
+	proxySecret := "proxy-error-secret-456"
+	optInSecret := "database-error-secret-789"
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENAI_API_KEY", secret)
+	t.Setenv("HTTPS_PROXY", "https://proxy-user:"+proxySecret+"@example.invalid")
+	t.Setenv("DATABASE_URL", optInSecret)
+	t.Setenv("HEIMDALLM_AI_CODEX_ENV_ALLOWLIST", "DATABASE_URL")
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$OPENAI_API_KEY\" >&2\n" +
+		"printf '%s\\n' \"$HTTPS_PROXY\" >&2\n" +
+		"printf '%s\\n' '" + proxySecret + "' >&2\n" +
+		"printf '%s\\n' \"$DATABASE_URL\" >&2\n" +
+		"exit 7\n"
+	if err := os.WriteFile(filepath.Join(binDir, "codex"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := executor.New().ExecuteRaw("codex", "prompt", executor.ExecOptions{})
+	if err == nil {
+		t.Fatal("ExecuteRaw unexpectedly succeeded")
+	}
+	for _, value := range []string{secret, proxySecret, optInSecret} {
+		if strings.Contains(err.Error(), value) {
+			t.Fatalf("error exposed %q: %v", value, err)
+		}
+	}
+	if !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("error did not redact credential: %v", err)
+	}
+}
+
+func TestExecutorEnvironmentSnapshotDoesNotCrossContaminateConcurrentRuns(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENAI_API_KEY", "snapshot-one")
+	first := executor.New()
+	t.Setenv("OPENAI_API_KEY", "snapshot-two")
+	second := executor.New()
+
+	binDir := t.TempDir()
+	script := "#!/bin/sh\nprintf '%s\\n' \"$OPENAI_API_KEY\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "codex"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var firstOut, secondOut []byte
+	var firstErr, secondErr error
+	var wait sync.WaitGroup
+	wait.Add(2)
+	go func() {
+		defer wait.Done()
+		firstOut, firstErr = first.ExecuteRaw("codex", "prompt", executor.ExecOptions{})
+	}()
+	go func() {
+		defer wait.Done()
+		secondOut, secondErr = second.ExecuteRaw("codex", "prompt", executor.ExecOptions{})
+	}()
+	wait.Wait()
+	if firstErr != nil || secondErr != nil {
+		t.Fatalf("concurrent runs failed: first=%v second=%v", firstErr, secondErr)
+	}
+	if strings.TrimSpace(string(firstOut)) != "snapshot-one" {
+		t.Errorf("first output = %q", firstOut)
+	}
+	if strings.TrimSpace(string(secondOut)) != "snapshot-two" {
+		t.Errorf("second output = %q", secondOut)
+	}
+}
+
+func installEnvironmentCLI(t *testing.T, cli, envCapture, homeCapture, body string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		body +
+		"env > " + shellQuote(envCapture) + "\n" +
+		"printf '%s\\n' \"$HOME\" > " + shellQuote(homeCapture) + "\n" +
+		"touch \"$HOME/execution-was-here\"\n" +
+		"printf '{\"ok\":true}\\n'\n"
+	if err := os.WriteFile(filepath.Join(binDir, cli), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake %s CLI: %v", cli, err)
+	}
+	return binDir
+}
+
+func readEnvironmentCapture(t *testing.T, path string) map[string]string {
+	t.Helper()
+	result := make(map[string]string)
+	for _, line := range strings.Split(string(mustReadFile(t, path)), "\n") {
+		name, value, ok := strings.Cut(line, "=")
+		if ok {
+			result[name] = value
+		}
+	}
+	return result
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}

--- a/daemon/internal/executor/environment_test.go
+++ b/daemon/internal/executor/environment_test.go
@@ -1,6 +1,8 @@
 package executor_test
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,6 +40,7 @@ func TestExecuteRawUsesProviderSpecificEnvironment(t *testing.T) {
 			originalHome := t.TempDir()
 			t.Setenv("HOME", originalHome)
 			t.Setenv("LANG", "es_ES.UTF-8")
+			t.Setenv("http_proxy", "http://lowercase-proxy.invalid:8080")
 			t.Setenv("GITHUB_TOKEN", "github-daemon-secret")
 			t.Setenv("GH_TOKEN", "gh-daemon-secret")
 			t.Setenv("HEIMDALLM_API_TOKEN", "heimdallm-daemon-secret")
@@ -112,6 +115,9 @@ func TestExecuteRawUsesProviderSpecificEnvironment(t *testing.T) {
 			if env["LANG"] != "es_ES.UTF-8" {
 				t.Errorf("LANG = %q, want preserved locale", env["LANG"])
 			}
+			if env["http_proxy"] != "http://lowercase-proxy.invalid:8080" {
+				t.Errorf("lowercase proxy was not matched case-insensitively: %q", env["http_proxy"])
+			}
 			if env["CI"] != "true" {
 				t.Errorf("CI = %q, want true", env["CI"])
 			}
@@ -137,7 +143,7 @@ func TestExecuteRawUsesProviderSpecificEnvironment(t *testing.T) {
 
 func TestExecuteRawBridgesOnlySelectedProviderState(t *testing.T) {
 	statePaths := map[string][]string{
-		"claude":   {".claude", ".claude.json"},
+		"claude":   {".claude/.credentials.json", ".claude.json"},
 		"codex":    {".codex"},
 		"gemini":   {".gemini"},
 		"opencode": {".config/opencode", ".local/share/opencode"},
@@ -151,7 +157,10 @@ func TestExecuteRawBridgesOnlySelectedProviderState(t *testing.T) {
 				for _, rel := range paths {
 					path := filepath.Join(sourceHome, filepath.FromSlash(rel))
 					if strings.HasSuffix(rel, ".json") {
-						if err := os.WriteFile(path, []byte(provider), 0o600); err != nil {
+						if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+							t.Fatalf("create state file directory: %v", err)
+						}
+						if err := os.WriteFile(path, []byte(`{"provider":"`+provider+`"}`), 0o600); err != nil {
 							t.Fatalf("write state file: %v", err)
 						}
 						continue
@@ -164,7 +173,7 @@ func TestExecuteRawBridgesOnlySelectedProviderState(t *testing.T) {
 
 			stateCapture := filepath.Join(t.TempDir(), "state")
 			homeCapture := filepath.Join(t.TempDir(), "home")
-			scriptBody := "for path in .claude .claude.json .codex .gemini .config/opencode .local/share/opencode; do\n" +
+			scriptBody := "for path in .claude/.credentials.json .claude.json .codex .gemini .config/opencode .local/share/opencode; do\n" +
 				"  if [ -e \"$HOME/$path\" ]; then printf '%s\\n' \"$path\"; fi\n" +
 				"done > " + shellQuote(stateCapture) + "\n"
 			binDir := installEnvironmentCLI(t, cli, filepath.Join(t.TempDir(), "env"), homeCapture, scriptBody)
@@ -182,10 +191,188 @@ func TestExecuteRawBridgesOnlySelectedProviderState(t *testing.T) {
 	}
 }
 
-func TestGeminiStateBridgeExcludesDotEnvButPreservesOAuth(t *testing.T) {
+func TestClaudeStateBridgeRotatesFilesWithoutLoadingPersistentConfig(t *testing.T) {
+	sourceHome := t.TempDir()
+	claudeDir := filepath.Join(sourceHome, ".claude")
+	if err := os.MkdirAll(filepath.Join(claudeDir, "hooks"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	credentialsPath := filepath.Join(claudeDir, ".credentials.json")
+	globalStatePath := filepath.Join(sourceHome, ".claude.json")
+	if err := os.WriteFile(credentialsPath, []byte(`{"token":"old"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		globalStatePath,
+		[]byte(`{"oauth":"old","mcpServers":{"operator":{}}}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(claudeDir, "settings.json"),
+		[]byte(`{"hooks":{"PreToolUse":[{"command":"must-not-run"}]}}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "hooks", "persist.sh"), []byte("host"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", sourceHome)
+
+	workDir := t.TempDir()
+	policyCapture := filepath.Join(t.TempDir(), "policy")
+	cwdCapture := filepath.Join(t.TempDir(), "cwd")
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+if [ "$1" = "--help" ]; then
+  printf '%s\n' 'Usage: claude' '  --safe-mode' '  --add-dir <directories...>'
+  exit 0
+fi
+safe_mode=0
+added_dir=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --safe-mode)
+      safe_mode=1
+      ;;
+    --add-dir)
+      shift
+      if [ "$1" = ` + shellQuote(workDir) + ` ]; then added_dir=1; fi
+      ;;
+  esac
+  shift
+done
+printf '%s,%s\n' "$safe_mode" "$added_dir" > ` + shellQuote(policyCapture) + `
+printf '%s\n' "$PWD" > ` + shellQuote(cwdCapture) + `
+if [ -e "$HOME/.claude/settings.json" ] || [ -e "$HOME/.claude/hooks" ]; then
+  printf 'persistent Claude config was bridged\n' >&2
+  exit 12
+fi
+cat "$HOME/.claude/.credentials.json" >/dev/null
+cat "$HOME/.claude.json" >/dev/null
+printf '%s\n' '{"token":"rotated"}' > "$HOME/.claude/.credentials.json.tmp"
+mv "$HOME/.claude/.credentials.json.tmp" "$HOME/.claude/.credentials.json"
+printf '%s\n' '{"oauth":"rotated","mcpServers":{"operator":{}}}' > "$HOME/.claude.json.tmp"
+mv "$HOME/.claude.json.tmp" "$HOME/.claude.json"
+printf '{"ok":true}\n'
+`
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if _, err := executor.New().ExecuteRaw(
+		"claude",
+		"prompt",
+		executor.ExecOptions{WorkDir: workDir},
+	); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, policyCapture))); got != "1,1" {
+		t.Fatalf("managed Claude policy capture = %q, want all controls enabled", got)
+	}
+	isolatedCWD := strings.TrimSpace(string(mustReadFile(t, cwdCapture)))
+	if cleanResolvedPath(isolatedCWD) == cleanResolvedPath(workDir) {
+		t.Fatal("Claude ran inside the repository instead of its isolated directory")
+	}
+	if _, err := os.Stat(isolatedCWD); !os.IsNotExist(err) {
+		t.Fatalf("isolated Claude cwd was not removed: %v", err)
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, credentialsPath))); got != `{"token":"rotated"}` {
+		t.Fatalf("credentials after atomic rotation = %q", got)
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, globalStatePath))); got != `{"oauth":"rotated","mcpServers":{"operator":{}}}` {
+		t.Fatalf("global state after atomic rotation = %q", got)
+	}
+	for _, path := range []string{credentialsPath, globalStatePath} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("%s mode = %o, want 600", path, info.Mode().Perm())
+		}
+	}
+	if got := string(mustReadFile(t, filepath.Join(claudeDir, "hooks", "persist.sh"))); got != "host" {
+		t.Fatalf("persistent hook changed to %q", got)
+	}
+}
+
+func TestClaudeStateBridgeRejectsSymlinkReplacement(t *testing.T) {
+	sourceHome := t.TempDir()
+	claudeDir := filepath.Join(sourceHome, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	credentialsPath := filepath.Join(claudeDir, ".credentials.json")
+	const original = `{"token":"original"}`
+	if err := os.WriteFile(credentialsPath, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	externalPath := filepath.Join(t.TempDir(), "external.json")
+	if err := os.WriteFile(externalPath, []byte(`{"token":"external"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", sourceHome)
+
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then printf '%s\\n' 'Usage: claude' '  --safe-mode'; exit 0; fi\n" +
+		"rm \"$HOME/.claude/.credentials.json\"\n" +
+		"ln -s " + shellQuote(externalPath) + " \"$HOME/.claude/.credentials.json\"\n" +
+		"printf '{\"ok\":true}\\n'\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := executor.New().ExecuteRaw("claude", "prompt", executor.ExecOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("ExecuteRaw error = %v, want non-regular state rejection", err)
+	}
+	if got := string(mustReadFile(t, credentialsPath)); got != original {
+		t.Fatalf("source credentials changed to %q", got)
+	}
+	if got := string(mustReadFile(t, externalPath)); got != `{"token":"external"}` {
+		t.Fatalf("symlink target changed to %q", got)
+	}
+}
+
+func TestClaudeStateBridgePersistsRotationWhenCLIExitsWithError(t *testing.T) {
+	sourceHome := t.TempDir()
+	statePath := filepath.Join(sourceHome, ".claude.json")
+	if err := os.WriteFile(statePath, []byte(`{"oauth":"old"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", sourceHome)
+
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then printf '%s\\n' 'Usage: claude' '  --safe-mode'; exit 0; fi\n" +
+		"printf '%s\\n' '{\"oauth\":\"rotated-before-error\"}' > \"$HOME/.claude.json.tmp\"\n" +
+		"mv \"$HOME/.claude.json.tmp\" \"$HOME/.claude.json\"\n" +
+		"printf 'provider failed\\n' >&2\n" +
+		"exit 7\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := executor.New().ExecuteRaw("claude", "prompt", executor.ExecOptions{})
+	if err == nil || !strings.Contains(err.Error(), "provider failed") {
+		t.Fatalf("ExecuteRaw error = %v, want provider failure", err)
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, statePath))); got != `{"oauth":"rotated-before-error"}` {
+		t.Fatalf("state after CLI error = %q", got)
+	}
+}
+
+func TestGeminiStateBridgeProjectsOnlyAuthAndPersistsMutableState(t *testing.T) {
 	sourceHome := t.TempDir()
 	stateDir := filepath.Join(sourceHome, ".gemini")
-	if err := os.Mkdir(stateDir, 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Join(stateDir, "commands"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(
@@ -199,15 +386,56 @@ func TestGeminiStateBridgeExcludesDotEnvButPreservesOAuth(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(stateDir, "oauth_creds.json"), []byte(oauth), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(stateDir, "installation_id"), []byte("old-installation"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const persistentSettings = `{
+  "selectedAuthType": "oauth-personal",
+  "security": {
+    "auth": {
+      "selectedType": "oauth-personal",
+      "useExternal": true
+    }
+  },
+  "mcpServers": {
+    "operator": {
+      "command": "must-not-run"
+    }
+  },
+  "tools": {
+    "discoveryCommand": "must-not-run"
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(stateDir, "settings.json"), []byte(persistentSettings), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "GEMINI.md"), []byte("host instructions"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "commands", "host.toml"), []byte("command"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("HOME", sourceHome)
 
-	stateCapture := filepath.Join(t.TempDir(), "state")
+	settingsCapture := filepath.Join(t.TempDir(), "settings")
 	argsCapture := filepath.Join(t.TempDir(), "args")
 	binDir := t.TempDir()
 	script := "#!/bin/sh\n" +
 		"if [ \"$1\" = \"--help\" ]; then printf '%s\\n' '--include-directories'; exit 0; fi\n" +
-		"if [ -e \"$HOME/.gemini/.env\" ]; then printf dot-env-visible > " + shellQuote(stateCapture) + "; exit 8; fi\n" +
-		"cat \"$HOME/.gemini/oauth_creds.json\" > " + shellQuote(stateCapture) + "\n" +
+		"for blocked in .env GEMINI.md commands extensions policies skills agents; do\n" +
+		"  if [ -e \"$HOME/.gemini/$blocked\" ]; then printf '%s visible\\n' \"$blocked\" >&2; exit 8; fi\n" +
+		"done\n" +
+		"cat \"$HOME/.gemini/settings.json\" > " + shellQuote(settingsCapture) + "\n" +
+		"cat \"$HOME/.gemini/oauth_creds.json\" >/dev/null\n" +
+		"printf '%s\\n' '{\"refresh_token\":\"rotated\"}' > \"$HOME/.gemini/oauth_creds.json.tmp\"\n" +
+		"mv \"$HOME/.gemini/oauth_creds.json.tmp\" \"$HOME/.gemini/oauth_creds.json\"\n" +
+		"printf '%s\\n' '{\"accounts\":[\"new-account\"]}' > \"$HOME/.gemini/google_accounts.json.tmp\"\n" +
+		"mv \"$HOME/.gemini/google_accounts.json.tmp\" \"$HOME/.gemini/google_accounts.json\"\n" +
+		"printf '%s\\n' 'new-installation' > \"$HOME/.gemini/installation_id.tmp\"\n" +
+		"mv \"$HOME/.gemini/installation_id.tmp\" \"$HOME/.gemini/installation_id\"\n" +
+		"printf '%s\\n' '{\"security\":{\"auth\":{\"selectedType\":\"attacker\",\"useExternal\":true}},\"mcpServers\":{\"attacker\":{\"command\":\"run\"}}}' > \"$HOME/.gemini/settings.json.tmp\"\n" +
+		"mv \"$HOME/.gemini/settings.json.tmp\" \"$HOME/.gemini/settings.json\"\n" +
 		"printf '%s\\n' \"$@\" > " + shellQuote(argsCapture) + "\n" +
 		"printf ok\n"
 	if err := os.WriteFile(filepath.Join(binDir, "gemini"), []byte(script), 0o755); err != nil {
@@ -222,8 +450,28 @@ func TestGeminiStateBridgeExcludesDotEnvButPreservesOAuth(t *testing.T) {
 	); err != nil {
 		t.Fatalf("ExecuteRaw: %v", err)
 	}
-	if got := string(mustReadFile(t, stateCapture)); got != oauth {
-		t.Fatalf("Gemini state capture = %q, want OAuth state only", got)
+	projectedSettings := string(mustReadFile(t, settingsCapture))
+	for _, want := range []string{`"selectedAuthType": "oauth-personal"`, `"selectedType": "oauth-personal"`} {
+		if !strings.Contains(projectedSettings, want) {
+			t.Errorf("projected Gemini settings missing %s: %s", want, projectedSettings)
+		}
+	}
+	for _, blocked := range []string{"useExternal", "mcpServers", "discoveryCommand", "must-not-run"} {
+		if strings.Contains(projectedSettings, blocked) {
+			t.Errorf("projected Gemini settings exposed %q: %s", blocked, projectedSettings)
+		}
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, filepath.Join(stateDir, "oauth_creds.json")))); got != `{"refresh_token":"rotated"}` {
+		t.Fatalf("Gemini OAuth rotation = %q", got)
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, filepath.Join(stateDir, "google_accounts.json")))); got != `{"accounts":["new-account"]}` {
+		t.Fatalf("Gemini first-run account state = %q", got)
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, filepath.Join(stateDir, "installation_id")))); got != "new-installation" {
+		t.Fatalf("Gemini installation id rotation = %q", got)
+	}
+	if got := string(mustReadFile(t, filepath.Join(stateDir, "settings.json"))); got != persistentSettings {
+		t.Fatalf("persistent Gemini settings were modified:\n%s", got)
 	}
 	args := strings.Fields(string(mustReadFile(t, argsCapture)))
 	ignoreIndex := indexOf(args, "--ignore-env")
@@ -235,11 +483,50 @@ func TestGeminiStateBridgeExcludesDotEnvButPreservesOAuth(t *testing.T) {
 	}
 }
 
+func TestGeminiReadOnlyOAuthStateKeepsSuccessfulReviewEphemeral(t *testing.T) {
+	sourceHome := t.TempDir()
+	stateDir := filepath.Join(sourceHome, ".gemini")
+	if err := os.Mkdir(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oauthPath := filepath.Join(stateDir, "oauth_creds.json")
+	const original = `{"refresh_token":"read-only"}`
+	if err := os.WriteFile(oauthPath, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(stateDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(stateDir, 0o700) }()
+	t.Setenv("HOME", sourceHome)
+
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' '{\"refresh_token\":\"ephemeral-rotation\"}' > \"$HOME/.gemini/oauth_creds.json.tmp\"\n" +
+		"mv \"$HOME/.gemini/oauth_creds.json.tmp\" \"$HOME/.gemini/oauth_creds.json\"\n" +
+		"printf review-ok\n"
+	if err := os.WriteFile(filepath.Join(binDir, "gemini"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	output, err := executor.New().ExecuteRaw("gemini", "prompt", executor.ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteRaw with read-only Gemini state: %v", err)
+	}
+	if got := strings.TrimSpace(string(output)); got != "review-ok" {
+		t.Fatalf("output = %q, want successful review", got)
+	}
+	if got := string(mustReadFile(t, oauthPath)); got != original {
+		t.Fatalf("read-only OAuth source changed to %q", got)
+	}
+}
+
 func TestExecuteRawAdditionalEnvironmentRequiresSafeExplicitOptIn(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CUSTOM_REGION", "eu-test-1")
 	t.Setenv("SSH_AUTH_SOCK", "/tmp/operator-selected-agent.sock")
-	t.Setenv("HEIMDALLM_AI_CODEX_ENV_ALLOWLIST", " CUSTOM_REGION, SSH_AUTH_SOCK ")
+	t.Setenv("HEIMDALLM_AI_CODEX_ENV_ALLOWLIST", " , CUSTOM_REGION,, SSH_AUTH_SOCK, ")
 
 	envCapture := filepath.Join(t.TempDir(), "environment")
 	binDir := installEnvironmentCLI(t, "codex", envCapture, filepath.Join(t.TempDir(), "home"), "")
@@ -254,6 +541,49 @@ func TestExecuteRawAdditionalEnvironmentRequiresSafeExplicitOptIn(t *testing.T) 
 	}
 	if env["SSH_AUTH_SOCK"] != "/tmp/operator-selected-agent.sock" {
 		t.Errorf("SSH_AUTH_SOCK = %q, want explicit socket", env["SSH_AUTH_SOCK"])
+	}
+}
+
+func TestMissingAllowlistedVariableAndStatePathEmitOperatorVisibleDiagnostics(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HEIMDALLM_AI_CODEX_ENV_ALLOWLIST", "MISSING_SELECTOR")
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(
+		&logs,
+		&slog.HandlerOptions{Level: slog.LevelInfo},
+	)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	binDir := installEnvironmentCLI(
+		t,
+		"codex",
+		filepath.Join(t.TempDir(), "environment"),
+		filepath.Join(t.TempDir(), "home"),
+		"",
+	)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if _, err := executor.New().ExecuteRaw("codex", "prompt", executor.ExecOptions{}); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	if _, err := executor.New().ExecuteRaw("codex", "prompt", executor.ExecOptions{}); err != nil {
+		t.Fatalf("second ExecuteRaw: %v", err)
+	}
+
+	got := logs.String()
+	for _, fragment := range []string{
+		"allowlisted environment variable is not set",
+		"name=MISSING_SELECTOR",
+		"provider state path is absent",
+		filepath.Join(home, ".codex"),
+	} {
+		if !strings.Contains(got, fragment) {
+			t.Errorf("operator-visible logs missing %q:\n%s", fragment, got)
+		}
+	}
+	if count := strings.Count(got, "provider state path is absent"); count != 1 {
+		t.Errorf("state-absence diagnostic count = %d, want deduplicated once:\n%s", count, got)
 	}
 }
 
@@ -293,8 +623,27 @@ func TestExecuteRawRejectsDangerousAdditionalEnvironmentBeforeCLI(t *testing.T) 
 		{name: "Claude nested credential scrub", allowlist: "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"},
 		{name: "OpenCode project config policy", allowlist: "OPENCODE_DISABLE_PROJECT_CONFIG"},
 		{name: "OpenCode pure-mode policy", allowlist: "OPENCODE_PURE"},
+		{name: "OpenCode custom config file", allowlist: "OPENCODE_CONFIG"},
+		{name: "OpenCode inline config", allowlist: "OPENCODE_CONFIG_CONTENT"},
+		{name: "OpenCode executable config directory", allowlist: "OPENCODE_CONFIG_DIR"},
+		{name: "Gemini custom system prompt", allowlist: "GEMINI_SYSTEM_MD"},
+		{name: "Gemini system prompt writer", allowlist: "GEMINI_WRITE_SYSTEM_MD"},
+		{name: "Gemini home relocation", allowlist: "GEMINI_CLI_HOME"},
+		{name: "Gemini IDE command", allowlist: "GEMINI_CLI_IDE_SERVER_STDIO_COMMAND"},
+		{name: "Gemini sandbox command", allowlist: "GEMINI_SANDBOX"},
+		{name: "Gemini sandbox proxy command", allowlist: "GEMINI_SANDBOX_PROXY_COMMAND"},
 		{name: "Git config injection", allowlist: "GIT_CONFIG_COUNT"},
 		{name: "loader injection", allowlist: "LD_PRELOAD"},
+		{name: "JVM agent injection", allowlist: "JAVA_TOOL_OPTIONS"},
+		{name: "legacy JVM option injection", allowlist: "_JAVA_OPTIONS"},
+		{name: "JDK option injection", allowlist: "JDK_JAVA_OPTIONS"},
+		{name: ".NET startup hook", allowlist: "DOTNET_STARTUP_HOOKS"},
+		{name: "GTK module injection", allowlist: "GTK_MODULES"},
+		{name: "GTK 3 module injection", allowlist: "GTK3_MODULES"},
+		{name: "GTK path injection", allowlist: "GTK_PATH"},
+		{name: "GIO module directory", allowlist: "GIO_MODULE_DIR"},
+		{name: "GIO extra modules", allowlist: "GIO_EXTRA_MODULES"},
+		{name: "Python warning import", allowlist: "PYTHONWARNINGS"},
 		{name: "managed home", allowlist: "HOME"},
 		{name: "invalid name", allowlist: "VALID,NOT-VALID"},
 	}
@@ -454,17 +803,35 @@ func TestExecuteRawRedactsCredentialFromCLIError(t *testing.T) {
 	secret := "openai-error-secret-123"
 	proxySecret := "proxy-error-secret-456"
 	optInSecret := "database-error-secret-789"
+	serviceSecret := "service-error-secret-321"
+	const sentryDSN = "https://sentry-public-key@sentry.invalid/42"
+	const publicEndpoint = "https://true@example.invalid"
+	const nonSecret = "eu-error-visible"
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("OPENAI_API_KEY", secret)
 	t.Setenv("HTTPS_PROXY", "https://proxy-user:"+proxySecret+"@example.invalid")
 	t.Setenv("DATABASE_URL", optInSecret)
-	t.Setenv("HEIMDALLM_AI_CODEX_ENV_ALLOWLIST", "DATABASE_URL")
+	t.Setenv("SERVICE_TOKEN", serviceSecret)
+	t.Setenv("SENTRY_DSN", sentryDSN)
+	t.Setenv("PUBLIC_ENDPOINT", publicEndpoint)
+	t.Setenv("TOKENIZER_MODE", "true")
+	t.Setenv("CUSTOM_REGION", nonSecret)
+	t.Setenv(
+		"HEIMDALLM_AI_CODEX_ENV_ALLOWLIST",
+		"DATABASE_URL,SERVICE_TOKEN,SENTRY_DSN,PUBLIC_ENDPOINT,TOKENIZER_MODE,CUSTOM_REGION",
+	)
 	binDir := t.TempDir()
 	script := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$OPENAI_API_KEY\" >&2\n" +
 		"printf '%s\\n' \"$HTTPS_PROXY\" >&2\n" +
 		"printf '%s\\n' '" + proxySecret + "' >&2\n" +
 		"printf '%s\\n' \"$DATABASE_URL\" >&2\n" +
+		"printf '%s\\n' \"$SERVICE_TOKEN\" >&2\n" +
+		"printf '%s\\n' \"$SENTRY_DSN\" >&2\n" +
+		"printf '%s\\n' \"$PUBLIC_ENDPOINT\" >&2\n" +
+		"printf '%s\\n' 'endpoint-user=true' >&2\n" +
+		"printf 'tokenizer=%s\\n' \"$TOKENIZER_MODE\" >&2\n" +
+		"printf 'region=%s\\n' \"$CUSTOM_REGION\" >&2\n" +
 		"exit 7\n"
 	if err := os.WriteFile(filepath.Join(binDir, "codex"), []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake CLI: %v", err)
@@ -475,13 +842,65 @@ func TestExecuteRawRedactsCredentialFromCLIError(t *testing.T) {
 	if err == nil {
 		t.Fatal("ExecuteRaw unexpectedly succeeded")
 	}
-	for _, value := range []string{secret, proxySecret, optInSecret} {
+	for _, value := range []string{
+		secret,
+		proxySecret,
+		optInSecret,
+		serviceSecret,
+		sentryDSN,
+		publicEndpoint,
+	} {
 		if strings.Contains(err.Error(), value) {
 			t.Fatalf("error exposed %q: %v", value, err)
 		}
 	}
 	if !strings.Contains(err.Error(), "[REDACTED]") {
 		t.Fatalf("error did not redact credential: %v", err)
+	}
+	for _, visible := range []string{"endpoint-user=true", "tokenizer=true", "region=" + nonSecret} {
+		if !strings.Contains(err.Error(), visible) {
+			t.Fatalf("error redacted non-secret allowlisted selector %q: %v", visible, err)
+		}
+	}
+}
+
+func TestGeminiErrorRedactsSecretsWithoutCorruptingRuntimeSelectors(t *testing.T) {
+	const secret = "gemini-error-secret-123"
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GEMINI_API_KEY", secret)
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/private/google/credentials.json")
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "operator-project")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+	t.Setenv("GOOGLE_GENAI_USE_VERTEXAI", "true")
+	// Repeating a built-in non-secret selector in the explicit allowlist must
+	// not reclassify it as a secret merely because its name says credentials.
+	t.Setenv("HEIMDALLM_AI_GEMINI_ENV_ALLOWLIST", "GOOGLE_APPLICATION_CREDENTIALS")
+
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"printf '%s|%s|%s|%s|%s\\n' \"$GEMINI_API_KEY\" \"$GOOGLE_APPLICATION_CREDENTIALS\" \"$GOOGLE_CLOUD_PROJECT\" \"$GOOGLE_CLOUD_LOCATION\" \"$GOOGLE_GENAI_USE_VERTEXAI\" >&2\n" +
+		"exit 7\n"
+	if err := os.WriteFile(filepath.Join(binDir, "gemini"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := executor.New().ExecuteRaw("gemini", "prompt", executor.ExecOptions{})
+	if err == nil {
+		t.Fatal("ExecuteRaw unexpectedly succeeded")
+	}
+	if strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("Gemini API key was not redacted: %v", err)
+	}
+	for _, selector := range []string{
+		"/private/google/credentials.json",
+		"operator-project",
+		"us-central1",
+		"true",
+	} {
+		if !strings.Contains(err.Error(), selector) {
+			t.Errorf("Gemini error lost non-secret selector %q: %v", selector, err)
+		}
 	}
 }
 
@@ -526,12 +945,16 @@ func TestExecutorEnvironmentSnapshotDoesNotCrossContaminateConcurrentRuns(t *tes
 func installEnvironmentCLI(t *testing.T, cli, envCapture, homeCapture, body string) string {
 	t.Helper()
 	binDir := t.TempDir()
-	script := "#!/bin/sh\n" +
+	script := "#!/bin/sh\n"
+	if cli == "claude" {
+		script += "if [ \"$1\" = \"--help\" ]; then printf '%s\\n' 'Usage: claude' '  --safe-mode'; exit 0; fi\n"
+	}
+	script +=
 		body +
-		"env > " + shellQuote(envCapture) + "\n" +
-		"printf '%s\\n' \"$HOME\" > " + shellQuote(homeCapture) + "\n" +
-		"touch \"$HOME/execution-was-here\"\n" +
-		"printf '{\"ok\":true}\\n'\n"
+			"env > " + shellQuote(envCapture) + "\n" +
+			"printf '%s\\n' \"$HOME\" > " + shellQuote(homeCapture) + "\n" +
+			"touch \"$HOME/execution-was-here\"\n" +
+			"printf '{\"ok\":true}\\n'\n"
 	if err := os.WriteFile(filepath.Join(binDir, cli), []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake %s CLI: %v", cli, err)
 	}

--- a/daemon/internal/executor/environment_test.go
+++ b/daemon/internal/executor/environment_test.go
@@ -12,10 +12,29 @@ import (
 	"github.com/heimdallm/daemon/internal/executor"
 )
 
-var testProviderCredentials = map[string][]string{
+var testProviderEnvironmentNames = map[string][]string{
 	"claude": {
 		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_AUTH_TOKEN",
+		"ANTHROPIC_BASE_URL",
+		"ANTHROPIC_BEDROCK_BASE_URL",
+		"ANTHROPIC_VERTEX_BASE_URL",
+		"ANTHROPIC_VERTEX_PROJECT_ID",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_BEARER_TOKEN_BEDROCK",
+		"AWS_DEFAULT_REGION",
+		"AWS_REGION",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
 		"CLAUDE_CODE_OAUTH_TOKEN",
+		"CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+		"CLAUDE_CODE_SKIP_VERTEX_AUTH",
+		"CLAUDE_CODE_USE_BEDROCK",
+		"CLAUDE_CODE_USE_VERTEX",
+		"CLOUD_ML_REGION",
+		"GCLOUD_PROJECT",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"GOOGLE_CLOUD_PROJECT",
 	},
 	"codex": {
 		"OPENAI_API_KEY",
@@ -35,8 +54,25 @@ var testProviderCredentials = map[string][]string{
 }
 
 func TestExecuteRawUsesProviderSpecificEnvironment(t *testing.T) {
-	for cli, selectedNames := range testProviderCredentials {
+	allNames := make(map[string]struct{})
+	for _, names := range testProviderEnvironmentNames {
+		for _, name := range names {
+			allNames[name] = struct{}{}
+		}
+	}
+
+	for cli, selectedNames := range testProviderEnvironmentNames {
 		t.Run(cli, func(t *testing.T) {
+			if cli == "claude" {
+				// Enterprise backends have their own conditional matrix below.
+				// This provider-boundary test exercises Claude's direct route.
+				selectedNames = []string{
+					"ANTHROPIC_API_KEY",
+					"ANTHROPIC_AUTH_TOKEN",
+					"ANTHROPIC_BASE_URL",
+					"CLAUDE_CODE_OAUTH_TOKEN",
+				}
+			}
 			originalHome := t.TempDir()
 			t.Setenv("HOME", originalHome)
 			t.Setenv("LANG", "es_ES.UTF-8")
@@ -53,10 +89,14 @@ func TestExecuteRawUsesProviderSpecificEnvironment(t *testing.T) {
 			t.Setenv("OPENCODE_DISABLE_AUTOUPDATE", "true")
 			t.Setenv("OPENCODE_DISABLE_PROJECT_CONFIG", "0")
 			t.Setenv("OPENCODE_PURE", "0")
-			for provider, names := range testProviderCredentials {
-				for _, name := range names {
-					t.Setenv(name, provider+"-"+strings.ToLower(name)+"-secret")
-				}
+			for name := range allNames {
+				t.Setenv(name, "captured-"+strings.ToLower(name)+"-value")
+			}
+			if cli == "claude" {
+				t.Setenv("CLAUDE_CODE_USE_BEDROCK", "")
+				t.Setenv("CLAUDE_CODE_SKIP_BEDROCK_AUTH", "")
+				t.Setenv("CLAUDE_CODE_USE_VERTEX", "")
+				t.Setenv("CLAUDE_CODE_SKIP_VERTEX_AUTH", "")
 			}
 
 			envCapture := filepath.Join(t.TempDir(), "environment")
@@ -69,15 +109,15 @@ func TestExecuteRawUsesProviderSpecificEnvironment(t *testing.T) {
 			}
 
 			env := readEnvironmentCapture(t, envCapture)
-			for provider, names := range testProviderCredentials {
-				for _, name := range names {
-					_, present := env[name]
-					if provider == cli && !present {
-						t.Errorf("%s credential %s was not forwarded", cli, name)
-					}
-					if provider != cli && present {
-						t.Errorf("%s received %s credential %s", cli, provider, name)
-					}
+			selected := make(map[string]struct{}, len(selectedNames))
+			for _, name := range selectedNames {
+				selected[name] = struct{}{}
+			}
+			for name := range allNames {
+				_, want := selected[name]
+				_, present := env[name]
+				if want != present {
+					t.Errorf("%s environment %s presence = %t, want %t", cli, name, present, want)
 				}
 			}
 			for _, name := range []string{
@@ -141,6 +181,113 @@ func TestExecuteRawUsesProviderSpecificEnvironment(t *testing.T) {
 	}
 }
 
+func TestClaudeEnterpriseEnvironmentFollowsSelectedBackend(t *testing.T) {
+	bedrockSelectors := []string{
+		"ANTHROPIC_BEDROCK_BASE_URL",
+		"AWS_DEFAULT_REGION",
+		"AWS_REGION",
+		"CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+		"CLAUDE_CODE_USE_BEDROCK",
+	}
+	bedrockCredentials := []string{
+		"AWS_ACCESS_KEY_ID",
+		"AWS_BEARER_TOKEN_BEDROCK",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+	}
+	vertexSelectors := []string{
+		"ANTHROPIC_VERTEX_BASE_URL",
+		"ANTHROPIC_VERTEX_PROJECT_ID",
+		"CLAUDE_CODE_SKIP_VERTEX_AUTH",
+		"CLAUDE_CODE_USE_VERTEX",
+		"CLOUD_ML_REGION",
+		"GCLOUD_PROJECT",
+		"GOOGLE_CLOUD_PROJECT",
+	}
+	vertexCredentials := []string{"GOOGLE_APPLICATION_CREDENTIALS"}
+	allEnterpriseNames := append(
+		append(append([]string{}, bedrockSelectors...), bedrockCredentials...),
+		append(vertexSelectors, vertexCredentials...)...,
+	)
+
+	tests := []struct {
+		name          string
+		useBedrock    string
+		skipBedrock   string
+		useVertex     string
+		skipVertex    string
+		wantSelectors []string
+		wantSecrets   []string
+	}{
+		{name: "inactive"},
+		{
+			name:          "Bedrock credentials",
+			useBedrock:    "yes",
+			skipBedrock:   "false",
+			wantSelectors: bedrockSelectors,
+			wantSecrets:   bedrockCredentials,
+		},
+		{
+			name:          "Bedrock gateway injects credentials",
+			useBedrock:    "true",
+			skipBedrock:   "on",
+			wantSelectors: bedrockSelectors,
+		},
+		{
+			name:          "Vertex credentials",
+			useVertex:     "on",
+			skipVertex:    "0",
+			wantSelectors: vertexSelectors,
+			wantSecrets:   vertexCredentials,
+		},
+		{
+			name:          "Vertex gateway injects credentials",
+			useVertex:     "1",
+			skipVertex:    "yes",
+			wantSelectors: vertexSelectors,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			for _, name := range allEnterpriseNames {
+				t.Setenv(name, "value-"+strings.ToLower(name))
+			}
+			t.Setenv("CLAUDE_CODE_USE_BEDROCK", tc.useBedrock)
+			t.Setenv("CLAUDE_CODE_SKIP_BEDROCK_AUTH", tc.skipBedrock)
+			t.Setenv("CLAUDE_CODE_USE_VERTEX", tc.useVertex)
+			t.Setenv("CLAUDE_CODE_SKIP_VERTEX_AUTH", tc.skipVertex)
+
+			envCapture := filepath.Join(t.TempDir(), "environment")
+			binDir := installEnvironmentCLI(
+				t,
+				"claude",
+				envCapture,
+				filepath.Join(t.TempDir(), "home"),
+				"",
+			)
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			if _, err := executor.New().ExecuteRaw("claude", "prompt", executor.ExecOptions{}); err != nil {
+				t.Fatalf("ExecuteRaw: %v", err)
+			}
+			env := readEnvironmentCapture(t, envCapture)
+			want := make(map[string]struct{})
+			for _, name := range append(tc.wantSelectors, tc.wantSecrets...) {
+				want[name] = struct{}{}
+			}
+			for _, name := range allEnterpriseNames {
+				_, present := env[name]
+				_, expected := want[name]
+				if present != expected {
+					t.Errorf("%s presence = %t, want %t", name, present, expected)
+				}
+			}
+		})
+	}
+}
+
 func TestExecuteRawBridgesOnlySelectedProviderState(t *testing.T) {
 	statePaths := map[string][]string{
 		"claude":   {".claude/.credentials.json", ".claude.json"},
@@ -149,7 +296,7 @@ func TestExecuteRawBridgesOnlySelectedProviderState(t *testing.T) {
 		"opencode": {".config/opencode", ".local/share/opencode"},
 	}
 
-	for cli := range testProviderCredentials {
+	for cli := range testProviderEnvironmentNames {
 		t.Run(cli, func(t *testing.T) {
 			sourceHome := t.TempDir()
 			t.Setenv("HOME", sourceHome)
@@ -369,6 +516,63 @@ func TestClaudeStateBridgePersistsRotationWhenCLIExitsWithError(t *testing.T) {
 	}
 }
 
+func TestClaudeReadOnlyCredentialStateKeepsSuccessfulReviewEphemeral(t *testing.T) {
+	sourceHome := t.TempDir()
+	claudeDir := filepath.Join(sourceHome, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	credentialsPath := filepath.Join(claudeDir, ".credentials.json")
+	const original = `{"token":"original"}`
+	if err := os.WriteFile(credentialsPath, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(claudeDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(claudeDir, 0o700) }()
+	t.Setenv("HOME", sourceHome)
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(
+		&logs,
+		&slog.HandlerOptions{Level: slog.LevelWarn},
+	)))
+	defer slog.SetDefault(previousLogger)
+
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then printf '%s\\n' 'Usage: claude' '  --safe-mode'; exit 0; fi\n" +
+		"printf '%s\\n' '{\"token\":\"ephemeral-rotation\"}' > \"$HOME/.claude/.credentials.json.tmp\"\n" +
+		"mv \"$HOME/.claude/.credentials.json.tmp\" \"$HOME/.claude/.credentials.json\"\n" +
+		"printf review-ok\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	output, err := executor.New().ExecuteRaw("claude", "prompt", executor.ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteRaw with read-only Claude state: %v", err)
+	}
+	if got := strings.TrimSpace(string(output)); got != "review-ok" {
+		t.Fatalf("output = %q, want successful review", got)
+	}
+	if got := string(mustReadFile(t, credentialsPath)); got != original {
+		t.Fatalf("read-only Claude credentials changed to %q", got)
+	}
+	for _, fragment := range []string{
+		"refreshed state is ephemeral",
+		"cli=claude",
+		credentialsPath,
+	} {
+		if got := logs.String(); !strings.Contains(got, fragment) {
+			t.Errorf("operator warning missing %q:\n%s", fragment, got)
+		}
+	}
+}
+
 func TestGeminiStateBridgeProjectsOnlyAuthAndPersistsMutableState(t *testing.T) {
 	sourceHome := t.TempDir()
 	stateDir := filepath.Join(sourceHome, ".gemini")
@@ -525,11 +729,24 @@ func TestGeminiReadOnlyOAuthStateKeepsSuccessfulReviewEphemeral(t *testing.T) {
 func TestExecuteRawAdditionalEnvironmentRequiresSafeExplicitOptIn(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CUSTOM_REGION", "eu-test-1")
+	t.Setenv("AWS_REGION", "eu-west-1")
+	t.Setenv("Mixed_Case", "case-sensitive-value")
+	t.Setenv("MIXED_CASE", "different-value")
 	t.Setenv("SSH_AUTH_SOCK", "/tmp/operator-selected-agent.sock")
-	t.Setenv("HEIMDALLM_AI_CODEX_ENV_ALLOWLIST", " , CUSTOM_REGION,, SSH_AUTH_SOCK, ")
+	t.Setenv(
+		"HEIMDALLM_AI_CODEX_ENV_ALLOWLIST",
+		" , AWS_REGION,CUSTOM_REGION,, Mixed_Case,ssh_auth_sock,SSH_AUTH_SOCK, ",
+	)
 
 	envCapture := filepath.Join(t.TempDir(), "environment")
-	binDir := installEnvironmentCLI(t, "codex", envCapture, filepath.Join(t.TempDir(), "home"), "")
+	argsCapture := filepath.Join(t.TempDir(), "arguments")
+	binDir := installEnvironmentCLI(
+		t,
+		"codex",
+		envCapture,
+		filepath.Join(t.TempDir(), "home"),
+		"printf '%s\\n' \"$@\" > "+shellQuote(argsCapture)+"\n",
+	)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	if _, err := executor.New().ExecuteRaw("codex", "prompt", executor.ExecOptions{}); err != nil {
@@ -539,8 +756,26 @@ func TestExecuteRawAdditionalEnvironmentRequiresSafeExplicitOptIn(t *testing.T) 
 	if env["CUSTOM_REGION"] != "eu-test-1" {
 		t.Errorf("CUSTOM_REGION = %q, want explicit value", env["CUSTOM_REGION"])
 	}
+	if env["AWS_REGION"] != "eu-west-1" {
+		t.Errorf("AWS_REGION = %q, want explicit non-secret selector", env["AWS_REGION"])
+	}
+	if env["Mixed_Case"] != "case-sensitive-value" {
+		t.Errorf("Mixed_Case = %q, want exact-case value", env["Mixed_Case"])
+	}
+	if _, present := env["MIXED_CASE"]; present {
+		t.Error("case-sensitive extra was unexpectedly uppercased")
+	}
 	if env["SSH_AUTH_SOCK"] != "/tmp/operator-selected-agent.sock" {
 		t.Errorf("SSH_AUTH_SOCK = %q, want explicit socket", env["SSH_AUTH_SOCK"])
+	}
+	if _, present := env["ssh_auth_sock"]; present {
+		t.Error("SSH socket opt-in was not canonicalized")
+	}
+	args := string(mustReadFile(t, argsCapture))
+	for _, fragment := range []string{"SSH_AUTH_SOCK", "/tmp/operator-selected-agent.sock"} {
+		if !strings.Contains(args, fragment) {
+			t.Errorf("Codex nested-tool policy missing %q:\n%s", fragment, args)
+		}
 	}
 }
 
@@ -620,6 +855,7 @@ func TestExecuteRawRejectsDangerousAdditionalEnvironmentBeforeCLI(t *testing.T) 
 	}{
 		{name: "daemon GitHub token", allowlist: "GITHUB_TOKEN"},
 		{name: "other provider token", allowlist: "ANTHROPIC_API_KEY"},
+		{name: "other provider credential file", allowlist: "GOOGLE_APPLICATION_CREDENTIALS"},
 		{name: "Claude nested credential scrub", allowlist: "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"},
 		{name: "OpenCode project config policy", allowlist: "OPENCODE_DISABLE_PROJECT_CONFIG"},
 		{name: "OpenCode pure-mode policy", allowlist: "OPENCODE_PURE"},
@@ -901,6 +1137,114 @@ func TestGeminiErrorRedactsSecretsWithoutCorruptingRuntimeSelectors(t *testing.T
 		if !strings.Contains(err.Error(), selector) {
 			t.Errorf("Gemini error lost non-secret selector %q: %v", selector, err)
 		}
+	}
+}
+
+func TestClaudeEnterpriseErrorRedactsSecretsWithoutCorruptingSelectors(t *testing.T) {
+	directSecrets := map[string]string{
+		"ANTHROPIC_API_KEY":       "anthropic-api-secret-123",
+		"ANTHROPIC_AUTH_TOKEN":    "gateway-auth-secret-456",
+		"CLAUDE_CODE_OAUTH_TOKEN": "claude-oauth-secret-123",
+	}
+	const gatewayURL = "https://gateway-user:embedded-secret@gateway.invalid"
+	tests := []struct {
+		name      string
+		secrets   map[string]string
+		selectors map[string]string
+		visible   []string
+	}{
+		{
+			name: "Bedrock",
+			secrets: map[string]string{
+				"AWS_ACCESS_KEY_ID":        "AKIAREDACTME123456",
+				"AWS_BEARER_TOKEN_BEDROCK": "bedrock-bearer-secret-123",
+				"AWS_SECRET_ACCESS_KEY":    "aws-access-secret-456",
+				"AWS_SESSION_TOKEN":        "aws-session-secret-789",
+			},
+			selectors: map[string]string{
+				"ANTHROPIC_BEDROCK_BASE_URL":    "https://bedrock-gateway.invalid",
+				"AWS_REGION":                    "eu-west-1",
+				"CLAUDE_CODE_SKIP_BEDROCK_AUTH": "false",
+				"CLAUDE_CODE_USE_BEDROCK":       "true",
+			},
+			visible: []string{
+				"https://bedrock-gateway.invalid",
+				"eu-west-1",
+				"CLAUDE_CODE_USE_BEDROCK=true",
+			},
+		},
+		{
+			name: "Vertex",
+			selectors: map[string]string{
+				"ANTHROPIC_VERTEX_BASE_URL":      "https://vertex-gateway.invalid",
+				"ANTHROPIC_VERTEX_PROJECT_ID":    "operator-project",
+				"CLAUDE_CODE_SKIP_VERTEX_AUTH":   "false",
+				"CLAUDE_CODE_USE_VERTEX":         "on",
+				"CLOUD_ML_REGION":                "europe-west1",
+				"GOOGLE_APPLICATION_CREDENTIALS": "/private/google/credentials.json",
+			},
+			visible: []string{
+				"https://vertex-gateway.invalid",
+				"operator-project",
+				"europe-west1",
+				"/private/google/credentials.json",
+				"CLAUDE_CODE_USE_VERTEX=on",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			for name, value := range directSecrets {
+				t.Setenv(name, value)
+			}
+			for name, value := range tc.secrets {
+				t.Setenv(name, value)
+			}
+			t.Setenv("ANTHROPIC_BASE_URL", gatewayURL)
+			for name, value := range tc.selectors {
+				t.Setenv(name, value)
+			}
+
+			binDir := t.TempDir()
+			script := "#!/bin/sh\n" +
+				"if [ \"$1\" = \"--help\" ]; then printf '%s\\n' 'Usage: claude' '  --safe-mode'; exit 0; fi\n" +
+				"env >&2\n" +
+				"exit 7\n"
+			if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			_, err := executor.New().ExecuteRaw("claude", "prompt", executor.ExecOptions{})
+			if err == nil {
+				t.Fatal("ExecuteRaw unexpectedly succeeded")
+			}
+			for name, secret := range directSecrets {
+				if strings.Contains(err.Error(), secret) {
+					t.Errorf("Claude error exposed %s", name)
+				}
+			}
+			for name, secret := range tc.secrets {
+				if strings.Contains(err.Error(), secret) {
+					t.Errorf("Claude error exposed %s", name)
+				}
+			}
+			for _, secret := range []string{"embedded-secret", gatewayURL} {
+				if strings.Contains(err.Error(), secret) {
+					t.Errorf("Claude error exposed base-URL credential %q", secret)
+				}
+			}
+			if !strings.Contains(err.Error(), "[REDACTED]") {
+				t.Fatalf("Claude error did not contain a redaction marker: %v", err)
+			}
+			for _, visible := range tc.visible {
+				if !strings.Contains(err.Error(), visible) {
+					t.Errorf("Claude error lost non-secret selector %q: %v", visible, err)
+				}
+			}
+		})
 	}
 }
 

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -88,12 +88,16 @@ func OptionsForSelectedCLI(primary, selected string, opts ExecOptions) ExecOptio
 	return opts
 }
 
-// Executor runs AI CLI tools for code review.
-type Executor struct{}
+// Executor runs AI CLI tools for code review. The environment snapshot is
+// captured once so an execution can never observe credentials that another
+// goroutine adds to the daemon process later.
+type Executor struct {
+	environment capturedEnvironment
+}
 
 // New creates a new Executor.
 func New() *Executor {
-	return &Executor{}
+	return &Executor{environment: captureEnvironment()}
 }
 
 // Detect returns the first available CLI (primary → fallback).
@@ -971,9 +975,13 @@ func resolveCLIPath(name string) string {
 // Pass name as $1 (positional arg) so it is never shell-interpolated, even
 // though validateCLIName already guarantees it is safe.
 var loginShellLookPath = func(name string) string {
+	env := captureEnvironment().loginProbeEnvironment()
 	for _, shell := range []string{"/bin/zsh", "/bin/bash"} {
-		cmd := exec.Command(shell, "-l", "-c", `which "$1"`, "--", name)
+		ctx, cancel := context.WithTimeout(context.Background(), cliHelpTimeout)
+		cmd := exec.CommandContext(ctx, shell, "-l", "-c", `which "$1"`, "--", name)
+		cmd.Env = env
 		out, err := cmd.Output()
+		cancel()
 		if err == nil {
 			if path := strings.TrimSpace(string(out)); path != "" {
 				return path
@@ -1130,6 +1138,11 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	if err := validateExecutionRequest(cli, opts); err != nil {
 		return nil, err
 	}
+	prepared, err := e.environment.prepare(cli)
+	if err != nil {
+		return nil, err
+	}
+	defer prepared.cleanup()
 
 	timeout := executionTimeout
 	if opts.Timeout > 0 {
@@ -1147,21 +1160,23 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	var workDirFlags []string
 	if opts.WorkDir != "" {
 		workDirFlags = detectWorkDirFlags(cli, cliPath, opts.WorkDir)
+		switch {
+		case cli == "gemini" && len(workDirFlags) == 0:
+			return nil, fmt.Errorf("executor: Gemini CLI must support an include-directory flag for isolated repository analysis")
+		case cli == "opencode" && len(workDirFlags) == 0:
+			return nil, fmt.Errorf("executor: OpenCode CLI must support --pure and run --dir for isolated repository analysis")
+		}
 	}
 
-	args := buildArgs(cli, opts, workDirFlags)
+	args := buildArgs(cli, opts, workDirFlags, prepared.codexToolEnv)
 	cmd := exec.CommandContext(ctx, cliPath, args...)
 	cmd.Stdin = strings.NewReader(prompt)
-
-	// Augment PATH with paths from the login shell so the CLI can find its own
-	// dependencies, without running stdin THROUGH the shell (which would cause
-	// shell startup scripts to consume our prompt).
-	enrichedEnv := enrichEnvWithLoginPath()
-	if enrichedEnv != nil {
-		cmd.Env = enrichedEnv
-	}
+	cmd.Env = prepared.env
+	cmd.Dir = prepared.runDir
 	if opts.WorkDir != "" {
-		cmd.Dir = opts.WorkDir
+		if cli != "gemini" && cli != "opencode" {
+			cmd.Dir = opts.WorkDir
+		}
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -1174,7 +1189,7 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 		if errDetail == "" {
 			errDetail = strings.TrimSpace(stdout.String())
 		}
-		return nil, fmt.Errorf("executor: run %s: %w (output: %s)", cli, err, errDetail)
+		return nil, fmt.Errorf("executor: run %s: %w (output: %s)", cli, err, prepared.redact(errDetail))
 	}
 
 	return stdout.Bytes(), nil
@@ -1203,14 +1218,16 @@ func validateExecutionRequest(cli string, opts ExecOptions) error {
 }
 
 // buildArgs constructs the CLI argument list based on the CLI name and options.
-func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
+func buildArgs(cli string, opts ExecOptions, workDirFlags []string, codexToolEnv map[string]string) []string {
 	var args []string
 
 	switch cli {
 	case "opencode":
-		// opencode uses "run" subcommand; reads prompt from stdin when no
-		// positional message args are given.
-		args = append(args, "run")
+		// OpenCode uses the run subcommand and reads the prompt from stdin
+		// when no positional message is given. Pure mode is a managed global
+		// policy: repository-local plugins are executable code and would
+		// otherwise inherit the selected provider credential.
+		args = append(args, "--pure", "run")
 		if opts.Model != "" {
 			args = append(args, "-m", strings.TrimSpace(opts.Model))
 		}
@@ -1218,6 +1235,15 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
 		// Codex's top-level command is interactive and requires a TTY. The
 		// daemon must use the non-interactive subcommand and feed the prompt on
 		// stdin, otherwise Codex exits with "stdin is not a terminal".
+		//
+		// The CLI itself needs its selected provider credential, but commands
+		// proposed by the model do not. These command-line overrides have the
+		// highest Codex config precedence, so a project .codex/config.toml
+		// cannot restore inheritance or login-shell startup files.
+		args = append(args,
+			"--config", "allow_login_shell=false",
+			"--config", "shell_environment_policy="+codexShellEnvironmentPolicy(codexToolEnv),
+		)
 		if mode := strings.TrimSpace(opts.ApprovalMode); mode != "" {
 			if normalized, err := NormalizeApprovalModeForCLI(cli, mode); err != nil {
 				slog.Warn("buildArgs: ApprovalMode rejected, ignoring", "mode", mode, "err", err)
@@ -1231,6 +1257,14 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
 		}
 	default:
 		// claude, gemini: stdin mode
+		if cli == "gemini" {
+			// Gemini's settings-only ignoreLocalEnv switch deliberately still
+			// loads some .env locations. Force the CLI-level guard as well.
+			// The process CWD is an empty Heimdallm-owned directory, so trust
+			// applies only to that directory; the repository remains an
+			// explicitly included external context.
+			args = append(args, "--ignore-env", "--skip-trust")
+		}
 		if cli == "claude" && len(workDirFlags) > 0 {
 			args = append(args, "-p")
 		} else {
@@ -1294,8 +1328,8 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string) []string {
 
 var (
 	loginPathOnce sync.Once
-	loginPathEnv  []string // os.Environ() + enriched PATH from login shell
-	cliHelpCache  sync.Map // map[string]string, keyed by resolved CLI path
+	loginPath     string
+	cliHelpCache  sync.Map // map[string]string, keyed by path plus help arguments
 )
 
 func detectWorkDirFlags(cli, cliPath, workDir string) []string {
@@ -1317,8 +1351,9 @@ func detectWorkDirFlags(cli, cliPath, workDir string) []string {
 		if cliHelpSupports(cliPath, "--include-directory") {
 			return []string{"--include-directory", workDir}
 		}
-		if cliHelpSupports(cliPath, "--cwd") {
-			return []string{"--cwd", workDir}
+	case "opencode":
+		if cliArgsHelpSupports(cliPath, "--dir", "--pure", "run", "--help") {
+			return []string{"--dir", workDir}
 		}
 	case "codex":
 		if cliHelpSupports(cliPath, "--cd") {
@@ -1332,71 +1367,64 @@ func detectWorkDirFlags(cli, cliPath, workDir string) []string {
 }
 
 func cliHelpSupports(cliPath, flag string) bool {
-	help, ok := cliHelp(cliPath)
+	help, ok := cliHelp(cliPath, "--help")
 	return ok && strings.Contains(help, flag)
 }
 
-func cliHelp(cliPath string) (string, bool) {
-	if cached, ok := cliHelpCache.Load(cliPath); ok {
+func cliArgsHelpSupports(cliPath, flag string, args ...string) bool {
+	help, ok := cliHelp(cliPath, args...)
+	return ok && strings.Contains(help, flag)
+}
+
+func cliHelp(cliPath string, args ...string) (string, bool) {
+	cacheKey := cliPath + "\x00" + strings.Join(args, "\x00")
+	if cached, ok := cliHelpCache.Load(cacheKey); ok {
 		return cached.(string), true
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), cliHelpTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, cliPath, "--help")
-	if env := enrichEnvWithLoginPath(); env != nil {
-		cmd.Env = env
+	prepared, err := captureEnvironment().prepareProbe()
+	if err != nil {
+		slog.Debug("executor: cannot prepare isolated CLI help environment", "cli", cliPath, "err", err)
+		return "", false
 	}
+	defer prepared.cleanup()
+	cmd := exec.CommandContext(ctx, cliPath, args...)
+	cmd.Env = prepared.env
+	cmd.Dir = prepared.runDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		slog.Debug("executor: CLI help unavailable; using cwd-only repo context", "cli", cliPath, "err", err)
+		slog.Debug("executor: CLI help probe unavailable", "cli", cliPath, "args", args, "err", err)
 		return "", false
 	}
 	help := string(out)
-	cliHelpCache.Store(cliPath, help)
+	cliHelpCache.Store(cacheKey, help)
 	return help, true
 }
 
-// enrichEnvWithLoginPath returns the process environment augmented with the PATH
-// from a login shell. Cached after the first call — cheap after startup.
-// Using a login shell ONLY for PATH (not for execution) avoids the stdin
-// consumption bug where shell startup scripts read our prompt.
-func enrichEnvWithLoginPath() []string {
+// enrichedPath returns a de-duplicated absolute PATH containing the daemon's
+// startup PATH and any extra entries discovered from the user's login shell.
+// Only the path string is cached: no credential-bearing environment snapshot
+// survives in package globals or reaches the shell probe.
+func enrichedPath(values map[string]string) string {
 	loginPathOnce.Do(func() {
-		base := os.Environ()
-		// Ask the login shell for its PATH without providing any stdin
-		// (pass /dev/null so startup scripts cannot accidentally consume stdin)
-		cmd := exec.Command("/bin/zsh", "-l", "-c", "echo $PATH")
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		cmd = exec.CommandContext(ctx, "/bin/zsh", "-l", "-c", "echo $PATH")
-		cmd.Stdin, _ = os.Open(os.DevNull)
-		cmd.Stderr = nil
-		out, err := cmd.Output()
-		if err != nil {
-			loginPathEnv = base
-			return
-		}
-		loginShellPath := strings.TrimSpace(string(out))
-		if loginShellPath == "" {
-			loginPathEnv = base
-			return
-		}
-		// Merge: put login shell PATH first so Homebrew bins take precedence
-		currentPath := os.Getenv("PATH")
-		merged := loginShellPath
-		if currentPath != "" {
-			merged = loginShellPath + ":" + currentPath
-		}
-		result := make([]string, 0, len(base)+1)
-		for _, e := range base {
-			if !strings.HasPrefix(e, "PATH=") {
-				result = append(result, e)
+		snapshot := captureEnvironment()
+		for _, shell := range []string{"/bin/zsh", "/bin/bash"} {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			cmd := exec.CommandContext(ctx, shell, "-l", "-c", "printf %s \"$PATH\"")
+			cmd.Env = snapshot.loginProbeEnvironment()
+			cmd.Stdin = strings.NewReader("")
+			out, err := cmd.Output()
+			cancel()
+			if err == nil {
+				loginPath = strings.TrimSpace(string(out))
+				if loginPath != "" {
+					break
+				}
 			}
 		}
-		result = append(result, "PATH="+merged)
-		loginPathEnv = result
 	})
-	return loginPathEnv
+	return sanitizePath(values["PATH"], loginPath)
 }
 
 // StripToJSON strips common LLM output wrappers (leading/trailing whitespace,

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -1131,7 +1132,7 @@ func (e *Executor) Execute(cli, prompt string, opts ExecOptions) (*ReviewResult,
 // that parse a schema other than ReviewResult (issue triage, auto_implement
 // output, etc.). Callers should pass the bytes through StripToJSON before
 // json.Unmarshal — CLIs routinely wrap JSON in code fences or surrounding text.
-func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, error) {
+func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) (output []byte, resultErr error) {
 	// This is the final trust boundary before creating a subprocess. Callers
 	// validate configuration on ingress too, but legacy rows, direct TOML edits,
 	// and future call paths must not be able to bypass the execution policy.
@@ -1142,7 +1143,15 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	if err != nil {
 		return nil, err
 	}
-	defer prepared.cleanup()
+	defer func() {
+		if cleanupErr := prepared.cleanup(); cleanupErr != nil {
+			output = nil
+			resultErr = errors.Join(
+				resultErr,
+				fmt.Errorf("executor: persist %s provider state: %w", cli, cleanupErr),
+			)
+		}
+	}()
 
 	timeout := executionTimeout
 	if opts.Timeout > 0 {
@@ -1156,11 +1165,18 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	if cliPath == "" {
 		cliPath = cli // best effort; execution will fail with a useful error
 	}
+	if cli == "claude" && !cliHelpSupports(cliPath, "--safe-mode") {
+		return nil, fmt.Errorf(
+			"executor: Claude CLI must support --safe-mode for isolated execution (Claude Code 2.1.169 or newer)",
+		)
+	}
 
 	var workDirFlags []string
 	if opts.WorkDir != "" {
 		workDirFlags = detectWorkDirFlags(cli, cliPath, opts.WorkDir)
 		switch {
+		case cli == "claude" && len(workDirFlags) == 0:
+			return nil, fmt.Errorf("executor: Claude CLI must support --add-dir or --directory for isolated repository analysis")
 		case cli == "gemini" && len(workDirFlags) == 0:
 			return nil, fmt.Errorf("executor: Gemini CLI must support an include-directory flag for isolated repository analysis")
 		case cli == "opencode" && len(workDirFlags) == 0:
@@ -1168,13 +1184,16 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 		}
 	}
 
-	args := buildArgs(cli, opts, workDirFlags, prepared.codexToolEnv)
+	args, err := buildArgs(cli, opts, workDirFlags, prepared.codexToolEnv)
+	if err != nil {
+		return nil, err
+	}
 	cmd := exec.CommandContext(ctx, cliPath, args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = prepared.env
 	cmd.Dir = prepared.runDir
 	if opts.WorkDir != "" {
-		if cli != "gemini" && cli != "opencode" {
+		if cli != "claude" && cli != "gemini" && cli != "opencode" {
 			cmd.Dir = opts.WorkDir
 		}
 	}
@@ -1218,7 +1237,7 @@ func validateExecutionRequest(cli string, opts ExecOptions) error {
 }
 
 // buildArgs constructs the CLI argument list based on the CLI name and options.
-func buildArgs(cli string, opts ExecOptions, workDirFlags []string, codexToolEnv map[string]string) []string {
+func buildArgs(cli string, opts ExecOptions, workDirFlags []string, codexToolEnv map[string]string) ([]string, error) {
 	var args []string
 
 	switch cli {
@@ -1232,6 +1251,10 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string, codexToolEnv
 			args = append(args, "-m", strings.TrimSpace(opts.Model))
 		}
 	case "codex":
+		shellPolicy, err := codexShellEnvironmentPolicy(codexToolEnv)
+		if err != nil {
+			return nil, fmt.Errorf("executor: build Codex shell environment policy: %w", err)
+		}
 		// Codex's top-level command is interactive and requires a TTY. The
 		// daemon must use the non-interactive subcommand and feed the prompt on
 		// stdin, otherwise Codex exits with "stdin is not a terminal".
@@ -1242,7 +1265,7 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string, codexToolEnv
 		// cannot restore inheritance or login-shell startup files.
 		args = append(args,
 			"--config", "allow_login_shell=false",
-			"--config", "shell_environment_policy="+codexShellEnvironmentPolicy(codexToolEnv),
+			"--config", "shell_environment_policy="+shellPolicy,
 		)
 		if mode := strings.TrimSpace(opts.ApprovalMode); mode != "" {
 			if normalized, err := NormalizeApprovalModeForCLI(cli, mode); err != nil {
@@ -1257,6 +1280,13 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string, codexToolEnv
 		}
 	default:
 		// claude, gemini: stdin mode
+		if cli == "claude" {
+			// Safe mode is the upstream fail-closed boundary that disables
+			// CLAUDE.md, hooks, plugins, skills, commands, agents, workflows,
+			// output styles and MCP servers while preserving authentication,
+			// model/tool choices and managed policy.
+			args = append(args, "--safe-mode")
+		}
 		if cli == "gemini" {
 			// Gemini's settings-only ignoreLocalEnv switch deliberately still
 			// loads some .env locations. Force the CLI-level guard as well.
@@ -1323,7 +1353,7 @@ func buildArgs(cli string, opts ExecOptions, workDirFlags []string, codexToolEnv
 		args = append(args, "-")
 	}
 
-	return args
+	return args, nil
 }
 
 var (

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -239,7 +239,7 @@ func TestExecuteRawAddsDetectedWorkDirFlags(t *testing.T) {
 		help     string
 		wantFlag string
 	}{
-		{cli: "claude", help: "Usage: claude\n  --add-dir <directories...>\n", wantFlag: "--add-dir"},
+		{cli: "claude", help: "Usage: claude\n  --safe-mode\n  --add-dir <directories...>\n", wantFlag: "--add-dir"},
 		{cli: "gemini", help: "Usage: gemini\n  --include-directories <dirs>\n", wantFlag: "--include-directories"},
 		{cli: "codex", help: "Usage: codex\n  -C, --cd <DIR>\n", wantFlag: "--cd"},
 	}
@@ -275,7 +275,7 @@ func TestExecuteRawAddsDetectedWorkDirFlags(t *testing.T) {
 				t.Fatalf("read captured cwd: %v", err)
 			}
 			capturedCWD := strings.TrimSpace(string(cwdBytes))
-			if tc.cli == "gemini" || tc.cli == "opencode" {
+			if tc.cli == "claude" || tc.cli == "gemini" || tc.cli == "opencode" {
 				if cleanResolvedPath(capturedCWD) == cleanResolvedPath(workDir) {
 					t.Fatalf("%s ran inside the repository instead of its isolated directory", tc.cli)
 				}
@@ -344,11 +344,11 @@ func TestExecuteRawDetectsOpenCodeDirFromRunHelp(t *testing.T) {
 	}
 }
 
-func TestExecuteRawFallsBackToCWDWhenWorkDirFlagUnsupported(t *testing.T) {
+func TestClaudeRepositoryAnalysisRejectsCWDOnlyCLI(t *testing.T) {
 	binDir := t.TempDir()
 	captureArgs := filepath.Join(t.TempDir(), "args.txt")
 	captureCWD := filepath.Join(t.TempDir(), "cwd.txt")
-	script := fakeCLIScript("Usage: claude\n", captureArgs, captureCWD)
+	script := fakeCLIScript("Usage: claude\n  --safe-mode\n", captureArgs, captureCWD)
 	path := filepath.Join(binDir, "claude")
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake CLI: %v", err)
@@ -357,21 +357,36 @@ func TestExecuteRawFallsBackToCWDWhenWorkDirFlagUnsupported(t *testing.T) {
 
 	workDir := t.TempDir()
 	e := executor.New()
-	if _, err := e.ExecuteRaw("claude", "prompt", executor.ExecOptions{WorkDir: workDir}); err != nil {
-		t.Fatalf("ExecuteRaw: %v", err)
+	_, err := e.ExecuteRaw("claude", "prompt", executor.ExecOptions{WorkDir: workDir})
+	if err == nil || !strings.Contains(err.Error(), "must support --add-dir or --directory") {
+		t.Fatalf("ExecuteRaw error = %v, want fail-closed Claude policy error", err)
 	}
-	argsBytes, err := os.ReadFile(captureArgs)
-	if err != nil {
-		t.Fatalf("read captured args: %v", err)
+	if _, statErr := os.Stat(captureArgs); !os.IsNotExist(statErr) {
+		t.Fatalf("Claude executed after unsafe CWD-only detection: %v", statErr)
 	}
-	if strings.Contains(string(argsBytes), workDir) {
-		t.Fatalf("args = %q, workdir should only be passed via cwd when no supported flag is advertised", string(argsBytes))
+	if _, statErr := os.Stat(captureCWD); !os.IsNotExist(statErr) {
+		t.Fatalf("Claude captured a repository cwd after policy rejection: %v", statErr)
 	}
-	cwdBytes, err := os.ReadFile(captureCWD)
-	if err != nil {
-		t.Fatalf("read captured cwd: %v", err)
+}
+
+func TestClaudeExecutionRejectsCLIWithoutSafeMode(t *testing.T) {
+	binDir := t.TempDir()
+	started := filepath.Join(t.TempDir(), "started")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then printf '%s\\n' 'Usage: claude' '  --add-dir <directories...>'; exit 0; fi\n" +
+		"printf started > " + shellQuote(started) + "\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	requireSameDir(t, strings.TrimSpace(string(cwdBytes)), workDir)
+	t.Setenv("PATH", binDir)
+
+	_, err := executor.New().ExecuteRaw("claude", "prompt", executor.ExecOptions{})
+	if err == nil || !strings.Contains(err.Error(), "must support --safe-mode") {
+		t.Fatalf("ExecuteRaw error = %v, want fail-closed safe-mode error", err)
+	}
+	if _, statErr := os.Stat(started); !os.IsNotExist(statErr) {
+		t.Fatalf("Claude executed before safe-mode capability rejection: %v", statErr)
+	}
 }
 
 func TestOpenCodeRepositoryAnalysisRejectsCWDOnlyCLI(t *testing.T) {
@@ -401,6 +416,7 @@ func TestOpenCodeRepositoryAnalysisRejectsCWDOnlyCLI(t *testing.T) {
 func TestExecuteRawCodexUsesExecAndReadsPromptFromStdin(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "codex-parent-secret")
 	t.Setenv("HTTPS_PROXY", "https://proxy-user:proxy-secret@example.invalid")
+	t.Setenv("NO_PROXY", "localhost,.internal.example")
 	binDir := t.TempDir()
 	captureArgs := filepath.Join(t.TempDir(), "args.txt")
 	capturePrompt := filepath.Join(t.TempDir(), "prompt.txt")
@@ -463,6 +479,9 @@ func TestExecuteRawCodexUsesExecAndReadsPromptFromStdin(t *testing.T) {
 	}
 	if !strings.Contains(string(argsBytes), `shell_environment_policy={inherit="none"`) {
 		t.Fatalf("args = %v, want a clean nested-command environment", args)
+	}
+	if !strings.Contains(string(argsBytes), "localhost,.internal.example") {
+		t.Fatalf("args = %v, want non-secret NO_PROXY in nested-command policy", args)
 	}
 	for _, secret := range []string{"codex-parent-secret", "proxy-secret"} {
 		if strings.Contains(string(argsBytes), secret) {

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -274,8 +274,73 @@ func TestExecuteRawAddsDetectedWorkDirFlags(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read captured cwd: %v", err)
 			}
-			requireSameDir(t, strings.TrimSpace(string(cwdBytes)), workDir)
+			capturedCWD := strings.TrimSpace(string(cwdBytes))
+			if tc.cli == "gemini" || tc.cli == "opencode" {
+				if cleanResolvedPath(capturedCWD) == cleanResolvedPath(workDir) {
+					t.Fatalf("%s ran inside the repository instead of its isolated directory", tc.cli)
+				}
+				if _, err := os.Stat(capturedCWD); !os.IsNotExist(err) {
+					t.Fatalf("%s isolated cwd was not removed after execution: %v", tc.cli, err)
+				}
+			} else {
+				requireSameDir(t, capturedCWD, workDir)
+			}
 		})
+	}
+}
+
+func TestExecuteRawDetectsOpenCodeDirFromRunHelp(t *testing.T) {
+	binDir := t.TempDir()
+	captureArgs := filepath.Join(t.TempDir(), "args.txt")
+	captureCWD := filepath.Join(t.TempDir(), "cwd.txt")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  printf '%s\\n' 'Usage: opencode [command]' 'Commands: run'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = \"--pure\" ] && [ \"$2\" = \"run\" ] && [ \"$3\" = \"--help\" ]; then\n" +
+		"  printf '%s\\n' 'Usage: opencode run [message..]' '  --dir <path>'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"printf '%s\\n' \"$*\" > " + shellQuote(captureArgs) + "\n" +
+		"printf '%s\\n' \"$PWD\" > " + shellQuote(captureCWD) + "\n" +
+		"printf '{\"ok\":true}\\n'\n"
+	if err := os.WriteFile(filepath.Join(binDir, "opencode"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake OpenCode: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	workDir := t.TempDir()
+	if _, err := executor.New().ExecuteRaw(
+		"opencode",
+		"prompt",
+		executor.ExecOptions{WorkDir: workDir},
+	); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+
+	argsBytes, err := os.ReadFile(captureArgs)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	args := strings.Fields(string(argsBytes))
+	runIndex := indexOf(args, "run")
+	pureIndex := indexOf(args, "--pure")
+	dirIndex := indexOf(args, "--dir")
+	workDirIndex := indexOf(args, workDir)
+	if pureIndex < 0 || runIndex <= pureIndex || dirIndex <= runIndex || workDirIndex != dirIndex+1 {
+		t.Fatalf("args = %v, want OpenCode --pure run --dir %s", args, workDir)
+	}
+	cwdBytes, err := os.ReadFile(captureCWD)
+	if err != nil {
+		t.Fatalf("read captured cwd: %v", err)
+	}
+	capturedCWD := strings.TrimSpace(string(cwdBytes))
+	if cleanResolvedPath(capturedCWD) == cleanResolvedPath(workDir) {
+		t.Fatal("OpenCode ran inside the repository instead of its isolated directory")
+	}
+	if _, err := os.Stat(capturedCWD); !os.IsNotExist(err) {
+		t.Fatalf("OpenCode isolated cwd was not removed after execution: %v", err)
 	}
 }
 
@@ -309,7 +374,33 @@ func TestExecuteRawFallsBackToCWDWhenWorkDirFlagUnsupported(t *testing.T) {
 	requireSameDir(t, strings.TrimSpace(string(cwdBytes)), workDir)
 }
 
+func TestOpenCodeRepositoryAnalysisRejectsCWDOnlyCLI(t *testing.T) {
+	binDir := t.TempDir()
+	started := filepath.Join(t.TempDir(), "started")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--pure\" ] && [ \"$2\" = \"run\" ] && [ \"$3\" = \"--help\" ]; then printf '%s\\n' 'Usage: opencode run'; exit 0; fi\n" +
+		"printf started > " + shellQuote(started) + "\n"
+	if err := os.WriteFile(filepath.Join(binDir, "opencode"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake OpenCode: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	_, err := executor.New().ExecuteRaw(
+		"opencode",
+		"prompt",
+		executor.ExecOptions{WorkDir: t.TempDir()},
+	)
+	if err == nil || !strings.Contains(err.Error(), "must support --pure and run --dir") {
+		t.Fatalf("ExecuteRaw error = %v, want fail-closed OpenCode policy error", err)
+	}
+	if _, statErr := os.Stat(started); !os.IsNotExist(statErr) {
+		t.Fatalf("OpenCode executed after unsafe CWD-only detection: %v", statErr)
+	}
+}
+
 func TestExecuteRawCodexUsesExecAndReadsPromptFromStdin(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "codex-parent-secret")
+	t.Setenv("HTTPS_PROXY", "https://proxy-user:proxy-secret@example.invalid")
 	binDir := t.TempDir()
 	captureArgs := filepath.Join(t.TempDir(), "args.txt")
 	capturePrompt := filepath.Join(t.TempDir(), "prompt.txt")
@@ -366,6 +457,17 @@ func TestExecuteRawCodexUsesExecAndReadsPromptFromStdin(t *testing.T) {
 	}
 	if strings.Contains(string(argsBytes), "--approval-mode") {
 		t.Fatalf("args = %v, must not use removed --approval-mode flag", args)
+	}
+	if !strings.Contains(string(argsBytes), "allow_login_shell=false") {
+		t.Fatalf("args = %v, want login shells disabled", args)
+	}
+	if !strings.Contains(string(argsBytes), `shell_environment_policy={inherit="none"`) {
+		t.Fatalf("args = %v, want a clean nested-command environment", args)
+	}
+	for _, secret := range []string{"codex-parent-secret", "proxy-secret"} {
+		if strings.Contains(string(argsBytes), secret) {
+			t.Fatalf("args exposed secret %q: %v", secret, args)
+		}
 	}
 	promptBytes, err := os.ReadFile(capturePrompt)
 	if err != nil {
@@ -571,6 +673,10 @@ func indexOf(args []string, target string) int {
 func fakeCLIScript(help, captureArgs, captureCWD string) string {
 	return "#!/bin/sh\n" +
 		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  printf '%s\\n' " + shellQuote(help) + "\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = \"--pure\" ] && [ \"$2\" = \"run\" ] && [ \"$3\" = \"--help\" ]; then\n" +
 		"  printf '%s\\n' " + shellQuote(help) + "\n" +
 		"  exit 0\n" +
 		"fi\n" +
@@ -876,6 +982,7 @@ func TestValidateExtraFlagsForCLIRejectsPolicyAliases(t *testing.T) {
 		{name: "OpenCode command config", cli: "opencode", flags: "--command unsafe"},
 		{name: "OpenCode future permission alias", cli: "opencode", flags: "--permission=allow"},
 		{name: "OpenCode external share", cli: "opencode", flags: "--share"},
+		{name: "OpenCode pure negation", cli: "opencode", flags: "--pure=false"},
 		{name: "OpenCode sandbox negation", cli: "opencode", flags: "--no-sandbox"},
 		{name: "OpenCode resumed session", cli: "opencode", flags: "-sSESSION"},
 		{name: "OpenCode continued session", cli: "opencode", flags: "--continue"},

--- a/daemon/internal/executor/testdata/bin/claude
+++ b/daemon/internal/executor/testdata/bin/claude
@@ -1,5 +1,9 @@
 #!/bin/sh
 # Fake claude CLI — reads stdin, prints review JSON
+if [ "$1" = "--help" ]; then
+  printf '%s\n' 'Usage: claude' '  --safe-mode'
+  exit 0
+fi
 cat <<'EOF'
 {"summary":"Looks good overall","issues":[{"file":"main.go","line":10,"description":"possible nil dereference","severity":"medium"}],"suggestions":["add nil check before use"],"severity":"medium"}
 EOF

--- a/daemon/internal/gitproc/audit.go
+++ b/daemon/internal/gitproc/audit.go
@@ -1,0 +1,360 @@
+package gitproc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const maxGitMetadataFile = 1024 * 1024
+
+// AuditRepository resolves an existing worktree without asking Git to inspect
+// it, then rejects local configuration capable of starting another process or
+// changing where Git obtains objects and configuration. The returned path is
+// canonical so a repository symlink cannot be swapped after the audit.
+func (r *Runner) AuditRepository(ctx context.Context, dir string) (string, error) {
+	worktree, err := canonicalDirectory(dir, "worktree")
+	if err != nil {
+		return "", fmt.Errorf("gitproc: audit repository: %w", err)
+	}
+
+	gitDir, linked, err := resolveGitDir(worktree)
+	if err != nil {
+		return "", fmt.Errorf("gitproc: audit repository: %w", err)
+	}
+	commonDir := gitDir
+	if linked {
+		commonDir, err = resolveLinkedCommonDir(gitDir)
+		if err != nil {
+			return "", fmt.Errorf("gitproc: audit repository: %w", err)
+		}
+		if err := validateLinkedWorktree(worktree, gitDir, commonDir); err != nil {
+			return "", fmt.Errorf("gitproc: audit repository: %w", err)
+		}
+	} else if _, err := os.Lstat(filepath.Join(gitDir, "commondir")); err == nil {
+		return "", errors.New("gitproc: audit repository: main git directory must not contain commondir")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("gitproc: audit repository: inspect commondir: %w", err)
+	}
+
+	configs := []string{filepath.Join(commonDir, "config")}
+	worktreeConfig := filepath.Join(gitDir, "config.worktree")
+	if worktreeConfig != configs[0] {
+		configs = append(configs, worktreeConfig)
+	}
+	for _, path := range configs {
+		if err := r.auditConfigFile(ctx, path); err != nil {
+			return "", fmt.Errorf("gitproc: audit repository: %w", err)
+		}
+	}
+
+	for _, path := range []string{
+		filepath.Join(commonDir, "objects", "info", "alternates"),
+		filepath.Join(gitDir, "objects", "info", "alternates"),
+	} {
+		if err := rejectExistingMetadata(path, "object alternates"); err != nil {
+			return "", fmt.Errorf("gitproc: audit repository: %w", err)
+		}
+	}
+
+	return worktree, nil
+}
+
+func canonicalDirectory(path, name string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("%s path is empty", name)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s path: %w", name, err)
+	}
+	info, err := os.Lstat(abs)
+	if err != nil {
+		return "", fmt.Errorf("inspect %s: %w", name, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("%s must not be a symlink", name)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", name)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize %s: %w", name, err)
+	}
+	return resolved, nil
+}
+
+func resolveGitDir(worktree string) (string, bool, error) {
+	dotGit := filepath.Join(worktree, ".git")
+	info, err := os.Lstat(dotGit)
+	if err != nil {
+		return "", false, fmt.Errorf("inspect .git: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", false, errors.New(".git must not be a symlink")
+	}
+	if info.IsDir() {
+		path, err := canonicalDirectory(dotGit, "git directory")
+		return path, false, err
+	}
+	if !info.Mode().IsRegular() {
+		return "", false, errors.New(".git is neither a directory nor a worktree pointer")
+	}
+
+	data, err := readSmallRegularFile(dotGit)
+	if err != nil {
+		return "", false, fmt.Errorf("read .git worktree pointer: %w", err)
+	}
+	line := strings.TrimSpace(string(data))
+	if strings.ContainsAny(line, "\r\n\x00") || !strings.HasPrefix(line, "gitdir: ") {
+		return "", false, errors.New("invalid .git worktree pointer")
+	}
+	target := strings.TrimSpace(strings.TrimPrefix(line, "gitdir: "))
+	if target == "" {
+		return "", false, errors.New("empty .git worktree pointer")
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(worktree, target)
+	}
+	path, err := canonicalDirectory(target, "git directory")
+	return path, true, err
+}
+
+func resolveLinkedCommonDir(gitDir string) (string, error) {
+	path := filepath.Join(gitDir, "commondir")
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", errors.New("linked worktree git directory has no commondir")
+	}
+	if err != nil {
+		return "", fmt.Errorf("inspect commondir: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return "", errors.New("commondir must be a regular file")
+	}
+	data, err := readSmallRegularFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read commondir: %w", err)
+	}
+	target := strings.TrimSpace(string(data))
+	if target == "" || strings.ContainsAny(target, "\r\n\x00") {
+		return "", errors.New("invalid commondir")
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(gitDir, target)
+	}
+	return canonicalDirectory(target, "common git directory")
+}
+
+func validateLinkedWorktree(worktree, gitDir, commonDir string) error {
+	if gitDir == commonDir {
+		return errors.New("linked worktree git directory equals its common directory")
+	}
+	worktreesDir, err := canonicalDirectory(filepath.Join(commonDir, "worktrees"), "worktrees metadata directory")
+	if err != nil {
+		return err
+	}
+	if filepath.Dir(gitDir) != worktreesDir || filepath.Base(gitDir) == "." {
+		return fmt.Errorf(
+			"linked worktree git directory %q is not a direct child of %q",
+			gitDir,
+			worktreesDir,
+		)
+	}
+
+	backlinkPath := filepath.Join(gitDir, "gitdir")
+	data, err := readSmallRegularFile(backlinkPath)
+	if err != nil {
+		return fmt.Errorf("read linked worktree backlink: %w", err)
+	}
+	backlink := strings.TrimSpace(string(data))
+	if backlink == "" || strings.ContainsAny(backlink, "\r\n\x00") {
+		return errors.New("invalid linked worktree backlink")
+	}
+	if !filepath.IsAbs(backlink) {
+		backlink = filepath.Join(gitDir, backlink)
+	}
+	backlink, err = filepath.EvalSymlinks(filepath.Clean(backlink))
+	if err != nil {
+		return fmt.Errorf("canonicalize linked worktree backlink: %w", err)
+	}
+	expected := filepath.Join(worktree, ".git")
+	expected, err = filepath.EvalSymlinks(expected)
+	if err != nil {
+		return fmt.Errorf("canonicalize worktree .git file: %w", err)
+	}
+	if backlink != expected {
+		return fmt.Errorf(
+			"linked worktree backlink %q does not point to %q",
+			backlink,
+			expected,
+		)
+	}
+	return nil
+}
+
+func (r *Runner) auditConfigFile(ctx context.Context, path string) error {
+	data, err := readSmallRegularFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read Git config %q: %w", path, err)
+	}
+	safeDir, err := os.MkdirTemp("", "heimdallm-git-config-*")
+	if err != nil {
+		return fmt.Errorf("copy Git config %q: %w", path, err)
+	}
+	defer os.RemoveAll(safeDir)
+	if err := os.Chmod(safeDir, 0o700); err != nil {
+		return fmt.Errorf("secure Git config copy directory: %w", err)
+	}
+	safePath := filepath.Join(safeDir, "config")
+	if err := os.WriteFile(safePath, data, 0o600); err != nil {
+		return fmt.Errorf("copy Git config %q: %w", path, err)
+	}
+
+	names, err := r.captureTrusted(
+		ctx,
+		"",
+		false,
+		"config",
+		"--file", safePath,
+		"--null",
+		"--name-only",
+		"--list",
+		"--no-includes",
+	)
+	if err != nil {
+		return fmt.Errorf("parse Git config %q: %w", path, err)
+	}
+	for _, raw := range strings.Split(string(names), "\x00") {
+		key := strings.ToLower(strings.TrimSpace(raw))
+		if key == "" {
+			continue
+		}
+		if unsafeConfigKey(key) {
+			return fmt.Errorf("unsafe local Git config key %q in %q", key, path)
+		}
+	}
+	return nil
+}
+
+func unsafeConfigKey(key string) bool {
+	switch key {
+	case "core.hookspath", "core.fsmonitor", "core.fsmonitorhookversion":
+		// These are common in legitimate developer checkouts and are
+		// unconditionally neutralized by higher-precedence -c options on
+		// every invocation. Rejecting them would make local_dir unusable
+		// without adding any protection beyond the enforced overrides.
+		return false
+	case "core.sshcommand",
+		"core.gitproxy",
+		"core.askpass",
+		"core.editor",
+		"core.pager",
+		"core.attributesfile",
+		"core.worktree",
+		"core.alternaterefscommand",
+		"interactive.difffilter",
+		"sequence.editor",
+		"init.templatedir",
+		"user.signingkey",
+		"commit.gpgsign",
+		"push.gpgsign",
+		"tag.gpgsign",
+		"uploadpack.packobjectshook",
+		"receive.procreceiverefs",
+		"extensions.partialclone":
+		return true
+	}
+
+	for _, prefix := range []string{
+		"include.",
+		"includeif.",
+		"credential.",
+		"filter.",
+		"gpg.",
+		"url.",
+		"pager.",
+		"browser.",
+		"maintenance.",
+		"submodule.",
+	} {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	if key == "include.path" || key == "diff.external" {
+		return true
+	}
+	if strings.HasPrefix(key, "diff.") &&
+		(strings.HasSuffix(key, ".command") || strings.HasSuffix(key, ".textconv")) {
+		return true
+	}
+	if strings.HasPrefix(key, "merge.") && strings.HasSuffix(key, ".driver") {
+		return true
+	}
+	if strings.HasPrefix(key, "remote.") {
+		return strings.HasSuffix(key, ".proxy") ||
+			strings.HasSuffix(key, ".proxyauthmethod") ||
+			strings.HasSuffix(key, ".vcs") ||
+			strings.HasSuffix(key, ".uploadpack") ||
+			strings.HasSuffix(key, ".receivepack") ||
+			strings.HasSuffix(key, ".promisor") ||
+			strings.HasSuffix(key, ".partialclonefilter")
+	}
+	return false
+}
+
+func readSmallRegularFile(path string) ([]byte, error) {
+	before, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
+		return nil, errors.New("metadata is not a regular file")
+	}
+	if before.Size() > maxGitMetadataFile {
+		return nil, fmt.Errorf("metadata exceeds %d bytes", maxGitMetadataFile)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+		return nil, errors.New("metadata changed while being opened")
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxGitMetadataFile+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxGitMetadataFile {
+		return nil, fmt.Errorf("metadata exceeds %d bytes", maxGitMetadataFile)
+	}
+	return data, nil
+}
+
+func rejectExistingMetadata(path, kind string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect %s: %w", kind, err)
+	}
+	if info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.IsDir() {
+		return fmt.Errorf("%s are not allowed (%q)", kind, path)
+	}
+	return fmt.Errorf("unsupported %s metadata (%q)", kind, path)
+}

--- a/daemon/internal/gitproc/runner.go
+++ b/daemon/internal/gitproc/runner.go
@@ -1,0 +1,484 @@
+package gitproc
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	defaultTimeout = 3 * time.Minute
+	maxStderrBytes = 16 * 1024
+)
+
+// Runner is the single subprocess boundary for daemon-owned Git commands.
+// It builds the child environment from scratch, forwarding only an explicit
+// proxy/CA compatibility allowlist. Each invocation gets a fresh, owner-only
+// HOME, XDG config root, temporary directory and empty hooks directory.
+type Runner struct {
+	gitPath string
+	initErr error
+	timeout time.Duration
+}
+
+// New resolves the Git executable once. Resolution happens before any
+// repository-controlled working directory is selected and the resulting
+// absolute path is used for every child process.
+func New() *Runner {
+	path, err := exec.LookPath("git")
+	if err == nil {
+		path, err = filepath.Abs(path)
+	}
+	if err == nil {
+		path, err = filepath.EvalSymlinks(path)
+	}
+	return &Runner{gitPath: path, initErr: err, timeout: defaultTimeout}
+}
+
+// NewWithPath is intended for hermetic tests and packaged deployments that
+// already know the trusted Git binary path.
+func NewWithPath(path string) *Runner {
+	abs, err := filepath.Abs(path)
+	if err == nil {
+		abs, err = filepath.EvalSymlinks(abs)
+	}
+	return &Runner{gitPath: abs, initErr: err, timeout: defaultTimeout}
+}
+
+// Run executes a Git command in an existing repository. Local and worktree
+// configuration is audited before the command starts.
+func (r *Runner) Run(ctx context.Context, dir string, args ...string) error {
+	_, err := r.execute(ctx, request{
+		dir:   dir,
+		args:  args,
+		audit: true,
+	})
+	return err
+}
+
+// Capture is Run with stdout returned to the caller.
+func (r *Runner) Capture(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	return r.execute(ctx, request{
+		dir:   dir,
+		args:  args,
+		audit: true,
+	})
+}
+
+func (r *Runner) runAudited(ctx context.Context, dir string, allowFile bool, args ...string) error {
+	_, err := r.execute(ctx, request{
+		dir:       dir,
+		args:      args,
+		audit:     true,
+		allowFile: allowFile,
+	})
+	return err
+}
+
+type request struct {
+	dir       string
+	args      []string
+	audit     bool
+	allowFile bool
+	token     string
+}
+
+func (r *Runner) runTrusted(ctx context.Context, dir string, allowFile bool, args ...string) error {
+	_, err := r.execute(ctx, request{
+		dir:       dir,
+		args:      args,
+		allowFile: allowFile,
+	})
+	return err
+}
+
+func (r *Runner) captureTrusted(ctx context.Context, dir string, allowFile bool, args ...string) ([]byte, error) {
+	return r.execute(ctx, request{
+		dir:       dir,
+		args:      args,
+		allowFile: allowFile,
+	})
+}
+
+func (r *Runner) runTrustedWithToken(
+	ctx context.Context,
+	dir string,
+	token string,
+	args ...string,
+) error {
+	_, err := r.execute(ctx, request{
+		dir:   dir,
+		args:  args,
+		token: token,
+	})
+	return err
+}
+
+func (r *Runner) execute(ctx context.Context, req request) ([]byte, error) {
+	if r == nil {
+		return nil, errors.New("gitproc: nil runner")
+	}
+	if r.initErr != nil {
+		return nil, fmt.Errorf("gitproc: resolve git executable: %w", r.initErr)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	dir := req.dir
+	safeDirectory := ""
+	if req.audit {
+		if err := validateAuditedArgs(req.args); err != nil {
+			return nil, err
+		}
+		var err error
+		dir, err = r.AuditRepository(ctx, dir)
+		if err != nil {
+			return nil, err
+		}
+		safeDirectory = dir
+	}
+
+	box, err := newSandbox()
+	if err != nil {
+		return nil, err
+	}
+	defer box.cleanup()
+
+	env := box.environment(r.gitPath)
+	if req.token != "" {
+		askpass, err := box.writeAskPass()
+		if err != nil {
+			return nil, err
+		}
+		env = append(env,
+			"GIT_ASKPASS="+askpass,
+			"GIT_ASKPASS_REQUIRE=force",
+			"HEIMDALLM_GIT_TOKEN="+req.token,
+		)
+	}
+	sort.Strings(env)
+
+	args := hardenedArgs(box.hooks, req.allowFile, safeDirectory, req.args)
+	runCtx, cancel := context.WithTimeout(ctx, r.commandTimeout())
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, r.gitPath, args...)
+	if dir == "" {
+		cmd.Dir = box.root
+	} else {
+		cmd.Dir = dir
+	}
+	cmd.Env = env
+
+	var stdout bytes.Buffer
+	stderr := &boundedBuffer{limit: maxStderrBytes}
+	cmd.Stdout = &stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		errText := redact(stderr.String(), req.token)
+		for _, secret := range forwardedEnvironmentSecrets(env) {
+			errText = redact(errText, secret)
+		}
+		if stderr.truncated {
+			errText += "\n... (stderr truncated)"
+		}
+		return nil, fmt.Errorf("%w (stderr: %s)", err, strings.TrimSpace(errText))
+	}
+	return stdout.Bytes(), nil
+}
+
+func validateAuditedArgs(args []string) error {
+	if len(args) == 0 {
+		return errors.New("gitproc: Git command is required")
+	}
+	for index := 0; index < len(args); {
+		arg := args[index]
+		if arg == "-c" {
+			if index+1 >= len(args) {
+				return errors.New("gitproc: missing value for Git -c")
+			}
+			config := args[index+1]
+			key, _, hasValue := strings.Cut(config, "=")
+			key = strings.ToLower(strings.TrimSpace(key))
+			if !hasValue || !allowedAuditedConfigKey(key) {
+				return fmt.Errorf("gitproc: Git config override %q is not allowed", config)
+			}
+			index += 2
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			return fmt.Errorf("gitproc: Git global option %q is not allowed", arg)
+		}
+		// The first non-option is the subcommand. Later arguments are parsed
+		// by that fixed subcommand and cannot override Git's global config.
+		if !allowedAuditedSubcommand(arg) {
+			return fmt.Errorf("gitproc: Git subcommand %q is not allowed", arg)
+		}
+		return nil
+	}
+	return errors.New("gitproc: Git subcommand is required")
+}
+
+func allowedAuditedConfigKey(key string) bool {
+	switch key {
+	case "core.quotepath", "user.name", "user.email":
+		return true
+	default:
+		return false
+	}
+}
+
+func allowedAuditedSubcommand(command string) bool {
+	switch command {
+	case "add",
+		"checkout",
+		"clean",
+		"commit",
+		"diff",
+		"fetch",
+		"log",
+		"remote",
+		"reset",
+		"rev-parse",
+		"status",
+		"worktree":
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *Runner) commandTimeout() time.Duration {
+	if r.timeout <= 0 {
+		return defaultTimeout
+	}
+	return r.timeout
+}
+
+func hardenedArgs(hooksDir string, allowFile bool, safeDirectory string, args []string) []string {
+	safe := []string{
+		"--no-pager",
+		"-c", "core.hooksPath=" + hooksDir,
+		"-c", "core.fsmonitor=false",
+		"-c", "core.attributesFile=" + os.DevNull,
+		"-c", "core.excludesFile=" + os.DevNull,
+		"-c", "core.askPass=",
+		"-c", "core.editor=false",
+		"-c", "sequence.editor=false",
+		"-c", "credential.helper=",
+		"-c", "credential.interactive=never",
+		"-c", "credential.useHttpPath=false",
+		"-c", "commit.gpgSign=false",
+		"-c", "push.gpgSign=false",
+		"-c", "tag.gpgSign=false",
+		"-c", "log.showSignature=false",
+		"-c", "submodule.recurse=false",
+		"-c", "fetch.recurseSubmodules=false",
+		"-c", "push.recurseSubmodules=no",
+		"-c", "gc.auto=0",
+		"-c", "maintenance.auto=false",
+		"-c", "protocol.allow=never",
+		"-c", "protocol.https.allow=always",
+		"-c", "protocol.ssh.allow=never",
+		"-c", "protocol.ext.allow=never",
+		"-c", "core.sshCommand=false",
+	}
+	if safeDirectory != "" {
+		// Linux bind mounts can retain a host UID different from the daemon's
+		// UID. Trust only the canonical worktree that AuditRepository just
+		// accepted; never use safe.directory=* or an unresolved caller path.
+		safe = append(safe, "-c", "safe.directory="+safeDirectory)
+	}
+	if allowFile {
+		safe = append(safe, "-c", "protocol.file.allow=always")
+	} else {
+		safe = append(safe, "-c", "protocol.file.allow=never")
+	}
+	return append(safe, args...)
+}
+
+type sandbox struct {
+	root  string
+	home  string
+	xdg   string
+	tmp   string
+	hooks string
+}
+
+func newSandbox() (*sandbox, error) {
+	root, err := os.MkdirTemp("", "heimdallm-git-*")
+	if err != nil {
+		return nil, fmt.Errorf("gitproc: create sandbox: %w", err)
+	}
+	cleanupOnError := func(cause error) (*sandbox, error) {
+		_ = os.RemoveAll(root)
+		return nil, cause
+	}
+	if err := os.Chmod(root, 0o700); err != nil {
+		return cleanupOnError(fmt.Errorf("gitproc: chmod sandbox: %w", err))
+	}
+	box := &sandbox{
+		root:  root,
+		home:  filepath.Join(root, "home"),
+		xdg:   filepath.Join(root, "xdg"),
+		tmp:   filepath.Join(root, "tmp"),
+		hooks: filepath.Join(root, "hooks"),
+	}
+	for _, dir := range []string{box.home, box.xdg, box.tmp, box.hooks} {
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			return cleanupOnError(fmt.Errorf("gitproc: create sandbox directory: %w", err))
+		}
+	}
+	return box, nil
+}
+
+func (s *sandbox) cleanup() {
+	if s != nil && s.root != "" {
+		_ = os.RemoveAll(s.root)
+	}
+}
+
+func (s *sandbox) environment(gitPath string) []string {
+	var pathEntries []string
+	seen := make(map[string]struct{})
+	for _, entry := range []string{filepath.Dir(gitPath), "/usr/local/bin", "/usr/bin", "/bin"} {
+		if !filepath.IsAbs(entry) {
+			continue
+		}
+		entry = filepath.Clean(entry)
+		if _, exists := seen[entry]; exists {
+			continue
+		}
+		seen[entry] = struct{}{}
+		pathEntries = append(pathEntries, entry)
+	}
+	env := []string{
+		"GCM_INTERACTIVE=never",
+		"GIT_ATTR_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_SYSTEM=" + os.DevNull,
+		"GIT_NO_REPLACE_OBJECTS=1",
+		"GIT_PAGER=cat",
+		"GIT_TERMINAL_PROMPT=0",
+		"HOME=" + s.home,
+		"LANG=C",
+		"LC_ALL=C",
+		"PAGER=cat",
+		"PATH=" + strings.Join(pathEntries, string(os.PathListSeparator)),
+		"TMPDIR=" + s.tmp,
+		"XDG_CONFIG_HOME=" + s.xdg,
+	}
+	// Network and CA settings are an explicit compatibility allowlist for
+	// corporate proxies. No Git-, shell- or language-runtime control
+	// variables are inherited.
+	for _, name := range []string{
+		"ALL_PROXY", "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY",
+		"all_proxy", "https_proxy", "http_proxy", "no_proxy",
+		"CURL_CA_BUNDLE", "SSL_CERT_DIR", "SSL_CERT_FILE",
+	} {
+		if value, ok := os.LookupEnv(name); ok {
+			env = append(env, name+"="+value)
+		}
+	}
+	return env
+}
+
+func (s *sandbox) writeAskPass() (string, error) {
+	path := filepath.Join(s.root, "askpass.sh")
+	const script = `#!/bin/sh
+prompt=$1
+while [ "${prompt% }" != "$prompt" ]; do
+  prompt=${prompt% }
+done
+case "$prompt" in
+  "Password for 'https://x-access-token@github.com':")
+    printf '%s' "$HEIMDALLM_GIT_TOKEN"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		return "", fmt.Errorf("gitproc: write askpass helper: %w", err)
+	}
+	return path, nil
+}
+
+type boundedBuffer struct {
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	original := len(p)
+	remaining := b.limit - b.buf.Len()
+	if remaining > 0 {
+		if len(p) > remaining {
+			p = p[:remaining]
+		}
+		_, _ = b.buf.Write(p)
+	}
+	if original > remaining {
+		b.truncated = true
+	}
+	return original, nil
+}
+
+func (b *boundedBuffer) String() string { return b.buf.String() }
+
+func redact(value, token string) string {
+	if token == "" {
+		return value
+	}
+	forms := []string{
+		token,
+		url.QueryEscape(token),
+		url.PathEscape(token),
+		base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token)),
+	}
+	for _, form := range forms {
+		if form != "" {
+			value = strings.ReplaceAll(value, form, "[REDACTED]")
+		}
+	}
+	return value
+}
+
+func forwardedEnvironmentSecrets(env []string) []string {
+	var secrets []string
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok || value == "" {
+			continue
+		}
+		switch strings.ToUpper(name) {
+		case "ALL_PROXY", "HTTPS_PROXY", "HTTP_PROXY":
+			secrets = append(secrets, value)
+			parsed, err := url.Parse(value)
+			if err != nil || parsed.User == nil {
+				continue
+			}
+			if password, ok := parsed.User.Password(); ok && password != "" {
+				secrets = append(secrets, password)
+			}
+			if userInfo := parsed.User.String(); userInfo != "" {
+				secrets = append(secrets, userInfo)
+			}
+		}
+	}
+	return secrets
+}

--- a/daemon/internal/gitproc/runner_test.go
+++ b/daemon/internal/gitproc/runner_test.go
@@ -1,0 +1,704 @@
+package gitproc
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRunnerBuildsEnvironmentFromScratch(t *testing.T) {
+	script := writeExecutable(t, `#!/bin/sh
+/usr/bin/env
+`)
+	t.Setenv("GIT_DIR", "/attacker/git")
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "core.hooksPath")
+	t.Setenv("GIT_CONFIG_VALUE_0", "/attacker/hooks")
+	t.Setenv("HEIMDALLM_GIT_TOKEN", "parent-token")
+	t.Setenv("LD_PRELOAD", "/attacker/library.so")
+	t.Setenv("PATH", ".:/attacker/bin")
+	t.Setenv("HTTPS_PROXY", "https://proxy.example.invalid")
+	t.Setenv("SSL_CERT_FILE", "/operator/corporate-ca.pem")
+
+	out, err := NewWithPath(script).captureTrusted(context.Background(), "", false, "version")
+	if err != nil {
+		t.Fatalf("captureTrusted: %v", err)
+	}
+	env := parseEnvironment(string(out))
+	for _, key := range []string{
+		"GIT_DIR",
+		"GIT_CONFIG_COUNT",
+		"GIT_CONFIG_KEY_0",
+		"GIT_CONFIG_VALUE_0",
+		"HEIMDALLM_GIT_TOKEN",
+		"LD_PRELOAD",
+	} {
+		if value, found := env[key]; found {
+			t.Fatalf("inherited %s=%q", key, value)
+		}
+	}
+	for _, key := range []string{"HOME", "XDG_CONFIG_HOME", "TMPDIR"} {
+		if !filepath.IsAbs(env[key]) {
+			t.Fatalf("%s = %q, want an absolute sandbox path", key, env[key])
+		}
+	}
+	for _, entry := range filepath.SplitList(env["PATH"]) {
+		if !filepath.IsAbs(entry) {
+			t.Fatalf("PATH contains non-absolute entry %q: %q", entry, env["PATH"])
+		}
+	}
+	if env["GIT_CONFIG_GLOBAL"] != os.DevNull ||
+		env["GIT_CONFIG_SYSTEM"] != os.DevNull ||
+		env["GIT_CONFIG_NOSYSTEM"] != "1" {
+		t.Fatalf("global/system config was not disabled: %#v", env)
+	}
+	if env["HTTPS_PROXY"] != "https://proxy.example.invalid" ||
+		env["SSL_CERT_FILE"] != "/operator/corporate-ca.pem" {
+		t.Fatalf("network/CA allowlist was not forwarded: %#v", env)
+	}
+}
+
+func TestSandboxDirectoriesAreOwnerOnly(t *testing.T) {
+	box, err := newSandbox()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer box.cleanup()
+	for _, path := range []string{box.root, box.home, box.xdg, box.tmp, box.hooks} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o700 {
+			t.Fatalf("%s mode = %o, want 700", path, got)
+		}
+	}
+}
+
+func TestRunnerForcesNonExecutableRepositoryPolicy(t *testing.T) {
+	argsCapture := filepath.Join(t.TempDir(), "args")
+	script := writeExecutable(t, "#!/bin/sh\nprintf '%s\\n' \"$@\" > "+strconv.Quote(argsCapture)+"\n")
+	dir := repositoryWithConfig(t, "")
+
+	if err := NewWithPath(script).Run(context.Background(), dir, "status"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	args := mustRead(t, argsCapture)
+	for _, policy := range []string{
+		"core.fsmonitor=false",
+		"core.attributesFile=" + os.DevNull,
+		"core.excludesFile=" + os.DevNull,
+		"credential.helper=",
+		"log.showSignature=false",
+		"protocol.ssh.allow=never",
+		"protocol.ext.allow=never",
+	} {
+		if !strings.Contains(args, policy+"\n") {
+			t.Errorf("Git args do not force %q:\n%s", policy, args)
+		}
+	}
+	if !strings.Contains(args, "core.hooksPath=") {
+		t.Errorf("Git args do not force an isolated hooks path:\n%s", args)
+	}
+	canonicalDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(args, "safe.directory="+canonicalDir+"\n") {
+		t.Errorf("Git args do not trust only the audited repository path:\n%s", args)
+	}
+}
+
+func TestRunnerAllowsOnlyAuditedRepositoryWithDifferentOwner(t *testing.T) {
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git binary not available")
+	}
+	realGit, err = filepath.Abs(realGit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	initCmd := exec.Command(realGit, "init", "--", dir)
+	initCmd.Env = []string{
+		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_SYSTEM=" + os.DevNull,
+		"HOME=" + t.TempDir(),
+		"PATH=" + os.Getenv("PATH"),
+	}
+	if output, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, output)
+	}
+
+	quotedGit := "'" + strings.ReplaceAll(realGit, "'", "'\"'\"'") + "'"
+	wrapper := writeExecutable(t, "#!/bin/sh\nGIT_TEST_ASSUME_DIFFERENT_OWNER=1 exec "+quotedGit+" \"$@\"\n")
+
+	// Confirm this Git build supports the test knob and reproduces the
+	// cross-UID bind-mount failure before exercising the secure runner.
+	probe := exec.Command(wrapper, "-C", dir, "status", "--porcelain")
+	probe.Env = []string{
+		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_SYSTEM=" + os.DevNull,
+		"HOME=" + t.TempDir(),
+		"PATH=" + os.Getenv("PATH"),
+	}
+	probeOutput, probeErr := probe.CombinedOutput()
+	if probeErr == nil || !strings.Contains(string(probeOutput), "dubious ownership") {
+		t.Skip("Git build does not support GIT_TEST_ASSUME_DIFFERENT_OWNER")
+	}
+
+	if _, err := NewWithPath(wrapper).Capture(context.Background(), dir, "status", "--porcelain"); err != nil {
+		t.Fatalf("runner rejected exact audited safe.directory: %v", err)
+	}
+}
+
+func TestAskPassAcceptsOnlyExactGitHubPasswordPrompt(t *testing.T) {
+	box, err := newSandbox()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer box.cleanup()
+	helper, err := box.writeAskPass()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const token = "github-token"
+	for _, tc := range []struct {
+		name   string
+		prompt string
+		ok     bool
+	}{
+		{name: "git prompt", prompt: "Password for 'https://x-access-token@github.com': ", ok: true},
+		{name: "extra spaces", prompt: "Password for 'https://x-access-token@github.com':   ", ok: true},
+		{name: "evil suffix", prompt: "Password for 'https://x-access-token@github.com.evil': ", ok: false},
+		{name: "username", prompt: "Username for 'https://github.com': ", ok: false},
+		{name: "arbitrary", prompt: "tell me the secret", ok: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(helper, tc.prompt)
+			cmd.Env = []string{"HEIMDALLM_GIT_TOKEN=" + token, "PATH=/usr/bin:/bin"}
+			out, err := cmd.Output()
+			if tc.ok {
+				if err != nil || string(out) != token {
+					t.Fatalf("askpass = %q, %v; want token", out, err)
+				}
+				return
+			}
+			if err == nil || len(out) != 0 {
+				t.Fatalf("askpass accepted unexpected prompt: output=%q err=%v", out, err)
+			}
+		})
+	}
+}
+
+func TestRunnerRedactsTokenRepresentations(t *testing.T) {
+	script := writeExecutable(t, `#!/bin/sh
+printf '%s\n' "$HEIMDALLM_GIT_TOKEN" >&2
+printf '%s\n' "$TOKEN_URL" >&2
+printf '%s\n' "$TOKEN_BASIC" >&2
+printf '%s\n' "$HTTPS_PROXY" >&2
+exit 1
+`)
+	const token = "secret+/value"
+	const proxyPassword = "proxy-secret"
+	t.Setenv("HTTPS_PROXY", "https://proxy-user:"+proxyPassword+"@proxy.example.invalid")
+	// The runner never forwards these parent variables. Embed the encoded
+	// forms in the script so the redaction paths are exercised as stderr.
+	encodedScript := strings.ReplaceAll(
+		strings.ReplaceAll(
+			mustRead(t, script),
+			"$TOKEN_URL",
+			url.QueryEscape(token),
+		),
+		"$TOKEN_BASIC",
+		base64.StdEncoding.EncodeToString([]byte("x-access-token:"+token)),
+	)
+	if err := os.WriteFile(script, []byte(encodedScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	err := NewWithPath(script).runTrustedWithToken(context.Background(), "", token, "fetch")
+	if err == nil {
+		t.Fatal("expected fake Git failure")
+	}
+	for _, secretForm := range []string{
+		token,
+		url.QueryEscape(token),
+		base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token)),
+		proxyPassword,
+		"proxy-user:" + proxyPassword,
+	} {
+		if strings.Contains(err.Error(), secretForm) {
+			t.Fatalf("error leaked token representation %q: %v", secretForm, err)
+		}
+	}
+}
+
+func TestAuditRepositoryRejectsExecutableConfig(t *testing.T) {
+	dir := repositoryWithConfig(t, "[filter \"attacker\"]\n\tclean = /tmp/attacker-filter\n")
+	parser := writeExecutable(t, "#!/bin/sh\nprintf 'filter.attacker.clean\\0'\n")
+
+	_, err := NewWithPath(parser).AuditRepository(context.Background(), dir)
+	if err == nil || !strings.Contains(err.Error(), "filter.attacker.clean") {
+		t.Fatalf("AuditRepository error = %v, want unsafe filter command", err)
+	}
+}
+
+func TestAuditRepositoryAllowsConfigNeutralizedByEveryCommand(t *testing.T) {
+	dir := repositoryWithConfig(t, "[core]\n\thooksPath = /tmp/hooks\n\tfsmonitor = /tmp/fsmonitor\n\tfsmonitorHookVersion = 1\n")
+	parser := writeExecutable(t, "#!/bin/sh\nprintf 'core.hookspath\\0core.fsmonitor\\0core.fsmonitorhookversion\\0'\n")
+
+	got, err := NewWithPath(parser).AuditRepository(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("AuditRepository rejected neutralized config: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("AuditRepository path = %q, want %q", got, want)
+	}
+}
+
+func TestAuditRepositoryRejectsIncludesWithoutFollowingThem(t *testing.T) {
+	dir := repositoryWithConfig(t, "[include]\n\tpath = /tmp/attacker.conf\n")
+	included := filepath.Join(t.TempDir(), "attacker.conf")
+	if err := os.WriteFile(included, []byte("[core]\n\thooksPath = /tmp/attacker\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	parser := writeExecutable(t, "#!/bin/sh\nprintf 'include.path\\0'\n")
+
+	_, err := NewWithPath(parser).AuditRepository(context.Background(), dir)
+	if err == nil || !strings.Contains(err.Error(), "include.path") {
+		t.Fatalf("AuditRepository error = %v, want rejected include.path", err)
+	}
+}
+
+func TestAuditRepositoryRejectsObjectAlternates(t *testing.T) {
+	dir := repositoryWithConfig(t, "")
+	alternates := filepath.Join(dir, ".git", "objects", "info", "alternates")
+	if err := os.WriteFile(alternates, []byte("/tmp/attacker/objects\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	parser := writeExecutable(t, "#!/bin/sh\nexit 0\n")
+
+	_, err := NewWithPath(parser).AuditRepository(context.Background(), dir)
+	if err == nil || !strings.Contains(err.Error(), "alternates") {
+		t.Fatalf("AuditRepository error = %v, want rejected object alternates", err)
+	}
+}
+
+func TestAuditRepositoryAcceptsRealLinkedWorktreeLayout(t *testing.T) {
+	for _, relative := range []bool{false, true} {
+		name := "absolute"
+		if relative {
+			name = "relative"
+		}
+		t.Run(name, func(t *testing.T) {
+			worktree := linkedRepository(t, relative)
+			parser := writeExecutable(t, "#!/bin/sh\nexit 0\n")
+
+			got, err := NewWithPath(parser).AuditRepository(context.Background(), worktree)
+			if err != nil {
+				t.Fatalf("AuditRepository: %v", err)
+			}
+			want, err := filepath.EvalSymlinks(worktree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != want {
+				t.Fatalf("AuditRepository path = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestAuditRepositoryRejectsGitFilePointingAtMainGitDir(t *testing.T) {
+	victim := repositoryWithConfig(t, "")
+	spoof := t.TempDir()
+	pointer := "gitdir: " + filepath.Join(victim, ".git") + "\n"
+	if err := os.WriteFile(filepath.Join(spoof, ".git"), []byte(pointer), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	parser := writeExecutable(t, "#!/bin/sh\nexit 0\n")
+
+	_, err := NewWithPath(parser).AuditRepository(context.Background(), spoof)
+	if err == nil || !strings.Contains(err.Error(), "commondir") {
+		t.Fatalf("AuditRepository error = %v, want spoofed main gitdir rejection", err)
+	}
+}
+
+func TestAuditRepositoryRejectsArbitraryGitDirAndWrongBacklink(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		arbitrary bool
+	}{
+		{name: "outside worktrees metadata", arbitrary: true},
+		{name: "wrong backlink"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			common := filepath.Join(root, "main", ".git")
+			private := filepath.Join(common, "worktrees", "linked")
+			if tc.arbitrary {
+				private = filepath.Join(root, "arbitrary-gitdir")
+			}
+			if err := os.MkdirAll(private, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Join(common, "worktrees"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(common, "config"), nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			relativeCommon, err := filepath.Rel(private, common)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(private, "commondir"), []byte(relativeCommon+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			worktree := filepath.Join(root, "linked")
+			if err := os.MkdirAll(worktree, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(
+				filepath.Join(worktree, ".git"),
+				[]byte("gitdir: "+private+"\n"),
+				0o600,
+			); err != nil {
+				t.Fatal(err)
+			}
+			wrong := filepath.Join(root, "other", ".git")
+			if err := os.MkdirAll(filepath.Dir(wrong), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(wrong, []byte("not the backlink target\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(private, "gitdir"), []byte(wrong+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			parser := writeExecutable(t, "#!/bin/sh\nexit 0\n")
+
+			_, err = NewWithPath(parser).AuditRepository(context.Background(), worktree)
+			if err == nil {
+				t.Fatal("AuditRepository accepted spoofed linked-worktree metadata")
+			}
+			if tc.arbitrary && !strings.Contains(err.Error(), "direct child") {
+				t.Fatalf("AuditRepository error = %v, want arbitrary gitdir rejection", err)
+			}
+			if !tc.arbitrary && !strings.Contains(err.Error(), "does not point") {
+				t.Fatalf("AuditRepository error = %v, want backlink rejection", err)
+			}
+		})
+	}
+}
+
+func TestValidateBranch(t *testing.T) {
+	for _, branch := range []string{"main", "heimdallm/issue-608", "release/v1.2.3"} {
+		if err := ValidateBranch(branch); err != nil {
+			t.Errorf("ValidateBranch(%q): %v", branch, err)
+		}
+	}
+	for _, branch := range []string{
+		"",
+		"-c",
+		"../main",
+		"main..evil",
+		"main@{1}",
+		"main lock",
+		"main:evil",
+		".hidden",
+		"main/.hidden",
+		"main.lock",
+		"main//evil",
+		"main\nother",
+	} {
+		if err := ValidateBranch(branch); err == nil {
+			t.Errorf("ValidateBranch(%q) unexpectedly succeeded", branch)
+		}
+	}
+}
+
+func TestGitHubRemoteIsCanonicalAndCredentialFree(t *testing.T) {
+	remote, err := GitHubRemote("theburrowhub/heimdallm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remote != "https://x-access-token@github.com/theburrowhub/heimdallm.git" {
+		t.Fatalf("remote = %q", remote)
+	}
+	if err := validateRemote(remote); err != nil {
+		t.Fatalf("validateRemote: %v", err)
+	}
+	for _, repo := range []string{
+		"",
+		"owner",
+		"owner/repo/extra",
+		"owner/repo?token=secret",
+		"owner/repo%2Fevil",
+		"-owner/repo",
+	} {
+		if _, err := GitHubRemote(repo); err == nil {
+			t.Errorf("GitHubRemote(%q) unexpectedly succeeded", repo)
+		}
+	}
+	for _, candidate := range []string{
+		"https://x-access-token:secret@github.com/owner/repo.git",
+		"https://x-access-token@github.com.evil/owner/repo.git",
+		"http://x-access-token@github.com/owner/repo.git",
+		"https://x-access-token@github.com/owner/repo.git?x=y",
+	} {
+		if err := validateRemote(candidate); err == nil {
+			t.Errorf("validateRemote(%q) unexpectedly succeeded", candidate)
+		}
+	}
+}
+
+func TestAuditedRunnerRejectsGlobalOverridesAndAliases(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "hooks config", args: []string{"-c", "core.hooksPath=/attacker", "status"}},
+		{name: "compact config", args: []string{"-ccore.fsmonitor=/attacker", "status"}},
+		{name: "config env", args: []string{"--config-env=core.hooksPath=EVIL", "status"}},
+		{name: "git dir", args: []string{"--git-dir=/attacker", "status"}},
+		{name: "working directory", args: []string{"-C", "/attacker", "status"}},
+		{name: "alias subcommand", args: []string{"attacker-alias"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := repositoryWithConfig(t, "")
+			marker := filepath.Join(t.TempDir(), "git-ran")
+			fake := writeExecutable(t, "#!/bin/sh\n: > "+strconv.Quote(marker)+"\n")
+			err := NewWithPath(fake).Run(context.Background(), dir, tc.args...)
+			if err == nil || !strings.Contains(err.Error(), "not allowed") {
+				t.Fatalf("Run(%q) error = %v, want fail-closed rejection", tc.args, err)
+			}
+			if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+				t.Fatalf("Git executed before rejecting %q: %v", tc.args, statErr)
+			}
+		})
+	}
+}
+
+func TestAuthenticatedOperationsNeverRunInCheckout(t *testing.T) {
+	root := t.TempDir()
+	logPath := filepath.Join(root, "calls.log")
+	fake := writeExecutable(t, fmt.Sprintf(`#!/bin/sh
+auth=no
+if [ -n "$HEIMDALLM_GIT_TOKEN" ]; then auth=yes; fi
+{
+  printf 'AUTH=%%s	PWD=%%s	ARGS=' "$auth" "$PWD"
+  printf '%%s ' "$@"
+  printf '\n'
+} >> %s
+case " $* " in
+  *" clone "*)
+    for last do :; done
+    mkdir -p "$last/.git"
+    : > "$last/.git/config"
+    ;;
+  *" rev-parse "*)
+    printf '0123456789012345678901234567890123456789\n'
+    ;;
+esac
+exit 0
+`, strconv.Quote(logPath)))
+	runner := NewWithPath(fake)
+	target := filepath.Join(root, "checkout")
+	remote, err := GitHubRemote("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runner.CloneNoCheckout(context.Background(), remote, target, "secret-token", 1); err != nil {
+		t.Fatalf("CloneNoCheckout: %v", err)
+	}
+	if err := runner.Fetch(
+		context.Background(),
+		target,
+		remote,
+		"main",
+		"secret-token",
+		FetchOptions{Depth: 1},
+	); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if _, err := runner.PushBranch(context.Background(), target, remote, "main", "secret-token"); err != nil {
+		t.Fatalf("PushBranch: %v", err)
+	}
+	if err := runner.DeleteBranch(
+		context.Background(),
+		remote,
+		"main",
+		"0123456789012345678901234567890123456789",
+		"secret-token",
+	); err != nil {
+		t.Fatalf("DeleteBranch: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(mustRead(t, logPath)), "\n")
+	var authenticated int
+	var tokenlessCheckout bool
+	for _, line := range lines {
+		if strings.Contains(line, "secret-token") {
+			t.Fatalf("token appeared in argv/logged command: %s", line)
+		}
+		if strings.HasPrefix(line, "AUTH=yes") {
+			authenticated++
+			if strings.Contains(line, "PWD="+target+"\t") ||
+				strings.Contains(line, "file://"+target) {
+				t.Fatalf("authenticated Git opened or referenced checkout: %s", line)
+			}
+			if strings.Contains(line, " push ") {
+				if !strings.Contains(line, " --no-verify ") {
+					t.Fatalf("authenticated push did not disable pre-push hooks: %s", line)
+				}
+				if !strings.Contains(line, " core.hooksPath=") {
+					t.Fatalf("authenticated push did not force an isolated hooks path: %s", line)
+				}
+			}
+		}
+		if strings.HasPrefix(line, "AUTH=no\tPWD="+target+"\t") &&
+			strings.Contains(line, " checkout ") {
+			tokenlessCheckout = true
+		}
+	}
+	if authenticated != 4 {
+		t.Fatalf("authenticated command count = %d, want clone/fetch/push/delete; calls:\n%s",
+			authenticated, strings.Join(lines, "\n"))
+	}
+	if !tokenlessCheckout {
+		t.Fatalf("clone did not separate authenticated clone from tokenless checkout; calls:\n%s",
+			strings.Join(lines, "\n"))
+	}
+}
+
+func TestCloneNoCheckoutRemovesTargetWhenAuditFails(t *testing.T) {
+	fake := writeExecutable(t, `#!/bin/sh
+case " $* " in
+  *" clone "*)
+    for last do :; done
+    mkdir -p "$last/.git"
+    printf '[filter "attacker"]\n\tclean = /tmp/attacker\n' > "$last/.git/config"
+    ;;
+  *" config "*)
+    printf 'filter.attacker.clean\0'
+    ;;
+esac
+exit 0
+`)
+	target := filepath.Join(t.TempDir(), "partial-clone")
+	remote, err := GitHubRemote("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = NewWithPath(fake).CloneNoCheckout(
+		context.Background(),
+		remote,
+		target,
+		"secret-token",
+		1,
+	)
+	if err == nil || !strings.Contains(err.Error(), "filter.attacker.clean") {
+		t.Fatalf("CloneNoCheckout error = %v, want audit failure", err)
+	}
+	if _, statErr := os.Stat(target); !os.IsNotExist(statErr) {
+		t.Fatalf("partial clone target still exists: %v", statErr)
+	}
+}
+
+func parseEnvironment(output string) map[string]string {
+	env := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	return env
+}
+
+func writeExecutable(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "git")
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func repositoryWithConfig(t *testing.T, config string) string {
+	t.Helper()
+	dir := t.TempDir()
+	info := filepath.Join(dir, ".git", "objects", "info")
+	if err := os.MkdirAll(info, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git", "config"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func linkedRepository(t *testing.T, relative bool) string {
+	t.Helper()
+	root := t.TempDir()
+	common := filepath.Join(root, "main", ".git")
+	private := filepath.Join(common, "worktrees", "linked")
+	worktree := filepath.Join(root, "linked")
+	if err := os.MkdirAll(filepath.Join(private, "objects", "info"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(worktree, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(common, "config"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(private, "commondir"), []byte("../..\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dotGit := filepath.Join(worktree, ".git")
+	pointer := private
+	backlink := dotGit
+	if relative {
+		var err error
+		pointer, err = filepath.Rel(worktree, private)
+		if err != nil {
+			t.Fatal(err)
+		}
+		backlink, err = filepath.Rel(private, dotGit)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(dotGit, []byte("gitdir: "+pointer+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(private, "gitdir"), []byte(backlink+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return worktree
+}

--- a/daemon/internal/gitproc/runner_test.go
+++ b/daemon/internal/gitproc/runner_test.go
@@ -548,6 +548,15 @@ exit 0
 		t.Fatalf("DeleteBranch: %v", err)
 	}
 
+	targetPaths := []string{target}
+	canonicalTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatalf("resolve checkout path: %v", err)
+	}
+	if canonicalTarget != target {
+		targetPaths = append(targetPaths, canonicalTarget)
+	}
+
 	lines := strings.Split(strings.TrimSpace(mustRead(t, logPath)), "\n")
 	var authenticated int
 	var tokenlessCheckout bool
@@ -557,9 +566,11 @@ exit 0
 		}
 		if strings.HasPrefix(line, "AUTH=yes") {
 			authenticated++
-			if strings.Contains(line, "PWD="+target+"\t") ||
-				strings.Contains(line, "file://"+target) {
-				t.Fatalf("authenticated Git opened or referenced checkout: %s", line)
+			for _, targetPath := range targetPaths {
+				if strings.Contains(line, "PWD="+targetPath+"\t") ||
+					strings.Contains(line, "file://"+targetPath) {
+					t.Fatalf("authenticated Git opened or referenced checkout: %s", line)
+				}
 			}
 			if strings.Contains(line, " push ") {
 				if !strings.Contains(line, " --no-verify ") {
@@ -570,9 +581,11 @@ exit 0
 				}
 			}
 		}
-		if strings.HasPrefix(line, "AUTH=no\tPWD="+target+"\t") &&
-			strings.Contains(line, " checkout ") {
-			tokenlessCheckout = true
+		for _, targetPath := range targetPaths {
+			if strings.HasPrefix(line, "AUTH=no\tPWD="+targetPath+"\t") &&
+				strings.Contains(line, " checkout ") {
+				tokenlessCheckout = true
+			}
 		}
 	}
 	if authenticated != 4 {

--- a/daemon/internal/gitproc/transport.go
+++ b/daemon/internal/gitproc/transport.go
@@ -1,0 +1,487 @@
+package gitproc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const transportRef = "refs/heimdallm/transport"
+
+// FetchOptions controls how an authenticated fetch is imported into the
+// checkout. Depth zero fetches complete history. Unshallow upgrades an
+// existing shallow repository and cannot be combined with Depth.
+type FetchOptions struct {
+	Depth     int
+	Unshallow bool
+}
+
+// GitHubRemote constructs the only network endpoint accepted by the
+// authenticated transport. The token is intentionally not part of the URL.
+func GitHubRemote(repo string) (string, error) {
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || !safeRepoComponent(parts[0]) || !safeRepoComponent(parts[1]) {
+		return "", fmt.Errorf("gitproc: invalid GitHub repository %q", repo)
+	}
+	return "https://x-access-token@github.com/" + parts[0] + "/" + parts[1] + ".git", nil
+}
+
+func safeRepoComponent(part string) bool {
+	if part == "" || part == "." || part == ".." || strings.HasPrefix(part, "-") {
+		return false
+	}
+	for _, ch := range part {
+		if (ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '.' || ch == '_' || ch == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// ValidateBranch rejects option injection, revision expressions and refname
+// edge cases before a caller places a branch in an exact refspec.
+func ValidateBranch(branch string) error {
+	if branch == "" || len(branch) > 1024 || branch == "@" ||
+		strings.HasPrefix(branch, "-") ||
+		strings.HasPrefix(branch, "/") ||
+		strings.HasSuffix(branch, "/") ||
+		strings.HasSuffix(branch, ".") ||
+		strings.Contains(branch, "..") ||
+		strings.Contains(branch, "@{") ||
+		strings.Contains(branch, "//") ||
+		strings.ContainsAny(branch, " ~^:?*[\\\x7f") {
+		return fmt.Errorf("gitproc: invalid branch %q", branch)
+	}
+	for _, ch := range branch {
+		if ch < 0x20 {
+			return fmt.Errorf("gitproc: invalid branch %q", branch)
+		}
+	}
+	for _, component := range strings.Split(branch, "/") {
+		if component == "" || strings.HasPrefix(component, ".") || strings.HasSuffix(component, ".lock") {
+			return fmt.Errorf("gitproc: invalid branch %q", branch)
+		}
+	}
+	return nil
+}
+
+func branchRef(branch string) (string, error) {
+	if err := ValidateBranch(branch); err != nil {
+		return "", err
+	}
+	return "refs/heads/" + branch, nil
+}
+
+func validateRemote(remote string) error {
+	parsed, err := url.Parse(remote)
+	if err != nil ||
+		parsed.Scheme != "https" ||
+		parsed.Host != "github.com" ||
+		parsed.User == nil ||
+		parsed.User.Username() != "x-access-token" {
+		return errors.New("gitproc: authenticated remote must be https://x-access-token@github.com/<owner>/<repo>.git")
+	}
+	if _, hasPassword := parsed.User.Password(); hasPassword ||
+		parsed.RawQuery != "" ||
+		parsed.Fragment != "" ||
+		parsed.RawPath != "" {
+		return errors.New("gitproc: authenticated remote contains credentials or unsupported URL data")
+	}
+	path := strings.TrimPrefix(parsed.Path, "/")
+	if !strings.HasSuffix(path, ".git") {
+		return errors.New("gitproc: authenticated remote must end in .git")
+	}
+	expected, err := GitHubRemote(strings.TrimSuffix(path, ".git"))
+	if err != nil || expected != remote {
+		return errors.New("gitproc: authenticated remote is not canonical")
+	}
+	return nil
+}
+
+// Fetch obtains an exact branch or HEAD through a temporary bare repository.
+// The only token-bearing child has a safe cwd and never opens target config;
+// target imports from the bare over file:// in a later tokenless process.
+func (r *Runner) Fetch(
+	ctx context.Context,
+	target string,
+	remote string,
+	ref string,
+	token string,
+	opts FetchOptions,
+) error {
+	if token == "" {
+		return errors.New("gitproc: fetch requires a non-empty token")
+	}
+	if err := validateRemote(remote); err != nil {
+		return err
+	}
+	if opts.Depth < 0 || (opts.Depth > 0 && opts.Unshallow) {
+		return errors.New("gitproc: invalid fetch depth options")
+	}
+	remoteRef := "HEAD"
+	if ref != "HEAD" {
+		var err error
+		remoteRef, err = branchRef(ref)
+		if err != nil {
+			return err
+		}
+	}
+	canonicalTarget, err := r.AuditRepository(ctx, target)
+	if err != nil {
+		return err
+	}
+
+	transport, err := r.newTransport(ctx)
+	if err != nil {
+		return err
+	}
+	defer transport.cleanup()
+
+	authArgs := []string{
+		"--git-dir=" + transport.gitDir,
+		"fetch",
+		"--no-tags",
+		"--no-recurse-submodules",
+		"--no-auto-maintenance",
+		"--force",
+	}
+	if opts.Depth > 0 {
+		authArgs = append(authArgs, "--depth="+strconv.Itoa(opts.Depth))
+	}
+	authArgs = append(authArgs, "--", remote, remoteRef+":"+transportRef)
+	if err := r.runTrustedWithToken(ctx, transport.root, token, authArgs...); err != nil {
+		return fmt.Errorf("gitproc: authenticated fetch: %w", err)
+	}
+
+	expected, err := r.transportRevision(ctx, transport.gitDir)
+	if err != nil {
+		return err
+	}
+	importArgs := []string{
+		"fetch",
+		"--no-tags",
+		"--no-recurse-submodules",
+		"--no-auto-maintenance",
+		"--force",
+	}
+	switch {
+	case opts.Unshallow:
+		importArgs = append(importArgs, "--unshallow")
+	case opts.Depth > 0:
+		importArgs = append(importArgs, "--depth="+strconv.Itoa(opts.Depth), "--update-shallow")
+	}
+	importArgs = append(importArgs, "--", fileRemote(transport.gitDir), transportRef)
+	if err := r.runAudited(ctx, canonicalTarget, true, importArgs...); err != nil {
+		return fmt.Errorf("gitproc: import authenticated fetch: %w", err)
+	}
+	imported, err := r.Capture(ctx, canonicalTarget, "rev-parse", "--verify", "FETCH_HEAD^{commit}")
+	if err != nil {
+		return fmt.Errorf("gitproc: verify imported fetch: %w", err)
+	}
+	if strings.TrimSpace(string(imported)) != expected {
+		return errors.New("gitproc: imported fetch did not match authenticated object ID")
+	}
+	return nil
+}
+
+// CloneNoCheckout authenticates only while Git has a safe cwd and is
+// creating repository metadata from an empty template. Worktree files are
+// materialized later, without the token, after auditing the generated config.
+func (r *Runner) CloneNoCheckout(
+	ctx context.Context,
+	remote string,
+	target string,
+	token string,
+	depth int,
+) (returnErr error) {
+	if token == "" {
+		return errors.New("gitproc: clone requires a non-empty token")
+	}
+	if err := validateRemote(remote); err != nil {
+		return err
+	}
+	if depth < 0 {
+		return errors.New("gitproc: clone depth must not be negative")
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return fmt.Errorf("gitproc: resolve clone target: %w", err)
+	}
+	if absTarget == string(filepath.Separator) {
+		return errors.New("gitproc: refusing root as clone target")
+	}
+	if _, err := os.Lstat(absTarget); !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			return fmt.Errorf("gitproc: clone target %q already exists", absTarget)
+		}
+		return fmt.Errorf("gitproc: inspect clone target: %w", err)
+	}
+	if err := os.Mkdir(absTarget, 0o700); err != nil {
+		return fmt.Errorf("gitproc: create clone target: %w", err)
+	}
+	defer func() {
+		if returnErr == nil {
+			return
+		}
+		if err := os.RemoveAll(absTarget); err != nil {
+			returnErr = errors.Join(
+				returnErr,
+				fmt.Errorf("gitproc: remove partial clone %q: %w", absTarget, err),
+			)
+		}
+	}()
+
+	transport, err := r.newTransport(ctx)
+	if err != nil {
+		return err
+	}
+	defer transport.cleanup()
+	args := []string{
+		"clone",
+		"--no-checkout",
+		"--no-recurse-submodules",
+		"--template=" + transport.template,
+	}
+	if depth > 0 {
+		args = append(args, "--depth="+strconv.Itoa(depth))
+	}
+	args = append(args, "--", remote, absTarget)
+	if err := r.runTrustedWithToken(ctx, transport.root, token, args...); err != nil {
+		return fmt.Errorf("gitproc: authenticated clone: %w", err)
+	}
+	if err := r.Run(ctx, absTarget, "checkout", "--force"); err != nil {
+		return fmt.Errorf("gitproc: tokenless checkout: %w", err)
+	}
+	return nil
+}
+
+// PushBranch copies the exact local branch into a temporary bare repository
+// without a token, verifies the object ID, then authenticates from that bare
+// repository. Repository config and hooks are therefore unavailable to the
+// token-bearing process.
+func (r *Runner) PushBranch(
+	ctx context.Context,
+	target string,
+	remote string,
+	branch string,
+	token string,
+) (string, error) {
+	if token == "" {
+		return "", errors.New("gitproc: push requires a non-empty token")
+	}
+	if err := validateRemote(remote); err != nil {
+		return "", err
+	}
+	ref, err := branchRef(branch)
+	if err != nil {
+		return "", err
+	}
+	canonicalTarget, err := r.AuditRepository(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	expected, err := r.Revision(ctx, canonicalTarget, ref)
+	if err != nil {
+		return "", fmt.Errorf("gitproc: resolve local branch: %w", err)
+	}
+
+	transport, err := r.newTransport(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer transport.cleanup()
+	if err := r.runTrusted(
+		ctx,
+		transport.root,
+		true,
+		"--git-dir="+transport.gitDir,
+		"fetch",
+		"--no-tags",
+		"--no-recurse-submodules",
+		"--no-auto-maintenance",
+		"--force",
+		"--",
+		fileRemote(canonicalTarget),
+		ref+":"+transportRef,
+	); err != nil {
+		return "", fmt.Errorf("gitproc: stage local branch for push: %w", err)
+	}
+	staged, err := r.transportRevision(ctx, transport.gitDir)
+	if err != nil {
+		return "", err
+	}
+	if staged != expected {
+		return "", errors.New("gitproc: staged push did not match local branch object ID")
+	}
+	if err := r.runTrustedWithToken(
+		ctx,
+		transport.root,
+		token,
+		"--git-dir="+transport.gitDir,
+		"push",
+		"--no-verify",
+		"--signed=false",
+		"--recurse-submodules=no",
+		"--",
+		remote,
+		transportRef+":"+ref,
+	); err != nil {
+		return "", fmt.Errorf("gitproc: authenticated push: %w", err)
+	}
+	return expected, nil
+}
+
+// DeleteBranch removes a remote branch only if it still points at expected.
+// This prevents cleanup after a failed PR creation from deleting a branch
+// another actor advanced after Heimdallm's push.
+func (r *Runner) DeleteBranch(
+	ctx context.Context,
+	remote string,
+	branch string,
+	expected string,
+	token string,
+) error {
+	if token == "" {
+		return errors.New("gitproc: delete requires a non-empty token")
+	}
+	if err := validateRemote(remote); err != nil {
+		return err
+	}
+	ref, err := branchRef(branch)
+	if err != nil {
+		return err
+	}
+	if !validObjectID(expected) {
+		return errors.New("gitproc: delete requires a valid expected object ID")
+	}
+	transport, err := r.newTransport(ctx)
+	if err != nil {
+		return err
+	}
+	defer transport.cleanup()
+	if err := r.runTrustedWithToken(
+		ctx,
+		transport.root,
+		token,
+		"--git-dir="+transport.gitDir,
+		"push",
+		"--no-verify",
+		"--signed=false",
+		"--recurse-submodules=no",
+		"--force-with-lease="+ref+":"+expected,
+		"--",
+		remote,
+		":"+ref,
+	); err != nil {
+		return fmt.Errorf("gitproc: authenticated conditional delete: %w", err)
+	}
+	return nil
+}
+
+// Revision resolves a ref to an exact commit ID in an audited repository.
+func (r *Runner) Revision(ctx context.Context, target, ref string) (string, error) {
+	if ref == "" || strings.HasPrefix(ref, "-") || strings.ContainsAny(ref, "\x00\r\n ") {
+		return "", errors.New("gitproc: invalid revision")
+	}
+	out, err := r.Capture(ctx, target, "rev-parse", "--verify", ref+"^{commit}")
+	if err != nil {
+		return "", err
+	}
+	oid := strings.TrimSpace(string(out))
+	if !validObjectID(oid) {
+		return "", errors.New("gitproc: Git returned an invalid object ID")
+	}
+	return oid, nil
+}
+
+func (r *Runner) transportRevision(ctx context.Context, gitDir string) (string, error) {
+	out, err := r.captureTrusted(
+		ctx,
+		"",
+		false,
+		"--git-dir="+gitDir,
+		"rev-parse",
+		"--verify",
+		transportRef+"^{commit}",
+	)
+	if err != nil {
+		return "", fmt.Errorf("gitproc: resolve transport object ID: %w", err)
+	}
+	oid := strings.TrimSpace(string(out))
+	if !validObjectID(oid) {
+		return "", errors.New("gitproc: transport returned an invalid object ID")
+	}
+	return oid, nil
+}
+
+func validObjectID(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	for _, ch := range value {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') && (ch < 'A' || ch > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+type tempTransport struct {
+	root     string
+	gitDir   string
+	template string
+}
+
+func (r *Runner) newTransport(ctx context.Context) (*tempTransport, error) {
+	root, err := os.MkdirTemp("", "heimdallm-git-transport-*")
+	if err != nil {
+		return nil, fmt.Errorf("gitproc: create transport: %w", err)
+	}
+	cleanupOnError := func(cause error) (*tempTransport, error) {
+		_ = os.RemoveAll(root)
+		return nil, cause
+	}
+	if err := os.Chmod(root, 0o700); err != nil {
+		return cleanupOnError(fmt.Errorf("gitproc: chmod transport: %w", err))
+	}
+	transport := &tempTransport{
+		root:     root,
+		gitDir:   filepath.Join(root, "repo.git"),
+		template: filepath.Join(root, "template"),
+	}
+	if err := os.Mkdir(transport.template, 0o700); err != nil {
+		return cleanupOnError(fmt.Errorf("gitproc: create empty template: %w", err))
+	}
+	if err := r.runTrusted(
+		ctx,
+		root,
+		false,
+		"init",
+		"--bare",
+		"--template="+transport.template,
+		"--",
+		transport.gitDir,
+	); err != nil {
+		return cleanupOnError(fmt.Errorf("gitproc: init transport: %w", err))
+	}
+	return transport, nil
+}
+
+func (t *tempTransport) cleanup() {
+	if t != nil && t.root != "" {
+		_ = os.RemoveAll(t.root)
+	}
+}
+
+func fileRemote(path string) string {
+	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(path)}).String()
+}

--- a/daemon/internal/issues/gitops.go
+++ b/daemon/internal/issues/gitops.go
@@ -1,22 +1,15 @@
 package issues
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
-)
 
-// gitTimeout caps each `git` invocation so a hung network or huge fetch
-// cannot stall the pipeline indefinitely. Three minutes is generous for
-// fetch/push on a typical repo and still short enough to unblock operators.
-// Callers may tighten this per-call via the context they pass in.
-const gitTimeout = 3 * time.Minute
+	"github.com/heimdallm/daemon/internal/gitproc"
+)
 
 // CommitAuthorName / CommitAuthorEmail identify the daemon in the commits it
 // makes on behalf of the auto_implement pipeline. Using a clearly-synthetic
@@ -25,12 +18,6 @@ const (
 	CommitAuthorName  = "Heimdallm"
 	CommitAuthorEmail = "noreply@heimdallm.local"
 )
-
-// maxGitStderrBytes caps the amount of stderr we keep in memory for error
-// messages. Git can dump huge merge-conflict reports or verbose network
-// traces; keeping all of it would let a single bad repo push the daemon
-// toward OOM.
-const maxGitStderrBytes = 16 * 1024 // 16 KiB
 
 // managedCloneMarkerFile is written by repoctx into Heimdallm-managed clones.
 // It is operational metadata, not implementation output, so auto_implement
@@ -68,13 +55,22 @@ type GitOps interface {
 	Diff(ctx context.Context, dir, base string) (string, error)
 }
 
-// GitExec is the default GitOps implementation — shells out to the `git`
-// binary. The daemon assumes git is available in PATH; the first command
-// that runs returns a descriptive error if it is not.
-type GitExec struct{}
+// GitExec is the default GitOps implementation. All subprocesses pass through
+// gitproc so repository config, hooks and inherited environment cannot affect
+// daemon-owned Git operations.
+type GitExec struct {
+	runner *gitproc.Runner
+}
 
 // NewGitExec returns a ready-to-use GitExec. Zero configuration required.
-func NewGitExec() *GitExec { return &GitExec{} }
+func NewGitExec() *GitExec { return &GitExec{runner: gitproc.New()} }
+
+func (g *GitExec) proc() *gitproc.Runner {
+	if g == nil || g.runner == nil {
+		return gitproc.New()
+	}
+	return g.runner
+}
 
 // CheckoutNewBranch fetches the base branch via HTTPS (using the same
 // GIT_ASKPASS mechanism as Push) and creates (or resets) the work branch
@@ -88,18 +84,18 @@ func (g *GitExec) CheckoutNewBranch(ctx context.Context, dir, repo, branch, base
 	if token == "" {
 		return fmt.Errorf("gitops: checkout requires a non-empty token")
 	}
-	env, cleanup, err := buildAskPassEnv(token)
-	if err != nil {
-		return fmt.Errorf("gitops: setup askpass for fetch: %w", err)
+	if err := gitproc.ValidateBranch(branch); err != nil {
+		return fmt.Errorf("gitops: checkout branch: %w", err)
 	}
-	defer cleanup()
-
-	url := fmt.Sprintf("https://x-access-token@github.com/%s.git", repo)
-	if err := runGit(ctx, dir, env, "fetch", url, baseBranch); err != nil {
+	remote, err := gitproc.GitHubRemote(repo)
+	if err != nil {
+		return fmt.Errorf("gitops: remote: %w", err)
+	}
+	if err := g.proc().Fetch(ctx, dir, remote, baseBranch, token, gitproc.FetchOptions{}); err != nil {
 		return fmt.Errorf("gitops: fetch %s/%s: %w", repo, baseBranch, err)
 	}
 	// FETCH_HEAD points to the tip of what we just fetched.
-	if err := runGit(ctx, dir, nil, "checkout", "-B", branch, "FETCH_HEAD"); err != nil {
+	if err := g.proc().Run(ctx, dir, "checkout", "-B", branch, "FETCH_HEAD"); err != nil {
 		return fmt.Errorf("gitops: checkout -B %s: %w", branch, err)
 	}
 	return nil
@@ -109,7 +105,16 @@ func (g *GitExec) CheckoutNewBranch(ctx context.Context, dir, repo, branch, base
 // non-empty line means there is a modified, added, deleted, or untracked
 // file to commit.
 func (g *GitExec) HasChanges(ctx context.Context, dir string) (bool, error) {
-	out, err := captureGit(ctx, dir, nil, "status", "--porcelain", "--", ".", ":(exclude)"+managedCloneMarkerFile)
+	out, err := g.proc().Capture(
+		ctx,
+		dir,
+		"status",
+		"--porcelain",
+		"--untracked-files=all",
+		"--",
+		".",
+		":(exclude)"+managedCloneMarkerFile,
+	)
 	if err != nil {
 		return false, fmt.Errorf("gitops: status: %w", err)
 	}
@@ -199,14 +204,25 @@ func matchesSensitivePattern(path string) (string, bool) {
 // worktree to exfiltrate them via the PR, the commit is refused and
 // the index is reset so a retry from scratch is not poisoned.
 func (g *GitExec) CommitAll(ctx context.Context, dir, message string) error {
-	if err := runGit(ctx, dir, nil, "add", "-A", "--", ".", ":(exclude)"+managedCloneMarkerFile); err != nil {
+	if err := g.proc().Run(ctx, dir, "add", "-A", "--", ".", ":(exclude)"+managedCloneMarkerFile); err != nil {
 		return fmt.Errorf("gitops: add: %w", err)
 	}
 	// `-z` + NUL split: defeats core.quotepath=on (the git default)
 	// which would escape non-ASCII paths like `weird\303\251.pem` and
 	// make filepath.Match miss them. `-c core.quotepath=off` is
 	// redundant when -z is used but kept as belt-and-suspenders.
-	staged, err := captureGit(ctx, dir, nil, "-c", "core.quotepath=off", "diff", "--cached", "--name-only", "-z")
+	staged, err := g.proc().Capture(
+		ctx,
+		dir,
+		"-c", "core.quotepath=off",
+		"diff",
+		"--cached",
+		"--no-ext-diff",
+		"--no-textconv",
+		"--name-only",
+		"-z",
+		"--",
+	)
 	if err != nil {
 		return fmt.Errorf("gitops: list staged: %w", err)
 	}
@@ -241,7 +257,7 @@ func (g *GitExec) CommitAll(ctx context.Context, dir, message string) error {
 		// legitimate edits) stays intact for triage. Cleanup errors
 		// are surfaced via slog so a stuck worktree (read-only FS,
 		// missing perms) is diagnosable.
-		if resetErr := runGit(ctx, dir, nil, "reset", "--", "."); resetErr != nil {
+		if resetErr := g.proc().Run(ctx, dir, "reset", "--", "."); resetErr != nil {
 			slog.Error("gitops: failed to reset index after denylist hit", "err", resetErr)
 		}
 		for _, p := range refused {
@@ -253,19 +269,18 @@ func (g *GitExec) CommitAll(ctx context.Context, dir, message string) error {
 		return fmt.Errorf("gitops: refusing commit — staged %d file(s) matched sensitive-path denylist (e.g. %q); prompt-injection defense aborted the auto-implement run",
 			len(refused), refused[0])
 	}
-	if err := runGit(ctx, dir, nil,
+	if err := g.proc().Run(ctx, dir,
 		"-c", "user.name="+CommitAuthorName,
 		"-c", "user.email="+CommitAuthorEmail,
-		"commit", "-m", message,
+		"commit", "--no-verify", "-m", message,
 	); err != nil {
 		return fmt.Errorf("gitops: commit: %w", err)
 	}
 	return nil
 }
 
-// Push uploads the branch to origin. The token is handed to git via
-// GIT_ASKPASS: we write a tiny executable that echoes the token, set the
-// env var, and let git call it when it needs the password.
+// Push uploads the branch through gitproc's temporary bare transport. The
+// token is handed only to that transport's Git process via GIT_ASKPASS.
 //
 // This keeps the token out of:
 //   - argv (no token in `git push https://…@github.com/…` → invisible to
@@ -274,42 +289,40 @@ func (g *GitExec) CommitAll(ctx context.Context, dir, message string) error {
 //   - the error message path (git's stderr only ever sees an opaque
 //     "Password for 'https://x-access-token@github.com'" prompt).
 //
-// The helper file is written with 0700 perms in an owner-only temp dir and
-// removed on function exit.
+// The helper and transport live in owner-only temporary directories and are
+// removed when the operation returns.
 func (g *GitExec) Push(ctx context.Context, dir, repo, branch, token string) error {
 	if token == "" {
 		return fmt.Errorf("gitops: push requires a non-empty token")
 	}
-	env, cleanup, err := buildAskPassEnv(token)
+	remote, err := gitproc.GitHubRemote(repo)
 	if err != nil {
-		return fmt.Errorf("gitops: setup askpass: %w", err)
+		return fmt.Errorf("gitops: remote: %w", err)
 	}
-	defer cleanup()
-
-	url := fmt.Sprintf("https://x-access-token@github.com/%s.git", repo)
-	refspec := branch + ":" + branch
-	if err := runGit(ctx, dir, env, "push", url, refspec); err != nil {
+	if _, err := g.proc().PushBranch(ctx, dir, remote, branch, token); err != nil {
 		return fmt.Errorf("gitops: push %s:%s: %w", repo, branch, err)
 	}
 	return nil
 }
 
-// DeleteRemoteBranch drops the named branch from origin. Runs through the
-// same GIT_ASKPASS path as Push so the token stays off argv.
+// DeleteRemoteBranch drops the named branch only if it still points at the
+// local object that Push uploaded. It uses the same isolated transport as Push.
 func (g *GitExec) DeleteRemoteBranch(ctx context.Context, dir, repo, branch, token string) error {
 	if token == "" {
 		return fmt.Errorf("gitops: delete remote requires a non-empty token")
 	}
-	env, cleanup, err := buildAskPassEnv(token)
-	if err != nil {
-		return fmt.Errorf("gitops: setup askpass: %w", err)
+	if err := gitproc.ValidateBranch(branch); err != nil {
+		return fmt.Errorf("gitops: delete remote branch: %w", err)
 	}
-	defer cleanup()
-
-	url := fmt.Sprintf("https://x-access-token@github.com/%s.git", repo)
-	// `:<branch>` is the standard "delete the remote branch" refspec.
-	refspec := ":" + branch
-	if err := runGit(ctx, dir, env, "push", url, refspec); err != nil {
+	remote, err := gitproc.GitHubRemote(repo)
+	if err != nil {
+		return fmt.Errorf("gitops: remote: %w", err)
+	}
+	expected, err := g.proc().Revision(ctx, dir, "refs/heads/"+branch)
+	if err != nil {
+		return fmt.Errorf("gitops: resolve pushed branch %s: %w", branch, err)
+	}
+	if err := g.proc().DeleteBranch(ctx, remote, branch, expected, token); err != nil {
 		return fmt.Errorf("gitops: delete remote %s:%s: %w", repo, branch, err)
 	}
 	return nil
@@ -317,79 +330,23 @@ func (g *GitExec) DeleteRemoteBranch(ctx context.Context, dir, repo, branch, tok
 
 // Diff returns the unified diff between base and HEAD.
 func (g *GitExec) Diff(ctx context.Context, dir, base string) (string, error) {
-	out, err := captureGit(ctx, dir, nil, "diff", base+"..HEAD")
+	baseOID, err := g.proc().Revision(ctx, dir, base)
+	if err != nil {
+		return "", fmt.Errorf("gitops: resolve diff base %s: %w", base, err)
+	}
+	out, err := g.proc().Capture(ctx, dir, "diff", "--no-ext-diff", "--no-textconv", baseOID+"..HEAD", "--")
 	if err != nil {
 		return "", fmt.Errorf("gitops: diff %s..HEAD: %w", base, err)
 	}
 	return string(out), nil
 }
 
-// buildAskPassEnv writes a small helper script that echoes the token, and
-// returns an env slice that points GIT_ASKPASS at it. The returned cleanup
-// function must be called (via defer) to remove the temp dir.
-//
-// Using a temp directory — not just a temp file — means the helper script's
-// parent is owner-only too, so even momentarily the file is not world-
-// readable.
-func buildAskPassEnv(token string) ([]string, func(), error) {
-	dir, err := os.MkdirTemp("", "heimdallm-askpass-*")
-	if err != nil {
-		return nil, nil, fmt.Errorf("create askpass dir: %w", err)
-	}
-	if err := os.Chmod(dir, 0o700); err != nil {
-		os.RemoveAll(dir)
-		return nil, nil, fmt.Errorf("chmod askpass dir: %w", err)
-	}
-
-	helperPath := filepath.Join(dir, "askpass.sh")
-	// The script simply prints the token. Git ignores the "prompt" argument
-	// passed in $1; we do not read it. Writing the token verbatim with `cat`
-	// avoids shell-escaping pitfalls — the token is fed on stdin-less invoke.
-	script := "#!/bin/sh\nprintf '%s' \"$HEIMDALLM_GIT_TOKEN\"\n"
-	if err := os.WriteFile(helperPath, []byte(script), 0o700); err != nil {
-		os.RemoveAll(dir)
-		return nil, nil, fmt.Errorf("write askpass script: %w", err)
-	}
-
-	env := append(os.Environ(),
-		"GIT_ASKPASS="+helperPath,
-		"GIT_TERMINAL_PROMPT=0",
-		"HEIMDALLM_GIT_TOKEN="+token, // read by the helper script via env
-	)
-	cleanup := func() { os.RemoveAll(dir) }
-	return env, cleanup, nil
-}
-
-// runGit discards stdout and returns an error that wraps whatever git wrote
-// to stderr (truncated to maxGitStderrBytes so a verbose failure cannot
-// balloon the daemon's memory).
-func runGit(ctx context.Context, dir string, env []string, args ...string) error {
-	_, err := captureGit(ctx, dir, env, args...)
-	return err
-}
-
-// captureGit runs git with the effective dir / env / args and returns its
-// stdout. When git exits non-zero, the returned error includes a trimmed
-// stderr excerpt so the caller can diagnose without digging into logs.
+// captureGit remains the package-level history-reader seam used by triage.
+// Environment injection is deliberately unsupported: all callers now share
+// gitproc's clean subprocess boundary.
 func captureGit(ctx context.Context, dir string, env []string, args ...string) ([]byte, error) {
-	runCtx, cancel := context.WithTimeout(ctx, gitTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(runCtx, "git", args...)
-	cmd.Dir = dir
-	if env != nil {
-		cmd.Env = env
+	if len(env) != 0 {
+		return nil, fmt.Errorf("gitops: custom Git environments are disabled")
 	}
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		// Cap stderr to protect against pathological output (e.g. huge
-		// merge-conflict reports, repeated progress lines, etc).
-		errText := stderr.String()
-		if len(errText) > maxGitStderrBytes {
-			errText = errText[:maxGitStderrBytes] + "\n... (stderr truncated)"
-		}
-		return nil, fmt.Errorf("%w (stderr: %s)", err, strings.TrimSpace(errText))
-	}
-	return stdout.Bytes(), nil
+	return gitproc.New().Capture(ctx, dir, args...)
 }

--- a/daemon/internal/issues/gitops_test.go
+++ b/daemon/internal/issues/gitops_test.go
@@ -338,6 +338,134 @@ func TestCommitAll_AllowsLegitimateChanges(t *testing.T) {
 	}
 }
 
+func TestCommitAllNeutralizesRepositoryHooksAndFSMonitor(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	dir := t.TempDir()
+	runGitForTest(t, dir, "init")
+	runGitForTest(t, dir, "config", "user.name", "Test User")
+	runGitForTest(t, dir, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# init\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, dir, "add", "README.md")
+	runGitForTest(t, dir, "commit", "-m", "initial")
+
+	hooksDir := t.TempDir()
+	runGitForTest(t, dir, "config", "core.hooksPath", hooksDir)
+	for _, hookName := range []string{"pre-commit", "commit-msg"} {
+		hook := filepath.Join(hooksDir, hookName)
+		script := "#!/bin/sh\nprintf ran > ." + hookName + "-ran\n"
+		if err := os.WriteFile(hook, []byte(script), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fsmonitor := filepath.Join(t.TempDir(), "fsmonitor")
+	if err := os.WriteFile(fsmonitor, []byte("#!/bin/sh\nprintf ran > .fsmonitor-ran\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, dir, "config", "core.fsmonitor", fsmonitor)
+	runGitForTest(t, dir, "config", "core.fsmonitorHookVersion", "1")
+	if err := os.WriteFile(filepath.Join(dir, "change.txt"), []byte("safe change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := issues.NewGitExec().CommitAll(context.Background(), dir, "fix: safe change"); err != nil {
+		t.Fatalf("CommitAll: %v", err)
+	}
+	for _, hookName := range []string{"pre-commit", "commit-msg"} {
+		if _, err := os.Stat(filepath.Join(dir, "."+hookName+"-ran")); !os.IsNotExist(err) {
+			t.Fatalf("repository %s hook ran: %v", hookName, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".fsmonitor-ran")); !os.IsNotExist(err) {
+		t.Fatalf("repository fsmonitor hook ran: %v", err)
+	}
+}
+
+func TestGitExecRejectsExecutableLocalConfig(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	dir := t.TempDir()
+	runGitForTest(t, dir, "init")
+	runGitForTest(t, dir, "config", "filter.attacker.clean", "/tmp/attacker-filter")
+
+	_, err := issues.NewGitExec().HasChanges(context.Background(), dir)
+	if err == nil || !strings.Contains(err.Error(), "filter.attacker.clean") {
+		t.Fatalf("HasChanges error = %v, want rejected executable filter config", err)
+	}
+}
+
+func TestGitExecDoesNotInheritGitEnvironment(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	dir := t.TempDir()
+	runGitForTest(t, dir, "init")
+	if err := os.WriteFile(filepath.Join(dir, "change.txt"), []byte("change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GIT_DIR", filepath.Join(t.TempDir(), "attacker.git"))
+	t.Setenv("GIT_WORK_TREE", t.TempDir())
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "core.hooksPath")
+	t.Setenv("GIT_CONFIG_VALUE_0", "/tmp/attacker-hooks")
+
+	changed, err := issues.NewGitExec().HasChanges(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("HasChanges inherited a hostile Git environment: %v", err)
+	}
+	if !changed {
+		t.Fatal("HasChanges did not inspect the intended repository")
+	}
+}
+
+func TestHasChangesOverridesHiddenUntrackedConfig(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	dir := t.TempDir()
+	runGitForTest(t, dir, "init")
+	runGitForTest(t, dir, "config", "status.showUntrackedFiles", "no")
+	if err := os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("must be seen\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := issues.NewGitExec().HasChanges(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("HasChanges: %v", err)
+	}
+	if !changed {
+		t.Fatal("local status.showUntrackedFiles=no hid an untracked implementation change")
+	}
+}
+
+func TestHasChangesIgnoresConfiguredGlobalExcludesFile(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	dir := t.TempDir()
+	runGitForTest(t, dir, "init")
+	excludes := filepath.Join(t.TempDir(), "excludes")
+	if err := os.WriteFile(excludes, []byte("*\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, dir, "config", "core.excludesFile", excludes)
+	if err := os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("must be seen\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := issues.NewGitExec().HasChanges(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("HasChanges: %v", err)
+	}
+	if !changed {
+		t.Fatal("local core.excludesFile hid an untracked implementation change")
+	}
+}
+
 func runGitForTest(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -1,14 +1,12 @@
 package repoctx
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -17,14 +15,14 @@ import (
 	"time"
 
 	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/gitproc"
 )
 
 const (
 	// MarkerFile identifies clones that Heimdallm is allowed to mutate.
 	MarkerFile = ".heimdallm-managed"
 
-	gitTimeout        = 3 * time.Minute
-	maxGitStderrBytes = 16 * 1024
+	gitTimeout = 3 * time.Minute
 )
 
 var repoNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
@@ -135,6 +133,15 @@ type gitRunner interface {
 	Run(ctx context.Context, dir string, env []string, args ...string) error
 }
 
+// secureGitRunner is implemented by the production runner. Keeping gitRunner
+// as the smaller seam preserves deterministic fakes while network operations
+// gain the isolated bare-transport path.
+type secureGitRunner interface {
+	gitRunner
+	CloneRemote(ctx context.Context, target, repo, token string) error
+	FetchRemote(ctx context.Context, target, repo, ref, token string, opts gitproc.FetchOptions) error
+}
+
 // PurgeReport summarizes managed clone cleanup without exposing local paths to
 // HTTP callers.
 type PurgeReport struct {
@@ -204,7 +211,7 @@ func NewManagerWithOptions(opts ManagerOptions) *Manager {
 		locks:          make(map[string]*repoLock),
 		caps:           make(map[string]*repoCap),
 		active:         make(map[string]struct{}),
-		git:            execGit{},
+		git:            execGit{runner: gitproc.New()},
 		tempDir:        os.TempDir,
 		maxWorktrees:   opts.MaxWorktreesPerRepo,
 		releaseTimeout: gitTimeout,
@@ -440,12 +447,23 @@ func (m *Manager) EnsureFullHistory(ctx context.Context, h *Handle, token string
 	} else if err != nil {
 		return fmt.Errorf("repoctx: inspect shallow marker: %w", err)
 	}
-	env, cleanup, err := buildAskPassEnv(token)
-	if err != nil {
-		return fmt.Errorf("repoctx: setup askpass: %w", err)
-	}
-	defer cleanup()
-	if err := m.runner().Run(ctx, h.Path(), env, "fetch", "--unshallow", "--prune", "origin"); err != nil {
+	runner := m.runner()
+	if secure, ok := runner.(secureGitRunner); ok {
+		metadata, _, err := readMarkerInfo(h.Path())
+		if err != nil {
+			return fmt.Errorf("repoctx: read managed clone marker for full history: %w", err)
+		}
+		if err := secure.FetchRemote(
+			ctx,
+			h.Path(),
+			metadata.Repo,
+			"HEAD",
+			token,
+			gitproc.FetchOptions{Unshallow: true},
+		); err != nil {
+			return fmt.Errorf("repoctx: unshallow %s: %w", h.Path(), err)
+		}
+	} else if err := runner.Run(ctx, h.Path(), nil, "fetch", "--unshallow", "--prune", "origin"); err != nil {
 		return fmt.Errorf("repoctx: unshallow %s: %w", h.Path(), err)
 	}
 	if err := touchMarker(h.Path()); err != nil {
@@ -618,14 +636,19 @@ func (m *Manager) ensureManagedClone(ctx context.Context, owner, name string, re
 }
 
 func (m *Manager) clone(ctx context.Context, target, repo, token string) error {
-	env, cleanup, err := buildAskPassEnv(token)
-	if err != nil {
-		return fmt.Errorf("repoctx: setup askpass: %w", err)
-	}
-	defer cleanup()
-	url := fmt.Sprintf("https://x-access-token@github.com/%s.git", repo)
-	if err := m.runner().Run(ctx, "", env, "clone", "--depth=1", url, target); err != nil {
-		return fmt.Errorf("repoctx: clone %s: %w", repo, err)
+	runner := m.runner()
+	if secure, ok := runner.(secureGitRunner); ok {
+		if err := secure.CloneRemote(ctx, target, repo, token); err != nil {
+			return fmt.Errorf("repoctx: clone %s: %w", repo, err)
+		}
+	} else {
+		url, err := gitproc.GitHubRemote(repo)
+		if err != nil {
+			return fmt.Errorf("repoctx: remote: %w", err)
+		}
+		if err := runner.Run(ctx, "", nil, "clone", "--depth=1", url, target); err != nil {
+			return fmt.Errorf("repoctx: clone %s: %w", repo, err)
+		}
 	}
 	if err := requireGitDir(target); err != nil {
 		return err
@@ -634,24 +657,34 @@ func (m *Manager) clone(ctx context.Context, target, repo, token string) error {
 }
 
 func (m *Manager) updateManagedClone(ctx context.Context, target, repo, token string) error {
-	env, cleanup, err := buildAskPassEnv(token)
+	url, err := gitproc.GitHubRemote(repo)
 	if err != nil {
-		return fmt.Errorf("repoctx: setup askpass: %w", err)
+		return fmt.Errorf("repoctx: remote: %w", err)
 	}
-	defer cleanup()
-	url := fmt.Sprintf("https://x-access-token@github.com/%s.git", repo)
+	runner := m.runner()
 	// set-url writes an opaque username-only URL and does not need
-	// credentials; keep the askpass env scoped to network operations.
-	if err := m.runner().Run(ctx, target, nil, "remote", "set-url", "origin", url); err != nil {
+	// credentials.
+	if err := runner.Run(ctx, target, nil, "remote", "set-url", "origin", url); err != nil {
 		return fmt.Errorf("repoctx: set remote url: %w", err)
 	}
-	if err := m.runner().Run(ctx, target, env, "fetch", "--depth=1", "--prune", "origin", "HEAD"); err != nil {
+	if secure, ok := runner.(secureGitRunner); ok {
+		if err := secure.FetchRemote(
+			ctx,
+			target,
+			repo,
+			"HEAD",
+			token,
+			gitproc.FetchOptions{Depth: 1},
+		); err != nil {
+			return fmt.Errorf("repoctx: fetch %s: %w", repo, err)
+		}
+	} else if err := runner.Run(ctx, target, nil, "fetch", "--depth=1", "--prune", "origin", "HEAD"); err != nil {
 		return fmt.Errorf("repoctx: fetch %s: %w", repo, err)
 	}
-	if err := m.runner().Run(ctx, target, nil, "reset", "--hard", "FETCH_HEAD"); err != nil {
+	if err := runner.Run(ctx, target, nil, "reset", "--hard", "FETCH_HEAD"); err != nil {
 		return fmt.Errorf("repoctx: reset %s: %w", repo, err)
 	}
-	if err := m.runner().Run(ctx, target, nil, "clean", "-fd", "-e", MarkerFile, "-e", worktreesDir); err != nil {
+	if err := runner.Run(ctx, target, nil, "clean", "-fd", "-e", MarkerFile, "-e", worktreesDir); err != nil {
 		return fmt.Errorf("repoctx: clean %s: %w", repo, err)
 	}
 	return nil
@@ -806,7 +839,7 @@ func (m *Manager) purgeTarget(ctx context.Context, repo, target string) error {
 
 func (m *Manager) runner() gitRunner {
 	if m == nil || m.git == nil {
-		return execGit{}
+		return execGit{runner: gitproc.New()}
 	}
 	return m.git
 }
@@ -1122,57 +1155,51 @@ func touchMarker(dir string) error {
 }
 
 func requireGitDir(dir string) error {
-	if info, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+	path := filepath.Join(dir, ".git")
+	if info, err := os.Lstat(path); err != nil {
 		return fmt.Errorf("repoctx: clone target %q has no .git directory: %w", dir, err)
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("repoctx: clone target %q has symlinked .git", dir)
 	} else if !info.IsDir() {
 		return fmt.Errorf("repoctx: clone target %q has non-directory .git", dir)
 	}
 	return nil
 }
 
-func buildAskPassEnv(token string) ([]string, func(), error) {
-	dir, err := os.MkdirTemp("", "heimdallm-askpass-*")
-	if err != nil {
-		return nil, nil, fmt.Errorf("create askpass dir: %w", err)
-	}
-	if err := os.Chmod(dir, 0o700); err != nil {
-		os.RemoveAll(dir)
-		return nil, nil, fmt.Errorf("chmod askpass dir: %w", err)
-	}
-	helperPath := filepath.Join(dir, "askpass.sh")
-	script := "#!/bin/sh\nprintf '%s' \"$HEIMDALLM_GIT_TOKEN\"\n"
-	if err := os.WriteFile(helperPath, []byte(script), 0o700); err != nil {
-		os.RemoveAll(dir)
-		return nil, nil, fmt.Errorf("write askpass script: %w", err)
-	}
-	env := append(os.Environ(),
-		"GIT_ASKPASS="+helperPath,
-		"GIT_TERMINAL_PROMPT=0",
-		"HEIMDALLM_GIT_TOKEN="+token,
-	)
-	cleanup := func() { os.RemoveAll(dir) }
-	return env, cleanup, nil
+type execGit struct {
+	runner *gitproc.Runner
 }
 
-type execGit struct{}
+func (g execGit) proc() *gitproc.Runner {
+	if g.runner == nil {
+		return gitproc.New()
+	}
+	return g.runner
+}
 
-func (execGit) Run(ctx context.Context, dir string, env []string, args ...string) error {
-	runCtx, cancel := context.WithTimeout(ctx, gitTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(runCtx, "git", args...)
-	cmd.Dir = dir
-	cmd.Env = os.Environ()
-	if env != nil {
-		cmd.Env = env
+func (g execGit) Run(ctx context.Context, dir string, env []string, args ...string) error {
+	if len(env) != 0 {
+		return errors.New("repoctx: custom Git environments are disabled")
 	}
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		errText := stderr.String()
-		if len(errText) > maxGitStderrBytes {
-			errText = errText[:maxGitStderrBytes] + "\n... (stderr truncated)"
-		}
-		return fmt.Errorf("%w (stderr: %s)", err, strings.TrimSpace(errText))
+	return g.proc().Run(ctx, dir, args...)
+}
+
+func (g execGit) CloneRemote(ctx context.Context, target, repo, token string) error {
+	remote, err := gitproc.GitHubRemote(repo)
+	if err != nil {
+		return err
 	}
-	return nil
+	return g.proc().CloneNoCheckout(ctx, remote, target, token, 1)
+}
+
+func (g execGit) FetchRemote(
+	ctx context.Context,
+	target, repo, ref, token string,
+	opts gitproc.FetchOptions,
+) error {
+	remote, err := gitproc.GitHubRemote(repo)
+	if err != nil {
+		return err
+	}
+	return g.proc().Fetch(ctx, target, remote, ref, token, opts)
 }

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -1103,3 +1103,17 @@ func TestEnsureFullHistoryUnshallowsManagedClone(t *testing.T) {
 		t.Fatalf("git calls = %v, want unshallow fetch", calls)
 	}
 }
+
+func TestRequireGitDirRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	attackerGitDir := filepath.Join(t.TempDir(), "git")
+	if err := os.MkdirAll(attackerGitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(attackerGitDir, filepath.Join(dir, ".git")); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireGitDir(dir); err == nil || !strings.Contains(err.Error(), "symlinked .git") {
+		t.Fatalf("requireGitDir error = %v, want symlink rejection", err)
+	}
+}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -83,6 +83,35 @@ ANTHROPIC_API_KEY=
 # If set, Claude Code authenticates via your Anthropic subscription.
 # NOTE: bare = true in config.toml disables OAuth — use API key instead.
 # CLAUDE_CODE_OAUTH_TOKEN=
+#
+# Option C: Anthropic-compatible enterprise gateway
+# ANTHROPIC_BASE_URL=https://gateway.example.com
+# ANTHROPIC_AUTH_TOKEN=
+#
+# Option D: Amazon Bedrock. Choose either the bearer token or the access-key
+# trio. AWS credentials are forwarded to Claude only while USE_BEDROCK is
+# enabled and SKIP_BEDROCK_AUTH is not enabled. Do not enable Vertex at the
+# same time; Heimdallm rejects conflicting backends before starting Claude.
+# CLAUDE_CODE_USE_BEDROCK=1
+# AWS_REGION=us-east-1
+# AWS_DEFAULT_REGION=
+# AWS_BEARER_TOKEN_BEDROCK=
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_SESSION_TOKEN=
+# ANTHROPIC_BEDROCK_BASE_URL=
+# CLAUDE_CODE_SKIP_BEDROCK_AUTH=
+#
+# Option E: Google Vertex AI. GOOGLE_APPLICATION_CREDENTIALS,
+# GOOGLE_CLOUD_PROJECT, and the required container mount are shared with the
+# Google section below. ADC is omitted from Claude when SKIP_VERTEX_AUTH is on.
+# Do not enable Bedrock at the same time.
+# CLAUDE_CODE_USE_VERTEX=1
+# CLOUD_ML_REGION=global
+# ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project
+# ANTHROPIC_VERTEX_BASE_URL=
+# CLAUDE_CODE_SKIP_VERTEX_AUTH=
+# GCLOUD_PROJECT=
 
 # ── Codex CLI (OpenAI) ──────────────────────────────────────────────────────
 # Get from: https://platform.openai.com/api-keys
@@ -125,6 +154,10 @@ GEMINI_API_KEY=
 # GITHUB_TOKEN, GH_TOKEN, HEIMDALLM_*, GIT_* and known loader/startup injection
 # variables are permanently denied. The denylist is defense in depth, not proof
 # that every other name is safe: each entry remains an operator trust decision.
+# AWS_PROFILE, AWS_CONFIG_FILE, and AWS_SHARED_CREDENTIALS_FILE are not forwarded
+# automatically: the isolated HOME cannot see ~/.aws, and an AWS config may run
+# credential_process. Using them requires exact Claude allowlist entries,
+# container-visible absolute paths, and operator-owned read-only mounts.
 # SSH_AUTH_SOCK is excluded by default but can be opted in deliberately; see
 # docs/subprocess-security.md for the required socket mount and risk warning.
 HEIMDALLM_AI_CLAUDE_ENV_ALLOWLIST=

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -122,10 +122,11 @@ GEMINI_API_KEY=
 # provider variables above are already forwarded by docker-compose.yml; custom
 # variables need an operator-owned compose overlay under `environment:`.
 #
-# GITHUB_TOKEN, GH_TOKEN, HEIMDALLM_*, GIT_* and loader/shell-injection
-# variables are permanently denied. SSH_AUTH_SOCK is excluded by default but
-# can be opted in deliberately; see docs/subprocess-security.md for the
-# required socket mount and risk warning.
+# GITHUB_TOKEN, GH_TOKEN, HEIMDALLM_*, GIT_* and known loader/startup injection
+# variables are permanently denied. The denylist is defense in depth, not proof
+# that every other name is safe: each entry remains an operator trust decision.
+# SSH_AUTH_SOCK is excluded by default but can be opted in deliberately; see
+# docs/subprocess-security.md for the required socket mount and risk warning.
 HEIMDALLM_AI_CLAUDE_ENV_ALLOWLIST=
 HEIMDALLM_AI_CODEX_ENV_ALLOWLIST=
 HEIMDALLM_AI_GEMINI_ENV_ALLOWLIST=

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -76,7 +76,6 @@ HEIMDALLM_REPOSITORIES=
 # Option A: API Key
 # Get from: https://console.anthropic.com/settings/keys
 # Required if HEIMDALLM_AI_PRIMARY=claude
-# Also used by opencode when configured with Anthropic provider.
 ANTHROPIC_API_KEY=
 
 # Option B: OAuth Token (for Max/Pro/Team subscription users)
@@ -88,7 +87,6 @@ ANTHROPIC_API_KEY=
 # ── Codex CLI (OpenAI) ──────────────────────────────────────────────────────
 # Get from: https://platform.openai.com/api-keys
 # CODEX_API_KEY is preferred for codex; OPENAI_API_KEY also works.
-# Also used by opencode when configured with OpenAI provider.
 OPENAI_API_KEY=
 # CODEX_API_KEY=
 
@@ -96,13 +94,42 @@ OPENAI_API_KEY=
 # Get from: https://aistudio.google.com/apikey
 # Required if HEIMDALLM_AI_PRIMARY=gemini
 GEMINI_API_KEY=
+# GOOGLE_API_KEY=
+#
+# Vertex AI alternative. GOOGLE_APPLICATION_CREDENTIALS must be a path inside
+# the container; mount the service-account file with a private compose overlay.
+# GOOGLE_GENAI_USE_VERTEXAI=true
+# GOOGLE_CLOUD_PROJECT=your-gcp-project
+# GOOGLE_CLOUD_LOCATION=global
+# GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google-application-credentials.json
 
 # ── OpenCode CLI ─────────────────────────────────────────────────────────────
-# OpenCode supports multiple providers. Set the key for your chosen provider:
-#   - Anthropic: uses ANTHROPIC_API_KEY (above)
-#   - OpenAI:    uses OPENAI_API_KEY (above)
-#   - OpenRouter: set OPENROUTER_API_KEY below
+# OpenRouter is the default OpenCode credential. For an OpenCode backend using
+# Anthropic, OpenAI, or Gemini, explicitly name only that backend key in
+# HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST below.
 # OPENROUTER_API_KEY=
+
+# ── Additional AI CLI environment (advanced, optional) ──────────────────────
+# AI subprocesses start from an empty environment and receive only common
+# runtime values (including standard proxy and CA variables) plus the selected
+# provider's credentials. Add exact names here only for provider-specific
+# auxiliary settings not in that baseline; values are never placed in the
+# list. Comma-separated, no globs. Cross-provider credentials stay blocked for
+# Claude, Codex, and Gemini; OpenCode's exact list selects its configured
+# multi-provider backend.
+#
+# Variables named here must also exist in the daemon container. The built-in
+# provider variables above are already forwarded by docker-compose.yml; custom
+# variables need an operator-owned compose overlay under `environment:`.
+#
+# GITHUB_TOKEN, GH_TOKEN, HEIMDALLM_*, GIT_* and loader/shell-injection
+# variables are permanently denied. SSH_AUTH_SOCK is excluded by default but
+# can be opted in deliberately; see docs/subprocess-security.md for the
+# required socket mount and risk warning.
+HEIMDALLM_AI_CLAUDE_ENV_ALLOWLIST=
+HEIMDALLM_AI_CODEX_ENV_ALLOWLIST=
+HEIMDALLM_AI_GEMINI_ENV_ALLOWLIST=
+HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST=
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # OPTIONAL — Heimdallm settings (defaults shown)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN npm install -g @google/gemini-cli 2>/dev/null || true
 # Codex CLI (OpenAI) — requires OPENAI_API_KEY or CODEX_API_KEY at runtime
 RUN npm install -g @openai/codex 2>/dev/null || true
 
-# OpenCode CLI — requires provider API key (e.g. ANTHROPIC_API_KEY) at runtime
+# OpenCode CLI — OpenRouter by default; other backend keys require explicit opt-in
 # Install the musl-specific binary package alongside the main package (Alpine uses musl).
 # Then symlink the musl binary into the wrapper's expected location.
 RUN npm install -g opencode-ai opencode-linux-x64-musl 2>/dev/null || true \
@@ -51,9 +51,10 @@ RUN mkdir -p /home/heimdallm/.claude \
              /home/heimdallm/.local/share/opencode \
     && chown -R heimdallm:heimdallm /home/heimdallm
 
-# ── SSH setup for git operations (auto_implement) ───────────────────────────
-# Pre-seed GitHub's host key so git fetch/push over SSH never prompts.
-# The host's SSH agent socket is forwarded at runtime via docker-compose.
+# ── Optional SSH setup for explicitly opted-in AI CLIs ──────────────────────
+# Heimdallm's own Git transport uses HTTPS. Keep GitHub's host key available
+# only for operators who deliberately mount an agent and allow SSH_AUTH_SOCK
+# for one AI provider through a private compose overlay.
 RUN mkdir -p /home/heimdallm/.ssh \
     && ssh-keyscan github.com >> /home/heimdallm/.ssh/known_hosts 2>/dev/null \
     && chmod 700 /home/heimdallm/.ssh \

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -20,7 +20,7 @@ RUN npm install -g @google/gemini-cli 2>/dev/null || true
 # Codex CLI (OpenAI) — requires OPENAI_API_KEY or CODEX_API_KEY at runtime
 RUN npm install -g @openai/codex 2>/dev/null || true
 
-# OpenCode CLI — requires provider API key (e.g. ANTHROPIC_API_KEY) at runtime
+# OpenCode CLI — OpenRouter by default; other backend keys require explicit opt-in
 # Install the musl-specific binary package alongside the main package (Alpine uses musl).
 # Then symlink the musl binary into the wrapper's expected location.
 RUN npm install -g opencode-ai opencode-linux-x64-musl 2>/dev/null || true \
@@ -46,9 +46,10 @@ RUN mkdir -p /home/heimdallm/.claude \
              /home/heimdallm/.local/share/opencode \
     && chown -R heimdallm:heimdallm /home/heimdallm
 
-# ── SSH setup for git operations (auto_implement) ───────────────────────────
-# Pre-seed GitHub's host key so git fetch/push over SSH never prompts.
-# The host's SSH agent socket is forwarded at runtime via docker-compose.
+# ── Optional SSH setup for explicitly opted-in AI CLIs ──────────────────────
+# Heimdallm's own Git transport uses HTTPS. Keep GitHub's host key available
+# only for operators who deliberately mount an agent and allow SSH_AUTH_SOCK
+# for one AI provider through a private compose overlay.
 RUN mkdir -p /home/heimdallm/.ssh \
     && ssh-keyscan github.com >> /home/heimdallm/.ssh/known_hosts 2>/dev/null \
     && chmod 700 /home/heimdallm/.ssh \

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -12,7 +12,8 @@ services:
     volumes:
       - heimdallm-test-data:/data
       - heimdallm-test-config:/config
-      # Gemini OAuth tokens from host (uncomment for Level 3 E2E test):
+      # Gemini OAuth tokens from host (read-only; refresh is ephemeral;
+      # uncomment for Level 3 E2E test):
       # - ~/.gemini:/home/heimdallm/.gemini:ro
 
   web:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -108,7 +108,8 @@ services:
       # through the store layer and survive the volume swap.
       - heimdallm-config:/config
       #
-      # Gemini OAuth tokens from host (if using browser-based auth):
+      # Gemini OAuth tokens from host (browser auth; refresh is ephemeral
+      # because this security-sensitive source stays read-only):
       # - ~/.gemini:/home/heimdallm/.gemini:ro
       #
       # Local repos for full-repo analysis. The agent runs with its CWD

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,7 +47,30 @@ services:
       # ── AI CLI authentication ──────────────────────────────────────────
       # Claude Code CLI (Anthropic)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN:-}
+      - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-}
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
+      # Bedrock is activated by Claude's 1/true/yes/on boolean values. When
+      # SKIP_BEDROCK_AUTH is enabled, Heimdallm keeps AWS credentials out of
+      # the Claude subprocess because the gateway supplies authentication.
+      - ANTHROPIC_BEDROCK_BASE_URL=${ANTHROPIC_BEDROCK_BASE_URL:-}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_BEARER_TOKEN_BEDROCK=${AWS_BEARER_TOKEN_BEDROCK:-}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
+      - AWS_REGION=${AWS_REGION:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      - CLAUDE_CODE_SKIP_BEDROCK_AUTH=${CLAUDE_CODE_SKIP_BEDROCK_AUTH:-}
+      - CLAUDE_CODE_USE_BEDROCK=${CLAUDE_CODE_USE_BEDROCK:-}
+      # Claude Vertex authentication reuses the Google variables below.
+      # USE_BEDROCK and USE_VERTEX are mutually exclusive; the executor
+      # rejects a conflict before exposing either cloud credential group.
+      - ANTHROPIC_VERTEX_BASE_URL=${ANTHROPIC_VERTEX_BASE_URL:-}
+      - ANTHROPIC_VERTEX_PROJECT_ID=${ANTHROPIC_VERTEX_PROJECT_ID:-}
+      - CLAUDE_CODE_SKIP_VERTEX_AUTH=${CLAUDE_CODE_SKIP_VERTEX_AUTH:-}
+      - CLAUDE_CODE_USE_VERTEX=${CLAUDE_CODE_USE_VERTEX:-}
+      - CLOUD_ML_REGION=${CLOUD_ML_REGION:-}
+      - GCLOUD_PROJECT=${GCLOUD_PROJECT:-}
 
       # Codex CLI (OpenAI)
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
@@ -56,8 +79,9 @@ services:
       # Gemini CLI (Google)
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
-      # Vertex AI is opt-in. GOOGLE_APPLICATION_CREDENTIALS must name a
-      # container-visible file supplied by an operator-owned compose overlay.
+      # Vertex AI is opt-in for Gemini and Claude. GOOGLE_APPLICATION_CREDENTIALS
+      # must name a container-visible file supplied by an operator-owned
+      # compose overlay.
       - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:-}
       - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-}
       - GOOGLE_CLOUD_LOCATION=${GOOGLE_CLOUD_LOCATION:-}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -55,16 +55,31 @@ services:
 
       # Gemini CLI (Google)
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      # Vertex AI is opt-in. GOOGLE_APPLICATION_CREDENTIALS must name a
+      # container-visible file supplied by an operator-owned compose overlay.
+      - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:-}
+      - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-}
+      - GOOGLE_CLOUD_LOCATION=${GOOGLE_CLOUD_LOCATION:-}
+      - GOOGLE_GENAI_USE_VERTEXAI=${GOOGLE_GENAI_USE_VERTEXAI:-}
 
-      # OpenCode CLI (uses any provider key above, or OpenRouter)
+      # OpenRouter is OpenCode's default. A different OpenCode backend key
+      # requires an exact HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST entry.
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+
+      # ── AI CLI environment opt-ins ─────────────────────────────────────
+      # Each child starts from an empty environment. These comma-separated
+      # lists can expose additional daemon env vars only to the named CLI.
+      # Permanent deny rules still reject GitHub/Heimdallm/Git and
+      # loader/shell-injection variables. See docs/subprocess-security.md.
+      - HEIMDALLM_AI_CLAUDE_ENV_ALLOWLIST=${HEIMDALLM_AI_CLAUDE_ENV_ALLOWLIST:-}
+      - HEIMDALLM_AI_CODEX_ENV_ALLOWLIST=${HEIMDALLM_AI_CODEX_ENV_ALLOWLIST:-}
+      - HEIMDALLM_AI_GEMINI_ENV_ALLOWLIST=${HEIMDALLM_AI_GEMINI_ENV_ALLOWLIST:-}
+      - HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST=${HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST:-}
 
       # ── Headless / non-interactive mode ────────────────────────────────
       - CI=true
       - OPENCODE_DISABLE_AUTOUPDATE=true
-
-      # ── SSH agent forwarding for git operations (auto_implement) ──────
-      - SSH_AUTH_SOCK=/ssh-agent
     volumes:
       # Persistent data (SQLite DB + API token)
       - heimdallm-data:/data
@@ -115,11 +130,6 @@ services:
       # error and the feature just returns "directory not found" in
       # the UI — opt-in without breaking the default `make up-build`.
       - ${HEIMDALLM_LOCAL_DIR_BASE:-./repos-placeholder}:/home/heimdallm/repos:ro
-      #
-      # SSH agent forwarding for git operations (auto_implement).
-      # macOS: Docker Desktop exposes the host agent at a fixed path.
-      # Linux: set SSH_AUTH_SOCK in docker/.env.
-      - ${HEIMDALLM_SSH_AUTH_SOCK:-/run/host-services/ssh-auth.sock}:/ssh-agent:ro
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:7842/health"]
       interval: 30s

--- a/docker/scripts/test-local.sh
+++ b/docker/scripts/test-local.sh
@@ -488,7 +488,7 @@ test_e2e() {
     echo "  1. .env file with GITHUB_TOKEN, HEIMDALLM_AI_PRIMARY, HEIMDALLM_REPOSITORIES"
     echo "  2. AI CLI authentication:"
     echo "     - Gemini: GEMINI_API_KEY in .env, or mount ~/.gemini in docker-compose.test.yml"
-    echo "     - Claude: ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN in .env"
+    echo "     - Claude: API/OAuth, gateway, Bedrock, or Vertex variables in .env"
     echo "     - Codex:  OPENAI_API_KEY in .env"
     echo "  3. An open PR where the GITHUB_TOKEN user is a requested reviewer"
     echo ""
@@ -510,14 +510,22 @@ test_e2e() {
     # Check at least one AI key
     local has_ai_key=false
     [ -n "${ANTHROPIC_API_KEY:-}" ] && has_ai_key=true
+    [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] && has_ai_key=true
     [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && has_ai_key=true
+    case "${CLAUDE_CODE_USE_BEDROCK:-}" in
+        1|[Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]|[Oo][Nn]) has_ai_key=true ;;
+    esac
+    case "${CLAUDE_CODE_USE_VERTEX:-}" in
+        1|[Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]|[Oo][Nn]) has_ai_key=true ;;
+    esac
     [ -n "${GEMINI_API_KEY:-}" ] && has_ai_key=true
+    [ -n "${GOOGLE_API_KEY:-}" ] && has_ai_key=true
     [ -n "${OPENAI_API_KEY:-}" ] && has_ai_key=true
     [ -n "${CODEX_API_KEY:-}" ] && has_ai_key=true
 
     if [ "$has_ai_key" = false ]; then
-        warn "No AI API keys found in .env."
-        echo "  If using Gemini OAuth, uncomment the ~/.gemini volume in docker-compose.test.yml"
+        warn "No AI authentication route found in .env."
+        echo "  Gemini OAuth can instead use the ~/.gemini test volume."
         echo ""
     fi
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -609,9 +609,22 @@ selected provider's default credentials:
 | OpenCode | `OPENROUTER_API_KEY` |
 
 Each execution also gets a new mode-`0700` temporary `HOME`. Only the selected
-provider's state/authentication directories are bridged into it, preserving
+provider's minimum state/authentication paths are projected into it, preserving
 file-based login without exposing another CLI's state or unrelated home files.
 Detection and `--help` probes receive no provider credentials.
+Claude runs from the isolated directory with its upstream `--safe-mode`; support
+is verified before every cached CLI version is used, and versions older than
+2.1.169 fail closed. The repository is granted only as an additional directory.
+Only `.claude/.credentials.json` and `.claude.json` are copied into the
+temporary home and safely synchronized back, so persistent user settings,
+CLAUDE.md, hooks, plugins, MCP servers, skills, commands, and agents are not
+loaded.
+Gemini projects only mutable OAuth/account/installation state and an input-only
+authentication selector. User settings, `.env`, GEMINI.md, MCP tokens,
+extensions, commands, skills, agents, and policies are excluded. Atomic
+rotations are synchronized on read-write native state; rotations against the
+documented read-only Docker mount are ephemeral and produce a warning without
+discarding a successful review.
 OpenCode runs with its managed `--pure` policy, so repository and user-state
 plugins are not executed with the selected backend credential. Heimdallm also
 sets `OPENCODE_DISABLE_PROJECT_CONFIG=1`; repository `opencode.json`,
@@ -627,10 +640,17 @@ HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST=CORPORATE_TENANT_ID
 ```
 
 Standard proxy and CA variables are already part of the common runtime
-baseline and do not need to be repeated.
+baseline and do not need to be repeated. Their names are matched
+case-insensitively, and empty elements in a comma-separated allowlist are
+ignored. A configured allowlist name that is absent produces a warning without
+logging its value; optional missing provider-state paths are reported once at
+info level.
 
-`GITHUB_TOKEN`, `GH_TOKEN`, `HEIMDALLM_*`, `GIT_*`, and dynamic-loader or
-shell-startup injection variables are permanently denied. `SSH_AUTH_SOCK` is
+`GITHUB_TOKEN`, `GH_TOKEN`, `HEIMDALLM_*`, `GIT_*`, and known dynamic-loader,
+runtime-agent, module-loader, or shell-startup injection variables are
+permanently denied. This denylist is defense in depth rather than an exhaustive
+safety catalogue; every additional name remains an explicit operator trust
+decision. `SSH_AUTH_SOCK` is
 absent by default and requires both an explicit per-CLI allowlist entry and an
 operator-owned socket mount. Custom allowlisted values must also be forwarded
 to the daemon container through a private compose overlay. Cross-provider
@@ -906,8 +926,11 @@ volumes:
 ```
 
 Leave `GEMINI_API_KEY` and `GOOGLE_API_KEY` empty. The container reads your
-host's OAuth tokens read-only and projects only Gemini state into the
-execution's isolated temporary home.
+host's OAuth tokens read-only and projects only Gemini authentication state
+into the execution's isolated temporary home. Token refreshes from that
+read-only mount are intentionally ephemeral; use an API key for fully stateless
+Docker operation, or authenticate the native/`make run-linux` installation when
+rotations must persist.
 
 ---
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -595,6 +595,53 @@ startup or discarding unrelated stored settings. When execution falls back to a
 different CLI, provider-specific options from the unavailable primary are not
 forwarded.
 
+### AI subprocess environment isolation
+
+AI CLIs do not inherit `os.Environ()` from the daemon. Every execution starts
+from an empty environment and receives only a small runtime baseline plus the
+selected provider's default credentials:
+
+| CLI | Credentials exposed by default |
+|---|---|
+| Claude | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` |
+| Codex | `OPENAI_API_KEY`, `CODEX_API_KEY` |
+| Gemini | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, and explicitly configured Vertex AI variables |
+| OpenCode | `OPENROUTER_API_KEY` |
+
+Each execution also gets a new mode-`0700` temporary `HOME`. Only the selected
+provider's state/authentication directories are bridged into it, preserving
+file-based login without exposing another CLI's state or unrelated home files.
+Detection and `--help` probes receive no provider credentials.
+OpenCode runs with its managed `--pure` policy, so repository and user-state
+plugins are not executed with the selected backend credential. Heimdallm also
+sets `OPENCODE_DISABLE_PROJECT_CONFIG=1`; repository `opencode.json`,
+`.opencode`, MCP, command, agent, and dependency-install configuration is not
+loaded, while operator-level configuration remains available through the
+isolated state bridge.
+
+Additional variables require an exact, comma-separated names allowlist:
+
+```bash
+HEIMDALLM_AI_GEMINI_ENV_ALLOWLIST=GOOGLE_CLOUD_QUOTA_PROJECT
+HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST=CORPORATE_TENANT_ID
+```
+
+Standard proxy and CA variables are already part of the common runtime
+baseline and do not need to be repeated.
+
+`GITHUB_TOKEN`, `GH_TOKEN`, `HEIMDALLM_*`, `GIT_*`, and dynamic-loader or
+shell-startup injection variables are permanently denied. `SSH_AUTH_SOCK` is
+absent by default and requires both an explicit per-CLI allowlist entry and an
+operator-owned socket mount. Custom allowlisted values must also be forwarded
+to the daemon container through a private compose overlay. Cross-provider
+credential boundaries are permanent for Claude, Codex, and Gemini. OpenCode
+is the deliberate exception because it is a multi-provider client: an exact
+OpenCode allowlist entry authorizes only its configured backend key.
+
+See [AI subprocess security](subprocess-security.md) for the complete
+environment contract, provider-state bridge, SSH overlay, and residual threat
+model.
+
 ### Prompt categories
 
 Each repo can use different agent profiles for different pipeline stages:
@@ -808,11 +855,46 @@ Copy only the `sk-ant-oat...` line it prints and paste it into `docker/.env`.
 
 | CLI | Env var | Where to get it |
 |---|---|---|
-| Gemini | `GEMINI_API_KEY` | https://aistudio.google.com/apikey |
+| Gemini API key | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | https://aistudio.google.com/apikey |
+| Gemini Vertex AI | `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_APPLICATION_CREDENTIALS` | Google Cloud |
 | Codex / OpenAI | `OPENAI_API_KEY` or `CODEX_API_KEY` | https://platform.openai.com/api-keys |
 | OpenCode (OpenRouter) | `OPENROUTER_API_KEY` | https://openrouter.ai/keys |
 
-OpenCode also accepts `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` depending on your configured provider.
+`OPENROUTER_API_KEY` is OpenCode's default credential. To preserve OpenCode's
+multi-provider support without exposing every daemon key, name only the
+configured backend credential explicitly:
+
+```bash
+HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST=ANTHROPIC_API_KEY
+```
+
+The same opt-in supports `OPENAI_API_KEY`, `CODEX_API_KEY`, `GEMINI_API_KEY`,
+or `GOOGLE_API_KEY`. Credentials not named in the OpenCode allowlist remain
+absent.
+
+**Gemini with Vertex AI:**
+
+```bash
+# docker/.env
+GOOGLE_GENAI_USE_VERTEXAI=true
+GOOGLE_CLOUD_PROJECT=my-project
+GOOGLE_CLOUD_LOCATION=global
+GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google-application-credentials.json
+```
+
+The credentials path is container-local. Mount the service-account file with
+an operator-owned override rather than adding it to the repository:
+
+```yaml
+# docker/docker-compose.vertex.yml
+services:
+  heimdallm:
+    volumes:
+      - type: bind
+        source: /absolute/host/path/service-account.json
+        target: /run/secrets/google-application-credentials.json
+        read_only: true
+```
 
 **Reusing Gemini browser OAuth from your host:**
 
@@ -823,7 +905,9 @@ volumes:
   - ~/.gemini:/home/heimdallm/.gemini:ro
 ```
 
-Leave `GEMINI_API_KEY` empty. The container reads your host's OAuth tokens read-only.
+Leave `GEMINI_API_KEY` and `GOOGLE_API_KEY` empty. The container reads your
+host's OAuth tokens read-only and projects only Gemini state into the
+execution's isolated temporary home.
 
 ---
 
@@ -847,34 +931,50 @@ The `web` service depends on the daemon's healthcheck (`/health`) before accepti
 | `heimdallm-data` (named) | `/data` | SQLite database and API token |
 | `heimdallm-config` (named) | `/config` | `config.toml` (daemon-owned, web UI edits here) |
 | `$HEIMDALLM_LOCAL_DIR_BASE` | `/home/heimdallm/repos` (read-only) | Host repos root for full-repo analysis |
-| SSH agent socket | `/ssh-agent` (read-only) | SSH agent for git operations in `auto_implement` |
 
 The config volume is a **named volume** (not a bind mount). This is intentional — a bind mount would be owned by root on the host, which blocked the daemon from writing `config.toml`. The image chowns `/config` to the `heimdallm` user during build.
 
-### SSH agent forwarding
+### Optional SSH agent access for an AI CLI
 
-`auto_implement` pushes branches over SSH. Forward your host's SSH agent into the container:
+The base deployment does not expose the host SSH agent. Heimdallm's
+`auto_implement` Git fetch/push path uses HTTPS with an ephemeral askpass helper
+and does not require SSH.
 
-**macOS (Docker Desktop):**
-
-Docker Desktop exposes the host agent at a fixed path. The compose file uses it by default:
-
-```yaml
-- ${HEIMDALLM_SSH_AUTH_SOCK:-/run/host-services/ssh-auth.sock}:/ssh-agent:ro
-```
-
-No extra configuration needed on macOS.
-
-**Linux:**
-
-Set `HEIMDALLM_SSH_AUTH_SOCK` to your agent socket path in `docker/.env`:
+If the selected AI CLI itself needs SSH, explicitly allow `SSH_AUTH_SOCK` for
+that provider and mount the socket with a private compose overlay. Example for
+Claude on macOS Docker Desktop:
 
 ```bash
 # docker/.env
-HEIMDALLM_SSH_AUTH_SOCK=/run/user/1000/keyring/ssh
-# or
-HEIMDALLM_SSH_AUTH_SOCK=$SSH_AUTH_SOCK
+HEIMDALLM_AI_CLAUDE_ENV_ALLOWLIST=SSH_AUTH_SOCK
+HEIMDALLM_SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
 ```
+
+```yaml
+# docker/docker-compose.ssh.yml
+services:
+  heimdallm:
+    environment:
+      SSH_AUTH_SOCK: /ssh-agent
+    volumes:
+      - type: bind
+        source: ${HEIMDALLM_SSH_AUTH_SOCK}
+        target: /ssh-agent
+        read_only: true
+```
+
+```bash
+docker compose \
+  --env-file docker/.env \
+  -f docker/docker-compose.yml \
+  -f docker/docker-compose.ssh.yml \
+  up -d
+```
+
+On Linux, set `HEIMDALLM_SSH_AUTH_SOCK` to the host agent's actual socket.
+Change the allowlist variable when the selected CLI is Codex, Gemini, or
+OpenCode. This gives that CLI signing authority through every key loaded in the
+agent; enable it only when that expanded authority is intentional.
 
 ### Day-to-day commands
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -603,10 +603,22 @@ selected provider's default credentials:
 
 | CLI | Credentials exposed by default |
 |---|---|
-| Claude | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` |
+| Claude | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_AUTH_TOKEN`, and a conditionally selected Bedrock or Vertex group |
 | Codex | `OPENAI_API_KEY`, `CODEX_API_KEY` |
 | Gemini | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, and explicitly configured Vertex AI variables |
 | OpenCode | `OPENROUTER_API_KEY` |
+
+For Claude, `ANTHROPIC_BASE_URL` supports an Anthropic-compatible gateway.
+Bedrock variables and AWS credentials are forwarded only when
+`CLAUDE_CODE_USE_BEDROCK` has one of Claude Code's enabled boolean values
+(`1`, `true`, `yes`, or `on`); Vertex selectors and ADC are forwarded only
+when `CLAUDE_CODE_USE_VERTEX` has an enabled value. The corresponding
+`CLAUDE_CODE_SKIP_*_AUTH` switch preserves gateway routing but omits client
+credentials. The Bedrock and Vertex selectors are mutually exclusive; enabling
+both fails before Claude starts so the two cloud credential groups are never
+co-resident. AWS profiles/config files remain explicit allowlist opt-ins
+because the isolated `HOME` does not project `~/.aws` and `credential_process`
+can execute operator-configured commands.
 
 Each execution also gets a new mode-`0700` temporary `HOME`. Only the selected
 provider's minimum state/authentication paths are projected into it, preserving
@@ -618,7 +630,9 @@ is verified before every cached CLI version is used, and versions older than
 Only `.claude/.credentials.json` and `.claude.json` are copied into the
 temporary home and safely synchronized back, so persistent user settings,
 CLAUDE.md, hooks, plugins, MCP servers, skills, commands, and agents are not
-loaded.
+loaded. A refresh against a source that is read-only or owned by another uid is
+ephemeral and warns without discarding a successful review; validation,
+concurrency and non-permission persistence failures remain fatal.
 Gemini projects only mutable OAuth/account/installation state and an input-only
 authentication selector. User settings, `.env`, GEMINI.md, MCP tokens,
 extensions, commands, skills, agents, and policies are excluded. Atomic
@@ -845,7 +859,7 @@ echo "GITHUB_TOKEN=$(gh auth token)" >> docker/.env
 
 ### Claude Code
 
-Two authentication options:
+Claude supports direct credentials plus three enterprise routes:
 
 **Option A: API key (pay-as-you-go)**
 
@@ -870,6 +884,55 @@ claude setup-token
 Copy only the `sk-ant-oat...` line it prints and paste it into `docker/.env`.
 
 **Do not** set `bare = true` in `config.toml` when using OAuth — `bare` disables OAuth and forces API-key mode.
+
+**Option C: Anthropic-compatible gateway**
+
+```bash
+ANTHROPIC_BASE_URL=https://gateway.example.com
+ANTHROPIC_AUTH_TOKEN=<gateway bearer token>
+```
+
+`ANTHROPIC_AUTH_TOKEN` and credentials embedded in a base URL are redacted
+from CLI errors. A normal base URL remains visible for diagnostics.
+
+**Option D: Amazon Bedrock**
+
+```bash
+CLAUDE_CODE_USE_BEDROCK=1
+AWS_REGION=us-east-1
+
+# Choose one authentication form:
+AWS_BEARER_TOKEN_BEDROCK=<bedrock API key>
+# or:
+AWS_ACCESS_KEY_ID=<access key id>
+AWS_SECRET_ACCESS_KEY=<secret access key>
+AWS_SESSION_TOKEN=<optional session token>
+```
+
+For a gateway that signs Bedrock requests, set
+`ANTHROPIC_BEDROCK_BASE_URL` and `CLAUDE_CODE_SKIP_BEDROCK_AUTH=1`.
+Heimdallm then omits every AWS credential from the Claude subprocess.
+Do not combine this route with `CLAUDE_CODE_USE_VERTEX`; Heimdallm rejects
+conflicting cloud backends before starting Claude.
+
+**Option E: Google Vertex AI**
+
+```bash
+CLAUDE_CODE_USE_VERTEX=1
+CLOUD_ML_REGION=global
+ANTHROPIC_VERTEX_PROJECT_ID=my-project
+GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google-application-credentials.json
+```
+
+The ADC path is container-local and needs the same operator-owned read-only
+mount shown in the Gemini Vertex example below. For a gateway that supplies
+Google authentication, set `ANTHROPIC_VERTEX_BASE_URL` and
+`CLAUDE_CODE_SKIP_VERTEX_AUTH=1`; the ADC path is then omitted.
+
+`AWS_PROFILE`, `AWS_CONFIG_FILE`, and `AWS_SHARED_CREDENTIALS_FILE` are not
+automatic. If a reviewed deployment needs them, add their exact names to
+`HEIMDALLM_AI_CLAUDE_ENV_ALLOWLIST`, expose absolute container paths through a
+private read-only mount, and audit any `credential_process` command first.
 
 ### Other AI CLIs
 

--- a/docs/e2e-test-guide.md
+++ b/docs/e2e-test-guide.md
@@ -201,6 +201,8 @@ If you've already authenticated `gemini` on your host:
    volumes:
      - ~/.gemini:/home/heimdallm/.gemini:ro
    ```
+   The test imports authentication state read-only. Any OAuth refresh is
+   confined to that run and is not written back to the host.
 
 ### Option C: Vertex AI + Service Account
 

--- a/docs/e2e-test-guide.md
+++ b/docs/e2e-test-guide.md
@@ -7,7 +7,7 @@ This guide walks you through verifying the full Heimdallm review pipeline: daemo
 | Requirement | Details |
 |---|---|
 | **GitHub Token** | A `GITHUB_TOKEN` with `repo` scope for a user/bot account |
-| **AI Authentication** | At least one: `GEMINI_API_KEY`, `ANTHROPIC_API_KEY` (or `CLAUDE_CODE_OAUTH_TOKEN`), or `OPENAI_API_KEY` |
+| **AI Authentication** | At least one configured API/OAuth credential, or a selected Claude Bedrock/Vertex/gateway route |
 | **Monitored Repo** | A repo listed in `HEIMDALLM_REPOSITORIES` where the token user has write access |
 | **Open PR** | The token user must be **explicitly requested as a reviewer** on the PR |
 | **Collaborator** | GitHub does not allow requesting yourself as reviewer — another account must do it |
@@ -45,6 +45,8 @@ HEIMDALLM_POLL_INTERVAL=1m
 GEMINI_API_KEY=your_gemini_key
 # ANTHROPIC_API_KEY=your_anthropic_key
 # CLAUDE_CODE_OAUTH_TOKEN=your_oauth_token    # alternative to ANTHROPIC_API_KEY
+# ANTHROPIC_BASE_URL=https://gateway.example.com
+# ANTHROPIC_AUTH_TOKEN=your_gateway_token
 # OPENAI_API_KEY=your_openai_key
 ```
 
@@ -213,7 +215,9 @@ For production/CI environments:
 
 ## Claude Code Authentication for Docker
 
-Two options for authenticating Claude Code inside Docker:
+Five routes are supported. The Compose file forwards their exact documented
+variables; the executor activates Bedrock/Vertex credentials only when the
+matching provider selector is enabled.
 
 ### Option A: API Key (Simplest)
 
@@ -227,6 +231,29 @@ For Max/Pro/Team subscription users:
 2. Set `CLAUDE_CODE_OAUTH_TOKEN` in `docker/.env`
 
 > **Note:** Do not enable `bare = true` in `config.toml` when using OAuth tokens — bare mode disables OAuth and requires an API key.
+
+### Option C: Anthropic-Compatible Gateway
+
+Set `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN`.
+
+### Option D: Amazon Bedrock
+
+Set `CLAUDE_CODE_USE_BEDROCK=1`, `AWS_REGION`, and either
+`AWS_BEARER_TOKEN_BEDROCK` or the standard access-key/session-token variables.
+A signing gateway can instead set `ANTHROPIC_BEDROCK_BASE_URL` and
+`CLAUDE_CODE_SKIP_BEDROCK_AUTH=1`.
+
+### Option E: Google Vertex AI
+
+Set `CLAUDE_CODE_USE_VERTEX=1`, `CLOUD_ML_REGION`,
+`ANTHROPIC_VERTEX_PROJECT_ID`, and a container-visible
+`GOOGLE_APPLICATION_CREDENTIALS` mount. A gateway can use
+`ANTHROPIC_VERTEX_BASE_URL` plus `CLAUDE_CODE_SKIP_VERTEX_AUTH=1`.
+
+AWS profiles and config files are intentionally not automatic because the
+isolated home does not project `~/.aws` and `credential_process` can execute a
+command. See the [Configuration Guide](configuration-guide.md#claude-code)
+before explicitly allowlisting those paths.
 
 ## Troubleshooting
 

--- a/docs/subprocess-security.md
+++ b/docs/subprocess-security.md
@@ -1,0 +1,209 @@
+# AI subprocess security
+
+Heimdallm runs third-party AI CLIs against repository content, including
+untrusted pull-request diffs and issue text. The daemon therefore treats every
+CLI launch as a credential boundary: selecting one provider must not disclose
+the GitHub token, Heimdallm configuration, another provider's key, or unrelated
+host credentials to that process.
+
+## Environment contract
+
+AI subprocess environments are built from an empty set. They receive a small
+cross-platform runtime baseline (`PATH`, locale, temporary-directory and user
+identity variables), headless-mode settings, and only the default credentials
+for the selected CLI:
+
+| CLI | Credentials exposed by default |
+|---|---|
+| Claude | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` |
+| Codex | `OPENAI_API_KEY`, `CODEX_API_KEY` |
+| Gemini | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, plus explicitly configured Vertex AI variables |
+| OpenCode | `OPENROUTER_API_KEY` |
+
+OpenCode also preserves the non-secret `OPENCODE_DISABLE_AUTOUPDATE` runtime
+setting used by the container image.
+
+The Vertex AI variables are `GOOGLE_APPLICATION_CREDENTIALS`,
+`GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and
+`GOOGLE_GENAI_USE_VERTEXAI`. A credentials path must point to a file visible
+inside the container; Heimdallm does not mount host service-account files
+automatically.
+
+Detection and `--help` probes do not receive provider credentials.
+
+For full-repository Gemini analysis, the process CWD remains inside the
+temporary home and the validated repository is passed through Gemini's
+include-directory option. Heimdallm also supplies a mode-`0600` system
+settings override with `advanced.ignoreLocalEnv=true`, forces `--ignore-env`,
+and omits Gemini's special `.gemini/.env` from the state projection. The
+temporary CWD alone is trusted for the headless session; the repository stays
+an included external directory. A repository or user-state `.env` therefore
+cannot repopulate the sanitized parent environment. An older Gemini CLI
+without these flags or a supported include-directory option fails closed
+instead of falling back to an unsafe repository CWD.
+
+OpenCode likewise starts from the isolated temporary directory and receives
+the validated repository through its `run --dir` option. This prevents the
+runtime itself from loading repository-local environment files before the CLI
+has established its own policy. Heimdallm probes the managed
+`--pure run --help` path and fails closed when the CLI does not support both
+pure mode and `run --dir`. Pure mode prevents executable plugins declared by
+the repository or user state from inheriting the selected provider credential.
+Its managed
+`OPENCODE_DISABLE_PROJECT_CONFIG=1` policy also prevents repository
+`opencode.json`, `.opencode`, MCP, command, agent, and dependency-install
+configuration from being loaded; operator configuration remains available
+through the isolated global state bridge.
+
+## Isolated home directories
+
+Each execution gets a new mode-`0700` temporary `HOME`. Heimdallm projects only
+the selected provider's state/authentication paths into that home:
+
+- Claude: `.claude` and `.claude.json`
+- Codex: `.codex`
+- Gemini: `.gemini`, except `.gemini/.env`
+- OpenCode: `.config/opencode` and `.local/share/opencode`
+
+This preserves file-based login and session refresh without exposing unrelated
+home-directory state such as `.ssh`, `.aws`, `.gitconfig`, or another CLI's
+credentials. In Docker, an explicitly mounted read-only provider directory
+(for example the documented Gemini OAuth mount) remains read-only through the
+bridge. Values stored only in `.gemini/.env` are intentionally not imported;
+configure built-in Gemini variables in the daemon environment, or use an
+explicit Gemini allowlist plus a private Compose overlay.
+
+## Opting in additional variables
+
+Some enterprise or CLI integrations need auxiliary environment variables
+beyond the standard proxy and CA variables already present in the common
+runtime baseline. Opt in exact variable names per CLI with a comma-separated
+list:
+
+```dotenv
+HEIMDALLM_AI_GEMINI_ENV_ALLOWLIST=GOOGLE_CLOUD_QUOTA_PROJECT
+HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST=CORPORATE_TENANT_ID
+```
+
+This is a names-only policy. The corresponding values must be present in the
+daemon environment. Docker Compose forwards the documented provider variables;
+custom variables must also be added to an operator-owned compose overlay:
+
+```yaml
+services:
+  heimdallm:
+    environment:
+      CORPORATE_TENANT_ID: ${CORPORATE_TENANT_ID}
+```
+
+The following classes are denied even when named in an allowlist:
+
+- `GITHUB_TOKEN` and `GH_TOKEN`
+- every `HEIMDALLM_*` variable
+- every `GIT_*` variable
+- managed home, state, and policy controls such as `HOME`, `PATH`,
+  `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `GEMINI_CLI_SYSTEM_SETTINGS_PATH`,
+  `OPENCODE_DISABLE_PROJECT_CONFIG`, and `OPENCODE_PURE`
+- dynamic-loader and shell-startup injection variables, including
+  `LD_PRELOAD`, `DYLD_*`, `BASH_ENV`, `ENV`, `PROMPT_COMMAND`, `NODE_OPTIONS`,
+  and `NODE_PATH`
+
+Empty names, invalid names, and wildcard patterns are rejected. Do not treat an
+allowlist as a convenient way to copy the daemon's environment wholesale.
+Provider credential boundaries are permanent for Claude, Codex, and Gemini.
+OpenCode is the deliberate exception because it is a multi-provider client:
+`OPENROUTER_API_KEY` is available by default, while an Anthropic, OpenAI, or
+Gemini backend key requires its exact name in
+`HEIMDALLM_AI_OPENCODE_ENV_ALLOWLIST`. Unnamed backend credentials remain
+absent.
+
+## SSH agent access is explicit
+
+The base Docker deployment neither mounts the host SSH agent nor sets
+`SSH_AUTH_SOCK`. Heimdallm's own `auto_implement` Git operations use HTTPS with
+an ephemeral askpass helper, so they do not need the agent.
+
+If an AI CLI itself must perform an SSH operation, opt the socket into that CLI
+and add a private compose overlay. For Claude on macOS Docker Desktop:
+
+```dotenv
+# docker/.env
+HEIMDALLM_AI_CLAUDE_ENV_ALLOWLIST=SSH_AUTH_SOCK
+HEIMDALLM_SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+```
+
+```yaml
+# docker/docker-compose.ssh.yml — operator-owned; do not commit credentials
+services:
+  heimdallm:
+    environment:
+      SSH_AUTH_SOCK: /ssh-agent
+    volumes:
+      - type: bind
+        source: ${HEIMDALLM_SSH_AUTH_SOCK}
+        target: /ssh-agent
+        read_only: true
+```
+
+Start with both files:
+
+```bash
+docker compose \
+  --env-file docker/.env \
+  -f docker/docker-compose.yml \
+  -f docker/docker-compose.ssh.yml \
+  up -d
+```
+
+On Linux, set `HEIMDALLM_SSH_AUTH_SOCK` to the host agent's actual socket.
+Change the allowlist variable for Codex, Gemini, or OpenCode as appropriate.
+Agent access lets the selected CLI request signatures with every key loaded in
+that agent; enable it only when this broader authority is intentional.
+
+## Automated Git subprocesses
+
+Daemon-owned Git commands use a separate boundary from AI CLIs. Every command
+gets a fresh mode-`0700` home, config root, temporary directory, and empty hooks
+directory. The runner ignores inherited `GIT_*`, GitHub, loader, shell, global,
+and system configuration; permits only an absolute trusted Git binary path;
+and forces hooks, credential helpers, editors, pagers, signing, recursive
+submodules, maintenance, external diff/text-conversion, and unsafe transport
+protocols off. Repository and worktree config is audited before use, including
+includes, filters, executable helpers, object alternates, and remote helper
+settings. For Linux bind mounts whose host ownership differs from the daemon
+UID, Git receives `safe.directory` only for the exact canonical worktree that
+passed that audit; wildcard trust is never enabled.
+
+Authenticated clone, fetch, push, and conditional branch deletion accept only
+canonical GitHub HTTPS remotes. The token is supplied through an ephemeral
+askpass helper, never in argv or a remote URL. For fetch and push, the
+token-bearing Git process works against an empty temporary bare repository;
+the checkout is imported or staged later by a tokenless process. Clone
+materializes the worktree only after its authenticated `--no-checkout` phase,
+and all commits and pushes explicitly disable hooks.
+
+Corporate proxy and CA variables are the only host network settings forwarded
+to Git. Error output is bounded and redacts the GitHub token, its encoded
+representations, and proxy credentials.
+
+## Threat model and residual risk
+
+Environment and home isolation reduce accidental disclosure and common prompt
+injection paths. They are not a filesystem or operating-system sandbox.
+
+The CLI still runs as the daemon's UID, in the same container or host account,
+and can access any absolute path, mounted repository, device, socket, or network
+destination available to that identity. A malicious or compromised CLI can
+also exfiltrate its own authorized provider credential.
+
+For strong isolation, run Heimdallm in a dedicated container or VM with:
+
+- only the required repositories mounted, read-only unless implementation
+  writes are needed;
+- no Docker socket, cloud metadata credentials, host home, or unrelated
+  volumes;
+- a dedicated UID and narrowly scoped network egress;
+- short-lived, least-privilege provider and GitHub credentials.
+
+The GitHub token remains in the daemon because it is required for API and
+HTTPS Git operations, but it is not passed to AI subprocesses.

--- a/docs/subprocess-security.md
+++ b/docs/subprocess-security.md
@@ -31,6 +31,16 @@ automatically.
 
 Detection and `--help` probes do not receive provider credentials.
 
+For full-repository Claude analysis, the process also stays in the isolated
+temporary directory and receives the validated repository only through
+`--add-dir` (or the compatible `--directory` form). Heimdallm always forces
+Claude's upstream `--safe-mode`, which disables CLAUDE.md instructions, hooks,
+plugins, skills, commands, agents, workflows, output styles, and MCP servers
+while preserving authentication and managed policy. Support for that flag is
+verified with the credential-free help probe; Claude Code older than 2.1.169
+fails closed. A Claude CLI without a supported additional-directory option
+also fails closed instead of running inside the repository.
+
 For full-repository Gemini analysis, the process CWD remains inside the
 temporary home and the validated repository is passed through Gemini's
 include-directory option. Heimdallm also supplies a mode-`0600` system
@@ -60,16 +70,39 @@ through the isolated global state bridge.
 Each execution gets a new mode-`0700` temporary `HOME`. Heimdallm projects only
 the selected provider's state/authentication paths into that home:
 
-- Claude: `.claude` and `.claude.json`
+- Claude: `.claude/.credentials.json` and `.claude.json`
 - Codex: `.codex`
-- Gemini: `.gemini`, except `.gemini/.env`
+- Gemini: `oauth_creds.json`, `google_accounts.json`, `installation_id`, and
+  legacy `user_id`, plus an input-only auth selector from `settings.json`
 - OpenCode: `.config/opencode` and `.local/share/opencode`
+
+Claude's two JSON files use mode-`0600` copy-in/copy-out instead of symlinks.
+Changed state is validated, normally synchronized with an atomic replace before
+the temporary home is removed, and rejected on concurrent modification or
+symlink/device replacement. This preserves OAuth rotation, including when the
+CLI exits with an error, without exposing persistent `.claude/settings.json`,
+hooks, plugins, skills, or commands. Empty first-run `.claude.json` files are
+accepted. Linux file bind mounts, which reject replacement with `EBUSY`, use a
+narrowly scoped in-place fallback with mode `0600` and `fsync`. The
+`.claude.json` file remains trusted
+provider-owned state and can be updated by Claude itself; safe mode prevents
+entries stored there from starting MCP processes in a Heimdallm run.
+
+Gemini likewise uses copy-in/copy-out for only the four mutable token or
+identifier files, preserving first-run creation and atomic rotations. Its user
+`settings.json` is reduced to `selectedAuthType` and
+`security.auth.selectedType` for headless login; it is input-only and never
+copied back. `.env`, `GEMINI.md`, MCP tokens, settings, extensions, commands,
+skills, agents, and policies are not projected. A read-only Docker OAuth mount
+remains read-only: a refresh is usable for that execution but cannot be
+persisted, and Heimdallm emits a warning instead of discarding a successful
+review. Native and `make run-linux` read-write state persists rotations.
 
 This preserves file-based login and session refresh without exposing unrelated
 home-directory state such as `.ssh`, `.aws`, `.gitconfig`, or another CLI's
 credentials. In Docker, an explicitly mounted read-only provider directory
-(for example the documented Gemini OAuth mount) remains read-only through the
-bridge. Values stored only in `.gemini/.env` are intentionally not imported;
+(for example the documented Gemini OAuth mount) remains read-only. Values
+stored only in `.gemini/.env` are intentionally not imported;
 configure built-in Gemini variables in the daemon environment, or use an
 explicit Gemini allowlist plus a private Compose overlay.
 
@@ -96,20 +129,34 @@ services:
       CORPORATE_TENANT_ID: ${CORPORATE_TENANT_ID}
 ```
 
+An allowlisted name that is absent emits an operator-visible warning without
+logging a value. Missing optional provider-state paths emit an info breadcrumb
+once per path, so first-run behavior is diagnosable without flooding logs.
+
 The following classes are denied even when named in an allowlist:
 
 - `GITHUB_TOKEN` and `GH_TOKEN`
 - every `HEIMDALLM_*` variable
 - every `GIT_*` variable
 - managed home, state, and policy controls such as `HOME`, `PATH`,
-  `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `GEMINI_CLI_SYSTEM_SETTINGS_PATH`,
+  `CLAUDE_CODE_SAFE_MODE`, `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`,
+  `GEMINI_CLI_HOME`, Gemini settings/system-prompt/sandbox command overrides,
+  OpenCode config path/content/directory overrides,
   `OPENCODE_DISABLE_PROJECT_CONFIG`, and `OPENCODE_PURE`
 - dynamic-loader and shell-startup injection variables, including
   `LD_PRELOAD`, `DYLD_*`, `BASH_ENV`, `ENV`, `PROMPT_COMMAND`, `NODE_OPTIONS`,
-  and `NODE_PATH`
+  `NODE_PATH`, JVM agent options, `.NET` startup hooks, GTK/GIO module paths,
+  and Python warning-import controls
 
-Empty names, invalid names, and wildcard patterns are rejected. Do not treat an
-allowlist as a convenient way to copy the daemon's environment wholesale.
+Empty CSV elements are ignored, so a trailing or doubled comma does not disable
+valid entries. Invalid names and wildcard patterns are rejected. Matching is
+case-insensitive for the common runtime baseline while preserving the parent's
+original spelling. Do not treat an allowlist as a convenient way to copy the
+daemon's environment wholesale.
+The permanent denylist is defense in depth, not an exhaustive catalogue of
+every runtime's future injection variables. A name not present in the denylist
+is not automatically safe: each explicit opt-in remains an operator trust
+decision.
 Provider credential boundaries are permanent for Claude, Codex, and Gemini.
 OpenCode is the deliberate exception because it is a multi-provider client:
 `OPENROUTER_API_KEY` is available by default, while an Anthropic, OpenAI, or
@@ -185,6 +232,16 @@ and all commits and pushes explicitly disable hooks.
 Corporate proxy and CA variables are the only host network settings forwarded
 to Git. Error output is bounded and redacts the GitHub token, its encoded
 representations, and proxy credentials.
+
+AI CLI errors redact selected provider secrets, proxy credentials, and
+explicitly opted-in values whose names have an exact secret suffix (`_TOKEN`,
+`_SECRET`, `_PASSWORD`, `_API_KEY`, `_DATABASE_URL`, `_DSN`, and related
+forms). Allowlisted URL values with user information are also redacted even
+when their names are neutral. This avoids false positives such as
+`TOKENIZER_MODE` or `COOKIE_POLICY`. Non-secret runtime selectors such as
+Vertex project, location, mode, credential-file path, or a custom region remain
+intact so diagnostics are not corrupted. Codex tool subprocesses do not receive
+credential-bearing proxy URLs but retain `NO_PROXY`.
 
 ## Threat model and residual risk
 

--- a/docs/subprocess-security.md
+++ b/docs/subprocess-security.md
@@ -15,7 +15,7 @@ for the selected CLI:
 
 | CLI | Credentials exposed by default |
 |---|---|
-| Claude | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` |
+| Claude | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_AUTH_TOKEN`, plus the selected Bedrock or Vertex authentication group |
 | Codex | `OPENAI_API_KEY`, `CODEX_API_KEY` |
 | Gemini | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, plus explicitly configured Vertex AI variables |
 | OpenCode | `OPENROUTER_API_KEY` |
@@ -28,6 +28,33 @@ The Vertex AI variables are `GOOGLE_APPLICATION_CREDENTIALS`,
 `GOOGLE_GENAI_USE_VERTEXAI`. A credentials path must point to a file visible
 inside the container; Heimdallm does not mount host service-account files
 automatically.
+
+Claude gateway routing preserves `ANTHROPIC_BASE_URL` and treats
+`ANTHROPIC_AUTH_TOKEN` as a secret. Its enterprise groups are conditional:
+
+- `CLAUDE_CODE_USE_BEDROCK=1|true|yes|on` enables
+  `ANTHROPIC_BEDROCK_BASE_URL`, `AWS_REGION`, `AWS_DEFAULT_REGION`,
+  `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and
+  `AWS_BEARER_TOKEN_BEDROCK`. All four credential values are redacted.
+  `CLAUDE_CODE_SKIP_BEDROCK_AUTH=1|true|yes|on` keeps those credentials out of the
+  subprocess while preserving routing selectors for a gateway that signs
+  requests itself.
+- `CLAUDE_CODE_USE_VERTEX=1|true|yes|on` enables `ANTHROPIC_VERTEX_BASE_URL`,
+  `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`, `GCLOUD_PROJECT`,
+  `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_APPLICATION_CREDENTIALS`.
+  `CLAUDE_CODE_SKIP_VERTEX_AUTH=1|true|yes|on` omits the ADC credential path while
+  preserving routing selectors.
+
+The Bedrock and Vertex selectors are mutually exclusive. If both are enabled,
+environment preparation fails before either cloud credential group is exposed
+to Claude.
+
+There is no `AWS_*` wildcard. `AWS_PROFILE`, `AWS_CONFIG_FILE`,
+`AWS_SHARED_CREDENTIALS_FILE`, web-identity/ECS variables, model pins, and
+other advanced knobs require exact Claude allowlist entries. The isolated
+`HOME` cannot see the daemon's `~/.aws`, and an operator-supplied AWS config
+can execute `credential_process`; use container-visible absolute paths and
+operator-owned read-only mounts only after reviewing that configuration.
 
 Detection and `--help` probes do not receive provider credentials.
 
@@ -87,6 +114,11 @@ narrowly scoped in-place fallback with mode `0600` and `fsync`. The
 `.claude.json` file remains trusted
 provider-owned state and can be updated by Claude itself; safe mode prevents
 entries stored there from starting MCP processes in a Heimdallm run.
+If a Claude state source cannot be written because of `EROFS`, `EACCES`, or
+`EPERM`, a refreshed copy remains ephemeral and an operator-visible warning is
+emitted without discarding an otherwise successful review. Validation,
+concurrent replacement, symlink/device changes, disk-full and I/O errors remain
+fatal.
 
 Gemini likewise uses copy-in/copy-out for only the four mutable token or
 identifier files, preserving first-run creation and atomic rotations. Its user
@@ -151,8 +183,11 @@ The following classes are denied even when named in an allowlist:
 Empty CSV elements are ignored, so a trailing or doubled comma does not disable
 valid entries. Invalid names and wildcard patterns are rejected. Matching is
 case-insensitive for the common runtime baseline while preserving the parent's
-original spelling. Do not treat an allowlist as a convenient way to copy the
-daemon's environment wholesale.
+original spelling. The sole canonicalized capability is `SSH_AUTH_SOCK`, so a
+lowercase allowlist spelling still reaches both the selected CLI and Codex's
+nested-tool policy. Other operator-defined names remain case-sensitive on
+Unix. Do not treat an allowlist as a convenient way to copy the daemon's
+environment wholesale.
 The permanent denylist is defense in depth, not an exhaustive catalogue of
 every runtime's future injection variables. A name not present in the denylist
 is not automatically safe: each explicit opt-in remains an operator trust


### PR DESCRIPTION
## Resumen

- Aísla cada CLI de IA en un entorno construido desde cero, con credenciales y estado limitados al proveedor seleccionado, HOME/XDG/TMP temporales y redacción de secretos.
- Endurece Codex, Gemini y OpenCode frente a configuración, plugins, MCP y variables heredadas del repositorio; `SSH_AUTH_SOCK` queda como opt-in explícito.
- Centraliza las operaciones Git automatizadas en un runner auditado que neutraliza hooks, configuración externa, helpers y variables peligrosas.
- Mantiene los tokens de push/fetch en procesos temporales mínimos sin checkout y valida transportes, referencias y OID.
- Documenta el modelo de amenazas, las variables de opt-in y la configuración Docker/Compose.

## No regresión

- `make test-docker`
- `make test-cli`
- `docker compose --env-file docker/.env.example -f docker/docker-compose.yml config --quiet`
- `git diff --check`
- Pruebas específicas con entornos falsos, hooks maliciosos (`pre-commit`, `commit-msg`, `pre-push`), configuración Git hostil, worktrees, `safe.directory`, credenciales de todos los proveedores, transporte HTTPS y redacción.

Closes #608