### PR TITLE
fix(daemon): kill git's process group on timeout and reap orphans in PID 1

### DIFF
--- a/daemon/internal/issues/gitops.go
+++ b/daemon/internal/issues/gitops.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/heimdallm/daemon/internal/procgroup"
 )
 
 // gitTimeout caps each `git` invocation so a hung network or huge fetch
@@ -382,7 +384,12 @@ func captureGit(ctx context.Context, dir string, env []string, args ...string) (
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
+	// procgroup.Run rather than cmd.Run: this helper backs every git call in
+	// GitExec, including CheckoutNewBranch / Push / DeleteRemoteBranch, which
+	// fork `ssh` for SSH remotes. exec.CommandContext's cancellation reaches
+	// only git, leaving that ssh child orphaned onto PID 1 as a zombie
+	// (theburrowhub/heimdallm#665).
+	if err := procgroup.Run(cmd); err != nil {
 		// Cap stderr to protect against pathological output (e.g. huge
 		// merge-conflict reports, repeated progress lines, etc).
 		errText := stderr.String()

--- a/daemon/internal/procgroup/procgroup.go
+++ b/daemon/internal/procgroup/procgroup.go
@@ -1,0 +1,130 @@
+// Package procgroup runs an *exec.Cmd in its own process group so that
+// cancelling the command's context terminates the whole process tree rather
+// than just the direct child.
+//
+// The problem it solves: exec.CommandContext's default cancellation kills only
+// the process it started. Anything that process forked survives, gets reparented
+// to PID 1, and — because nothing calls wait() on a process it did not spawn —
+// becomes a permanent zombie once it exits. For `git` over SSH the forked child
+// is `ssh`, which is how a container accumulated 13 [ssh] + 2 [git] zombies in
+// 23h of uptime (theburrowhub/heimdallm#665). The same shape was already
+// diagnosed for the AI CLI launchers in #614.
+//
+// Killing the group is only half of the fix. A descendant that is already
+// orphaned still needs PID 1 to reap it, and the kernel does not do that
+// automatically for PID 1 — hence the init process in docker/Dockerfile. This
+// package stops the daemon from leaking live processes; the init stops the dead
+// ones from piling up as zombies.
+//
+// Note for future readers: internal/executor carries a richer variant of this
+// logic (it also registers groups so TerminateAll can reach agents at shutdown,
+// and tolerates ErrWaitDelay when the payload is already complete). That was
+// deliberately left in place rather than folded in here — see #614.
+package procgroup
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+const (
+	// termGrace is how long the group gets to exit after SIGTERM before the
+	// escalation to SIGKILL. Short on purpose: cancellation here means a
+	// timeout has already elapsed, so the caller is past waiting politely.
+	termGrace = 2 * time.Second
+	// waitDelay bounds Wait once the direct child has exited but a descendant
+	// still holds the inherited stdout/stderr pipes. Without it, Wait blocks
+	// until every copy of those descriptors is closed, which lets a stalled
+	// grandchild hang the caller indefinitely.
+	waitDelay = 2 * time.Second
+)
+
+// Run starts cmd in its own process group, waits for it, and on context
+// cancellation signals the entire group (SIGTERM, then SIGKILL after
+// termGrace).
+//
+// cmd MUST have been created with exec.CommandContext. Run installs a
+// cmd.Cancel hook, and os/exec refuses to start a command that has one without
+// an associated context — so misuse fails immediately at Start with an explicit
+// error rather than silently losing the group kill. The requirement is
+// semantic, not incidental: with no context there is nothing to cancel and
+// nothing for this package to do.
+//
+// Run replaces cmd.Run and takes ownership of cmd.SysProcAttr.Setpgid,
+// cmd.Cancel and cmd.WaitDelay. It deliberately wraps Start+Wait instead of
+// exposing a "configure this cmd" helper: the escalation goroutine must be told
+// when the child has been reaped, and a caller that forgot to do so would
+// eventually signal a pgid the kernel had already recycled onto an unrelated
+// process group.
+//
+// The residual race is the same one documented in #614 and is narrowed, not
+// closed: `reaped` is set the instant Wait returns and is checked immediately
+// before the kill, so the window is the gap between those two statements.
+// Closing it entirely needs a wait-without-reap (wait4(WNOWAIT) or pidfd).
+func Run(cmd *exec.Cmd) error {
+	// Setpgid makes the child the leader of a new group whose ID is its own
+	// PID, which is what lets a single negated PID address every descendant
+	// that has not created a group of its own.
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+
+	runDone := make(chan struct{})
+	var reaped atomic.Bool
+
+	cmd.Cancel = func() error {
+		err := signalGroup(cmd, syscall.SIGTERM)
+		go func() {
+			select {
+			case <-time.After(termGrace):
+				if reaped.Load() {
+					// The pgid may already have been handed to somebody else;
+					// a late signal would hit an unrelated group.
+					return
+				}
+				if killErr := signalGroup(cmd, syscall.SIGKILL); killErr != nil {
+					slog.Debug("procgroup: group already gone before SIGKILL",
+						"path", cmd.Path, "err", killErr)
+				}
+			case <-runDone:
+			}
+		}()
+		return err
+	}
+	cmd.WaitDelay = waitDelay
+
+	if err := cmd.Start(); err != nil {
+		close(runDone)
+		return err
+	}
+	err := cmd.Wait()
+	reaped.Store(true) // before closing runDone: no signal may follow the reap
+	close(runDone)
+	return err
+}
+
+// signalGroup sends sig to the whole group led by cmd's child, reporting an
+// already-exited group as os.ErrProcessDone.
+//
+// That translation is required, not cosmetic: os/exec only tolerates a
+// cmd.Cancel error that is os.ErrProcessDone, so a raw ESRCH would surface out
+// of Wait and disguise a normal cancellation as a bogus "no such process"
+// failure on the caller's error path.
+func signalGroup(cmd *exec.Cmd, sig syscall.Signal) error {
+	if cmd == nil || cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, sig); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return nil
+}

--- a/daemon/internal/procgroup/procgroup.go
+++ b/daemon/internal/procgroup/procgroup.go
@@ -18,8 +18,10 @@
 //
 // Note for future readers: internal/executor carries a richer variant of this
 // logic (it also registers groups so TerminateAll can reach agents at shutdown,
-// and tolerates ErrWaitDelay when the payload is already complete). That was
-// deliberately left in place rather than folded in here — see #614.
+// and returns the collected payload alongside its ErrWaitDelay tolerance). That
+// was deliberately left in place rather than folded in here — see #614. The two
+// copies must agree on the timer ordering and on tolerating a clean exit whose
+// descendant holds the pipes; both are called out at their definitions.
 package procgroup
 
 import (
@@ -36,12 +38,22 @@ const (
 	// termGrace is how long the group gets to exit after SIGTERM before the
 	// escalation to SIGKILL. Short on purpose: cancellation here means a
 	// timeout has already elapsed, so the caller is past waiting politely.
-	termGrace = 2 * time.Second
+	//
+	// INVARIANT: termGrace must stay strictly — and comfortably — below
+	// waitDelay. On cancellation os/exec arms its own WaitDelay timer at the
+	// same moment Cancel fires, and when that timer expires os/exec kills only
+	// the DIRECT child and lets Wait return. If the two timers were equal (or
+	// termGrace were larger) the escalation goroutine would find `reaped`
+	// already true, skip kill(-pgid, SIGKILL), and leave alive precisely the
+	// descendant that ignored SIGTERM — reintroducing #665 on every timeout
+	// where the group does not die on the first signal. internal/executor
+	// encodes the same ordering as 1s vs 3s; keep both copies in step.
+	termGrace = 1 * time.Second
 	// waitDelay bounds Wait once the direct child has exited but a descendant
 	// still holds the inherited stdout/stderr pipes. Without it, Wait blocks
 	// until every copy of those descriptors is closed, which lets a stalled
-	// grandchild hang the caller indefinitely.
-	waitDelay = 2 * time.Second
+	// grandchild hang the caller indefinitely. See the termGrace invariant.
+	waitDelay = 3 * time.Second
 )
 
 // Run starts cmd in its own process group, waits for it, and on context
@@ -61,6 +73,9 @@ const (
 // when the child has been reaped, and a caller that forgot to do so would
 // eventually signal a pgid the kernel had already recycled onto an unrelated
 // process group.
+//
+// A clean exit whose descendant still holds the inherited pipes is reported as
+// success, not as exec.ErrWaitDelay — see the comment at that branch.
 //
 // The residual race is the same one documented in #614 and is narrowed, not
 // closed: `reaped` is set the instant Wait returns and is checked immediately
@@ -103,9 +118,38 @@ func Run(cmd *exec.Cmd) error {
 		close(runDone)
 		return err
 	}
+	pgid := cmd.Process.Pid // Setpgid makes the child its own group leader
 	err := cmd.Wait()
 	reaped.Store(true) // before closing runDone: no signal may follow the reap
 	close(runDone)
+
+	// WaitDelay also fires when the command itself exited cleanly but a
+	// descendant still holds the inherited pipes. That is common for git, not
+	// exotic: `git gc --auto` is spawned in the background after fetch/commit/
+	// merge, and an SSH remote using ControlMaster/ControlPersist leaves the mux
+	// master running on purpose. Returning ErrWaitDelay to the caller in that
+	// case would report a `git push` that actually succeeded as a failure and
+	// discard its output, so the pipeline would retry or fail an operation that
+	// already applied.
+	//
+	// Everything the command itself wrote is already buffered — it wrote it
+	// before exiting, and the copier drains concurrently — so the collected
+	// output is complete and the exit status is authoritative. Swallow the
+	// error and report success, matching internal/executor's handling of the
+	// identical case.
+	//
+	// The descendant is NOT swept here: the child has been reaped, so its pgid
+	// may already belong to another group and a signal would be aimed at
+	// strangers. Log its identity instead — this is the one place with positive
+	// evidence of a live leaked process, so it should be traceable while #614
+	// is open. With Setpgid the group ID is the leader's PID, so one number
+	// identifies both.
+	if errors.Is(err, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == 0 {
+		slog.Warn("procgroup: command exited 0 but a descendant held the output pipes; "+
+			"reporting success and leaving the descendant running",
+			"path", cmd.Path, "pgid", pgid)
+		return nil
+	}
 	return err
 }
 

--- a/daemon/internal/procgroup/procgroup_test.go
+++ b/daemon/internal/procgroup/procgroup_test.go
@@ -19,6 +19,11 @@ import (
 // readPID reads one newline-terminated PID from r. The child prints its own PID
 // rather than the test reading cmd.Process, because procgroup.Run owns Start and
 // touching that field from the test goroutine would be a data race.
+//
+// r must be an ExtraFiles pipe, never cmd.StdoutPipe(): os/exec closes the
+// StdoutPipe read end from Wait, so a test racing a read against cancellation
+// would intermittently get os.ErrClosed instead of the PID and fail for reasons
+// unrelated to the behaviour under test.
 func readPID(t *testing.T, r io.Reader) int {
 	t.Helper()
 	line, err := bufio.NewReader(r).ReadString('\n')
@@ -42,38 +47,43 @@ func TestRun_KillsGrandchildOnTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
 
-	// An inherited pipe is the liveness probe. fd 3 reaches both the shell and
-	// the sleep it backgrounds, and the kernel reports EOF on the read end only
-	// once every process holding the write end has exited.
+	// Two inherited pipes, both on ExtraFiles so neither races os/exec's
+	// handling of the stdout pipe:
+	//   fd 3 (pidW)   — the child announces the grandchild's PID here
+	//   fd 4 (probeW) — liveness probe; the kernel reports EOF on the read end
+	//                   only once every process holding the write end has exited
 	//
-	// A PID existence check (kill(pid, 0)) is unusable here: it also succeeds
-	// for a zombie, which is exactly the state this issue is about — the first
-	// version of this test passed a live grandchild and failed a correctly
-	// killed one for that reason. The pipe distinguishes "running" from
-	// "exited but not yet reaped"; kill(pid, 0) cannot.
+	// A PID existence check (kill(pid, 0)) is unusable as the probe: it also
+	// succeeds for a zombie, which is exactly the state this issue is about — an
+	// earlier version of this test passed a live grandchild and failed a
+	// correctly killed one for that reason.
+	pidR, pidW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pid pipe: %v", err)
+	}
+	defer pidR.Close()
 	probeR, probeW, err := os.Pipe()
 	if err != nil {
-		t.Fatalf("pipe: %v", err)
+		t.Fatalf("probe pipe: %v", err)
 	}
 	defer probeR.Close()
 
-	// Background a long sleep, announce its PID, then block. The parent must not
-	// exit by itself, otherwise the test would pass without cancellation having
-	// done any work.
-	cmd := exec.CommandContext(ctx, "sh", "-c", `sleep 60 & echo $!; wait`)
-	cmd.ExtraFiles = []*os.File{probeW}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		t.Fatalf("stdout pipe: %v", err)
-	}
+	// Background a long sleep, announce its PID on fd 3, then block. The parent
+	// must not exit by itself, otherwise the test would pass without
+	// cancellation having done any work.
+	cmd := exec.CommandContext(ctx, "sh", "-c", `sleep 60 & echo $! >&3; wait`)
+	cmd.ExtraFiles = []*os.File{pidW, probeW}
 
-	// Run in a goroutine so the PID can be read while the child is still alive:
-	// Wait closes the stdout pipe once the command exits.
 	runErrCh := make(chan error, 1)
 	go func() { runErrCh <- procgroup.Run(cmd) }()
 
-	grandchild := readPID(t, stdout)
-	// The parent must drop its own copy or EOF can never arrive.
+	// The parent must drop its own copies or EOF can never arrive. Closing after
+	// Start has certainly happened — which reading the PID guarantees — keeps
+	// the descriptors valid for the child.
+	grandchild := readPID(t, pidR)
+	if err := pidW.Close(); err != nil {
+		t.Fatalf("close pid write end: %v", err)
+	}
 	if err := probeW.Close(); err != nil {
 		t.Fatalf("close probe write end: %v", err)
 	}
@@ -102,6 +112,81 @@ func TestRun_KillsGrandchildOnTimeout(t *testing.T) {
 		_ = syscall.Kill(grandchild, syscall.SIGKILL) // don't leak a stray process
 		t.Fatalf("grandchild %d still holds the inherited pipe — it outlived "+
 			"cancellation, so the process group was not signalled", grandchild)
+	}
+}
+
+// TestRun_EscalatesToSIGKILLWhenGroupIgnoresSIGTERM covers the escalation path,
+// which every other test skips because their children die on the first signal.
+// The whole tree traps SIGTERM, so only the SIGKILL aimed at the group can end
+// it; removing the escalation makes this test fail.
+//
+// What it does NOT pin: the termGrace-vs-waitDelay ordering. When those timers
+// are equal the outcome is a genuine race between this package's escalation
+// goroutine and os/exec's own WaitDelay expiry, and which side wins is
+// scheduling-dependent — verified by running this test against termGrace ==
+// waitDelay == 2s, where it still passes because the escalation happens to win.
+// The ordering is enforced by the invariant documented on the constants, not by
+// a test, because a probabilistic failure cannot be asserted reliably.
+func TestRun_EscalatesToSIGKILLWhenGroupIgnoresSIGTERM(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	pidR, pidW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pid pipe: %v", err)
+	}
+	defer pidR.Close()
+	probeR, probeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("probe pipe: %v", err)
+	}
+	defer probeR.Close()
+
+	// BOTH levels must ignore SIGTERM for this to test what it claims. Trapping
+	// only in the parent shell is not enough: the group SIGTERM would still kill
+	// the grandchild directly, the probe would reach EOF, and the test would pass
+	// whether or not the escalation ever fired (an earlier version of this test
+	// did exactly that and passed against the buggy timers).
+	//
+	// os/exec's own WaitDelay always kills the DIRECT child, so the parent dies
+	// either way. The escalation is the only thing that can reach a grandchild
+	// which ignores SIGTERM — and SIGKILL cannot be trapped.
+	cmd := exec.CommandContext(ctx, "sh", "-c",
+		`trap '' TERM; sh -c "trap '' TERM; exec sleep 60" & echo $! >&3; wait`)
+	cmd.ExtraFiles = []*os.File{pidW, probeW}
+
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- procgroup.Run(cmd) }()
+
+	grandchild := readPID(t, pidR)
+	if err := pidW.Close(); err != nil {
+		t.Fatalf("close pid write end: %v", err)
+	}
+	if err := probeW.Close(); err != nil {
+		t.Fatalf("close probe write end: %v", err)
+	}
+
+	select {
+	case <-runErrCh:
+	case <-time.After(20 * time.Second):
+		t.Fatal("Run never returned; the SIGKILL escalation did not fire")
+	}
+
+	eof := make(chan error, 1)
+	go func() {
+		b := make([]byte, 1)
+		_, readErr := probeR.Read(b)
+		eof <- readErr
+	}()
+	select {
+	case readErr := <-eof:
+		if !errors.Is(readErr, io.EOF) {
+			t.Fatalf("probe read returned %v, want io.EOF", readErr)
+		}
+	case <-time.After(10 * time.Second):
+		_ = syscall.Kill(grandchild, syscall.SIGKILL)
+		t.Fatalf("grandchild %d survived a SIGTERM-ignoring group — the SIGKILL "+
+			"escalation never reached the process group", grandchild)
 	}
 }
 
