### PR TITLE
install: Stop the outgoing daemon on install-linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,17 +56,21 @@ jobs:
           # and only the stderr detail survives.
           log="$RUNNER_TEMP/pkill-guard.log"
           make test-install-linux 2>&1 | tee "$log"
-          output="$(cat "$log")"
+          # greps read $log directly rather than piping a variable into grep -q:
+          # under pipefail, grep -q exiting on first match can SIGPIPE the writer
+          # and invert the condition. Unreachable at this output size, but the
+          # guard is built to be un-skippable, so the hole goes for free.
+          #
           # A silent skip here would defeat the purpose: the guard exits 0 when it
           # cannot run, which is right locally on macOS but must never pass in CI.
-          if printf '%s\n' "$output" | grep -q '^1\.\.0'; then
+          if grep -q '^1\.\.0' "$log"; then
             echo "::error::the pkill guard skipped entirely — it must run on ubuntu-latest"
             exit 1
           fi
           # Per-test skips are also coverage loss, not success: on this runner
           # every assertion is meant to execute, so any "# SKIP" means the
           # environment stopped reproducing what the guard exists to prove.
-          if printf '%s\n' "$output" | grep -q '# SKIP'; then
+          if grep -q '# SKIP' "$log"; then
             echo "::error::a pkill guard assertion skipped — coverage is incomplete"
             exit 1
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,27 @@ jobs:
           make -n install-linux >/dev/null
           make -n uninstall-linux >/dev/null
 
+      # The parse checks above cannot catch a dropped -x: `make -n` expands the
+      # recipe without ever running pkill. This job is the only place the pkill
+      # semantics are executed, and ubuntu-latest has the /proc the guard needs.
+      - name: pkill semantics in the Linux targets
+        run: |
+          set -eu
+          for script in scripts/pkill-escape.sh scripts/test-linux-install.sh; do
+            if [ ! -x "$script" ]; then
+              echo "::error::$script must be executable"
+              exit 1
+            fi
+          done
+          output="$(make test-install-linux)"
+          printf '%s\n' "$output"
+          # A silent skip here would defeat the purpose: the guard exits 0 when it
+          # cannot run, which is right locally on macOS but must never pass in CI.
+          if printf '%s\n' "$output" | grep -q '^1\.\.0'; then
+            echo "::error::the pkill guard skipped entirely — it must run on ubuntu-latest"
+            exit 1
+          fi
+
       - name: macOS targets stop at the platform guard
         run: |
           set -eu

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,13 @@ jobs:
             echo "::error::the pkill guard skipped entirely — it must run on ubuntu-latest"
             exit 1
           fi
+          # Per-test skips are also coverage loss, not success: on this runner
+          # every assertion is meant to execute, so any "# SKIP" means the
+          # environment stopped reproducing what the guard exists to prove.
+          if printf '%s\n' "$output" | grep -q '# SKIP'; then
+            echo "::error::a pkill guard assertion skipped — coverage is incomplete"
+            exit 1
+          fi
 
       - name: macOS targets stop at the platform guard
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,15 +42,21 @@ jobs:
       # semantics are executed, and ubuntu-latest has the /proc the guard needs.
       - name: pkill semantics in the Linux targets
         run: |
-          set -eu
+          # pipefail so a guard failure still fails the step through the tee.
+          set -euo pipefail
           for script in scripts/pkill-escape.sh scripts/test-linux-install.sh; do
             if [ ! -x "$script" ]; then
               echo "::error::$script must be executable"
               exit 1
             fi
           done
-          output="$(make test-install-linux)"
-          printf '%s\n' "$output"
+          # Streamed through tee rather than captured into a variable: with
+          # `output="$(make …)"` under set -e, a failing guard aborts the step
+          # before the echo runs, so the ok/not ok TAP lines never reach the log
+          # and only the stderr detail survives.
+          log="$RUNNER_TEMP/pkill-guard.log"
+          make test-install-linux 2>&1 | tee "$log"
+          output="$(cat "$log")"
           # A silent skip here would defeat the purpose: the guard exits 0 when it
           # cannot run, which is right locally on macOS but must never pass in CI.
           if printf '%s\n' "$output" | grep -q '^1\.\.0'; then

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,8 @@ dev-stop:
 	@# aborts — taking `make dev` / `make dev-daemon` with it, whether or not a
 	@# daemon was running. The dev daemon is spawned with no arguments, so its
 	@# cmdline equals the pattern exactly. Guarded by scripts/test-linux-install.sh.
-	@DAEMON_RE=$$($(PKILL_ESCAPE) "$(DAEMON_BIN)"); \
+	@DAEMON_RE=$$($(PKILL_ESCAPE) "$(DAEMON_BIN)") || exit 1; \
+	[ -n "$$DAEMON_RE" ] || { echo "❌  pkill-escape.sh produced an empty pattern"; exit 1; }; \
 	pkill -x -f "$$DAEMON_RE" 2>/dev/null && echo "↓  Daemon parado" || true
 	@UI_PID_FILE="$$HOME/.local/share/heimdallm/ui.pid"; \
 	 if [ -f "$$UI_PID_FILE" ]; then \
@@ -780,7 +781,9 @@ install-linux: _check-linux verify-linux
 	@# cmdline equal the pattern, which the daemon satisfies (spawned with no
 	@# arguments) and the longer shell cmdline does not. Guarded by
 	@# scripts/test-linux-install.sh.
-	@DAEMON_RE=$$($(PKILL_ESCAPE) "$$HOME/.local/opt/heimdallm/heimdalld"); \
+	@DAEMON_RE=$$($(PKILL_ESCAPE) "$$HOME/.local/opt/heimdallm/heimdalld") || exit 1; \
+	[ -n "$$DAEMON_RE" ] || { echo "❌  pkill-escape.sh produced an empty pattern — the"; \
+	  echo "   previous daemon is still running; stop it before launching."; exit 1; }; \
 	if pkill -x -f "$$DAEMON_RE" 2>/dev/null; then \
 	  echo ""; \
 	  echo "↓  Stopped the previously running daemon (it was serving the old binary)."; \
@@ -854,10 +857,12 @@ uninstall-linux: _check-linux
 	@# its cmdline is longer than the pattern. Same rationale as above — the
 	@# rm -rf is safe against a running process — and plain -f never actually
 	@# reached that case anyway, because it killed this recipe's shell first.
-	@APP_RE=$$($(PKILL_ESCAPE) "$$HOME/.local/opt/heimdallm/heimdallm"); \
-	 pkill -x -f "$$APP_RE" 2>/dev/null || true
-	@DAEMON_RE=$$($(PKILL_ESCAPE) "$$HOME/.local/opt/heimdallm/heimdalld"); \
-	 pkill -x -f "$$DAEMON_RE" 2>/dev/null || true
+	@APP_RE=$$($(PKILL_ESCAPE) "$$HOME/.local/opt/heimdallm/heimdallm" 2>/dev/null); \
+	 if [ -n "$$APP_RE" ]; then pkill -x -f "$$APP_RE" 2>/dev/null || true; \
+	 else echo "⚠  could not build the app pattern; leaving any running app alone"; fi
+	@DAEMON_RE=$$($(PKILL_ESCAPE) "$$HOME/.local/opt/heimdallm/heimdalld" 2>/dev/null); \
+	 if [ -n "$$DAEMON_RE" ]; then pkill -x -f "$$DAEMON_RE" 2>/dev/null || true; \
+	 else echo "⚠  could not build the daemon pattern; leaving any running daemon alone"; fi
 	@rm -f "$$HOME/.local/share/heimdallm/ui.pid"
 	rm -f "$$HOME/.local/share/applications/com.theburrowhub.heimdallm.desktop"
 	@for SIZE in 48 128 256 512; do \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ endif
 .PHONY: build-daemon build-app build-web build-cli test test-cli lint-cli test-web-tooling test-compose-isolation \
         test-smoke test-github test-e2e test-web dev-cli test-docker dev dev-daemon dev-stop \
         release-local package-macos install-service verify-linux run-linux test-install-macos \
