### PR TITLE
fix(repoctx): reject non-git review workdirs

### DIFF
--- a/.github/coverage-baseline.json
+++ b/.github/coverage-baseline.json
@@ -4,8 +4,8 @@
   "diff_percent": 90,
   "modules": {
     "daemon": {
-      "covered": 8470,
-      "total": 12340
+      "covered": 8503,
+      "total": 12357
     },
     "cli": {
       "covered": 1160,

--- a/daemon/cmd/heimdallm/main_tier3_repo_context_test.go
+++ b/daemon/cmd/heimdallm/main_tier3_repo_context_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -62,6 +63,15 @@ func tier3WatchItem() (*scheduler.WatchItem, *scheduler.ItemSnapshot) {
 		&scheduler.ItemSnapshot{State: "open", Author: "alice", UpdatedAt: time.Now(), HeadSHA: "abc123"}
 }
 
+func tier3GitCheckout(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatalf("create checkout marker: %v", err)
+	}
+	return root
+}
+
 // TestTier3Adapter_HandleChange_RespectsWorktreeCap is the success-path
 // counterpart that actually pins the acquisition: with the per-repo worktree cap
 // already exhausted, a HandleChange that goes through repoctx cannot obtain a
@@ -69,7 +79,7 @@ func tier3WatchItem() (*scheduler.WatchItem, *scheduler.ItemSnapshot) {
 // forwarded the configured local_dir without asking repoctx — the bug — would
 // hand the path over regardless and bypass the concurrency budget entirely.
 func TestTier3Adapter_HandleChange_RespectsWorktreeCap(t *testing.T) {
-	localDir := t.TempDir()
+	localDir := tier3GitCheckout(t)
 	mgr := repoctx.NewManagerWithOptions(repoctx.ManagerOptions{MaxWorktreesPerRepo: 1})
 
 	// Hold the repo's only slot for the duration of the call.
@@ -110,7 +120,7 @@ func TestTier3Adapter_HandleChange_RespectsWorktreeCap(t *testing.T) {
 // starves every later execution on the repo. With the cap free, runReview must
 // receive the reserved checkout, and the slot must be available again afterwards.
 func TestTier3Adapter_HandleChange_ReleasesTheReservation(t *testing.T) {
-	localDir := t.TempDir()
+	localDir := tier3GitCheckout(t)
 	mgr := repoctx.NewManagerWithOptions(repoctx.ManagerOptions{MaxWorktreesPerRepo: 1})
 
 	var (
@@ -146,6 +156,35 @@ func TestTier3Adapter_HandleChange_ReleasesTheReservation(t *testing.T) {
 	h.Release()
 }
 
+// TestTier3Adapter_HandleChange_InvalidLocalDirFallsBackToDiffOnly covers the
+// final availability branch of #695. If an invalid configured workspace cannot
+// be replaced with the exact managed clone, a read-only PR review must clear
+// LocalDir. The executor then uses its isolated diff-only workspace instead of
+// handing Codex the unsafe multi-repo root.
+func TestTier3Adapter_HandleChange_InvalidLocalDirFallsBackToDiffOnly(t *testing.T) {
+	invalidLocalDir := t.TempDir()
+	// Force managed-clone acquisition to fail deterministically without a
+	// network call. The production adapter must still invoke runReview.
+	t.Setenv("PATH", t.TempDir())
+	mgr := repoctx.NewManagerWithOptions(repoctx.ManagerOptions{MaxWorktreesPerRepo: 1})
+
+	var (
+		gotAI config.RepoAI
+		calls int
+	)
+	a := newTier3Adapter(t, tier3ConfigWithLocalDir(invalidLocalDir), mgr, &gotAI, &calls)
+	item, snap := tier3WatchItem()
+	if err := a.HandleChange(context.Background(), item, snap); err != nil {
+		t.Fatalf("HandleChange: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("runReview called %d time(s), want 1", calls)
+	}
+	if gotAI.LocalDir != "" {
+		t.Fatalf("LocalDir = %q, want diff-only fallback after clone failure", gotAI.LocalDir)
+	}
+}
+
 // TestTier3Adapter_HandleChange_RechecksMonitoredAfterAcquire mirrors the
 // post_acquire guard review-worker already has (main.go:1057). Reserving a
 // checkout can block for seconds or minutes — cloning, fetching, or waiting on
@@ -154,7 +193,7 @@ func TestTier3Adapter_HandleChange_ReleasesTheReservation(t *testing.T) {
 // acquisition, so a slow clone ended up spending provider quota on a repo that
 // was no longer monitored, with no review_skipped event to show for it.
 func TestTier3Adapter_HandleChange_RechecksMonitoredAfterAcquire(t *testing.T) {
-	localDir := t.TempDir()
+	localDir := tier3GitCheckout(t)
 	mgr := repoctx.NewManagerWithOptions(repoctx.ManagerOptions{MaxWorktreesPerRepo: 1})
 
 	// Occupy the only slot so the acquisition inside HandleChange has to wait.

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/heimdallm/daemon/internal/config"
+	"github.com/heimdallm/daemon/internal/executor"
 	"github.com/heimdallm/daemon/internal/procgroup"
 )
 
@@ -350,11 +351,25 @@ func (m *Manager) acquireWorktree(ctx context.Context, req Request, owner, name 
 	}()
 
 	if local := resolveLocal(req); local != "" {
-		// User-mapped repos sidestep worktree creation until the
-		// gitignore bootstrap step lands; release the crit lock now
-		// and keep the cap so concurrency is still bounded.
-		releaseCrit()
-		return &Handle{path: local, managed: false, release: releaseCap}, nil
+		if checkout, ok := canonicalLocalGitWorkTree(local); ok {
+			if policyErr := executor.ValidateWorkDir(checkout); policyErr == nil {
+				// User-mapped repos sidestep worktree creation until the
+				// gitignore bootstrap step lands; release the crit lock now
+				// and keep the cap so concurrency is still bounded.
+				releaseCrit()
+				return &Handle{path: checkout, managed: false, release: releaseCap}, nil
+			} else {
+				slog.Warn("repoctx: resolved Git checkout violates executor WorkDir policy; using managed clone",
+					"repo", req.Repo, "path", checkout, "err", policyErr)
+			}
+		} else {
+			// An org-scoped local_dir is sometimes configured as a workspace
+			// containing many sibling repositories. Passing that root to an AI
+			// agent both breaks Codex's repository check and exposes unrelated
+			// checkouts. Fall through to the repo-specific managed clone instead.
+			slog.Warn("repoctx: resolved local directory is not a Git checkout root; using managed clone",
+				"repo", req.Repo, "path", local)
+		}
 	}
 
 	var cloneRoot string
@@ -564,6 +579,35 @@ func resolveLocal(req Request) string {
 		return ""
 	}
 	return config.ResolveLocalDir("", req.Repo, req.LocalDirBases)
+}
+
+// canonicalLocalGitWorkTree accepts only a checkout root and returns the
+// symlink-resolved path that the child process should enter. A configured
+// workspace may contain Git repositories below it, but descendants do not make
+// the workspace itself a checkout. Requiring .git at the resolved root also
+// keeps repository discovery and executor path validation on the same path.
+func canonicalLocalGitWorkTree(dir string) (string, bool) {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", false
+	}
+	workDir, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", false
+	}
+	// Codex's repository guard only checks for a .git entry while walking the
+	// path. Restrict that entry to the two legitimate marker shapes without
+	// opening repository-controlled content: a directory for normal checkouts
+	// or a regular gitfile for linked worktrees and submodules.
+	gitInfo, err := os.Lstat(filepath.Join(workDir, ".git"))
+	if err != nil || (!gitInfo.IsDir() && !gitInfo.Mode().IsRegular()) {
+		return "", false
+	}
+	return workDir, true
 }
 
 func (m *Manager) ensureManagedClone(ctx context.Context, owner, name string, req Request) (string, error) {

--- a/daemon/internal/repoctx/manager.go
+++ b/daemon/internal/repoctx/manager.go
@@ -592,13 +592,13 @@ func canonicalLocalGitWorkTree(dir string) (string, bool) {
 		return "", false
 	}
 	resolved, err := filepath.EvalSymlinks(dir)
+	if err == nil {
+		resolved, err = filepath.Abs(resolved)
+	}
 	if err != nil {
 		return "", false
 	}
-	workDir, err := filepath.Abs(resolved)
-	if err != nil {
-		return "", false
-	}
+	workDir := resolved
 	// Codex's repository guard only checks for a .git entry while walking the
 	// path. Restrict that entry to the two legitimate marker shapes without
 	// opening repository-controlled content: a directory for normal checkouts

--- a/daemon/internal/repoctx/manager_test.go
+++ b/daemon/internal/repoctx/manager_test.go
@@ -734,6 +734,187 @@ func TestAcquireWorktreeWithBranchCreatesAndChecksOut(t *testing.T) {
 	}
 }
 
+// TestAcquireWorktreeRejectsInvalidConfiguredLocalDir covers #695. An
+// org-scoped local_dir may be a multi-repo workspace, while a repo override may
+// be stale or symlink outside its checkout. None may become the AI process CWD;
+// the fallback is the managed worktree for the exact requested repo.
+func TestAcquireWorktreeRejectsInvalidConfiguredLocalDir(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		makeLocal func(t *testing.T) string
+	}{
+		{
+			name: "workspace containing sibling repositories",
+			makeLocal: func(t *testing.T) string {
+				workspace := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(workspace, "repo", ".git"), 0o755); err != nil {
+					t.Fatalf("create sibling repository: %v", err)
+				}
+				return workspace
+			},
+		},
+		{
+			name: "stale repo override",
+			makeLocal: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "mobile")
+			},
+		},
+		{
+			name: "symlink from checkout to non-Git directory",
+			makeLocal: func(t *testing.T) string {
+				checkout := t.TempDir()
+				if err := os.Mkdir(filepath.Join(checkout, ".git"), 0o755); err != nil {
+					t.Fatalf("create .git directory: %v", err)
+				}
+				link := filepath.Join(checkout, "linked-workspace")
+				if err := os.Symlink(t.TempDir(), link); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+				return link
+			},
+		},
+		{
+			name: "subdirectory instead of checkout root",
+			makeLocal: func(t *testing.T) string {
+				checkout := t.TempDir()
+				if err := os.Mkdir(filepath.Join(checkout, ".git"), 0o755); err != nil {
+					t.Fatalf("create .git directory: %v", err)
+				}
+				subdir := filepath.Join(checkout, "packages", "service")
+				if err := os.MkdirAll(subdir, 0o755); err != nil {
+					t.Fatalf("create checkout subdirectory: %v", err)
+				}
+				return subdir
+			},
+		},
+		{
+			name: "checkout rejected by executor path policy",
+			makeLocal: func(t *testing.T) string {
+				checkout := filepath.Join(t.TempDir(), ".ssh", "repo")
+				if err := os.MkdirAll(filepath.Join(checkout, ".git"), 0o755); err != nil {
+					t.Fatalf("create sensitive checkout: %v", err)
+				}
+				return checkout
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, git, base := newTestManagerWithCap(t, 0)
+			managed := filepath.Join(base, "heimdallm", "org", "repo")
+			configured := tc.makeLocal(t)
+
+			h, err := m.Acquire(context.Background(), Request{
+				Repo:               "org/repo",
+				ConfiguredLocalDir: configured,
+				Token:              "secret",
+				Mode:               ModeRead,
+				WorktreeToken:      "pr-review-24",
+			})
+			if err != nil {
+				t.Fatalf("Acquire: %v", err)
+			}
+			defer h.Release()
+
+			want := filepath.Join(managed, ".worktrees", "pr-review-24.1")
+			if h.Path() != want || !h.Managed() {
+				t.Fatalf("handle = (%q, managed=%v), want repo-specific managed worktree %q", h.Path(), h.Managed(), want)
+			}
+			exactClone := false
+			for _, call := range git.snapshot() {
+				if call.Dir == configured || strings.HasPrefix(call.Dir, configured+string(filepath.Separator)) {
+					t.Fatalf("git call used invalid configured directory %q: %+v", configured, call)
+				}
+				if len(call.Args) == 4 && call.Args[0] == "clone" &&
+					call.Args[2] == "https://x-access-token@github.com/org/repo.git" && call.Args[3] == managed {
+					exactClone = true
+				}
+			}
+			if !exactClone {
+				t.Fatalf("managed fallback did not clone exact repo org/repo; calls = %v", git.snapshot())
+			}
+		})
+	}
+}
+
+// TestAcquireWorktreeKeepsValidConfiguredCheckout ensures the #695 fallback is
+// limited to invalid roots. Normal checkouts, linked worktrees and symlinks to
+// checkout roots remain operator-owned and are canonicalised before execution.
+func TestAcquireWorktreeKeepsValidConfiguredCheckout(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		makeLocal func(t *testing.T) (configured, canonical string)
+	}{
+		{
+			name: "checkout",
+			makeLocal: func(t *testing.T) (string, string) {
+				root := t.TempDir()
+				if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+					t.Fatalf("create .git directory: %v", err)
+				}
+				return root, root
+			},
+		},
+		{
+			name: "linked worktree",
+			makeLocal: func(t *testing.T) (string, string) {
+				root := t.TempDir()
+				gitDir := t.TempDir()
+				if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/test\n"), 0o644); err != nil {
+					t.Fatalf("create linked-worktree HEAD: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: "+gitDir+"\n"), 0o644); err != nil {
+					t.Fatalf("create .git file: %v", err)
+				}
+				return root, root
+			},
+		},
+		{
+			name: "symlink to checkout root",
+			makeLocal: func(t *testing.T) (string, string) {
+				root := t.TempDir()
+				if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+					t.Fatalf("create .git directory: %v", err)
+				}
+				link := filepath.Join(t.TempDir(), "checkout-link")
+				if err := os.Symlink(root, link); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+				return link, root
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, git, _ := newTestManagerWithCap(t, 0)
+			configured, canonical := tc.makeLocal(t)
+			canonical, err := filepath.EvalSymlinks(canonical)
+			if err != nil {
+				t.Fatalf("resolve expected checkout: %v", err)
+			}
+			canonical, err = filepath.Abs(canonical)
+			if err != nil {
+				t.Fatalf("make expected checkout absolute: %v", err)
+			}
+
+			h, err := m.Acquire(context.Background(), Request{
+				Repo:               "org/repo",
+				ConfiguredLocalDir: configured,
+				WorktreeToken:      "pr-review-25",
+			})
+			if err != nil {
+				t.Fatalf("Acquire: %v", err)
+			}
+			defer h.Release()
+
+			if h.Path() != canonical || h.Managed() {
+				t.Fatalf("handle = (%q, managed=%v), want canonical operator checkout %q", h.Path(), h.Managed(), canonical)
+			}
+			if calls := git.snapshot(); len(calls) != 0 {
+				t.Fatalf("git calls = %v, want none for valid configured checkout", calls)
+			}
+		})
+	}
+}
+
 func TestAcquireInspectSkipsWorktreeAndCap(t *testing.T) {
 	// Inspect callers (HTTP /config/clones) want the clone path only.
 	// They must not take a cap slot — otherwise a single inspection


### PR DESCRIPTION
## Summary

- reject configured `local_dir` values that are not canonical Git checkout roots before they reach the AI executor
- fall back to the managed clone/worktree for the exact requested `owner/repo`
- preserve the existing isolated diff-only review path when managed acquisition fails
- apply the executor WorkDir policy during repo-context selection so unsafe paths degrade before execution

## Root cause

`repoctx.acquireWorktree` trusted a flattened repo/org `local_dir` and returned it directly. An org workspace such as `/.../overmind` therefore became Codex's CWD even though it was not itself Git, producing:

```
Not inside a trusted directory and --skip-git-repo-check was not specified.
```

Blindly adding `--skip-git-repo-check` would expose unrelated sibling repositories. This fix keeps Codex's guard and corrects repository-context selection instead.

## Validation

- `make test-docker GO_TEST_ARGS='-run=TestAcquireWorktree.* -count=1 ./internal/repoctx/...'`
- `make test-docker GO_TEST_ARGS='-run=TestTier3Adapter_HandleChange_ -count=1 ./cmd/heimdallm'`
- `make test-docker`
- `git diff --check`
- independent static security/correctness review: no blockers

Closes #695