@@ -199,18 +284,66 @@ func TestRun_PreservesExistingSysProcAttr(t *testing.T) {
 	}
 }
 
+// TestRun_ReportsSuccessWhenCleanExitLeavesADescendantHoldingThePipes is the
+// regression test for the second review finding on #667.
+//
+// `git gc --auto` (spawned in the background after fetch/commit/merge) and an
+// ssh ControlMaster/ControlPersist mux both outlive the git command that started
+// them while still holding its inherited stdout/stderr. With WaitDelay armed,
+// os/exec surfaces exec.ErrWaitDelay from Wait even though the command exited 0.
+// Propagating that would report a `git push` that actually succeeded as a
+// failure and throw away its output, so the pipeline would retry or fail an
+// operation that already applied.
+func TestRun_ReportsSuccessWhenCleanExitLeavesADescendantHoldingThePipes(t *testing.T) {
+	// The shell writes its output and exits 0 immediately; the backgrounded
+	// sleep inherits stdout and holds it open well past waitDelay.
+	cmd := exec.CommandContext(context.Background(), "sh", "-c",
+		`sleep 30 & printf complete-output; exit 0`)
+	var out strings.Builder
+	cmd.Stdout = &out
+
+	start := time.Now()
+	err := procgroup.Run(cmd)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("run returned %v; a command that exited 0 must be reported as "+
+			"successful even when a descendant holds the pipes", err)
+	}
+	if out.String() != "complete-output" {
+		t.Errorf("stdout = %q, want %q — the buffered output must survive", out.String(), "complete-output")
+	}
+	// Confirms the test actually exercised the WaitDelay path rather than
+	// finishing before it could fire.
+	if elapsed < waitDelayForTest {
+		t.Errorf("returned after %s, faster than waitDelay — the ErrWaitDelay "+
+			"branch was not exercised, so this test proves nothing", elapsed)
+	}
+	if code := cmd.ProcessState.ExitCode(); code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+}
+
+// waitDelayForTest mirrors procgroup's unexported waitDelay. Kept as a separate
+// constant on purpose: if the production value shrinks below this, the timing
+// assertion above starts failing loudly instead of silently passing without
+// having exercised the branch.
+const waitDelayForTest = 3 * time.Second
+
 // TestRun_RejectsCommandWithoutContext documents the one precondition callers