+        test-install-linux \
         install-macos uninstall-macos install-linux uninstall-linux \
         setup up up-build up-daemon up-build-daemon down logs logs-daemon \
         ps restart clean clean-clones _check-docker _check-buildkit _check-env \
@@ -69,6 +70,12 @@ test-install-macos:
 	@sh -n scripts/macos-install.sh
 	@sh -n scripts/test-macos-install.sh
 	@./scripts/test-macos-install.sh
+
+# Guards the pkill invocations in dev-stop / install-linux / uninstall-linux.
+# Static-plus-behavioural; starts no daemon and touches no installed files.
+test-install-linux:
+	@sh -n scripts/test-linux-install.sh
+	@./scripts/test-linux-install.sh
 
 test-web-tooling:
 	@sh docker/scripts/tests/test-web-tooling.sh
@@ -149,7 +156,12 @@ dev-cli:
 	$(MAKE) -C cli dev
 
 dev-stop:
-	@pkill -f "$(DAEMON_BIN)" 2>/dev/null && echo "↓  Daemon parado" || true
+	@# -x is REQUIRED: without it the pattern also matches this recipe's own
+	@# `sh -c` command line, so pkill SIGTERMs the shell running it and dev-stop
+	@# aborts — taking `make dev` / `make dev-daemon` with it, whether or not a
+	@# daemon was running. The dev daemon is spawned with no arguments, so its
+	@# cmdline equals the pattern exactly. Guarded by scripts/test-linux-install.sh.
+	@pkill -x -f "$(DAEMON_BIN)" 2>/dev/null && echo "↓  Daemon parado" || true
 	@UI_PID_FILE="$$HOME/.local/share/heimdallm/ui.pid"; \
 	 if [ -f "$$UI_PID_FILE" ]; then \
 	   UI_PID=$$(cat "$$UI_PID_FILE"); \
@@ -742,6 +754,39 @@ install-linux: _check-linux verify-linux
 	  update-desktop-database "$$HOME/.local/share/applications/" 2>/dev/null || true
 	@command -v gtk-update-icon-cache >/dev/null 2>&1 && \
 	  gtk-update-icon-cache -q -t "$$HOME/.local/share/icons/hicolor/" 2>/dev/null || true
+	@# Stop the outgoing daemon — see #661. Replacing the binary above does not
+	@# touch the process already serving it (Linux unlink-while-running), and
+	@# DaemonLifecycle.ensureRunning() adopts any healthy daemon on the port
+	@# instead of spawning the one just installed. Left alone, the previous
+	@# release keeps running indefinitely: stale review logic, stale version in
+	@# the Status tab, no indication anything is wrong.
+	@#
+	@# Runs last, so a failure earlier in this target never takes down a working
+	@# daemon. SIGTERM (pkill's default) is the daemon's own graceful path — it
+	@# drains HTTP and sweeps in-flight agents.
+	@#
+	@# -x is REQUIRED, not a refinement: with -f alone the pattern also matches
+	@# the recipe's own `sh -c` command line, which contains the path — pkill
+	@# SIGTERMs the shell running it and the target dies mid-recipe (`|| true`
+	@# does not help; the signal hits the shell, not pkill). -x demands the whole
+	@# cmdline equal the pattern, which the daemon satisfies (spawned with no
+	@# arguments) and the longer shell cmdline does not. Guarded by
+	@# scripts/test-linux-install.sh.
+	@DAEMON="$$HOME/.local/opt/heimdallm/heimdalld"; \
+	if pkill -x -f "$$DAEMON" 2>/dev/null; then \
+	  echo ""; \
+	  echo "↓  Stopped the previously running daemon (it was serving the old binary)."; \
+	  for _ in 1 2 3 4 5 6 7 8 9 10; do \
+	    pgrep -x -f "$$DAEMON" >/dev/null 2>&1 || break; \
+	    sleep 1; \
+	  done; \
+	  if pgrep -x -f "$$DAEMON" >/dev/null 2>&1; then \
+	    echo "⚠  It has not exited after 10s — stop it manually, or it will keep"; \
+	    echo "   serving the old binary."; \
+	  else \
+	    echo "   Start the new one from the app: Server → Status → Start server."; \
+	  fi; \
+	fi
 	@echo ""
 	@echo "✅  Heimdallm installed:"
 	@echo "    Bundle:  $$HOME/.local/opt/heimdallm/"
@@ -774,6 +819,13 @@ uninstall-linux: _check-linux
 	@echo "▶  Uninstalling Heimdallm from $$HOME/.local/..."
 	@# Stop running instances (best-effort — ignored if nothing is running).
 	@#
+	@# -x is REQUIRED: with -f alone the pattern also matches the recipe's own
+	@# `sh -c` command line, so pkill SIGTERMs the shell running it and this
+	@# target dies here — before the desktop entry, icons and symlink below are
+	@# removed (`|| true` does not help; the signal hits the shell, not pkill).
+	@# -x demands the whole cmdline equal the pattern, which the shell's longer
+	@# cmdline never does. Guarded by scripts/test-linux-install.sh.
+	@#
 	@# Coverage caveat: pkill -f matches against /proc/<pid>/cmdline. This
 	@# catches:
 	@#   - launcher-launched Flutter apps (desktop entry Exec= is absolute,
@@ -788,8 +840,8 @@ uninstall-linux: _check-linux
 	@# running process, and the user can close the window whenever. We
 	@# intentionally avoid a broader `-f 'heimdallm'` match to prevent
 	@# hitting unrelated dev processes (e.g. `flutter run` of this repo).
-	@pkill -f "$$HOME/.local/opt/heimdallm/heimdallm" 2>/dev/null || true
-	@pkill -f "$$HOME/.local/opt/heimdallm/heimdalld" 2>/dev/null || true
+	@pkill -x -f "$$HOME/.local/opt/heimdallm/heimdallm" 2>/dev/null || true
+	@pkill -x -f "$$HOME/.local/opt/heimdallm/heimdalld" 2>/dev/null || true
 	@rm -f "$$HOME/.local/share/heimdallm/ui.pid"
 	rm -f "$$HOME/.local/share/applications/com.theburrowhub.heimdallm.desktop"
 	@for SIZE in 48 128 256 512; do \

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,13 @@ OS := $(shell uname -s)
 
 DAEMON_BIN  := $(shell pwd)/daemon/bin/heimdallm
 
+# pkill/pgrep -f treat their pattern as an ERE, so a path containing regex
+# metacharacters silently fails to match — a $HOME or checkout directory with
+# `+`, `(` or `[` in it would leave the daemon running with no error. The script
+# is the single implementation, shared with scripts/test-linux-install.sh, which
+# asserts it against a metacharacter-laden path.
+PKILL_ESCAPE = ./scripts/pkill-escape.sh
+
 ifeq ($(OS),Darwin)
   FLUTTER_DEVICE   := macos
   FLUTTER_BUILD    := flutter_app/build/macos/Build/Products
@@ -161,7 +168,8 @@ dev-stop:
 	@# aborts — taking `make dev` / `make dev-daemon` with it, whether or not a
 	@# daemon was running. The dev daemon is spawned with no arguments, so its
 	@# cmdline equals the pattern exactly. Guarded by scripts/test-linux-install.sh.
