### PR TITLE
fix(executor): resolve AI CLIs from well-known installer directories

### DIFF
--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -959,7 +959,42 @@ func resolveCLIPath(name string) string {
 		return path
 	}
 	// Fall back to the user's login shell.
-	return loginShellLookPath(name)
+	if path := loginShellLookPath(name); path != "" {
+		return path
+	}
+	// Last resort: installer directories commonly missing from both launchd's
+	// minimal PATH and non-interactive login shells.
+	return lookInWellKnownDirs(name)
+}
+
+// wellKnownBinDirs returns the installer directories probed when neither the
+// process PATH nor the login shell resolves a CLI. Package-level var so tests
+// can stub it and stay hermetic on dev machines with real CLIs installed.
+//
+// ~/.local/bin is where the Claude Code native installer places its binary,
+// exporting it only in ~/.zshrc — which non-interactive login shells never
+// source, so the login-shell probe cannot see it either (issue #643).
+var wellKnownBinDirs = func() []string {
+	dirs := make([]string, 0, 3)
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".local", "bin"))
+	}
+	return append(dirs, "/opt/homebrew/bin", "/usr/local/bin")
+}
+
+// lookInWellKnownDirs returns the path of an executable named name inside the
+// well-known installer directories, or "" if none qualifies. Mirrors
+// exec.LookPath's requirement that the candidate be an executable regular file.
+func lookInWellKnownDirs(name string) string {
+	for _, dir := range wellKnownBinDirs() {
+		candidate := filepath.Join(dir, name)
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() || info.Mode().Perm()&0o111 == 0 {
+			continue
+		}
+		return candidate
+	}
+	return ""
 }
 
 // loginShellLookPath resolves name via the user's login shell, which sources

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -964,7 +964,41 @@ func resolveCLIPath(name string) string {
 	}
 	// Last resort: installer directories commonly missing from both launchd's
 	// minimal PATH and non-interactive login shells.
-	return lookInWellKnownDirs(name)
+	if path := lookInWellKnownDirs(name); path != "" {
+		return path
+	}
+	slog.Debug("executor: CLI not found on PATH, login shell, or well-known dirs", "cli", name)
+	return ""
+}
+
+// appendDirToPath returns env (the process environment when nil) with dir
+// appended to PATH when missing. The resolved CLI may live in a directory that
+// is absent from both the process and login-shell PATH (the well-known-dir
+// fallback); without this, a CLI that re-invokes itself or a sibling tool by
+// bare name would still fail in the launchd environment even though Heimdallm
+// launched it by absolute path. Appending (not prepending) means resolution of
+// every other binary is unchanged.
+func appendDirToPath(env []string, dir string) []string {
+	if dir == "" || dir == "." {
+		return env
+	}
+	if env == nil {
+		env = os.Environ()
+	}
+	for i, kv := range env {
+		if !strings.HasPrefix(kv, "PATH=") {
+			continue
+		}
+		for _, p := range filepath.SplitList(strings.TrimPrefix(kv, "PATH=")) {
+			if p == dir {
+				return env
+			}
+		}
+		out := append([]string(nil), env...)
+		out[i] = kv + string(os.PathListSeparator) + dir
+		return out
+	}
+	return append(append([]string(nil), env...), "PATH="+dir)
 }
 
 // wellKnownBinDirs returns the installer directories probed when neither the
@@ -983,16 +1017,18 @@ var wellKnownBinDirs = func() []string {
 }
 
 // lookInWellKnownDirs returns the path of an executable named name inside the
