### PR TITLE
tui: Report the daemon's version in the Server tab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build-app:
 	cd flutter_app && flutter build $(FLUTTER_DEVICE) --release
 
 build-cli:
-	$(MAKE) -C cli build
+	$(MAKE) -C cli build VERSION=$(GIT_VERSION)
 
 # Flutter Web bundle, consumed by docker/Dockerfile.web (served via Nginx).
 # --base-href=/ matches the Nginx server block that expects assets at the root.

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,9 +1,14 @@
 BINARY = bin/heimdallm-cli
 CMD    = ./cmd/heimdallm-cli
 
-# Stamped into main.version. Overridden by the root Makefile with GIT_VERSION,
-# matching how daemon/Makefile is driven, so both binaries report the same
-# format (e.g. "0.8.0"). Left as "dev" for a bare `make -C cli build`.
+# Stamped into main.version. Left as "dev" for a bare `make -C cli build`.
+#
+# Invariant: the root Makefile passes GIT_VERSION here and to daemon/Makefile
+# from the same variable (build-cli and build-daemon), so the CLI and the daemon
+# always report the same format (e.g. "0.8.0"). If that variable is renamed or
+# its format changes, both call sites must move together — a CLI stamped from a
+# different source than the daemon makes the Server tab's Daemon/CLI comparison
+# meaningless, which is the whole point of showing them side by side.
 VERSION ?= dev
 
 .PHONY: build test test-race lint clean dev

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,11 +1,16 @@
 BINARY = bin/heimdallm-cli
 CMD    = ./cmd/heimdallm-cli
 
+# Stamped into main.version. Overridden by the root Makefile with GIT_VERSION,
+# matching how daemon/Makefile is driven, so both binaries report the same
+# format (e.g. "0.8.0"). Left as "dev" for a bare `make -C cli build`.
+VERSION ?= dev
+
 .PHONY: build test test-race lint clean dev
 
 build:
 	@mkdir -p $(dir $(BINARY))
-	go build -o $(BINARY) $(CMD)
+	go build -ldflags "-X main.version=$(VERSION)" -o $(BINARY) $(CMD)
 
 test:
 	go test -timeout 60s ./...

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,14 +1,9 @@
 BINARY = bin/heimdallm-cli
 CMD    = ./cmd/heimdallm-cli
 
-# Stamped into main.version. Left as "dev" for a bare `make -C cli build`.
-#
-# Invariant: the root Makefile passes GIT_VERSION here and to daemon/Makefile
-# from the same variable (build-cli and build-daemon), so the CLI and the daemon
-# always report the same format (e.g. "0.8.0"). If that variable is renamed or
-# its format changes, both call sites must move together — a CLI stamped from a
-# different source than the daemon makes the Server tab's Daemon/CLI comparison
-# meaningless, which is the whole point of showing them side by side.
+# Stamped into main.version; "dev" for a bare `make -C cli build`. The root
+# Makefile must keep passing the same GIT_VERSION to build-cli and build-daemon,
+# or the Server tab's Daemon/CLI rows stop being comparable.
 VERSION ?= dev
 
 .PHONY: build test test-race lint clean dev

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -4,7 +4,15 @@ CMD    = ./cmd/heimdallm-cli
 # Stamped into main.version; "dev" for a bare `make -C cli build`. The root
 # Makefile must keep passing the same GIT_VERSION to build-cli and build-daemon,
 # or the Server tab's Daemon/CLI rows stop being comparable.
+#
+# ?= is not enough on its own: a command-line VERSION= counts as defined even
+# when empty, so it would stamp an empty version — and cobra then drops the
+# --version flag entirely, rather than reporting "dev". `override` is required
+# because a plain assignment here would lose to the command line.
 VERSION ?= dev
+ifeq ($(strip $(VERSION)),)
+override VERSION := dev
+endif
 
 .PHONY: build test test-race lint clean dev
 

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -88,19 +88,21 @@ const (
 	versionDisplayMax = 48
 )
 
-// displayField reduces a daemon-supplied string to something safe to print: both
-// Status and Version reach a TUI row and a terminal line verbatim, where a
-// control byte would corrupt the layout and an unbounded string would overrun
-// it. The cap counts runes, not bytes, so multibyte input is not truncated far
-// short of it.
+// DisplayText reduces a daemon-supplied string to something safe to print. Every
+// such string reaching a TUI row or a terminal line goes through here: a control
+// byte would corrupt the layout and an unbounded string would overrun it. The cap
+// counts runes, not bytes, so multibyte input is not truncated far short of it.
+//
+// unicode.IsPrint already excludes tab, newline and carriage return, so they need
+// no separate test.
 //
 // Note what this does NOT do: dropping ESC is what defuses an ANSI sequence, so
 // the inert remainder ("[31m") is deliberately kept rather than parsed out.