-	@pkill -x -f "$(DAEMON_BIN)" 2>/dev/null && echo "↓  Daemon parado" || true
+	@DAEMON_RE=$$($(PKILL_ESCAPE) "$(DAEMON_BIN)"); \
+	pkill -x -f "$$DAEMON_RE" 2>/dev/null && echo "↓  Daemon parado" || true
 	@UI_PID_FILE="$$HOME/.local/share/heimdallm/ui.pid"; \
 	 if [ -f "$$UI_PID_FILE" ]; then \
 	   UI_PID=$$(cat "$$UI_PID_FILE"); \
@@ -772,15 +780,15 @@ install-linux: _check-linux verify-linux
 	@# cmdline equal the pattern, which the daemon satisfies (spawned with no
 	@# arguments) and the longer shell cmdline does not. Guarded by
 	@# scripts/test-linux-install.sh.
-	@DAEMON="$$HOME/.local/opt/heimdallm/heimdalld"; \
-	if pkill -x -f "$$DAEMON" 2>/dev/null; then \
+	@DAEMON_RE=$$($(PKILL_ESCAPE) "$$HOME/.local/opt/heimdallm/heimdalld"); \
+	if pkill -x -f "$$DAEMON_RE" 2>/dev/null; then \
 	  echo ""; \
 	  echo "↓  Stopped the previously running daemon (it was serving the old binary)."; \
 	  for _ in 1 2 3 4 5 6 7 8 9 10; do \
-	    pgrep -x -f "$$DAEMON" >/dev/null 2>&1 || break; \
+	    pgrep -x -f "$$DAEMON_RE" >/dev/null 2>&1 || break; \
 	    sleep 1; \
 	  done; \
-	  if pgrep -x -f "$$DAEMON" >/dev/null 2>&1; then \
+	  if pgrep -x -f "$$DAEMON_RE" >/dev/null 2>&1; then \
 	    echo "⚠  It has not exited after 10s — stop it manually, or it will keep"; \
 	    echo "   serving the old binary."; \
 	  else \
@@ -840,8 +848,16 @@ uninstall-linux: _check-linux
 	@# running process, and the user can close the window whenever. We
 	@# intentionally avoid a broader `-f 'heimdallm'` match to prevent
 	@# hitting unrelated dev processes (e.g. `flutter run` of this repo).
-	@pkill -x -f "$$HOME/.local/opt/heimdallm/heimdallm" 2>/dev/null || true
-	@pkill -x -f "$$HOME/.local/opt/heimdallm/heimdalld" 2>/dev/null || true
+	@#
+	@# -x narrows this further: an app launched WITH arguments (e.g.
+	@# `~/.local/opt/heimdallm/heimdallm --some-flag`) no longer matches, since
+	@# its cmdline is longer than the pattern. Same rationale as above — the
+	@# rm -rf is safe against a running process — and plain -f never actually
+	@# reached that case anyway, because it killed this recipe's shell first.
+	@APP_RE=$$($(PKILL_ESCAPE) "$$HOME/.local/opt/heimdallm/heimdallm"); \
+	 pkill -x -f "$$APP_RE" 2>/dev/null || true
+	@DAEMON_RE=$$($(PKILL_ESCAPE) "$$HOME/.local/opt/heimdallm/heimdalld"); \
+	 pkill -x -f "$$DAEMON_RE" 2>/dev/null || true
 	@rm -f "$$HOME/.local/share/heimdallm/ui.pid"
 	rm -f "$$HOME/.local/share/applications/com.theburrowhub.heimdallm.desktop"
 	@for SIZE in 48 128 256 512; do \

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,23 @@
 # ── Platform detection ─────────────────────────────────────────────────────────
 OS := $(shell uname -s)
 
-DAEMON_BIN  := $(shell pwd)/daemon/bin/heimdallm
+# Anchored to this Makefile's directory for the same reason as PKILL_ESCAPE
+# below: with $(shell pwd) a `make -f /path/to/Makefile` from elsewhere pointed
+# dev-stop at a daemon path that does not exist. Identical from the repo root.
+DAEMON_BIN  := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/daemon/bin/heimdallm
 
 # pkill/pgrep -f treat their pattern as an ERE, so a path containing regex
 # metacharacters silently fails to match — a $HOME or checkout directory with
 # `+`, `(` or `[` in it would leave the daemon running with no error. The script
 # is the single implementation, shared with scripts/test-linux-install.sh, which
 # asserts it against a metacharacter-laden path.
-PKILL_ESCAPE = ./scripts/pkill-escape.sh
+#
+# Anchored to this Makefile's own directory rather than the cwd: with a relative
+# path, `make -f /path/to/Makefile` from elsewhere cannot find the script, and
+# since the callers now abort on an empty pattern that would turn an unusual
+# invocation into a hard failure of dev-stop and install-linux.
+REPO_ROOT_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+PKILL_ESCAPE = $(REPO_ROOT_DIR)scripts/pkill-escape.sh
 
 ifeq ($(OS),Darwin)
   FLUTTER_DEVICE   := macos

--- a/scripts/pkill-escape.sh
+++ b/scripts/pkill-escape.sh
@@ -25,4 +25,16 @@ if [ "$#" -ne 1 ]; then
   exit 2
 fi
 
+# sed is line-oriented, so a path containing an embedded newline would be
+# escaped per line and the resulting pattern could never match the target's
+# cmdline — pkill would silently no-op, which is the failure this script exists to
+# prevent. Refuse it loudly instead.
+# Counted rather than glob-matched: "$(printf '\n')" collapses to an empty
+# string in a command substitution, so `case $1 in *""*)` matches everything.
+# printf '%s' adds no trailing newline, so wc -l counts only embedded ones.
+if [ "$(printf '%s' "$1" | wc -l)" -gt 0 ]; then
+  echo "$(basename "$0"): refusing a path containing a newline" >&2
+  exit 2
+fi
+
 printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/[]^$.*+?(){}|[]/\\&/g'

--- a/scripts/pkill-escape.sh
+++ b/scripts/pkill-escape.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Escapes a literal path so it can be used as a pkill/pgrep -f pattern.
+#
+# `pkill -f` and `pgrep -f` treat their argument as an ERE, so a path containing
+# regex metacharacters does not match itself: a $HOME or checkout directory with
+# `+`, `(` or `[` in it makes the pattern silently miss, and the Makefile's
+# daemon-stop leaves the old daemon running with no error at all.
+#
+# Escaping runs in two passes because a single bracket expression cannot hold
+# both `\` and the rest of the metacharacters, and because `[.` inside a bracket
+# expression is read as the start of a POSIX collating symbol — hence `[` sits
+# last in the class. Backslashes go first so the escapes added by the second pass
+# are not escaped again.
+#
+# Used by the Makefile's dev-stop / install-linux / uninstall-linux and asserted
+# by scripts/test-linux-install.sh, so both share one implementation.
+#
+# Usage: pkill-escape.sh <literal-path>
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $(basename "$0") <literal-path>" >&2
+  exit 2
+fi
+
+printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/[]^$.*+?(){}|[]/\\&/g'

--- a/scripts/test-linux-install.sh
+++ b/scripts/test-linux-install.sh
@@ -147,6 +147,11 @@ fi
 #
 # No target process exists here on purpose: the self-match is what ends the
 # recipe, so the bug reproduces against nothing at all.
+#
+# PAT goes through the ENVIRONMENT, not make's command line: a command-line
+# `PAT=…` lands in make's own /proc cmdline, so `pkill -f` would match the make
+# process too and the test would only prove "something in the chain self-matched"
+# rather than pinning it on the recipe shell.
 mkdir -p "$WORK/opt"
 : > "$WORK/opt/heimdalld"
 
