### PR TITLE
fix(review): keep tier3 on repoctx, give codex a workspace, kill process groups

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2423,8 +2423,42 @@ func main() {
 	stopProducersThenAgents([]context.CancelFunc{
 		workerCancel, publishWCancel, triageWCancel, refinementWCancel,
 		implementWCancel, statePollerCancel, stateWCancel,
-	}, exec.TerminateAll)
+	}, exec.TerminateAll, producerSettleDelay)
 	broker.Stop()
+}
+
+// producerSettleDelay is how long the shutdown path waits between cancelling the
+// work producers and its second sweep of in-flight agents. Cancelling a context
+// does not wait for the worker to act on it.
+const producerSettleDelay = 500 * time.Millisecond
+
+// stopProducersThenAgents runs the ordering the shutdown path depends on:
+// silence everything that can start an execution, then sweep the executions
+// still running. Reversing it leaves a window where a worker starts a CLI the
+// sweep has already snapshotted past, and that CLI — in its own process group
+// since #656 — outlives the daemon.
+//
+// It sweeps twice because cancellation is asynchronous: a worker already past its
+// context check and about to call cmd.Start() still starts an execution after the
+// first snapshot. The settle delay plus a second pass catches that one. This
+// narrows the window rather than closing it — closing it needs the workers to
+// report completion (a WaitGroup joined with a bounded wait), which is #614's
+// "shutdown ... waits for all goroutines" criterion. Nil cancels are skipped so a
+// producer that never started is not a special case at the call site.
+func stopProducersThenAgents(stopProducers []context.CancelFunc, terminateAgents func(), settle time.Duration) {
+	for _, stop := range stopProducers {
+		if stop != nil {
+			stop()
+		}
+	}
+	if terminateAgents == nil {
+		return
+	}
+	terminateAgents()
+	if settle > 0 {
+		time.Sleep(settle)
+	}
+	terminateAgents()
 }
 
 // logRotationConfig reads HEIMDALLM_LOG_MAX_MB and HEIMDALLM_LOG_KEEP from
@@ -5424,23 +5458,6 @@ func monitoredRepoSet(cfg *config.Config, discovered []string) map[string]struct
 // paths. Passing no discovered slice is sufficient after discovery has been
 // persisted into Repositories/NonMonitored; callers that own a fresh discovery
 // snapshot should use monitoredRepoSet directly.
