### PR TITLE
fix(breaker): count review runs, not published reviews

### DIFF
--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -778,6 +778,11 @@ func main() {
 			defer wg.Done()
 			const sweepInterval = 5 * time.Minute
 			const inflightSweepMaxAge = 30 * time.Minute
+			// The attempt ledger is only ever read through the breaker's
+			// windows (24h per-PR, 1h per-repo). 48h keeps a full margin over
+			// the widest of those: pruning anything still inside a window would
+			// silently reset a cap that is meant to be in force.
+			const attemptLedgerMaxAge = 48 * time.Hour
 			ticker := time.NewTicker(sweepInterval)
 			defer ticker.Stop()
 			for {
@@ -794,6 +799,11 @@ func main() {
 						slog.Warn("sweep: clear stale issue triage inflight failed", "err", err)
 					} else if n > 0 {
 						slog.Info("sweep: cleared stale issue triage inflight rows", "count", n)
+					}
+					if n, err := s.PruneReviewAttempts(attemptLedgerMaxAge); err != nil {
+						slog.Warn("sweep: prune review attempts failed", "err", err)
+					} else if n > 0 {
+						slog.Info("sweep: pruned review attempt rows", "count", n)
 					}
 				}
 			}

--- a/daemon/cmd/heimdallm/main_test.go
+++ b/daemon/cmd/heimdallm/main_test.go
@@ -1169,7 +1169,11 @@ drain:
 	if count != 1 {
 		t.Fatalf("circuit breaker events = %d, want 1", count)
 	}
-	if reason != "per-PR HEAD cap reached: 3 reviews on this commit in last 24h (cap 3)" {
+	// "review runs", not "reviews": the cap counts every run that spent CLI
+	// credits, including ones that failed before a review row was written
+	// (#663). Saying "3 reviews" when only one was ever published sent the
+	// operator looking for reviews that do not exist.
+	if reason != "per-PR HEAD cap reached: 3 review runs on this commit in last 24h (cap 3)" {
 		t.Fatalf("reason = %q", reason)
 	}
 }

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -729,32 +729,6 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 		}
 	}
 
-	// 4c. Record the attempt now: the breaker has cleared this run and every
-	// path from here leads to the CLI, so this is the moment the run becomes
-	// chargeable.
-	//
-	// It has to happen BEFORE Execute and must survive failure. `reviews` rows
-	// are only written on success (step 7), so a run that dies in between — a
-	// CLI whose output will not parse, say — used to leave no trace anywhere:
-	// the in-flight claim was released by the caller's defer, no review row
-	// existed, and the breaker's counter never moved. Every dedup layer keys off
-	// one of those two, so all of them were blind at once and the retry of the
-	// identical commit was unbounded, each iteration paying full price
-	// (theburrowhub/heimdallm#663).
-	//
-	// Forced runs are recorded too. Force bypasses the breaker CHECK because a
-	// human clicking "Re-review" is deliberate intent, but the spend is real and
-	// an unrecorded run would leave the same blind spot for whatever runs next.
-	//
-	// Fail-open on a write error, matching the breaker check just above: a
-	// transient SQLite blip must not block a legitimate review. The cost of
-	// being wrong is bounded by the caller's in-flight claim plus the dedup
-	// layers, which is the same posture the pre-existing code documents.
-	if err := p.store.RecordReviewAttempt(prID, pr.Head.SHA); err != nil {
-		slog.Warn("pipeline: could not record review attempt, proceeding",
-			"repo", pr.Repo, "pr", pr.Number, "head_sha", pr.Head.SHA, "err", err)
-	}
-
 	// All early-exit paths above are exhausted (gate, SHA-skip,
 	// legacy-backfill, circuit breaker): from this point we are committed
 	// to running the CLI and posting a real review. Both the desktop
@@ -771,6 +745,51 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	if stopped, err := p.stopIfRepoBecameIneligible(pr, opts.RepoEligible); stopped {
 		return nil, err
 	}
+	// 4c. Record the attempt. Every remaining path leads to Execute, which is
+	// what makes this — and not a line earlier — the point at which the run
+	// becomes chargeable.
+	//
+	// Placement is load-bearing. This deliberately sits AFTER
+	// stopIfRepoBecameIneligible: that guard is a zero-spend, explicitly
+	// retryable exit ("deferring review"), so recording before it meant a repo
+	// toggled off mid-poll burned a ledger row per tick without touching the
+	// CLI. After PerPR24h such ticks the commit was capped for 24h and the
+	// legitimate review was refused once the repo came back, recoverable only
+	// via Force.
+	//
+	// It has to happen BEFORE Execute and must survive failure. Rows in the
+	// reviews table are only written on success (step 7), so a run that dies in
+	// between — a CLI whose output will not parse, say — used to leave no trace
+	// anywhere: the in-flight claim was released by the caller's defer, no
+	// review row existed, and the breaker's counter never moved. Every dedup
+	// layer keys off one of those two, so all of them were blind at once and the
+	// retry of the identical commit was unbounded, each iteration paying full
+	// price (theburrowhub/heimdallm#663).
+	//
+	// Forced runs are recorded too. Force bypasses the breaker CHECK because a
+	// human clicking "Re-review" is deliberate intent, but the spend is real and
+	// an unrecorded run would leave the same blind spot for whatever runs next.
+	//
+	// Known trade-off: the ledger cannot tell a failure that spent credits from
+	// one that did not (provider auth rejection, an execution timeout, context
+	// cancellation on daemon shutdown). Those count too, so a restart loop can
+	// cap a commit for 24h and report "N review runs" for runs that cost
+	// nothing. Accepted deliberately — classifying CLI errors by whether they
+	// billed is guesswork, and under-counting is what #663 was. Force is the
+	// operator's escape hatch.
+	//
+	// Fail-open on a write error, matching the breaker check above: a transient
+	// SQLite blip must not block a legitimate review. Logged at Error, not Warn:
+	// this single write is what the entire cost brake now rests on, so a
+	// persistent failure (read-only DB, disk full) silently restores the
+	// unbounded retry loop and must be visible in the logs rather than inferred
+	// from the bill.
+	if err := p.store.RecordReviewAttempt(prID, pr.Head.SHA); err != nil {
+		slog.Error("pipeline: could not record review attempt — the per-PR/per-repo "+
+			"cost cap is not counting this run",
+			"repo", pr.Repo, "pr", pr.Number, "head_sha", pr.Head.SHA, "err", err)
+	}
+
 	p.notify.Notify("PR Review Started", fmt.Sprintf("%s #%d", pr.Repo, pr.Number))
 	p.publish(sse.EventPRDetected, map[string]any{
 		"pr_number": pr.Number,

--- a/daemon/internal/pipeline/pipeline.go
+++ b/daemon/internal/pipeline/pipeline.go
@@ -712,7 +712,7 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 	}
 	slog.Info("pipeline: using CLI", "cli", cli)
 
-	// 4b. Circuit breaker: hard cap on review count per PR HEAD / per repo.
+	// 4b. Circuit breaker: hard cap on review runs per PR HEAD / per repo.
 	// Runs AFTER all dedup layers so it only fires when the dedup failed but
 	// the caller is about to spend Claude credits anyway. See
 	// theburrowhub/heimdallm#243.
@@ -727,6 +727,32 @@ func (p *Pipeline) Run(pr *github.PullRequest, opts RunOptions) (*store.Review, 
 				fmt.Sprintf("%s #%d: %s", pr.Repo, pr.Number, reason))
 			return nil, &CircuitBreakerError{Reason: reason}
 		}