@@ -160,7 +165,7 @@ with-x:
 	@echo RECIPE-COMPLETED
 EOF
 
-out=$(make -C "$WORK" without-x PAT="$WORK/opt/heimdalld" 2>/dev/null || true)
+out=$(PAT="$WORK/opt/heimdalld" make -C "$WORK" without-x 2>/dev/null || true)
 case "$out" in
   *RECIPE-COMPLETED*)
     # BusyBox and other non-procps pkill may not match ancestors this way. The
@@ -171,7 +176,7 @@ case "$out" in
     pass 'pkill -f alone kills its own recipe shell — -x is load-bearing' ;;
 esac
 
-out=$(make -C "$WORK" with-x PAT="$WORK/opt/heimdalld" 2>/dev/null || true)
+out=$(PAT="$WORK/opt/heimdalld" make -C "$WORK" with-x 2>/dev/null || true)
 case "$out" in
   *RECIPE-COMPLETED*) pass 'pkill -x -f leaves the recipe shell alone' ;;
   *) fail 'pkill -x -f killed its own recipe shell' "output: $out" ;;
@@ -185,7 +190,7 @@ if [ "$actual" != "$WORK/opt/heimdalld" ]; then
 elif ! kill -0 "$TARGET" 2>/dev/null; then
   fail 'fixture exited before the assertion' 'cannot verify -x matches the daemon shape'
 else
-  make -C "$WORK" with-x PAT="$WORK/opt/heimdalld" >/dev/null 2>&1 || true
+  PAT="$WORK/opt/heimdalld" make -C "$WORK" with-x >/dev/null 2>&1 || true
   if wait_gone "$TARGET"; then
     pass 'pkill -x -f signals a process whose cmdline is exactly the path'
   else

--- a/scripts/test-linux-install.sh
+++ b/scripts/test-linux-install.sh
@@ -120,15 +120,20 @@ wait_gone() {
 # Flag-order independent: -x may appear anywhere among the invocation's flags,
 # bundled (-xf) or spelled --exact. Comment lines are excluded — the recipes
 # mention plain `pkill -f` on purpose, to explain why -x is required.
+# Every invocation on the line is checked, not just the last: extracting with a
+# greedy `.*` prefix would inspect only the final one, so a line carrying two
+# calls could hide a bare `pkill -f` behind a correct neighbour.
 offenders=$(
   grep -nE '(pkill|pgrep)[[:space:]]' "$MAKEFILE" |
     grep -vE '^[0-9]+:[[:space:]]*@?#' |
     while IFS= read -r line; do
-      flags=$(printf '%s' "$line" | sed -n 's/.*\(pkill\|pgrep\)\([^"]*\).*/\2/p')
-      case "$flags" in
-        *-x*|*--exact*) ;;
-        *) printf '%s\n' "$line" ;;
-      esac
+      printf '%s\n' "$line" | grep -oE '(pkill|pgrep)[^"]*' |
+        while IFS= read -r invocation; do
+          case "$invocation" in
+            *-x*|*--exact*) ;;
+            *) printf '%s\n' "$line" ;;
+          esac
+        done
     done
 )
 if [ -z "$offenders" ]; then

--- a/scripts/test-linux-install.sh
+++ b/scripts/test-linux-install.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+#
+# Regression guard for the pkill invocations in the Makefile's Linux targets.
+#
+# `pkill -f <pattern>` matches against /proc/<pid>/cmdline. Inside a make recipe
+# that contains shell metacharacters, make runs the line via `sh -c`, whose own
+# cmdline embeds the pattern — so pkill signals the shell running it and the
+# recipe dies mid-target. Nothing about the output makes this visible: the
+# target simply stops, having already printed its progress lines.
+#
+# That silently broke `make dev` (dev-stop aborted before launching anything)
+# and `make uninstall-linux` (aborted before removing the desktop entry, icons
+# and PATH symlink), and would have broken install-linux's daemon stop (#661).
+#
+# The fix is `-x`, which requires the whole cmdline to equal the pattern: the
+# daemon and app are spawned with no arguments so they match, while the longer
+# shell cmdline cannot. These tests pin that down behaviourally rather than by
+# inspection, because the failure mode is invisible in normal output.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && /bin/pwd -P)
+REPO_ROOT=$(CDPATH= cd "$SCRIPT_DIR/.." && /bin/pwd -P)
+MAKEFILE="$REPO_ROOT/Makefile"
+
+TEST_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  TEST_COUNT=$((TEST_COUNT + 1))
+  printf 'ok %d - %s\n' "$TEST_COUNT" "$1"
+}
+
+fail() {
+  TEST_COUNT=$((TEST_COUNT + 1))
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'not ok %d - %s\n' "$TEST_COUNT" "$1" >&2
+  if [ "$#" -gt 1 ]; then
+    printf '  %s\n' "$2" >&2
+  fi
+}
+
+if ! command -v pkill >/dev/null 2>&1 || ! command -v pgrep >/dev/null 2>&1; then
+  printf '1..0 # SKIP pkill/pgrep unavailable\n'
+  exit 0
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# ── 1. Static: every pkill/pgrep that targets a process must pass -x ──────────
+#
+# Matches invocations only (not the explanatory comments, which mention `pkill
+# -f` deliberately). Comment lines in these recipes start with `@#` or `#`.
+offenders=$(
+  grep -nE '^[[:space:]]*@?[^#]*(pkill|pgrep)[[:space:]]' "$MAKEFILE" |
+    grep -vE '(pkill|pgrep)[[:space:]]+(-[a-zA-Z]*x[a-zA-Z]*[[:space:]])' ||
+    true
+)
+if [ -z "$offenders" ]; then
+  pass 'every pkill/pgrep invocation in the Makefile passes -x'
+else
+  fail 'a pkill/pgrep invocation is missing -x (it will kill its own recipe shell)' \
+    "$offenders"
+fi
+
+# ── 2. Behavioural: -f alone kills the recipe, -x -f does not ─────────────────
+#
+# No target process exists here on purpose: the self-match is what ends the
+# recipe, so the bug reproduces against nothing at all.
+mkdir -p "$WORK/opt"
+FAKE="$WORK/opt/heimdalld"
+: > "$FAKE"
+
+cat > "$WORK/Makefile" <<EOF
+without-x:
+	@pkill -f "$FAKE" 2>/dev/null || true
+	@echo RECIPE-COMPLETED
+
+with-x:
+	@pkill -x -f "$FAKE" 2>/dev/null || true
+	@echo RECIPE-COMPLETED
+EOF
+
+out=$(make -C "$WORK" without-x 2>/dev/null || true)
+case "$out" in
+  *RECIPE-COMPLETED*)
+    fail 'pkill -f should self-match the recipe shell (test is no longer proving anything)' \
+      "recipe survived; this environment's pkill may differ" ;;
+  *)
+    pass 'pkill -f alone kills its own recipe shell — -x is load-bearing' ;;
+esac
+
+out=$(make -C "$WORK" with-x 2>/dev/null || true)
+case "$out" in
+  *RECIPE-COMPLETED*) pass 'pkill -x -f leaves the recipe shell alone' ;;
+  *) fail 'pkill -x -f killed its own recipe shell' "output: $out" ;;
+esac
+
+# ── 3. Behavioural: -x -f still signals the intended process ─────────────────
+#
+# The daemon's cmdline is exactly its absolute path (spawned with no arguments).
+# /bin/cat reading a fifo reproduces that shape: a real binary, argv = [path],
+# blocked rather than spinning. A shell script would not — its cmdline carries
+# the interpreter, so it could never match -x and the test would pass vacuously.
+cp /bin/cat "$FAKE"
+chmod +x "$FAKE"
+mkfifo "$WORK/fifo"
+sleep 30 > "$WORK/fifo" &
+WRITER=$!
+"$FAKE" < "$WORK/fifo" > /dev/null &
+TARGET=$!
+sleep 1
+
+if ! kill -0 "$TARGET" 2>/dev/null; then
+  fail 'fixture process did not start' 'cannot verify -x matches the daemon shape'
+else
+  actual=$(tr '\0' ' ' < "/proc/$TARGET/cmdline" 2>/dev/null | sed 's/ *$//' || echo '')
+  if [ "$actual" != "$FAKE" ]; then
+    fail 'fixture cmdline is not exactly the binary path' "got: '$actual'"
+  else
+    make -C "$WORK" with-x >/dev/null 2>&1 || true
+    sleep 1
+    if kill -0 "$TARGET" 2>/dev/null; then
+      fail 'pkill -x -f did not signal a process whose cmdline is exactly the path' \
+        'install-linux would leave the previous daemon running'
+    else
+      pass 'pkill -x -f signals a process whose cmdline is exactly the path'
+    fi
+  fi
+fi
+kill "$TARGET" "$WRITER" 2>/dev/null || true
+wait "$TARGET" "$WRITER" 2>/dev/null || true
+
+printf '1..%d\n' "$TEST_COUNT"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  printf '# %d of %d tests failed\n' "$FAIL_COUNT" "$TEST_COUNT" >&2
+  exit 1
+fi
+printf '# all %d tests passed\n' "$TEST_COUNT"

