### PR TITLE
fix(pipeline): re-check HEAD SHA before publishing a review

### DIFF
--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -46,6 +46,31 @@ type HeadSHAResolver interface {
 	GetPRHeadSHA(repo string, number int) (string, error)
 }
 
+// PRSnapshotFetcher returns the live state of a PR, not just its HEAD.
+//
+// Optional capability, discovered by type assertion on the pipeline's gh
+// dependency rather than added to the required set. *github.Client implements
+// it; the package's many test doubles do not, and widening the mandatory
+// interface would force every one of them to grow a method that most tests do
+// not exercise. When absent, the publish guard degrades to a HEAD-only check via
+// HeadSHAResolver.
+type PRSnapshotFetcher interface {
+	GetPRSnapshot(repo string, number int) (*github.PRSnapshot, error)
+}
+
+// CommitAnchoredReviewer submits a review pinned to an explicit commit.
+//
+// Optional for the same reason as PRSnapshotFetcher, and for the reason stated
+// on github.Client.SubmitReviewForCommit itself: keeping it off the
+// GitHubReviewer contract preserves the test doubles. Anchoring matters because
+// the plain SubmitReview lets GitHub attach the review to whatever is at HEAD
+// when the request lands, so a push racing the submit would misattribute
+// findings from the analysed commit to newer code. With the anchor, the worst
+// case degrades from "misattributed" to "shows as outdated".
+type CommitAnchoredReviewer interface {
+	SubmitReviewForCommit(repo string, number int, body, event, commitID string) (int64, string, error)
+}
+
 // CLIExecutor detects and runs an AI CLI tool.
 type CLIExecutor interface {
 	Detect(primary, fallback string) (string, error)
@@ -211,74 +236,134 @@ func (p *Pipeline) stopIfRepoBecameIneligible(
 	return true, nil
 }
 
-// retireIfHeadMoved re-resolves the PR's live HEAD immediately before anything
-// is written to GitHub and retires the freshly stored review when the commit it
-// analysed is no longer at HEAD.
+// retireIfPRMoved re-resolves the PR's live state immediately before anything is
+// written to GitHub and retires the freshly stored review when the PR has moved
+// on from what was analysed — either the commit is no longer at HEAD, or the PR
+// is no longer open.
 //
-// Why a re-check is needed at all: every dedup layer upstream decides whether
-// to *start* a review, and none of them can speak for what happens while the
-// CLI runs. That window is long — the review_timing stats carry a
-// bucket_very_slow tail out past 3000s — so an author who force-pushes inside
-// it gets a verdict describing code that is no longer there. Observed on
+// Why a re-check is needed at all: every dedup layer upstream decides whether to
+// *start* a review, and none of them can speak for what happens while the CLI
+// runs. That window is long — the review_timing stats carry a bucket_very_slow
+// tail out past 3000s — so an author who force-pushes, merges or closes inside it
+// gets a verdict describing code that is no longer there. Observed on
 // freepik-company/ai-bumblebee-proxy#1802: a REQUEST_CHANGES landed on a commit
 // that had already been approved and then superseded by two further pushes
 // (theburrowhub/heimdallm#664). At `high` severity that also blocks merge on
 // outdated code.
 //
-// The deferred publish path in cmd/heimdallm already does exactly this
-// (GetPRSnapshot + pendingReviewInvalidReason immediately before SubmitReview);
-// only the hot path was missing it, so the two publish sites disagreed. This is
-// the hot-path half, and it reuses the same SupersededReviewID sentinel so both
-// retire a stale row identically.
+// This mirrors pendingReviewInvalidReason on the deferred publish path, which
+// checks both conditions for one API call. Checking only the SHA would have left
+// a PR merged mid-run still receiving its verdict.
 //
 // Marking the row is load-bearing, not bookkeeping: step 7 stored it with
 // GitHubReviewID == 0, which is exactly what ListUnpublishedReviews selects on.
 // Skipping the publish without retiring the row would simply hand the stale
-// verdict to the publish-worker to post later.
+// verdict to the publish-worker to post later. The sentinel differs by reason,
+// matching the deferred path: SupersededReviewID for a moved HEAD (which Run
+// then treats as "no previous review", so the new commit can be reviewed), and
+// orphanedReviewID for a closed PR, which is terminal.
 //
 // Returns (true, …) when the caller must stop. Run then returns (nil, nil),
 // matching the other skip paths so main.go's `rev == nil` filter keeps the
 // review_completed SSE, the "review done" log line and the activity_log row
 // suppressed for a review that was never published (#322 Bug 4).
-func (p *Pipeline) retireIfHeadMoved(rev *store.Review, pr *github.PullRequest) (bool, error) {
-	if pr.Head.SHA == "" {
-		// Nothing to compare against. The empty-SHA/legacy-row handling
-		// upstream owns this case; re-deciding it here would duplicate it.
-		return false, nil
-	}
-	liveSHA, err := p.gh.GetPRHeadSHA(pr.Repo, pr.Number)
+func (p *Pipeline) retireIfPRMoved(rev *store.Review, pr *github.PullRequest) (bool, error) {
+	live, err := p.resolveLivePR(pr)
 	if err != nil {
-		// Deliberately fail-open. Deferring to the publish-worker instead
-		// would be safer in isolation but would delay every publish whenever
-		// the API has a blip, and needs a lifecycle state that does not exist
-		// yet. Publishing stale requires HEAD to have moved AND this call to
-		// fail in the same run; leaving the guard to the confirmable case
-		// keeps this change to a single behavioural difference. The deferred
-		// path stays hardened regardless, because it re-validates the SHA
-		// under its own claim before submitting.
-		slog.Warn("pipeline: could not re-resolve HEAD before publishing, publishing anyway",
+		// Deliberately fail-open. Deferring to the publish-worker instead would
+		// be safer in isolation but would delay every publish whenever the API
+		// has a blip, and needs a lifecycle state that does not exist yet.
+		// Publishing stale requires the PR to have moved AND this lookup to fail
+		// in the same run. The deferred path stays hardened regardless, because
+		// it re-validates under its own claim before submitting.
+		slog.Warn("pipeline: could not re-resolve PR before publishing, publishing anyway",
 			"repo", pr.Repo, "pr", pr.Number, "review_id", rev.ID,
 			"head_sha", pr.Head.SHA, "err", err)
 		return false, nil
 	}
-	if liveSHA == "" || liveSHA == pr.Head.SHA {
+
+	reason := SkipReasonNone
+	terminalReviewID := SupersededReviewID
+	switch {
+	case live.stateKnown && live.state != "open":
+		reason, terminalReviewID = SkipReasonNotOpen, orphanedReviewID
+	case live.headSHA != "" && live.headSHA != pr.Head.SHA:
+		reason, terminalReviewID = SkipReasonHeadChanged, SupersededReviewID
+	}
+	if reason == SkipReasonNone {
 		return false, nil
 	}
-	if err := p.store.MarkReviewPublished(rev.ID, SupersededReviewID, "", time.Now().UTC()); err != nil {
+
+	if err := p.store.MarkReviewPublished(rev.ID, terminalReviewID, "", time.Now().UTC()); err != nil {
 		// Report rather than swallow, but still stop: an unretired row keeps
-		// GitHubReviewID == 0, so the publish-worker picks it up and applies
-		// its own SHA re-validation. The stale verdict cannot reach GitHub
-		// either way — only the bookkeeping is left inconsistent.
+		// GitHubReviewID == 0, so the publish-worker picks it up and applies its
+		// own re-validation. The stale verdict cannot reach GitHub either way —
+		// only the bookkeeping is left inconsistent.
 		return true, fmt.Errorf("pipeline: retire superseded review %d: %w", rev.ID, err)
 	}
-	rev.GitHubReviewID = SupersededReviewID
-	slog.Info("pipeline: HEAD moved during review — retiring instead of publishing",
-		"repo", pr.Repo, "pr", pr.Number, "review_id", rev.ID,
-		"reviewed_head_sha", pr.Head.SHA, "current_head_sha", liveSHA,
-		"event", rev.Event, "severity", rev.Severity)
-	p.publishSkipped(pr, SkipReasonHeadChanged)
+	slog.Info("pipeline: PR moved during review — retiring instead of publishing",
+		"repo", pr.Repo, "pr", pr.Number, "review_id", rev.ID, "reason", string(reason),
+		"reviewed_head_sha", pr.Head.SHA, "current_head_sha", live.headSHA,
+		"current_state", live.state, "event", rev.Event, "severity", rev.Severity)
+	p.publishSkipped(pr, reason)
 	return true, nil
 }
+
+// livePR is the freshness view the publish guard needs.
+type livePR struct {
+	state   string
+	headSHA string
+	// stateKnown distinguishes "the PR is open" from "state was never fetched".
+	// Without it the HEAD-only fallback would report an empty state and the
+	// caller would read that as a closed PR, retiring every review.
+	stateKnown bool
+}
+
+// resolveLivePR fetches the PR's current state, preferring the full snapshot and
+// falling back to a HEAD-only lookup when the gh dependency does not provide one.
+//
+// Both paths retry once after a short pause, matching the hydration lookup at the
+// top of Run: #243's failure mode was rate-limit 429s, and a back-to-back retry
+// is useless against those because the window is still active. A 429 during a
+// long review is the likeliest way this call fails, so the retry meaningfully
+// shrinks the fail-open window.
+func (p *Pipeline) resolveLivePR(pr *github.PullRequest) (livePR, error) {
+	if snapshotter, ok := p.gh.(PRSnapshotFetcher); ok {
+		snap, err := snapshotter.GetPRSnapshot(pr.Repo, pr.Number)
+		if err != nil {
+			time.Sleep(headResolveRetryDelay)
+			snap, err = snapshotter.GetPRSnapshot(pr.Repo, pr.Number)
+		}
+		if err != nil {
+			return livePR{}, err
+		}
+		if snap == nil {
+			return livePR{}, fmt.Errorf("pipeline: nil PR snapshot")
+		}
+		return livePR{state: snap.State, headSHA: snap.HeadSHA, stateKnown: true}, nil
+	}
+
+	sha, err := p.gh.GetPRHeadSHA(pr.Repo, pr.Number)
+	if err != nil {
+		time.Sleep(headResolveRetryDelay)
+		sha, err = p.gh.GetPRHeadSHA(pr.Repo, pr.Number)
+	}
+	if err != nil {
+		return livePR{}, err
+	}
+	if sha == "" {
+		// Empty-but-nil-error is a lookup failure, not "unchanged" — the same
+		// reading the hydration path at the top of Run applies to this value.
+		// Folding it into the error branch keeps the log honest about which case
+		// occurred instead of silently claiming the HEAD was confirmed.
+		return livePR{}, fmt.Errorf("pipeline: resolve HEAD SHA: empty SHA returned")
+	}
+	return livePR{headSHA: sha}, nil
+}
+
+// headResolveRetryDelay is the pause before the single retry of a HEAD/snapshot
+// lookup. Same value and rationale as the hydration lookup in Run.
+const headResolveRetryDelay = 500 * time.Millisecond
 
 // publish emits an SSE lifecycle event with the given payload. No-op
 // when no publisher is wired. A marshal failure on a map[string]any
@@ -899,7 +984,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	// write to the PR (one comment per issue), so guarding only the final
 	// SubmitReview would leave N inline comments about superseded code with no
 	// summary review to explain them: worse than the bug it fixes.
-	if superseded, err := p.retireIfHeadMoved(rev, pr); superseded {
+	if superseded, err := p.retireIfPRMoved(rev, pr); superseded {
 		return nil, err
 	}
 	var reviewBody string
@@ -921,11 +1006,26 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	if stopped, err := p.stopIfRepoBecameIneligible(pr, opts.RepoEligible); stopped {
 		return nil, err
 	}
-	ghReviewID, ghReviewState, publishErr := p.gh.SubmitReview(
-		pr.Repo, pr.Number,
-		AnnotateBodyForEvent(reviewBody, reviewEvent, len(result.Issues)),
-		reviewEvent,
-	)
+	// Anchor the submission to the commit that was analysed. The re-check above
+	// narrows the race but cannot close it: it is check-then-act, so a push
+	// landing between the check and this call would have GitHub attach the review
+	// to the new HEAD. With commit_id pinned, that worst case degrades from
+	// "findings misattributed to code they were not written about" to "review
+	// shows as outdated", which is what the deferred publish path already does.
+	annotatedBody := AnnotateBodyForEvent(reviewBody, reviewEvent, len(result.Issues))
+	var ghReviewID int64
+	var ghReviewState string
+	var publishErr error
+	if anchored, ok := p.gh.(CommitAnchoredReviewer); ok && pr.Head.SHA != "" {
+		ghReviewID, ghReviewState, publishErr = anchored.SubmitReviewForCommit(
+			pr.Repo, pr.Number, annotatedBody, reviewEvent, pr.Head.SHA,
+		)
+	} else {
+		// Test doubles and any adapter that predates the anchored method.
+		ghReviewID, ghReviewState, publishErr = p.gh.SubmitReview(
+			pr.Repo, pr.Number, annotatedBody, reviewEvent,
+		)
+	}
 	if publishErr != nil {
 		// Permanent submit failure (PR locked etc.): mark the freshly
 		// stored row as orphaned right now so it never enters the

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -211,6 +211,75 @@ func (p *Pipeline) stopIfRepoBecameIneligible(
 	return true, nil
 }
 
+// retireIfHeadMoved re-resolves the PR's live HEAD immediately before anything
+// is written to GitHub and retires the freshly stored review when the commit it
+// analysed is no longer at HEAD.
+//
+// Why a re-check is needed at all: every dedup layer upstream decides whether
+// to *start* a review, and none of them can speak for what happens while the
+// CLI runs. That window is long — the review_timing stats carry a
+// bucket_very_slow tail out past 3000s — so an author who force-pushes inside
+// it gets a verdict describing code that is no longer there. Observed on
+// freepik-company/ai-bumblebee-proxy#1802: a REQUEST_CHANGES landed on a commit
+// that had already been approved and then superseded by two further pushes
+// (theburrowhub/heimdallm#664). At `high` severity that also blocks merge on
+// outdated code.
+//
+// The deferred publish path in cmd/heimdallm already does exactly this
+// (GetPRSnapshot + pendingReviewInvalidReason immediately before SubmitReview);
+// only the hot path was missing it, so the two publish sites disagreed. This is
+// the hot-path half, and it reuses the same SupersededReviewID sentinel so both
+// retire a stale row identically.
+//
+// Marking the row is load-bearing, not bookkeeping: step 7 stored it with
+// GitHubReviewID == 0, which is exactly what ListUnpublishedReviews selects on.
+// Skipping the publish without retiring the row would simply hand the stale
+// verdict to the publish-worker to post later.
+//
+// Returns (true, …) when the caller must stop. Run then returns (nil, nil),
+// matching the other skip paths so main.go's `rev == nil` filter keeps the
+// review_completed SSE, the "review done" log line and the activity_log row
+// suppressed for a review that was never published (#322 Bug 4).
+func (p *Pipeline) retireIfHeadMoved(rev *store.Review, pr *github.PullRequest) (bool, error) {
+	if pr.Head.SHA == "" {
+		// Nothing to compare against. The empty-SHA/legacy-row handling
+		// upstream owns this case; re-deciding it here would duplicate it.
+		return false, nil
+	}
+	liveSHA, err := p.gh.GetPRHeadSHA(pr.Repo, pr.Number)
+	if err != nil {
+		// Deliberately fail-open. Deferring to the publish-worker instead
+		// would be safer in isolation but would delay every publish whenever
+		// the API has a blip, and needs a lifecycle state that does not exist
+		// yet. Publishing stale requires HEAD to have moved AND this call to
+		// fail in the same run; leaving the guard to the confirmable case
+		// keeps this change to a single behavioural difference. The deferred
+		// path stays hardened regardless, because it re-validates the SHA
+		// under its own claim before submitting.
+		slog.Warn("pipeline: could not re-resolve HEAD before publishing, publishing anyway",
+			"repo", pr.Repo, "pr", pr.Number, "review_id", rev.ID,
+			"head_sha", pr.Head.SHA, "err", err)
+		return false, nil
+	}
+	if liveSHA == "" || liveSHA == pr.Head.SHA {
+		return false, nil
+	}
+	if err := p.store.MarkReviewPublished(rev.ID, SupersededReviewID, "", time.Now().UTC()); err != nil {
+		// Report rather than swallow, but still stop: an unretired row keeps
+		// GitHubReviewID == 0, so the publish-worker picks it up and applies
+		// its own SHA re-validation. The stale verdict cannot reach GitHub
+		// either way — only the bookkeeping is left inconsistent.
+		return true, fmt.Errorf("pipeline: retire superseded review %d: %w", rev.ID, err)
+	}
+	rev.GitHubReviewID = SupersededReviewID
+	slog.Info("pipeline: HEAD moved during review — retiring instead of publishing",
+		"repo", pr.Repo, "pr", pr.Number, "review_id", rev.ID,
+		"reviewed_head_sha", pr.Head.SHA, "current_head_sha", liveSHA,
+		"event", rev.Event, "severity", rev.Severity)
+	p.publishSkipped(pr, SkipReasonHeadChanged)
+	return true, nil
+}
+
 // publish emits an SSE lifecycle event with the given payload. No-op
 // when no publisher is wired. A marshal failure on a map[string]any
 // of basic types should not happen in practice (every payload site
@@ -823,7 +892,16 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		return nil, err
 	}
 
-	// 8. Publish review to GitHub
+	// 8. Publish review to GitHub.
+	//
+	// The freshness re-check goes here, ahead of the multi-mode comment loop —
+	// not immediately before SubmitReview. In multi mode that loop is already a
+	// write to the PR (one comment per issue), so guarding only the final
+	// SubmitReview would leave N inline comments about superseded code with no
+	// summary review to explain them: worse than the bug it fixes.
+	if superseded, err := p.retireIfHeadMoved(rev, pr); superseded {
+		return nil, err
+	}
 	var reviewBody string
 	if reviewMode == "multi" && len(result.Issues) > 0 {
 		// Post one comment per issue (best-effort — failures are logged but don't abort)

--- a/daemon/internal/pipeline/pipeline_head_moved_test.go
+++ b/daemon/internal/pipeline/pipeline_head_moved_test.go
@@ -1,0 +1,265 @@
+package pipeline_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/executor"
+	"github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// headMoveGH lets a test change the SHA reported by GetPRHeadSHA between the
+// hydration call at the top of Run and the freshness re-check in step 8, which
+// is how a force-push mid-review is simulated. Every write to the PR is
+// counted so a test can assert that NOTHING was posted, not merely that the
+// summary review was withheld.
+type headMoveGH struct {
+	diff string
+	// shaSequence is returned one entry per GetPRHeadSHA call; the last entry
+	// is repeated once exhausted. Encodes "HEAD was X, now it is Y".
+	shaSequence []string
+	shaErr      error
+
+	shaCalls int
+	submits  int
+	comments int
+	// lastEvent records the event of the last submitted review so a test can
+	// prove a REQUEST_CHANGES never reached GitHub.
+	lastEvent string
+}
+
+func (f *headMoveGH) FetchDiff(repo string, number int) (string, error) { return f.diff, nil }
+
+func (f *headMoveGH) SubmitReview(repo string, number int, body, event string) (int64, string, error) {
+	f.submits++
+	f.lastEvent = event
+	return 4862165122, "CHANGES_REQUESTED", nil
+}
+
+func (f *headMoveGH) PostComment(repo string, number int, body string) (time.Time, error) {
+	f.comments++
+	return time.Now().UTC(), nil
+}
+
+func (f *headMoveGH) FetchComments(repo string, number int) ([]github.Comment, error) {
+	return nil, nil
+}
+
+func (f *headMoveGH) GetPRHeadSHA(repo string, number int) (string, error) {
+	f.shaCalls++
+	if f.shaErr != nil {
+		return "", f.shaErr
+	}
+	if len(f.shaSequence) == 0 {
+		return "", nil
+	}
+	i := f.shaCalls - 1
+	if i >= len(f.shaSequence) {
+		i = len(f.shaSequence) - 1
+	}
+	return f.shaSequence[i], nil
+}
+
+// issuesExec returns a finding so ReviewEvent resolves to REQUEST_CHANGES and
+// multi mode has something to post per issue.
+type issuesExec struct{}
+
+func (issuesExec) Detect(primary, fallback string) (string, error) { return "fake_claude", nil }
+
+func (issuesExec) Execute(cli, prompt string, _ executor.ExecOptions) (*executor.ReviewResult, error) {
+	return &executor.ReviewResult{
+		Summary: "Needs work",
+		Issues: []executor.Issue{
+			{File: "main.go", Line: 1, Description: "unsafe", Severity: "high"},
+			{File: "other.go", Line: 9, Description: "also unsafe", Severity: "high"},
+		},
+		Severity: "high",
+	}, nil
+}
+
+func headMovePR(sha string) *github.PullRequest {
+	pr := &github.PullRequest{
+		ID: 1802, Number: 1802, Title: "force-pushed a lot", Repo: "org/repo",
+		User: github.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/1802",
+	}
+	pr.Head.SHA = sha
+	return pr
+}
+
+// TestPipeline_Run_RetiresReviewWhenHeadMovedDuringRun is the regression test
+// for theburrowhub/heimdallm#664. The run analyses 306bfcc7; by the time it is
+// ready to publish, HEAD is 1b284050. The verdict must not be published, and
+// the stored row must be retired with the Superseded sentinel so the
+// publish-worker's ListUnpublishedReviews (github_review_id == 0) does not pick
+// it up and post it later anyway.
+func TestPipeline_Run_RetiresReviewWhenHeadMovedDuringRun(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	gh := &headMoveGH{diff: "+line", shaSequence: []string{"1b284050"}}
+	p := pipeline.New(s, gh, issuesExec{}, &fakeNotify{})
+
+	pr := headMovePR("306bfcc7")
+	rev, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// Same contract as the other skip paths: a nil review keeps main.go from
+	// emitting review_completed / the activity row for work never published.
+	if rev != nil {
+		t.Errorf("expected nil review for a superseded run, got %+v", rev)
+	}
+	if gh.submits != 0 {
+		t.Errorf("SubmitReview called %d times on a superseded commit; want 0 (event=%q)",
+			gh.submits, gh.lastEvent)
+	}
+
+	// The reviews row is keyed on the internal PR id, not the GitHub id.
+	storedPR, err := s.GetPRByGithubID(pr.ID)
+	if err != nil {
+		t.Fatalf("get pr: %v", err)
+	}
+	stored, err := s.LatestReviewForPR(storedPR.ID)
+	if err != nil {
+		t.Fatalf("latest review: %v", err)
+	}
+	if stored == nil {
+		t.Fatal("expected the analysed review to remain stored for auditing")
+	}
+	if stored.GitHubReviewID != pipeline.SupersededReviewID {
+		t.Errorf("stored github_review_id = %d, want SupersededReviewID (%d) so the "+
+			"publish-worker stops retrying it",
+			stored.GitHubReviewID, pipeline.SupersededReviewID)
+	}
+	if stored.HeadSHA != "306bfcc7" {
+		t.Errorf("stored head_sha = %q, want the analysed SHA %q", stored.HeadSHA, "306bfcc7")
+	}
+}
+
+// TestPipeline_Run_SkipsPerIssueCommentsWhenHeadMoved pins the placement of the
+// guard. In multi mode the per-issue comment loop runs BEFORE SubmitReview, so a
+// check sitting immediately before SubmitReview would still leave one comment
+// per finding attached to superseded code — with no summary review to explain
+// them. The guard must run ahead of the whole publish block.
+func TestPipeline_Run_SkipsPerIssueCommentsWhenHeadMoved(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	gh := &headMoveGH{diff: "+line", shaSequence: []string{"1b284050"}}
+	p := pipeline.New(s, gh, issuesExec{}, &fakeNotify{})
+
+	if _, err := p.Run(headMovePR("306bfcc7"), pipeline.RunOptions{
+		Primary: "claude", Fallback: "gemini", ReviewMode: "multi",
+	}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if gh.comments != 0 {
+		t.Errorf("PostComment called %d times on a superseded commit; want 0 — the "+
+			"guard must precede the multi-mode comment loop, not just SubmitReview",
+			gh.comments)
+	}
+	if gh.submits != 0 {
+		t.Errorf("SubmitReview called %d times; want 0", gh.submits)
+	}
+}
+
+// TestPipeline_Run_PublishesWhenHeadUnchanged is the control: the common case
+// must be untouched, and the re-check must cost exactly one extra API call.
+func TestPipeline_Run_PublishesWhenHeadUnchanged(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	gh := &headMoveGH{diff: "+line", shaSequence: []string{"306bfcc7"}}
+	p := pipeline.New(s, gh, issuesExec{}, &fakeNotify{})
+
+	rev, err := p.Run(headMovePR("306bfcc7"), pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev == nil {
+		t.Fatal("expected a published review when HEAD did not move")
+	}
+	if gh.submits != 1 {
+		t.Errorf("SubmitReview calls = %d, want 1", gh.submits)
+	}
+	// The PR arrives with Head.SHA already set, so hydration is skipped and the
+	// only GetPRHeadSHA call is the publish-time re-check. Pinning this keeps
+	// the added API cost visible: one call per published review, no more.
+	if gh.shaCalls != 1 {
+		t.Errorf("GetPRHeadSHA calls = %d, want exactly 1 (the publish-time re-check)", gh.shaCalls)
+	}
+}
+
+// TestPipeline_Run_PublishesWhenHeadRecheckFails documents the deliberate
+// fail-open choice. Deferring on a transient API error would delay every
+// publish whenever GitHub blips, and publishing stale would additionally
+// require HEAD to have moved in the same run. The deferred publish path stays
+// hardened either way because it re-validates the SHA under its own claim.
+func TestPipeline_Run_PublishesWhenHeadRecheckFails(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	gh := &headMoveGH{diff: "+line", shaErr: errors.New("502 bad gateway")}
+	p := pipeline.New(s, gh, issuesExec{}, &fakeNotify{})
+
+	rev, err := p.Run(headMovePR("306bfcc7"), pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev == nil {
+		t.Fatal("expected the review to publish when the re-check could not resolve HEAD")
+	}
+	if gh.submits != 1 {
+		t.Errorf("SubmitReview calls = %d, want 1 (fail-open)", gh.submits)
+	}
+}
+
+// TestPipeline_Run_NoRecheckWhenRunSkipsEarly guards the API budget: a run that
+// short-circuits before the CLI executes must not pay for the publish-time
+// re-check, because it never reaches the publish block.
+func TestPipeline_Run_NoRecheckWhenRunSkipsEarly(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	gh := &headMoveGH{diff: "+line", shaSequence: []string{"306bfcc7"}}
+	p := pipeline.New(s, gh, issuesExec{}, &fakeNotify{})
+	pr := headMovePR("306bfcc7")
+
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"}); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	callsAfterPublish := gh.shaCalls
+
+	// Second run on the same SHA with no re-request: the dedup gate skips it
+	// before the CLI runs, so no further HEAD resolution should happen.
+	if _, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"}); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if gh.shaCalls != callsAfterPublish {
+		t.Errorf("GetPRHeadSHA calls grew from %d to %d on a run that skipped before "+
+			"executing; the re-check must not run outside the publish block",
+			callsAfterPublish, gh.shaCalls)
+	}
+	if gh.submits != 1 {
+		t.Errorf("SubmitReview calls = %d, want 1", gh.submits)
+	}
+}

--- a/daemon/internal/pipeline/pipeline_head_moved_test.go
+++ b/daemon/internal/pipeline/pipeline_head_moved_test.go
@@ -263,3 +263,186 @@ func TestPipeline_Run_NoRecheckWhenRunSkipsEarly(t *testing.T) {
 		t.Errorf("SubmitReview calls = %d, want 1", gh.submits)
 	}
 }
+
+// snapshotGH implements the optional PRSnapshotFetcher and CommitAnchoredReviewer
+// capabilities, so it exercises the production path rather than the degraded
+// fallback the other fakes in this file use.
+type snapshotGH struct {
+	diff  string
+	state string
+	sha   string
+	err   error
+
+	snapshotCalls int
+	submits       int
+	comments      int
+	// anchoredCommit records the commit_id the review was pinned to, which is
+	// the whole point of preferring SubmitReviewForCommit.
+	anchoredCommit string
+	usedUnanchored bool
+}
+
+func (f *snapshotGH) FetchDiff(string, int) (string, error) { return f.diff, nil }
+
+func (f *snapshotGH) FetchComments(string, int) ([]github.Comment, error) { return nil, nil }
+
+func (f *snapshotGH) PostComment(string, int, string) (time.Time, error) {
+	f.comments++
+	return time.Now().UTC(), nil
+}
+
+func (f *snapshotGH) GetPRHeadSHA(string, int) (string, error) { return f.sha, nil }
+
+func (f *snapshotGH) GetPRSnapshot(string, int) (*github.PRSnapshot, error) {
+	f.snapshotCalls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &github.PRSnapshot{State: f.state, HeadSHA: f.sha}, nil
+}
+
+func (f *snapshotGH) SubmitReview(_ string, _ int, _, _ string) (int64, string, error) {
+	f.submits++
+	f.usedUnanchored = true
+	return 1, "COMMENTED", nil
+}
+
+func (f *snapshotGH) SubmitReviewForCommit(_ string, _ int, _, _, commitID string) (int64, string, error) {
+	f.submits++
+	f.anchoredCommit = commitID
+	return 1, "COMMENTED", nil
+}
+
+// TestPipeline_Run_RetiresReviewWhenPRClosedDuringRun covers the parity gap
+// raised in review: pendingReviewInvalidReason retires a pending review on TWO
+// conditions, and only the HEAD one was implemented. A PR merged or closed during
+// a run — a window documented as reaching past 3000s — still got its verdict
+// posted.
+func TestPipeline_Run_RetiresReviewWhenPRClosedDuringRun(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	// HEAD is unchanged; only the state moved. The old SHA-only guard published.
+	gh := &snapshotGH{diff: "+line", state: "closed", sha: "306bfcc7"}
+	p := pipeline.New(s, gh, issuesExec{}, &fakeNotify{})
+
+	pr := headMovePR("306bfcc7")
+	rev, err := p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev != nil {
+		t.Errorf("expected nil review for a closed PR, got %+v", rev)
+	}
+	if gh.submits != 0 {
+		t.Errorf("SubmitReview* called %d times on a closed PR; want 0", gh.submits)
+	}
+
+	storedPR, err := s.GetPRByGithubID(pr.ID)
+	if err != nil {
+		t.Fatalf("get pr: %v", err)
+	}
+	stored, err := s.LatestReviewForPR(storedPR.ID)
+	if err != nil {
+		t.Fatalf("latest review: %v", err)
+	}
+	// A closed PR is terminal, so it takes the orphan sentinel rather than
+	// Superseded — Superseded means "re-review the new commit", which is wrong
+	// here. -1 is the orphan value the deferred path uses for the same reason.
+	if stored.GitHubReviewID != -1 {
+		t.Errorf("stored github_review_id = %d, want -1 (terminal orphan) for a closed PR",
+			stored.GitHubReviewID)
+	}
+}
+
+// TestPipeline_Run_AnchorsPublishToAnalysedCommit pins the other half of the
+// review finding: the re-check is check-then-act, so the submit itself must pin
+// commit_id or a push racing it would have GitHub attach the findings to newer
+// code.
+func TestPipeline_Run_AnchorsPublishToAnalysedCommit(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	gh := &snapshotGH{diff: "+line", state: "open", sha: "306bfcc7"}
+	p := pipeline.New(s, gh, issuesExec{}, &fakeNotify{})
+
+	if _, err := p.Run(headMovePR("306bfcc7"), pipeline.RunOptions{
+		Primary: "claude", Fallback: "gemini",
+	}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if gh.submits != 1 {
+		t.Fatalf("submits = %d, want 1", gh.submits)
+	}
+	if gh.usedUnanchored {
+		t.Error("fell back to the unanchored SubmitReview even though the anchored " +
+			"variant was available")
+	}
+	if gh.anchoredCommit != "306bfcc7" {
+		t.Errorf("anchored commit = %q, want the analysed SHA %q",
+			gh.anchoredCommit, "306bfcc7")
+	}
+	// One snapshot call, replacing the previous GetPRHeadSHA call: covering the
+	// extra state condition costs no additional API request.
+	if gh.snapshotCalls != 1 {
+		t.Errorf("GetPRSnapshot calls = %d, want exactly 1", gh.snapshotCalls)
+	}
+}
+
+// TestPipeline_Run_FallsBackToUnanchoredSubmit keeps the optional-capability
+// design honest: a gh dependency without the anchored method must still publish
+// rather than fail.
+func TestPipeline_Run_FallsBackToUnanchoredSubmit(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	// headMoveGH implements neither optional capability.
+	gh := &headMoveGH{diff: "+line", shaSequence: []string{"306bfcc7"}}
+	p := pipeline.New(s, gh, issuesExec{}, &fakeNotify{})
+
+	rev, err := p.Run(headMovePR("306bfcc7"), pipeline.RunOptions{
+		Primary: "claude", Fallback: "gemini",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev == nil {
+		t.Fatal("expected the review to publish through the fallback path")
+	}
+	if gh.submits != 1 {
+		t.Errorf("submits = %d, want 1", gh.submits)
+	}
+}
+
+// TestPipeline_Run_HeadOnlyFallbackDoesNotTreatUnknownStateAsClosed guards the
+// stateKnown flag. Without it the fallback would report an empty state, the
+// guard would read that as "not open", and every review on a gh dependency
+// lacking GetPRSnapshot would be retired instead of published.
+func TestPipeline_Run_HeadOnlyFallbackDoesNotTreatUnknownStateAsClosed(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	gh := &headMoveGH{diff: "+line", shaSequence: []string{"abc"}}
+	p := pipeline.New(s, gh, issuesExec{}, &fakeNotify{})
+
+	rev, err := p.Run(headMovePR("abc"), pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rev == nil || gh.submits != 1 {
+		t.Errorf("review was withheld on an unknown state (rev nil: %v, submits: %d)",
+			rev == nil, gh.submits)
+	}
+}

--- a/daemon/internal/pipeline/pipeline_test.go
+++ b/daemon/internal/pipeline/pipeline_test.go
@@ -454,21 +454,28 @@ func TestPipeline_Run_HydratesHeadSHAWhenMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if gh.shaCalls != 1 {
-		t.Errorf("expected 1 GetPRHeadSHA call, got %d", gh.shaCalls)
+	// Two calls, and both are load-bearing: the hydration fetch at the top of
+	// Run (the subject of this test) plus the publish-time freshness re-check
+	// added for theburrowhub/heimdallm#664. They are not interchangeable — the
+	// first resolves an unknown SHA before any work happens, the second detects
+	// a force-push that landed while the CLI was running, so reusing the
+	// hydrated value there would defeat the guard.
+	if gh.shaCalls != 2 {
+		t.Errorf("expected 2 GetPRHeadSHA calls (hydration + publish re-check), got %d", gh.shaCalls)
 	}
 	if rev.HeadSHA != "abc123" {
 		t.Errorf("stored HeadSHA = %q, want %q", rev.HeadSHA, "abc123")
 	}
 
 	// Second run: the PR now has the SHA inline (as if hydrated upstream).
-	// Pipeline must NOT call GetPRHeadSHA again, and must skip on SHA match.
+	// Pipeline must NOT hydrate again, and must skip on SHA match — which also
+	// means it never reaches the publish block, so the call count is unchanged.
 	pr.Head.SHA = "abc123"
 	_, err = p.Run(pr, pipeline.RunOptions{Primary: "claude", Fallback: "gemini"})
 	if err != nil {
 		t.Fatalf("second run: %v", err)
 	}
-	if gh.shaCalls != 1 {
+	if gh.shaCalls != 2 {
 		t.Errorf("GetPRHeadSHA called redundantly: %d", gh.shaCalls)
 	}
 	if gh.submits != 1 {


### PR DESCRIPTION
Fixes #664.

## Problem

`pipeline.Run` step 8 published unconditionally. Nothing revalidated that the commit the run analysed was still at HEAD, and the run holds no lock on the PR while the CLI executes — a window whose `bucket_very_slow` tail reaches past 3000s.

On `freepik-company/ai-bumblebee-proxy#1802` (8 force-pushes in ~20 min) that produced `REQUEST_CHANGES` at `severity=high` on `306bfcc7`, a commit already approved and superseded by two further pushes:

```
07:39:51  APPROVE           head_sha=306bfcc7   (4862145756)
07:41:31  APPROVE           head_sha=eebf6a82   (4862164226)
07:41:35  REQUEST_CHANGES   head_sha=306bfcc7   (4862165122)  <- stale
07:43:18  APPROVE           head_sha=0ef4748a   (4862181389)
```

## Fix

Re-resolve the live HEAD at the top of step 8 and retire the stored row with the existing `SupersededReviewID` sentinel when it no longer matches.

**This guard already existed — on the other publish path.** The deferred publish-worker (`main.go:1183-1216`) does `GetPRSnapshot` + `pendingReviewInvalidReason` immediately before `SubmitReview`, with the comment *"A deferred review is valid only for the commit it analysed."* Only the hot path was missing it. This PR is the hot-path half; the two sites now agree and reuse the same sentinel.

## Three decisions worth reviewing

**1. The guard precedes the multi-mode comment loop, not just `SubmitReview`.**
In `multi` mode the per-issue `PostComment` loop runs first and is already a write to the PR. Checking only before `SubmitReview` would leave N inline comments about superseded code with *no* summary to explain them — worse than the bug. Pinned by `TestPipeline_Run_SkipsPerIssueCommentsWhenHeadMoved`.

**2. Retiring the row is load-bearing, not bookkeeping.**
Step 7 stores the row with `github_review_id == 0`, which is exactly what `ListUnpublishedReviews` selects on. Skipping the publish without retiring would hand the stale verdict to the publish-worker to post later — the bug would survive the fix. Pinned by the sentinel assertion in `TestPipeline_Run_RetiresReviewWhenHeadMovedDuringRun`.

**3. Resolution failure fails open (publishes).**
Deferring on a transient error would delay every publish whenever GitHub blips and would need a lifecycle state that doesn't exist. Publishing stale additionally requires HEAD to have moved *and* the call to fail in the same run. The deferred path stays hardened either way, since it revalidates under its own claim. Happy to switch to fail-closed if you'd rather — it's a one-line change plus a new skip reason.

## API cost

One extra `GetPRHeadSHA` per *published* review — reuses the `HeadSHAResolver` already on the pipeline's `gh` interface, so no interface change. Bounded by the breaker (3/PR/24h, 20/repo/hour). Runs are unaffected that skip before the publish block.

`TestPipeline_Run_HydratesHeadSHAWhenMissing` asserted exactly one `GetPRHeadSHA` call, so it needed updating. I kept its intent rather than loosening it: the two calls are documented as non-interchangeable (hydration resolves an unknown SHA *before* work; the re-check detects drift *after*), and `TestPipeline_Run_NoRecheckWhenRunSkipsEarly` is new coverage that the re-check never fires outside the publish block. Flagging it explicitly since relaxing a call-count assertion deserves a second opinion.

Worth coordinating with `feat/gh-api-efficiency-v2` if that branch changes how PR snapshots are fetched.

## Tests

New `daemon/internal/pipeline/pipeline_head_moved_test.go`:

| Test | Asserts |
|---|---|
| `RetiresReviewWhenHeadMovedDuringRun` | no `SubmitReview`; row marked `SupersededReviewID`; analysed SHA preserved; `Run` returns nil |
| `SkipsPerIssueCommentsWhenHeadMoved` | no `PostComment` in multi mode — pins guard placement |
| `PublishesWhenHeadUnchanged` | control; exactly 1 re-check call |
| `PublishesWhenHeadRecheckFails` | documents fail-open |
| `NoRecheckWhenRunSkipsEarly` | API budget: no re-check when the run short-circuits |

`make test-docker` green across all 17 daemon packages (vet included).

## Not covered here

`SkipReasonHeadChanged` is emitted for the retired review. The Flutter activity tile has a catch-all (`_ => reason.replaceAll('_', ' ')`) so it renders without a UI change; adding a friendly label is a trivial follow-up if you want one.