+	}
+
+	// 4c. Record the attempt now: the breaker has cleared this run and every
+	// path from here leads to the CLI, so this is the moment the run becomes
+	// chargeable.
+	//
+	// It has to happen BEFORE Execute and must survive failure. `reviews` rows
+	// are only written on success (step 7), so a run that dies in between — a
+	// CLI whose output will not parse, say — used to leave no trace anywhere:
+	// the in-flight claim was released by the caller's defer, no review row
+	// existed, and the breaker's counter never moved. Every dedup layer keys off
+	// one of those two, so all of them were blind at once and the retry of the
+	// identical commit was unbounded, each iteration paying full price
+	// (theburrowhub/heimdallm#663).
+	//
+	// Forced runs are recorded too. Force bypasses the breaker CHECK because a
+	// human clicking "Re-review" is deliberate intent, but the spend is real and
+	// an unrecorded run would leave the same blind spot for whatever runs next.
+	//
+	// Fail-open on a write error, matching the breaker check just above: a
+	// transient SQLite blip must not block a legitimate review. The cost of
+	// being wrong is bounded by the caller's in-flight claim plus the dedup
+	// layers, which is the same posture the pre-existing code documents.
+	if err := p.store.RecordReviewAttempt(prID, pr.Head.SHA); err != nil {
+		slog.Warn("pipeline: could not record review attempt, proceeding",
+			"repo", pr.Repo, "pr", pr.Number, "head_sha", pr.Head.SHA, "err", err)
 	}
 
 	// All early-exit paths above are exhausted (gate, SHA-skip,

--- a/daemon/internal/pipeline/pipeline_attempt_ledger_test.go
+++ b/daemon/internal/pipeline/pipeline_attempt_ledger_test.go
@@ -2,6 +2,7 @@ package pipeline_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,9 +117,18 @@ func TestRun_FailedRunsCountTowardTheBreaker(t *testing.T) {
 	if attempts != 3 {
 		t.Errorf("ledger attempts = %d, want 3", attempts)
 	}
+	// Pin the premise rather than skip it on error: LatestReviewForPR reports
+	// "no rows" as an error, so swallowing that would leave the whole point of
+	// this test — that the count came from the ledger and not from a review row
+	// — unverified.
 	rev, err := s.LatestReviewForPR(storedPR.ID)
-	if err == nil && rev != nil {
+	switch {
+	case err == nil && rev != nil:
 		t.Errorf("a review row exists (id %d); the premise of this test is that none does", rev.ID)
+	case err == nil && rev == nil:
+		// Acceptable: no row, reported without an error.
+	case !strings.Contains(err.Error(), "no rows"):
+		t.Errorf("LatestReviewForPR failed for an unexpected reason: %v", err)
 	}
 }
 
@@ -172,3 +182,95 @@ func TestRun_ForcedRunIsRecordedEvenThoughItBypassesTheCheck(t *testing.T) {
 			"to the runs that follow it", attempts)
 	}
 }
+
+// TestRun_IneligibleRepoDoesNotConsumeLedgerQuota is the regression test for the
+// review finding on placement.
+//
+// stopIfRepoBecameIneligible is a zero-spend, explicitly retryable exit — it logs
+// "deferring review". Recording the attempt before it meant a repo toggled off
+// while a poll was in flight burned one ledger row per tick without ever
+// invoking the CLI; after PerPR24h such ticks the commit was capped for 24h and
+// the legitimate review was refused once the repo came back, recoverable only
+// via Force.
+func TestRun_IneligibleRepoDoesNotConsumeLedgerQuota(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	const sha = "cafebabe"
+	fexec := &failingExec{}
+	p := pipeline.New(s, &attemptGH{sha: sha}, fexec, &fakeNotify{})
+	p.SetBotLogin("heimdallm-bot")
+	p.SetCircuitBreakerLimits(&store.CircuitBreakerLimits{PerPR24h: 3, PerRepoHr: 999})
+
+	pr := &gh.PullRequest{
+		ID: 77, Number: 77, Title: "t", Repo: "org/repo",
+		User: gh.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/77",
+	}
+	pr.Head.SHA = sha
+
+	// The repo must be eligible for the EARLIER guards and ineligible only at the
+	// one just before Execute — that is the whole point, and a func that always
+	// returns false would exit at the first guard (pipeline.go:466) without ever
+	// reaching the record site, making this test vacuous. Verified: it passed
+	// against the buggy placement until this was fixed.
+	//
+	// eligibleUntilLastCheck reports true for every call except the final guard
+	// preceding Execute, reproducing a config reload that lands mid-poll.
+	var checks int
+	opts := pipeline.RunOptions{
+		Primary: "claude", Fallback: "gemini",
+		RepoEligible: func(string) bool {
+			checks++
+			return checks < eligibilityChecksBeforeExecute
+		},
+	}
+
+	// More ticks than the cap: if any of them charged the ledger, the commit
+	// would be capped afterwards.
+	for i := 0; i < 5; i++ {
+		checks = 0
+		rev, runErr := p.Run(pr, opts)
+		if runErr != nil {
+			t.Fatalf("tick %d: deferring a review must not error: %v", i, runErr)
+		}
+		if rev != nil {
+			t.Fatalf("tick %d: expected no review when the repo is ineligible", i)
+		}
+	}
+	if fexec.calls != 0 {
+		t.Fatalf("Execute was called %d times for an ineligible repo", fexec.calls)
+	}
+
+	storedPR, err := s.GetPRByGithubID(pr.ID)
+	if err != nil {
+		t.Fatalf("get pr: %v", err)
+	}
+	attempts, err := s.CountReviewAttemptsForPRHeadSHA(storedPR.ID, sha, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("count attempts: %v", err)
+	}
+	if attempts != 0 {
+		t.Errorf("ledger charged %d attempts for runs that never reached the CLI; a "+
+			"disabled repo would cap the commit for 24h", attempts)
+	}
+
+	// The cap must still be intact, so the review lands when the repo returns.
+	tripped, reason, err := s.CheckCircuitBreaker(storedPR.ID, pr.Repo, sha,
+		store.CircuitBreakerLimits{PerPR24h: 3, PerRepoHr: 999})
+	if err != nil {
+		t.Fatalf("check breaker: %v", err)
+	}
+	if tripped {
+		t.Errorf("breaker tripped after only deferred runs (%s)", reason)
+	}
+}
+
+// eligibilityChecksBeforeExecute is the number of RepoEligible calls Run makes
+// up to and including the guard immediately before Execute. Pinned as a constant
+// so that if Run gains or loses a guard this test fails loudly rather than
+// quietly stopping to exercise the placement it exists to protect.
+const eligibilityChecksBeforeExecute = 2