--- a/scripts/test-linux-install.sh
+++ b/scripts/test-linux-install.sh
@@ -180,28 +180,39 @@ fi
 SPAWN_SITES="flutter_app/lib/core/daemon/daemon_lifecycle.dart
 flutter_app/lib/core/platform/platform_services_desktop.dart"
 spawn_offenders=""
-spawn_found=0
 for rel in $SPAWN_SITES; do
   f="$REPO_ROOT/$rel"
-  [ -f "$f" ] || { spawn_offenders="$spawn_offenders$rel: file not found
-"; continue; }
-  while IFS= read -r call; do
-    spawn_found=$((spawn_found + 1))
-    # Everything after the first argument must start with an empty list.
+  if [ ! -f "$f" ]; then
+    spawn_offenders="$spawn_offenders$rel: file not found
+"
+    continue
+  fi
+  # Counted PER FILE, not globally: a global counter would still pass if the
+  # daemon spawn moved to a new file while the other listed site kept its own.
+  # Each listed file must contribute at least one call.
+  calls=$(grep -c 'Process\.start(' "$f" || true)
+  if [ "${calls:-0}" -eq 0 ]; then
+    spawn_offenders="$spawn_offenders$rel: no Process.start call (did the spawn move?)
+"
+    continue
+  fi
+  # The argument list is read from the call site joined onto one logical line, so
+  # a call wrapped across lines — or written as `const []` — is judged on its
+  # arguments rather than on its formatting.
+  joined=$(tr '\n' ' ' < "$f" | sed 's/  */ /g')
+  offenders_here=$(printf '%s\n' "$joined" | grep -oE 'Process\.start\([^)]*' || true)
+  printf '%s\n' "$offenders_here" | while IFS= read -r call; do
+    [ -n "$call" ] || continue
     case "$call" in
-      *"Process.start("*", []"*) ;;
-      *) spawn_offenders="$spawn_offenders$rel: $call
-" ;;
+      *", []"*|*", const []"*) ;;
+      *) printf '%s: %s\n' "$rel" "$call" ;;
     esac
-  done <<EOF
-$(grep -n 'Process\.start(' "$f" || true)
-EOF
+  done >> "$WORK/spawn_offenders"
 done
-if [ "$spawn_found" -eq 0 ]; then
-  fail 'no Process.start call found at the known spawn sites' \
-    'the -x contract is unverified; update SPAWN_SITES if the code moved'
-elif [ -n "$(printf '%s' "$spawn_offenders" | tr -d '[:space:]')" ]; then
-  fail 'a daemon/app spawn passes arguments, which breaks the pkill -x contract' \
+[ -f "$WORK/spawn_offenders" ] || : > "$WORK/spawn_offenders"
+spawn_offenders="$spawn_offenders$(cat "$WORK/spawn_offenders")"
+if [ -n "$(printf '%s' "$spawn_offenders" | tr -d '[:space:]')" ]; then
+  fail 'a daemon/app spawn breaks the pkill -x contract (arguments, or site moved)' \
     "$spawn_offenders"
 else
   pass 'the daemon/app spawn sites still pass an empty argument list'

--- a/scripts/test-linux-install.sh
+++ b/scripts/test-linux-install.sh
@@ -2,20 +2,24 @@
 #
 # Regression guard for the pkill invocations in the Makefile's Linux targets.
 #
-# `pkill -f <pattern>` matches against /proc/<pid>/cmdline. Inside a make recipe
-# that contains shell metacharacters, make runs the line via `sh -c`, whose own
-# cmdline embeds the pattern — so pkill signals the shell running it and the
-# recipe dies mid-target. Nothing about the output makes this visible: the
-# target simply stops, having already printed its progress lines.
+# Two failure modes, both silent:
 #
-# That silently broke `make dev` (dev-stop aborted before launching anything)
-# and `make uninstall-linux` (aborted before removing the desktop entry, icons
-# and PATH symlink), and would have broken install-linux's daemon stop (#661).
+# 1. `pkill -f <pattern>` matches against /proc/<pid>/cmdline. Inside a make
+#    recipe that contains shell metacharacters, make runs the line via `sh -c`,
+#    whose own cmdline embeds the pattern — so pkill signals the shell running it
+#    and the recipe dies mid-target. Nothing in the output makes this visible:
+#    the target simply stops, having already printed its progress lines. That
+#    broke `make dev` (dev-stop aborted before launching anything) and
+#    `make uninstall-linux` (aborted before removing the desktop entry, icons and
+#    PATH symlink), and would have broken install-linux's daemon stop (#661).
+#    The fix is `-x`, which requires the whole cmdline to equal the pattern.
 #
-# The fix is `-x`, which requires the whole cmdline to equal the pattern: the
-# daemon and app are spawned with no arguments so they match, while the longer
-# shell cmdline cannot. These tests pin that down behaviourally rather than by
-# inspection, because the failure mode is invisible in normal output.
+# 2. The pattern is an ERE, so a path containing regex metacharacters (`+`, `(`,
+#    `[` — all legal in a $HOME or a checkout directory) fails to match and
+#    leaves the process running, with no error. The fix is PKILL_ESCAPE.
+#
+# Both are asserted behaviourally, not by inspection, because neither leaves any
+# trace in normal output.
 
 set -eu
 
@@ -23,12 +27,31 @@ SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && /bin/pwd -P)
 REPO_ROOT=$(CDPATH= cd "$SCRIPT_DIR/.." && /bin/pwd -P)
 MAKEFILE="$REPO_ROOT/Makefile"
 