-func displayField(s string, maxRunes int) string {
+func DisplayText(s string, maxRunes int) string {
 	var b strings.Builder
 	kept := 0
 	for _, r := range s {
-		if r == '\t' || r == '\n' || r == '\r' || !unicode.IsPrint(r) {
+		if !unicode.IsPrint(r) {
 			continue
 		}
 		if kept >= maxRunes {
@@ -118,7 +120,7 @@ func (h *Health) DisplayStatus() string {
 	if h == nil {
 		return ""
 	}
-	return displayField(h.Status, statusDisplayMax)
+	return DisplayText(h.Status, statusDisplayMax)
 }
 
 // DisplayVersion is the same treatment for Version, which travels the same path
@@ -127,7 +129,7 @@ func (h *Health) DisplayVersion() string {
 	if h == nil {
 		return ""
 	}
-	return displayField(h.Version, versionDisplayMax)
+	return DisplayText(h.Version, versionDisplayMax)
 }
 
 // GetHealth returns the daemon's health payload, including the version it was

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -70,6 +70,29 @@ func (c *Client) Health() error {
 	return err
 }
 
+// Health is the subset of /health the dashboard renders. Version is empty for
+// daemons built before version stamping (they omit the field), so callers must
+// treat "" as unknown rather than an error.
+type Health struct {
+	Status    string    `json:"status"`
+	Version   string    `json:"version"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// GetHealth returns the daemon's health payload, including the version it was
+// built from — the authoritative server version, distinct from this CLI's.
+func (c *Client) GetHealth() (*Health, error) {
+	data, err := c.do("GET", "/health")
+	if err != nil {
+		return nil, err
+	}
+	var h Health
+	if err := json.Unmarshal(data, &h); err != nil {
+		return nil, fmt.Errorf("decoding health: %w", err)
+	}
+	return &h, nil
+}
+
 // PR types matching daemon API responses.
 
 type Review struct {

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -64,9 +64,10 @@ func (c *Client) do(method, path string) ([]byte, error) {
 	return data, nil
 }
 
-// Health checks daemon connectivity.
+// Health checks daemon connectivity. Shares GetHealth's transport, so a
+// degraded-but-reachable daemon is not reported as a connectivity failure.
 func (c *Client) Health() error {
-	_, err := c.do("GET", "/health")
+	_, err := c.GetHealth()
 	return err
 }
 
@@ -81,10 +82,29 @@ type Health struct {
 
 // GetHealth returns the daemon's health payload, including the version it was
 // built from — the authoritative server version, distinct from this CLI's.
+//
+// Deliberately does not go through do(), which errors on any status >= 400: the
+// daemon answers 503 with status "degraded" whenever a nats/sqlite/last_poll
+// check fails, and that response still carries the version — precisely the state
+// in which knowing the running build matters most. 200 and 503 both decode; the
+// caller reads Status to tell them apart. Everything else (401, a proxy's HTML
+// 502, an undecodable body) stays an error.
 func (c *Client) GetHealth() (*Health, error) {
-	data, err := c.do("GET", "/health")
+	req, err := c.newRequest("GET", "/health", nil)
 	if err != nil {
 		return nil, err
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusServiceUnavailable {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
 	}
 	var h Health
 	if err := json.Unmarshal(data, &h); err != nil {

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -81,29 +81,53 @@ type Health struct {
 	StartedAt time.Time `json:"started_at"`
 }
 
-// statusDisplayMax bounds the rendered status so one field cannot overrun a TUI
-// row. Comfortably above the daemon's "ok"/"degraded".
-const statusDisplayMax = 32
+// Caps for the rendered fields, in runes. Both sit comfortably above what the
+// daemon emits — "ok"/"degraded", and versions like "0.8.0-3-g86f49fa-dirty".
+const (
+	statusDisplayMax  = 32
+	versionDisplayMax = 48
+)
 
-// DisplayStatus returns Status reduced to something safe to print: the daemon's
-// value reaches a TUI row and a terminal line verbatim, where a control byte
-// would corrupt the layout and an unbounded string would overrun it. Today the
+// displayField reduces a daemon-supplied string to something safe to print: both
+// Status and Version reach a TUI row and a terminal line verbatim, where a
+// control byte would corrupt the layout and an unbounded string would overrun
+// it. The cap counts runes, not bytes, so multibyte input is not truncated far
+// short of it.
+//
+// Note what this does NOT do: dropping ESC is what defuses an ANSI sequence, so
+// the inert remainder ("[31m") is deliberately kept rather than parsed out.
+func displayField(s string, maxRunes int) string {
+	var b strings.Builder
+	kept := 0
+	for _, r := range s {
+		if r == '\t' || r == '\n' || r == '\r' || !unicode.IsPrint(r) {
+			continue
+		}
+		if kept >= maxRunes {
+			break
+		}
+		b.WriteRune(r)
+		kept++
+	}
+	return b.String()
+}
+
+// DisplayStatus returns Status bounded and stripped of control bytes. Today the
 // daemon only emits "ok" and "degraded", so this is about not depending on that.
 func (h *Health) DisplayStatus() string {
 	if h == nil {
 		return ""
 	}
-	var b strings.Builder
-	for _, r := range h.Status {
-		if r == '\t' || r == '\n' || r == '\r' || !unicode.IsPrint(r) {
-			continue
-		}
-		if b.Len() >= statusDisplayMax {
-			break
-		}
-		b.WriteRune(r)
+	return displayField(h.Status, statusDisplayMax)
+}
+
+// DisplayVersion is the same treatment for Version, which travels the same path
+// to the same rows and was previously printed raw and unbounded.
+func (h *Health) DisplayVersion() string {
+	if h == nil {
+		return ""
 	}
-	return b.String()
+	return displayField(h.Version, versionDisplayMax)
 }
 
 // GetHealth returns the daemon's health payload, including the version it was

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode"
 )
 
 const DefaultHost = "http://localhost:7842"
@@ -78,6 +79,31 @@ type Health struct {
 	Status    string    `json:"status"`
 	Version   string    `json:"version"`
 	StartedAt time.Time `json:"started_at"`
+}
+
+// statusDisplayMax bounds the rendered status so one field cannot overrun a TUI
+// row. Comfortably above the daemon's "ok"/"degraded".
+const statusDisplayMax = 32
+
+// DisplayStatus returns Status reduced to something safe to print: the daemon's
+// value reaches a TUI row and a terminal line verbatim, where a control byte
+// would corrupt the layout and an unbounded string would overrun it. Today the
+// daemon only emits "ok" and "degraded", so this is about not depending on that.
+func (h *Health) DisplayStatus() string {
+	if h == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range h.Status {
+		if r == '\t' || r == '\n' || r == '\r' || !unicode.IsPrint(r) {
+			continue
+		}
+		if b.Len() >= statusDisplayMax {
+			break
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // GetHealth returns the daemon's health payload, including the version it was

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -149,5 +150,36 @@ func TestGetHealthErrorsOnUnexpectedStatusAndGarbage(t *testing.T) {
 				t.Errorf("GetHealth on %s = nil error, want error", tc.name)
 			}
 		})
+	}
+}
+
+// Status is rendered into a TUI row and a terminal line, so control bytes would
+// corrupt the layout and an unbounded string would overrun it. The daemon only
+// emits "ok"/"degraded" today; this keeps a future value from breaking callers.
+func TestHealthDisplayStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "degraded", "degraded"},
+		{"empty", "", ""},
+		// Dropping ESC is what defuses the sequence; the remaining "[31m" is
+		// inert literal text, so it is deliberately kept rather than parsed out.
+		{"defuses ANSI by dropping ESC", "deg\x1b[31mraded\n", "deg[31mraded"},
+		{"strips tabs and CR", "de\tgra\rded", "degraded"},
+		{"caps length", strings.Repeat("x", 80), strings.Repeat("x", 32)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Health{Status: tc.in}
+			if got := h.DisplayStatus(); got != tc.want {
+				t.Errorf("DisplayStatus() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+	var nilH *Health
+	if got := nilH.DisplayStatus(); got != "" {
+		t.Errorf("nil receiver DisplayStatus() = %q, want empty", got)
 	}
 }

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -47,3 +47,42 @@ func TestStreamEventsReturnsWhenContextCanceledWithBlockedSend(t *testing.T) {
 		t.Fatal("StreamEvents did not return after context cancellation")
 	}
 }
+
+func TestGetHealthParsesDaemonVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"ok","version":"0.8.0","started_at":"2026-08-04T09:20:26Z"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	h, err := New(srv.URL, "").GetHealth()
+	if err != nil {
+		t.Fatalf("GetHealth: %v", err)
+	}
+	if h.Version != "0.8.0" {
+		t.Errorf("Version = %q, want 0.8.0", h.Version)
+	}
+	if h.Status != "ok" {
+		t.Errorf("Status = %q, want ok", h.Status)
+	}
+}
+
+// A daemon built before version stamping omits the field entirely; GetHealth
+// must succeed with an empty Version rather than failing the whole fetch.
+func TestGetHealthToleratesMissingVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"status":"ok"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	h, err := New(srv.URL, "").GetHealth()
+	if err != nil {
+		t.Fatalf("GetHealth: %v", err)
+	}
+	if h.Version != "" {
+		t.Errorf("Version = %q, want empty", h.Version)
+	}
+}

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -183,3 +183,47 @@ func TestHealthDisplayStatus(t *testing.T) {
 		t.Errorf("nil receiver DisplayStatus() = %q, want empty", got)
 	}
 }
+
+// The cap is documented in runes, so it must count runes: a byte-based check
+// truncated multibyte input at ~11 characters and could still emit 32+ bytes.
+func TestDisplayFieldsCapInRunes(t *testing.T) {
+	multibyte := strings.Repeat("é", 80) // 2 bytes per rune
+	h := &Health{Status: multibyte, Version: multibyte}
+
+	gotStatus := h.DisplayStatus()
+	if n := len([]rune(gotStatus)); n != statusDisplayMax {
+		t.Errorf("DisplayStatus() kept %d runes, want %d", n, statusDisplayMax)
+	}
+	gotVersion := h.DisplayVersion()
+	if n := len([]rune(gotVersion)); n != versionDisplayMax {
+		t.Errorf("DisplayVersion() kept %d runes, want %d", n, versionDisplayMax)
+	}
+}
+
+// Version reaches the same TUI row and terminal line as Status, so it gets the
+// same treatment — it was previously printed raw and unbounded.
+func TestHealthDisplayVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "0.8.0", "0.8.0"},
+		{"describe output", "0.8.0-3-g86f49fa-dirty", "0.8.0-3-g86f49fa-dirty"},
+		{"empty", "", ""},
+		{"drops control bytes", "0.8\x00.0\n", "0.8.0"},
+		{"caps length", strings.Repeat("v", 200), strings.Repeat("v", versionDisplayMax)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Health{Version: tc.in}
+			if got := h.DisplayVersion(); got != tc.want {
+				t.Errorf("DisplayVersion() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+	var nilH *Health
+	if got := nilH.DisplayVersion(); got != "" {
+		t.Errorf("nil receiver DisplayVersion() = %q, want empty", got)
+	}
+}

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -227,3 +227,30 @@ func TestHealthDisplayVersion(t *testing.T) {
 		t.Errorf("nil receiver DisplayVersion() = %q, want empty", got)
 	}
 }
+
+// GetHealth embeds the raw response body in its error (TrimSpace only touches the
+// ends), so a proxy's HTML 502 can carry interior newlines or ESC bytes. That
+// error is rendered on the same TUI row as Status and Version, so it needs the
+// same treatment — DisplayText is the entry point for that third string.
+func TestDisplayText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"plain", "connection refused", 60, "connection refused"},
+		{"interior newlines", "HTTP 502: <html>\n<body>\nBad Gateway\n</html>", 60,
+			"HTTP 502: <html><body>Bad Gateway</html>"},
+		{"drops ESC", "HTTP 502: \x1b[2Jcleared", 60, "HTTP 502: [2Jcleared"},
+		{"caps in runes", "ééééé", 3, "ééé"},
+		{"empty", "", 60, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DisplayText(tc.in, tc.max); got != tc.want {
+				t.Errorf("DisplayText(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -86,3 +86,68 @@ func TestGetHealthToleratesMissingVersion(t *testing.T) {
 		t.Errorf("Version = %q, want empty", h.Version)
 	}
 }
+
+// The daemon answers 503 with status "degraded" when a check fails, but the body
+// still carries the version (daemon/internal/server/handlers.go). That is exactly
+// when an operator needs to know which build is running, so 503 must decode.
+func TestGetHealthDecodesDegraded503(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, `{"status":"degraded","version":"0.8.0","started_at":"2026-08-04T09:20:26Z"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	h, err := New(srv.URL, "").GetHealth()
+	if err != nil {
+		t.Fatalf("GetHealth on 503: %v", err)
+	}
+	if h.Version != "0.8.0" {
+		t.Errorf("Version = %q, want 0.8.0", h.Version)
+	}
+	if h.Status != "degraded" {
+		t.Errorf("Status = %q, want degraded", h.Status)
+	}
+}
+
+// Health() shares GetHealth's transport, so a degraded-but-reachable daemon is
+// not a connectivity failure for the SSE watchdog either.
+func TestHealthTreatsDegradedAsReachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, `{"status":"degraded","version":"0.8.0"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := New(srv.URL, "").Health(); err != nil {
+		t.Errorf("Health() on a reachable degraded daemon = %v, want nil", err)
+	}
+}
+
+// Statuses other than 200/503, and bodies that are not health payloads, remain
+// errors — tolerating 503 must not swallow a 401 or an HTML error page.
+func TestGetHealthErrorsOnUnexpectedStatusAndGarbage(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"unauthorized", http.StatusUnauthorized, `{"error":"unauthorized"}`},
+		{"gateway html", http.StatusBadGateway, `<html>502 Bad Gateway</html>`},
+		{"undecodable 200", http.StatusOK, `not json at all`},
+		{"undecodable 503", http.StatusServiceUnavailable, `<html>upstream down</html>`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, tc.body)
+			}))
+			t.Cleanup(srv.Close)
+
+			if _, err := New(srv.URL, "").GetHealth(); err == nil {
+				t.Errorf("GetHealth on %s = nil error, want error", tc.name)
+			}
+		})
+	}
+}

--- a/cli/internal/cli/status.go
+++ b/cli/internal/cli/status.go
@@ -92,11 +92,16 @@ func newStatusCmd() *cobra.Command {
 // reports (notably "degraded", which /health returns with 503) is printed as-is
 // rather than flattened, and a payload without a status says so instead of
 // asserting health it cannot confirm.
+// Every branch reads the sanitised value, including the "unreported" guard: a
+// status of only non-printable bytes is non-empty, so testing the raw field let
+// it past the guard and then printed the sanitised "" as a blank Status line. The
+// dashboard avoids the same asymmetry by storing daemonStatus already sanitised.
+// DisplayStatus is nil-safe, so it also covers a nil payload.
 func statusLine(h *api.Health) string {
-	if h == nil || h.Status == "" {
+	status := h.DisplayStatus()
+	if status == "" {
 		return "online (status unreported)"
 	}
-	status := h.DisplayStatus()
 	if status == "ok" {
 		return "online"
 	}

--- a/cli/internal/cli/status.go
+++ b/cli/internal/cli/status.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 
 	"github.com/spf13/cobra"
+
+	"github.com/theburrowhub/heimdallm/cli/internal/api"
 )
 
 func newStatusCmd() *cobra.Command {
@@ -13,7 +15,13 @@ func newStatusCmd() *cobra.Command {
 		Short: "Show daemon state, uptime, and monitored repos",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := clientFromContext(cmd.Context())
-			if err := c.Health(); err != nil {
+			// GetHealth rather than Health: the latter is only a reachability
+			// gate, and it treats a 503 "degraded" daemon as reachable so the
+			// dashboard can still read its version. Reporting that as a flat
+			// "online" would hide the fault in the state this command exists to
+			// diagnose, so the payload drives the Status line below.
+			health, err := c.GetHealth()
+			if err != nil {
 				return fmt.Errorf("daemon unreachable: %w", err)
 			}
 
@@ -29,7 +37,10 @@ func newStatusCmd() *cobra.Command {
 
 			fmt.Println("Heimdallm Daemon Status")
 			fmt.Println("═══════════════════════")
-			fmt.Printf("  Status:       online\n")
+			fmt.Printf("  Status:       %s\n", statusLine(health))
+			if health.Version != "" {
+				fmt.Printf("  Version:      %s\n", health.Version)
+			}
 
 			if repos, ok := cfg["repositories"]; ok {
 				if arr, ok := repos.([]any); ok {
@@ -74,4 +85,19 @@ func newStatusCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// statusLine renders the daemon's state for the status command. "ok" is spelled
+// "online" for continuity with the previous output; any other state the daemon
+// reports (notably "degraded", which /health returns with 503) is printed as-is
+// rather than flattened, and a payload without a status says so instead of
+// asserting health it cannot confirm.
+func statusLine(h *api.Health) string {
+	if h == nil || h.Status == "" {
+		return "online (status unreported)"
+	}
+	if h.Status == "ok" {
+		return "online"
+	}
+	return h.Status
 }

--- a/cli/internal/cli/status.go
+++ b/cli/internal/cli/status.go
@@ -38,8 +38,8 @@ func newStatusCmd() *cobra.Command {
 			fmt.Println("Heimdallm Daemon Status")
 			fmt.Println("═══════════════════════")
 			fmt.Printf("  Status:       %s\n", statusLine(health))
-			if health.Version != "" {
-				fmt.Printf("  Version:      %s\n", health.Version)
+			if v := health.DisplayVersion(); v != "" {
+				fmt.Printf("  Version:      %s\n", v)
 			}
 
 			if repos, ok := cfg["repositories"]; ok {

--- a/cli/internal/cli/status.go
+++ b/cli/internal/cli/status.go
@@ -96,8 +96,9 @@ func statusLine(h *api.Health) string {
 	if h == nil || h.Status == "" {
 		return "online (status unreported)"
 	}
-	if h.Status == "ok" {
+	status := h.DisplayStatus()
+	if status == "ok" {
 		return "online"
 	}
-	return h.DisplayStatus()
+	return status
 }

--- a/cli/internal/cli/status.go
+++ b/cli/internal/cli/status.go
@@ -99,5 +99,5 @@ func statusLine(h *api.Health) string {
 	if h.Status == "ok" {
 		return "online"
 	}
-	return h.Status
+	return h.DisplayStatus()
 }

--- a/cli/internal/cli/status_test.go
+++ b/cli/internal/cli/status_test.go
@@ -19,6 +19,11 @@ func TestStatusLine(t *testing.T) {
 		{"degraded", &api.Health{Status: "degraded"}, "degraded"},
 		{"unknown word passes through", &api.Health{Status: "starting"}, "starting"},
 		{"no status reported", &api.Health{}, "online (status unreported)"},
+		// The guard must evaluate the SANITISED value: a status made only of
+		// non-printable bytes is non-empty, so a raw `h.Status == ""` check let it
+		// through and then printed the sanitised "" — a blank Status line.
+		{"only non-printable bytes", &api.Health{Status: "\n"}, "online (status unreported)"},
+		{"control bytes around ok", &api.Health{Status: "\nok\r"}, "online"},
 		{"nil payload", nil, "online (status unreported)"},
 	}
 	for _, tc := range cases {

--- a/cli/internal/cli/status_test.go
+++ b/cli/internal/cli/status_test.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/theburrowhub/heimdallm/cli/internal/api"
+)
+
+// GetHealth treats 503 as reachable so the dashboard can still read the version.
+// The status command must not turn that into a flat "online": a degraded daemon
+// is exactly the case an operator runs `status` to find.
+func TestStatusLine(t *testing.T) {
+	cases := []struct {
+		name string
+		h    *api.Health
+		want string
+	}{
+		{"healthy", &api.Health{Status: "ok"}, "online"},
+		{"degraded", &api.Health{Status: "degraded"}, "degraded"},
+		{"unknown word passes through", &api.Health{Status: "starting"}, "starting"},
+		{"no status reported", &api.Health{}, "online (status unreported)"},
+		{"nil payload", nil, "online (status unreported)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusLine(tc.h); got != tc.want {
+				t.Errorf("statusLine() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -334,7 +334,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// stopped badge would misstate which build is running, and a daemon that
 		// restarted on a different version would keep showing the old one.
 		if msg.health != nil {
-			d.daemonVersion = msg.health.Version
+			d.daemonVersion = msg.health.DisplayVersion()
 			d.daemonStartedAt = msg.health.StartedAt
 			d.daemonStatus = msg.health.Status
 			d.daemonHealthErr = nil

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -1104,14 +1104,21 @@ func (d *Dashboard) serverStatusBadge() string {
 	if d.sseStale {
 		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).Render("● unresponsive")
 	}
+	// /health answering at all is proof the daemon is up, and its own word
+	// outranks connectedness, which only tracks the authenticated endpoints. This
+	// is checked BEFORE !connected on purpose: fetchData can read a 503
+	// "degraded" payload and then fail on /prs, /config or /stats, and reporting
+	// "stopped" for a daemon that just answered would hide the degradation behind
+	// an outright wrong state.
+	if d.daemonHealthErr == nil && d.daemonStatus != "" {
+		if d.daemonStatus != "ok" {
+			return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).
+				Render("● " + (&api.Health{Status: d.daemonStatus}).DisplayStatus())
+		}
+		return lipgloss.NewStyle().Foreground(colorSuccess).Bold(true).Render("● running")
+	}
 	if !d.connected {
 		return lipgloss.NewStyle().Foreground(colorMuted).Render("● stopped")
-	}
-	// A degraded daemon (/health 503) answers every endpoint, so connectedness
-	// alone would render it as plainly running. Its own word takes precedence.
-	if d.daemonStatus != "" && d.daemonStatus != "ok" {
-		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).
-			Render("● " + d.daemonStatus)
 	}
 	return lipgloss.NewStyle().Foreground(colorSuccess).Bold(true).Render("● running")
 }

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -336,7 +336,7 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.health != nil {
 			d.daemonVersion = msg.health.DisplayVersion()
 			d.daemonStartedAt = msg.health.StartedAt
-			d.daemonStatus = msg.health.Status
+			d.daemonStatus = msg.health.DisplayStatus()
 			d.daemonHealthErr = nil
 		} else if msg.healthErr != nil {
 			d.daemonVersion = ""
@@ -1113,7 +1113,7 @@ func (d *Dashboard) serverStatusBadge() string {
 	if d.daemonHealthErr == nil && d.daemonStatus != "" {
 		if d.daemonStatus != "ok" {
 			return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).
-				Render("● " + (&api.Health{Status: d.daemonStatus}).DisplayStatus())
+				Render("● " + d.daemonStatus)
 		}
 		return lipgloss.NewStyle().Foreground(colorSuccess).Bold(true).Render("● running")
 	}
@@ -1146,7 +1146,7 @@ func (d *Dashboard) renderServer(height int) string {
 		daemonVersion = mutedNote.Render("(unknown)")
 		if d.daemonHealthErr != nil {
 			daemonVersion += mutedNote.Render(
-				" — " + truncateRunes(d.daemonHealthErr.Error(), 60))
+				" — " + api.DisplayText(d.daemonHealthErr.Error(), 60))
 		}
 	}
 	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Daemon", daemonVersion))

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -66,6 +66,10 @@ type Dashboard struct {
 	version         string
 	daemonVersion   string
 	daemonStartedAt time.Time
+	// The daemon's own view of its health ("ok", "degraded"). Distinct from
+	// connected, which only tracks whether the authenticated endpoints answered:
+	// a degraded daemon answers everything and would otherwise look healthy.
+	daemonStatus string
 	// Last /health failure. Kept so the Server section can say why the version
 	// is unknown: the fetch is best-effort and would otherwise leave no trail.
 	daemonHealthErr error
@@ -332,10 +336,12 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.health != nil {
 			d.daemonVersion = msg.health.Version
 			d.daemonStartedAt = msg.health.StartedAt
+			d.daemonStatus = msg.health.Status
 			d.daemonHealthErr = nil
 		} else if msg.healthErr != nil {
 			d.daemonVersion = ""
 			d.daemonStartedAt = time.Time{}
+			d.daemonStatus = ""
 			d.daemonHealthErr = msg.healthErr
 		}
 		if msg.err != nil {
@@ -1101,6 +1107,12 @@ func (d *Dashboard) serverStatusBadge() string {
 	if !d.connected {
 		return lipgloss.NewStyle().Foreground(colorMuted).Render("● stopped")
 	}
+	// A degraded daemon (/health 503) answers every endpoint, so connectedness
+	// alone would render it as plainly running. Its own word takes precedence.
+	if d.daemonStatus != "" && d.daemonStatus != "ok" {
+		return lipgloss.NewStyle().Foreground(colorWarning).Bold(true).
+			Render("● " + d.daemonStatus)
+	}
 	return lipgloss.NewStyle().Foreground(colorSuccess).Bold(true).Render("● running")
 }
 
@@ -1144,9 +1156,15 @@ func (d *Dashboard) renderServer(height int) string {
 	// belongs to the footer status bar; reporting it here next to a server-side
 	// version row would read as the server's. Unknown for daemons that omit
 	// started_at, and while unreachable.
+	// Clamped at zero: a daemon on another host whose clock runs ahead of ours
+	// reports a started_at in the future, which would render as a negative age.
 	uptime := mutedNote.Render("(unknown)")
 	if !d.daemonStartedAt.IsZero() {
-		uptime = time.Since(d.daemonStartedAt).Truncate(time.Second).String()
+		age := time.Since(d.daemonStartedAt).Truncate(time.Second)
+		if age < 0 {
+			age = 0
+		}
+		uptime = age.String()
 	}
 	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Uptime", uptime))
 

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -63,8 +63,12 @@ type Dashboard struct {
 	// version is this CLI binary's build version; daemonVersion is the
 	// server's, from /health. They are independent — a stamped CLI says
 	// nothing about the daemon it happens to be pointed at.
-	version       string
-	daemonVersion string
+	version         string
+	daemonVersion   string
+	daemonStartedAt time.Time
+	// Last /health failure. Kept so the Server section can say why the version
+	// is unknown: the fetch is best-effort and would otherwise leave no trail.
+	daemonHealthErr error
 
 	sseEvents    chan api.SSEEvent
 	sseCtx       context.Context
@@ -87,7 +91,11 @@ type dataMsg struct {
 	stats    *api.Stats
 	activity *api.ActivityResponse
 	health   *api.Health
-	err      error
+	// Set when the /health fetch itself failed. Distinct from health == nil,
+	// which also covers "not fetched yet"; the difference decides whether a
+	// previously known version is kept or cleared.
+	healthErr error
+	err       error
 }
 type sseMsg struct {
 	sessionID int64
@@ -154,9 +162,12 @@ func (d *Dashboard) fetchData() tea.Msg {
 	// Fetched first and best-effort: /health needs no token, so the Server tab
 	// can still report the daemon's version when the authenticated endpoints
 	// below fail with 401. A health failure is left to those endpoints to
-	// report rather than blanking the whole dashboard.
+	// report rather than blanking the whole dashboard — but it is recorded, so
+	// the Server section can explain an unknown version instead of going quiet.
 	if health, err := d.client.GetHealth(); err == nil {
 		msg.health = health
+	} else {
+		msg.healthErr = err
 	}
 
 	prs, err := d.client.ListPRs()
@@ -315,8 +326,17 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		d.refreshing = false
 		// Applied before the error branch: health is fetched best-effort and
 		// unauthenticated, so the daemon version survives a 401 on the rest.
+		// A failed fetch clears both — reporting a last-known version next to a
+		// stopped badge would misstate which build is running, and a daemon that
+		// restarted on a different version would keep showing the old one.
 		if msg.health != nil {
 			d.daemonVersion = msg.health.Version
+			d.daemonStartedAt = msg.health.StartedAt
+			d.daemonHealthErr = nil
+		} else if msg.healthErr != nil {
+			d.daemonVersion = ""
+			d.daemonStartedAt = time.Time{}
+			d.daemonHealthErr = msg.healthErr
 		}
 		if msg.err != nil {
 			d.err = msg.err
@@ -1097,14 +1117,20 @@ func (d *Dashboard) renderServer(height int) string {
 	// Status row
 	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Status", d.serverStatusBadge()))
 
-	// Version row — the daemon's own version, reported by /health. Empty means
-	// either the daemon has not been reached yet or it predates version
-	// stamping (older builds omit the field).
+	// Daemon row — the daemon's own version, reported by /health. Labelled in
+	// parallel with the CLI row below: under a "Server" header a bare "Version"
+	// reads as the whole product's, which is the ambiguity this pair resolves.
+	// Empty means the daemon was unreachable, has not been reached yet, or
+	// predates version stamping (older builds omit the field).
 	daemonVersion := d.daemonVersion
 	if daemonVersion == "" {
 		daemonVersion = mutedNote.Render("(unknown)")
+		if d.daemonHealthErr != nil {
+			daemonVersion += mutedNote.Render(
+				" — " + truncateRunes(d.daemonHealthErr.Error(), 60))
+		}
 	}
-	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Version", daemonVersion))
+	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Daemon", daemonVersion))
 
 	// CLI row — this binary's build version, shown separately so a mismatch
 	// against the daemon is visible instead of being conflated with it.
@@ -1114,8 +1140,14 @@ func (d *Dashboard) renderServer(height int) string {
 	}
 	b.WriteString(fmt.Sprintf("  %-10s %s\n", "CLI", cliVersion))
 
-	// Uptime row
-	uptime := time.Since(d.startTime).Truncate(time.Second).String()
+	// Uptime row — the daemon's, from /health started_at. The CLI's own uptime
+	// belongs to the footer status bar; reporting it here next to a server-side
+	// version row would read as the server's. Unknown for daemons that omit
+	// started_at, and while unreachable.
+	uptime := mutedNote.Render("(unknown)")
+	if !d.daemonStartedAt.IsZero() {
+		uptime = time.Since(d.daemonStartedAt).Truncate(time.Second).String()
+	}
 	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Uptime", uptime))
 
 	// Bind addr / port — sourced from d.config (last successful /config fetch)

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -60,7 +60,11 @@ type Dashboard struct {
 	startTime         time.Time
 	lastUpdate        time.Time
 	lastSSEEvent      time.Time
-	version           string
+	// version is this CLI binary's build version; daemonVersion is the
+	// server's, from /health. They are independent — a stamped CLI says
+	// nothing about the daemon it happens to be pointed at.
+	version       string
+	daemonVersion string
 
 	sseEvents    chan api.SSEEvent
 	sseCtx       context.Context
@@ -82,6 +86,7 @@ type dataMsg struct {
 	config   map[string]any
 	stats    *api.Stats
 	activity *api.ActivityResponse
+	health   *api.Health
 	err      error
 }
 type sseMsg struct {
@@ -145,6 +150,14 @@ func sseWatchdogCmd() tea.Cmd {
 
 func (d *Dashboard) fetchData() tea.Msg {
 	msg := dataMsg{}
+
+	// Fetched first and best-effort: /health needs no token, so the Server tab
+	// can still report the daemon's version when the authenticated endpoints
+	// below fail with 401. A health failure is left to those endpoints to
+	// report rather than blanking the whole dashboard.
+	if health, err := d.client.GetHealth(); err == nil {
+		msg.health = health
+	}
 
 	prs, err := d.client.ListPRs()
 	if err != nil {
@@ -300,6 +313,11 @@ func (d *Dashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case dataMsg:
 		d.refreshing = false
+		// Applied before the error branch: health is fetched best-effort and
+		// unauthenticated, so the daemon version survives a 401 on the rest.
+		if msg.health != nil {
+			d.daemonVersion = msg.health.Version
+		}
 		if msg.err != nil {
 			d.err = msg.err
 			d.connected = false
@@ -1079,12 +1097,22 @@ func (d *Dashboard) renderServer(height int) string {
 	// Status row
 	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Status", d.serverStatusBadge()))
 
-	// Version row — d.version is the build-time version passed into NewDashboard
-	version := d.version
-	if version == "" {
-		version = mutedNote.Render("(unknown)")
+	// Version row — the daemon's own version, reported by /health. Empty means
+	// either the daemon has not been reached yet or it predates version
+	// stamping (older builds omit the field).
+	daemonVersion := d.daemonVersion
+	if daemonVersion == "" {
+		daemonVersion = mutedNote.Render("(unknown)")
 	}
-	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Version", version))
+	b.WriteString(fmt.Sprintf("  %-10s %s\n", "Version", daemonVersion))
+
+	// CLI row — this binary's build version, shown separately so a mismatch
+	// against the daemon is visible instead of being conflated with it.
+	cliVersion := d.version
+	if cliVersion == "" {
+		cliVersion = mutedNote.Render("(unknown)")
+	}
+	b.WriteString(fmt.Sprintf("  %-10s %s\n", "CLI", cliVersion))
 
 	// Uptime row
 	uptime := time.Since(d.startTime).Truncate(time.Second).String()

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -540,8 +540,24 @@ func TestBuildConfigLinesPollingAbsentWhenMissing(t *testing.T) {
 	}
 }
 
-// The Server section describes the daemon, so its Version row must report the
-// daemon's version from /health — not the CLI binary's own build version.
+// serverRow returns the value of the Server section's "<label>" row. Anchored on
+// the label at the start of the trimmed line rather than a substring search, so
+// renaming one row cannot silently make another row's assertion vacuous.
+func serverRow(t *testing.T, out, label string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == label {
+			return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), label))
+		}
+	}
+	t.Fatalf("Server section has no %q row:\n%s", label, out)
+	return ""
+}
+
+// The Server section describes the daemon, so its Daemon row must report the
+// version from /health — not the CLI binary's own build version, which gets its
+// own row.
 func TestServerSectionShowsDaemonVersionNotCLIVersion(t *testing.T) {
 	d := NewDashboard("http://localhost:0", "", "9.9.9-cli")
 	d.width = 120
@@ -549,19 +565,14 @@ func TestServerSectionShowsDaemonVersionNotCLIVersion(t *testing.T) {
 	d.daemonVersion = "0.8.0"
 
 	out := d.renderServer(40)
-	if !strings.Contains(out, "0.8.0") {
-		t.Errorf("Server section omits daemon version 0.8.0:\n%s", out)
+	if got := serverRow(t, out, "Daemon"); !strings.Contains(got, "0.8.0") {
+		t.Errorf("Daemon row = %q, want the daemon version 0.8.0", got)
 	}
-	// The CLI's version must not be presented as the server's.
-	serverRow := ""
-	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains(line, "Version") {
-			serverRow = line
-			break
-		}
+	if got := serverRow(t, out, "Daemon"); strings.Contains(got, "9.9.9-cli") {
+		t.Errorf("Daemon row reports the CLI version: %q", got)
 	}
-	if strings.Contains(serverRow, "9.9.9-cli") {
-		t.Errorf("Version row reports the CLI version, not the daemon's: %q", serverRow)
+	if got := serverRow(t, out, "CLI"); !strings.Contains(got, "9.9.9-cli") {
+		t.Errorf("CLI row = %q, want the CLI version 9.9.9-cli", got)
 	}
 }
 
@@ -572,25 +583,113 @@ func TestServerSectionUnknownDaemonVersion(t *testing.T) {
 	d.daemonVersion = ""
 
 	out := d.renderServer(40)
-	if !strings.Contains(out, "(unknown)") {
-		t.Errorf("missing daemon version should render (unknown):\n%s", out)
+	if got := serverRow(t, out, "Daemon"); !strings.Contains(got, "(unknown)") {
+		t.Errorf("Daemon row = %q, want (unknown)", got)
 	}
 }
 
-func TestDataMsgStoresDaemonVersion(t *testing.T) {
+func TestDataMsgStoresDaemonVersionAndStart(t *testing.T) {
 	d := NewDashboard("http://localhost:0", "", "test")
 	d.width = 120
 	d.height = 40
+	started := time.Date(2026, 8, 4, 9, 20, 26, 0, time.UTC)
 
 	msg := dataMsg{
 		config: map[string]any{},
 		stats:  &api.Stats{},
-		health: &api.Health{Status: "ok", Version: "0.8.0"},
+		health: &api.Health{Status: "ok", Version: "0.8.0", StartedAt: started},
 	}
 	model, _ := d.Update(msg)
 	d = model.(*Dashboard)
 
 	if d.daemonVersion != "0.8.0" {
 		t.Errorf("daemonVersion = %q, want 0.8.0", d.daemonVersion)
+	}
+	if !d.daemonStartedAt.Equal(started) {
+		t.Errorf("daemonStartedAt = %v, want %v", d.daemonStartedAt, started)
+	}
+}
+
+// A degraded daemon answers 503 but still reports its version, so the Daemon row
+// must show it — the operator needs the build precisely when things are broken.
+func TestServerSectionShowsVersionWhenDegraded(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+
+	model, _ := d.Update(dataMsg{
+		config: map[string]any{},
+		stats:  &api.Stats{},
+		health: &api.Health{Status: "degraded", Version: "0.8.0"},
+	})
+	d = model.(*Dashboard)
+
+	if got := serverRow(t, d.renderServer(40), "Daemon"); !strings.Contains(got, "0.8.0") {
+		t.Errorf("Daemon row = %q, want 0.8.0 for a degraded daemon", got)
+	}
+}
+
+// Pairing a last-known version with a "stopped" badge misreports what is
+// running, so an unreachable daemon clears the version instead of keeping it.
+func TestUnreachableDaemonClearsVersion(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+
+	model, _ := d.Update(dataMsg{
+		config: map[string]any{},
+		stats:  &api.Stats{},
+		health: &api.Health{Version: "0.8.0", StartedAt: time.Now()},
+	})
+	d = model.(*Dashboard)
+	if d.daemonVersion == "" {
+		t.Fatal("precondition: version should be set after a successful fetch")
+	}
+
+	model, _ = d.Update(dataMsg{healthErr: errors.New("connection refused"), err: errors.New("connection refused")})
+	d = model.(*Dashboard)
+
+	if d.daemonVersion != "" {
+		t.Errorf("daemonVersion = %q after the daemon became unreachable, want cleared", d.daemonVersion)
+	}
+	if !d.daemonStartedAt.IsZero() {
+		t.Errorf("daemonStartedAt = %v, want zero", d.daemonStartedAt)
+	}
+	out := d.renderServer(40)
+	if got := serverRow(t, out, "Daemon"); !strings.Contains(got, "(unknown)") {
+		t.Errorf("Daemon row = %q, want (unknown)", got)
+	}
+	// The swallowed error used to leave no trail; surface it on the row.
+	if !strings.Contains(out, "connection refused") {
+		t.Errorf("Server section gives no diagnostic for the failed health fetch:\n%s", out)
+	}
+}
+
+// Uptime in the Server section is the daemon's, derived from /health started_at,
+// not the CLI process's own age.
+func TestServerSectionUptimeIsDaemonUptime(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+	d.startTime = time.Now().Add(-99 * time.Hour) // CLI running far longer
+	d.daemonStartedAt = time.Now().Add(-90 * time.Minute)
+
+	got := serverRow(t, d.renderServer(40), "Uptime")
+	if strings.Contains(got, "99h") {
+		t.Errorf("Uptime row = %q, reports the CLI's uptime instead of the daemon's", got)
+	}
+	if !strings.Contains(got, "1h30m") {
+		t.Errorf("Uptime row = %q, want the daemon's 1h30m", got)
+	}
+}
+
+func TestServerSectionUptimeUnknownWithoutStartedAt(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+	d.daemonStartedAt = time.Time{}
+
+	if got := serverRow(t, d.renderServer(40), "Uptime"); !strings.Contains(got, "(unknown)") {
+		t.Errorf("Uptime row = %q, want (unknown) when the daemon reports no started_at", got)
 	}
 }

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -750,3 +750,51 @@ func TestServerSectionUptimeNeverNegative(t *testing.T) {
 		t.Errorf("Uptime row = %q, want no negative duration for a skewed clock", got)
 	}
 }
+
+// /health answering at all proves the daemon is up, so its own word outranks
+// connectedness — which only tracks the authenticated endpoints. fetchData can
+// read a 503 "degraded" payload and then fail on ListPRs/config/stats, which
+// sets connected=false while daemonStatus stays "degraded"; reporting "stopped"
+// there hides a known-degraded daemon behind a wrong state.
+func TestServerStatusBadgeDegradedOutranksDisconnected(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+	d.connected = true
+
+	model, _ := d.Update(dataMsg{
+		health: &api.Health{Status: "degraded", Version: "0.8.0"},
+		err:    errors.New("GET /prs failed: 500"),
+	})
+	d = model.(*Dashboard)
+
+	if d.connected {
+		t.Fatal("precondition: a dataMsg error should mark the dashboard disconnected")
+	}
+	got := serverRow(t, d.renderServer(40), "Status")
+	if !strings.Contains(got, "degraded") {
+		t.Errorf("Status row = %q, want degraded (the daemon answered /health)", got)
+	}
+	if strings.Contains(got, "stopped") {
+		t.Errorf("Status row = %q, reports stopped for a daemon that answered /health", got)
+	}
+}
+
+// When /health itself fails there is no evidence the daemon is up, so the
+// disconnected badge is still correct.
+func TestServerStatusBadgeStoppedWhenHealthUnreachable(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+	d.connected = true
+
+	model, _ := d.Update(dataMsg{
+		healthErr: errors.New("connection refused"),
+		err:       errors.New("connection refused"),
+	})
+	d = model.(*Dashboard)
+
+	if got := serverRow(t, d.renderServer(40), "Status"); !strings.Contains(got, "stopped") {
+		t.Errorf("Status row = %q, want stopped when /health is unreachable", got)
+	}
+}

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -693,3 +693,60 @@ func TestServerSectionUptimeUnknownWithoutStartedAt(t *testing.T) {
 		t.Errorf("Uptime row = %q, want (unknown) when the daemon reports no started_at", got)
 	}
 }
+
+// api.Health.Status was parsed but never shown: a degraded daemon (503) rendered
+// a plain "● running" badge, because connectedness only tracks the authenticated
+// endpoints. The badge now reflects what the daemon says about itself.
+func TestServerStatusBadgeReflectsDegraded(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+	d.connected = true
+
+	model, _ := d.Update(dataMsg{
+		config: map[string]any{},
+		stats:  &api.Stats{},
+		health: &api.Health{Status: "degraded", Version: "0.8.0"},
+	})
+	d = model.(*Dashboard)
+
+	got := serverRow(t, d.renderServer(40), "Status")
+	if !strings.Contains(got, "degraded") {
+		t.Errorf("Status row = %q, want it to report degraded", got)
+	}
+	if strings.Contains(got, "running") {
+		t.Errorf("Status row = %q, still claims running for a degraded daemon", got)
+	}
+}
+
+func TestServerStatusBadgeRunningWhenOK(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+	d.connected = true
+
+	model, _ := d.Update(dataMsg{
+		config: map[string]any{},
+		stats:  &api.Stats{},
+		health: &api.Health{Status: "ok", Version: "0.8.0"},
+	})
+	d = model.(*Dashboard)
+
+	if got := serverRow(t, d.renderServer(40), "Status"); !strings.Contains(got, "running") {
+		t.Errorf("Status row = %q, want running for a healthy daemon", got)
+	}
+}
+
+// A daemon on another host with a clock ahead of ours yields a started_at in the
+// future; a raw time.Since would render a negative duration.
+func TestServerSectionUptimeNeverNegative(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+	d.daemonStartedAt = time.Now().Add(2 * time.Hour)
+
+	got := serverRow(t, d.renderServer(40), "Uptime")
+	if strings.Contains(got, "-") {
+		t.Errorf("Uptime row = %q, want no negative duration for a skewed clock", got)
+	}
+}

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -798,3 +798,49 @@ func TestServerStatusBadgeStoppedWhenHealthUnreachable(t *testing.T) {
 		t.Errorf("Status row = %q, want stopped when /health is unreachable", got)
 	}
 }
+
+// The health error is the third daemon-supplied string on the Daemon row, and it
+// carries a raw response body: GetHealth formats `HTTP %d: %s` with the body,
+// TrimSpace touching only the ends. A proxy's HTML 502 with interior newlines or
+// an ESC byte would break the Server section's layout, so it is sanitised like
+// Status and Version rather than only length-truncated.
+func TestDaemonRowSanitisesHealthError(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+
+	model, _ := d.Update(dataMsg{
+		healthErr: errors.New("HTTP 502: <html>\n<body>\x1b[2JBad Gateway\r\n</body>"),
+		err:       errors.New("HTTP 502"),
+	})
+	d = model.(*Dashboard)
+
+	out := d.renderServer(40)
+
+	// Asserted over the WHOLE section, not the Daemon row alone: a leaked newline
+	// splits the row, so the control bytes after it land on lines a row-scoped
+	// assertion would never inspect (this test passed against the unsanitised
+	// code when it only looked at the row).
+	// Only control bytes: printable remnants of the HTML ("<body>") are inert and
+	// deliberately kept, exactly as "[31m" is once its ESC is gone.
+	for _, bad := range []string{"\x1b", "\r"} {
+		if strings.Contains(out, bad) {
+			t.Errorf("Server section leaks %q from the health error:\n%q", bad, out)
+		}
+	}
+
+	// A leaked newline would also add lines to the section. Compare against the
+	// same state with a single-line error.
+	clean := NewDashboard("http://localhost:0", "", "test")
+	clean.width, clean.height = 120, 40
+	m, _ := clean.Update(dataMsg{healthErr: errors.New("HTTP 502"), err: errors.New("HTTP 502")})
+	wantLines := len(strings.Split(m.(*Dashboard).renderServer(40), "\n"))
+	if got := len(strings.Split(out, "\n")); got != wantLines {
+		t.Errorf("Server section has %d lines, want %d — the error leaked a newline", got, wantLines)
+	}
+
+	// The useful part still survives.
+	if got := serverRow(t, out, "Daemon"); !strings.Contains(got, "HTTP 502") {
+		t.Errorf("Daemon row = %q, want the leading cause preserved", got)
+	}
+}

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -539,3 +539,58 @@ func TestBuildConfigLinesPollingAbsentWhenMissing(t *testing.T) {
 		}
 	}
 }
+
+// The Server section describes the daemon, so its Version row must report the
+// daemon's version from /health — not the CLI binary's own build version.
+func TestServerSectionShowsDaemonVersionNotCLIVersion(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "9.9.9-cli")
+	d.width = 120
+	d.height = 40
+	d.daemonVersion = "0.8.0"
+
+	out := d.renderServer(40)
+	if !strings.Contains(out, "0.8.0") {
+		t.Errorf("Server section omits daemon version 0.8.0:\n%s", out)
+	}
+	// The CLI's version must not be presented as the server's.
+	serverRow := ""
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Version") {
+			serverRow = line
+			break
+		}
+	}
+	if strings.Contains(serverRow, "9.9.9-cli") {
+		t.Errorf("Version row reports the CLI version, not the daemon's: %q", serverRow)
+	}
+}
+
+func TestServerSectionUnknownDaemonVersion(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "0.8.0")
+	d.width = 120
+	d.height = 40
+	d.daemonVersion = ""
+
+	out := d.renderServer(40)
+	if !strings.Contains(out, "(unknown)") {
+		t.Errorf("missing daemon version should render (unknown):\n%s", out)
+	}
+}
+
+func TestDataMsgStoresDaemonVersion(t *testing.T) {
+	d := NewDashboard("http://localhost:0", "", "test")
+	d.width = 120
+	d.height = 40
+
+	msg := dataMsg{
+		config: map[string]any{},
+		stats:  &api.Stats{},
+		health: &api.Health{Status: "ok", Version: "0.8.0"},
+	}
+	model, _ := d.Update(msg)
+	d = model.(*Dashboard)
+
+	if d.daemonVersion != "0.8.0" {
+		t.Errorf("daemonVersion = %q, want 0.8.0", d.daemonVersion)
+	}
+}


### PR DESCRIPTION
The TUI's Server tab showed the CLI binary's own build version instead of the daemon's, and `cli/Makefile` never stamped `main.version` — so the row read `dev` no matter which daemon was running. Neither defect was addressed by the daemon version stamping in #648, which is why that fix appeared not to work.

**Changes:**
- `api`: add `Health` + `GetHealth()`; a missing `version` field is tolerated so daemons predating stamping don't error the whole fetch
- `tui`: render the daemon's `/health` version as `Version`, with the CLI's own version on a separate `CLI` row so a mismatch stays visible. `/health` is fetched first and best-effort since it needs no token, so the version still shows when the authenticated endpoints return 401
- `build`: stamp `main.version` in `cli/Makefile`, driven by the root Makefile's existing `GIT_VERSION` exactly as `build-daemon` drives `daemon/Makefile` (release builds already stamped via `cli/.goreleaser.yml`)

Before / after against a daemon reporting `0.8.0`:

```
  Version    dev                 Version    0.8.0
                                 CLI        0.8.0
```

Follow-up for the desktop app's equivalent staleness: #661