--- a/daemon/internal/pipeline/pipeline_attempt_ledger_test.go
+++ b/daemon/internal/pipeline/pipeline_attempt_ledger_test.go
@@ -1,0 +1,174 @@
+package pipeline_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/executor"
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/pipeline"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// failingExec reproduces the incident's failure mode: the CLI runs, bills for
+// the work, and then returns output the pipeline cannot parse. Run aborts before
+// step 7, so no review row is ever written.
+type failingExec struct {
+	calls int
+}
+
+func (f *failingExec) Detect(_, _ string) (string, error) { return "fake_claude", nil }
+
+func (f *failingExec) Execute(_, _ string, _ executor.ExecOptions) (*executor.ReviewResult, error) {
+	f.calls++
+	return nil, errors.New("executor: parse JSON result: invalid character 'e' looking for beginning of object key string")
+}
+
+// attemptGH is a minimal github dependency; nothing here should be reached once
+// the breaker trips.
+type attemptGH struct{ sha string }
+
+func (a *attemptGH) GetPRHeadSHA(_ string, _ int) (string, error) { return a.sha, nil }
+func (a *attemptGH) FetchDiff(_ string, _ int) (string, error)    { return "+line", nil }
+func (a *attemptGH) SubmitReview(_ string, _ int, _, _ string) (int64, string, error) {
+	return 0, "", nil
+}
+func (a *attemptGH) PostComment(_ string, _ int, _ string) (time.Time, error) {
+	return time.Now().UTC(), nil
+}
+func (a *attemptGH) FetchComments(_ string, _ int) ([]gh.Comment, error) { return nil, nil }
+
+// TestRun_FailedRunsCountTowardTheBreaker is the end-to-end regression test for
+// theburrowhub/heimdallm#663.
+//
+// Every run dies inside Execute, so none of them writes a review row. The old
+// breaker counted review rows, which meant its counter never moved and the same
+// commit could be re-run at full price without limit — the incident showed two
+// full-price runs 37s apart on 31615409, and nothing in the code would have
+// stopped a third, or a thirtieth.
+//
+// With the attempt ledger the configured cap of 3 must be enforced against the
+// failures themselves: the fourth call must trip the breaker and must NOT reach
+// the CLI.
+func TestRun_FailedRunsCountTowardTheBreaker(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	const sha = "31615409a9152613021ddccfec2c6e2001d4575d"
+	fexec := &failingExec{}
+	p := pipeline.New(s, &attemptGH{sha: sha}, fexec, &fakeNotify{})
+	p.SetBotLogin("heimdallm-bot")
+	p.SetCircuitBreakerLimits(&store.CircuitBreakerLimits{PerPR24h: 3, PerRepoHr: 999})
+
+	pr := &gh.PullRequest{
+		ID: 12, Number: 12, Title: "wails frontend", Repo: "theburrowhub/thaimaturgy",
+		User: gh.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/theburrowhub/thaimaturgy/pull/12",
+	}
+	pr.Head.SHA = sha
+	opts := pipeline.RunOptions{Primary: "claude", Fallback: "gemini"}
+
+	// Three failing runs are allowed: the cap is 3, and the breaker must not
+	// fire early or it would block legitimate work.
+	for i := 1; i <= 3; i++ {
+		_, runErr := p.Run(pr, opts)
+		if runErr == nil {
+			t.Fatalf("run %d: expected the parse failure to surface", i)
+		}
+		var breakerErr *pipeline.CircuitBreakerError
+		if errors.As(runErr, &breakerErr) {
+			t.Fatalf("run %d tripped the breaker early: %v", i, runErr)
+		}
+	}
+	if fexec.calls != 3 {
+		t.Fatalf("Execute calls = %d, want 3 (nothing should have blocked the first three)", fexec.calls)
+	}
+
+	// The fourth attempt must be refused. Under the old behaviour this ran the
+	// CLI again — and would have kept doing so indefinitely.
+	_, runErr := p.Run(pr, opts)
+	if runErr == nil {
+		t.Fatal("fourth run returned no error; the breaker did not trip")
+	}
+	var breakerErr *pipeline.CircuitBreakerError
+	if !errors.As(runErr, &breakerErr) {
+		t.Fatalf("fourth run failed with %v, want a CircuitBreakerError — failed runs are "+
+			"still not counted, so the retry loop remains unbounded (#663)", runErr)
+	}
+	if fexec.calls != 3 {
+		t.Errorf("Execute calls = %d after the trip, want 3 — the breaker must short-circuit "+
+			"before spending credits", fexec.calls)
+	}
+
+	// Sanity: the ledger is what carried the count, since no review row exists.
+	storedPR, err := s.GetPRByGithubID(pr.ID)
+	if err != nil {
+		t.Fatalf("get pr: %v", err)
+	}
+	attempts, err := s.CountReviewAttemptsForPRHeadSHA(storedPR.ID, sha, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("count attempts: %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("ledger attempts = %d, want 3", attempts)
+	}
+	rev, err := s.LatestReviewForPR(storedPR.ID)
+	if err == nil && rev != nil {
+		t.Errorf("a review row exists (id %d); the premise of this test is that none does", rev.ID)
+	}
+}
+
+// TestRun_ForcedRunIsRecordedEvenThoughItBypassesTheCheck documents the
+// asymmetry: Force skips the breaker CHECK because a human clicking "Re-review"
+// is deliberate intent, but the spend is real, so the run is still ledgered.
+// Leaving it unrecorded would recreate the same blind spot for whatever runs
+// next on that commit.
+func TestRun_ForcedRunIsRecordedEvenThoughItBypassesTheCheck(t *testing.T) {
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	const sha = "deadbeef"
+	fexec := &failingExec{}
+	p := pipeline.New(s, &attemptGH{sha: sha}, fexec, &fakeNotify{})
+	p.SetBotLogin("heimdallm-bot")
+	// Cap of 1: a forced run would trip it immediately if Force were checked.
+	p.SetCircuitBreakerLimits(&store.CircuitBreakerLimits{PerPR24h: 1, PerRepoHr: 999})
+
+	pr := &gh.PullRequest{
+		ID: 99, Number: 99, Title: "t", Repo: "org/repo",
+		User: gh.User{Login: "alice"}, State: "open",
+		UpdatedAt: time.Now(), HTMLURL: "https://github.com/org/repo/pull/99",
+	}
+	pr.Head.SHA = sha
+
+	if _, err := p.Run(pr, pipeline.RunOptions{
+		Primary: "claude", Fallback: "gemini", Force: true,
+	}); err == nil {
+		t.Fatal("expected the parse failure to surface")
+	}
+
+	// Ran despite the cap of 1 already being satisfiable...
+	if fexec.calls != 1 {
+		t.Errorf("Execute calls = %d, want 1 — Force must bypass the check", fexec.calls)
+	}
+	// ...but the spend was still recorded.
+	storedPR, err := s.GetPRByGithubID(pr.ID)
+	if err != nil {
+		t.Fatalf("get pr: %v", err)
+	}
+	attempts, err := s.CountReviewAttemptsForPRHeadSHA(storedPR.ID, sha, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("count attempts: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("ledger attempts = %d, want 1 — a forced run's cost must still be visible "+
+			"to the runs that follow it", attempts)
+	}
+}

--- a/daemon/internal/store/circuitbreaker.go
+++ b/daemon/internal/store/circuitbreaker.go
@@ -59,42 +59,83 @@ func (s *Store) CountReviewsForRepo(repo string, since time.Time) (int, error) {
 // CircuitBreakerLimits is the configured set of caps. Enforced by
 // CheckCircuitBreaker; zero values mean "unlimited" for that axis.
 type CircuitBreakerLimits struct {
-	PerPR24h  int // max reviews per PR HEAD SHA in any 24h window
-	PerRepoHr int // max reviews per repo in any 1h window
+	PerPR24h  int // max review runs per PR HEAD SHA in any 24h window
+	PerRepoHr int // max review runs per repo in any 1h window
+}
+
+// chargeableRuns returns how many review runs in the window should count against
+// a cap, given the attempt count from the ledger and the row count from
+// `reviews`.
+//
+// The larger of the two, deliberately:
+//
+//   - The ledger is authoritative going forward — it records every run that
+//     reached the point of spending credits, including the ones that failed
+//     before InsertReview and were therefore invisible to the old counter.
+//   - `reviews` still has to be consulted because a database upgraded in place
+//     has review history but no ledger rows for it. Counting attempts alone
+//     would treat that history as if it never happened and hand out a fresh
+//     full quota on the first tick after deploy.
+//   - max rather than sum: a successful run writes one ledger row AND one
+//     reviews row, so adding them would double-count every normal review and
+//     halve the operator's configured cap.
+func chargeableRuns(attempts, reviews int) int {
+	if attempts > reviews {
+		return attempts
+	}
+	return reviews
 }
 
 // CheckCircuitBreaker returns (tripped, reason, err). When tripped is true,
 // the caller MUST NOT proceed to spend Claude credits for this PR. reason is
 // a human-readable explanation suitable for logs and UI surfaces; it is
 // empty when tripped is false.
+//
+// The caps count review *runs*, not published reviews. Counting only the latter
+// was theburrowhub/heimdallm#663: a run whose CLI output failed to parse never
+// reached InsertReview, so it advanced no counter, and the immediate retry of
+// the same commit was unbounded. Callers must therefore record an attempt via
+// RecordReviewAttempt once this check passes and before invoking the CLI.
 func (s *Store) CheckCircuitBreaker(prID int64, repo, headSHA string, cfg CircuitBreakerLimits) (bool, string, error) {
 	if cfg.PerPR24h > 0 {
+		since := time.Now().Add(-24 * time.Hour)
 		var (
-			n   int
-			err error
+			attempts, reviews int
+			err               error
 		)
 		if headSHA != "" {
-			n, err = s.CountReviewsForPRHeadSHA(prID, headSHA, time.Now().Add(-24*time.Hour))
+			if attempts, err = s.CountReviewAttemptsForPRHeadSHA(prID, headSHA, since); err != nil {
+				return false, "", err
+			}
+			reviews, err = s.CountReviewsForPRHeadSHA(prID, headSHA, since)
 		} else {
-			n, err = s.CountReviewsForPR(prID, time.Now().Add(-24*time.Hour))
+			if attempts, err = s.CountReviewAttemptsForPR(prID, since); err != nil {
+				return false, "", err
+			}
+			reviews, err = s.CountReviewsForPR(prID, since)
 		}
 		if err != nil {
 			return false, "", err
 		}
-		if n >= cfg.PerPR24h {
+		if n := chargeableRuns(attempts, reviews); n >= cfg.PerPR24h {
 			if headSHA != "" {
-				return true, fmt.Sprintf("per-PR HEAD cap reached: %d reviews on this commit in last 24h (cap %d)", n, cfg.PerPR24h), nil
+				return true, fmt.Sprintf("per-PR HEAD cap reached: %d review runs on this commit in last 24h (cap %d)", n, cfg.PerPR24h), nil
 			}
-			return true, fmt.Sprintf("per-PR cap reached: %d reviews in last 24h (cap %d)", n, cfg.PerPR24h), nil
+			return true, fmt.Sprintf("per-PR cap reached: %d review runs in last 24h (cap %d)", n, cfg.PerPR24h), nil
 		}
 	}
 	if cfg.PerRepoHr > 0 && repo != "" {
-		n, err := s.CountReviewsForRepo(repo, time.Now().Add(-1*time.Hour))
+		since := time.Now().Add(-1 * time.Hour)
+		attempts, err := s.CountReviewAttemptsForRepo(repo, since)
 		if err != nil {
 			return false, "", err
 		}
-		if n >= cfg.PerRepoHr {
-			return true, fmt.Sprintf("per-repo cap reached: %d reviews on %s in last 1h (cap %d)", n, repo, cfg.PerRepoHr), nil
+		reviews, err := s.CountReviewsForRepo(repo, since)
+		if err != nil {
+			return false, "", err
+		}
+		if n := chargeableRuns(attempts, reviews); n >= cfg.PerRepoHr {
+			return true, fmt.Sprintf("per-repo cap reached: %d review runs on %s in last 1h (cap %d)", n, repo, cfg.PerRepoHr), nil
 		}
 	}
 	return false, "", nil

--- a/daemon/internal/store/circuitbreaker.go
+++ b/daemon/internal/store/circuitbreaker.go
@@ -79,6 +79,14 @@ type CircuitBreakerLimits struct {
 //   - max rather than sum: a successful run writes one ledger row AND one
 //     reviews row, so adding them would double-count every normal review and
 //     halve the operator's configured cap.
+//
+// max is a floor, not an exact count, and it undercounts in one bounded case: a
+// commit carrying N legacy reviews rows inside the live window plus M new ledger
+// rows is charged max(N, M) rather than N+M, so up to 2*cap-1 runs can be
+// chargeable. That is confined to the first window after an upgrade, since from
+// then on every run writes a ledger row and the ledger dominates. Accepted in
+// exchange for never double-counting during normal operation, which would be
+// permanent.
 func chargeableRuns(attempts, reviews int) int {
 	if attempts > reviews {
 		return attempts

--- a/daemon/internal/store/review_attempts.go
+++ b/daemon/internal/store/review_attempts.go
@@ -1,0 +1,104 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// RecordReviewAttempt appends one row to the review-attempt ledger for
+// (prID, headSHA).
+//
+// Callers must invoke this immediately BEFORE spending CLI credits and must NOT
+// remove the row when the run fails. That is the entire point: the circuit
+// breaker used to count rows in `reviews`, which only exist for runs that
+// succeeded, so a run that died before InsertReview advanced no counter at all
+// and the next tick re-ran the same commit at full price with nothing to stop
+// it (theburrowhub/heimdallm#663).
+//
+// An empty headSHA is allowed and recorded as such; the per-PR axis of the
+// breaker falls back to counting every attempt on the PR in that case, which
+// matches how CountReviewsForPR is used for the same situation.
+func (s *Store) RecordReviewAttempt(prID int64, headSHA string) error {
+	_, err := s.db.Exec(
+		"INSERT INTO review_attempts (pr_id, head_sha, started_at) VALUES (?, ?, ?)",
+		prID, headSHA, time.Now().UTC().Format(sqliteTimeFormat),
+	)
+	if err != nil {
+		return fmt.Errorf("store: record review attempt: %w", err)
+	}
+	return nil
+}
+
+// CountReviewAttemptsForPR returns how many attempts were recorded for the PR at
+// or after `since`, regardless of HEAD SHA.
+func (s *Store) CountReviewAttemptsForPR(prID int64, since time.Time) (int, error) {
+	var n int
+	err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM review_attempts WHERE pr_id = ? AND started_at >= ?",
+		prID, since.UTC().Format(sqliteTimeFormat),
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("store: count review attempts for pr: %w", err)
+	}
+	return n, nil
+}
+
+// CountReviewAttemptsForPRHeadSHA returns how many attempts were recorded for
+// the PR at that exact commit at or after `since`. This is the breaker's primary
+// axis: cap repeated work on one commit while leaving a follow-up commit free to
+// be reviewed normally.
+func (s *Store) CountReviewAttemptsForPRHeadSHA(prID int64, headSHA string, since time.Time) (int, error) {
+	var n int
+	err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM review_attempts WHERE pr_id = ? AND head_sha = ? AND started_at >= ?",
+		prID, headSHA, since.UTC().Format(sqliteTimeFormat),
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("store: count review attempts for pr head sha: %w", err)
+	}
+	return n, nil
+}
+
+// CountReviewAttemptsForRepo returns how many attempts were recorded across ANY
+// PR of the repo at or after `since`. Mirrors CountReviewsForRepo, including the
+// join, so both axes of the breaker read the same shape of data.
+func (s *Store) CountReviewAttemptsForRepo(repo string, since time.Time) (int, error) {
+	var n int
+	err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM review_attempts a
+		JOIN prs p ON a.pr_id = p.id
+		WHERE p.repo = ? AND a.started_at >= ?`,
+		repo, since.UTC().Format(sqliteTimeFormat),
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("store: count review attempts for repo: %w", err)
+	}
+	return n, nil
+}
+
+// PruneReviewAttempts deletes ledger rows older than maxAge and returns how many
+// were removed.
+//
+// The ledger is append-only and only ever read through a 24h (per-PR) or 1h
+// (per-repo) window, so anything older is dead weight. maxAge must stay
+// comfortably above the widest breaker window, otherwise pruning would silently
+// reset a cap that is still meant to be in force.
+//
+// Note on precision: started_at is stored in sqliteTimeFormat, which is
+// second-granular, and the comparison is strictly less-than. A row written in
+// the same second as the computed cutoff therefore survives — the same dead zone
+// documented on ClearAllInFlight (#544). Harmless at the 48h maxAge the sweep
+// uses; it only matters to a caller passing a maxAge near zero, which no
+// production path does.
+func (s *Store) PruneReviewAttempts(maxAge time.Duration) (int, error) {
+	cutoff := time.Now().Add(-maxAge).UTC().Format(sqliteTimeFormat)
+	res, err := s.db.Exec("DELETE FROM review_attempts WHERE started_at < ?", cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("store: prune review attempts: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("store: prune review attempts rowsaffected: %w", err)
+	}
+	return int(n), nil
+}

--- a/daemon/internal/store/review_attempts_test.go
+++ b/daemon/internal/store/review_attempts_test.go
@@ -1,0 +1,292 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+func attemptStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+// seedPR inserts a PR so the per-repo join has something to resolve.
+func seedPR(t *testing.T, s *store.Store, githubID int64, repo string) int64 {
+	t.Helper()
+	id, err := s.UpsertPR(&store.PR{
+		GithubID: githubID,
+		Repo:     repo,
+		Number:   int(githubID),
+		Title:    "t",
+		Author:   "alice",
+		State:    "open",
+		URL:      "https://example.test",
+	})
+	if err != nil {
+		t.Fatalf("upsert pr: %v", err)
+	}
+	return id
+}
+
+// TestCircuitBreaker_CountsFailedRunsThatNeverProducedAReview is the regression
+// test for theburrowhub/heimdallm#663.
+//
+// Three runs all die before InsertReview — the shape of the incident, where the
+// CLI's output would not parse. Under the old implementation the breaker counted
+// rows in `reviews`, so this scenario left the counter at 0 forever and the
+// retry of the identical commit was unbounded. The cap must now be reached.
+func TestCircuitBreaker_CountsFailedRunsThatNeverProducedAReview(t *testing.T) {
+	s := attemptStore(t)
+	prID := seedPR(t, s, 12, "org/repo")
+	cfg := store.CircuitBreakerLimits{PerPR24h: 3}
+	const sha = "31615409a9152613021ddccfec2c6e2001d4575d"
+
+	for i := 1; i <= 3; i++ {
+		tripped, _, err := s.CheckCircuitBreaker(prID, "org/repo", sha, cfg)
+		if err != nil {
+			t.Fatalf("check %d: %v", i, err)
+		}
+		if tripped {
+			t.Fatalf("breaker tripped on run %d of 3; the cap must allow the configured number", i)
+		}
+		// Record the attempt, then return without ever inserting a review —
+		// exactly what a parse failure does.
+		if err := s.RecordReviewAttempt(prID, sha); err != nil {
+			t.Fatalf("record attempt %d: %v", i, err)
+		}
+	}
+
+	tripped, reason, err := s.CheckCircuitBreaker(prID, "org/repo", sha, cfg)
+	if err != nil {
+		t.Fatalf("final check: %v", err)
+	}
+	if !tripped {
+		t.Fatal("breaker did not trip after 3 failed runs — a failing commit can still " +
+			"be retried without limit, which is #663")
+	}
+	if reason == "" {
+		t.Error("tripped with an empty reason; operators and the UI need the explanation")
+	}
+}
+
+// TestCircuitBreaker_DoesNotDoubleCountSuccessfulRuns guards the cap's meaning.
+// A successful run writes BOTH a ledger row and a reviews row; if the breaker
+// summed the two sources it would halve the operator's configured cap.
+func TestCircuitBreaker_DoesNotDoubleCountSuccessfulRuns(t *testing.T) {
+	s := attemptStore(t)
+	prID := seedPR(t, s, 13, "org/repo")
+	cfg := store.CircuitBreakerLimits{PerPR24h: 3}
+	const sha = "abc123"
+
+	// Two complete runs: ledger row + review row each.
+	for i := 0; i < 2; i++ {
+		if err := s.RecordReviewAttempt(prID, sha); err != nil {
+			t.Fatalf("record attempt: %v", err)
+		}
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Summary: "ok", Issues: "[]",
+			Suggestions: "[]", Severity: "low", Event: "COMMENT",
+			CreatedAt: time.Now().UTC(), HeadSHA: sha,
+		}); err != nil {
+			t.Fatalf("insert review: %v", err)
+		}
+	}
+
+	tripped, reason, err := s.CheckCircuitBreaker(prID, "org/repo", sha, cfg)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if tripped {
+		t.Fatalf("breaker tripped after 2 successful runs with a cap of 3 — the two "+
+			"sources are being summed instead of maxed (reason: %s)", reason)
+	}
+}
+
+// TestCircuitBreaker_CountsPreExistingReviewsWithoutLedgerRows covers the
+// in-place upgrade. A database that predates the ledger has reviews history and
+// no attempts; counting attempts alone would forget that history and hand out a
+// fresh full quota on the first tick after deploy.
+func TestCircuitBreaker_CountsPreExistingReviewsWithoutLedgerRows(t *testing.T) {
+	s := attemptStore(t)
+	prID := seedPR(t, s, 14, "org/repo")
+	cfg := store.CircuitBreakerLimits{PerPR24h: 3}
+	const sha = "legacy1"
+
+	// Three reviews, no ledger rows — the state of an upgraded DB.
+	for i := 0; i < 3; i++ {
+		if _, err := s.InsertReview(&store.Review{
+			PRID: prID, CLIUsed: "claude", Summary: "ok", Issues: "[]",
+			Suggestions: "[]", Severity: "low", Event: "COMMENT",
+			CreatedAt: time.Now().UTC(), HeadSHA: sha,
+		}); err != nil {
+			t.Fatalf("insert review: %v", err)
+		}
+	}
+
+	tripped, _, err := s.CheckCircuitBreaker(prID, "org/repo", sha, cfg)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if !tripped {
+		t.Fatal("breaker ignored pre-existing reviews with no ledger rows; an upgrade " +
+			"would reset every PR's cap")
+	}
+}
+
+// TestCircuitBreaker_AttemptsAreScopedToTheCommit keeps the fix from blocking
+// legitimate work: a developer's follow-up commit must still be reviewable after
+// an earlier commit exhausted its own cap.
+func TestCircuitBreaker_AttemptsAreScopedToTheCommit(t *testing.T) {
+	s := attemptStore(t)
+	prID := seedPR(t, s, 15, "org/repo")
+	cfg := store.CircuitBreakerLimits{PerPR24h: 3}
+
+	for i := 0; i < 3; i++ {
+		if err := s.RecordReviewAttempt(prID, "old-sha"); err != nil {
+			t.Fatalf("record attempt: %v", err)
+		}
+	}
+	if tripped, _, err := s.CheckCircuitBreaker(prID, "org/repo", "old-sha", cfg); err != nil {
+		t.Fatalf("check old sha: %v", err)
+	} else if !tripped {
+		t.Fatal("expected the exhausted commit to be capped")
+	}
+
+	tripped, reason, err := s.CheckCircuitBreaker(prID, "org/repo", "new-sha", cfg)
+	if err != nil {
+		t.Fatalf("check new sha: %v", err)
+	}
+	if tripped {
+		t.Fatalf("a new commit was capped by the previous commit's attempts (%s)", reason)
+	}
+}
+
+// TestCircuitBreaker_PerRepoAxisCountsAttempts checks the hourly repo cap reads
+// the ledger too — otherwise a repo where every run fails could burn credits
+// across many PRs with nothing counting them.
+func TestCircuitBreaker_PerRepoAxisCountsAttempts(t *testing.T) {
+	s := attemptStore(t)
+	cfg := store.CircuitBreakerLimits{PerRepoHr: 2}
+
+	first := seedPR(t, s, 21, "org/repo")
+	second := seedPR(t, s, 22, "org/repo")
+	if err := s.RecordReviewAttempt(first, "sha1"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if err := s.RecordReviewAttempt(second, "sha2"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	third := seedPR(t, s, 23, "org/repo")
+	tripped, reason, err := s.CheckCircuitBreaker(third, "org/repo", "sha3", cfg)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if !tripped {
+		t.Fatal("per-repo cap ignored failed runs on other PRs of the same repo")
+	}
+	if reason == "" {
+		t.Error("expected a non-empty reason for the per-repo trip")
+	}
+
+	// A different repo must be unaffected.
+	other := seedPR(t, s, 24, "org/other")
+	if tripped, _, err := s.CheckCircuitBreaker(other, "org/other", "sha4", cfg); err != nil {
+		t.Fatalf("check other repo: %v", err)
+	} else if tripped {
+		t.Error("one repo's attempts leaked into another repo's cap")
+	}
+}
+
+// TestCircuitBreaker_AttemptsOutsideWindowDoNotCount confirms the ledger is read
+// through a window rather than for all time, so a cap eventually releases.
+func TestCircuitBreaker_AttemptsOutsideWindowDoNotCount(t *testing.T) {
+	s := attemptStore(t)
+	prID := seedPR(t, s, 31, "org/repo")
+
+	if err := s.RecordReviewAttempt(prID, "sha"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	// A window in the future relative to the row: nothing should be counted.
+	n, err := s.CountReviewAttemptsForPRHeadSHA(prID, "sha", time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("attempts inside a future window = %d, want 0", n)
+	}
+
+	n, err = s.CountReviewAttemptsForPRHeadSHA(prID, "sha", time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("attempts inside the 24h window = %d, want 1", n)
+	}
+}
+
+// TestPruneReviewAttempts_KeepsRowsInsideTheWidestWindow pins the retention
+// contract: pruning must never remove a row the breaker would still count, or a
+// live cap would silently reset.
+func TestPruneReviewAttempts_KeepsRowsInsideTheWidestWindow(t *testing.T) {
+	s := attemptStore(t)
+	prID := seedPR(t, s, 41, "org/repo")
+
+	if err := s.RecordReviewAttempt(prID, "sha"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	// The production sweep prunes at 48h, twice the widest breaker window.
+	removed, err := s.PruneReviewAttempts(48 * time.Hour)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("pruned %d fresh rows; a row inside the 24h window must survive", removed)
+	}
+
+	// A negative max-age puts the cutoff in the future so the row is
+	// unambiguously older. Passing 0 would NOT work: started_at has
+	// second granularity and the comparison is strictly less-than, so a row
+	// written in the same second as the cutoff survives — the dead zone
+	// documented on PruneReviewAttempts and ClearAllInFlight (#544).
+	removed, err = s.PruneReviewAttempts(-1 * time.Second)
+	if err != nil {
+		t.Fatalf("prune all: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("pruned %d rows, want 1", removed)
+	}
+	n, err := s.CountReviewAttemptsForPR(prID, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("ledger still reports %d attempts after a full prune", n)
+	}
+}
+
+// TestRecordReviewAttempt_AllowsEmptyHeadSHA covers the Search-API path, where
+// the SHA is not yet known. The per-PR fallback axis must still see the run.
+func TestRecordReviewAttempt_AllowsEmptyHeadSHA(t *testing.T) {
+	s := attemptStore(t)
+	prID := seedPR(t, s, 51, "org/repo")
+
+	if err := s.RecordReviewAttempt(prID, ""); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	n, err := s.CountReviewAttemptsForPR(prID, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("attempts = %d, want 1", n)
+	}
+}

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -163,9 +163,13 @@ CREATE TABLE IF NOT EXISTS reviews_in_flight (
 --
 -- Deliberately NOT keyed (pr_id, head_sha): the point is to count repeats, so
 -- every attempt needs its own row. See theburrowhub/heimdallm#663.
+-- pr_id mirrors reviews.pr_id, REFERENCES included: CountReviewAttemptsForRepo
+-- joins prs, so an orphaned row would silently drop off the per-repo axis while
+-- still counting on the per-PR axis, and the two axes are documented as reading
+-- the same data.
 CREATE TABLE IF NOT EXISTS review_attempts (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
-  pr_id       INTEGER NOT NULL,
+  pr_id       INTEGER NOT NULL REFERENCES prs(id),
   head_sha    TEXT    NOT NULL,
   started_at  DATETIME NOT NULL
 );
@@ -315,7 +319,7 @@ func Open(dsn string) (*Store, error) {
 	// are consulted.
 	db.Exec(`CREATE TABLE IF NOT EXISTS review_attempts (
 		id          INTEGER PRIMARY KEY AUTOINCREMENT,
-		pr_id       INTEGER NOT NULL,
+		pr_id       INTEGER NOT NULL REFERENCES prs(id),
 		head_sha    TEXT    NOT NULL,
 		started_at  DATETIME NOT NULL
 	)`)

--- a/daemon/internal/store/store.go
+++ b/daemon/internal/store/store.go
@@ -149,6 +149,29 @@ CREATE TABLE IF NOT EXISTS reviews_in_flight (
   PRIMARY KEY (pr_id, head_sha)
 );
 
+-- Append-only ledger of review attempts: one row per run that got far enough to
+-- spend CLI credits, written BEFORE the CLI is invoked and never deleted on
+-- failure. This is what the circuit breaker counts.
+--
+-- Why a separate table rather than counting the reviews table: a row there only
+-- exists once a run succeeded (InsertReview is step 7, after the CLI returns a
+-- parseable result). A run that died earlier — e.g. the CLI output failed to
+-- parse — left no trace anywhere, so the breaker's counter never advanced and
+-- the next tick re-ran a full-price review of the same commit, without limit.
+-- reviews_in_flight could not serve either: it is released when the run ends,
+-- by design, since its job is to dedup CONCURRENT runs.
+--
+-- Deliberately NOT keyed (pr_id, head_sha): the point is to count repeats, so
+-- every attempt needs its own row. See theburrowhub/heimdallm#663.
+CREATE TABLE IF NOT EXISTS review_attempts (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  pr_id       INTEGER NOT NULL,
+  head_sha    TEXT    NOT NULL,
+  started_at  DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_review_attempts_pr_sha ON review_attempts(pr_id, head_sha, started_at);
+CREATE INDEX IF NOT EXISTS idx_review_attempts_started ON review_attempts(started_at);
+
 -- Mirror of reviews_in_flight for the issue-triage pipeline. The updated_at
 -- column stores the issue's UpdatedAt truncated to an ISO-seconds string so
 -- two fetcher ticks observing the same snapshot collapse onto the same row.
@@ -286,6 +309,18 @@ func Open(dsn string) (*Store, error) {
 		started_at  DATETIME NOT NULL,
 		PRIMARY KEY (issue_id, updated_at)
 	)`)
+	// Review-attempt ledger (#663). Same pattern again. Existing DBs pick the
+	// table up empty, so the breaker keeps counting their historical reviews
+	// rows until attempts accumulate — see chargeableRuns for why both sources
+	// are consulted.
+	db.Exec(`CREATE TABLE IF NOT EXISTS review_attempts (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		pr_id       INTEGER NOT NULL,
+		head_sha    TEXT    NOT NULL,
+		started_at  DATETIME NOT NULL
+	)`)
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_review_attempts_pr_sha ON review_attempts(pr_id, head_sha, started_at)")
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_review_attempts_started ON review_attempts(started_at)")
 	// Repo rename audit table (#489). RenameRepo writes a row here
 	// in the same TX that bulk-renames prs/issues/activity_log/
 	// watch_state. The audit table is informational — it is NOT


### PR DESCRIPTION
Fixes #663.

## The bug is worse than the issue describes

The issue frames the impact as one duplicate review. It is **unbounded**.

`CheckCircuitBreaker` counted rows in `reviews`, which only exist once a run succeeded — `InsertReview` is step 7, after the CLI returns a parseable result. A run that died earlier left no trace anywhere:

| Layer | Keyed on | State after an early failure |
|---|---|---|
| circuit breaker | `SELECT COUNT(*) FROM reviews` | counter never advanced |
| in-flight claim | `reviews_in_flight` | released by the caller's `defer` |
| `PRAlreadyReviewed` | `PublishedAt` | never set |

All three blinded simultaneously, so the retry of the identical commit had **no upper bound**, each iteration paying full price. The incident stopped at 2 only because attempt 2 happened to parse — that's a property of the CLI's output, not of anything in the code. Same failure class as #243 (the €1,300 runaway).

`store/circuitbreaker.go` even stated the assumption without drawing the conclusion:

> *"Only reviews already persisted to SQLite count — an in-flight review that has not called InsertReview yet is gated separately via the inflight table (Task 5)."*

...and the inflight table is precisely what the `defer` deletes.

## Approach: count runs, not outcomes

Per the discussion, this does **not** add a cooldown. A cooldown limits *frequency*; against a deterministic failure it still retries forever, just slower. Counting attempts limits the *total*, which is what actually stops the bleeding — and it does so with the cap the operator already configured, so the existing 3/PR-SHA/24h bounds the loop at 3 with no new knobs.

New append-only `review_attempts` ledger, written after the breaker clears a run and before the CLI is invoked, never removed on failure.

## Decisions worth reviewing

**`max(attempts, reviews)` per axis, not either alone.** Attempts are authoritative going forward, but a DB upgraded in place has review history and no ledger rows — counting attempts alone would forget that history and grant a fresh full quota on the first tick after deploy. `max` rather than `sum` because a successful run writes one row of *each*; summing would double-count every normal review and halve the configured cap. Both directions are pinned by tests.

**Forced runs are ledgered even though `Force` bypasses the check.** A human clicking "Re-review" is deliberate intent, so the check is skipped — but the spend is real, and an unrecorded run would recreate the same blind spot for whatever runs next on that commit. Flagging it because it does mean an operator forcing N times consumes budget; in practice the automatic path wouldn't re-review that SHA anyway (a review row exists). Easy to invert if you disagree.

**Recording fails open**, matching the breaker check directly above it: a transient SQLite error must not block a legitimate review.

**Retention: 48h**, twice the widest breaker window (24h), so pruning can never reset a cap still in force. Added to the existing 5-minute sweep.

**Message wording changed** to "review runs" from "reviews". Reporting "3 reviews on this commit" when only one was published sent the operator hunting for reviews that don't exist. This required updating one assertion in `main_test.go` — flagging it since I touched an existing test.

**Why not the two cheaper options** I raised while analysing: not releasing the claim on failure (the 30-min sweep would act as a free cooldown) is ~3 lines but leaves the total unbounded and is wiped by `ClearAllInFlight` on restart; reusing `reviews_in_flight` with a status column breaks `ClaimInFlightReview`, which treats *any* row as in-flight.

## Tests

The end-to-end test was **verified to fail without the fix**: with attempt recording disabled, the 4th run invokes the CLI again instead of tripping — the unbounded loop, reproduced.

`daemon/internal/pipeline/pipeline_attempt_ledger_test.go`
- `FailedRunsCountTowardTheBreaker` — 3 runs all failing in `Execute` (real incident error string), 4th must return `CircuitBreakerError` with `Execute` calls still at 3; asserts the ledger carried the count and that no review row exists
- `ForcedRunIsRecordedEvenThoughItBypassesTheCheck` — documents the asymmetry

`daemon/internal/store/review_attempts_test.go` — 8 tests: failed-run counting, no double-counting, legacy DBs with no ledger rows, per-commit scoping (a follow-up commit stays reviewable), per-repo axis + repo isolation, window boundaries, retention contract, empty-SHA path.

`make test-docker` green across all 17 daemon packages (vet included).

## One thing found along the way

`PruneReviewAttempts(0)` does not delete same-second rows: `started_at` is second-granular and the comparison is strictly less-than — the same dead zone documented on `ClearAllInFlight` (#544). Harmless at the 48h the sweep uses, but I documented it on the method rather than leave it as a trap.

## Attribution correction

The issue blames `65557eb6` (#258). That commit only swapped a process-local `map[int64]bool` for the SQLite claim table, **preserving the existing release-on-defer semantics** — it also added persistence and SHA keying, both improvements. The unconditional release comes from `07df482c`, and the "persist only on success" half from `6f874cef` (18 minutes earlier, its direct DAG ancestor). Details in my comment on the issue. Worth correcting since #258 currently reads as the regression.