+# The behavioural tests read /proc and rely on procps-style pkill semantics.
+# pkill and pgrep both exist on macOS/BSD — the platform this repo is primarily
+# developed on — while /proc does not, so guarding on the binaries alone would
+# make this target fail deterministically on a correct tree. A test that always
+# fails locally is a test people learn to ignore.
+if [ "$(uname -s)" != Linux ] || [ ! -d /proc ]; then
+  printf '1..0 # SKIP requires Linux /proc (pkill -f semantics under test)\n'
+  exit 0
+fi
+if ! command -v pkill >/dev/null 2>&1 || ! command -v pgrep >/dev/null 2>&1; then
+  printf '1..0 # SKIP pkill/pgrep unavailable\n'
+  exit 0
+fi
+
 TEST_COUNT=0
 FAIL_COUNT=0
 
 pass() {
   TEST_COUNT=$((TEST_COUNT + 1))
   printf 'ok %d - %s\n' "$TEST_COUNT" "$1"
+}
+
+skip() {
+  TEST_COUNT=$((TEST_COUNT + 1))
+  printf 'ok %d - %s # SKIP %s\n' "$TEST_COUNT" "$1" "$2"
 }
 
 fail() {
@@ -40,22 +63,73 @@ fail() {
   fi
 }
 
-if ! command -v pkill >/dev/null 2>&1 || ! command -v pgrep >/dev/null 2>&1; then
-  printf '1..0 # SKIP pkill/pgrep unavailable\n'
-  exit 0
-fi
-
 WORK=$(mktemp -d)
-trap 'rm -rf "$WORK"' EXIT
+: > "$WORK/writers"
+cleanup() {
+  while read -r w; do kill "$w" 2>/dev/null || true; done < "$WORK/writers"
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# Starts a process whose cmdline is EXACTLY $1 and echoes its pid. /bin/cat on a
+# fifo reproduces the daemon's shape: a real binary with argv = [path], blocked
+# rather than spinning. A shell script would not — its cmdline would carry the
+# interpreter, could never match -x, and every assertion below would pass
+# vacuously. The writer outlives the assertions by an hour, and callers re-check
+# the process is alive immediately before acting, so a loaded machine cannot turn
+# an early exit into a false pass.
+start_fixture() {
+  _sf_path=$1
+  mkdir -p "$(dirname "$_sf_path")"
+  cp /bin/cat "$_sf_path"
+  chmod +x "$_sf_path"
+  # mktemp, not a counter: this runs inside a command substitution, so a shell
+  # variable incremented here would not survive into the next call.
+  _sf_fifo=$(mktemp -u "$WORK/fifo.XXXXXX")
+  mkfifo "$_sf_fifo"
+  sleep 3600 > "$_sf_fifo" &
+  echo "$!" >> "$WORK/writers"
+  "$_sf_path" < "$_sf_fifo" > /dev/null &
+  _sf_pid=$!
+  # Poll rather than sleep: a fixed sleep is a race on a loaded runner.
+  _sf_i=0
+  while [ "$_sf_i" -lt 50 ] && [ ! -r "/proc/$_sf_pid/cmdline" ]; do
+    _sf_i=$((_sf_i + 1))
+    sleep 0.1
+  done
+  echo "$_sf_pid"
+}
+
+cmdline_of() {
+  tr '\0' '\n' < "/proc/$1/cmdline" 2>/dev/null | head -1
+}
+
+# Waits up to 3s for $1 to exit; returns 0 if it did.
+wait_gone() {
+  _wg_i=0
+  while [ "$_wg_i" -lt 30 ]; do
+    kill -0 "$1" 2>/dev/null || return 0
+    _wg_i=$((_wg_i + 1))
+    sleep 0.1
+  done
+  ! kill -0 "$1" 2>/dev/null
+}
 
 # ── 1. Static: every pkill/pgrep that targets a process must pass -x ──────────
 #
-# Matches invocations only (not the explanatory comments, which mention `pkill
-# -f` deliberately). Comment lines in these recipes start with `@#` or `#`.
+# Flag-order independent: -x may appear anywhere among the invocation's flags,
+# bundled (-xf) or spelled --exact. Comment lines are excluded — the recipes
+# mention plain `pkill -f` on purpose, to explain why -x is required.
 offenders=$(
-  grep -nE '^[[:space:]]*@?[^#]*(pkill|pgrep)[[:space:]]' "$MAKEFILE" |
-    grep -vE '(pkill|pgrep)[[:space:]]+(-[a-zA-Z]*x[a-zA-Z]*[[:space:]])' ||
-    true
+  grep -nE '(pkill|pgrep)[[:space:]]' "$MAKEFILE" |
+    grep -vE '^[0-9]+:[[:space:]]*@?#' |
+    while IFS= read -r line; do
+      flags=$(printf '%s' "$line" | sed -n 's/.*\(pkill\|pgrep\)\([^"]*\).*/\2/p')
+      case "$flags" in
+        *-x*|*--exact*) ;;
+        *) printf '%s\n' "$line" ;;
+      esac
+    done
 )
 if [ -z "$offenders" ]; then
   pass 'every pkill/pgrep invocation in the Makefile passes -x'
@@ -69,68 +143,89 @@ fi
 # No target process exists here on purpose: the self-match is what ends the
 # recipe, so the bug reproduces against nothing at all.
 mkdir -p "$WORK/opt"
-FAKE="$WORK/opt/heimdalld"
-: > "$FAKE"
+: > "$WORK/opt/heimdalld"
 
 cat > "$WORK/Makefile" <<EOF
 without-x:
-	@pkill -f "$FAKE" 2>/dev/null || true
+	@pkill -f "\$(PAT)" 2>/dev/null || true
 	@echo RECIPE-COMPLETED
 
 with-x:
-	@pkill -x -f "$FAKE" 2>/dev/null || true
+	@pkill -x -f "\$(PAT)" 2>/dev/null || true
 	@echo RECIPE-COMPLETED
 EOF
 
-out=$(make -C "$WORK" without-x 2>/dev/null || true)
+out=$(make -C "$WORK" without-x PAT="$WORK/opt/heimdalld" 2>/dev/null || true)
 case "$out" in
   *RECIPE-COMPLETED*)
-    fail 'pkill -f should self-match the recipe shell (test is no longer proving anything)' \
-      "recipe survived; this environment's pkill may differ" ;;
+    # BusyBox and other non-procps pkill may not match ancestors this way. The
+    # -x fix stays correct; this environment just cannot demonstrate the bug.
+    skip 'pkill -f alone kills its own recipe shell — -x is load-bearing' \
+      'this pkill does not self-match the recipe shell' ;;
   *)
     pass 'pkill -f alone kills its own recipe shell — -x is load-bearing' ;;
 esac
 
-out=$(make -C "$WORK" with-x 2>/dev/null || true)
+out=$(make -C "$WORK" with-x PAT="$WORK/opt/heimdalld" 2>/dev/null || true)
 case "$out" in
   *RECIPE-COMPLETED*) pass 'pkill -x -f leaves the recipe shell alone' ;;
   *) fail 'pkill -x -f killed its own recipe shell' "output: $out" ;;
 esac
 
-# ── 3. Behavioural: -x -f still signals the intended process ─────────────────
-#
-# The daemon's cmdline is exactly its absolute path (spawned with no arguments).
-# /bin/cat reading a fifo reproduces that shape: a real binary, argv = [path],
-# blocked rather than spinning. A shell script would not — its cmdline carries
-# the interpreter, so it could never match -x and the test would pass vacuously.
-cp /bin/cat "$FAKE"
-chmod +x "$FAKE"
-mkfifo "$WORK/fifo"
-sleep 30 > "$WORK/fifo" &
-WRITER=$!
-"$FAKE" < "$WORK/fifo" > /dev/null &
-TARGET=$!
-sleep 1
-
-if ! kill -0 "$TARGET" 2>/dev/null; then
-  fail 'fixture process did not start' 'cannot verify -x matches the daemon shape'
+# ── 3. Behavioural: -x -f signals the intended process ───────────────────────
+TARGET=$(start_fixture "$WORK/opt/heimdalld")
+actual=$(cmdline_of "$TARGET")
+if [ "$actual" != "$WORK/opt/heimdalld" ]; then
+  fail 'fixture cmdline is not exactly the binary path' "got: '$actual'"
+elif ! kill -0 "$TARGET" 2>/dev/null; then
+  fail 'fixture exited before the assertion' 'cannot verify -x matches the daemon shape'
 else