-// well-known installer directories, or "" if none qualifies. Mirrors
-// exec.LookPath's requirement that the candidate be an executable regular file.
+// well-known installer directories, or "" if none qualifies. exec.LookPath on
+// a path containing a separator checks that exact file with the same
+// effective-user executability test (eaccess X_OK) the PATH lookup applies, so
+// a candidate the daemon cannot actually execute (e.g. a root-owned 0700 file)
+// is skipped rather than selected and failed at exec time.
 func lookInWellKnownDirs(name string) string {
 	for _, dir := range wellKnownBinDirs() {
 		candidate := filepath.Join(dir, name)
-		info, err := os.Stat(candidate)
-		if err != nil || info.IsDir() || info.Mode().Perm()&0o111 == 0 {
-			continue
+		if path, err := exec.LookPath(candidate); err == nil {
+			slog.Debug("executor: CLI resolved from well-known installer dir", "cli", name, "path", path)
+			return path
 		}
-		return candidate
 	}
 	return ""
 }
@@ -1194,6 +1230,11 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	enrichedEnv := enrichEnvWithLoginPath()
 	if enrichedEnv != nil {
 		cmd.Env = enrichedEnv
+	}
+	// Make sure the CLI's own directory is on the child's PATH — it may have
+	// been resolved from a well-known installer dir that no PATH source knows.
+	if filepath.IsAbs(cliPath) {
+		cmd.Env = appendDirToPath(cmd.Env, filepath.Dir(cliPath))
 	}
 	if opts.WorkDir != "" {
 		cmd.Dir = opts.WorkDir

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -989,15 +989,25 @@ func appendDirToPath(env []string, dir string) []string {
 		if !strings.HasPrefix(kv, "PATH=") {
 			continue
 		}
-		for _, p := range filepath.SplitList(strings.TrimPrefix(kv, "PATH=")) {
+		path := strings.TrimPrefix(kv, "PATH=")
+		for _, p := range filepath.SplitList(path) {
 			if p == dir {
 				return env
 			}
 		}
 		out := append([]string(nil), env...)
-		out[i] = kv + string(os.PathListSeparator) + dir
+		if path == "" {
+			// "PATH=:" + dir would create a leading empty element, which
+			// POSIX interprets as the current directory.
+			out[i] = "PATH=" + dir
+		} else {
+			out[i] = kv + string(os.PathListSeparator) + dir
+		}
 		return out
 	}
+	// No PATH entry at all — unreachable via os.Environ()/the enriched env,
+	// both of which always carry PATH. Setting the CLI's own dir is still
+	// strictly more capable than leaving the child with no PATH.
 	return append(append([]string(nil), env...), "PATH="+dir)
 }
 
@@ -1421,6 +1431,11 @@ func cliHelp(cliPath string) (string, bool) {
 	cmd := exec.CommandContext(ctx, cliPath, "--help")
 	if env := enrichEnvWithLoginPath(); env != nil {
 		cmd.Env = env
+	}
+	// Same PATH enrichment as ExecuteRaw: a CLI resolved from a well-known
+	// dir may exec a sibling tool by bare name while printing --help.
+	if filepath.IsAbs(cliPath) {
+		cmd.Env = appendDirToPath(cmd.Env, filepath.Dir(cliPath))
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -36,6 +36,8 @@ func TestDetect_Fallback(t *testing.T) {
 	// the isolated $PATH, so the primary never "fails" and the fallback path is
 	// never exercised (the test then flakes on any dev box with codex present).
 	defer executor.SetLoginShellLookPathForTest(func(string) string { return "" })()
+	// Same for the well-known-dirs probe (e.g. codex in /opt/homebrew/bin).
+	defer executor.SetWellKnownBinDirsForTest(func() []string { return nil })()
 
 	e := executor.New()
 	cli, err := e.Detect("codex", "gemini")
@@ -44,6 +46,75 @@ func TestDetect_Fallback(t *testing.T) {
 	}
 	if cli != "gemini" {
 		t.Errorf("expected fake_gemini fallback, got %q", cli)
+	}
+}
+
+func TestDetect_WellKnownDirFallback(t *testing.T) {
+	// Neither the process PATH nor the login shell can resolve the CLI — the
+	// exact environment of a daemon started by launchd with the minimal system
+	// PATH and a CLI installed by an installer that only edits ~/.zshrc.
+	t.Setenv("PATH", t.TempDir())
+	defer executor.SetLoginShellLookPathForTest(func(string) string { return "" })()
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer executor.SetWellKnownBinDirsForTest(func() []string { return []string{binDir} })()
+
+	e := executor.New()
+	cli, err := e.Detect("claude", "")
+	if err != nil {
+		t.Fatalf("detect via well-known dir: %v", err)
+	}
+	if cli != "claude" {
+		t.Errorf("expected claude, got %q", cli)
+	}
+}
+
+func TestDetect_WellKnownDirSkipsNonExecutable(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	defer executor.SetLoginShellLookPathForTest(func(string) string { return "" })()
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("not a binary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer executor.SetWellKnownBinDirsForTest(func() []string { return []string{binDir} })()
+
+	e := executor.New()
+	if _, err := e.Detect("claude", ""); err == nil {
+		t.Error("expected error: a non-executable candidate must not be selected")
+	}
+}
+
+func TestWellKnownBinDirsDefaults(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dirs := executor.DefaultWellKnownBinDirsForTest()
+	want := []string{
+		filepath.Join(home, ".local", "bin"),
+		"/opt/homebrew/bin",
+		"/usr/local/bin",
+	}
+	for _, w := range want {
+		found := false
+		for _, d := range dirs {
+			if d == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("default well-known dirs %v missing %q", dirs, w)
+		}
 	}
 }
 

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -94,7 +94,51 @@ func TestDetect_WellKnownDirSkipsNonExecutable(t *testing.T) {
 	}
 }
 
+func TestDetect_WellKnownDirSkipsDirectoryNamedLikeCLI(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	defer executor.SetLoginShellLookPathForTest(func(string) string { return "" })()
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(filepath.Join(binDir, "claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer executor.SetWellKnownBinDirsForTest(func() []string { return []string{binDir} })()
+
+	e := executor.New()
+	if _, err := e.Detect("claude", ""); err == nil {
+		t.Error("expected error: a directory named like the CLI must not be selected")
+	}
+}
+
+func TestExecuteRawWellKnownDirPrecedence(t *testing.T) {
+	// System dirs, not an empty temp dir — see TestExecuteRawAddsWellKnownDirToChildPATH.
+	t.Setenv("PATH", "/usr/bin:/bin")
+	defer executor.SetLoginShellLookPathForTest(func(string) string { return "" })()
+
+	first := t.TempDir()
+	second := t.TempDir()
+	for dir, marker := range map[string]string{first: "first", second: "second"} {
+		script := "#!/bin/sh\nprintf '" + marker + "'\n"
+		if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	defer executor.SetWellKnownBinDirsForTest(func() []string { return []string{first, second} })()
+
+	e := executor.New()
+	out, err := e.ExecuteRaw("claude", "prompt", executor.ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "first" {
+		t.Errorf("expected the CLI from the first well-known dir to win, got %q", got)
+	}
+}
+
 func TestWellKnownBinDirsDefaults(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME-based derivation is Unix-only; the daemon does not target Windows")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -116,6 +160,43 @@ func TestWellKnownBinDirsDefaults(t *testing.T) {
 			t.Errorf("default well-known dirs %v missing %q", dirs, w)
 		}
 	}
+}
+
+func TestExecuteRawAddsWellKnownDirToChildPATH(t *testing.T) {
+	// The CLI is launched by absolute path, but if it re-invokes itself (or a
+	// sibling tool installed next to it) by bare name, the child's PATH must
+	// contain the well-known dir the CLI was resolved from — that dir is, by
+	// definition of this fallback, missing from both the process PATH and the
+	// login-shell PATH.
+	//
+	// Keep the system dirs (not an empty temp dir) on PATH: the first
+	// ExecuteRaw call in the process freezes os.Environ() into the
+	// enrichEnvWithLoginPath cache, and later tests' fake CLIs need coreutils
+	// from that frozen PATH (see the comment in TestExecute).
+	t.Setenv("PATH", "/usr/bin:/bin")
+	defer executor.SetLoginShellLookPathForTest(func(string) string { return "" })()
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\nprintf '%s' \"$PATH\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer executor.SetWellKnownBinDirsForTest(func() []string { return []string{binDir} })()
+
+	e := executor.New()
+	out, err := e.ExecuteRaw("claude", "prompt", executor.ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	for _, p := range filepath.SplitList(strings.TrimSpace(string(out))) {
+		if p == binDir {
+			return
+		}
+	}
+	t.Fatalf("child PATH %q does not contain the resolved CLI dir %q", out, binDir)
 }
 
 func TestDetect_NoneAvailable(t *testing.T) {

--- a/daemon/internal/executor/executor_test.go
+++ b/daemon/internal/executor/executor_test.go
@@ -114,6 +114,7 @@ func TestExecuteRawWellKnownDirPrecedence(t *testing.T) {
 	// System dirs, not an empty temp dir — see TestExecuteRawAddsWellKnownDirToChildPATH.
 	t.Setenv("PATH", "/usr/bin:/bin")
 	defer executor.SetLoginShellLookPathForTest(func(string) string { return "" })()
+	defer executor.ResetLoginPathCacheForTest()()
 
 	first := t.TempDir()
 	second := t.TempDir()
@@ -169,12 +170,13 @@ func TestExecuteRawAddsWellKnownDirToChildPATH(t *testing.T) {
 	// definition of this fallback, missing from both the process PATH and the
 	// login-shell PATH.
 	//
-	// Keep the system dirs (not an empty temp dir) on PATH: the first
-	// ExecuteRaw call in the process freezes os.Environ() into the
-	// enrichEnvWithLoginPath cache, and later tests' fake CLIs need coreutils
-	// from that frozen PATH (see the comment in TestExecute).
+	// Keep the system dirs (not an empty temp dir) on PATH: later tests' fake
+	// CLIs need coreutils (see the comment in TestExecute). The cache reset
+	// additionally guarantees this test's PATH snapshot cannot leak into other
+	// tests regardless of execution order.
 	t.Setenv("PATH", "/usr/bin:/bin")
 	defer executor.SetLoginShellLookPathForTest(func(string) string { return "" })()
+	defer executor.ResetLoginPathCacheForTest()()
 
 	binDir := filepath.Join(t.TempDir(), "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
@@ -197,6 +199,56 @@ func TestExecuteRawAddsWellKnownDirToChildPATH(t *testing.T) {
 		}
 	}
 	t.Fatalf("child PATH %q does not contain the resolved CLI dir %q", out, binDir)
+}
+
+func TestAppendDirToPathHandlesEmptyPathValue(t *testing.T) {
+	// "PATH=" + ":" + dir would create a leading empty element, which POSIX
+	// PATH semantics interpret as the current directory.
+	env := executor.AppendDirToPathForTest([]string{"PATH="}, "/opt/tools")
+	if got, want := env[0], "PATH=/opt/tools"; got != want {
+		t.Errorf("appendDirToPath on empty PATH = %q, want %q", got, want)
+	}
+}
+
+func TestCliHelpChildPATHIncludesResolvedDir(t *testing.T) {
+	// The --help probe (cliHelp) must run with the same PATH enrichment as the
+	// real execution: a CLI resolved from a well-known dir may exec a sibling
+	// tool by bare name during --help. If that fails, detectWorkDirFlags
+	// silently degrades to cwd-only context and the CLI runs without
+	// --add-dir even though it supports it.
+	t.Setenv("PATH", "/usr/bin:/bin")
+	defer executor.SetLoginShellLookPathForTest(func(string) string { return "" })()
+	defer executor.ResetLoginPathCacheForTest()()
+
+	binDir := t.TempDir()
+	helper := "#!/bin/sh\nprintf 'Usage: claude\\n  --add-dir <directories...>\\n'\n"
+	if err := os.WriteFile(filepath.Join(binDir, "help-sibling"), []byte(helper), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	captureArgs := filepath.Join(t.TempDir(), "args.txt")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  exec help-sibling\n" +
+		"fi\n" +
+		"printf '%s' \"$*\" > " + captureArgs + "\n" +
+		"printf '{}'\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer executor.SetWellKnownBinDirsForTest(func() []string { return []string{binDir} })()
+
+	e := executor.New()
+	workDir := t.TempDir()
+	if _, err := e.ExecuteRaw("claude", "prompt", executor.ExecOptions{WorkDir: workDir}); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	argsBytes, err := os.ReadFile(captureArgs)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if !strings.Contains(string(argsBytes), "--add-dir") {
+		t.Fatalf("args %q missing --add-dir — cliHelp could not resolve the sibling tool", string(argsBytes))
+	}
 }
 
 func TestDetect_NoneAvailable(t *testing.T) {

--- a/daemon/internal/executor/export_test.go
+++ b/daemon/internal/executor/export_test.go
@@ -9,3 +9,16 @@ func SetLoginShellLookPathForTest(f func(string) string) func() {
 	loginShellLookPath = f
 	return func() { loginShellLookPath = old }
 }
+
+// SetWellKnownBinDirsForTest overrides the well-known installer directory
+// probe so tests can stay hermetic. Returns a restore func to defer.
+func SetWellKnownBinDirsForTest(f func() []string) func() {
+	old := wellKnownBinDirs
+	wellKnownBinDirs = f
+	return func() { wellKnownBinDirs = old }
+}
+
+// DefaultWellKnownBinDirsForTest exposes the production directory derivation.
+func DefaultWellKnownBinDirsForTest() []string {
+	return wellKnownBinDirs()
+}

--- a/daemon/internal/executor/export_test.go
+++ b/daemon/internal/executor/export_test.go
@@ -35,6 +35,12 @@ func AppendDirToPathForTest(env []string, dir string) []string {
 // and leaks one test's $PATH into every later subprocess. It resets
 // immediately and returns a func to defer so the test also cleans up after
 // itself, keeping tests order- and shuffle-independent.
+//
+// NOT safe for parallel tests: it reassigns the sync.Once guarding
+// enrichEnvWithLoginPath without synchronization, so a t.Parallel() test
+// running ExecuteRaw/cliHelp concurrently with a reset is a data race. All
+// tests in this package run sequentially; keep it that way for any test that
+// touches this helper (or $PATH at all — t.Setenv forbids t.Parallel anyway).
 func ResetLoginPathCacheForTest() func() {
 	reset := func() {
 		loginPathOnce = sync.Once{}

--- a/daemon/internal/executor/export_test.go
+++ b/daemon/internal/executor/export_test.go
@@ -1,5 +1,7 @@
 package executor
 
+import "sync"
+
 // SetLoginShellLookPathForTest overrides the login-shell CLI probe so tests can
 // stay hermetic. The real probe sources the developer's shell profile and would
 // otherwise resolve a CLI installed outside the test's $PATH, defeating $PATH
@@ -21,4 +23,23 @@ func SetWellKnownBinDirsForTest(f func() []string) func() {
 // DefaultWellKnownBinDirsForTest exposes the production directory derivation.
 func DefaultWellKnownBinDirsForTest() []string {
 	return wellKnownBinDirs()
+}
+
+// AppendDirToPathForTest exposes appendDirToPath.
+func AppendDirToPathForTest(env []string, dir string) []string {
+	return appendDirToPath(env, dir)
+}
+
+// ResetLoginPathCacheForTest clears the process-wide login-shell PATH cache,
+// which otherwise freezes os.Environ() at the first ExecuteRaw/cliHelp call
+// and leaks one test's $PATH into every later subprocess. It resets
+// immediately and returns a func to defer so the test also cleans up after
+// itself, keeping tests order- and shuffle-independent.
+func ResetLoginPathCacheForTest() func() {
+	reset := func() {
+		loginPathOnce = sync.Once{}
+		loginPathEnv = nil
+	}
+	reset()
+	return reset
 }

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -1992,6 +1992,14 @@ func httpJSONErr(w http.ResponseWriter, code int, msg string) {
 // below) so the two sides cannot drift.
 const DaemonLogFileName = "heimdallm.log"
 
+// launchAgentLogRecencyMargin is how much fresher the data-dir log must be
+// than the LaunchAgent stderr file before the latter is considered a leftover
+// from a previous install rather than the active sink. Sequential writes from
+// setupLogging's MultiWriter (plus any buffering) keep the two files within
+// milliseconds of each other while the daemon runs under the agent; a daemon
+// running outside launchd leaves the agent file behind by hours or days.
+const launchAgentLogRecencyMargin = 2 * time.Minute
+
 // daemonLogPath returns the path to the daemon log file the /logs stream
 // tails. Priority (matches cmd/heimdallm/main.go's dataDir() ordering, which
 // is the directory setupLogging writes to):
@@ -1999,12 +2007,12 @@ const DaemonLogFileName = "heimdallm.log"
 //  1. $HEIMDALLM_DATA_DIR/heimdallm.log — explicit override (native or Docker).
 //  2. /data/heimdallm.log — Docker convention, used when /data exists as a
 //     directory (the compose file mounts the heimdallm-data volume there).
-//  3. macOS: the fresher of ~/Library/Logs/heimdallm/heimdallm-daemon-error.log
-//     (LaunchAgent convention — the plist redirects stderr there) and
-//     ~/.local/share/heimdallm/heimdallm.log (the file setupLogging always
-//     writes regardless of how the daemon was started). Recency, not mere
-//     existence, decides: a LaunchAgent file left behind from a previous
-//     install must not shadow the log the current daemon is writing.
+//  3. macOS: ~/Library/Logs/heimdallm/heimdallm-daemon-error.log (LaunchAgent
+//     convention — the plist redirects stderr there) unless the data-dir log
+//     (~/.local/share/heimdallm/heimdallm.log, always written by setupLogging)
+//     is fresher by more than launchAgentLogRecencyMargin — which marks the
+//     LaunchAgent file as a leftover from a previous install that must not
+//     shadow the log the current daemon is writing.
 //  4. Linux/other: $XDG_STATE_HOME/heimdallm/heimdallm.log, fallback
 //     ~/.local/share/heimdallm/heimdallm.log.
 //
@@ -2035,10 +2043,15 @@ func daemonLogPathFor(goos string, mtime func(string) (time.Time, bool)) string 
 		// Existence alone does not make the LaunchAgent file the active sink:
 		// it survives after the agent is uninstalled or bypassed (daemon later
 		// launched directly by the app), while setupLogging keeps writing
-		// <dataDir>/heimdallm.log. The active sink is the fresher file, so
-		// pick by recency; ties keep the LaunchAgent file (under the agent
-		// both files are written).
-		if launchdOK && (!dataOK || !dataTime.After(launchdTime)) {
+		// <dataDir>/heimdallm.log. But strict recency would be wrong in the
+		// other direction: under the agent, setupLogging's io.MultiWriter
+		// writes stderr (→ launchd file) first and the data-dir log after, so
+		// the data-dir file is ALWAYS marginally fresher and a plain mtime
+		// comparison would never serve the LaunchAgent file — losing its
+		// stderr-exclusive content (Go panics, crash traces, launchd
+		// messages). Hence the margin: only a data-dir log fresher by a clear
+		// gap marks the LaunchAgent file as a leftover.
+		if launchdOK && (!dataOK || !dataTime.After(launchdTime.Add(launchAgentLogRecencyMargin))) {
 			return launchd
 		}
 		return dataLog

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -2001,7 +2001,10 @@ const DaemonLogFileName = "heimdallm.log"
 //     directory (the compose file mounts the heimdallm-data volume there).
 //  3. macOS: ~/Library/Logs/heimdallm/heimdallm-daemon-error.log — LaunchAgent
 //     convention; the plist redirects stderr there so the file pre-exists
-//     without setupLogging having to write it.
+//     without setupLogging having to write it. When that file does not exist
+//     (daemon launched directly by the app, no LaunchAgent installed), fall
+//     back to ~/.local/share/heimdallm/heimdallm.log — the file setupLogging
+//     always writes regardless of how the daemon was started.
 //  4. Linux/other: $XDG_STATE_HOME/heimdallm/heimdallm.log, fallback
 //     ~/.local/share/heimdallm/heimdallm.log.
 //
@@ -2009,6 +2012,13 @@ const DaemonLogFileName = "heimdallm.log"
 // returned "file not found" under Docker because stderr was redirected to
 // `docker logs`, never to a file.
 func daemonLogPath() string {
+	return daemonLogPathFor(runtime.GOOS, fileExists)
+}
+
+// daemonLogPathFor is the testable core of daemonLogPath: goos and the
+// file-existence probe are parameters so the darwin-only branch can be
+// exercised by tests running on Linux (the test-docker sandbox).
+func daemonLogPathFor(goos string, exists func(string) bool) string {
 	if v := os.Getenv("HEIMDALLM_DATA_DIR"); v != "" {
 		return filepath.Join(v, DaemonLogFileName)
 	}
@@ -2016,15 +2026,27 @@ func daemonLogPath() string {
 		return filepath.Join("/data", DaemonLogFileName)
 	}
 	home, _ := os.UserHomeDir()
-	switch runtime.GOOS {
+	switch goos {
 	case "darwin":
-		return filepath.Join(home, "Library", "Logs", "heimdallm", "heimdallm-daemon-error.log")
+		launchd := filepath.Join(home, "Library", "Logs", "heimdallm", "heimdallm-daemon-error.log")
+		if exists(launchd) {
+			return launchd
+		}
+		// No LaunchAgent stderr file — the daemon was launched directly
+		// (e.g. by the app bundle). setupLogging always mirrors slog into
+		// <dataDir>/heimdallm.log, so serve that instead of "not found".
+		return filepath.Join(home, ".local", "share", "heimdallm", DaemonLogFileName)
 	default:
 		if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
 			return filepath.Join(xdg, "heimdallm", DaemonLogFileName)
 		}
 		return filepath.Join(home, ".local", "share", "heimdallm", DaemonLogFileName)
 	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 func (srv *Server) handleLogsStream(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -1999,12 +1999,12 @@ const DaemonLogFileName = "heimdallm.log"
 //  1. $HEIMDALLM_DATA_DIR/heimdallm.log — explicit override (native or Docker).
 //  2. /data/heimdallm.log — Docker convention, used when /data exists as a
 //     directory (the compose file mounts the heimdallm-data volume there).
-//  3. macOS: ~/Library/Logs/heimdallm/heimdallm-daemon-error.log — LaunchAgent
-//     convention; the plist redirects stderr there so the file pre-exists
-//     without setupLogging having to write it. When that file does not exist
-//     (daemon launched directly by the app, no LaunchAgent installed), fall
-//     back to ~/.local/share/heimdallm/heimdallm.log — the file setupLogging
-//     always writes regardless of how the daemon was started.
+//  3. macOS: the fresher of ~/Library/Logs/heimdallm/heimdallm-daemon-error.log
+//     (LaunchAgent convention — the plist redirects stderr there) and
+//     ~/.local/share/heimdallm/heimdallm.log (the file setupLogging always
+//     writes regardless of how the daemon was started). Recency, not mere
+//     existence, decides: a LaunchAgent file left behind from a previous
+//     install must not shadow the log the current daemon is writing.
 //  4. Linux/other: $XDG_STATE_HOME/heimdallm/heimdallm.log, fallback
 //     ~/.local/share/heimdallm/heimdallm.log.
 //
@@ -2012,13 +2012,13 @@ const DaemonLogFileName = "heimdallm.log"
 // returned "file not found" under Docker because stderr was redirected to
 // `docker logs`, never to a file.
 func daemonLogPath() string {
-	return daemonLogPathFor(runtime.GOOS, fileExists)
+	return daemonLogPathFor(runtime.GOOS, fileModTime)
 }
 
 // daemonLogPathFor is the testable core of daemonLogPath: goos and the
-// file-existence probe are parameters so the darwin-only branch can be
-// exercised by tests running on Linux (the test-docker sandbox).
-func daemonLogPathFor(goos string, exists func(string) bool) string {
+// file-modification-time probe are parameters so the darwin-only branch can
+// be exercised by tests running on Linux (the test-docker sandbox).
+func daemonLogPathFor(goos string, mtime func(string) (time.Time, bool)) string {
 	if v := os.Getenv("HEIMDALLM_DATA_DIR"); v != "" {
 		return filepath.Join(v, DaemonLogFileName)
 	}
@@ -2029,13 +2029,19 @@ func daemonLogPathFor(goos string, exists func(string) bool) string {
 	switch goos {
 	case "darwin":
 		launchd := filepath.Join(home, "Library", "Logs", "heimdallm", "heimdallm-daemon-error.log")
-		if exists(launchd) {
+		dataLog := filepath.Join(home, ".local", "share", "heimdallm", DaemonLogFileName)
+		launchdTime, launchdOK := mtime(launchd)
+		dataTime, dataOK := mtime(dataLog)
+		// Existence alone does not make the LaunchAgent file the active sink:
+		// it survives after the agent is uninstalled or bypassed (daemon later
+		// launched directly by the app), while setupLogging keeps writing
+		// <dataDir>/heimdallm.log. The active sink is the fresher file, so
+		// pick by recency; ties keep the LaunchAgent file (under the agent
+		// both files are written).
+		if launchdOK && (!dataOK || !dataTime.After(launchdTime)) {
 			return launchd
 		}
-		// No LaunchAgent stderr file — the daemon was launched directly
-		// (e.g. by the app bundle). setupLogging always mirrors slog into
-		// <dataDir>/heimdallm.log, so serve that instead of "not found".
-		return filepath.Join(home, ".local", "share", "heimdallm", DaemonLogFileName)
+		return dataLog
 	default:
 		if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
 			return filepath.Join(xdg, "heimdallm", DaemonLogFileName)
@@ -2044,9 +2050,12 @@ func daemonLogPathFor(goos string, exists func(string) bool) string {
 	}
 }
 
-func fileExists(path string) bool {
+func fileModTime(path string) (time.Time, bool) {
 	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
+	if err != nil || info.IsDir() {
+		return time.Time{}, false
+	}
+	return info.ModTime(), true
 }
 
 func (srv *Server) handleLogsStream(w http.ResponseWriter, r *http.Request) {

--- a/daemon/internal/server/handlers_internal_test.go
+++ b/daemon/internal/server/handlers_internal_test.go
@@ -76,7 +76,7 @@ func TestDaemonLogPath_FallsBackToNativeWhenDataDirUnset(t *testing.T) {
 		want := dataLog
 		if lInfo, lErr := os.Stat(launchd); lErr == nil {
 			dInfo, dErr := os.Stat(dataLog)
-			if dErr != nil || !dInfo.ModTime().After(lInfo.ModTime()) {
+			if dErr != nil || !dInfo.ModTime().After(lInfo.ModTime().Add(launchAgentLogRecencyMargin)) {
 				want = launchd
 			}
 		}
@@ -436,6 +436,34 @@ func TestDaemonLogPath_DarwinFallsBackToDataDirLogWithoutLaunchAgent(t *testing.
 	}
 }
 
+func TestDaemonLogPath_DarwinKeepsLaunchAgentLogWithinRecencyMargin(t *testing.T) {
+	// Under the LaunchAgent every slog line reaches both files within
+	// milliseconds (setupLogging's io.MultiWriter writes stderr first, then
+	// the data-dir log), so the data-dir file is always marginally fresher. A
+	// strict mtime comparison would never select the LaunchAgent file and
+	// would lose its stderr-exclusive content (panics, crash traces). A
+	// small freshness lead must therefore still resolve to the LaunchAgent
+	// file; only a clear margin means it is a leftover.
+	withEnv(t, "HEIMDALLM_DATA_DIR", "")
+	if _, err := os.Stat("/data"); err == nil {
+		t.Skip("/data exists on this host — Docker path wins, which is correct")
+	}
+	launchd, dataLog := darwinLogCandidates(t)
+
+	base := time.Unix(10_000, 0)
+	mtimes := map[string]time.Time{
+		launchd: base,
+		dataLog: base.Add(time.Second), // fresher, but well within the margin
+	}
+	probe := func(p string) (time.Time, bool) {
+		ts, ok := mtimes[p]
+		return ts, ok
+	}
+	if got := daemonLogPathFor("darwin", probe); got != launchd {
+		t.Fatalf("data-dir log 1s fresher: daemonLogPathFor(darwin) = %q, want LaunchAgent log %q", got, launchd)
+	}
+}
+
 func TestDaemonLogPath_DarwinPrefersFresherDataDirLogOverStaleLaunchAgent(t *testing.T) {
 	// The LaunchAgent stderr file survives after the agent is uninstalled or
 	// bypassed (daemon later launched directly by the app). Existence alone
@@ -447,10 +475,14 @@ func TestDaemonLogPath_DarwinPrefersFresherDataDirLogOverStaleLaunchAgent(t *tes
 	}
 	launchd, dataLog := darwinLogCandidates(t)
 
-	mtimes := map[string]int64{launchd: 1000, dataLog: 2000}
+	base := time.Unix(10_000, 0)
+	mtimes := map[string]time.Time{
+		launchd: base,
+		dataLog: base.Add(launchAgentLogRecencyMargin + time.Second),
+	}
 	probe := func(p string) (time.Time, bool) {
-		sec, ok := mtimes[p]
-		return time.Unix(sec, 0), ok
+		ts, ok := mtimes[p]
+		return ts, ok
 	}
 	if got := daemonLogPathFor("darwin", probe); got != dataLog {
 		t.Fatalf("stale launchd log: daemonLogPathFor(darwin) = %q, want fresher data-dir log %q", got, dataLog)

--- a/daemon/internal/server/handlers_internal_test.go
+++ b/daemon/internal/server/handlers_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // Regression coverage for #75: the /logs SSE stream reads from
@@ -66,11 +67,18 @@ func TestDaemonLogPath_FallsBackToNativeWhenDataDirUnset(t *testing.T) {
 			}
 			return
 		}
-		home, _ := os.UserHomeDir()
-		launchd := filepath.Join(home, "Library", "Logs", "heimdallm", "heimdallm-daemon-error.log")
-		want := launchd
-		if _, err := os.Stat(launchd); err != nil {
-			want = filepath.Join(home, ".local", "share", "heimdallm", DaemonLogFileName)
+		// Mirror the recency rule against the real host state: the fresher
+		// of the two candidate files wins; only-existing wins; neither means
+		// the data-dir path is reported. The hermetic stub tests below carry
+		// the behavioral coverage — this test just keeps daemonLogPath()'s
+		// real probe wired to that rule.
+		launchd, dataLog := darwinLogCandidates(t)
+		want := dataLog
+		if lInfo, lErr := os.Stat(launchd); lErr == nil {
+			dInfo, dErr := os.Stat(dataLog)
+			if dErr != nil || !dInfo.ModTime().After(lInfo.ModTime()) {
+				want = launchd
+			}
 		}
 		if got != want {
 			t.Fatalf("daemonLogPath() = %q, want %q", got, want)
@@ -381,18 +389,33 @@ func TestRejectUnsupportedScopedAgentPatchKeys(t *testing.T) {
 	}
 }
 
-func TestDaemonLogPath_DarwinPrefersLaunchAgentLogWhenPresent(t *testing.T) {
+func darwinLogCandidates(t *testing.T) (launchd, dataLog string) {
+	t.Helper()
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "Logs", "heimdallm", "heimdallm-daemon-error.log"),
+		filepath.Join(home, ".local", "share", "heimdallm", DaemonLogFileName)
+}
+
+func TestDaemonLogPath_DarwinPrefersLaunchAgentLogWhenActive(t *testing.T) {
 	withEnv(t, "HEIMDALLM_DATA_DIR", "")
 	if _, err := os.Stat("/data"); err == nil {
 		t.Skip("/data exists on this host — Docker path wins, which is correct")
 	}
+	launchd, dataLog := darwinLogCandidates(t)
 
-	home, _ := os.UserHomeDir()
-	launchd := filepath.Join(home, "Library", "Logs", "heimdallm", "heimdallm-daemon-error.log")
-
-	got := daemonLogPathFor("darwin", func(p string) bool { return p == launchd })
-	if got != launchd {
-		t.Fatalf("daemonLogPathFor(darwin) = %q, want LaunchAgent log %q", got, launchd)
+	// LaunchAgent log is the only file, or is at least as fresh as the
+	// data-dir log (both are written while running under the LaunchAgent).
+	mtimes := map[string]int64{launchd: 2000}
+	probe := func(p string) (time.Time, bool) {
+		sec, ok := mtimes[p]
+		return time.Unix(sec, 0), ok
+	}
+	if got := daemonLogPathFor("darwin", probe); got != launchd {
+		t.Fatalf("launchd-only: daemonLogPathFor(darwin) = %q, want %q", got, launchd)
+	}
+	mtimes[dataLog] = 1000
+	if got := daemonLogPathFor("darwin", probe); got != launchd {
+		t.Fatalf("launchd fresher: daemonLogPathFor(darwin) = %q, want %q", got, launchd)
 	}
 }
 
@@ -405,12 +428,32 @@ func TestDaemonLogPath_DarwinFallsBackToDataDirLogWithoutLaunchAgent(t *testing.
 	if _, err := os.Stat("/data"); err == nil {
 		t.Skip("/data exists on this host — Docker path wins, which is correct")
 	}
+	_, dataLog := darwinLogCandidates(t)
 
-	home, _ := os.UserHomeDir()
-	got := daemonLogPathFor("darwin", func(string) bool { return false })
-	want := filepath.Join(home, ".local", "share", "heimdallm", DaemonLogFileName)
-	if got != want {
-		t.Fatalf("daemonLogPathFor(darwin) = %q, want data-dir fallback %q", got, want)
+	got := daemonLogPathFor("darwin", func(string) (time.Time, bool) { return time.Time{}, false })
+	if got != dataLog {
+		t.Fatalf("daemonLogPathFor(darwin) = %q, want data-dir fallback %q", got, dataLog)
+	}
+}
+
+func TestDaemonLogPath_DarwinPrefersFresherDataDirLogOverStaleLaunchAgent(t *testing.T) {
+	// The LaunchAgent stderr file survives after the agent is uninstalled or
+	// bypassed (daemon later launched directly by the app). Existence alone
+	// does not make it the active sink: the file the daemon is writing NOW is
+	// the fresher one, so /logs must serve by recency, not presence.
+	withEnv(t, "HEIMDALLM_DATA_DIR", "")
+	if _, err := os.Stat("/data"); err == nil {
+		t.Skip("/data exists on this host — Docker path wins, which is correct")
+	}
+	launchd, dataLog := darwinLogCandidates(t)
+
+	mtimes := map[string]int64{launchd: 1000, dataLog: 2000}
+	probe := func(p string) (time.Time, bool) {
+		sec, ok := mtimes[p]
+		return time.Unix(sec, 0), ok
+	}
+	if got := daemonLogPathFor("darwin", probe); got != dataLog {
+		t.Fatalf("stale launchd log: daemonLogPathFor(darwin) = %q, want fresher data-dir log %q", got, dataLog)
 	}
 }
 

--- a/daemon/internal/server/handlers_internal_test.go
+++ b/daemon/internal/server/handlers_internal_test.go
@@ -55,9 +55,10 @@ func TestDaemonLogPath_FallsBackToNativeWhenDataDirUnset(t *testing.T) {
 	// the path rather than a hard-coded string so the test stays
 	// portable when run on both macOS and Linux CI.
 	if runtime.GOOS == "darwin" {
-		// macOS: ~/Library/Logs/heimdallm/heimdallm-daemon-error.log,
-		// unless /data happens to exist on the host (unusual on macOS
-		// dev machines but possible if something else mounted it).
+		// macOS: ~/Library/Logs/heimdallm/heimdallm-daemon-error.log when the
+		// LaunchAgent stderr file exists, otherwise the data-dir log the
+		// daemon itself writes. /data may also exist on the host (unusual on
+		// macOS dev machines but possible if something else mounted it).
 		dockerPath := filepath.Join("/data", DaemonLogFileName)
 		if _, err := os.Stat("/data"); err == nil {
 			if got != dockerPath {
@@ -65,8 +66,14 @@ func TestDaemonLogPath_FallsBackToNativeWhenDataDirUnset(t *testing.T) {
 			}
 			return
 		}
-		if !strings.Contains(got, filepath.Join("Library", "Logs", "heimdallm")) {
-			t.Fatalf("daemonLogPath() = %q, want macOS LaunchAgent path", got)
+		home, _ := os.UserHomeDir()
+		launchd := filepath.Join(home, "Library", "Logs", "heimdallm", "heimdallm-daemon-error.log")
+		want := launchd
+		if _, err := os.Stat(launchd); err != nil {
+			want = filepath.Join(home, ".local", "share", "heimdallm", DaemonLogFileName)
+		}
+		if got != want {
+			t.Fatalf("daemonLogPath() = %q, want %q", got, want)
 		}
 		return
 	}

--- a/daemon/internal/server/handlers_internal_test.go
+++ b/daemon/internal/server/handlers_internal_test.go
@@ -374,6 +374,39 @@ func TestRejectUnsupportedScopedAgentPatchKeys(t *testing.T) {
 	}
 }
 
+func TestDaemonLogPath_DarwinPrefersLaunchAgentLogWhenPresent(t *testing.T) {
+	withEnv(t, "HEIMDALLM_DATA_DIR", "")
+	if _, err := os.Stat("/data"); err == nil {
+		t.Skip("/data exists on this host — Docker path wins, which is correct")
+	}
+
+	home, _ := os.UserHomeDir()
+	launchd := filepath.Join(home, "Library", "Logs", "heimdallm", "heimdallm-daemon-error.log")
+
+	got := daemonLogPathFor("darwin", func(p string) bool { return p == launchd })
+	if got != launchd {
+		t.Fatalf("daemonLogPathFor(darwin) = %q, want LaunchAgent log %q", got, launchd)
+	}
+}
+
+func TestDaemonLogPath_DarwinFallsBackToDataDirLogWithoutLaunchAgent(t *testing.T) {
+	// When the daemon is launched directly by the app (no LaunchAgent), the
+	// launchd stderr file never exists — but setupLogging always mirrors slog
+	// into <dataDir>/heimdallm.log, so the /logs stream must read that instead
+	// of reporting "log file not found".
+	withEnv(t, "HEIMDALLM_DATA_DIR", "")
+	if _, err := os.Stat("/data"); err == nil {
+		t.Skip("/data exists on this host — Docker path wins, which is correct")
+	}
+
+	home, _ := os.UserHomeDir()
+	got := daemonLogPathFor("darwin", func(string) bool { return false })
+	want := filepath.Join(home, ".local", "share", "heimdallm", DaemonLogFileName)
+	if got != want {
+		t.Fatalf("daemonLogPathFor(darwin) = %q, want data-dir fallback %q", got, want)
+	}
+}
+
 func TestDaemonLogPath_XDGStateHomeUsedWhenSet(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip("XDG path only used on non-darwin when HEIMDALLM_DATA_DIR is unset")


### PR DESCRIPTION
Closes #643

> **Scope note:** this PR contains two related but independent fixes, both stemming from running the daemon directly from the installed app bundle (no LaunchAgent, minimal launchd PATH): (1) AI CLI resolution from well-known installer directories, and (2) the macOS `/logs` stream falling back to the daemon's own log file. (2) was added at the author's request to ship both symptoms' fixes together; revert-wise they are separate commits.

## Problem 1 — executor (#643)

The installed macOS bundle fails every pipeline run with:

```
pipeline: detect CLI: executor: no AI CLI available (tried "claude", "")
```

launchd starts `heimdalld` with the minimal system PATH, and the existing login-shell fallback (`/bin/zsh -l -c 'which "$1"'`) runs a **non-interactive** login shell, which sources `~/.zprofile` but never `~/.zshrc`. The Claude Code native installer puts its binary in `~/.local/bin` and exports that directory only in `~/.zshrc`, so both resolution steps miss it even though the CLI works from any terminal.

**Fix:** `resolveCLIPath` gains a last-resort probe over well-known installer directories — `~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin` — via `exec.LookPath` on the absolute candidate (effective-user eaccess X_OK). The resolved CLI's directory is appended to the child PATH in both `ExecuteRaw` and the `cliHelp` probe so re-invocations by bare name keep working. The CLI name is still validated against the allowlist before reaching this code and no shell is involved, so the injection surface is unchanged.

## Problem 2 — macOS Logs tab

On macOS the `/logs` stream only read the LaunchAgent stderr file (`~/Library/Logs/heimdallm/heimdallm-daemon-error.log`). With the daemon launched directly by the app that file never exists (or worse, exists stale from a previous LaunchAgent install), while `setupLogging` always writes `<dataDir>/heimdallm.log`.

**Fix:** `daemonLogPath` (darwin) now picks between the LaunchAgent file and the data-dir log **by recency** — the file being written by the current daemon is the fresher one. Ties keep the LaunchAgent file.

## Tests

TDD throughout: every behavioral change had its test observed failing first. Hermetic on any machine via `SetLoginShellLookPathForTest`, `SetWellKnownBinDirsForTest`, `ResetLoginPathCacheForTest` and an injectable mtime probe for the darwin-only branch (exercisable from the Linux test sandbox).

`make test-docker` (vet + full suite): green. CI including the macos-14 Daemon job: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)