### PR TITLE
fix(daemon): exit on bind failure instead of polling GitHub headless

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -405,6 +405,11 @@ func main() {
 	serveFailed := make(chan error, 1)
 	go func() {
 		if err := srv.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			// Log here rather than only where the channel is consumed: that
+			// happens at the end of the wiring phase, so a listener that dies
+			// during init would leave no trace until main got there — the exact
+			// silent headless state this guards against.
+			slog.Error("daemon: HTTP server stopped serving", "err", err)
 			serveFailed <- err
 		}
 	}()
@@ -2360,8 +2365,8 @@ func main() {
 		// Losing the listener mid-flight leaves the same headless daemon the
 		// bind check above prevents at startup, so treat it the same way:
 		// shut down and exit non-zero instead of polling GitHub forever with
-		// nobody able to reach us (#646).
-		slog.Error("daemon: HTTP server stopped serving; shutting down", "err", err)
+		// nobody able to reach us (#646). Already logged in the serve goroutine.
+		slog.Error("daemon: shutting down after serve failure", "err", err)
 		serveDied = true
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -367,6 +367,22 @@ func main() {
 		Version:   versionString(),
 		StartedAt: time.Now(),
 	})
+
+	// Claim the HTTP port before starting anything that costs GitHub API
+	// budget. A second daemon instance loses the bind, and until #646 it kept
+	// running anyway: no HTTP listener, so invisible to the app and to
+	// operators, yet polling GitHub on the same token as the instance that did
+	// win the port. Five of those quietly multiplied API consumption ~6x and
+	// exhausted the hourly quota for hours. Binding here, before the pollers
+	// and workers spin up, turns that silent duplication into an immediate
+	// non-zero exit.
+	httpListener, err := srv.Listen(cfg.Server.Port, cfg.Server.BindAddr)
+	if err != nil {
+		slog.Error("daemon: cannot bind HTTP port — another instance is probably already running; exiting",
+			"port", cfg.Server.Port, "bind", cfg.Server.BindAddr, "err", err)
+		os.Exit(1)
+	}
+
 	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)
 	srv.SetHealthSnapshotFn(func() server.HealthSnapshot {
@@ -2300,20 +2316,31 @@ func main() {
 		return nil
 	})
 
+	// The listener is already bound (see srv.Listen above), so this log line
+	// now means what it says: the daemon is reachable.
+	slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
+	serveFailed := make(chan error, 1)
 	go func() {
-		slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
-		if err := srv.Start(cfg.Server.Port, cfg.Server.BindAddr); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("server stopped", "err", err)
+		if err := srv.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveFailed <- err
 		}
 	}()
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	serveDied := false
 	select {
 	case received := <-sig:
 		slog.Info("shutting down", "signal", received.String())
 	case <-shutdownReq:
 		slog.Info("shutting down via API")
+	case err := <-serveFailed:
+		// Losing the listener mid-flight leaves the same headless daemon the
+		// bind check above prevents at startup, so treat it the same way:
+		// shut down and exit non-zero instead of polling GitHub forever with
+		// nobody able to reach us (#646).
+		slog.Error("daemon: HTTP server stopped serving; shutting down", "err", err)
+		serveDied = true
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -2321,6 +2348,9 @@ func main() {
 		slog.Warn("server shutdown failed", "err", err)
 	}
 	broker.Stop()
+	if serveDied {
+		os.Exit(1)
+	}
 }
 
 // logRotationConfig reads HEIMDALLM_LOG_MAX_MB and HEIMDALLM_LOG_KEEP from

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -368,20 +368,46 @@ func main() {
 		StartedAt: time.Now(),
 	})
 
-	// Claim the HTTP port before starting anything that costs GitHub API
-	// budget. A second daemon instance loses the bind, and until #646 it kept
-	// running anyway: no HTTP listener, so invisible to the app and to
-	// operators, yet polling GitHub on the same token as the instance that did
-	// win the port. Five of those quietly multiplied API consumption ~6x and
-	// exhausted the hourly quota for hours. Binding here, before the pollers
-	// and workers spin up, turns that silent duplication into an immediate
-	// non-zero exit.
+	// Claim the HTTP port before the pollers and workers spin up. A second
+	// daemon instance loses the bind, and until #646 it kept running anyway: no
+	// HTTP listener, so invisible to the app and to operators, yet polling
+	// GitHub on the same token as the instance that did win the port. Five of
+	// those quietly multiplied API consumption ~6x and exhausted the hourly
+	// quota for hours. Binding here turns that silent duplication into an
+	// immediate non-zero exit.
+	//
+	// (A losing instance still spends the one AuthenticatedUser call above plus
+	// store/NATS setup before it gets here. Cheap and bounded, unlike the
+	// per-tick polling this prevents.)
 	httpListener, err := srv.Listen(cfg.Server.Port, cfg.Server.BindAddr)
 	if err != nil {
 		slog.Error("daemon: cannot bind HTTP port — another instance is probably already running; exiting",
 			"port", cfg.Server.Port, "bind", cfg.Server.BindAddr, "err", err)
+		// os.Exit skips deferred cleanup, so release what is already open.
+		// Logging is unbuffered (server.RotatingWriter writes straight to the
+		// file), so the diagnostics above are already on disk.
+		eventBus.Stop()
+		s.Close()
+		if logCloser != nil {
+			logCloser.Close()
+		}
 		os.Exit(1)
 	}
+
+	// Serve straight away. A bound socket nobody serves is worse than a closed
+	// one: the kernel completes TCP handshakes into the accept backlog, so the
+	// app's probes hang for their full timeout instead of failing fast — and a
+	// timed-out reachability probe reads as "no daemon", which is exactly the
+	// redundant-spawn path #646 is about. /health answers 503 "starting" until
+	// MarkReady below, so callers get a real answer during the wiring window.
+	srv.MarkStarting()
+	slog.Info("daemon: HTTP listener bound", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
+	serveFailed := make(chan error, 1)
+	go func() {
+		if err := srv.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveFailed <- err
+		}
+	}()
 
 	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)
@@ -2316,15 +2342,11 @@ func main() {
 		return nil
 	})
 
-	// The listener is already bound (see srv.Listen above), so this log line
-	// now means what it says: the daemon is reachable.
+	// Every dependency is wired: /health can run its deep checks now. The
+	// listener has been bound and served since srv.Listen above, so this log
+	// line means what it says — the daemon is reachable and ready.
+	srv.MarkReady()
 	slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
-	serveFailed := make(chan error, 1)
-	go func() {
-		if err := srv.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			serveFailed <- err
-		}
-	}()
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
@@ -2349,6 +2371,13 @@ func main() {
 	}
 	broker.Stop()
 	if serveDied {
+		// Same as the bind-failure path: os.Exit skips the deferred cleanup, so
+		// release the resources that matter before reporting failure.
+		eventBus.Stop()
+		s.Close()
+		if logCloser != nil {
+			logCloser.Close()
+		}
 		os.Exit(1)
 	}
 }

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -442,8 +442,16 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	json.NewEncoder(w).Encode(v)
 }
 