-// must honour: os/exec refuses to start a command that has a Cancel hook but
-// was not created with CommandContext. Both git call sites use CommandContext,
-// and the failure is immediate and self-describing rather than silent — but pin
-// it so nobody "fixes" the requirement out of the doc comment by accident.
+// must honour: os/exec refuses to start a command that has a Cancel hook but was
+// not created with CommandContext. Both git call sites use CommandContext, and
+// the failure is immediate and self-describing rather than silent.
+//
+// Asserts only that Start failed. The review of #667 claimed the stdlib message
+// is "exec: command with Cancel requires a Context"; it is actually "exec:
+// command with a non-nil Cancel was not created with CommandContext"
+// (go1.25 os/exec/exec.go:692). Either way the text is Go's to reword, so
+// matching on it would be a fragile assertion — the precondition is what
+// matters, not its wording.
 func TestRun_RejectsCommandWithoutContext(t *testing.T) {
 	cmd := exec.Command("sh", "-c", "exit 0") //nolint:noctx // deliberate misuse
-	err := procgroup.Run(cmd)
-	if err == nil {
+	if err := procgroup.Run(cmd); err == nil {
 		t.Fatal("expected Run to fail for a command not created with CommandContext")
-	}
-	if !strings.Contains(err.Error(), "CommandContext") {
-		t.Errorf("error %q does not name the missing precondition", err)
 	}
 }

--- a/daemon/internal/procgroup/procgroup_test.go
+++ b/daemon/internal/procgroup/procgroup_test.go
@@ -1,0 +1,216 @@
+package procgroup_test
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/procgroup"
+)
+
+// readPID reads one newline-terminated PID from r. The child prints its own PID
+// rather than the test reading cmd.Process, because procgroup.Run owns Start and
+// touching that field from the test goroutine would be a data race.
+func readPID(t *testing.T, r io.Reader) int {
+	t.Helper()
+	line, err := bufio.NewReader(r).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read pid: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(line))
+	if err != nil {
+		t.Fatalf("parse pid %q: %v", line, err)
+	}
+	return pid
+}
+
+// TestRun_KillsGrandchildOnTimeout is the regression test for
+// theburrowhub/heimdallm#665. `sh` stands in for git and the backgrounded
+// `sleep` for the `ssh` child git forks for SSH remotes. Under plain cmd.Run
+// only the direct child is signalled, so the sleep survives, is reparented to
+// PID 1 and becomes a zombie there once it exits with nobody to wait() on it.
+// Cancelling must take the whole group down.
+func TestRun_KillsGrandchildOnTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	// An inherited pipe is the liveness probe. fd 3 reaches both the shell and
+	// the sleep it backgrounds, and the kernel reports EOF on the read end only
+	// once every process holding the write end has exited.
+	//
+	// A PID existence check (kill(pid, 0)) is unusable here: it also succeeds
+	// for a zombie, which is exactly the state this issue is about — the first
+	// version of this test passed a live grandchild and failed a correctly
+	// killed one for that reason. The pipe distinguishes "running" from
+	// "exited but not yet reaped"; kill(pid, 0) cannot.
+	probeR, probeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer probeR.Close()
+
+	// Background a long sleep, announce its PID, then block. The parent must not
+	// exit by itself, otherwise the test would pass without cancellation having
+	// done any work.
+	cmd := exec.CommandContext(ctx, "sh", "-c", `sleep 60 & echo $!; wait`)
+	cmd.ExtraFiles = []*os.File{probeW}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+
+	// Run in a goroutine so the PID can be read while the child is still alive:
+	// Wait closes the stdout pipe once the command exits.
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- procgroup.Run(cmd) }()
+
+	grandchild := readPID(t, stdout)
+	// The parent must drop its own copy or EOF can never arrive.
+	if err := probeW.Close(); err != nil {
+		t.Fatalf("close probe write end: %v", err)
+	}
+
+	select {
+	case runErr := <-runErrCh:
+		if runErr == nil {
+			t.Fatal("expected a cancellation error from a command that outlives its context")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Run never returned after the context expired")
+	}
+
+	eof := make(chan error, 1)
+	go func() {
+		b := make([]byte, 1)
+		_, readErr := probeR.Read(b)
+		eof <- readErr
+	}()
+	select {
+	case readErr := <-eof:
+		if !errors.Is(readErr, io.EOF) {
+			t.Fatalf("probe read returned %v, want io.EOF", readErr)
+		}
+	case <-time.After(10 * time.Second):
+		_ = syscall.Kill(grandchild, syscall.SIGKILL) // don't leak a stray process
+		t.Fatalf("grandchild %d still holds the inherited pipe — it outlived "+
+			"cancellation, so the process group was not signalled", grandchild)
+	}
+}
+
+// TestRun_ChildLeadsItsOwnGroup pins the precondition that makes the fix work:
+// the child must lead its own group, so kill(-pid) reaches its descendants. If
+// Setpgid were dropped the child would inherit the daemon's group and a
+// negated-PID signal would be aimed at the daemon itself.
+func TestRun_ChildLeadsItsOwnGroup(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", `echo $$; exec sleep 60`)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- procgroup.Run(cmd) }()
+
+	// `exec` replaces the shell in place, so this PID is also the sleep's.
+	child := readPID(t, stdout)
+
+	pgid, err := syscall.Getpgid(child)
+	if err != nil {
+		t.Fatalf("getpgid(%d): %v", child, err)
+	}
+	if pgid != child {
+		t.Errorf("pgid = %d, want %d (the child must lead its own group)", pgid, child)
+	}
+	if pgid == syscall.Getpgrp() {
+		t.Error("child shares the test process group; kill(-pgid) would signal the daemon itself")
+	}
+
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+		t.Fatalf("kill group: %v", err)
+	}
+	select {
+	case <-runErrCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Run did not return after the group was killed")
+	}
+}
+
+// TestRun_SucceedsAndPropagatesOutput guards the happy path: wrapping Start and
+// Wait must not change the observable behaviour of a command that completes
+// normally, since every git call in the daemon now goes through here.
+func TestRun_SucceedsAndPropagatesOutput(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", "printf hello")
+	var out strings.Builder
+	cmd.Stdout = &out
+
+	if err := procgroup.Run(cmd); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out.String() != "hello" {
+		t.Errorf("stdout = %q, want %q", out.String(), "hello")
+	}
+}
+
+// TestRun_PropagatesExitError keeps the error contract identical to cmd.Run:
+// the git wrappers unwrap *exec.ExitError to report the exit status, so losing
+// the error type would silently degrade their messages.
+func TestRun_PropagatesExitError(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", "exit 3")
+	err := procgroup.Run(cmd)
+	if err == nil {
+		t.Fatal("expected a non-nil error for exit status 3")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error %v (%T) is not an *exec.ExitError", err, err)
+	}
+	if got := exitErr.ExitCode(); got != 3 {
+		t.Errorf("exit code = %d, want 3", got)
+	}
+}
+
+// TestRun_ReportsStartFailure covers the early return, which must also close the
+// escalation channel rather than leave a goroutine parked on it.
+func TestRun_ReportsStartFailure(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "/nonexistent/heimdallm-procgroup-test")
+	if err := procgroup.Run(cmd); err == nil {
+		t.Fatal("expected an error when the binary cannot be started")
+	}
+}
+
+// TestRun_PreservesExistingSysProcAttr makes sure Run augments rather than
+// replaces a SysProcAttr the caller had already configured.
+func TestRun_PreservesExistingSysProcAttr(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", "exit 0")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: false, Foreground: false}
+	if err := procgroup.Run(cmd); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Error("Setpgid was not applied to the caller's existing SysProcAttr")
+	}
+}
+
+// TestRun_RejectsCommandWithoutContext documents the one precondition callers
+// must honour: os/exec refuses to start a command that has a Cancel hook but
+// was not created with CommandContext. Both git call sites use CommandContext,
+// and the failure is immediate and self-describing rather than silent — but pin
+// it so nobody "fixes" the requirement out of the doc comment by accident.
+func TestRun_RejectsCommandWithoutContext(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 0") //nolint:noctx // deliberate misuse
+	err := procgroup.Run(cmd)
+	if err == nil {
+		t.Fatal("expected Run to fail for a command not created with CommandContext")
+	}
+	if !strings.Contains(err.Error(), "CommandContext") {
+		t.Errorf("error %q does not name the missing precondition", err)
+	}
+}

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/procgroup"
 )
 
 const (
@@ -1167,7 +1168,11 @@ func (execGit) Run(ctx context.Context, dir string, env []string, args ...string
 	}
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
+	// procgroup.Run rather than cmd.Run: git forks `ssh` for SSH remotes, and
+	// exec.CommandContext's cancellation reaches only git itself. On a
+	// gitTimeout the ssh child was orphaned onto PID 1 and became a zombie
+	// there (theburrowhub/heimdallm#665).
+	if err := procgroup.Run(cmd); err != nil {
 		errText := stderr.String()
 		if len(errText) > maxGitStderrBytes {
 			errText = errText[:maxGitStderrBytes] + "\n... (stderr truncated)"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,12 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.version=$VERSION" 
 # ─── Stage 2: Runtime with AI CLIs ───────────────────────────────────────────
 FROM node:20-alpine
 
-RUN apk add --no-cache ca-certificates tzdata bash curl coreutils git openssh-client
+# tini is PID 1 (see ENTRYPOINT): the daemon spawns git, which forks ssh, and an
+# orphaned grandchild is reparented onto PID 1. The kernel does not auto-reap on
+# PID 1's behalf, so without a real init those grandchildren pile up as zombies
+# until the container hits its PID limit — 13 [ssh] + 2 [git] in 23h of uptime
+# on 0.8.0 (theburrowhub/heimdallm#665).
+RUN apk add --no-cache ca-certificates tzdata bash curl coreutils git openssh-client tini
 
 # ── Install AI CLI tools ──────────────────────────────────────────────────────
 # Claude Code CLI (Anthropic) — requires ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN at runtime
@@ -86,4 +91,8 @@ WORKDIR /home/heimdallm
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:7842/health || exit 1
 
-ENTRYPOINT ["/usr/local/bin/heimdallm"]
+# tini reaps orphaned grandchildren and forwards signals to the daemon, so
+# graceful shutdown (and the daemon's own agent termination) is unchanged.
+# No `-g`: SIGTERM must reach the daemon alone so it can run its own shutdown
+# sequence rather than having the whole group killed underneath it.
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/heimdallm"]

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -8,7 +8,12 @@
 
 FROM node:20-alpine
 
-RUN apk add --no-cache ca-certificates tzdata bash curl coreutils git openssh-client
+# tini is PID 1 (see ENTRYPOINT): the daemon spawns git, which forks ssh, and an
+# orphaned grandchild is reparented onto PID 1. The kernel does not auto-reap on
+# PID 1's behalf, so without a real init those grandchildren pile up as zombies
+# until the container hits its PID limit — 13 [ssh] + 2 [git] in 23h of uptime
+# on 0.8.0 (theburrowhub/heimdallm#665).
+RUN apk add --no-cache ca-certificates tzdata bash curl coreutils git openssh-client tini
 
 # ── Install AI CLI tools ──────────────────────────────────────────────────────
 # Claude Code CLI (Anthropic) — requires ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN at runtime
@@ -78,4 +83,8 @@ WORKDIR /home/heimdallm
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:7842/health || exit 1
 
-ENTRYPOINT ["/usr/local/bin/heimdallm"]
+# tini reaps orphaned grandchildren and forwards signals to the daemon, so
+# graceful shutdown (and the daemon's own agent termination) is unchanged.
+# No `-g`: SIGTERM must reach the daemon alone so it can run its own shutdown
+# sequence rather than having the whole group killed underneath it.
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/heimdallm"]


### PR DESCRIPTION
Fixes #665.

## Two causes, both required

The issue diagnosed cause (1). Investigating it turned up a second one, and **the suggested fix alone would not have removed the reported symptom**:

1. `exec.CommandContext` signals only the process it started. `git` forks `ssh` for SSH remotes, so a `gitTimeout` killed `git` and left `ssh` running, reparented onto PID 1.
2. **Nothing reaps it there.** The kernel does not auto-reap on PID 1's behalf, and `ENTRYPOINT` was the daemon binary with no init. Every orphan that exited stayed a zombie forever.

Killing the process group makes the orphan *die*; it is still reparented onto PID 1 and still needs a reaper. So (1) without (2) leaves the zombies. (2) without (1) hides the leak while the daemon keeps losing track of subprocesses. Both are here.

### Empirical confirmation

PID 1 = a process that does not reap adopted children (like the Go daemon):

```
# no init                          # with init
PID  PPID STAT COMMAND             PID  PPID STAT COMMAND
  1     0 S    node                  1     0 S    tini
 15     1 Z    sleep   <- zombie      7     1 S    node
```

Same shape as the report (`[ssh]`/`[git]` with `PPID 1`). Also verified with the exact `ENTRYPOINT ["/sbin/tini", "--", …]` form used here, and that tini forwards SIGTERM so graceful shutdown still works (`docker stop` → handler runs → exit 0).

## Scope: a third call site the issue missed

The issue named only `repoctx/manager.go` (`302ea3f1`). `issues/gitops.go` `captureGit` has the identical pattern and is **20 days older** (`1186af4e`, #45). It is the shared helper behind `CheckoutNewBranch`, `Push`, `DeleteRemoteBranch`, `HasChanges`, `CommitAll`, `Diff` — the push/fetch ones fork `ssh` just the same. Fixing only `repoctx` would leave the auto_implement pipeline leaking. Both are routed through the new helper.

## Design notes for review

**`internal/procgroup` wraps `Start`+`Wait` instead of offering a "configure this cmd" helper.** The escalation goroutine must be told when the child was reaped; a caller who forgot would eventually signal a pgid the kernel had recycled onto an unrelated group. Owning the lifecycle makes that unforgettable.

**One precondition:** the cmd must come from `exec.CommandContext`. `os/exec` refuses to start a command with a `Cancel` hook and no context, so misuse fails immediately with an explicit error. Semantically correct too — with no context there is nothing to cancel. Pinned by `TestRun_RejectsCommandWithoutContext`.

**`internal/executor` was left alone.** It already has a richer variant of this logic (group tracking for `TerminateAll`, tolerating `ErrWaitDelay` when the payload is complete) added in #656 for #614. Folding those needs into a shared helper would turn this PR into a refactor of the most delicate path in the daemon. Flagging the duplication deliberately — converging them is follow-up for #614, which this PR should probably be linked to since it is the same bug class.

**`ErrWaitDelay` is not special-cased for git.** The executor returns collected output when the child exited 0 but a descendant held the pipes. git output is parsed (`status --porcelain`, `diff --name-only -z`), so silently returning a truncated read could produce wrong decisions. It propagates as an error instead.

## Tests

New `daemon/internal/procgroup/procgroup_test.go`, 7 tests. The regression test was **verified to fail without the fix** (sabotaged `Setpgid` + parent-only kill → fails in 10.3s; with the fix, passes in 0.30s).

One thing worth knowing: the first version of that test used `kill(pid, 0)` for liveness and was **wrong in both directions** — that call also succeeds for a zombie, which is exactly the state under test. It now uses an inherited pipe and waits for EOF, which distinguishes "running" from "exited but not reaped" and is portable to the macOS CI runners (no `/proc`).

`make test-docker` green across all 18 daemon packages (vet included); `make test-compose-isolation` green.

## Not covered here

The `--init`/tini change only affects the container images. Host installs (`install-linux`) run under systemd, which already reaps. The process-group fix helps both.