-  actual=$(tr '\0' ' ' < "/proc/$TARGET/cmdline" 2>/dev/null | sed 's/ *$//' || echo '')
-  if [ "$actual" != "$FAKE" ]; then
-    fail 'fixture cmdline is not exactly the binary path' "got: '$actual'"
+  make -C "$WORK" with-x PAT="$WORK/opt/heimdalld" >/dev/null 2>&1 || true
+  if wait_gone "$TARGET"; then
+    pass 'pkill -x -f signals a process whose cmdline is exactly the path'
   else
-    make -C "$WORK" with-x >/dev/null 2>&1 || true
-    sleep 1
-    if kill -0 "$TARGET" 2>/dev/null; then
-      fail 'pkill -x -f did not signal a process whose cmdline is exactly the path' \
-        'install-linux would leave the previous daemon running'
-    else
-      pass 'pkill -x -f signals a process whose cmdline is exactly the path'
-    fi
+    fail 'pkill -x -f did not signal a process whose cmdline is exactly the path' \
+      'install-linux would leave the previous daemon running'
   fi
 fi
-kill "$TARGET" "$WRITER" 2>/dev/null || true
-wait "$TARGET" "$WRITER" 2>/dev/null || true
+
+# ── 4. Behavioural: the Makefile's escaping survives regex metacharacters ────
+#
+# Calls the same scripts/pkill-escape.sh the Makefile uses, so this tracks the
+# real implementation rather than a copy of it.
+ESCAPE="$SCRIPT_DIR/pkill-escape.sh"
+if [ ! -x "$ESCAPE" ]; then
+  fail 'scripts/pkill-escape.sh is missing or not executable' 'escaping is unverified'
+else
+  META="$WORK/we+ird(dir)[x]/opt/heimdalld"
+  TARGET=$(start_fixture "$META")
+  if ! kill -0 "$TARGET" 2>/dev/null; then
+    fail 'metacharacter fixture did not start' 'escaping is unverified'
+  else
+    if pgrep -x -f "$META" >/dev/null 2>&1; then
+      skip 'an unescaped metacharacter path fails to match' \
+        'this pgrep matched it literally, so escaping cannot be demonstrated'
+    else
+      pass 'an unescaped metacharacter path fails to match (escaping is needed)'
+    fi
+
+    META_RE=$("$ESCAPE" "$META")
+    if pgrep -x -f "$META_RE" >/dev/null 2>&1; then
+      pass 'PKILL_ESCAPE makes a metacharacter path match'
+    else
+      fail 'PKILL_ESCAPE does not match a path containing regex metacharacters' \
+        "pattern: $META_RE"
+    fi
+
+    OTHER_RE=$("$ESCAPE" "$WORK/other/heimdalld")
+    if pgrep -x -f "$OTHER_RE" >/dev/null 2>&1; then
+      fail 'the escaped pattern matched an unrelated path' 'escaping is too loose'
+    else
+      pass 'the escaped pattern does not match an unrelated path'
+    fi
+    kill "$TARGET" 2>/dev/null || true
+  fi
+fi
 
 printf '1..%d\n' "$TEST_COUNT"
 if [ "$FAIL_COUNT" -gt 0 ]; then

--- a/scripts/test-linux-install.sh
+++ b/scripts/test-linux-install.sh
@@ -20,26 +20,16 @@
 #
 # Both are asserted behaviourally, not by inspection, because neither leaves any
 # trace in normal output.
+#
+# The static half also ties the Makefile to the invariant it depends on: `-x` only
+# matches while the daemon and app are exec'd with an empty argv, and that lives
+# in Dart. The static tests run everywhere; only the behavioural half needs Linux.
 
 set -eu
 
 SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && /bin/pwd -P)
 REPO_ROOT=$(CDPATH= cd "$SCRIPT_DIR/.." && /bin/pwd -P)
 MAKEFILE="$REPO_ROOT/Makefile"
-
-# The behavioural tests read /proc and rely on procps-style pkill semantics.
-# pkill and pgrep both exist on macOS/BSD — the platform this repo is primarily
-# developed on — while /proc does not, so guarding on the binaries alone would
-# make this target fail deterministically on a correct tree. A test that always
-# fails locally is a test people learn to ignore.
-if [ "$(uname -s)" != Linux ] || [ ! -d /proc ]; then
-  printf '1..0 # SKIP requires Linux /proc (pkill -f semantics under test)\n'
-  exit 0
-fi
-if ! command -v pkill >/dev/null 2>&1 || ! command -v pgrep >/dev/null 2>&1; then
-  printf '1..0 # SKIP pkill/pgrep unavailable\n'
-  exit 0
-fi
 
 TEST_COUNT=0
 FAIL_COUNT=0
@@ -62,6 +52,21 @@ fail() {
     printf '  %s\n' "$2" >&2
   fi
 }
+
+# The behavioural tests read /proc and rely on procps-style pkill semantics.
+# pkill and pgrep both exist on macOS/BSD — the platform this repo is primarily
+# developed on — while /proc does not. Only that half is gated: the static checks
+# below are portable, and they are the ones that catch a dropped -x or a changed
+# spawn site, which matters most on the platform where the rest cannot run.
+BEHAVIOURAL=yes
+SKIP_WHY=""
+if [ "$(uname -s)" != Linux ] || [ ! -d /proc ]; then
+  BEHAVIOURAL=no
+  SKIP_WHY="requires Linux /proc (pkill -f semantics under test)"
+elif ! command -v pkill >/dev/null 2>&1 || ! command -v pgrep >/dev/null 2>&1; then
+  BEHAVIOURAL=no
+  SKIP_WHY="pkill/pgrep unavailable"
+fi
 
 WORK=$(mktemp -d)
 : > "$WORK/writers"
@@ -123,27 +128,105 @@ wait_gone() {
 # Every invocation on the line is checked, not just the last: extracting with a
 # greedy `.*` prefix would inspect only the final one, so a line carrying two
 # calls could hide a bare `pkill -f` behind a correct neighbour.
+#
+# Quoted arguments are blanked out BEFORE extracting, for two reasons: an
+# extraction that stops at the first double quote would miss a flag written after
+# the pattern (`pkill -f "$PAT" -x`, legal under GNU getopt permutation) and
+# report it as an offender; and a bare `*-x*` glob over the raw text would accept
+# an "-x" appearing inside an argument rather than as a flag. Flags are then
+# matched as whole tokens beginning with "-".
 offenders=$(
   grep -nE '(pkill|pgrep)[[:space:]]' "$MAKEFILE" |
     grep -vE '^[0-9]+:[[:space:]]*@?#' |
     while IFS= read -r line; do
-      printf '%s\n' "$line" | grep -oE '(pkill|pgrep)[^"]*' |
+      # Replace every "…" with a placeholder token so quoted patterns cannot
+      # contribute flag-looking text, and cannot terminate the extraction.
+      unquoted=$(printf '%s\n' "$line" | sed 's/"[^"]*"/QUOTED/g')
+      printf '%s\n' "$unquoted" | grep -oE '(pkill|pgrep)[^;|&]*' |
         while IFS= read -r invocation; do
-          case "$invocation" in
-            *-x*|*--exact*) ;;
-            *) printf '%s\n' "$line" ;;
-          esac
+          exact=no
+          for token in $invocation; do
+            case "$token" in
+              --exact) exact=yes ;;
+              --*) ;;
+              -*x*) exact=yes ;;
+            esac
+          done
+          [ "$exact" = yes ] || printf '%s\n' "$line"
         done
     done
 )