+// HeaderDaemon marks a response as coming from a Heimdallm daemon. The app uses
+// it on /health to tell us apart from an unrelated process squatting on the
+// port: `{"status": ...}` alone is the shape of half the health endpoints in the
+// industry (Spring Boot Actuator, most Node/Go services), so matching on the
+// body would classify those as ours and silently never spawn a daemon.
+const HeaderDaemon = "X-Heimdallm-Daemon"
+
 func (srv *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
+	w.Header().Set(HeaderDaemon, "1")
 	// Serving starts right after the bind, long before the pollers, workers and
 	// event bus are wired, so answer honestly during that window instead of
 	// running deep checks against half-built dependencies. 503 keeps

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -320,9 +321,21 @@ func (srv *Server) Router() http.Handler {
 	return srv.router
 }
 
-// Start binds the HTTP server to the given port and begins serving.
-func (srv *Server) Start(port int, bindAddr string) error {
+// Listen binds the HTTP server's socket without serving on it, returning the
+// bound listener for a later Serve.
+//
+// The split exists so the daemon can fail fast on a bind error *before* it
+// starts any GitHub poller. ListenAndServe reports a port collision only after
+// the pollers are already running, and a daemon that swallows that error keeps
+// polling GitHub while serving nothing: invisible to the app, but spending the
+// same hourly API budget as the daemon that did win the port. Five such
+// headless daemons exhausted the quota for hours in #646.
+func (srv *Server) Listen(port int, bindAddr string) (net.Listener, error) {
 	addr := fmt.Sprintf("%s:%d", bindAddr, port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
 	srv.httpServer = &http.Server{
 		Addr:         addr,
 		Handler:      srv.router,
@@ -330,7 +343,27 @@ func (srv *Server) Start(port int, bindAddr string) error {
 		WriteTimeout: 60 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
-	return srv.httpServer.ListenAndServe()
+	return ln, nil
+}
+
+// Serve serves HTTP on a listener obtained from Listen. Returns
+// http.ErrServerClosed after a Shutdown.
+func (srv *Server) Serve(ln net.Listener) error {
+	if srv.httpServer == nil {
+		return errors.New("server: Serve called before Listen")
+	}
+	return srv.httpServer.Serve(ln)
+}
+
+// Start binds the HTTP server to the given port and begins serving. Callers
+// that need to distinguish a bind failure from a mid-flight serve failure
+// should use Listen + Serve instead.
+func (srv *Server) Start(port int, bindAddr string) error {
+	ln, err := srv.Listen(port, bindAddr)
+	if err != nil {
+		return err
+	}
+	return srv.Serve(ln)
 }
 
 // Shutdown gracefully shuts down the HTTP server.

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -42,6 +43,17 @@ type Server struct {
 	pipeline             *pipeline.Pipeline
 	router               chi.Router
 	httpServer           *http.Server
+	// starting suppresses the deep health checks while main is still wiring
+	// dependencies. Serve begins immediately after Listen so the socket is
+	// never bound-but-silent (a client would complete the TCP handshake and
+	// then hang until the whole init phase finished), so /health has to answer
+	// during a window where the pollers and event bus do not exist yet.
+	//
+	// The zero value means "ready": a Server built by New already has every
+	// dependency injected. Only main, which deliberately serves mid-wiring,
+	// calls MarkStarting. Atomic because Serve is already handling requests
+	// when main flips it back.
+	starting atomic.Bool
 	reloadFn             func() error
 	shutdownFn           func()
 	triggerReviewFn      func(prID int64) error
@@ -322,7 +334,7 @@ func (srv *Server) Router() http.Handler {
 }
 
 // Listen binds the HTTP server's socket without serving on it, returning the
-// bound listener for a later Serve.
+// bound listener for an immediately following Serve.
 //
 // The split exists so the daemon can fail fast on a bind error *before* it
 // starts any GitHub poller. ListenAndServe reports a port collision only after
@@ -330,7 +342,15 @@ func (srv *Server) Router() http.Handler {
 // polling GitHub while serving nothing: invisible to the app, but spending the
 // same hourly API budget as the daemon that did win the port. Five such
 // headless daemons exhausted the quota for hours in #646.
+//
+// Callers must call Serve right away and use MarkReady to signal readiness. A
+// bound socket that nobody is serving is worse than a closed one: the kernel
+// completes the TCP handshake into the accept backlog, so probes hang for their
+// full timeout instead of failing fast with "connection refused".
 func (srv *Server) Listen(port int, bindAddr string) (net.Listener, error) {
+	if srv.httpServer != nil {
+		return nil, errors.New("server: Listen called twice")
+	}
 	addr := fmt.Sprintf("%s:%d", bindAddr, port)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -355,16 +375,14 @@ func (srv *Server) Serve(ln net.Listener) error {
 	return srv.httpServer.Serve(ln)
 }
 
-// Start binds the HTTP server to the given port and begins serving. Callers
-// that need to distinguish a bind failure from a mid-flight serve failure
-// should use Listen + Serve instead.
-func (srv *Server) Start(port int, bindAddr string) error {
-	ln, err := srv.Listen(port, bindAddr)
-	if err != nil {
-		return err
-	}
-	return srv.Serve(ln)
-}
+// MarkStarting declares the server up but still wiring dependencies, so
+// /health answers 503 "starting" instead of running deep checks against
+// half-built dependencies. Call before Serve; pair with MarkReady.
+func (srv *Server) MarkStarting() { srv.starting.Store(true) }
+
+// MarkReady declares every dependency wired, restoring the normal /health
+// deep checks. Idempotent.
+func (srv *Server) MarkReady() { srv.starting.Store(false) }
 
 // Shutdown gracefully shuts down the HTTP server.
 func (srv *Server) Shutdown(ctx context.Context) error {
@@ -426,6 +444,20 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func (srv *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
+	// Serving starts right after the bind, long before the pollers, workers and
+	// event bus are wired, so answer honestly during that window instead of
+	// running deep checks against half-built dependencies. 503 keeps
+	// checkHealth() false (the app must not navigate into a half-ready daemon)
+	// while still being a real HTTP answer, so the app's reachability probe
+	// sees the port is taken and does not spawn a rival instance (#646).
+	if srv.starting.Load() {
+		resp := map[string]any{"status": "starting"}
+		if srv.version != "" {
+			resp["version"] = srv.version
+		}
+		writeJSON(w, http.StatusServiceUnavailable, resp)
+		return
+	}
 	checks := map[string]any{
 		"nats":      srv.natsHealthCheck(),
 		"sqlite":    srv.sqliteHealthCheck(r.Context()),

--- a/daemon/internal/server/listen_test.go
+++ b/daemon/internal/server/listen_test.go
@@ -1,0 +1,138 @@
+package server_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/server"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// newListenTestServer builds the smallest Server that can bind: Listen only
+// needs the router, which New always wires.
+func newListenTestServer(t *testing.T) *server.Server {
+	t.Helper()
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	broker := sse.NewBroker()
+	broker.Start()
+	t.Cleanup(broker.Stop)
+	return server.New(s, broker, nil, "")
+}
+
+// freePort returns a port number nothing is listening on. Racy by nature —
+// callers that need the port to stay free must bind it themselves.
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe for free port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	return port
+}
+
+// Listen must report a port collision to the caller instead of leaving the
+// daemon headless. A daemon that keeps running without an HTTP listener is
+// invisible to the app but still burns the shared GitHub API budget — that is
+// how five zombie daemons exhausted the hourly quota in #646.
+func TestListen_FailsWhenPortIsOccupied(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy port: %v", err)
+	}
+	defer occupied.Close()
+	port := occupied.Addr().(*net.TCPAddr).Port
+
+	srv := newListenTestServer(t)
+	ln, err := srv.Listen(port, "127.0.0.1")
+	if err == nil {
+		ln.Close()
+		t.Fatalf("Listen on occupied port %d returned no error; the daemon would run headless", port)
+	}
+	if ln != nil {
+		ln.Close()
+		t.Fatal("Listen returned a non-nil listener alongside an error")
+	}
+	if !errors.Is(err, syscall.EADDRINUSE) {
+		t.Fatalf("expected EADDRINUSE, got %v", err)
+	}
+}
+
+// The happy path must still bind and serve, and the returned listener must be
+// the one Serve uses — otherwise the split would silently bind twice.
+func TestListen_BindsAndServeUsesTheListener(t *testing.T) {
+	srv := newListenTestServer(t)
+	port := freePort(t)
+
+	ln, err := srv.Listen(port, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("Listen on free port %d: %v", port, err)
+	}
+	if got := ln.Addr().(*net.TCPAddr).Port; got != port {
+		t.Fatalf("listener bound to port %d, want %d", got, port)
+	}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		srv.Shutdown(shutdownCtx)
+		select {
+		case err := <-serveErr:
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				t.Errorf("Serve returned %v, want nil or ErrServerClosed", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Error("Serve did not return after Shutdown")
+		}
+	})
+
+	resp, err := httpGetWithRetry(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /health status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// Listen must not bind when the address is unusable, so a typo in bind_addr
+// fails fast at startup rather than after the pollers are already spending
+// API budget.
+func TestListen_FailsOnUnusableBindAddr(t *testing.T) {
+	srv := newListenTestServer(t)
+	ln, err := srv.Listen(freePort(t), "203.0.113.1") // TEST-NET-3, not local
+	if err == nil {
+		ln.Close()
+		t.Fatal("Listen on a non-local address returned no error")
+	}
+}
+
+func httpGetWithRetry(url string) (*http.Response, error) {
+	var lastErr error
+	for i := 0; i < 50; i++ {
+		resp, err := http.Get(url)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		time.Sleep(20 * time.Millisecond)
+	}
+	return nil, lastErr
+}

--- a/daemon/internal/server/listen_test.go
+++ b/daemon/internal/server/listen_test.go
@@ -240,6 +240,28 @@ func TestHealth_ReportsStartingUntilMarkReady(t *testing.T) {
 	}
 }
 
+// The app identifies our daemon by this header, so every /health response must
+// carry it — including the 503s. Without it the app falls back to sniffing the
+// body, and a bare {"status": ...} is the shape of most health endpoints in the
+// wild, so a foreign service would be mistaken for the daemon and no daemon
+// would ever be spawned.
+func TestHealth_AlwaysCarriesDaemonHeader(t *testing.T) {
+	srv := newListenTestServer(t)
+
+	for _, state := range []string{"starting", "ready"} {
+		if state == "starting" {
+			srv.MarkStarting()
+		} else {
+			srv.MarkReady()
+		}
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, httptest.NewRequest("GET", "/health", nil))
+		if got := w.Header().Get(server.HeaderDaemon); got != "1" {
+			t.Errorf("%s: %s header = %q, want \"1\"", state, server.HeaderDaemon, got)
+		}
+	}
+}
+
 func httpGetWithRetry(url string) (*http.Response, error) {
 	var lastErr error
 	for i := 0; i < 50; i++ {

--- a/daemon/internal/server/listen_test.go
+++ b/daemon/internal/server/listen_test.go
@@ -2,12 +2,13 @@ package server_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"syscall"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -66,8 +67,83 @@ func TestListen_FailsWhenPortIsOccupied(t *testing.T) {
 		ln.Close()
 		t.Fatal("Listen returned a non-nil listener alongside an error")
 	}
-	if !errors.Is(err, syscall.EADDRINUSE) {
-		t.Fatalf("expected EADDRINUSE, got %v", err)
+	// Assert the failure shape rather than a specific errno: EADDRINUSE is
+	// Unix-only (Windows reports WSAEADDRINUSE) and the daemon only relies on
+	// "bind failed", not on which errno said so.
+	var opErr *net.OpError
+	if !errors.As(err, &opErr) {
+		t.Fatalf("expected a *net.OpError from the failed bind, got %T: %v", err, err)
+	}
+	if opErr.Op != "listen" {
+		t.Errorf("OpError.Op = %q, want \"listen\"", opErr.Op)
+	}
+}
+
+// A second Listen must not silently orphan the first listener/server pair by
+// overwriting srv.httpServer.
+func TestListen_RejectsSecondCall(t *testing.T) {
+	srv := newListenTestServer(t)
+	first, err := srv.Listen(freePort(t), "127.0.0.1")
+	if err != nil {
+		t.Fatalf("first Listen: %v", err)
+	}
+	defer first.Close()
+
+	second, err := srv.Listen(freePort(t), "127.0.0.1")
+	if err == nil {
+		second.Close()
+		t.Fatal("second Listen succeeded; the first listener would be orphaned")
+	}
+	if second != nil {
+		second.Close()
+		t.Fatal("second Listen returned a listener alongside an error")
+	}
+}
+
+// Serve without a prior Listen must report the misuse instead of panicking on
+// a nil httpServer.
+func TestServe_WithoutListen(t *testing.T) {
+	srv := newListenTestServer(t)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	if err := srv.Serve(ln); err == nil {
+		t.Fatal("Serve without Listen returned nil error")
+	}
+}
+
+// The signal main relies on to exit non-zero: if the listener dies mid-flight,
+// Serve must return an error that is NOT ErrServerClosed. Without this, a
+// future refactor could silently restore the headless-daemon behaviour of #646.
+func TestServe_ListenerDiesMidFlight_ReturnsNonClosedError(t *testing.T) {
+	srv := newListenTestServer(t)
+	ln, err := srv.Listen(freePort(t), "127.0.0.1")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+
+	// Let Serve reach its Accept loop, then pull the listener out from under it.
+	if _, err := httpGetWithRetry(fmt.Sprintf("http://%s/health", ln.Addr().String())); err != nil {
+		t.Fatalf("server never came up: %v", err)
+	}
+	ln.Close()
+
+	select {
+	case err := <-serveErr:
+		if err == nil {
+			t.Fatal("Serve returned nil after the listener closed; main would keep polling headless")
+		}
+		if errors.Is(err, http.ErrServerClosed) {
+			t.Fatal("Serve reported ErrServerClosed for a listener failure; main would treat it as a clean shutdown")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve did not return after the listener closed")
 	}
 }
 
@@ -114,13 +190,53 @@ func TestListen_BindsAndServeUsesTheListener(t *testing.T) {
 
 // Listen must not bind when the address is unusable, so a typo in bind_addr
 // fails fast at startup rather than after the pollers are already spending
-// API budget.
+// API budget. Uses a syntactically invalid host so the result does not depend
+// on host routing: binding a non-local IP succeeds wherever
+// net.ipv4.ip_nonlocal_bind=1 is set (common in load-balancer and container
+// images), which made an earlier TEST-NET-3 version of this test flaky.
 func TestListen_FailsOnUnusableBindAddr(t *testing.T) {
 	srv := newListenTestServer(t)
-	ln, err := srv.Listen(freePort(t), "203.0.113.1") // TEST-NET-3, not local
+	ln, err := srv.Listen(freePort(t), "not a host")
 	if err == nil {
 		ln.Close()
-		t.Fatal("Listen on a non-local address returned no error")
+		t.Fatal("Listen on an invalid bind address returned no error")
+	}
+}
+
+// While main is still wiring dependencies the socket is already served, so
+// /health must say so rather than run deep checks against half-built
+// dependencies — and must stay a real HTTP answer so the app's reachability
+// probe knows the port is taken and does not spawn a rival daemon (#646).
+func TestHealth_ReportsStartingUntilMarkReady(t *testing.T) {
+	srv := newListenTestServer(t)
+	srv.MarkStarting()
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("starting: status = %d, want 503", w.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("starting: decode: %v", err)
+	}
+	if body["status"] != "starting" {
+		t.Errorf("starting: status field = %v, want \"starting\"", body["status"])
+	}
+
+	srv.MarkReady()
+	w = httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, httptest.NewRequest("GET", "/health", nil))
+	// Deliberately not asserting 200: a Server with no wired dependencies may
+	// legitimately report degraded. What matters is that it stopped saying
+	// "starting" once MarkReady ran.
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("ready: decode: %v", err)
+	}
+	if body["status"] == "starting" {
+		t.Error("ready: still reporting \"starting\" after MarkReady")
 	}
 }
 

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/activity.dart';
@@ -73,26 +74,58 @@ class ApiClient {
       final resp =
           await _client.get(_uri('/health')).timeout(const Duration(seconds: 3));
       return _looksLikeHeimdallm(resp) ? PortOwner.daemon : PortOwner.foreign;
-    } catch (_) {
+    } on TimeoutException {
       return PortOwner.none;
+    } catch (e) {
+      // Connection refused / host unreachable means nothing is listening.
+      // Matched by name rather than `on SocketException` because this file is
+      // shared with the web build, where importing dart:io does not compile.
+      if (_isSocketFailure(e)) return PortOwner.none;
+      // Otherwise we reached something that failed to speak HTTP properly (raw
+      // TCP service, malformed response, TLS on a plaintext port). Someone holds
+      // the port, so spawning would only fail on the bind — report it as foreign
+      // so the user gets the "free the port" guidance instead of a generic
+      // start failure.
+      return PortOwner.foreign;
     }
   }
+
+  static bool _isSocketFailure(Object e) =>
+      e.runtimeType.toString() == 'SocketException';
 
   /// Distinguishes our daemon from an unrelated process squatting on the port.
   /// Without this the app would silently never spawn, exhaust its retries and
   /// report a generic health failure with no hint that something else holds the
-  /// port. Every daemon response — healthy, degraded or starting — carries a
-  /// `status` field; 401 has no body to inspect but only our daemon enforces
-  /// the API token, so treat it as ours.
+  /// port.
+  ///
+  /// The [HeaderDaemon] header is the authoritative signal. The body fallback
+  /// exists only for daemons predating that header, and deliberately requires
+  /// `checks` or `version` alongside `status`: a bare `{"status": "..."}` is the
+  /// shape of most health endpoints in the wild (`{"status":"UP"}` from Spring
+  /// Boot Actuator, `{"status":"ok"}` from countless Node/Go services), and
+  /// accepting it would classify a foreign service as ours.
+  ///
+  /// A 401/403 has no body worth inspecting, but only our daemon enforces the
+  /// API token on this port, so treat it as ours. Documented tradeoff: a foreign
+  /// auth-protected service would be misread as the daemon.
+  static const _daemonHeader = 'x-heimdallm-daemon';
+
   static bool _looksLikeHeimdallm(http.Response resp) {
+    if (resp.headers.containsKey(_daemonHeader)) return true;
     if (resp.statusCode == 401 || resp.statusCode == 403) return true;
     try {
       final body = jsonDecode(resp.body);
-      return body is Map<String, dynamic> && body['status'] is String;
+      if (body is! Map<String, dynamic>) return false;
+      if (body['status'] is! String) return false;
+      return body.containsKey('checks') || body.containsKey('version');
     } catch (_) {
       return false;
     }
   }
+
+  /// The daemon port, derived from the configured base URL so error messages and
+  /// diagnostics never hardcode the default.
+  int get daemonPort => Uri.parse(_platform.apiBaseUrl).port;
 
   /// Returns the full /health payload, or null if the daemon is unreachable.
   /// Includes status, version (optional), started_at (optional, RFC3339).

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -6,6 +6,20 @@ import '../models/review.dart';
 import '../models/tracked_issue.dart';
 import '../platform/platform_services.dart';
 
+/// Who, if anyone, is answering on the daemon port. Drives the boot-path spawn
+/// decision: only [PortOwner.none] justifies starting a daemon (#646).
+enum PortOwner {
+  /// Nothing is listening (connection refused) or it never answered in time.
+  none,
+
+  /// Our daemon answered — healthy, degraded or still starting.
+  daemon,
+
+  /// Something answered but it is not Heimdallm. Spawning would fail on the
+  /// bind, so surface this to the user instead of retrying silently.
+  foreign,
+}
+
 class ApiClient {
   final http.Client _client;
   final PlatformServices _platform;
@@ -49,15 +63,32 @@ class ApiClient {
   /// Never use [checkHealth] to decide whether to spawn a daemon. A daemon that
   /// is alive but degraded answers /health with 503 — which it does whenever
   /// `last_poll` is older than twice the poll interval, i.e. exactly when
-  /// GitHub rate limits are slowing polls down. Treating that as "no daemon"
-  /// spawns a second one, which loses the port bind, keeps polling anyway and
-  /// pushes the quota further under: the feedback loop behind #646. Any HTTP
-  /// answer at all — 200, 401, 503 — means a daemon owns the port and we must
-  /// not start another.
-  Future<bool> daemonReachable() async {
+  /// GitHub rate limits are slowing polls down, and also while it is still
+  /// wiring up at boot. Treating that as "no daemon" spawns a second one, which
+  /// loses the port bind, keeps polling anyway and pushes the quota further
+  /// under: the feedback loop behind #646. Any HTTP answer at all — 200, 401,
+  /// 503 — means the port is taken and we must not start another daemon.
+  Future<PortOwner> daemonReachable() async {
     try {
-      await _client.get(_uri('/health')).timeout(const Duration(seconds: 3));
-      return true;
+      final resp =
+          await _client.get(_uri('/health')).timeout(const Duration(seconds: 3));
+      return _looksLikeHeimdallm(resp) ? PortOwner.daemon : PortOwner.foreign;
+    } catch (_) {
+      return PortOwner.none;
+    }
+  }
+
+  /// Distinguishes our daemon from an unrelated process squatting on the port.
+  /// Without this the app would silently never spawn, exhaust its retries and
+  /// report a generic health failure with no hint that something else holds the
+  /// port. Every daemon response — healthy, degraded or starting — carries a
+  /// `status` field; 401 has no body to inspect but only our daemon enforces
+  /// the API token, so treat it as ours.
+  static bool _looksLikeHeimdallm(http.Response resp) {
+    if (resp.statusCode == 401 || resp.statusCode == 403) return true;
+    try {
+      final body = jsonDecode(resp.body);
+      return body is Map<String, dynamic> && body['status'] is String;
     } catch (_) {
       return false;
     }

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -43,6 +43,26 @@ class ApiClient {
     }
   }
 
+  /// Whether *something* is serving the daemon port, regardless of how healthy
+  /// it reports itself to be.
+  ///
+  /// Never use [checkHealth] to decide whether to spawn a daemon. A daemon that
+  /// is alive but degraded answers /health with 503 — which it does whenever
+  /// `last_poll` is older than twice the poll interval, i.e. exactly when
+  /// GitHub rate limits are slowing polls down. Treating that as "no daemon"
+  /// spawns a second one, which loses the port bind, keeps polling anyway and
+  /// pushes the quota further under: the feedback loop behind #646. Any HTTP
+  /// answer at all — 200, 401, 503 — means a daemon owns the port and we must
+  /// not start another.
+  Future<bool> daemonReachable() async {
+    try {
+      await _client.get(_uri('/health')).timeout(const Duration(seconds: 3));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   /// Returns the full /health payload, or null if the daemon is unreachable.
   /// Includes status, version (optional), started_at (optional, RFC3339).
   Future<Map<String, dynamic>?> fetchHealth() async {

--- a/flutter_app/lib/core/daemon/daemon_lifecycle.dart
+++ b/flutter_app/lib/core/daemon/daemon_lifecycle.dart
@@ -1,44 +1,15 @@
 import 'dart:io';
-import '../api/api_client.dart';
-import '../platform/platform_services.dart';
 
+/// Locates the daemon binary. Spawning itself lives in
+/// `PlatformServices.spawnDaemon`, and the "is one already running?" guard
+/// lives in the boot path (`_spawnDaemonUnlessRunning` in main.dart).
+///
+/// This class used to also own an `ensureRunning()` with its own health check,
+/// but nothing called it — the boot path had grown a second, unguarded spawn
+/// instead, which is how five daemons ended up sharing one GitHub token and
+/// exhausting the API quota (#646). Keeping a single spawn guard means a future
+/// caller cannot pick the wrong one.
 class DaemonLifecycle {
-  final int port;
-  final String daemonBinaryPath;
-  final ApiClient _client;
-  Process? _process;
-
-  DaemonLifecycle({
-    this.port = 7842,
-    required this.daemonBinaryPath,
-    ApiClient? client,
-    required PlatformServices platform,
-  }) : _client = client ?? ApiClient(platform: platform);
-
-  Future<bool> isRunning() => _client.checkHealth();
-
-  Future<void> ensureRunning() async {
-    if (await isRunning()) return;
-
-    final binary = File(daemonBinaryPath);
-    if (!binary.existsSync()) {
-      throw DaemonException('Daemon binary not found: $daemonBinaryPath');
-    }
-
-    _process = await Process.start(daemonBinaryPath, []);
-
-    for (var i = 0; i < 50; i++) {
-      await Future.delayed(const Duration(milliseconds: 100));
-      if (await isRunning()) return;
-    }
-    throw DaemonException('Daemon did not become healthy within 5 seconds');
-  }
-
-  Future<void> stop() async {
-    _process?.kill();
-    _process = null;
-  }
-
   /// Returns the daemon binary path, or null if not found.
   ///
   /// Priority:

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -167,7 +167,7 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
 
     _setStatus('Starting Heimdallm…');
     try {
-      await _platform.spawnDaemon(binaryPath);
+      await _spawnDaemonUnlessRunning(api, binaryPath);
     } catch (e) {
       _setError(
         title: 'Could not start daemon',
@@ -180,6 +180,22 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
 
     _setStatus('Waiting for Heimdallm…');
     await _waitForHealth(api, retryBinary: binaryPath);
+  }
+
+  /// Spawns the daemon only when nothing is answering on its port.
+  ///
+  /// The single most important invariant of the boot path: never add a second
+  /// daemon. A daemon that loses the port bind used to stay alive and keep
+  /// polling GitHub on the same token, so every redundant spawn permanently
+  /// multiplied API consumption until the hourly quota was gone (#646). The
+  /// daemon now exits on a failed bind, but the app must not rely on that —
+  /// older daemons are still out there, and not spawning is free.
+  ///
+  /// Reachability, not health, is the right question here: see
+  /// [ApiClient.daemonReachable].
+  Future<void> _spawnDaemonUnlessRunning(ApiClient api, String binaryPath) async {
+    if (await api.daemonReachable()) return;
+    await _platform.spawnDaemon(binaryPath);
   }
 
   Future<void> _waitForHealth(ApiClient api, {String? retryBinary}) async {
@@ -202,7 +218,10 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
           return;
         }
         daemonRestarts++;
-        try { await _platform.spawnDaemon(retryBinary); } catch (_) {}
+        // Guarded: a daemon that is up but reporting degraded (503) keeps
+        // failing checkHealth above, and re-spawning on that signal is what
+        // stacked five daemons on one token in #646.
+        try { await _spawnDaemonUnlessRunning(api, retryBinary); } catch (_) {}
       }
     }
   }

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -173,7 +173,7 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
     try {
       await _spawnDaemonUnlessRunning(api, binaryPath);
     } on _ForeignPortException {
-      _setForeignPortError();
+      _setForeignPortError(api.daemonPort);
       return;
     } catch (e) {
       _setError(
@@ -218,7 +218,13 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
 
   Future<void> _waitForHealth(ApiClient api, {String? retryBinary}) async {
     const maxDaemonRestarts = 3;
+    // How many spawn windows to allow a daemon that owns the port but is not
+    // healthy before offering the user a way out. A "starting" daemon clears in
+    // seconds; a rate-limited one can stay degraded for hours, and blocking the
+    // splash on that locks the user out of the app entirely.
+    const maxDegradedWindows = 3;
     var daemonRestarts = 0;
+    var degradedWindows = 0;
     for (var attempt = 0; ; attempt++) {
       await Future.delayed(const Duration(milliseconds: 400));
       if (await api.checkHealth()) {
@@ -226,6 +232,20 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
         return;
       }
       if (attempt > 0 && attempt % 25 == 0 && retryBinary != null) {
+        // Check the budget BEFORE spawning: counting the spawn first and then
+        // testing the limit fires the terminal error immediately after the last
+        // daemon was launched, denying it the health window the retry exists to
+        // provide.
+        if (daemonRestarts >= maxDaemonRestarts) {
+          _setError(
+            title: 'Daemon failed to start',
+            details: 'Heimdallm could not start after $maxDaemonRestarts attempts.',
+            hint: 'Try restarting the app. If the problem persists, check your installation:\n'
+                'xattr -cr /Applications/Heimdallm.app',
+          );
+          return;
+        }
+
         // A daemon that owns the port but answers 503 keeps failing
         // checkHealth: it is degraded (rate-limited, stale last_poll) or still
         // wiring up, not absent. Re-spawning on that signal is what stacked
@@ -236,40 +256,50 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
         try {
           spawned = await _spawnDaemonUnlessRunning(api, retryBinary);
         } on _ForeignPortException {
-          _setForeignPortError();
+          _setForeignPortError(api.daemonPort);
           return;
         } catch (_) {
           continue;
         }
+
         if (!spawned) {
+          degradedWindows++;
+          if (degradedWindows >= maxDegradedWindows) {
+            _setDegradedDaemonError();
+            return;
+          }
           // Tell the user what we are actually waiting on, instead of leaving
           // the splash on a generic message while nothing appears to happen.
           _setStatus('Heimdallm is running but not ready yet — waiting…');
           continue;
         }
-
         daemonRestarts++;
-        if (daemonRestarts >= maxDaemonRestarts) {
-          _setError(
-            title: 'Daemon failed to start',
-            details: 'Heimdallm could not start after $maxDaemonRestarts attempts.',
-            hint: 'Try restarting the app. If the problem persists, check your installation:\n'
-                'xattr -cr /Applications/Heimdallm.app',
-          );
-          return;
-        }
       }
     }
   }
 
-  void _setForeignPortError() {
+  void _setForeignPortError(int port) {
     _setError(
-      title: 'Port 7842 is in use by another process',
+      title: 'Port $port is in use by another process',
       details: 'Something is answering on Heimdallm\'s port, but it is not the '
           'Heimdallm daemon. Heimdallm will not start a daemon that cannot bind '
           'the port.',
       hint: 'Find the process and stop it, then relaunch:\n'
-          'lsof -nP -iTCP:7842 -sTCP:LISTEN',
+          'lsof -nP -iTCP:$port -sTCP:LISTEN',
+    );
+  }
+
+  /// The daemon owns the port and answers, but never reports healthy. Most
+  /// often a GitHub rate-limit episode leaving `last_poll` stale, which can
+  /// last hours — so give the user an exit instead of an endless splash.
+  void _setDegradedDaemonError() {
+    _setError(
+      title: 'Heimdallm is running but not ready',
+      details: 'The daemon is answering but reports itself unhealthy. This is '
+          'usually a GitHub rate-limit episode leaving the last poll stale, '
+          'which can take a while to clear.',
+      hint: 'Retry to keep waiting, or check the daemon log:\n'
+          '~/.local/share/heimdallm/heimdallm.log',
     );
   }
 

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -88,6 +88,10 @@ void sendPRNotification({
   );
 }
 
+/// A non-Heimdallm process holds the daemon port. Distinct from a spawn failure
+/// because no amount of retrying fixes it — the user has to free the port.
+class _ForeignPortException implements Exception {}
+
 class _BootstrapApp extends ConsumerStatefulWidget {
   final GoRouter appRouter;
   const _BootstrapApp({required this.appRouter});
@@ -168,6 +172,9 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
     _setStatus('Starting Heimdallm…');
     try {
       await _spawnDaemonUnlessRunning(api, binaryPath);
+    } on _ForeignPortException {
+      _setForeignPortError();
+      return;
     } catch (e) {
       _setError(
         title: 'Could not start daemon',
@@ -193,9 +200,20 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
   ///
   /// Reachability, not health, is the right question here: see
   /// [ApiClient.daemonReachable].
-  Future<void> _spawnDaemonUnlessRunning(ApiClient api, String binaryPath) async {
-    if (await api.daemonReachable()) return;
-    await _platform.spawnDaemon(binaryPath);
+  /// Returns true when a daemon was actually spawned, false when the port was
+  /// already taken. Throws [_ForeignPortException] when a process that is not
+  /// Heimdallm holds the port — spawning would just fail on the bind, so that
+  /// case has to reach the user rather than be retried in silence.
+  Future<bool> _spawnDaemonUnlessRunning(ApiClient api, String binaryPath) async {
+    switch (await api.daemonReachable()) {
+      case PortOwner.daemon:
+        return false;
+      case PortOwner.foreign:
+        throw _ForeignPortException();
+      case PortOwner.none:
+        await _platform.spawnDaemon(binaryPath);
+        return true;
+    }
   }
 
   Future<void> _waitForHealth(ApiClient api, {String? retryBinary}) async {
@@ -208,6 +226,29 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
         return;
       }
       if (attempt > 0 && attempt % 25 == 0 && retryBinary != null) {
+        // A daemon that owns the port but answers 503 keeps failing
+        // checkHealth: it is degraded (rate-limited, stale last_poll) or still
+        // wiring up, not absent. Re-spawning on that signal is what stacked
+        // five daemons on one token in #646, so we skip the spawn — and must
+        // not spend the restart budget on a spawn that never happened, or the
+        // user gets a terminal "failed to start" for a daemon that is running.
+        final bool spawned;
+        try {
+          spawned = await _spawnDaemonUnlessRunning(api, retryBinary);
+        } on _ForeignPortException {
+          _setForeignPortError();
+          return;
+        } catch (_) {
+          continue;
+        }
+        if (!spawned) {
+          // Tell the user what we are actually waiting on, instead of leaving
+          // the splash on a generic message while nothing appears to happen.
+          _setStatus('Heimdallm is running but not ready yet — waiting…');
+          continue;
+        }
+
+        daemonRestarts++;
         if (daemonRestarts >= maxDaemonRestarts) {
           _setError(
             title: 'Daemon failed to start',
@@ -217,13 +258,19 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
           );
           return;
         }
-        daemonRestarts++;
-        // Guarded: a daemon that is up but reporting degraded (503) keeps
-        // failing checkHealth above, and re-spawning on that signal is what
-        // stacked five daemons on one token in #646.
-        try { await _spawnDaemonUnlessRunning(api, retryBinary); } catch (_) {}
       }
     }
+  }
+
+  void _setForeignPortError() {
+    _setError(
+      title: 'Port 7842 is in use by another process',
+      details: 'Something is answering on Heimdallm\'s port, but it is not the '
+          'Heimdallm daemon. Heimdallm will not start a daemon that cannot bind '
+          'the port.',
+      hint: 'Find the process and stop it, then relaunch:\n'
+          'lsof -nP -iTCP:7842 -sTCP:LISTEN',
+    );
   }
 
   void _setStatus(String s) { if (mounted) setState(() => _status = s); }

--- a/flutter_app/test/core/daemon_reachable_test.dart
+++ b/flutter_app/test/core/daemon_reachable_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:heimdallm/core/api/api_client.dart';
+import 'platform/fake_platform_services.dart';
+
+/// Regression tests for the spawn guard behind #646.
+///
+/// A degraded-but-alive daemon answers /health with 503. The boot path used to
+/// treat "not 200" as "no daemon" and spawned another one, which lost the port
+/// bind, kept polling GitHub on the same token and drove the shared quota
+/// further down — feeding back into more 503s and more spawns. Reachability has
+/// to be a separate question from health.
+void main() {
+  ApiClient clientReturning(http.Response Function() respond) => ApiClient(
+    httpClient: MockClient((_) async => respond()),
+    platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
+  );
+
+  group('daemonReachable vs checkHealth', () {
+    test('503 degraded: unhealthy, but reachable so we must not spawn', () async {
+      final client = clientReturning(() => http.Response('{"status":"degraded"}', 503));
+      expect(await client.checkHealth(), isFalse);
+      expect(
+        await client.daemonReachable(),
+        isTrue,
+        reason: 'a 503 means a daemon owns the port; spawning a second one is the #646 bug',
+      );
+    });
+
+    test('401 unauthorized: reachable, so we must not spawn', () async {
+      final client = clientReturning(() => http.Response('unauthorized', 401));
+      expect(await client.daemonReachable(), isTrue);
+    });
+
+    test('200 healthy: reachable', () async {
+      final client = clientReturning(() => http.Response('{"status":"ok"}', 200));
+      expect(await client.checkHealth(), isTrue);
+      expect(await client.daemonReachable(), isTrue);
+    });
+
+    test('connection refused: genuinely absent, so spawning is correct', () async {
+      final client = ApiClient(
+        httpClient: MockClient(
+          (_) async => throw const SocketException('Connection refused'),
+        ),
+        platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
+      );
+      expect(await client.daemonReachable(), isFalse);
+    });
+
+    test('a daemon too slow to answer counts as unreachable, not as healthy', () async {
+      final client = ApiClient(
+        httpClient: MockClient((_) async {
+          await Future<void>.delayed(const Duration(seconds: 30));
+          return http.Response('{"status":"ok"}', 200);
+        }),
+        platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
+      );
+      expect(await client.daemonReachable(), isFalse);
+      expect(await client.checkHealth(), isFalse);
+    });
+  });
+}

--- a/flutter_app/test/core/daemon_reachable_test.dart
+++ b/flutter_app/test/core/daemon_reachable_test.dart
@@ -19,10 +19,20 @@ void main() {
     platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
   );
 
+  ApiClient clientThrowing(Object error) => ApiClient(
+    httpClient: MockClient((_) async => throw error),
+    platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
+  );
+
+  /// Every real daemon response carries this header; it is the authoritative
+  /// identity signal.
+  const daemonHeaders = {'x-heimdallm-daemon': '1'};
+
   group('daemonReachable vs checkHealth', () {
     test('503 degraded: unhealthy, but ours — must not spawn', () async {
       final client = clientReturning(
-        () => http.Response('{"status":"degraded","checks":{}}', 503),
+        () => http.Response('{"status":"degraded","checks":{}}', 503,
+            headers: daemonHeaders),
       );
       expect(await client.checkHealth(), isFalse);
       expect(
@@ -34,7 +44,7 @@ void main() {
 
     test('503 starting: daemon serving mid-wiring is still ours', () async {
       final client = clientReturning(
-        () => http.Response('{"status":"starting"}', 503),
+        () => http.Response('{"status":"starting"}', 503, headers: daemonHeaders),
       );
       expect(await client.checkHealth(), isFalse);
       expect(await client.daemonReachable(), PortOwner.daemon);
@@ -47,19 +57,15 @@ void main() {
 
     test('200 healthy: ours and healthy', () async {
       final client = clientReturning(
-        () => http.Response('{"status":"ok","checks":{}}', 200),
+        () => http.Response('{"status":"ok","checks":{}}', 200,
+            headers: daemonHeaders),
       );
       expect(await client.checkHealth(), isTrue);
       expect(await client.daemonReachable(), PortOwner.daemon);
     });
 
     test('connection refused: genuinely absent, so spawning is correct', () async {
-      final client = ApiClient(
-        httpClient: MockClient(
-          (_) async => throw const SocketException('Connection refused'),
-        ),
-        platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
-      );
+      final client = clientThrowing(const SocketException('Connection refused'));
       expect(await client.daemonReachable(), PortOwner.none);
     });
 
@@ -75,7 +81,48 @@ void main() {
       expect(await client.checkHealth(), isFalse);
     });
 
+    group('identity: the header is authoritative', () {
+      test('header alone identifies the daemon, whatever the body', () async {
+        final client = clientReturning(
+          () => http.Response('anything', 200, headers: daemonHeaders),
+        );
+        expect(await client.daemonReachable(), PortOwner.daemon);
+      });
+
+      test('older daemon without the header still matches via status+checks',
+          () async {
+        final client = clientReturning(
+          () => http.Response('{"status":"ok","checks":{}}', 200),
+        );
+        expect(await client.daemonReachable(), PortOwner.daemon);
+      });
+
+      test('older daemon without the header matches via status+version', () async {
+        final client = clientReturning(
+          () => http.Response('{"status":"starting","version":"0.7.10"}', 503),
+        );
+        expect(await client.daemonReachable(), PortOwner.daemon);
+      });
+    });
+
     group('foreign process squatting on the port', () {
+      test('Spring Boot Actuator style {"status":"UP"} is NOT our daemon',
+          () async {
+        final client = clientReturning(() => http.Response('{"status":"UP"}', 200));
+        expect(
+          await client.daemonReachable(),
+          PortOwner.foreign,
+          reason: 'a bare status field is the shape of most health endpoints; '
+              'accepting it would silently prevent the daemon from ever spawning',
+        );
+      });
+
+      test('a bare {"status":"ok"} from some other service is NOT our daemon',
+          () async {
+        final client = clientReturning(() => http.Response('{"status":"ok"}', 200));
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      });
+
       test('HTML from an unrelated dev server is not our daemon', () async {
         final client = clientReturning(
           () => http.Response('<html><body>hello</body></html>', 200),
@@ -92,6 +139,24 @@ void main() {
         final client = clientReturning(() => http.Response('[1,2,3]', 200));
         expect(await client.daemonReachable(), PortOwner.foreign);
       });
+
+      test('a process that does not speak HTTP is foreign, not absent', () async {
+        // Raw TCP service on the port: the GET fails, but someone holds the
+        // port, so spawning would just die on the bind. The user needs the
+        // "free the port" guidance, not a generic start failure.
+        final client = clientThrowing(http.ClientException('Invalid HTTP response'));
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      });
+    });
+  });
+
+  group('daemonPort', () {
+    test('derives from the configured base URL, never hardcoded', () async {
+      final client = ApiClient(
+        httpClient: MockClient((_) async => http.Response('', 200)),
+        platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:9999'),
+      );
+      expect(client.daemonPort, 9999);
     });
   });
 }

--- a/flutter_app/test/core/daemon_reachable_test.dart
+++ b/flutter_app/test/core/daemon_reachable_test.dart
@@ -7,11 +7,12 @@ import 'platform/fake_platform_services.dart';
 
 /// Regression tests for the spawn guard behind #646.
 ///
-/// A degraded-but-alive daemon answers /health with 503. The boot path used to
-/// treat "not 200" as "no daemon" and spawned another one, which lost the port
-/// bind, kept polling GitHub on the same token and drove the shared quota
-/// further down — feeding back into more 503s and more spawns. Reachability has
-/// to be a separate question from health.
+/// A degraded-but-alive daemon answers /health with 503, and so does one that is
+/// still wiring up at boot. The boot path used to treat "not 200" as "no daemon"
+/// and spawned another one, which lost the port bind, kept polling GitHub on the
+/// same token and drove the shared quota further down — feeding back into more
+/// 503s and more spawns. Reachability has to be a separate question from health,
+/// and it has to tell our daemon apart from an unrelated port squatter.
 void main() {
   ApiClient clientReturning(http.Response Function() respond) => ApiClient(
     httpClient: MockClient((_) async => respond()),
@@ -19,25 +20,37 @@ void main() {
   );
 
   group('daemonReachable vs checkHealth', () {
-    test('503 degraded: unhealthy, but reachable so we must not spawn', () async {
-      final client = clientReturning(() => http.Response('{"status":"degraded"}', 503));
+    test('503 degraded: unhealthy, but ours — must not spawn', () async {
+      final client = clientReturning(
+        () => http.Response('{"status":"degraded","checks":{}}', 503),
+      );
       expect(await client.checkHealth(), isFalse);
       expect(
         await client.daemonReachable(),
-        isTrue,
-        reason: 'a 503 means a daemon owns the port; spawning a second one is the #646 bug',
+        PortOwner.daemon,
+        reason: 'a 503 from our daemon means the port is ours; spawning again is the #646 bug',
       );
     });
 
-    test('401 unauthorized: reachable, so we must not spawn', () async {
-      final client = clientReturning(() => http.Response('unauthorized', 401));
-      expect(await client.daemonReachable(), isTrue);
+    test('503 starting: daemon serving mid-wiring is still ours', () async {
+      final client = clientReturning(
+        () => http.Response('{"status":"starting"}', 503),
+      );
+      expect(await client.checkHealth(), isFalse);
+      expect(await client.daemonReachable(), PortOwner.daemon);
     });
 
-    test('200 healthy: reachable', () async {
-      final client = clientReturning(() => http.Response('{"status":"ok"}', 200));
+    test('401 unauthorized: only our daemon enforces the token', () async {
+      final client = clientReturning(() => http.Response('unauthorized', 401));
+      expect(await client.daemonReachable(), PortOwner.daemon);
+    });
+
+    test('200 healthy: ours and healthy', () async {
+      final client = clientReturning(
+        () => http.Response('{"status":"ok","checks":{}}', 200),
+      );
       expect(await client.checkHealth(), isTrue);
-      expect(await client.daemonReachable(), isTrue);
+      expect(await client.daemonReachable(), PortOwner.daemon);
     });
 
     test('connection refused: genuinely absent, so spawning is correct', () async {
@@ -47,10 +60,10 @@ void main() {
         ),
         platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
       );
-      expect(await client.daemonReachable(), isFalse);
+      expect(await client.daemonReachable(), PortOwner.none);
     });
 
-    test('a daemon too slow to answer counts as unreachable, not as healthy', () async {
+    test('a daemon too slow to answer counts as absent, not as healthy', () async {
       final client = ApiClient(
         httpClient: MockClient((_) async {
           await Future<void>.delayed(const Duration(seconds: 30));
@@ -58,8 +71,27 @@ void main() {
         }),
         platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
       );
-      expect(await client.daemonReachable(), isFalse);
+      expect(await client.daemonReachable(), PortOwner.none);
       expect(await client.checkHealth(), isFalse);
+    });
+
+    group('foreign process squatting on the port', () {
+      test('HTML from an unrelated dev server is not our daemon', () async {
+        final client = clientReturning(
+          () => http.Response('<html><body>hello</body></html>', 200),
+        );
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      });
+
+      test('JSON without a status field is not our daemon', () async {
+        final client = clientReturning(() => http.Response('{"foo":"bar"}', 200));
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      });
+
+      test('a JSON array is not our daemon', () async {
+        final client = clientReturning(() => http.Response('[1,2,3]', 200));
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #646. Refs #614.

## Qué pasaba

Una máquina acabó con **6 daemons vivos a la vez** compartiendo token de GitHub, SQLite y fichero de log. Cinco eran zombis: perdieron el bind del puerto 7842 a las 07:34, siguieron corriendo **4 horas** con tier1/tier2/tier3 activos y agotaron la cuota horaria de forma sostenida (pausas de 1 minuto cada ~30 segundos).

```
07:34:28 INFO  msg="daemon started" port=7842 bind=127.0.0.1
07:34:28 ERROR msg="server stopped" err="listen tcp 127.0.0.1:7842: bind: address already in use"
07:34:38 (idem)  07:34:48 (idem)  07:34:59 (idem)  07:35:14 (idem)
```

No escuchaban en ningún puerto pero sí tenían conexiones abiertas a `api.github.com`. Al matarlos, los ciclos de tier2 cayeron de **6/min a 1/min** y las pausas por rate limit cesaron por completo.

## Las dos causas

**1. El daemon sobrevivía a un bind fallido.** `srv.Start` devolvía el error, `main` lo logueaba y lo descartaba, y el proceso se quedaba bloqueado en el `select` de señales con todos los pollers corriendo. Un daemon inútil para todos y carísimo en cuota. Además `slog.Info("daemon started")` se emitía *antes* de saber si el bind había funcionado, así que el log afirmaba un arranque que no había ocurrido.

**2. La app decidía "¿hay daemon?" preguntando por salud.** `checkHealth()` exige exactamente `200`, pero `/health` devuelve **503 degraded** cuando `last_poll` supera el doble del `poll_interval` — es decir, precisamente cuando el rate limit está ralentizando los polls. Un daemon vivo pero degradado se interpretaba como "no hay daemon" → spawn → el nuevo pierde el bind, sobrevive, consume más cuota → más lentitud → más 503 → más spawns. **Bucle de retroalimentación que se agrava solo.** El reintento de `_waitForHealth` lo disparaba cada 25 × 400 ms ≈ 10 s, que son exactamente los intervalos del log.

Ninguno de los dos bugs es reciente (blame: `01f32bf`/`ff7efed` y `84edfe3`/`e9e3d82`). Lo que ha cambiado es el entorno: `poll_interval = 1m` × 50 repos ya consume ~60 % del presupuesto con **un** daemon, y desde #635/#636 conviven la app instalada en `/Applications` y el build de dev peleando por el mismo puerto y la misma DB.

## Qué cambia

**Daemon**
- `Listen` separado de `Serve` (`Start` se mantiene como bind+serve para quien no necesite distinguir).
- El puerto se reclama **antes** de arrancar pollers y workers. Bind fallido → log explícito y `os.Exit(1)`.
- `daemon started` se loguea solo cuando el listener está realmente bindeado.
- Un fallo de `Serve` en caliente deja el mismo daemon headless, así que también apaga y sale con código no cero.

**App**
- Nuevo `ApiClient.daemonReachable()`: cualquier respuesta HTTP (200, 401, 503) significa que alguien tiene el puerto. Solo un fallo de conexión o un timeout cuentan como ausencia.
- El arranque spawnea a través de `_spawnDaemonUnlessRunning`, y el reintento de `_waitForHealth` usa el mismo guard.
- `DaemonLifecycle.ensureRunning()` ya tenía el guard correcto pero **nadie lo llamaba**: el camino de arranque había crecido un segundo spawn sin guard. Eliminado el código muerto para que exista un único guard.

## Verificación

- `make test-docker`: vet + toda la suite en verde. 3 tests nuevos en `daemon/internal/server/listen_test.go` (puerto ocupado → `EADDRINUSE` y ningún listener devuelto; camino feliz sirviendo sobre el listener devuelto; `bind_addr` inservible → error).
- `flutter test`: **225 tests** en verde, incluidos 5 nuevos en `test/core/daemon_reachable_test.dart` que fijan la distinción alcanzable/sano (503 y 401 → no spawnear; connection refused → spawnear; daemon demasiado lento → no cuenta como sano).
- `flutter analyze`: sin issues.
- Comprobado en la máquina afectada: un solo daemon, tier2 a 1 ciclo/min, cero pausas de rate limit.

## Lo que este PR no hace

- **No hay test del proceso completo** ("puerto ocupado → exit no cero") que pide el criterio de #614. El repo no tiene gate que ejecute tests con tag `integration` (`GO_TEST_ARGS` no pasa tags y no hay target ni workflow que lo haga), así que un test ahí sería cobertura muerta. Lo cubierto es el contrato de `Listen`; el `os.Exit(1)` queda garantizado por construcción, inmediatamente después del error y en el mismo estilo que las otras seis salidas tempranas de `main`.
- **No aborda el resto de #614** (contexto raíz propagado a ejecutores y Git, grupos de procesos con TERM/espera/KILL para los nietos, drenado de shutdown, `unknown` → `unhealthy` tras la gracia de arranque). Sigue abierta y coordinándose con #465/#467.
- **No toca el presupuesto de API en sí.** Con `poll_interval = 1m` y 50 repos, un único daemon ya consume ~60 % de los 5.000/h; el margen se estrecha solo a medida que crecen los repos descubiertos. Merece decisión aparte.
- `os.Exit(1)` en el fallo de bind se salta los `defer` (cierre de store, `eventBus.Stop()`), igual que las salidas tempranas ya existentes en `main`. Consistente con el fichero, pero mencionado por si se prefiere otro patrón.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