-// stopProducersThenAgents runs the ordering the shutdown path depends on:
-// silence everything that can start an execution, and only then sweep the
-// executions still running. Reversing it leaves a window where a worker starts a
-// CLI the sweep has already snapshotted past, and that CLI — in its own process
-// group since #656 — outlives the daemon. Nil cancels are skipped so a producer
-// that never started is not a special case at the call site.
-func stopProducersThenAgents(stopProducers []context.CancelFunc, terminateAgents func()) {
-	for _, stop := range stopProducers {
-		if stop != nil {
-			stop()
-		}
-	}
-	if terminateAgents != nil {
-		terminateAgents()
-	}
-}
-
 func repoIsMonitored(cfg *config.Config, repo string) bool {
 	repo = strings.TrimSpace(repo)
 	if repo == "" {

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -4466,6 +4466,7 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 		c := *a.cfg
 		monitored := repoIsMonitored(c, item.Repo)
 		aiCfg := c.AIForRepo(item.Repo)
+		localDirBase := c.GitHub.LocalDirBase
 		a.cfgMu.Unlock()
 		if !monitored {
 			a.broker.Publish(sse.Event{
@@ -4537,6 +4538,21 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 			ghPR.HTMLURL = stored.URL
 			ghPR.User = gh.User{Login: snap.Author}
 		}
+
+		// Reserve the checkout the same way review-worker and tier2 ProcessPR
+		// do. Without this the agent ran with no WorkDir and inherited the
+		// daemon's cwd — `/` under launchd — which aborts `codex exec` outright
+		// (#655). Acquired here, after every guard and the dedup above, so the
+		// paths that skip the review do not reserve a worktree they never use.
+		repoHandle, err := acquireRepoContext(ctx, a.repoCtx, item.Repo, &aiCfg, localDirBase, a.ghToken, repoctx.ModeRead, wtTokenFor("pr-tier3", item.Number), "", "")
+		if err != nil {
+			logRepoContextFallback("tier3 PR", item.Repo, err)
+			aiCfg.LocalDir = ""
+		}
+		if repoHandle != nil {
+			defer repoHandle.Release()
+		}
+
 		rev := a.runReview(ghPR, aiCfg)
 		if rev != nil && rev.GitHubReviewID == 0 && a.publishPub != nil {
 			if err := a.publishPub.PublishPRPublish(context.Background(), rev.ID); err != nil {
@@ -5042,7 +5058,7 @@ func acquireRepoContext(
 }
 
 // wtTokenFor produces a sanitisation-safe worktree token for a
-// pipeline stage. The prefix names the stage (`pr-review`, `triage`,
+// pipeline stage. The prefix names the stage (`pr-review`, `pr-tier3`, `triage`,
 // `develop`, `refinement`, `pr-tier2`) so operators can correlate
 // `<clone>/.worktrees/<token>/` with the running execution.
 func wtTokenFor(prefix string, n int) string {

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2408,6 +2408,12 @@ func main() {
 	if err := srv.Shutdown(ctx); err != nil {
 		slog.Warn("server shutdown failed", "err", err)
 	}
+	// Stop the agents this daemon started. Each execution runs in its own
+	// process group so a timeout can reach the CLI's grandchildren (#614), which
+	// also means a group-directed signal to the daemon no longer reaches them:
+	// without this sweep, in-flight agents survive the restart and keep spending
+	// provider quota. Ordered after the HTTP shutdown so no new work arrives.
+	exec.TerminateAll()
 	broker.Stop()
 }
 

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -2412,8 +2412,18 @@ func main() {
 	// process group so a timeout can reach the CLI's grandchildren (#614), which
 	// also means a group-directed signal to the daemon no longer reaches them:
 	// without this sweep, in-flight agents survive the restart and keep spending
-	// provider quota. Ordered after the HTTP shutdown so no new work arrives.
-	exec.TerminateAll()
+	// provider quota.
+	//
+	// Every producer of work is cancelled first. srv.Shutdown above only stops
+	// HTTP traffic; the workers and tickers below run on their own contexts,
+	// whose cancels are deferred to main's return — i.e. after this point. A
+	// worker starting an execution between the sweep's snapshot and process exit
+	// would leave exactly the orphan this sweep exists to prevent. CancelFunc is
+	// idempotent, so the deferred cancels remain harmless.
+	stopProducersThenAgents([]context.CancelFunc{
+		workerCancel, publishWCancel, triageWCancel, refinementWCancel,
+		implementWCancel, statePollerCancel, stateWCancel,
+	}, exec.TerminateAll)
 	broker.Stop()
 }
 
@@ -5414,6 +5424,23 @@ func monitoredRepoSet(cfg *config.Config, discovered []string) map[string]struct
 // paths. Passing no discovered slice is sufficient after discovery has been
 // persisted into Repositories/NonMonitored; callers that own a fresh discovery
 // snapshot should use monitoredRepoSet directly.
+// stopProducersThenAgents runs the ordering the shutdown path depends on:
+// silence everything that can start an execution, and only then sweep the
+// executions still running. Reversing it leaves a window where a worker starts a
+// CLI the sweep has already snapshotted past, and that CLI — in its own process
+// group since #656 — outlives the daemon. Nil cancels are skipped so a producer
+// that never started is not a special case at the call site.
+func stopProducersThenAgents(stopProducers []context.CancelFunc, terminateAgents func()) {
+	for _, stop := range stopProducers {
+		if stop != nil {
+			stop()
+		}
+	}
+	if terminateAgents != nil {
+		terminateAgents()
+	}
+}
+
 func repoIsMonitored(cfg *config.Config, repo string) bool {
 	repo = strings.TrimSpace(repo)
 	if repo == "" {

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -4558,6 +4558,28 @@ func (a *tier2Adapter) HandleChange(ctx context.Context, item *scheduler.WatchIt
 		if repoHandle != nil {
 			defer repoHandle.Release()
 		}
+		// Reserving the checkout can block for a long time — cloning, fetching,
+		// or queueing on the per-repo worktree cap — and the operator may disable
+		// the repo during that wait. Recheck at the execution boundary, mirroring
+		// review-worker's skipIfUnmonitored("post_acquire"), so a disable stops
+		// the CLI instead of spending provider quota on an un-monitored repo.
+		a.cfgMu.Lock()
+		stillMonitored := repoIsMonitored(*a.cfg, item.Repo)
+		a.cfgMu.Unlock()
+		if !stillMonitored {
+			a.broker.Publish(sse.Event{
+				Type: sse.EventReviewSkipped,
+				Data: sseData(map[string]any{
+					"repo":      item.Repo,
+					"pr_number": item.Number,
+					"pr_title":  title,
+					"reason":    string(pipeline.SkipReasonNotMonitored),
+				}),
+			})
+			slog.Info("tier3: repo un-monitored while reserving the checkout, skipping PR",
+				"repo", item.Repo, "pr", item.Number)
+			return nil
+		}
 
 		rev := a.runReview(ghPR, aiCfg)
 		if rev != nil && rev.GitHubReviewID == 0 && a.publishPub != nil {

--- a/daemon/cmd/heimdallm/main_shutdown_order_test.go
+++ b/daemon/cmd/heimdallm/main_shutdown_order_test.go
@@ -22,9 +22,14 @@ func TestStopProducersThenAgentsCancelsProducersFirst(t *testing.T) {
 	stopProducersThenAgents(
 		[]context.CancelFunc{producer("worker"), producer("triage"), producer("state")},
 		func() { order = append(order, "sweep") },
+		0,
 	)
 
-	want := []string{"worker", "triage", "state", "sweep"}
+	// Two sweeps: cancelling a context does not wait for the worker to notice.
+	// One that is already past its context check and about to call cmd.Start()
+	// would start an execution the first sweep has snapshotted past, so a second
+	// pass after a settle delay is what catches it.
+	want := []string{"worker", "triage", "state", "sweep", "sweep"}
 	if len(order) != len(want) {
 		t.Fatalf("order = %v, want %v", order, want)
 	}
@@ -39,8 +44,12 @@ func TestStopProducersThenAgentsCancelsProducersFirst(t *testing.T) {
 // producer was never started (its cancel is nil).
 func TestStopProducersThenAgentsToleratesNilCancels(t *testing.T) {
 	swept := false
-	stopProducersThenAgents([]context.CancelFunc{nil}, func() { swept = true })
+	sweeps := 0
+	stopProducersThenAgents([]context.CancelFunc{nil}, func() { sweeps++; swept = true }, 0)
 	if !swept {
 		t.Error("sweep did not run when a producer cancel was nil")
+	}
+	if sweeps != 2 {
+		t.Errorf("sweeps = %d, want 2", sweeps)
 	}
 }

--- a/daemon/cmd/heimdallm/main_shutdown_order_test.go
+++ b/daemon/cmd/heimdallm/main_shutdown_order_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+// TestStopProducersThenAgentsCancelsProducersFirst pins the shutdown ordering.
+// srv.Shutdown only stops HTTP traffic: the workers and tickers run on their own
+// contexts, whose cancels are deferred to main's return. If the agent sweep ran
+// while they were still live, a worker could start an execution between the
+// sweep's snapshot and process exit — and because each execution now has its own
+// process group, that CLI no longer receives a group-directed signal and would
+// survive the restart spending provider quota (#614's symptom in miniature).
+// Producers must therefore stop before the sweep, not after.
+func TestStopProducersThenAgentsCancelsProducersFirst(t *testing.T) {
+	var order []string
+
+	producer := func(name string) context.CancelFunc {
+		return func() { order = append(order, name) }
+	}
+	stopProducersThenAgents(
+		[]context.CancelFunc{producer("worker"), producer("triage"), producer("state")},
+		func() { order = append(order, "sweep") },
+	)
+
+	want := []string{"worker", "triage", "state", "sweep"}
+	if len(order) != len(want) {
+		t.Fatalf("order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("order = %v, want %v", order, want)
+		}
+	}
+}
+
+// TestStopProducersThenAgentsToleratesNilCancels keeps the call site safe if a
+// producer was never started (its cancel is nil).
+func TestStopProducersThenAgentsToleratesNilCancels(t *testing.T) {
+	swept := false
+	stopProducersThenAgents([]context.CancelFunc{nil}, func() { swept = true })
+	if !swept {
+		t.Error("sweep did not run when a producer cancel was nil")
+	}
+}

--- a/daemon/cmd/heimdallm/main_tier3_repo_context_test.go
+++ b/daemon/cmd/heimdallm/main_tier3_repo_context_test.go
@@ -2,16 +2,159 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/heimdallm/daemon/internal/config"
 	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/repoctx"
 	"github.com/heimdallm/daemon/internal/scheduler"
 	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
 )
+
+// newTier3Adapter builds the minimal adapter the HandleChange review path needs,
+// with a capture hook standing in for runReview.
+func newTier3Adapter(t *testing.T, cfg *config.Config, mgr *repoctx.Manager, got *config.RepoAI, calls *int) *tier2Adapter {
+	t.Helper()
+	broker := sse.NewBroker()
+	broker.Start()
+	t.Cleanup(broker.Stop)
+
+	loginMu := &sync.Mutex{}
+	login := "heimdallm-bot"
+	cfgMu := &sync.Mutex{}
+	cfgPtr := &cfg
+
+	return &tier2Adapter{
+		store:   newMemStore(t),
+		broker:  broker,
+		cfgMu:   cfgMu,
+		cfg:     cfgPtr,
+		loginMu: loginMu,
+		login:   &login,
+		repoCtx: mgr,
+		ghToken: "test-token",
+		runReview: func(_ *gh.PullRequest, aiCfg config.RepoAI) *store.Review {
+			*calls++
+			*got = aiCfg
+			return nil
+		},
+	}
+}
+
+func tier3ConfigWithLocalDir(localDir string) *config.Config {
+	return &config.Config{
+		GitHub: config.GitHubConfig{Repositories: []string{"org/repo"}},
+		AI: config.AIConfig{
+			Primary: "claude",
+			Repos:   map[string]config.RepoAI{"org/repo": {LocalDir: localDir}},
+		},
+	}
+}
+
+func tier3WatchItem() (*scheduler.WatchItem, *scheduler.ItemSnapshot) {
+	return &scheduler.WatchItem{Type: "pr", Repo: "org/repo", Number: 42, GithubID: 42},
+		&scheduler.ItemSnapshot{State: "open", Author: "alice", UpdatedAt: time.Now(), HeadSHA: "abc123"}
+}
+
+// TestTier3Adapter_HandleChange_RespectsWorktreeCap is the success-path
+// counterpart that actually pins the acquisition: with the per-repo worktree cap
+// already exhausted, a HandleChange that goes through repoctx cannot obtain a
+// checkout and must fall back to an empty LocalDir. An implementation that
+// forwarded the configured local_dir without asking repoctx — the bug — would
+// hand the path over regardless and bypass the concurrency budget entirely.
+func TestTier3Adapter_HandleChange_RespectsWorktreeCap(t *testing.T) {
+	localDir := t.TempDir()
+	mgr := repoctx.NewManagerWithOptions(repoctx.ManagerOptions{MaxWorktreesPerRepo: 1})
+
+	// Hold the repo's only slot for the duration of the call.
+	held, err := mgr.Acquire(context.Background(), repoctx.Request{
+		Repo:               "org/repo",
+		ConfiguredLocalDir: localDir,
+		Mode:               repoctx.ModeRead,
+		WorktreeToken:      "holder-1",
+	})
+	if err != nil {
+		t.Fatalf("seed acquire: %v", err)
+	}
+	defer held.Release()
+
+	var (
+		gotAI config.RepoAI
+		calls int
+	)
+	a := newTier3Adapter(t, tier3ConfigWithLocalDir(localDir), mgr, &gotAI, &calls)
+
+	// Short deadline: the cap wait must give up rather than hang the test.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	item, snap := tier3WatchItem()
+	if err := a.HandleChange(ctx, item, snap); err != nil {
+		t.Fatalf("HandleChange: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("runReview called %d time(s), want 1", calls)
+	}
+	if gotAI.LocalDir != "" {
+		t.Errorf("LocalDir = %q, want empty: the cap was exhausted, so no checkout could be reserved", gotAI.LocalDir)
+	}
+}
+
+// TestTier3Adapter_HandleChange_ReleasesTheReservation covers the risk of adding
+// an acquisition to this entry point: a reservation that is never released
+// starves every later execution on the repo. With the cap free, runReview must
+// receive the reserved checkout, and the slot must be available again afterwards.
+func TestTier3Adapter_HandleChange_ReleasesTheReservation(t *testing.T) {
+	localDir := t.TempDir()
+	mgr := repoctx.NewManagerWithOptions(repoctx.ManagerOptions{MaxWorktreesPerRepo: 1})
+
+	var (
+		gotAI config.RepoAI
+		calls int
+	)
+	a := newTier3Adapter(t, tier3ConfigWithLocalDir(localDir), mgr, &gotAI, &calls)
+
+	item, snap := tier3WatchItem()
+	if err := a.HandleChange(context.Background(), item, snap); err != nil {
+		t.Fatalf("HandleChange: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("runReview called %d time(s), want 1", calls)
+	}
+	if !sameDir(t, gotAI.LocalDir, localDir) {
+		t.Errorf("LocalDir = %q, want the reserved checkout %q", gotAI.LocalDir, localDir)
+	}
+
+	// The only slot must be free again: if the handle leaked, this blocks until
+	// the deadline and fails.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	h, err := mgr.Acquire(ctx, repoctx.Request{
+		Repo:               "org/repo",
+		ConfiguredLocalDir: localDir,
+		Mode:               repoctx.ModeRead,
+		WorktreeToken:      "probe-1",
+	})
+	if err != nil {
+		t.Fatalf("reservation leaked: re-acquiring the repo failed: %v", err)
+	}
+	h.Release()
+}
+
+// sameDir compares paths tolerating symlinked temp roots (macOS /var →
+// /private/var).
+func sameDir(t *testing.T, got, want string) bool {
+	t.Helper()
+	if got == want {
+		return true
+	}
+	gotResolved, err1 := filepath.EvalSymlinks(got)
+	wantResolved, err2 := filepath.EvalSymlinks(want)
+	return err1 == nil && err2 == nil && gotResolved == wantResolved
+}
 
 // TestTier3Adapter_HandleChange_ResolvesWorkDirThroughRepoContext covers
 // theburrowhub/heimdallm#655. HandleChange was the only review entry point that

--- a/daemon/cmd/heimdallm/main_tier3_repo_context_test.go
+++ b/daemon/cmd/heimdallm/main_tier3_repo_context_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/config"
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/scheduler"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// TestTier3Adapter_HandleChange_ResolvesWorkDirThroughRepoContext covers
+// theburrowhub/heimdallm#655. HandleChange was the only review entry point that
+// skipped acquireRepoContext: it forwarded the raw config local_dir (usually
+// empty) straight to runReview, so the agent ran with no WorkDir and inherited
+// the daemon's cwd — `/` under launchd — which makes `codex exec` abort with
+// "Not inside a trusted directory". The other two entry points (review-worker
+// and tier2 ProcessPR) go through repoctx and must not be the exception.
+//
+// With a nil manager the acquisition necessarily fails, and the contract is the
+// same one ProcessPR already honours: log the fallback and hand runReview an
+// empty LocalDir rather than an unreserved path. That is exactly what
+// distinguishes the fixed code from the old one, which passed the configured
+// value through untouched.
+func TestTier3Adapter_HandleChange_ResolvesWorkDirThroughRepoContext(t *testing.T) {
+	s := newMemStore(t)
+	broker := sse.NewBroker()
+	broker.Start()
+	defer broker.Stop()
+
+	var (
+		loginMu sync.Mutex
+		login   = "heimdallm-bot"
+		cfgMu   sync.Mutex
+		cfg     = &config.Config{
+			GitHub: config.GitHubConfig{Repositories: []string{"org/repo"}},
+			AI: config.AIConfig{
+				Primary: "claude",
+				Repos: map[string]config.RepoAI{
+					// A path the pipeline must never use directly: reviews run in
+					// a worktree reserved through repoctx, never in the operator's
+					// own checkout.
+					"org/repo": {LocalDir: "/tmp/unreserved-checkout"},
+				},
+			},
+		}
+	)
+
+	var (
+		gotAI  config.RepoAI
+		called int
+	)
+	a := &tier2Adapter{
+		store:   s,
+		broker:  broker,
+		cfgMu:   &cfgMu,
+		cfg:     &cfg,
+		loginMu: &loginMu,
+		login:   &login,
+		repoCtx: nil, // acquisition fails — exercises the fallback contract
+		runReview: func(_ *gh.PullRequest, aiCfg config.RepoAI) *store.Review {
+			called++
+			gotAI = aiCfg
+			return nil
+		},
+	}
+
+	err := a.HandleChange(context.Background(), &scheduler.WatchItem{
+		Type: "pr", Repo: "org/repo", Number: 42, GithubID: 42,
+	}, &scheduler.ItemSnapshot{
+		State: "open", Author: "alice", UpdatedAt: time.Now(), HeadSHA: "abc123",
+	})
+	if err != nil {
+		t.Fatalf("HandleChange: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("runReview called %d time(s), want 1", called)
+	}
+	if gotAI.LocalDir != "" {
+		t.Errorf("LocalDir = %q, want empty: the checkout must come from repoctx, not straight from config", gotAI.LocalDir)
+	}
+}

--- a/daemon/cmd/heimdallm/main_tier3_repo_context_test.go
+++ b/daemon/cmd/heimdallm/main_tier3_repo_context_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/heimdallm/daemon/internal/config"
 	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/pipeline"
 	"github.com/heimdallm/daemon/internal/repoctx"
 	"github.com/heimdallm/daemon/internal/scheduler"
 	"github.com/heimdallm/daemon/internal/sse"
@@ -142,6 +144,76 @@ func TestTier3Adapter_HandleChange_ReleasesTheReservation(t *testing.T) {
 		t.Fatalf("reservation leaked: re-acquiring the repo failed: %v", err)
 	}
 	h.Release()
+}
+
+// TestTier3Adapter_HandleChange_RechecksMonitoredAfterAcquire mirrors the
+// post_acquire guard review-worker already has (main.go:1057). Reserving a
+// checkout can block for seconds or minutes — cloning, fetching, or waiting on
+// the per-repo worktree cap — and the operator may disable the repo during that
+// wait. Before this guard, HandleChange read repoIsMonitored only *before* the
+// acquisition, so a slow clone ended up spending provider quota on a repo that
+// was no longer monitored, with no review_skipped event to show for it.
+func TestTier3Adapter_HandleChange_RechecksMonitoredAfterAcquire(t *testing.T) {
+	localDir := t.TempDir()
+	mgr := repoctx.NewManagerWithOptions(repoctx.ManagerOptions{MaxWorktreesPerRepo: 1})
+
+	// Occupy the only slot so the acquisition inside HandleChange has to wait.
+	held, err := mgr.Acquire(context.Background(), repoctx.Request{
+		Repo:               "org/repo",
+		ConfiguredLocalDir: localDir,
+		Mode:               repoctx.ModeRead,
+		WorktreeToken:      "holder-1",
+	})
+	if err != nil {
+		t.Fatalf("seed acquire: %v", err)
+	}
+
+	var (
+		gotAI config.RepoAI
+		calls int
+	)
+	cfg := tier3ConfigWithLocalDir(localDir)
+	a := newTier3Adapter(t, cfg, mgr, &gotAI, &calls)
+	events := a.broker.Subscribe()
+	defer a.broker.Unsubscribe(events)
+
+	// Un-monitor the repo *before* releasing the slot, so the acquisition can
+	// only complete after the config has changed. No timing assumptions.
+	go func() {
+		a.cfgMu.Lock()
+		(*a.cfg).GitHub.NonMonitored = []string{"org/repo"}
+		a.cfgMu.Unlock()
+		held.Release()
+	}()
+
+	item, snap := tier3WatchItem()
+	if err := a.HandleChange(context.Background(), item, snap); err != nil {
+		t.Fatalf("HandleChange: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("runReview called %d time(s), want 0: the repo was un-monitored while the checkout was being reserved", calls)
+	}
+
+	for {
+		select {
+		case ev := <-events:
+			if ev.Type != sse.EventReviewSkipped {
+				continue
+			}
+			var payload struct {
+				Reason string `json:"reason"`
+			}
+			if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+				t.Fatalf("decode event: %v", err)
+			}
+			if payload.Reason != string(pipeline.SkipReasonNotMonitored) {
+				t.Fatalf("reason = %q, want %q", payload.Reason, pipeline.SkipReasonNotMonitored)
+			}
+			return
+		case <-time.After(2 * time.Second):
+			t.Fatal("no review_skipped event emitted for the un-monitored repo")
+		}
+	}
 }
 
 // sameDir compares paths tolerating symlinked temp roots (macOS /var →

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -12,11 +12,18 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
 const executionTimeout = 5 * time.Minute
 const cliHelpTimeout = 2 * time.Second
+
+// processGroupKillGrace bounds how long a cancelled execution may keep running
+// after SIGTERM before the group is killed outright. It also bounds how long
+// Wait blocks on inherited stdout/stderr pipes: a grandchild holding them open
+// used to stall the pipeline long past the timeout (see #614).
+const processGroupKillGrace = 3 * time.Second
 
 // ReviewResult is the parsed JSON response from the AI CLI.
 type ReviewResult struct {
@@ -1226,13 +1233,44 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	}
 
 	var workDirFlags []string
-	if opts.WorkDir != "" {
+	switch {
+	case opts.WorkDir != "":
 		workDirFlags = detectWorkDirFlags(cli, cliPath, opts.WorkDir)
+	case cli == "codex":
+		// `codex exec` refuses to start outside a git repo or a directory
+		// trusted in ~/.codex/config.toml. With no checkout the child would
+		// inherit the daemon's cwd — `/` under launchd — and abort with "Not
+		// inside a trusted directory" (theburrowhub/heimdallm#655). A review
+		// needs no checkout at all (the diff travels in the prompt), so hand
+		// codex an empty per-execution directory and waive the repo check.
+		// Substituting `/` for an empty workspace also narrows what the agent
+		// can read, rather than widening it.
+		// The workspace is passed as cmd.Dir below rather than via --cd: the
+		// child's cwd is what codex inspects, and probing `--help` for --cd
+		// support would spend an extra subprocess per review for nothing.
+		ws, err := os.MkdirTemp("", "heimdallm-codex-ws-*")
+		if err != nil {
+			return nil, fmt.Errorf("executor: create codex workspace: %w", err)
+		}
+		defer os.RemoveAll(ws)
+		opts.WorkDir = ws
+		workDirFlags = []string{"--skip-git-repo-check"}
 	}
 
 	args := buildArgs(cli, opts, workDirFlags)
 	cmd := exec.CommandContext(ctx, cliPath, args...)
 	cmd.Stdin = strings.NewReader(prompt)
+	// Every supported CLI is a launcher: the process we start spawns the one
+	// that actually talks to the provider. exec.CommandContext signals only the
+	// direct child, so on timeout the launcher died while its grandchild was
+	// reparented to init and kept spending provider quota (#614). Give the
+	// execution its own process group and signal the whole group instead.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return signalProcessGroup(cmd, syscall.SIGTERM) }
+	// Bound the post-cancellation wait. Without this, Wait blocks until every
+	// inherited stdout/stderr pipe is closed — a grandchild ignoring SIGTERM
+	// stalled the pipeline for as long as it chose to run.
+	cmd.WaitDelay = processGroupKillGrace
 
 	// Augment PATH with paths from the login shell so the CLI can find its own
 	// dependencies, without running stdin THROUGH the shell (which would cause
@@ -1254,16 +1292,36 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
+	runErr := cmd.Run()
+	// SIGTERM is a request; a wedged or signal-ignoring descendant answers to
+	// SIGKILL only. Sweep the group once the wait is over so no member outlives
+	// the execution, whatever the outcome.
+	if ctx.Err() != nil {
+		if err := signalProcessGroup(cmd, syscall.SIGKILL); err != nil {
+			slog.Debug("executor: process group already gone", "cli", cli, "err", err)
+		}
+	}
+	if runErr != nil {
 		// Some CLIs (e.g. claude) write errors to stdout rather than stderr.
 		errDetail := strings.TrimSpace(stderr.String())
 		if errDetail == "" {
 			errDetail = strings.TrimSpace(stdout.String())
 		}
-		return nil, fmt.Errorf("executor: run %s: %w (output: %s)", cli, err, errDetail)
+		return nil, fmt.Errorf("executor: run %s: %w (output: %s)", cli, runErr, errDetail)
 	}
 
 	return stdout.Bytes(), nil
+}
+
+// signalProcessGroup sends sig to the entire process group led by cmd's child.
+// Setpgid makes the child's PID the group ID, so negating it addresses the child
+// and every descendant that has not created a group of its own. Returns
+// os.ErrProcessDone when there is no process left to signal.
+func signalProcessGroup(cmd *exec.Cmd, sig syscall.Signal) error {
+	if cmd == nil || cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	return syscall.Kill(-cmd.Process.Pid, sig)
 }
 
 func validateExecutionRequest(cli string, opts ExecOptions) error {

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -19,11 +20,14 @@ import (
 const executionTimeout = 5 * time.Minute
 const cliHelpTimeout = 2 * time.Second
 
-// processGroupKillGrace bounds how long a cancelled execution may keep running
-// after SIGTERM before the group is killed outright. It also bounds how long
-// Wait blocks on inherited stdout/stderr pipes: a grandchild holding them open
-// used to stall the pipeline long past the timeout (see #614).
-const processGroupKillGrace = 3 * time.Second
+// processGroupTermGrace is how long a cancelled execution may keep running
+// after SIGTERM before the whole group is killed outright (see #614).
+const processGroupTermGrace = time.Second
+
+// waitDelayAfterExit bounds how long Wait blocks on inherited stdout/stderr
+// pipes after the command itself is done: a descendant holding them open used to
+// stall the pipeline long past the timeout (see #614).
+const waitDelayAfterExit = 3 * time.Second
 
 // ReviewResult is the parsed JSON response from the AI CLI.
 type ReviewResult struct {
@@ -1246,8 +1250,12 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 		// Substituting `/` for an empty workspace also narrows what the agent
 		// can read, rather than widening it.
 		// The workspace is passed as cmd.Dir below rather than via --cd: the
-		// child's cwd is what codex inspects, and probing `--help` for --cd
-		// support would spend an extra subprocess per review for nothing.
+		// child's cwd is what codex inspects, so --cd would be redundant.
+		// --skip-git-repo-check is not gated behind cliHelpSupports like the
+		// other flags here: that probe reads the top-level `codex --help`, and
+		// the flag only appears under `codex exec --help` (verified on codex
+		// 0.146.0), so gating it would always resolve to false and reinstate the
+		// very failure this branch exists to prevent.
 		ws, err := os.MkdirTemp("", "heimdallm-codex-ws-*")
 		if err != nil {
 			return nil, fmt.Errorf("executor: create codex workspace: %w", err)
@@ -1266,11 +1274,29 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	// reparented to init and kept spending provider quota (#614). Give the
 	// execution its own process group and signal the whole group instead.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error { return signalProcessGroup(cmd, syscall.SIGTERM) }
-	// Bound the post-cancellation wait. Without this, Wait blocks until every
-	// inherited stdout/stderr pipe is closed — a grandchild ignoring SIGTERM
-	// stalled the pipeline for as long as it chose to run.
-	cmd.WaitDelay = processGroupKillGrace
+	// Cancellation escalates within the group: SIGTERM, then SIGKILL for a
+	// descendant that ignores it. Both are sent while Wait is still in flight,
+	// i.e. before the child is reaped: once every member of a group has exited
+	// the kernel may hand that pgid to somebody else, so a sweep issued after
+	// Wait could SIGKILL an unrelated group.
+	runDone := make(chan struct{})
+	cmd.Cancel = func() error {
+		err := signalProcessGroup(cmd, syscall.SIGTERM)
+		go func() {
+			select {
+			case <-time.After(processGroupTermGrace):
+				if killErr := signalProcessGroup(cmd, syscall.SIGKILL); killErr != nil {
+					slog.Debug("executor: process group already gone", "cli", cli, "err", killErr)
+				}
+			case <-runDone:
+			}
+		}()
+		return err
+	}
+	// Bound the wait on inherited pipes. Without this, Wait blocks until every
+	// copy of stdout/stderr is closed — a descendant holding them stalled the
+	// pipeline for as long as it chose to run.
+	cmd.WaitDelay = waitDelayAfterExit
 
 	// Augment PATH with paths from the login shell so the CLI can find its own
 	// dependencies, without running stdin THROUGH the shell (which would cause
@@ -1293,13 +1319,18 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	cmd.Stderr = &stderr
 
 	runErr := cmd.Run()
-	// SIGTERM is a request; a wedged or signal-ignoring descendant answers to
-	// SIGKILL only. Sweep the group once the wait is over so no member outlives
-	// the execution, whatever the outcome.
-	if ctx.Err() != nil {
-		if err := signalProcessGroup(cmd, syscall.SIGKILL); err != nil {
-			slog.Debug("executor: process group already gone", "cli", cli, "err", err)
-		}
+	close(runDone) // stop the escalation goroutine
+
+	// WaitDelay also fires when the command itself exited cleanly but a
+	// descendant still holds the inherited pipes — the exact shape of #614. The
+	// run succeeded and its output is already buffered, so return it instead of
+	// discarding a complete review. Such a descendant is not swept here: the
+	// child has been reaped, so its pgid may already belong to another group.
+	// Closing that remaining leak needs a wait-without-reap and belongs to #614.
+	if errors.Is(runErr, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == 0 {
+		slog.Warn("executor: CLI exited 0 but a descendant held the output pipes; returning collected output",
+			"cli", cli, "bytes", stdout.Len())
+		return stdout.Bytes(), nil
 	}
 	if runErr != nil {
 		// Some CLIs (e.g. claude) write errors to stdout rather than stderr.

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -100,11 +100,76 @@ func OptionsForSelectedCLI(primary, selected string, opts ExecOptions) ExecOptio
 }
 
 // Executor runs AI CLI tools for code review.
-type Executor struct{}
+type Executor struct {
+	// groupsMu guards inFlightGroups, which records the process-group IDs of
+	// executions currently running. Each execution gets its own group so a
+	// timeout can reach the grandchild that holds the provider connection
+	// (#614) — but that also detaches it from any group-directed signal the
+	// daemon receives, so the shutdown path needs this registry to sweep what
+	// is still running. See TerminateAll.
+	groupsMu       sync.Mutex
+	inFlightGroups map[int]struct{}
+}
 
 // New creates a new Executor.
 func New() *Executor {
 	return &Executor{}
+}
+
+// trackGroup registers a running execution's process group.
+func (e *Executor) trackGroup(pgid int) {
+	e.groupsMu.Lock()
+	defer e.groupsMu.Unlock()
+	if e.inFlightGroups == nil {
+		e.inFlightGroups = make(map[int]struct{})
+	}
+	e.inFlightGroups[pgid] = struct{}{}
+}
+
+// untrackGroup forgets an execution's process group once Wait has returned.
+func (e *Executor) untrackGroup(pgid int) {
+	e.groupsMu.Lock()
+	defer e.groupsMu.Unlock()
+	delete(e.inFlightGroups, pgid)
+}
+
+// TerminateAll ends every execution this Executor still has in flight, SIGTERM
+// first and SIGKILL after a grace period. The daemon's shutdown path must call
+// it: ExecuteRaw derives its context from context.Background() rather than from
+// the SIGINT/SIGTERM handler, and each execution runs in its own process group,
+// so nothing else would reach an in-flight agent. Without this a restart leaves
+// agents running and spending provider quota — the #614 symptom. Safe to call
+// when nothing is running.
+func (e *Executor) TerminateAll() {
+	e.groupsMu.Lock()
+	pgids := make([]int, 0, len(e.inFlightGroups))
+	for pgid := range e.inFlightGroups {
+		pgids = append(pgids, pgid)
+	}
+	e.groupsMu.Unlock()
+
+	if len(pgids) == 0 {
+		return
+	}
+	slog.Info("executor: terminating in-flight executions", "groups", len(pgids))
+	for _, pgid := range pgids {
+		if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
+			slog.Debug("executor: process group already gone", "pgid", pgid, "err", err)
+		}
+	}
+	// The groups are still registered — their ExecuteRaw calls have not
+	// returned — so the pgids cannot have been recycled while we wait.
+	time.Sleep(processGroupTermGrace)
+	e.groupsMu.Lock()
+	defer e.groupsMu.Unlock()
+	for _, pgid := range pgids {
+		if _, stillRunning := e.inFlightGroups[pgid]; !stillRunning {
+			continue
+		}
+		if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+			slog.Debug("executor: process group already gone", "pgid", pgid, "err", err)
+		}
+	}
 }
 
 // Detect returns the first available CLI (primary → fallback).
@@ -1263,6 +1328,14 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 		defer os.RemoveAll(ws)
 		opts.WorkDir = ws
 		workDirFlags = []string{"--skip-git-repo-check"}
+		// Loud on purpose. Only the review and triage paths reach this branch
+		// today (the write-mode callers abort when repoctx fails, so they never
+		// arrive with an empty WorkDir), and an agent asked to change code would
+		// silently succeed against an empty directory here. If this ever shows
+		// up alongside a develop/refinement run, that caller needs a checkout,
+		// not this workspace.
+		slog.Warn("executor: running codex without a checkout in a throwaway workspace",
+			"workspace", ws)
 	}
 
 	args := buildArgs(cli, opts, workDirFlags)
@@ -1318,7 +1391,16 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	runErr := cmd.Run()
+	// Start and Wait are split rather than calling Run so the process group can
+	// be registered while the execution is live — TerminateAll needs it to reach
+	// agents that are still running when the daemon shuts down.
+	runErr := cmd.Start()
+	if runErr == nil {
+		pgid := cmd.Process.Pid // Setpgid makes the child its own group leader
+		e.trackGroup(pgid)
+		runErr = cmd.Wait()
+		e.untrackGroup(pgid)
+	}
 	close(runDone) // stop the escalation goroutine
 
 	// WaitDelay also fires when the command itself exited cleanly but a

--- a/daemon/internal/executor/executor.go
+++ b/daemon/internal/executor/executor.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 )
@@ -108,7 +109,7 @@ type Executor struct {
 	// daemon receives, so the shutdown path needs this registry to sweep what
 	// is still running. See TerminateAll.
 	groupsMu       sync.Mutex
-	inFlightGroups map[int]struct{}
+	inFlightGroups map[int]*atomic.Bool
 }
 
 // New creates a new Executor.
@@ -116,14 +117,15 @@ func New() *Executor {
 	return &Executor{}
 }
 
-// trackGroup registers a running execution's process group.
-func (e *Executor) trackGroup(pgid int) {
+// trackGroup registers a running execution's process group, along with the flag
+// that reports whether its child has been reaped.
+func (e *Executor) trackGroup(pgid int, reaped *atomic.Bool) {
 	e.groupsMu.Lock()
 	defer e.groupsMu.Unlock()
 	if e.inFlightGroups == nil {
-		e.inFlightGroups = make(map[int]struct{})
+		e.inFlightGroups = make(map[int]*atomic.Bool)
 	}
-	e.inFlightGroups[pgid] = struct{}{}
+	e.inFlightGroups[pgid] = reaped
 }
 
 // untrackGroup forgets an execution's process group once Wait has returned.
@@ -141,33 +143,42 @@ func (e *Executor) untrackGroup(pgid int) {
 // agents running and spending provider quota — the #614 symptom. Safe to call
 // when nothing is running.
 func (e *Executor) TerminateAll() {
+	type liveGroup struct {
+		pgid   int
+		reaped *atomic.Bool
+	}
 	e.groupsMu.Lock()
-	pgids := make([]int, 0, len(e.inFlightGroups))
-	for pgid := range e.inFlightGroups {
-		pgids = append(pgids, pgid)
+	groups := make([]liveGroup, 0, len(e.inFlightGroups))
+	for pgid, reaped := range e.inFlightGroups {
+		groups = append(groups, liveGroup{pgid: pgid, reaped: reaped})
 	}
 	e.groupsMu.Unlock()
 
-	if len(pgids) == 0 {
+	if len(groups) == 0 {
 		return
 	}
-	slog.Info("executor: terminating in-flight executions", "groups", len(pgids))
-	for _, pgid := range pgids {
-		if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
-			slog.Debug("executor: process group already gone", "pgid", pgid, "err", err)
-		}
-	}
-	// The groups are still registered — their ExecuteRaw calls have not
-	// returned — so the pgids cannot have been recycled while we wait.
-	time.Sleep(processGroupTermGrace)
-	e.groupsMu.Lock()
-	defer e.groupsMu.Unlock()
-	for _, pgid := range pgids {
-		if _, stillRunning := e.inFlightGroups[pgid]; !stillRunning {
+	slog.Info("executor: terminating in-flight executions", "groups", len(groups))
+	// Registration alone does not prove the group is still ours: untrackGroup
+	// runs after Wait has reaped the child, so a registered pgid can already be
+	// free. The per-execution reaped flag is set before that, so checking it
+	// immediately before each signal keeps the sweep off recycled pgids in all
+	// but the gap between those two statements — the same residual window
+	// documented for the cancellation path, and likewise #614's to close.
+	for _, g := range groups {
+		if g.reaped.Load() {
 			continue
 		}
-		if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
-			slog.Debug("executor: process group already gone", "pgid", pgid, "err", err)
+		if err := killGroup(g.pgid, syscall.SIGTERM); err != nil {
+			slog.Debug("executor: process group already gone", "pgid", g.pgid, "err", err)
+		}
+	}
+	time.Sleep(processGroupTermGrace)
+	for _, g := range groups {
+		if g.reaped.Load() {
+			continue
+		}
+		if err := killGroup(g.pgid, syscall.SIGKILL); err != nil {
+			slog.Debug("executor: process group already gone", "pgid", g.pgid, "err", err)
 		}
 	}
 }
@@ -1348,16 +1359,24 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	// execution its own process group and signal the whole group instead.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	// Cancellation escalates within the group: SIGTERM, then SIGKILL for a
-	// descendant that ignores it. Both are sent while Wait is still in flight,
-	// i.e. before the child is reaped: once every member of a group has exited
-	// the kernel may hand that pgid to somebody else, so a sweep issued after
-	// Wait could SIGKILL an unrelated group.
+	// descendant that ignores it. Both are aimed at the group while the
+	// execution is still live, because once every member has exited the kernel
+	// may hand that pgid to somebody else and a late signal would hit an
+	// unrelated group. `reaped` is set the instant Wait returns and checked
+	// immediately before the kill: that narrows the window to the gap between
+	// those two statements, it does not remove it. Closing it entirely requires
+	// reserving the pgid with a wait-without-reap (wait4(WNOWAIT)/pidfd), which
+	// belongs to #614.
 	runDone := make(chan struct{})
+	var reaped atomic.Bool
 	cmd.Cancel = func() error {
 		err := signalProcessGroup(cmd, syscall.SIGTERM)
 		go func() {
 			select {
 			case <-time.After(processGroupTermGrace):
+				if reaped.Load() {
+					return // the pgid may already be reused — leave it alone
+				}
 				if killErr := signalProcessGroup(cmd, syscall.SIGKILL); killErr != nil {
 					slog.Debug("executor: process group already gone", "cli", cli, "err", killErr)
 				}
@@ -1394,11 +1413,13 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	// Start and Wait are split rather than calling Run so the process group can
 	// be registered while the execution is live — TerminateAll needs it to reach
 	// agents that are still running when the daemon shuts down.
+	var pgid int
 	runErr := cmd.Start()
 	if runErr == nil {
-		pgid := cmd.Process.Pid // Setpgid makes the child its own group leader
-		e.trackGroup(pgid)
+		pgid = cmd.Process.Pid // Setpgid makes the child its own group leader
+		e.trackGroup(pgid, &reaped)
 		runErr = cmd.Wait()
+		reaped.Store(true) // before untrackGroup: no signal must follow the reap
 		e.untrackGroup(pgid)
 	}
 	close(runDone) // stop the escalation goroutine
@@ -1406,12 +1427,16 @@ func (e *Executor) ExecuteRaw(cli, prompt string, opts ExecOptions) ([]byte, err
 	// WaitDelay also fires when the command itself exited cleanly but a
 	// descendant still holds the inherited pipes — the exact shape of #614. The
 	// run succeeded and its output is already buffered, so return it instead of
-	// discarding a complete review. Such a descendant is not swept here: the
-	// child has been reaped, so its pgid may already belong to another group.
-	// Closing that remaining leak needs a wait-without-reap and belongs to #614.
+	// discarding a complete review. Such a descendant is NOT swept here: the
+	// child has been reaped, so its pgid may already belong to another group, and
+	// closing that leak safely needs a wait-without-reap (#614). This is the one
+	// place with positive evidence of a live leaked process, so log its identity
+	// — pgid and leader PID — to make it traceable while #614 is open.
 	if errors.Is(runErr, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == 0 {
-		slog.Warn("executor: CLI exited 0 but a descendant held the output pipes; returning collected output",
-			"cli", cli, "bytes", stdout.Len())
+		slog.Warn("executor: CLI exited 0 but a descendant held the output pipes; returning collected output and leaving the descendant running",
+			// With Setpgid the group ID *is* the leader's PID, so one field
+			// identifies both the group and the process to look for.
+			"cli", cli, "bytes", stdout.Len(), "pgid", pgid)
 		return stdout.Bytes(), nil
 	}
 	if runErr != nil {
@@ -1434,7 +1459,22 @@ func signalProcessGroup(cmd *exec.Cmd, sig syscall.Signal) error {
 	if cmd == nil || cmd.Process == nil {
 		return os.ErrProcessDone
 	}
-	return syscall.Kill(-cmd.Process.Pid, sig)
+	return killGroup(cmd.Process.Pid, sig)
+}
+
+// killGroup signals the process group led by pgid, reporting a group that has
+// already exited as os.ErrProcessDone. That translation matters for cmd.Cancel:
+// os/exec only ignores a Cancel error equivalent to os.ErrProcessDone, so a raw
+// ESRCH would come back out of Wait and mask a cancellation as
+// "executor: run <cli>: no such process".
+func killGroup(pgid int, sig syscall.Signal) error {
+	if err := syscall.Kill(-pgid, sig); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return nil
 }
 
 func validateExecutionRequest(cli string, opts ExecOptions) error {

--- a/daemon/internal/executor/executor_codex_workspace_test.go
+++ b/daemon/internal/executor/executor_codex_workspace_test.go
@@ -1,0 +1,151 @@
+package executor_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/executor"
+)
+
+// TestExecuteRawGivesCodexAnIsolatedWorkspaceWithoutWorkDir covers the review
+// path that has no local checkout (see theburrowhub/heimdallm#655). Without a
+// WorkDir the child used to inherit the daemon's cwd — which under launchd is
+// `/` — and `codex exec` aborted with "Not inside a trusted directory and
+// --skip-git-repo-check was not specified." The daemon must hand codex an empty
+// per-execution workspace instead of the filesystem root, and tell codex not to
+// insist on a git repo, because a review needs no checkout at all: the diff is
+// already in the prompt.
+func TestExecuteRawGivesCodexAnIsolatedWorkspaceWithoutWorkDir(t *testing.T) {
+	defer executor.ResetLoginPathCacheForTest()()
+
+	binDir := t.TempDir()
+	captureArgs := filepath.Join(t.TempDir(), "args.txt")
+	captureCWD := filepath.Join(t.TempDir(), "cwd.txt")
+	script := fakeCLIScript("Usage: codex\n  -C, --cd <DIR>\n", captureArgs, captureCWD)
+	if err := os.WriteFile(filepath.Join(binDir, "codex"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	e := executor.New()
+	if _, err := e.ExecuteRaw("codex", "prompt", executor.ExecOptions{}); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+
+	argsBytes, err := os.ReadFile(captureArgs)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	args := strings.Fields(string(argsBytes))
+	if !contains(args, "--skip-git-repo-check") {
+		t.Errorf("args = %v, want --skip-git-repo-check when codex runs without a WorkDir", args)
+	}
+
+	cwdBytes, err := os.ReadFile(captureCWD)
+	if err != nil {
+		t.Fatalf("read captured cwd: %v", err)
+	}
+	cwd := strings.TrimSpace(string(cwdBytes))
+	if cwd == "/" {
+		t.Fatal("codex ran with cwd=/, want a dedicated empty workspace")
+	}
+	if cwd == "" {
+		t.Fatal("fake CLI captured an empty cwd")
+	}
+
+	entries, err := os.ReadDir(cwd)
+	if err == nil && len(entries) > 0 {
+		t.Errorf("workspace %q was not empty: %d entries", cwd, len(entries))
+	}
+	if _, err := os.Stat(cwd); !os.IsNotExist(err) {
+		t.Errorf("workspace %q still exists after the run (stat err = %v), want it removed", cwd, err)
+	}
+}
+
+// TestExecuteRawKeepsCodexTrustFlagOffWithWorkDir pins the behaviour that must
+// NOT change: when a checkout is available the daemon passes it via --cd and
+// adds no trust-policy flag, so codex keeps its own guard for real workspaces.
+func TestExecuteRawKeepsCodexTrustFlagOffWithWorkDir(t *testing.T) {
+	defer executor.ResetLoginPathCacheForTest()()
+
+	binDir := t.TempDir()
+	captureArgs := filepath.Join(t.TempDir(), "args.txt")
+	captureCWD := filepath.Join(t.TempDir(), "cwd.txt")
+	script := fakeCLIScript("Usage: codex\n  -C, --cd <DIR>\n", captureArgs, captureCWD)
+	if err := os.WriteFile(filepath.Join(binDir, "codex"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	workDir := t.TempDir()
+	e := executor.New()
+	if _, err := e.ExecuteRaw("codex", "prompt", executor.ExecOptions{WorkDir: workDir}); err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+
+	argsBytes, err := os.ReadFile(captureArgs)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	args := strings.Fields(string(argsBytes))
+	if contains(args, "--skip-git-repo-check") {
+		t.Errorf("args = %v, want no trust-policy flag when a WorkDir is provided", args)
+	}
+	if !containsInOrder(args, "--cd", workDir) {
+		t.Errorf("args = %v, want --cd %s", args, workDir)
+	}
+
+	cwdBytes, err := os.ReadFile(captureCWD)
+	if err != nil {
+		t.Fatalf("read captured cwd: %v", err)
+	}
+	requireSameDir(t, strings.TrimSpace(string(cwdBytes)), workDir)
+}
+
+// TestExecuteRawLeavesOtherCLIsAloneWithoutWorkDir keeps the workspace
+// substitution scoped to codex: claude and gemini have no such requirement and
+// their argument lists must stay untouched.
+func TestExecuteRawLeavesOtherCLIsAloneWithoutWorkDir(t *testing.T) {
+	for _, cli := range []string{"claude", "gemini"} {
+		t.Run(cli, func(t *testing.T) {
+			defer executor.ResetLoginPathCacheForTest()()
+
+			binDir := t.TempDir()
+			captureArgs := filepath.Join(t.TempDir(), "args.txt")
+			captureCWD := filepath.Join(t.TempDir(), "cwd.txt")
+			script := fakeCLIScript("Usage: "+cli+"\n", captureArgs, captureCWD)
+			if err := os.WriteFile(filepath.Join(binDir, cli), []byte(script), 0o755); err != nil {
+				t.Fatalf("write fake CLI: %v", err)
+			}
+			t.Setenv("PATH", binDir)
+
+			e := executor.New()
+			if _, err := e.ExecuteRaw(cli, "prompt", executor.ExecOptions{}); err != nil {
+				t.Fatalf("ExecuteRaw: %v", err)
+			}
+
+			argsBytes, err := os.ReadFile(captureArgs)
+			if err != nil {
+				t.Fatalf("read captured args: %v", err)
+			}
+			args := strings.Fields(string(argsBytes))
+			if contains(args, "--skip-git-repo-check") {
+				t.Errorf("args = %v, want no codex-specific flag for %s", args, cli)
+			}
+			if contains(args, "--cd") {
+				t.Errorf("args = %v, want no --cd for %s without a WorkDir", args, cli)
+			}
+		})
+	}
+}
+
+func contains(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}

--- a/daemon/internal/executor/executor_codex_workspace_test.go
+++ b/daemon/internal/executor/executor_codex_workspace_test.go
@@ -23,11 +23,27 @@ func TestExecuteRawGivesCodexAnIsolatedWorkspaceWithoutWorkDir(t *testing.T) {
 	binDir := t.TempDir()
 	captureArgs := filepath.Join(t.TempDir(), "args.txt")
 	captureCWD := filepath.Join(t.TempDir(), "cwd.txt")
-	script := fakeCLIScript("Usage: codex\n  -C, --cd <DIR>\n", captureArgs, captureCWD)
+	captureEntries := filepath.Join(t.TempDir(), "entries.txt")
+	// The listing must be taken while the CLI runs: ExecuteRaw removes the
+	// workspace before returning, so inspecting it afterwards proves nothing.
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  printf 'Usage: codex\\n  -C, --cd <DIR>\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"printf '%s\\n' \"$*\" > " + shellQuote(captureArgs) + "\n" +
+		"printf '%s\\n' \"$PWD\" > " + shellQuote(captureCWD) + "\n" +
+		"ls -A . > " + shellQuote(captureEntries) + "\n" +
+		"printf '{\"ok\":true}\\n'\n"
 	if err := os.WriteFile(filepath.Join(binDir, "codex"), []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake CLI: %v", err)
 	}
-	t.Setenv("PATH", binDir)
+	// Prepend rather than replace: the fake wins because binDir comes first,
+	// while `ls` stays resolvable. With a replaced PATH the listing command
+	// fails, the redirection still creates an empty file, and the emptiness
+	// assertion below would pass vacuously — see TestExecute for the same
+	// constraint around `cat`.
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	e := executor.New()
 	if _, err := e.ExecuteRaw("codex", "prompt", executor.ExecOptions{}); err != nil {
@@ -55,10 +71,14 @@ func TestExecuteRawGivesCodexAnIsolatedWorkspaceWithoutWorkDir(t *testing.T) {
 		t.Fatal("fake CLI captured an empty cwd")
 	}
 
-	entries, err := os.ReadDir(cwd)
-	if err == nil && len(entries) > 0 {
-		t.Errorf("workspace %q was not empty: %d entries", cwd, len(entries))
+	entriesBytes, err := os.ReadFile(captureEntries)
+	if err != nil {
+		t.Fatalf("read captured workspace listing: %v", err)
 	}
+	if listing := strings.TrimSpace(string(entriesBytes)); listing != "" {
+		t.Errorf("workspace was not empty during the run: %q", listing)
+	}
+
 	if _, err := os.Stat(cwd); !os.IsNotExist(err) {
 		t.Errorf("workspace %q still exists after the run (stat err = %v), want it removed", cwd, err)
 	}

--- a/daemon/internal/executor/executor_killgroup_test.go
+++ b/daemon/internal/executor/executor_killgroup_test.go
@@ -1,0 +1,55 @@
+package executor_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/executor"
+)
+
+// TestKillGroupReportsProcessDoneForVanishedGroup pins the contract os/exec
+// relies on. cmd.Cancel's error reaches Wait, and os/exec only ignores it when
+// it is equivalent to os.ErrProcessDone — a raw ESRCH ("no such process") is
+// surfaced instead, so a cancelled execution whose group had already exited
+// reported "executor: run <cli>: no such process" and hid the fact that the real
+// cause was the timeout. That is precisely the diagnosis this work is meant to
+// improve, so a group that is already gone must read as done, not as a failure.
+func TestKillGroupReportsProcessDoneForVanishedGroup(t *testing.T) {
+	// Take a real PID and let it exit, so the group is guaranteed to be gone.
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	pgid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait helper: %v", err)
+	}
+
+	err := executor.KillGroupForTest(pgid, syscall.SIGTERM)
+	if !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("KillGroup on a vanished group = %v, want os.ErrProcessDone", err)
+	}
+}
+
+// TestKillGroupSignalsLiveGroup keeps the happy path honest: a real group must
+// be signalled and report no error.
+func TestKillGroupSignalsLiveGroup(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "sleep 30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	pgid := cmd.Process.Pid
+	defer func() {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	}()
+
+	if err := executor.KillGroupForTest(pgid, syscall.SIGKILL); err != nil {
+		t.Fatalf("KillGroup on a live group = %v, want nil", err)
+	}
+}

--- a/daemon/internal/executor/executor_process_group_test.go
+++ b/daemon/internal/executor/executor_process_group_test.go
@@ -192,3 +192,11 @@ func readPIDFile(t *testing.T, path string) int {
 		time.Sleep(50 * time.Millisecond)
 	}
 }
+
+// killPID best-effort kills a PID captured by a fake CLI, keeping leaked test
+// descendants out of the rest of the suite.
+func killPID(pid string) {
+	if n, err := strconv.Atoi(strings.TrimSpace(pid)); err == nil && n > 0 {
+		_ = syscall.Kill(n, syscall.SIGKILL)
+	}
+}

--- a/daemon/internal/executor/executor_process_group_test.go
+++ b/daemon/internal/executor/executor_process_group_test.go
@@ -1,0 +1,194 @@
+package executor_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/executor"
+)
+
+// TestExecuteRawTimeoutKillsGrandchildren covers the process leak seen in
+// production (theburrowhub/heimdallm#614): exec.CommandContext signals only the
+// direct child, and every supported AI CLI is a launcher — codex ships a node
+// shim that spawns a native binary, and that grandchild is what holds the
+// provider connection. When the execution timeout fired, the shim died and the
+// grandchild was reparented to init, kept running and kept spending provider
+// quota until killed by hand. The executor must put each execution in its own
+// process group and signal the whole group.
+func TestExecuteRawTimeoutKillsGrandchildren(t *testing.T) {
+	defer executor.ResetLoginPathCacheForTest()()
+
+	binDir := t.TempDir()
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	// The grandchild outlives its parent on purpose: it records its own PID and
+	// then sleeps far past both the executor timeout and this test's deadline,
+	// so "still running" can only mean the group was never signalled — never
+	// that it happened to exit on its own. It also detaches from the inherited
+	// stdout/stderr pipes, keeping this test about process lifetime alone;
+	// TestExecuteRawReturnsPromptlyWhenGrandchildHoldsPipes covers the pipes.
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  printf 'Usage: claude\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"sh -c 'echo $$ > " + shellQuote(pidFile) + "; exec sleep 600' >/dev/null 2>&1 &\n" +
+		"sleep 600\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	e := executor.New()
+	_, err := e.ExecuteRaw("claude", "prompt", executor.ExecOptions{Timeout: time.Second})
+	if err == nil {
+		t.Fatal("ExecuteRaw returned nil error, want a timeout failure")
+	}
+
+	pid := readPIDFile(t, pidFile)
+
+	// Poll: the group kill and the kernel's teardown are not instantaneous.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if !processRunning(pid) {
+			return // grandchild is gone — the group was signalled
+		}
+		if time.Now().After(deadline) {
+			// Do not leak the process into the rest of the suite.
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+			t.Fatalf("grandchild %d survived the execution timeout", pid)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// processRunning reports whether pid is a live process. A reaped-but-unwaited
+// zombie must count as dead: the test container's PID 1 is a plain shell that
+// never reaps orphans, so a killed grandchild lingers as a zombie and signal 0
+// keeps succeeding on it — which would make the group-kill assertion pass or
+// fail for the wrong reason. On Linux the state comes from /proc; elsewhere fall
+// back to signal 0, where the test's own shell reaps promptly.
+func processRunning(pid int) bool {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err == nil {
+		// Fields: pid (comm) state ... — comm may contain spaces and parens,
+		// so parse the state from after the final ')'.
+		if idx := strings.LastIndex(string(data), ")"); idx >= 0 {
+			rest := strings.Fields(string(data)[idx+1:])
+			if len(rest) > 0 {
+				return rest[0] != "Z"
+			}
+		}
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+// TestExecuteRawReturnsPromptlyWhenGrandchildHoldsPipes covers the second half
+// of the production symptom: a grandchild inherits stdout/stderr, so Wait blocks
+// until it closes them — a review that timed out at 5 minutes kept the pipeline
+// stalled for as long as the leaked process chose to run (observed: ~12 minutes
+// wall clock for a 5-minute timeout). Cancellation must be bounded.
+func TestExecuteRawReturnsPromptlyWhenGrandchildHoldsPipes(t *testing.T) {
+	defer executor.ResetLoginPathCacheForTest()()
+
+	binDir := t.TempDir()
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	// No redirection: the grandchild keeps the inherited pipes open while it
+	// sleeps far longer than any deadline in this test.
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  printf 'Usage: claude\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"sh -c 'echo $$ > " + shellQuote(pidFile) + "; exec sleep 600' &\n" +
+		"sleep 600\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	done := make(chan error, 1)
+	go func() {
+		e := executor.New()
+		_, err := e.ExecuteRaw("claude", "prompt", executor.ExecOptions{Timeout: time.Second})
+		done <- err
+	}()
+
+	// Generous ceiling: the point is bounded-vs-unbounded, not the exact grace.
+	const ceiling = 30 * time.Second
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("ExecuteRaw returned nil error, want a timeout failure")
+		}
+	case <-time.After(ceiling):
+		if pid, readErr := os.ReadFile(pidFile); readErr == nil {
+			if n, convErr := strconv.Atoi(strings.TrimSpace(string(pid))); convErr == nil {
+				_ = syscall.Kill(n, syscall.SIGKILL)
+			}
+		}
+		t.Fatalf("ExecuteRaw still blocked %s after a 1s timeout: cancellation is unbounded", ceiling)
+	}
+}
+
+// TestExecuteRawStillReturnsOutputWithProcessGroup pins the happy path: putting
+// the child in its own process group must not disturb normal stdin/stdout
+// plumbing.
+func TestExecuteRawStillReturnsOutputWithProcessGroup(t *testing.T) {
+	defer executor.ResetLoginPathCacheForTest()()
+
+	binDir := t.TempDir()
+	capturePrompt := filepath.Join(t.TempDir(), "prompt.txt")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  printf 'Usage: claude\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"cat > " + shellQuote(capturePrompt) + "\n" +
+		"printf 'agent output\\n'\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	e := executor.New()
+	out, err := e.ExecuteRaw("claude", "review this PR", executor.ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteRaw: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "agent output" {
+		t.Errorf("stdout = %q, want %q", got, "agent output")
+	}
+	promptBytes, err := os.ReadFile(capturePrompt)
+	if err != nil {
+		t.Fatalf("read captured prompt: %v", err)
+	}
+	if got := string(promptBytes); got != "review this PR" {
+		t.Errorf("prompt = %q, want %q", got, "review this PR")
+	}
+}
+
+func readPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(data))); convErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("grandchild never recorded its PID in %s", path)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/daemon/internal/executor/executor_shutdown_test.go
+++ b/daemon/internal/executor/executor_shutdown_test.go
@@ -1,0 +1,75 @@
+package executor_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/executor"
+)
+
+// TestTerminateAllKillsInFlightExecutionGroups covers the regression that
+// Setpgid introduces. Putting each execution in its own process group is what
+// lets a timeout reach the grandchild, but it also detaches the CLI from any
+// group-directed signal the daemon receives: ExecuteRaw's context comes from
+// context.Background() and is not wired to the SIGINT/SIGTERM handler, so
+// launchd terminating the job — or Ctrl-C on a foreground daemon — no longer
+// reaches in-flight agents. They would survive a restart and keep spending
+// provider quota, which is the very symptom #614 describes. The executor must
+// therefore expose a way for the shutdown path to sweep what it started.
+func TestTerminateAllKillsInFlightExecutionGroups(t *testing.T) {
+	defer executor.ResetLoginPathCacheForTest()()
+
+	binDir := t.TempDir()
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	// Detach from the inherited pipes so this test is about process lifetime,
+	// and sleep far past its deadline so "alive" can only mean "not signalled".
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  printf 'Usage: claude\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"sh -c 'echo $$ > " + shellQuote(pidFile) + "; exec sleep 600' >/dev/null 2>&1 &\n" +
+		"sleep 600\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	e := executor.New()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// A long timeout: the execution must be ended by the shutdown sweep,
+		// not by its own deadline.
+		_, _ = e.ExecuteRaw("claude", "prompt", executor.ExecOptions{Timeout: 10 * time.Minute})
+	}()
+
+	pid := readPIDFile(t, pidFile)
+
+	e.TerminateAll()
+
+	deadline := time.Now().Add(15 * time.Second)
+	for processRunning(pid) {
+		if time.Now().After(deadline) {
+			if data, readErr := os.ReadFile(pidFile); readErr == nil {
+				killPID(string(data))
+			}
+			t.Fatalf("grandchild %d survived TerminateAll", pid)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("ExecuteRaw did not return after TerminateAll")
+	}
+}
+
+// TestTerminateAllIsSafeWithNoExecutions pins that the shutdown path can call
+// the sweep unconditionally, including before anything has run.
+func TestTerminateAllIsSafeWithNoExecutions(t *testing.T) {
+	executor.New().TerminateAll()
+}

--- a/daemon/internal/executor/executor_waitdelay_test.go
+++ b/daemon/internal/executor/executor_waitdelay_test.go
@@ -1,0 +1,57 @@
+package executor_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/executor"
+)
+
+// TestExecuteRawKeepsOutputWhenDescendantHoldsPipesAfterSuccess covers the
+// regression that bounding the wait introduces. With cmd.WaitDelay set, os/exec
+// also bounds the case where the command already exited but its inherited
+// stdout/stderr are still open: Wait closes the pipes and returns
+// exec.ErrWaitDelay *even for an exit code 0*. Treating every non-nil Wait error
+// as a failure therefore throws away a complete review — and it happens exactly
+// in the scenario this work is about, a launcher CLI leaving a descendant
+// holding the pipes. A successful run must still return its output.
+func TestExecuteRawKeepsOutputWhenDescendantHoldsPipesAfterSuccess(t *testing.T) {
+	defer executor.ResetLoginPathCacheForTest()()
+
+	binDir := t.TempDir()
+	pidFile := filepath.Join(t.TempDir(), "descendant.pid")
+	// The CLI prints its result and exits 0 straight away, but leaves a
+	// descendant holding the inherited pipes open well past WaitDelay.
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--help\" ]; then\n" +
+		"  printf 'Usage: claude\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"sh -c 'echo $$ > " + shellQuote(pidFile) + "; exec sleep 600' &\n" +
+		"printf 'agent output\\n'\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	e := executor.New()
+	out, err := e.ExecuteRaw("claude", "prompt", executor.ExecOptions{Timeout: time.Minute})
+
+	// Clean up the descendant regardless of the outcome.
+	t.Cleanup(func() {
+		if data, readErr := os.ReadFile(pidFile); readErr == nil {
+			killPID(strings.TrimSpace(string(data)))
+		}
+	})
+
+	if err != nil {
+		t.Fatalf("ExecuteRaw: %v — a CLI that exited 0 must not fail because a descendant held the pipes", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "agent output" {
+		t.Errorf("stdout = %q, want %q", got, "agent output")
+	}
+}

--- a/daemon/internal/executor/export_test.go
+++ b/daemon/internal/executor/export_test.go
@@ -1,6 +1,9 @@
 package executor
 
-import "sync"
+import (
+	"sync"
+	"syscall"
+)
 
 // SetLoginShellLookPathForTest overrides the login-shell CLI probe so tests can
 // stay hermetic. The real probe sources the developer's shell profile and would
@@ -48,4 +51,10 @@ func ResetLoginPathCacheForTest() func() {
 	}
 	reset()
 	return reset
+}
+
+// KillGroupForTest exposes killGroup so the ESRCH → os.ErrProcessDone
+// translation that cmd.Cancel depends on can be tested directly.
+func KillGroupForTest(pgid int, sig syscall.Signal) error {
+	return killGroup(pgid, sig)
 }


### PR DESCRIPTION
## Contexto

Diagnóstico salido de una incidencia real: con `ai.primary = "codex"` el daemon
llevaba dos meses y medio revisando con `claude` en silencio, y al forzar codex
aparecieron tres defectos encadenados. Ninguno es de codex: los tres estaban
ahí, pero `claude` los tolera (no necesita directorio de trabajo y su shim
muere junto a su hijo).

Cierra #655. Aporta la parte del executor de #614, que sigue abierta para el
resto de sus criterios (errores de bind, contexto raíz, shutdown, salud).

## Cambios

**1. Tier 3 vuelve a repoctx** (`main.go`)

`HandleChange` era la única de las tres entradas de review que no pasaba por
`acquireRepoContext`: reenviaba el `local_dir` crudo de la config —vacío en casi
todos los repos— directo a `runReview`, así que el agente heredaba el cwd del
daemon.

| Ruta | Antes | Ahora |
|---|---|---|
| review-worker (`main.go:1047`) | repoctx | repoctx |
| tier2 `ProcessPR` (`main.go:3847`) | repoctx | repoctx |
| tier3 `HandleChange` | **config en crudo** | repoctx |

La reserva se hace después de todas las guardas y del dedup, de modo que las
rutas que se saltan la review siguen sin asignar worktree.

**2. Workspace propio para codex sin checkout** (`executor.go`)

`codex exec` exige repo git o directorio de confianza; bajo launchd el cwd del
daemon es `/` y aborta con *"Not inside a trusted directory and
--skip-git-repo-check was not specified"*. Cuando no hay `WorkDir`, la ejecución
recibe un directorio temporal vacío y propio más `--skip-git-repo-check`. Una
review no necesita checkout —el diff va en el prompt—, y sustituir `/` por un
directorio vacío **reduce** lo que el agente puede leer. El flag está en la
denylist de `extra_flags`, así que esto no era mitigable desde la config.

**3. Grupo de procesos por ejecución** (`executor.go`, parte de #614)

`exec.CommandContext` señaliza solo al hijo directo y todas las CLIs soportadas
son lanzadores. Al expirar el timeout, el shim de node de codex moría mientras
el binario nativo nieto —el que mantiene la conexión con el proveedor— quedaba
reparentado a init y seguía gastando cuota:

```
PID    PPID  ELAPSED  ARGS
50176   1    06:14    .../codex-darwin-arm64/vendor/.../codex exec --cd ... -
```

Reproducido dos veces (PIDs 35504 y 50176). Además `Wait` seguía bloqueado en
los pipes heredados, estirando un timeout de 5 minutos hasta ~12 minutos de
reloj. Ahora cada ejecución tiene su propio grupo, la cancelación manda SIGTERM
al grupo, `WaitDelay` acota la espera y un barrido con SIGKILL la cierra.

## Verificación

Tests escritos antes del código, y cada uno observado fallando por el motivo
correcto (`make test-docker`):

| Test | Fallo sin el fix |
|---|---|
| `TestTier3Adapter_HandleChange_ResolvesWorkDirThroughRepoContext` | `LocalDir = "/tmp/unreserved-checkout"` |
| `TestExecuteRawGivesCodexAnIsolatedWorkspaceWithoutWorkDir` | `args = [exec -]`, cwd heredado |
| `TestExecuteRawTimeoutKillsGrandchildren` | `grandchild NNN survived the execution timeout` |
| `TestExecuteRawReturnsPromptlyWhenGrandchildHoldsPipes` | bloqueo hasta cortar go test a los 300 s |

Regresión cubierta: codex **con** `WorkDir` mantiene `--cd <workdir>` y no
recibe flags nuevos; claude y gemini sin `WorkDir` conservan sus argumentos;
stdin/stdout siguen intactos con el grupo de procesos activo.

Dos detalles que costaron una iteración y quedan documentados en los tests:
el contenedor de tests tiene un `sh` como PID 1 que no reapea huérfanos, así que
un nieto muerto queda zombi y `kill(pid, 0)` sigue devolviendo éxito —de ahí
`processRunning()` leyendo el estado en `/proc`—; y el nieto del test debe
dormir más que el propio test, porque si expira solo el test pasa por el motivo
equivocado.

Paquete completo en verde (17 paquetes + `go vet`), y smoke test con el binario
real de codex 0.146.0 en workspace vacío con el esquema nuevo.

## Fuera de alcance

El DTO de `GET /config` no expone `execution_timeout` de los agentes
(`main.go:1793-1804`), así que la app no puede mostrarlo ni editarlo y un
operador solo lo cambia por TOML. Es relevante aquí porque codex tarda bastante
más que claude y el default de 5 minutos se queda corto en repos grandes, pero
toca el contrato de la API y la app Flutter, así que no lo he mezclado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
