### PR TITLE
feat!: expose never-approve severity threshold in the UI, default it to medium

### DIFF
--- a/daemon/internal/config/config.go
+++ b/daemon/internal/config/config.go
@@ -480,10 +480,10 @@ type AIConfig struct {
 
 	// NeverApproveMinSeverity is the minimum finding severity that triggers
 	// the NeverApproveWithIssues downgrade: "low", "medium" or "high".
-	// Empty defaults to "low" (any finding downgrades — backwards compat).
-	// With "medium", reviews whose findings are all low-severity nits still
-	// approve. Only meaningful when NeverApproveWithIssues is on.
-	// Overridable per-org and per-repo.
+	// Empty resolves to pipeline.DefaultNeverApproveMinSeverity ("medium"),
+	// so reviews whose findings are all low-severity nits still approve; set
+	// "low" explicitly to downgrade on any finding at all. Only meaningful
+	// when NeverApproveWithIssues is on. Overridable per-org and per-repo.
 	NeverApproveMinSeverity string `toml:"never_approve_min_severity"`
 
 	// ReviewResponse configures phase 2 of the PR review-state vigilance
@@ -1710,7 +1710,8 @@ func deleteLegacyAgentFieldAliases(m map[string]any, canonical string) {
 
 // validateNeverApproveMinSeverity bounds never_approve_min_severity to the
 // canonical severities at every scope. Empty means "inherit" (repo/org) or
-// "low" (global), so it is always accepted.
+// "use the default" (global — pipeline.DefaultNeverApproveMinSeverity), so it
+// is always accepted.
 func (c *Config) validateNeverApproveMinSeverity() error {
 	check := func(scope, v string) error {
 		switch v {

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -1219,6 +1219,32 @@ func MaxIssueSeverity(issues []executor.Issue) string {
 	return rankToSeverity(maxRank)
 }
 
+// DefaultNeverApproveMinSeverity is the threshold applied when the operator
+// leaves never_approve_min_severity unset at every scope.
+//
+// It is "medium", not "low": a strong review model reports low-severity nits
+// (naming, doc-comment placement, cosmetic refactors) on essentially every
+// real diff, so a "low" threshold made the never-approve downgrade fire on
+// reviews that had nothing merge-relevant to say — the PR never converged on
+// an approval no matter how many fix commits landed. With "medium", all-low
+// reviews still approve and the findings stay visible in the review body;
+// only a finding the model rated medium or higher withholds the approval.
+//
+// Operators who want the old behavior set never_approve_min_severity = "low"
+// explicitly.
+const DefaultNeverApproveMinSeverity = "medium"
+
+// resolveNeverApproveMinSeverity maps the unset threshold to its default.
+// Non-empty values pass through untouched — Config.Validate has already
+// bounded them to low|medium|high, and severityRank ranks anything it does
+// not recognise as "low".
+func resolveNeverApproveMinSeverity(minSeverity string) string {
+	if strings.TrimSpace(minSeverity) == "" {
+		return DefaultNeverApproveMinSeverity
+	}
+	return minSeverity
+}
+
 // ReviewEvent decides the GitHub review event, honoring the
 // never-approve-with-issues setting. It builds on SeverityToEvent: when the
 // base decision would be APPROVE, the setting is on, and the review found at
@@ -1227,13 +1253,13 @@ func MaxIssueSeverity(issues []executor.Issue) string {
 // still approves.
 //
 // maxIssueSeverity is MaxIssueSeverity(issues): "" means no findings.
-// minSeverity is the never_approve_min_severity setting; empty means "low"
-// (any finding downgrades — the pre-#597 behavior), matching severityRank's
-// default rank for unknown values.
+// minSeverity is the never_approve_min_severity setting; empty resolves to
+// DefaultNeverApproveMinSeverity, so a review whose findings are all
+// low-severity keeps its approval.
 func ReviewEvent(finalSeverity, maxIssueSeverity string, neverApproveWithIssues bool, minSeverity string) string {
 	event := SeverityToEvent(finalSeverity)
 	if event == "APPROVE" && neverApproveWithIssues && maxIssueSeverity != "" &&
-		severityRank(maxIssueSeverity) >= severityRank(minSeverity) {
+		severityRank(maxIssueSeverity) >= severityRank(resolveNeverApproveMinSeverity(minSeverity)) {
 		return "COMMENT"
 	}
 	return event

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -1690,13 +1690,17 @@ func TestReviewEvent(t *testing.T) {
 		{"medium", "medium", false, "", "APPROVE"},
 		{"high", "high", false, "", "REQUEST_CHANGES"},
 		{"", "", false, "", "APPROVE"},
-		// flag ON, default threshold ("" = low: any finding downgrades)
-		{"low", "low", true, "", "COMMENT"},
+		// flag ON, default threshold ("" = medium: all-low reviews keep the
+		// approval, so a nit-only pass no longer blocks convergence)
+		{"low", "low", true, "", "APPROVE"},
 		{"medium", "medium", true, "", "COMMENT"},
-		{"", "low", true, "", "COMMENT"},
+		{"", "low", true, "", "APPROVE"},
 		{"high", "high", true, "", "REQUEST_CHANGES"}, // high never downgraded
 		{"low", "", true, "", "APPROVE"},              // clean review still approves
 		{"medium", "", true, "", "APPROVE"},
+		{"medium", "high", true, "", "COMMENT"}, // above the default threshold
+		// whitespace-only threshold resolves to the default, not to "low"
+		{"low", "low", true, "   ", "APPROVE"},
 		// flag ON, explicit "low" threshold — same as default
 		{"low", "low", true, "low", "COMMENT"},
 		// flag ON, "medium" threshold: low-only findings keep the approval

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -687,8 +687,8 @@ clone_dir = "/home/heimdallm/repos/myorg-worktrees"
 auto_promote_triage = true
 auto_promote_refinement = false
 generate_pr_description = true
-never_approve_with_issues = false   # true = comment instead of approving when any finding is raised
-never_approve_min_severity = "low"  # findings below this severity don't trigger the downgrade
+never_approve_with_issues = false      # true = comment instead of approving when a finding is raised
+never_approve_min_severity = "medium"  # findings below this severity don't trigger the downgrade (default: medium)
 
 pr_reviewers = ["alice", "bob", "carol"]
 pr_labels    = ["auto-generated", "ai-platform"]
@@ -1349,11 +1349,11 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # never_approve_with_issues = false
 
 # Minimum finding severity that triggers the never_approve_with_issues
-# downgrade: "low", "medium" or "high". Unset/empty = "low" (any finding
-# downgrades). With "medium", reviews whose findings are all low-severity
-# nits still approve. Overridable per org ([ai.orgs.*]) and per repo
-# ([ai.repos.*]).
-# never_approve_min_severity = "low"
+# downgrade: "low", "medium" or "high". Unset/empty = "medium", so reviews
+# whose findings are all low-severity nits still approve and the findings
+# stay visible in the review body. Set "low" to downgrade on any finding at
+# all. Overridable per org ([ai.orgs.*]) and per repo ([ai.repos.*]).
+# never_approve_min_severity = "medium"
 
 # When local_dir is unset, Heimdallm prepares a managed shallow clone for agent
 # context under clone_dir. If clone_dir is also unset, the default is
@@ -1421,7 +1421,7 @@ review_mode = "single"   # "single" | "multi" — env: HEIMDALLM_REVIEW_MODE
 # auto_promote_refinement = false
 # generate_pr_description = true
 # never_approve_with_issues = false
-# never_approve_min_severity = "low"
+# never_approve_min_severity = "medium"
 # pr_reviewers = ["alice", "bob"]
 # pr_labels    = ["auto-generated", "myorg-team"]
 # pr_assignee  = "myusername"

--- a/flutter_app/lib/core/models/config_model.dart
+++ b/flutter_app/lib/core/models/config_model.dart
@@ -1,3 +1,12 @@
+/// Severities `never_approve_min_severity` accepts, in ascending order.
+/// Mirrors the daemon's validator (config.validateNeverApproveMinSeverity).
+const neverApproveMinSeverityOptions = ['low', 'medium', 'high'];
+
+/// Threshold the daemon applies when `never_approve_min_severity` is unset at
+/// every scope. Mirrors pipeline.DefaultNeverApproveMinSeverity — keep both in
+/// sync, otherwise the dropdown shows a value the daemon is not using.
+const defaultNeverApproveMinSeverity = 'medium';
+
 /// Per-agent CLI execution settings.
 /// Stored under `ai.agents.<name>` in config.toml.
 class CLIAgentConfig {
@@ -150,6 +159,7 @@ class RepoConfig {
   final List<String>? prLabels;
   final bool? prDraft;
   final bool? neverApproveWithIssues;
+  final String? neverApproveMinSeverity;
 
   const RepoConfig({
     this.prEnabled,
@@ -180,6 +190,7 @@ class RepoConfig {
     this.prLabels,
     this.prDraft,
     this.neverApproveWithIssues,
+    this.neverApproveMinSeverity,
     this.firstSeenAt,
   });
 
@@ -229,7 +240,8 @@ class RepoConfig {
       prAssignee != null ||
       prLabels != null ||
       prDraft != null ||
-      neverApproveWithIssues != null;
+      neverApproveWithIssues != null ||
+      neverApproveMinSeverity != null;
 
   /// LED status for each feature: 'off', 'global', 'repo'
   String prLedStatus(bool globalMonitored) {
@@ -289,6 +301,7 @@ class RepoConfig {
     Object? prLabels = _sentinel,
     Object? prDraft = _sentinel,
     Object? neverApproveWithIssues = _sentinel,
+    Object? neverApproveMinSeverity = _sentinel,
     Object? firstSeenAt = _sentinel,
   }) {
     return RepoConfig(
@@ -362,6 +375,9 @@ class RepoConfig {
       neverApproveWithIssues: neverApproveWithIssues == _sentinel
           ? this.neverApproveWithIssues
           : neverApproveWithIssues as bool?,
+      neverApproveMinSeverity: neverApproveMinSeverity == _sentinel
+          ? this.neverApproveMinSeverity
+          : neverApproveMinSeverity as String?,
       firstSeenAt: firstSeenAt == _sentinel
           ? this.firstSeenAt
           : firstSeenAt as DateTime?,
@@ -398,6 +414,7 @@ class OrgConfig {
   final List<String>? prLabels;
   final bool? prDraft;
   final bool? neverApproveWithIssues;
+  final String? neverApproveMinSeverity;
 
   const OrgConfig({
     this.aiPrimary,
@@ -427,6 +444,7 @@ class OrgConfig {
     this.prLabels,
     this.prDraft,
     this.neverApproveWithIssues,
+    this.neverApproveMinSeverity,
   });
 
   bool get hasOverride =>
@@ -441,6 +459,7 @@ class OrgConfig {
       autoPromoteRefinement != null ||
       generatePRDescription != null ||
       neverApproveWithIssues != null ||
+      neverApproveMinSeverity != null ||
       issuePromptId != null ||
       developPromptId != null ||
       itEnabled != null ||
@@ -486,6 +505,7 @@ class OrgConfig {
     Object? prLabels = _sentinel,
     Object? prDraft = _sentinel,
     Object? neverApproveWithIssues = _sentinel,
+    Object? neverApproveMinSeverity = _sentinel,
   }) => OrgConfig(
     aiPrimary: aiPrimary == _sentinel ? this.aiPrimary : aiPrimary as String?,
     aiFallback: aiFallback == _sentinel
@@ -552,6 +572,9 @@ class OrgConfig {
     neverApproveWithIssues: neverApproveWithIssues == _sentinel
         ? this.neverApproveWithIssues
         : neverApproveWithIssues as bool?,
+    neverApproveMinSeverity: neverApproveMinSeverity == _sentinel
+        ? this.neverApproveMinSeverity
+        : neverApproveMinSeverity as String?,
   );
 
   factory OrgConfig.fromJson(Map<String, dynamic> json) {
@@ -612,6 +635,7 @@ class OrgConfig {
       prLabels: _nullableStringListAllowEmpty(json['pr_labels']),
       prDraft: json['pr_draft'] as bool?,
       neverApproveWithIssues: json['never_approve_with_issues'] as bool?,
+      neverApproveMinSeverity: _nonEmpty(json['never_approve_min_severity']),
     );
   }
 }
@@ -947,6 +971,12 @@ class AppConfig {
   final bool globalGeneratePRDescription;
   final bool globalNeverApproveWithIssues;
 
+  /// Minimum finding severity that triggers the never-approve downgrade:
+  /// 'low', 'medium' or 'high'. The daemon resolves an empty value to
+  /// [defaultNeverApproveMinSeverity], so the UI seeds the dropdown with that
+  /// same default rather than showing a blank selection.
+  final String globalNeverApproveMinSeverity;
+
   final AutonomousConfig autonomous;
   final CircuitBreakerConfig circuitBreaker;
   final PollingConfig polling;
@@ -990,6 +1020,7 @@ class AppConfig {
     this.autonomous = const AutonomousConfig(),
     this.circuitBreaker = const CircuitBreakerConfig(),
     this.globalNeverApproveWithIssues = false,
+    this.globalNeverApproveMinSeverity = defaultNeverApproveMinSeverity,
     this.polling = const PollingConfig(),
     this.localDirBase = const [],
     this.localDirsDetected = const {},
@@ -1068,6 +1099,7 @@ class AppConfig {
     AutonomousConfig? autonomous,
     CircuitBreakerConfig? circuitBreaker,
     bool? globalNeverApproveWithIssues,
+    String? globalNeverApproveMinSeverity,
     PollingConfig? polling,
     List<String>? localDirBase,
     Map<String, String>? localDirsDetected,
@@ -1105,6 +1137,8 @@ class AppConfig {
       circuitBreaker: circuitBreaker ?? this.circuitBreaker,
       globalNeverApproveWithIssues:
           globalNeverApproveWithIssues ?? this.globalNeverApproveWithIssues,
+      globalNeverApproveMinSeverity:
+          globalNeverApproveMinSeverity ?? this.globalNeverApproveMinSeverity,
       polling: polling ?? this.polling,
       localDirBase: localDirBase ?? this.localDirBase,
       localDirsDetected: localDirsDetected ?? this.localDirsDetected,
@@ -1127,6 +1161,7 @@ class AppConfig {
     'auto_promote_refinement': globalAutoPromoteRefinement,
     'generate_pr_description': globalGeneratePRDescription,
     'never_approve_with_issues': globalNeverApproveWithIssues,
+    'never_approve_min_severity': globalNeverApproveMinSeverity,
   };
 
   factory AppConfig.fromJson(Map<String, dynamic> json) {
@@ -1218,6 +1253,7 @@ class AppConfig {
           prLabels: _nullableStringListAllowEmpty(ov['pr_labels']),
           prDraft: ov['pr_draft'] as bool?,
           neverApproveWithIssues: ov['never_approve_with_issues'] as bool?,
+          neverApproveMinSeverity: _nonEmpty(ov['never_approve_min_severity']),
           firstSeenAt: firstSeen,
         );
       }
@@ -1302,6 +1338,11 @@ class AppConfig {
           : const CircuitBreakerConfig(),
       globalNeverApproveWithIssues:
           (json['never_approve_with_issues'] as bool?) ?? false,
+      // The daemon serves "" when unset; surface the default it will actually
+      // apply so the dropdown never renders an out-of-range empty value.
+      globalNeverApproveMinSeverity:
+          _nonEmpty(json['never_approve_min_severity']) ??
+          defaultNeverApproveMinSeverity,
       polling: json['polling'] != null
           ? PollingConfig.fromJson(json['polling'] as Map<String, dynamic>)
           : const PollingConfig(),

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -365,6 +365,11 @@ Map<String, dynamic> _computeGlobalDiff(AppConfig old, AppConfig updated) {
       updated.globalNeverApproveWithIssues) {
     aiDiff['never_approve_with_issues'] = updated.globalNeverApproveWithIssues;
   }
+  if (old.globalNeverApproveMinSeverity !=
+      updated.globalNeverApproveMinSeverity) {
+    aiDiff['never_approve_min_severity'] =
+        updated.globalNeverApproveMinSeverity;
+  }
 
   // Agent configs — diff each CLI agent's settings individually.
   final agentsDiff = <String, dynamic>{};

--- a/flutter_app/lib/features/config/config_screen.dart
+++ b/flutter_app/lib/features/config/config_screen.dart
@@ -692,6 +692,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
   String _globalPRAssignee = '';
   bool _globalPRDraft = false;
   bool _globalNeverApproveWithIssues = false;
+  String _globalNeverApproveMinSeverity = defaultNeverApproveMinSeverity;
   String _globalTriageOwner = '';
   String _globalCloneDir = '';
   bool _globalAutoPromoteTriage = false;
@@ -763,10 +764,35 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
       const SizedBox(height: 12),
       _globalSwitchTile(
         'Never approve PRs with issues',
-        "If the review finds any issue, it's posted as a comment on the PR "
-            'instead of an approval (high severity still requests changes)',
+        'If the review raises a finding at or above the threshold below, '
+            "it's posted as a comment on the PR instead of an approval "
+            '(high severity still requests changes)',
         _globalNeverApproveWithIssues,
         (v) => _globalNeverApproveWithIssues = v,
+      ),
+      const SizedBox(height: 12),
+      DropdownButtonFormField<String>(
+        initialValue: _globalNeverApproveMinSeverity,
+        decoration: const InputDecoration(
+          labelText: 'Never approve — minimum severity',
+          helperText:
+              'Findings below this severity keep the approval; they are still '
+              'listed in the review body. Default: medium (all-low reviews '
+              'approve).',
+          border: OutlineInputBorder(),
+          isDense: true,
+        ),
+        items: neverApproveMinSeverityOptions
+            .map((v) => DropdownMenuItem(value: v, child: Text(v)))
+            .toList(),
+        // Disabled while the toggle is off: the threshold has no effect then,
+        // and a live-looking control that changes nothing reads as a bug.
+        onChanged: _globalNeverApproveWithIssues
+            ? (v) => setState(
+                () => _globalNeverApproveMinSeverity =
+                    v ?? defaultNeverApproveMinSeverity,
+              )
+            : null,
       ),
     ]);
   }
@@ -779,6 +805,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     _globalPRAssignee = config.globalPRAssignee;
     _globalPRDraft = config.globalPRDraft;
     _globalNeverApproveWithIssues = config.globalNeverApproveWithIssues;
+    _globalNeverApproveMinSeverity = config.globalNeverApproveMinSeverity;
     _globalTriageOwner = config.globalTriageOwner;
     _globalCloneDir = config.globalCloneDir;
     _cloneDirController.text = config.globalCloneDir;
@@ -1405,6 +1432,7 @@ class _ConfigScreenState extends ConsumerState<ConfigScreen> {
     globalPRAssignee: _globalPRAssignee,
     globalPRDraft: _globalPRDraft,
     globalNeverApproveWithIssues: _globalNeverApproveWithIssues,
+    globalNeverApproveMinSeverity: _globalNeverApproveMinSeverity,
     globalTriageOwner: _globalTriageOwner,
     globalCloneDir: _globalCloneDir,
     globalAutoPromoteTriage: _globalAutoPromoteTriage,

--- a/flutter_app/lib/features/organizations/org_detail_screen.dart
+++ b/flutter_app/lib/features/organizations/org_detail_screen.dart
@@ -146,6 +146,10 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
         updated.neverApproveWithIssues != null) {
       diff['never_approve_with_issues'] = updated.neverApproveWithIssues!;
     }
+    if (old.neverApproveMinSeverity != updated.neverApproveMinSeverity) {
+      diff['never_approve_min_severity'] =
+          updated.neverApproveMinSeverity ?? '';
+    }
     if (!_listsEqual(old.prReviewers, updated.prReviewers)) {
       diff['pr_reviewers'] = updated.prReviewers ?? <String>[];
     }
@@ -314,6 +318,16 @@ class _OrgDetailScreenState extends ConsumerState<OrgDetailScreen> {
                       ),
                     ),
                     onReset: () => _resetField('never_approve_with_issues'),
+                  ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Never approve — minimum severity',
+                    globalValue: appConfig.globalNeverApproveMinSeverity,
+                    overrideValue: _config.neverApproveMinSeverity,
+                    options: neverApproveMinSeverityOptions,
+                    onChanged: (v) =>
+                        _update(_config.copyWith(neverApproveMinSeverity: v)),
+                    onReset: () => _resetField('never_approve_min_severity'),
                   ),
                 ], accent: FeaturePalette.prReview),
                 _sectionCard('Issue Tracking', [

--- a/flutter_app/lib/features/repositories/repo_detail_screen.dart
+++ b/flutter_app/lib/features/repositories/repo_detail_screen.dart
@@ -318,6 +318,21 @@ class _RepoDetailScreenState extends ConsumerState<RepoDetailScreen> {
                     ),
                     onReset: () => _resetField('never_approve_with_issues'),
                   ),
+                  const SizedBox(height: 10),
+                  OverrideDropdown(
+                    label: 'Never approve — minimum severity',
+                    globalValue:
+                        orgConfig?.neverApproveMinSeverity ??
+                        appConfig.globalNeverApproveMinSeverity,
+                    inheritedLabel: source(
+                      orgConfig?.neverApproveMinSeverity != null,
+                    ),
+                    overrideValue: _config.neverApproveMinSeverity,
+                    options: neverApproveMinSeverityOptions,
+                    onChanged: (v) =>
+                        _update(_config.copyWith(neverApproveMinSeverity: v)),
+                    onReset: () => _resetField('never_approve_min_severity'),
+                  ),
                 ], accent: FeaturePalette.prReview),
 
                 // ── Section 3: Issue Tracking ──────────────────────────

--- a/flutter_app/lib/features/repositories/repo_diff.dart
+++ b/flutter_app/lib/features/repositories/repo_diff.dart
@@ -32,6 +32,9 @@ Map<String, dynamic> computeRepoDiff(RepoConfig old, RepoConfig updated) {
       updated.neverApproveWithIssues != null) {
     diff['never_approve_with_issues'] = updated.neverApproveWithIssues!;
   }
+  if (old.neverApproveMinSeverity != updated.neverApproveMinSeverity) {
+    diff['never_approve_min_severity'] = updated.neverApproveMinSeverity ?? '';
+  }
   if (old.developPromptId != updated.developPromptId) {
     diff['implement_prompt'] = updated.developPromptId ?? '';
   }

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -60,6 +60,97 @@ void main() {
     // Primary agent ('claude') moved to Agents tab — no longer in ConfigScreen
   });
 
+  testWidgets('AI defaults expose the never-approve severity threshold', (
+    tester,
+  ) async {
+    const config = AppConfig(
+      pollInterval: '5m',
+      aiPrimary: 'claude',
+      globalNeverApproveWithIssues: true,
+      globalNeverApproveMinSeverity: 'high',
+      repoConfigs: {'org/repo': RepoConfig(prEnabled: true)},
+    );
+
+    final mockApi = MockApiClient();
+    when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
+    when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
+    when(() => mockApi.checkHealth()).thenAnswer((_) async => false);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiClientProvider.overrideWithValue(mockApi),
+          configNotifierProvider.overrideWith(ConfigNotifier.new),
+          platformServicesProvider.overrideWithValue(FakePlatformServices()),
+        ],
+        child: MaterialApp.router(
+          routerConfig: GoRouter(
+            routes: [
+              GoRoute(path: '/', builder: (_, _) => const ConfigScreen()),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Never approve — minimum severity'), findsOneWidget);
+    // Shows the configured threshold, and is enabled because the toggle is on.
+    final dropdown = tester.widget<DropdownButtonFormField<String>>(
+      find.byWidgetPredicate(
+        (w) => w is DropdownButtonFormField<String> && w.initialValue == 'high',
+      ),
+    );
+    expect(dropdown.onChanged, isNotNull);
+  });
+
+  testWidgets('severity threshold is disabled when never-approve is off', (
+    tester,
+  ) async {
+    // The threshold has no effect with the toggle off; a live-looking control
+    // that changes nothing would read as a bug.
+    const config = AppConfig(
+      pollInterval: '5m',
+      aiPrimary: 'claude',
+      globalNeverApproveWithIssues: false,
+      globalNeverApproveMinSeverity: 'medium',
+      repoConfigs: {'org/repo': RepoConfig(prEnabled: true)},
+    );
+
+    final mockApi = MockApiClient();
+    when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
+    when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
+    when(() => mockApi.checkHealth()).thenAnswer((_) async => false);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiClientProvider.overrideWithValue(mockApi),
+          configNotifierProvider.overrideWith(ConfigNotifier.new),
+          platformServicesProvider.overrideWithValue(FakePlatformServices()),
+        ],
+        child: MaterialApp.router(
+          routerConfig: GoRouter(
+            routes: [
+              GoRoute(path: '/', builder: (_, _) => const ConfigScreen()),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final dropdown = tester.widget<DropdownButtonFormField<String>>(
+      find.byWidgetPredicate(
+        (w) =>
+            w is DropdownButtonFormField<String> &&
+            w.initialValue == 'medium' &&
+            w.decoration.labelText == 'Never approve — minimum severity',
+      ),
+    );
+    expect(dropdown.onChanged, isNull);
+  });
+
   testWidgets('Save is gated on a valid poll interval', (tester) async {
     const config = AppConfig(
       pollInterval: '5m',
@@ -885,6 +976,69 @@ void main() {
     final updated = oldCfg.copyWith(neverApproveWithIssues: true);
     final diff = computeRepoDiff(oldCfg, updated);
     expect(diff['never_approve_with_issues'], isTrue);
+  });
+
+  test('never_approve_min_severity round-trips (global + org + repo)', () {
+    final json = {
+      'never_approve_min_severity': 'high',
+      'repositories': <String>[],
+      'repo_overrides': {
+        'org/repo1': {'never_approve_min_severity': 'low'},
+      },
+      'org_overrides': {
+        'org': {'never_approve_min_severity': 'medium'},
+      },
+    };
+    final cfg = AppConfig.fromJson(json);
+    expect(cfg.globalNeverApproveMinSeverity, 'high');
+    expect(cfg.repoConfigs['org/repo1']!.neverApproveMinSeverity, 'low');
+    expect(cfg.orgConfigs['org']!.neverApproveMinSeverity, 'medium');
+    expect(cfg.toJson()['never_approve_min_severity'], 'high');
+  });
+
+  test('unset never_approve_min_severity surfaces the daemon default', () {
+    // The daemon serves "" when the operator never set the key; the dropdown
+    // must show the threshold actually in effect, not a blank option.
+    final cfg = AppConfig.fromJson({'repositories': <String>[]});
+    expect(cfg.globalNeverApproveMinSeverity, defaultNeverApproveMinSeverity);
+    expect(defaultNeverApproveMinSeverity, 'medium');
+
+    final empty = AppConfig.fromJson({
+      'never_approve_min_severity': '',
+      'repositories': <String>[],
+    });
+    expect(empty.globalNeverApproveMinSeverity, 'medium');
+  });
+
+  test('empty scoped never_approve_min_severity stays null (inherit)', () {
+    final cfg = AppConfig.fromJson({
+      'repositories': <String>[],
+      'repo_overrides': {
+        'org/repo1': {'never_approve_min_severity': ''},
+      },
+      'org_overrides': {
+        'org': {'never_approve_min_severity': ''},
+      },
+    });
+    expect(cfg.repoConfigs['org/repo1']!.neverApproveMinSeverity, isNull);
+    expect(cfg.orgConfigs['org']!.neverApproveMinSeverity, isNull);
+  });
+
+  test('never_approve_min_severity marks scoped overrides as present', () {
+    const org = OrgConfig(neverApproveMinSeverity: 'high');
+    expect(org.hasOverride, isTrue);
+    const repo = RepoConfig(neverApproveMinSeverity: 'high');
+    expect(repo.hasAiOverride, isTrue);
+  });
+
+  test('repo diff carries never_approve_min_severity, clearing with ""', () {
+    const oldCfg = RepoConfig();
+    final set = oldCfg.copyWith(neverApproveMinSeverity: 'high');
+    expect(computeRepoDiff(oldCfg, set)['never_approve_min_severity'], 'high');
+
+    // String overrides emit '' to clear (same contract as review_mode).
+    final cleared = set.copyWith(neverApproveMinSeverity: null);
+    expect(computeRepoDiff(set, cleared)['never_approve_min_severity'], '');
   });
 
   test('repo diff includes Pipeline overrides when set', () {

--- a/flutter_app/test/features/organizations/org_detail_screen_test.dart
+++ b/flutter_app/test/features/organizations/org_detail_screen_test.dart
@@ -37,6 +37,7 @@ void main() {
             'auto_promote_refinement': true,
             'generate_pr_description': true,
             'never_approve_with_issues': true,
+            'never_approve_min_severity': 'high',
             'issue_tracking': {
               'organizations': ['acme'],
               'assignees': ['alice'],
@@ -66,6 +67,10 @@ void main() {
     expect(find.text('Refinement labels'), findsOneWidget);
     expect(find.text('Generate PR description'), findsOneWidget);
     expect(find.text('Never approve PRs with issues'), findsOneWidget);
+    // The severity threshold sits next to the toggle it qualifies, and renders
+    // the org's stored override rather than the global default.
+    expect(find.text('Never approve — minimum severity'), findsOneWidget);
+    expect(find.text('high'), findsWidgets);
     // "Organizations" now names both the new review-policy section header and
     // the Issue Tracking org filter; target the filter by its unique helper.
     expect(find.text('GitHub org names to filter issues'), findsOneWidget);


### PR DESCRIPTION
## Problem

`never_approve_min_severity` landed in #602 (v0.7.8) but never got a UI control. The `never_approve_with_issues` toggle is exposed in three places — AI defaults, org detail, repo detail — and the threshold that qualifies it is exposed in none of them, so the only way to move it was hand-editing `config.toml`. Anyone looking for the setting in the app concluded it didn't exist.

Worse, the unset default was the strictest possible value. `severityRank("")` falls through to `default: return 1` — the rank of `low` — so **any** finding withheld the approval, including a `🟡 LOW` nit.

That combination is what makes review loops fail to converge with the current generation of models. Real example on a feature PR: a re-review pass reported *"the six previous findings are all fixed, CI green"* and still did not approve, because two `low` findings remained — where a godoc comment sat relative to its function, and a latent trap that needs an unrelated future change to become reachable. A strong model finds something like that on essentially every diff, and each fix commit creates fresh lines for the next pass to find more in. The approval was unreachable.

## Changes

**UI (the actual gap).** The threshold now sits next to the toggle it qualifies, at all three scopes:

- **AI defaults** — `Never approve — minimum severity` dropdown (`low` / `medium` / `high`). Disabled while the toggle is off, since the threshold has no effect then and a live-looking control that changes nothing reads as a bug.
- **Org detail / Repo detail** — `OverrideDropdown` with the same inherit / override / reset semantics as `Review mode`, including the repo→org→global inheritance label.

`AppConfig`, `OrgConfig` and `RepoConfig` gained the field with the existing sentinel-`copyWith` contract; the diff builders emit `''` to clear a string override (same asymmetry as `review_mode`, documented in `repo_diff.dart`).

**Default.** Unset now resolves to `medium` via `pipeline.DefaultNeverApproveMinSeverity` instead of falling through `severityRank` to `low`. All-low reviews keep their approval; the findings are still listed in the review body, they just no longer withhold it.

Resolution happens at the use site rather than by materialising a value into the operator's `config.toml`, so `""` keeps meaning "inherit" at org/repo scope and nothing rewrites a user's file.

No daemon API changes: `GET /config` already served the key at all three scopes (`main.go:1850`, `addCommonAIOverrideFields`), `PATCH /config` already accepted it, and the validator already bounded it to `low|medium|high`.

## Behaviour

| Findings | Before (unset) | After (unset) |
|---|---|---|
| none | APPROVE | APPROVE |
| max `low` | **COMMENT** | **APPROVE** |
| max `medium` | COMMENT | COMMENT |
| final `high` | REQUEST_CHANGES | REQUEST_CHANGES |

⚠️ **Breaking**, hence `feat!`: repos with `never_approve_with_issues` on and no explicit threshold change behaviour. `never_approve_min_severity = "low"` restores the old strictness. Retitle to `feat:` if you'd rather this went out as a patch.

## Testing

- `go test ./... -timeout 60s` — 17 packages, all pass. `go vet ./...` clean.
- `TestReviewEvent` updated for the new default, plus new cases: `medium`/`high` findings above the default threshold, and a whitespace-only threshold resolving to the default rather than to `low`.
- `flutter analyze` — no issues. `flutter test` — 234 pass.
- 5 new model tests: round-trip at all three scopes, unset-serves-the-default, empty-scoped-stays-null (inherit), `hasOverride`/`hasAiOverride` detection, diff-clears-with-`''`.
- 2 new widget tests on `ConfigScreen`: the dropdown renders the configured threshold and is enabled with the toggle on; it is disabled with the toggle off.
- `org_detail_screen_test.dart` extended to assert the override renders the org's stored value instead of the global.
- `make build-daemon` produces a working binary.

Not verified by running a second daemon against live config on purpose — spawning one would have it poll GitHub with the operator's token and write to the production SQLite. The decision function is covered directly by `TestReviewEvent` and the payload path by the existing `main_test.go` override-map tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)