-if [ -z "$offenders" ]; then
+if [ ! -r "$MAKEFILE" ]; then
+  fail 'the Makefile is not readable' "$MAKEFILE — the -x check would pass vacuously"
+elif [ -z "$(grep -cE '(pkill|pgrep)[[:space:]]' "$MAKEFILE")" ] ||
+  [ "$(grep -cE '(pkill|pgrep)[[:space:]]' "$MAKEFILE")" -eq 0 ]; then
+  fail 'no pkill/pgrep invocation found in the Makefile' \
+    'the -x check would pass vacuously; update this guard if the calls moved'
+elif [ -z "$offenders" ]; then
   pass 'every pkill/pgrep invocation in the Makefile passes -x'
 else
   fail 'a pkill/pgrep invocation is missing -x (it will kill its own recipe shell)' \
     "$offenders"
 fi
 
-# ── 2. Behavioural: -f alone kills the recipe, -x -f does not ─────────────────
+# ── 2. Static: the spawn sites must keep passing an empty argument list ───────
+#
+# `-x` requires the target's whole cmdline to equal the binary path, which holds
+# only while the daemon and app are exec'd with no arguments. That invariant lives
+# in Dart, far from the Makefile that depends on it: if a future change adds a
+# flag to either spawn, `pkill -x -f` silently stops matching and install-linux
+# again leaves the old daemon running with no error. Comments cannot catch that,
+# so it is asserted here.
+SPAWN_SITES="flutter_app/lib/core/daemon/daemon_lifecycle.dart
+flutter_app/lib/core/platform/platform_services_desktop.dart"
+spawn_offenders=""
+spawn_found=0
+for rel in $SPAWN_SITES; do
+  f="$REPO_ROOT/$rel"
+  [ -f "$f" ] || { spawn_offenders="$spawn_offenders$rel: file not found
+"; continue; }
+  while IFS= read -r call; do
+    spawn_found=$((spawn_found + 1))
+    # Everything after the first argument must start with an empty list.
+    case "$call" in
+      *"Process.start("*", []"*) ;;
+      *) spawn_offenders="$spawn_offenders$rel: $call
+" ;;
+    esac
+  done <<EOF
+$(grep -n 'Process\.start(' "$f" || true)
+EOF
+done
+if [ "$spawn_found" -eq 0 ]; then
+  fail 'no Process.start call found at the known spawn sites' \
+    'the -x contract is unverified; update SPAWN_SITES if the code moved'
+elif [ -n "$(printf '%s' "$spawn_offenders" | tr -d '[:space:]')" ]; then
+  fail 'a daemon/app spawn passes arguments, which breaks the pkill -x contract' \
+    "$spawn_offenders"
+else
+  pass 'the daemon/app spawn sites still pass an empty argument list'
+fi
+
+# ── Behavioural half (tests 3-7): gated on Linux + /proc ─────────────────────
+if [ "$BEHAVIOURAL" = no ]; then
+  skip 'pkill -f alone kills its own recipe shell — -x is load-bearing' "$SKIP_WHY"
+  skip 'pkill -x -f leaves the recipe shell alone' "$SKIP_WHY"
+  skip 'pkill -x -f signals a process whose cmdline is exactly the path' "$SKIP_WHY"
+  skip 'an unescaped metacharacter path fails to match (escaping is needed)' "$SKIP_WHY"
+  skip 'PKILL_ESCAPE makes a metacharacter path match' "$SKIP_WHY"
+  skip 'the escaped pattern does not match an unrelated path' "$SKIP_WHY"
+  printf '1..%d\n' "$TEST_COUNT"
+  # Honours FAIL_COUNT: an early exit that ignored it would let a failing static
+  # test report success on every non-Linux machine.
+  if [ "$FAIL_COUNT" -gt 0 ]; then
+    printf '# %d of %d tests failed\n' "$FAIL_COUNT" "$TEST_COUNT" >&2
+    exit 1
+  fi
+  printf '# static tests passed; behavioural tests skipped (%s)\n' "$SKIP_WHY"
+  exit 0
+fi
+
+# ── 3. Behavioural: -f alone kills the recipe, -x -f does not ─────────────────
 #
 # No target process exists here on purpose: the self-match is what ends the
 # recipe, so the bug reproduces against nothing at all.
@@ -182,7 +265,7 @@ case "$out" in
   *) fail 'pkill -x -f killed its own recipe shell' "output: $out" ;;
 esac
 
-# ── 3. Behavioural: -x -f signals the intended process ───────────────────────
+# ── 4. Behavioural: -x -f signals the intended process ───────────────────────
 TARGET=$(start_fixture "$WORK/opt/heimdalld")
 actual=$(cmdline_of "$TARGET")
 if [ "$actual" != "$WORK/opt/heimdalld" ]; then
@@ -199,7 +282,7 @@ else
   fi
 fi
 
-# ── 4. Behavioural: the Makefile's escaping survives regex metacharacters ────
+# ── 5. Behavioural: the Makefile's escaping survives regex metacharacters ────
 #
 # Calls the same scripts/pkill-escape.sh the Makefile uses, so this tracks the
 # real implementation rather than a copy of it.


### PR DESCRIPTION
Closes #661.

`install-linux` replaced the binaries but left the running daemon alone, and `DaemonLifecycle.ensureRunning()` adopts any healthy daemon on the port rather than spawning the one just installed. Every upgrade kept serving the previous release indefinitely — stale review logic, stale version in the Status tab, no indication anything was wrong.

**Changes:**
- `install-linux`: SIGTERM the previous daemon after staging, wait up to 10s, and point at Server → Status → Start server. Runs last, so a failure earlier in the target never takes down a working daemon
- `dev-stop`, `uninstall-linux`: add a missing `-x` (see below)
- `scripts/test-linux-install.sh`: TAP regression guard, wired to a new `test-install-linux` target. Starts no daemon and touches no installed files

**Second defect found while fixing this** — worth a look, it is not cosmetic. `pkill -f <path>` inside a make recipe also matches the recipe's own `sh -c` command line, which embeds the pattern. pkill SIGTERMs the shell running it and the target dies mid-recipe, whether or not anything matched; `|| true` does not help, because the signal hits the shell rather than pkill. Consequences on `main` today:

- `dev-stop` aborts at its first line, taking `make dev` and `make dev-daemon` with it
- `uninstall-linux` aborts before removing the desktop entry, icons and PATH symlink

Reproduced with the `dev-stop` line verbatim and nothing running — `make` reports `*** [t] Terminated` and `REACHED-END` never prints:

```make
DAEMON_BIN := $(shell pwd)/daemon/bin/heimdallm
t:
	@pkill -f "$(DAEMON_BIN)" 2>/dev/null && echo "parado" || true
	@echo REACHED-END
```

`-x` requires the whole cmdline to equal the pattern: the daemon and app are spawned with no arguments so they still match, while the longer shell cmdline cannot.

The guard is static (every `pkill`/`pgrep` in the Makefile passes `-x`) plus behavioural (`-f` alone kills its recipe; `-x -f` does not, and still signals a process whose cmdline is exactly the path). The behavioural half matters because the failure leaves no trace in normal output — the target just stops after printing its progress lines.
