### PR TITLE
fix(daemon): enforce a single supervised lifecycle

### DIFF
--- a/.github/coverage-baseline.json
+++ b/.github/coverage-baseline.json
@@ -4,16 +4,16 @@
   "diff_percent": 90,
   "modules": {
     "daemon": {
-      "covered": 8534,
-      "total": 12388
+      "covered": 9187,
+      "total": 12537
     },
     "cli": {
       "covered": 1160,
       "total": 2554
     },
     "flutter": {
-      "covered": 4786,
-      "total": 8427
+      "covered": 5099,
+      "total": 8592
     }
   },
   "ignore": [

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -372,20 +372,46 @@ func main() {
 		StartedAt: time.Now(),
 	})
 
-	// Claim the HTTP port before starting anything that costs GitHub API
-	// budget. A second daemon instance loses the bind, and until #646 it kept
-	// running anyway: no HTTP listener, so invisible to the app and to
-	// operators, yet polling GitHub on the same token as the instance that did
-	// win the port. Five of those quietly multiplied API consumption ~6x and
-	// exhausted the hourly quota for hours. Binding here, before the pollers
-	// and workers spin up, turns that silent duplication into an immediate
-	// non-zero exit.
+	// Claim the HTTP port before the pollers and workers spin up. A second
+	// daemon instance loses the bind, and until #646 it kept running anyway: no
+	// HTTP listener, so invisible to the app and to operators, yet polling
+	// GitHub on the same token as the instance that did win the port. Five of
+	// those quietly multiplied API consumption ~6x and exhausted the hourly
+	// quota for hours. Binding here turns that silent duplication into an
+	// immediate non-zero exit.
+	//
+	// (A losing instance still spends the one AuthenticatedUser call above plus
+	// store/NATS setup before it gets here. Cheap and bounded, unlike the
+	// per-tick polling this prevents.)
 	httpListener, err := srv.Listen(cfg.Server.Port, cfg.Server.BindAddr)
 	if err != nil {
 		slog.Error("daemon: cannot bind HTTP port — another instance is probably already running; exiting",
 			"port", cfg.Server.Port, "bind", cfg.Server.BindAddr, "err", err)
+		// os.Exit skips deferred cleanup, so release what is already open.
+		// Logging is unbuffered (server.RotatingWriter writes straight to the
+		// file), so the diagnostics above are already on disk.
+		eventBus.Stop()
+		s.Close()
+		if logCloser != nil {
+			logCloser.Close()
+		}
 		os.Exit(1)
 	}
+
+	// Serve straight away. A bound socket nobody serves is worse than a closed
+	// one: the kernel completes TCP handshakes into the accept backlog, so the
+	// app's probes hang for their full timeout instead of failing fast — and a
+	// timed-out reachability probe reads as "no daemon", which is exactly the
+	// redundant-spawn path #646 is about. /health answers 503 "starting" until
+	// MarkReady below, so callers get a real answer during the wiring window.
+	srv.MarkStarting()
+	slog.Info("daemon: HTTP listener bound", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
+	serveFailed := make(chan error, 1)
+	go func() {
+		if err := srv.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveFailed <- err
+		}
+	}()
 
 	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)
@@ -2414,15 +2440,11 @@ func main() {
 		return nil
 	})
 
-	// The listener is already bound (see srv.Listen above), so this log line
-	// now means what it says: the daemon is reachable.
+	// Every dependency is wired: /health can run its deep checks now. The
+	// listener has been bound and served since srv.Listen above, so this log
+	// line means what it says — the daemon is reachable and ready.
+	srv.MarkReady()
 	slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
-	serveFailed := make(chan error, 1)
-	go func() {
-		if err := srv.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			serveFailed <- err
-		}
-	}()
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
@@ -2463,6 +2485,13 @@ func main() {
 	}, exec.TerminateAll, producerSettleDelay)
 	broker.Stop()
 	if serveDied {
+		// Same as the bind-failure path: os.Exit skips the deferred cleanup, so
+		// release the resources that matter before reporting failure.
+		eventBus.Stop()
+		s.Close()
+		if logCloser != nil {
+			logCloser.Close()
+		}
 		os.Exit(1)
 	}
 }

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -371,6 +371,22 @@ func main() {
 		Version:   versionString(),
 		StartedAt: time.Now(),
 	})
+
+	// Claim the HTTP port before starting anything that costs GitHub API
+	// budget. A second daemon instance loses the bind, and until #646 it kept
+	// running anyway: no HTTP listener, so invisible to the app and to
+	// operators, yet polling GitHub on the same token as the instance that did
+	// win the port. Five of those quietly multiplied API consumption ~6x and
+	// exhausted the hourly quota for hours. Binding here, before the pollers
+	// and workers spin up, turns that silent duplication into an immediate
+	// non-zero exit.
+	httpListener, err := srv.Listen(cfg.Server.Port, cfg.Server.BindAddr)
+	if err != nil {
+		slog.Error("daemon: cannot bind HTTP port — another instance is probably already running; exiting",
+			"port", cfg.Server.Port, "bind", cfg.Server.BindAddr, "err", err)
+		os.Exit(1)
+	}
+
 	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)
 	srv.SetHealthSnapshotFn(func() server.HealthSnapshot {
@@ -2398,20 +2414,31 @@ func main() {
 		return nil
 	})
 
+	// The listener is already bound (see srv.Listen above), so this log line
+	// now means what it says: the daemon is reachable.
+	slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
+	serveFailed := make(chan error, 1)
 	go func() {
-		slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
-		if err := srv.Start(cfg.Server.Port, cfg.Server.BindAddr); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("server stopped", "err", err)
+		if err := srv.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveFailed <- err
 		}
 	}()
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	serveDied := false
 	select {
 	case received := <-sig:
 		slog.Info("shutting down", "signal", received.String())
 	case <-shutdownReq:
 		slog.Info("shutting down via API")
+	case err := <-serveFailed:
+		// Losing the listener mid-flight leaves the same headless daemon the
+		// bind check above prevents at startup, so treat it the same way:
+		// shut down and exit non-zero instead of polling GitHub forever with
+		// nobody able to reach us (#646).
+		slog.Error("daemon: HTTP server stopped serving; shutting down", "err", err)
+		serveDied = true
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -2435,6 +2462,9 @@ func main() {
 		implementWCancel, statePollerCancel, stateWCancel,
 	}, exec.TerminateAll, producerSettleDelay)
 	broker.Stop()
+	if serveDied {
+		os.Exit(1)
+	}
 }
 
 // producerSettleDelay is how long the shutdown path waits between cancelling the

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -409,6 +409,11 @@ func main() {
 	serveFailed := make(chan error, 1)
 	go func() {
 		if err := srv.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			// Log here rather than only where the channel is consumed: that
+			// happens at the end of the wiring phase, so a listener that dies
+			// during init would leave no trace until main got there — the exact
+			// silent headless state this guards against.
+			slog.Error("daemon: HTTP server stopped serving", "err", err)
 			serveFailed <- err
 		}
 	}()
@@ -2458,8 +2463,8 @@ func main() {
 		// Losing the listener mid-flight leaves the same headless daemon the
 		// bind check above prevents at startup, so treat it the same way:
 		// shut down and exit non-zero instead of polling GitHub forever with
-		// nobody able to reach us (#646).
-		slog.Error("daemon: HTTP server stopped serving; shutting down", "err", err)
+		// nobody able to reach us (#646). Already logged in the serve goroutine.
+		slog.Error("daemon: shutting down after serve failure", "err", err)
 		serveDied = true
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -54,6 +55,19 @@ var version = "dev"
 // which opts into deterministic release so multiple cases can share a process.
 var processLifetimeLock *singleinstance.Lock
 
+// processDependencies keeps process-boundary effects injectable for lifecycle
+// tests while production uses the concrete defaults below.
+type processDependencies struct {
+	newGitHubClient    func(string, ...gh.Option) *gh.Client
+	listen             func(int, string) (net.Listener, error)
+	afterPollerRestart func()
+}
+
+var defaultProcessDependencies = processDependencies{
+	newGitHubClient: gh.NewClient,
+	listen:          server.Listen,
+}
+
 func versionString() string { return version }
 
 // publishBridgeEvents re-publishes every SSE broker event to NATS so the SSE
@@ -92,6 +106,10 @@ func run() int {
 // Keeping os.Exit in main means every return executes deferred cleanup first,
 // including fatal bind and HTTP-serve failures.
 func runProcess(releaseLock bool) int {
+	return runProcessWithDependencies(releaseLock, defaultProcessDependencies)
+}
+
+func runProcessWithDependencies(releaseLock bool, deps processDependencies) int {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "install":
@@ -169,7 +187,7 @@ func runProcess(releaseLock bool) int {
 	// SQLite, clearing restart claims or pruning worktrees. The old ordering
 	// discovered EADDRINUSE only after those destructive recovery steps, so a
 	// losing second instance could corrupt the live daemon before exiting.
-	httpListener, err := server.Listen(cfg.Server.Port, cfg.Server.BindAddr)
+	httpListener, err := deps.listen(cfg.Server.Port, cfg.Server.BindAddr)
 	if err != nil {
 		slog.Error("daemon: cannot bind HTTP port — another instance is probably already running; exiting",
 			"port", cfg.Server.Port, "bind", cfg.Server.BindAddr, "err", err)
@@ -350,7 +368,7 @@ func runProcess(releaseLock bool) int {
 	}
 
 	notifier := notify.New()
-	ghClient := gh.NewClient(token)
+	ghClient := deps.newGitHubClient(token)
 	exec := executor.New()
 	repoCtx := repoctx.NewManagerWithOptions(repoctx.ManagerOptions{
 		MaxWorktreesPerRepo: cfg.AI.MaxWorktreesPerRepo,
@@ -2151,6 +2169,9 @@ func runProcess(releaseLock bool) int {
 			cfgMu.Unlock()
 
 			slog.Info("config reload: pollers restarted")
+			if deps.afterPollerRestart != nil {
+				deps.afterPollerRestart()
+			}
 		}()
 
 		return nil

--- a/daemon/cmd/heimdallm/main.go
+++ b/daemon/cmd/heimdallm/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/heimdallm/daemon/internal/repoctx"
 	"github.com/heimdallm/daemon/internal/scheduler"
 	"github.com/heimdallm/daemon/internal/server"
+	"github.com/heimdallm/daemon/internal/singleinstance"
 	"github.com/heimdallm/daemon/internal/sse"
 	"github.com/heimdallm/daemon/internal/store"
 	"github.com/heimdallm/daemon/internal/worker"
@@ -46,6 +47,12 @@ import (
 
 // version is overridden via -ldflags "-X main.version=..." at build time.
 var version = "dev"
+
+// processLifetimeLock keeps the production lock descriptor reachable until
+// os.Exit. Closing it in run's last defer would still leave a tiny handoff gap
+// where other goroutines exist between return and os.Exit. Tests use run(),
+// which opts into deterministic release so multiple cases can share a process.
+var processLifetimeLock *singleinstance.Lock
 
 func versionString() string { return version }
 
@@ -72,32 +79,65 @@ func publishBridgeEvents(events <-chan sse.Event, publish func(subject string, d
 }
 
 func main() {
+	os.Exit(runProcess(false))
+}
+
+// run is the test-friendly lifecycle entry point. Production calls runProcess
+// directly and lets the OS release the instance lock atomically with exit.
+func run() int {
+	return runProcess(true)
+}
+
+// runProcess owns the daemon lifecycle and returns its process exit code.
+// Keeping os.Exit in main means every return executes deferred cleanup first,
+// including fatal bind and HTTP-serve failures.
+func runProcess(releaseLock bool) int {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "install":
 			bin, _ := os.Executable()
 			if err := launchagent.Install(bin); err != nil {
 				fmt.Fprintf(os.Stderr, "install: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
-			return
+			return 0
 		case "uninstall":
 			if err := launchagent.Uninstall(); err != nil {
 				fmt.Fprintf(os.Stderr, "uninstall: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
-			return
+			return 0
 		case "version", "--version", "-version":
 			fmt.Println(versionString())
-			return
+			return 0
 		}
 	}
 
-	// Resolve the data directory first so setupLogging can mirror the
-	// daemon's slog output into <dataDir>/heimdallm.log. The web UI's
+	// Resolve the data directory first and acquire a process-lifetime lock before
+	// opening even the shared log. Unlike the HTTP port, this ownership token is
+	// retained through every deferred worker/store cleanup, closing the teardown
+	// window where a replacement could otherwise mutate the same state while the
+	// old process was still alive (#646).
+	logDir := dataDir()
+	instanceLock, err := singleinstance.Acquire(filepath.Join(logDir, "daemon.lock"))
+	if err != nil {
+		slog.Error("daemon: another instance owns the data directory; exiting", "dir", logDir, "err", err)
+		return 1
+	}
+	if releaseLock {
+		defer func() {
+			if err := instanceLock.Close(); err != nil {
+				slog.Warn("daemon: release instance lock", "err", err)
+			}
+		}()
+	} else {
+		processLifetimeLock = instanceLock
+	}
+
+	// setupLogging mirrors the daemon's slog output into
+	// <dataDir>/heimdallm.log. The web UI's
 	// /logs stream reads that file; writing only to stderr (as we used
 	// to) left the stream empty under Docker — see #75.
-	logDir := dataDir()
 	logCloser := setupLogging(logDir)
 	if logCloser != nil {
 		// Flush buffered writes on shutdown so the last lines reach
@@ -122,20 +162,78 @@ func main() {
 	cfg, err := loadConfig(cfgPath)
 	if err != nil {
 		slog.Error("config load failed", "path", cfgPath, "err", err)
-		os.Exit(1)
+		return 1
+	}
+
+	// Claim single-instance ownership before reading credentials, opening
+	// SQLite, clearing restart claims or pruning worktrees. The old ordering
+	// discovered EADDRINUSE only after those destructive recovery steps, so a
+	// losing second instance could corrupt the live daemon before exiting.
+	httpListener, err := server.Listen(cfg.Server.Port, cfg.Server.BindAddr)
+	if err != nil {
+		slog.Error("daemon: cannot bind HTTP port — another instance is probably already running; exiting",
+			"port", cfg.Server.Port, "bind", cfg.Server.BindAddr, "err", err)
+		return 1
+	}
+	defer httpListener.Close()
+
+	// Start serving the claimed listener immediately. During the remainder of
+	// startup only GET /health is exposed, as a daemon-identifying 503 response;
+	// every other route is gated by startupMiddleware until Configure +
+	// MarkReady publish the fully wired dependencies. This avoids both failure
+	// modes from #646: a losing process cannot mutate shared state, and the
+	// winning process never leaves launchers staring at a bound-but-silent port.
+	runtimeCtx, runtimeCancel := context.WithCancel(context.Background())
+	defer runtimeCancel()
+	srv := server.NewWithOptions(nil, nil, nil, "", server.Options{
+		Version:   versionString(),
+		StartedAt: time.Now(),
+	})
+	srv.MarkStarting()
+	slog.Info("daemon: HTTP listener claimed", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
+	serveFailed := make(chan error, 1)
+	go func() {
+		if err := srv.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			// Cancel every producer immediately. The main goroutine may still be
+			// inside a bounded startup operation, but no poller/worker derived from
+			// runtimeCtx can remain alive as a headless daemon.
+			slog.Error("daemon: HTTP server stopped serving", "err", err)
+			select {
+			case serveFailed <- err:
+			default:
+			}
+			runtimeCancel()
+		}
+	}()
+	// Early startup failures must also stop the HTTP goroutine. Shutdown is
+	// idempotent; the normal path calls it explicitly for graceful draining.
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			slog.Warn("server shutdown failed", "err", err)
+		}
+	}()
+	takeServeFailure := func() error {
+		select {
+		case err := <-serveFailed:
+			return err
+		default:
+			return nil
+		}
 	}
 
 	token, err := keychain.Get()
 	if err != nil {
 		slog.Error("token not found", "err", err)
-		os.Exit(1)
+		return 1
 	}
 
 	dbPath := filepath.Join(dataDir(), "heimdallm.db")
 	s, err := store.Open(dbPath)
 	if err != nil {
 		slog.Error("store open failed", "err", err)
-		os.Exit(1)
+		return 1
 	}
 	defer s.Close()
 
@@ -191,9 +289,9 @@ func main() {
 	eventBus := bus.New(bus.Config{
 		MaxConcurrentWorkers: cfg.Server.MaxConcurrentWorkers,
 	})
-	if err := eventBus.Start(context.Background()); err != nil {
+	if err := eventBus.Start(runtimeCtx); err != nil {
 		slog.Error("nats bus failed to start", "err", err)
-		os.Exit(1)
+		return 1
 	}
 	defer eventBus.Stop()
 
@@ -201,11 +299,12 @@ func main() {
 	watchStore, err := bus.NewWatchStore(s.DB())
 	if err != nil {
 		slog.Error("watch store failed to initialize", "err", err)
-		os.Exit(1)
+		return 1
 	}
 
 	broker := sse.NewBroker()
 	broker.Start()
+	defer broker.Stop()
 
 	// ── Bridge: SSE broker → NATS events ────────────────────────────────
 	// Re-publishes every broker event to NATS so the SSE handler (which
@@ -231,7 +330,7 @@ func main() {
 		if rec == nil {
 			slog.Warn("activity: broker subscriber cap reached; activity log will not record this session")
 		} else {
-			activityCtx, activityCancel := context.WithCancel(context.Background())
+			activityCtx, activityCancel := context.WithCancel(runtimeCtx)
 			defer activityCancel()
 			go rec.Start(activityCtx)
 			slog.Info("activity recorder started")
@@ -262,7 +361,7 @@ func main() {
 	// under `<clone>/.worktrees/` is by definition stale and safe to
 	// remove. Mirrors the in-flight DB sweeps above. (#461)
 	{
-		ctx := context.Background()
+		ctx := runtimeCtx
 		for _, cloneDir := range managedCloneDirs(cfg) {
 			if n, err := repoCtx.PruneStaleWorktreesUnder(ctx, cloneDir); err != nil {
 				slog.Warn("startup: prune stale worktrees", "dir", cloneDir, "err", err)
@@ -277,7 +376,7 @@ func main() {
 	apiToken, err := loadOrCreateAPIToken(dataDir())
 	if err != nil {
 		slog.Error("could not create API token — refusing to start without authentication", "err", err)
-		os.Exit(1)
+		return 1
 	}
 
 	p := pipeline.New(s, ghClient, exec, &notifyWithSSE{notifier: notifier})
@@ -367,57 +466,10 @@ func main() {
 		atomic.StoreInt64(&lastPollUnixNano, at.UTC().UnixNano())
 	}
 
-	srv := server.NewWithOptions(s, broker, p, apiToken, server.Options{
-		Version:   versionString(),
-		StartedAt: time.Now(),
-	})
-
-	// Claim the HTTP port before the pollers and workers spin up. A second
-	// daemon instance loses the bind, and until #646 it kept running anyway: no
-	// HTTP listener, so invisible to the app and to operators, yet polling
-	// GitHub on the same token as the instance that did win the port. Five of
-	// those quietly multiplied API consumption ~6x and exhausted the hourly
-	// quota for hours. Binding here turns that silent duplication into an
-	// immediate non-zero exit.
-	//
-	// (A losing instance still spends the one AuthenticatedUser call above plus
-	// store/NATS setup before it gets here. Cheap and bounded, unlike the
-	// per-tick polling this prevents.)
-	httpListener, err := srv.Listen(cfg.Server.Port, cfg.Server.BindAddr)
-	if err != nil {
-		slog.Error("daemon: cannot bind HTTP port — another instance is probably already running; exiting",
-			"port", cfg.Server.Port, "bind", cfg.Server.BindAddr, "err", err)
-		// os.Exit skips deferred cleanup, so release what is already open.
-		// Logging is unbuffered (server.RotatingWriter writes straight to the
-		// file), so the diagnostics above are already on disk.
-		eventBus.Stop()
-		s.Close()
-		if logCloser != nil {
-			logCloser.Close()
-		}
-		os.Exit(1)
-	}
-
-	// Serve straight away. A bound socket nobody serves is worse than a closed
-	// one: the kernel completes TCP handshakes into the accept backlog, so the
-	// app's probes hang for their full timeout instead of failing fast — and a
-	// timed-out reachability probe reads as "no daemon", which is exactly the
-	// redundant-spawn path #646 is about. /health answers 503 "starting" until
-	// MarkReady below, so callers get a real answer during the wiring window.
-	srv.MarkStarting()
-	slog.Info("daemon: HTTP listener bound", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
-	serveFailed := make(chan error, 1)
-	go func() {
-		if err := srv.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			// Log here rather than only where the channel is consumed: that
-			// happens at the end of the wiring phase, so a listener that dies
-			// during init would leave no trace until main got there — the exact
-			// silent headless state this guards against.
-			slog.Error("daemon: HTTP server stopped serving", "err", err)
-			serveFailed <- err
-		}
-	}()
-
+	// Publish the dependencies before lifting the startup gate. The atomic
+	// MarkReady transition makes the fully configured server visible to HTTP
+	// handlers as one lifecycle step.
+	srv.Configure(s, broker, p, apiToken)
 	srv.SetNATSConn(eventBus.Conn())
 	srv.SetConfigPath(cfgPath)
 	srv.SetHealthSnapshotFn(func() server.HealthSnapshot {
@@ -466,7 +518,7 @@ func main() {
 			discovered = discoverySvc.Discovered()
 		}
 		cfgMu.Unlock()
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(runtimeCtx, 5*time.Minute)
 		defer cancel()
 		removed, err := purgeStaleManagedClones(ctx, repoCtx, cfgSnap, discovered)
 		if err != nil {
@@ -1040,7 +1092,11 @@ func main() {
 	// Initial daemon start → coldStart=true so Tier 2 fires its first tick
 	// immediately; operators see polling activity without waiting an entire
 	// PollInterval. The reload path below passes false.
-	pollerCancel, pollerWg := startPollers(context.Background(), true)
+	if err := takeServeFailure(); err != nil {
+		slog.Error("daemon: aborting startup after HTTP serve failure", "err", err)
+		return 1
+	}
+	pollerCancel, pollerWg := startPollers(runtimeCtx, true)
 
 	// ── NATS PR review worker ───────────────────────────────────────────
 	// Consumes PR review requests published by Tier 2 and runs the
@@ -1134,7 +1190,7 @@ func main() {
 	}
 
 	reviewWorker := worker.NewReviewWorker(conn, maxWorkers, reviewHandler)
-	workerCtx, workerCancel := context.WithCancel(context.Background())
+	workerCtx, workerCancel := context.WithCancel(runtimeCtx)
 	defer workerCancel()
 	go func() {
 		if err := reviewWorker.Start(workerCtx); err != nil {
@@ -1318,7 +1374,7 @@ func main() {
 	}
 
 	publishW := worker.NewPublishWorker(conn, maxWorkers, publishHandler)
-	publishWCtx, publishWCancel := context.WithCancel(context.Background())
+	publishWCtx, publishWCancel := context.WithCancel(runtimeCtx)
 	defer publishWCancel()
 	go func() {
 		if err := publishW.Start(publishWCtx); err != nil {
@@ -1431,7 +1487,7 @@ func main() {
 	}
 
 	triageW := worker.NewTriageWorker(conn, maxWorkers, triageHandler)
-	triageWCtx, triageWCancel := context.WithCancel(context.Background())
+	triageWCtx, triageWCancel := context.WithCancel(runtimeCtx)
 	defer triageWCancel()
 	go func() {
 		if err := triageW.Start(triageWCtx); err != nil {
@@ -1509,7 +1565,7 @@ func main() {
 	}
 
 	refinementW := worker.NewRefinementWorker(conn, maxWorkers, refinementHandler)
-	refinementWCtx, refinementWCancel := context.WithCancel(context.Background())
+	refinementWCtx, refinementWCancel := context.WithCancel(runtimeCtx)
 	defer refinementWCancel()
 	go func() {
 		if err := refinementW.Start(refinementWCtx); err != nil {
@@ -1625,7 +1681,7 @@ func main() {
 	}
 
 	implementW := worker.NewImplementWorker(conn, maxWorkers, implementHandler)
-	implementWCtx, implementWCancel := context.WithCancel(context.Background())
+	implementWCtx, implementWCancel := context.WithCancel(runtimeCtx)
 	defer implementWCancel()
 	go func() {
 		if err := implementW.Start(implementWCtx); err != nil {
@@ -1638,7 +1694,7 @@ func main() {
 	// publishes StateCheckMsg for items due for a state check. Replaces the
 	// in-memory WatchQueue. Default: 30s (matches previous hardcoded value).
 	stateCheckPub := bus.NewStateCheckPublisher(conn)
-	statePollerCtx, statePollerCancel := context.WithCancel(context.Background())
+	statePollerCtx, statePollerCancel := context.WithCancel(runtimeCtx)
 	defer statePollerCancel()
 	go func() {
 		cfgMu.Lock()
@@ -1764,7 +1820,7 @@ func main() {
 	}
 
 	stateW := worker.NewStateWorker(conn, maxWorkers*2, watchStore, stateHandler)
-	stateWCtx, stateWCancel := context.WithCancel(context.Background())
+	stateWCtx, stateWCancel := context.WithCancel(runtimeCtx)
 	defer stateWCancel()
 	go func() {
 		if err := stateW.Start(stateWCtx); err != nil {
@@ -1778,6 +1834,13 @@ func main() {
 	// defer would stop the already-halted original set and leak the
 	// post-reload ones.
 	defer func() {
+		// A reload restart owns restartMu across old-poller teardown and new-
+		// poller publication. Cancel the shared parent first, then wait for that
+		// critical section before snapshotting, so shutdown can never miss a
+		// newly published poller set.
+		runtimeCancel()
+		restartMu.Lock()
+		defer restartMu.Unlock()
 		cfgMu.Lock()
 		cancel := pollerCancel
 		wg := pollerWg
@@ -2069,7 +2132,18 @@ func main() {
 			oldCancel()
 			oldWg.Wait()
 
-			newCancel, newWg := startPollers(context.Background(), false)
+			if runtimeCtx.Err() != nil {
+				slog.Info("config reload: poller restart skipped during shutdown")
+				return
+			}
+
+			newCancel, newWg := startPollers(runtimeCtx, false)
+			if runtimeCtx.Err() != nil {
+				newCancel()
+				newWg.Wait()
+				slog.Info("config reload: new pollers stopped during shutdown")
+				return
+			}
 
 			cfgMu.Lock()
 			pollerCancel = newCancel
@@ -2124,7 +2198,7 @@ func main() {
 		aiCfg := cfg.AIForRepo(pr.Repo)
 		localDirBase := cfg.GitHub.LocalDirBase
 		cfgMu.Unlock()
-		repoHandle, err := acquireRepoContext(context.Background(), repoCtx, pr.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead, wtTokenFor("pr-review", pr.Number), "", "")
+		repoHandle, err := acquireRepoContext(runtimeCtx, repoCtx, pr.Repo, &aiCfg, localDirBase, token, repoctx.ModeRead, wtTokenFor("pr-review", pr.Number), "", "")
 		if err != nil {
 			logRepoContextFallback("trigger review", pr.Repo, err)
 			aiCfg.LocalDir = ""
@@ -2269,7 +2343,7 @@ func main() {
 		// so r.Context() would be cancelled as soon as the response is
 		// written. Use an explicit operation timeout instead so the
 		// GitHub refetch and NATS publish remain bounded.
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		ctx, cancel := context.WithTimeout(runtimeCtx, 1*time.Minute)
 		defer cancel()
 
 		publishIssueErr := func(msg string) {
@@ -2317,7 +2391,7 @@ func main() {
 
 	// Wire the issue-refinement trigger callback: run deep repo investigation on a stored issue.
 	srv.SetTriggerIssueRefineFn(func(issueID int64, force bool) error {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(runtimeCtx)
 		defer cancel()
 
 		publishIssueErr := func(msg string) {
@@ -2375,7 +2449,7 @@ func main() {
 	// Wire the promote callback. Promotion only changes GitHub stage labels and
 	// records an audit comment; the next poll executes the newly-visible stage.
 	srv.SetTriggerPromoteFn(func(issueID int64) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(runtimeCtx, 30*time.Second)
 		defer cancel()
 
 		publishIssueErr := func(msg string) {
@@ -2445,60 +2519,76 @@ func main() {
 		return nil
 	})
 
-	// Every dependency is wired: /health can run its deep checks now. The
-	// listener has been bound and served since srv.Listen above, so this log
-	// line means what it says — the daemon is reachable and ready.
-	srv.MarkReady()
-	slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
+	serveDied := false
+	if err := takeServeFailure(); err != nil {
+		// Workers now exist, so do not return directly: the common shutdown path
+		// below must cancel every producer and terminate any child CLI already
+		// launched during startup.
+		slog.Error("daemon: aborting startup after HTTP serve failure", "err", err)
+		serveDied = true
+	} else {
+		// Every dependency is wired: /health can run its deep checks now. The
+		// listener has been bound since the start of run and is actively served,
+		// so this log line means what it says — the daemon is reachable and ready.
+		srv.MarkReady()
+		slog.Info("daemon started", "port", cfg.Server.Port, "bind", cfg.Server.BindAddr)
+	}
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-	serveDied := false
-	select {
-	case received := <-sig:
-		slog.Info("shutting down", "signal", received.String())
-	case <-shutdownReq:
-		slog.Info("shutting down via API")
-	case err := <-serveFailed:
-		// Losing the listener mid-flight leaves the same headless daemon the
-		// bind check above prevents at startup, so treat it the same way:
-		// shut down and exit non-zero instead of polling GitHub forever with
-		// nobody able to reach us (#646). Already logged in the serve goroutine.
-		slog.Error("daemon: shutting down after serve failure", "err", err)
-		serveDied = true
+	defer signal.Stop(sig)
+	if !serveDied {
+		select {
+		case received := <-sig:
+			slog.Info("shutting down", "signal", received.String())
+		case <-shutdownReq:
+			slog.Info("shutting down via API")
+		case err := <-serveFailed:
+			// Losing the listener mid-flight leaves the same headless daemon the
+			// bind check above prevents at startup, so treat it the same way:
+			// shut down and exit non-zero instead of polling GitHub forever with
+			// nobody able to reach us (#646). Already logged in the serve goroutine.
+			slog.Error("daemon: shutting down after serve failure", "err", err)
+			serveDied = true
+		}
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := srv.Shutdown(ctx); err != nil {
-		slog.Warn("server shutdown failed", "err", err)
-	}
+	// Keep the HTTP ownership socket open but gate dependency-consuming routes
+	// while producers drain. The independent data-dir lock remains held even
+	// longer — through every deferred Wait/Close — so a replacement cannot
+	// overlap SQLite/worktree cleanup with this process.
+	srv.MarkStopping()
+	runtimeCancel()
 	// Stop the agents this daemon started. Each execution runs in its own
 	// process group so a timeout can reach the CLI's grandchildren (#614), which
 	// also means a group-directed signal to the daemon no longer reaches them:
 	// without this sweep, in-flight agents survive the restart and keep spending
 	// provider quota.
 	//
-	// Every producer of work is cancelled first. srv.Shutdown above only stops
-	// HTTP traffic; the workers and tickers below run on their own contexts,
+	// Every producer of work is cancelled first. The workers and tickers below
+	// run on their own contexts,
 	// whose cancels are deferred to main's return — i.e. after this point. A
 	// worker starting an execution between the sweep's snapshot and process exit
 	// would leave exactly the orphan this sweep exists to prevent. CancelFunc is
 	// idempotent, so the deferred cancels remain harmless.
 	stopProducersThenAgents([]context.CancelFunc{
+		func() {
+			cfgMu.Lock()
+			cancel := pollerCancel
+			cfgMu.Unlock()
+			cancel()
+		},
 		workerCancel, publishWCancel, triageWCancel, refinementWCancel,
 		implementWCancel, statePollerCancel, stateWCancel,
 	}, exec.TerminateAll, producerSettleDelay)
-	broker.Stop()
-	if serveDied {
-		// Same as the bind-failure path: os.Exit skips the deferred cleanup, so
-		// release the resources that matter before reporting failure.
-		eventBus.Stop()
-		s.Close()
-		if logCloser != nil {
-			logCloser.Close()
-		}
-		os.Exit(1)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		slog.Warn("server shutdown failed", "err", err)
 	}
+	if serveDied {
+		return 1
+	}
+	return 0
 }
 
 // producerSettleDelay is how long the shutdown path waits between cancelling the

--- a/daemon/cmd/heimdallm/process_lifecycle_test.go
+++ b/daemon/cmd/heimdallm/process_lifecycle_test.go
@@ -1,0 +1,571 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gh "github.com/heimdallm/daemon/internal/github"
+	"github.com/heimdallm/daemon/internal/server"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+const lifecycleTestTimeout = 10 * time.Second
+
+type lifecycleFixture struct {
+	dataDir          string
+	configPath       string
+	configBody       string
+	apiBaseURL       string
+	listener         net.Listener
+	result           <-chan int
+	remoteRequest    <-chan string
+	pollersRestarted <-chan struct{}
+	prID             int64
+	issueID          int64
+	releaseUser      func()
+	done             <-chan struct{}
+}
+
+func writeLifecycleConfig(t *testing.T, dataDir, localDirBase, pollInterval string) (string, string) {
+	t.Helper()
+	configPath := filepath.Join(dataDir, "config.toml")
+	body := fmt.Sprintf(`[server]
+port = 0
+bind_addr = "127.0.0.1"
+max_concurrent_workers = 1
+
+[github]
+poll_interval = %s
+repositories = []
+local_dir_base = [%s]
+
+[ai]
+primary = "codex"
+fallback = "claude"
+repo_rename_check_interval = "0"
+
+[activity_log]
+enabled = true
+retention_days = 1
+
+[polling]
+discovery_interval = "1h"
+tier3_interval = "1h"
+
+[retention]
+max_days = 1
+`, strconv.Quote(pollInterval), strconv.Quote(localDirBase))
+	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write lifecycle config: %v", err)
+	}
+	return configPath, body
+}
+
+func seedLifecycleStore(t *testing.T, dataDir string) (int64, int64) {
+	t.Helper()
+	s, err := store.Open(filepath.Join(dataDir, "heimdallm.db"))
+	if err != nil {
+		t.Fatalf("open lifecycle store: %v", err)
+	}
+	now := time.Now().UTC()
+	prID, err := s.UpsertPR(&store.PR{
+		GithubID:  101,
+		Repo:      "org/repo",
+		Number:    1,
+		Title:     "test PR",
+		Author:    "alice",
+		URL:       "https://example.invalid/org/repo/pull/1",
+		State:     "open",
+		UpdatedAt: now,
+		FetchedAt: now,
+	})
+	if err != nil {
+		s.Close()
+		t.Fatalf("seed PR: %v", err)
+	}
+	issueID, err := s.UpsertIssue(&store.Issue{
+		GithubID:  202,
+		Repo:      "org/repo",
+		Number:    2,
+		Title:     "test issue",
+		Author:    "alice",
+		State:     "open",
+		CreatedAt: now,
+		FetchedAt: now,
+	})
+	if err != nil {
+		s.Close()
+		t.Fatalf("seed issue: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close lifecycle store: %v", err)
+	}
+	return prID, issueID
+}
+
+func startLifecycleFixture(t *testing.T, blockAuthenticatedUser bool) (*lifecycleFixture, <-chan struct{}) {
+	t.Helper()
+	dataDir := t.TempDir()
+	localDirBase := filepath.Join(dataDir, "repos")
+	localRepo := filepath.Join(localDirBase, "repo")
+	if err := os.MkdirAll(filepath.Join(localRepo, ".git"), 0o700); err != nil {
+		t.Fatalf("create local repository marker: %v", err)
+	}
+	configPath, configBody := writeLifecycleConfig(t, dataDir, localDirBase, "1h")
+	prID, issueID := seedLifecycleStore(t, dataDir)
+
+	userRequested := make(chan struct{})
+	releaseUser := make(chan struct{})
+	var releaseUserOnce sync.Once
+	releaseUserFn := func() { releaseUserOnce.Do(func() { close(releaseUser) }) }
+	remoteRequests := make(chan string, 32)
+	var userOnce sync.Once
+	fakeGitHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/user" {
+			userOnce.Do(func() { close(userRequested) })
+			if blockAuthenticatedUser {
+				<-releaseUser
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"login":"heimdallm-test"}`)
+			return
+		}
+		select {
+		case remoteRequests <- r.URL.Path:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"message":"not found"}`)
+	}))
+
+	t.Setenv("HEIMDALLM_DATA_DIR", dataDir)
+	t.Setenv("HEIMDALLM_CONFIG_PATH", configPath)
+	t.Setenv("GITHUB_TOKEN", "lifecycle-test-token")
+	originalArgs := os.Args
+	originalLogger := slog.Default()
+	originalVersion := version
+	os.Args = []string{"heimdallm"}
+	version = "lifecycle-test-version"
+
+	listenerCh := make(chan net.Listener, 1)
+	pollersRestarted := make(chan struct{}, 1)
+	deps := processDependencies{
+		newGitHubClient: func(token string, _ ...gh.Option) *gh.Client {
+			return gh.NewClient(token, gh.WithBaseURL(fakeGitHub.URL))
+		},
+		listen: func(_ int, bindAddr string) (net.Listener, error) {
+			// The production listener behavior is covered in package server. This
+			// lifecycle harness always claims an ephemeral port so it cannot collide
+			// with another test process using the default daemon port.
+			ln, err := server.Listen(0, bindAddr)
+			if err == nil {
+				listenerCh <- ln
+			}
+			return ln, err
+		},
+		afterPollerRestart: func() { pollersRestarted <- struct{}{} },
+	}
+	result := make(chan int, 1)
+	done := make(chan struct{})
+	go func() {
+		result <- runProcessWithDependencies(true, deps)
+		close(done)
+	}()
+
+	var listener net.Listener
+	select {
+	case listener = <-listenerCh:
+	case <-time.After(lifecycleTestTimeout):
+		releaseUserFn()
+		fakeGitHub.Close()
+		os.Args = originalArgs
+		slog.SetDefault(originalLogger)
+		version = originalVersion
+		t.Fatal("daemon did not claim its test listener")
+	}
+
+	fixture := &lifecycleFixture{
+		dataDir:          dataDir,
+		configPath:       configPath,
+		configBody:       configBody,
+		apiBaseURL:       "http://" + listener.Addr().String(),
+		listener:         listener,
+		result:           result,
+		remoteRequest:    remoteRequests,
+		pollersRestarted: pollersRestarted,
+		prID:             prID,
+		issueID:          issueID,
+		releaseUser:      releaseUserFn,
+		done:             done,
+	}
+	t.Cleanup(func() {
+		releaseUserFn()
+		select {
+		case <-done:
+		default:
+			_ = listener.Close()
+			select {
+			case <-done:
+			case <-time.After(3 * time.Second):
+			}
+		}
+		fakeGitHub.Close()
+		os.Args = originalArgs
+		slog.SetDefault(originalLogger)
+		version = originalVersion
+	})
+	return fixture, userRequested
+}
+
+func decodeHealth(t *testing.T, response *http.Response) map[string]any {
+	t.Helper()
+	defer response.Body.Close()
+	var body map[string]any
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	return body
+}
+
+func getHealth(t *testing.T, baseURL string) (*http.Response, map[string]any) {
+	t.Helper()
+	client := &http.Client{Timeout: time.Second}
+	deadline := time.Now().Add(lifecycleTestTimeout)
+	for time.Now().Before(deadline) {
+		response, err := client.Get(baseURL + "/health")
+		if err == nil {
+			return response, decodeHealth(t, response)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("daemon health endpoint did not become reachable")
+	return nil, nil
+}
+
+func waitForReadyHealth(t *testing.T, baseURL string) {
+	t.Helper()
+	client := &http.Client{Timeout: time.Second}
+	deadline := time.Now().Add(lifecycleTestTimeout)
+	for time.Now().Before(deadline) {
+		response, err := client.Get(baseURL + "/health")
+		if err == nil {
+			body := decodeHealth(t, response)
+			if body["status"] != "starting" {
+				if response.Header.Get(server.HeaderDaemon) != "1" {
+					t.Fatal("ready health response lost daemon identity header")
+				}
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("daemon never left the starting state")
+}
+
+func waitForFile(t *testing.T, path string) []byte {
+	t.Helper()
+	deadline := time.Now().Add(lifecycleTestTimeout)
+	for time.Now().Before(deadline) {
+		body, err := os.ReadFile(path)
+		if err == nil && len(bytes.TrimSpace(body)) > 0 {
+			return body
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("file %s did not become readable", path)
+	return nil
+}
+
+func doLifecycleRequest(t *testing.T, method, url, token string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		t.Fatalf("create %s %s: %v", method, url, err)
+	}
+	if token != "" {
+		req.Header.Set("X-Heimdallm-Token", token)
+	}
+	response, err := (&http.Client{Timeout: 2 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	response.Body.Close()
+	return response
+}
+
+func postWhenReviewSlotIsFree(t *testing.T, url, token string) *http.Response {
+	t.Helper()
+	deadline := time.Now().Add(lifecycleTestTimeout)
+	for time.Now().Before(deadline) {
+		response := doLifecycleRequest(t, http.MethodPost, url, token)
+		if response.StatusCode != http.StatusTooManyRequests {
+			return response
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("review semaphore never became available")
+	return nil
+}
+
+func waitForRemoteRequest(t *testing.T, requests <-chan string, want string) {
+	t.Helper()
+	deadline := time.After(lifecycleTestTimeout)
+	for {
+		select {
+		case got := <-requests:
+			if got == want {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("fake GitHub never received %s", want)
+		}
+	}
+}
+
+func TestRunProcessFullLifecycleStartingReloadManualOperationsAndAPIShutdown(t *testing.T) {
+	fixture, userRequested := startLifecycleFixture(t, true)
+
+	select {
+	case <-userRequested:
+	case <-time.After(lifecycleTestTimeout):
+		t.Fatal("startup did not reach the authenticated-user request")
+	}
+	response, body := getHealth(t, fixture.apiBaseURL)
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("starting health status = %d, want 503", response.StatusCode)
+	}
+	if got := response.Header.Get(server.HeaderDaemon); got != "1" {
+		t.Fatalf("starting health daemon header = %q, want 1", got)
+	}
+	if body["status"] != "starting" || body["version"] != "lifecycle-test-version" {
+		t.Fatalf("starting health body = %#v", body)
+	}
+
+	// Release the deliberately blocked /user response and let startup finish.
+	fixture.releaseUser()
+	waitForReadyHealth(t, fixture.apiBaseURL)
+	apiToken := strings.TrimSpace(string(waitForFile(t, filepath.Join(fixture.dataDir, "api_token"))))
+	if len(apiToken) < 32 {
+		t.Fatalf("API token length = %d, want at least 32", len(apiToken))
+	}
+
+	// Exercise the normal poller-restart branch before shutdown. Waiting for its
+	// completion keeps the subsequent shutdown deterministic.
+	reloaded := strings.Replace(fixture.configBody, `poll_interval = "1h"`, `poll_interval = "2h"`, 1)
+	if reloaded == fixture.configBody {
+		t.Fatal("test config did not contain the poll interval to replace")
+	}
+	if err := os.WriteFile(fixture.configPath, []byte(reloaded), 0o600); err != nil {
+		t.Fatalf("rewrite lifecycle config: %v", err)
+	}
+	response = doLifecycleRequest(t, http.MethodPost, fixture.apiBaseURL+"/reload", apiToken)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("reload status = %d, want 200", response.StatusCode)
+	}
+	select {
+	case <-fixture.pollersRestarted:
+	case <-time.After(lifecycleTestTimeout):
+		t.Fatal("pollers did not finish restarting")
+	}
+
+	// Invoke every callback whose context was changed from Background to the
+	// daemon lifetime. The fake GitHub endpoint forces each operation to fail
+	// before an AI executable can be launched.
+	response = postWhenReviewSlotIsFree(t,
+		fmt.Sprintf("%s/prs/%d/review", fixture.apiBaseURL, fixture.prID), apiToken)
+	if response.StatusCode != http.StatusAccepted {
+		t.Fatalf("manual PR review status = %d, want 202", response.StatusCode)
+	}
+	waitForRemoteRequest(t, fixture.remoteRequest, "/repos/org/repo/pulls/1")
+
+	response = postWhenReviewSlotIsFree(t, fixture.apiBaseURL+"/issues/999999/review", apiToken)
+	if response.StatusCode != http.StatusAccepted {
+		t.Fatalf("manual issue review status = %d, want 202", response.StatusCode)
+	}
+
+	response = postWhenReviewSlotIsFree(t,
+		fmt.Sprintf("%s/issues/%d/refine?force=true", fixture.apiBaseURL, fixture.issueID), apiToken)
+	if response.StatusCode != http.StatusAccepted {
+		t.Fatalf("manual issue refinement status = %d, want 202", response.StatusCode)
+	}
+	waitForRemoteRequest(t, fixture.remoteRequest, "/repos/org/repo/issues/2")
+
+	response = doLifecycleRequest(t, http.MethodPost,
+		fmt.Sprintf("%s/issues/%d/promote", fixture.apiBaseURL, fixture.issueID), apiToken)
+	if response.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("manual issue promotion status = %d, want 500 from fake GitHub", response.StatusCode)
+	}
+	waitForRemoteRequest(t, fixture.remoteRequest, "/repos/org/repo/issues/2")
+
+	response = doLifecycleRequest(t, http.MethodPost, fixture.apiBaseURL+"/shutdown", apiToken)
+	if response.StatusCode != http.StatusAccepted {
+		t.Fatalf("shutdown status = %d, want 202", response.StatusCode)
+	}
+	select {
+	case code := <-fixture.result:
+		if code != 0 {
+			t.Fatalf("runProcessWithDependencies exit code = %d, want 0", code)
+		}
+	case <-time.After(lifecycleTestTimeout):
+		t.Fatal("daemon did not finish after API shutdown")
+	}
+}
+
+func TestRunProcessExitsWhenReadyListenerDies(t *testing.T) {
+	fixture, _ := startLifecycleFixture(t, false)
+	waitForReadyHealth(t, fixture.apiBaseURL)
+	if err := fixture.listener.Close(); err != nil {
+		t.Fatalf("close live listener: %v", err)
+	}
+	select {
+	case code := <-fixture.result:
+		if code != 1 {
+			t.Fatalf("runProcessWithDependencies exit code = %d, want 1", code)
+		}
+	case <-time.After(lifecycleTestTimeout):
+		t.Fatal("daemon did not finish after its ready listener died")
+	}
+}
+
+func writeFakeLaunchctl(t *testing.T, exitCode int) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := fmt.Sprintf("#!/bin/sh\nexit %d\n", exitCode)
+	if err := os.WriteFile(filepath.Join(dir, "launchctl"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake launchctl: %v", err)
+	}
+	return dir
+}
+
+func prepareCommandHome(t *testing.T) (string, string) {
+	t.Helper()
+	home := t.TempDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.heimdallm.daemon.plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o700); err != nil {
+		t.Fatalf("create fake LaunchAgents: %v", err)
+	}
+	return home, plistPath
+}
+
+func TestRunProcessCommands(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	home, _ := prepareCommandHome(t)
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", writeFakeLaunchctl(t, 0))
+	os.Args = []string{"heimdallm", "install"}
+	if code := runProcessWithDependencies(true, processDependencies{}); code != 0 {
+		t.Fatalf("install exit code = %d, want 0", code)
+	}
+	os.Args = []string{"heimdallm", "uninstall"}
+	if code := runProcessWithDependencies(true, processDependencies{}); code != 0 {
+		t.Fatalf("uninstall exit code = %d, want 0", code)
+	}
+	os.Args = []string{"heimdallm", "version"}
+	if code := runProcessWithDependencies(true, processDependencies{}); code != 0 {
+		t.Fatalf("version exit code = %d, want 0", code)
+	}
+
+	failingHome, _ := prepareCommandHome(t)
+	t.Setenv("HOME", failingHome)
+	t.Setenv("PATH", writeFakeLaunchctl(t, 23))
+	os.Args = []string{"heimdallm", "install"}
+	if code := runProcessWithDependencies(true, processDependencies{}); code != 1 {
+		t.Fatalf("failed install exit code = %d, want 1", code)
+	}
+
+	uninstallHome, uninstallPlist := prepareCommandHome(t)
+	if err := os.Mkdir(uninstallPlist, 0o700); err != nil {
+		t.Fatalf("create directory at plist path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(uninstallPlist, "child"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("make plist directory non-empty: %v", err)
+	}
+	t.Setenv("HOME", uninstallHome)
+	t.Setenv("PATH", writeFakeLaunchctl(t, 0))
+	os.Args = []string{"heimdallm", "uninstall"}
+	if code := runProcessWithDependencies(true, processDependencies{}); code != 1 {
+		t.Fatalf("failed uninstall exit code = %d, want 1", code)
+	}
+}
+
+func TestRunProcessRejectsMalformedConfigAndReleasesLock(t *testing.T) {
+	dataDir := t.TempDir()
+	configPath := filepath.Join(dataDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte("[server\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HEIMDALLM_DATA_DIR", dataDir)
+	t.Setenv("HEIMDALLM_CONFIG_PATH", configPath)
+	originalArgs := os.Args
+	originalLogger := slog.Default()
+	os.Args = []string{"heimdallm"}
+	t.Cleanup(func() {
+		os.Args = originalArgs
+		slog.SetDefault(originalLogger)
+	})
+
+	if code := run(); code != 1 {
+		t.Fatalf("run malformed config = %d, want 1", code)
+	}
+	if code := run(); code != 1 {
+		t.Fatalf("second run malformed config = %d, want 1 after lock release", code)
+	}
+}
+
+type immediateErrorListener struct{}
+
+func (immediateErrorListener) Accept() (net.Conn, error) { return nil, errors.New("accept failed") }
+func (immediateErrorListener) Close() error              { return nil }
+func (immediateErrorListener) Addr() net.Addr            { return testAddr("127.0.0.1:0") }
+
+type testAddr string
+
+func (a testAddr) Network() string { return "tcp" }
+func (a testAddr) String() string  { return string(a) }
+
+func TestRunProcessServeFailureCancelsStartup(t *testing.T) {
+	dataDir := t.TempDir()
+	configPath, _ := writeLifecycleConfig(t, dataDir, filepath.Join(dataDir, "repos"), "1h")
+	t.Setenv("HEIMDALLM_DATA_DIR", dataDir)
+	t.Setenv("HEIMDALLM_CONFIG_PATH", configPath)
+	t.Setenv("GITHUB_TOKEN", "serve-failure-token")
+	originalArgs := os.Args
+	originalLogger := slog.Default()
+	os.Args = []string{"heimdallm"}
+	t.Cleanup(func() {
+		os.Args = originalArgs
+		slog.SetDefault(originalLogger)
+	})
+
+	fakeGitHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"login":"heimdallm-test"}`)
+	}))
+	defer fakeGitHub.Close()
+	deps := processDependencies{
+		newGitHubClient: func(token string, _ ...gh.Option) *gh.Client {
+			return gh.NewClient(token, gh.WithBaseURL(fakeGitHub.URL))
+		},
+		listen: func(int, string) (net.Listener, error) { return immediateErrorListener{}, nil },
+	}
+	if code := runProcessWithDependencies(true, deps); code != 1 {
+		t.Fatalf("run after listener failure = %d, want 1", code)
+	}
+}

--- a/daemon/cmd/heimdallm/startup_exclusivity_test.go
+++ b/daemon/cmd/heimdallm/startup_exclusivity_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/singleinstance"
+)
+
+func TestRunInstanceLockPrecedesStateInitialization(t *testing.T) {
+	tempDir := t.TempDir()
+	lock, err := singleinstance.Acquire(filepath.Join(tempDir, "daemon.lock"))
+	if err != nil {
+		t.Fatalf("hold instance lock: %v", err)
+	}
+	defer lock.Close()
+
+	t.Setenv("HEIMDALLM_DATA_DIR", tempDir)
+	originalArgs := os.Args
+	os.Args = []string{"heimdallm"}
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	if code := run(); code != 1 {
+		t.Fatalf("run exit code = %d, want 1 for occupied lifecycle lock", code)
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, "heimdallm.db")); !os.IsNotExist(err) {
+		t.Fatalf("SQLite was initialized before the lifecycle lock failed: err=%v", err)
+	}
+}
+
+// A second process must lose single-instance ownership before it can open or
+// mutate the shared SQLite database. This process-level test pins the ordering
+// in run, not just the lower-level net.Listen contract.
+func TestRunBindFailurePrecedesStateInitialization(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy port: %v", err)
+	}
+	defer occupied.Close()
+	port := occupied.Addr().(*net.TCPAddr).Port
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.toml")
+	configBody := fmt.Sprintf(`[server]
+port = %d
+bind_addr = "127.0.0.1"
+
+[ai]
+primary = "codex"
+fallback = "claude"
+`, port)
+	if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("HEIMDALLM_CONFIG_PATH", configPath)
+	t.Setenv("HEIMDALLM_DATA_DIR", tempDir)
+
+	originalArgs := os.Args
+	originalLogger := slog.Default()
+	os.Args = []string{"heimdallm"}
+	t.Cleanup(func() {
+		os.Args = originalArgs
+		slog.SetDefault(originalLogger)
+	})
+
+	if code := run(); code != 1 {
+		t.Fatalf("run exit code = %d, want 1 for occupied port", code)
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, "heimdallm.db")); !os.IsNotExist(err) {
+		t.Fatalf("SQLite was initialized before the bind failed: err=%v", err)
+	}
+	logBody, err := os.ReadFile(filepath.Join(tempDir, "heimdallm.log"))
+	if err != nil {
+		t.Fatalf("read startup log: %v", err)
+	}
+	if !strings.Contains(string(logBody), "cannot bind HTTP port") {
+		t.Fatalf("run did not reach the bind-failure path; log=%s", logBody)
+	}
+}

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/nats-io/nats-server/v2 v2.12.7
 	github.com/nats-io/nats.go v1.51.0
+	golang.org/x/sys v0.42.0
 	modernc.org/sqlite v1.27.0
 )
 
@@ -25,7 +26,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -442,8 +442,16 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	json.NewEncoder(w).Encode(v)
 }
 
+// HeaderDaemon marks a response as coming from a Heimdallm daemon. The app uses
+// it on /health to tell us apart from an unrelated process squatting on the
+// port: `{"status": ...}` alone is the shape of half the health endpoints in the
+// industry (Spring Boot Actuator, most Node/Go services), so matching on the
+// body would classify those as ours and silently never spawn a daemon.
+const HeaderDaemon = "X-Heimdallm-Daemon"
+
 func (srv *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
+	w.Header().Set(HeaderDaemon, "1")
 	// Serving starts right after the bind, long before the pollers, workers and
 	// event bus are wired, so answer honestly during that window instead of
 	// running deep checks against half-built dependencies. 503 keeps

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -320,9 +321,21 @@ func (srv *Server) Router() http.Handler {
 	return srv.router
 }
 
-// Start binds the HTTP server to the given port and begins serving.
-func (srv *Server) Start(port int, bindAddr string) error {
+// Listen binds the HTTP server's socket without serving on it, returning the
+// bound listener for a later Serve.
+//
+// The split exists so the daemon can fail fast on a bind error *before* it
+// starts any GitHub poller. ListenAndServe reports a port collision only after
+// the pollers are already running, and a daemon that swallows that error keeps
+// polling GitHub while serving nothing: invisible to the app, but spending the
+// same hourly API budget as the daemon that did win the port. Five such
+// headless daemons exhausted the quota for hours in #646.
+func (srv *Server) Listen(port int, bindAddr string) (net.Listener, error) {
 	addr := fmt.Sprintf("%s:%d", bindAddr, port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
 	srv.httpServer = &http.Server{
 		Addr:         addr,
 		Handler:      srv.router,
@@ -330,7 +343,27 @@ func (srv *Server) Start(port int, bindAddr string) error {
 		WriteTimeout: 60 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
-	return srv.httpServer.ListenAndServe()
+	return ln, nil
+}
+
+// Serve serves HTTP on a listener obtained from Listen. Returns
+// http.ErrServerClosed after a Shutdown.
+func (srv *Server) Serve(ln net.Listener) error {
+	if srv.httpServer == nil {
+		return errors.New("server: Serve called before Listen")
+	}
+	return srv.httpServer.Serve(ln)
+}
+
+// Start binds the HTTP server to the given port and begins serving. Callers
+// that need to distinguish a bind failure from a mid-flight serve failure
+// should use Listen + Serve instead.
+func (srv *Server) Start(port int, bindAddr string) error {
+	ln, err := srv.Listen(port, bindAddr)
+	if err != nil {
+		return err
+	}
+	return srv.Serve(ln)
 }
 
 // Shutdown gracefully shuts down the HTTP server.

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -37,23 +37,34 @@ var ErrPromoteConflict = errors.New("issue promotion conflict")
 
 // Server holds the HTTP router, SSE broker, store, and optional pipeline.
 type Server struct {
-	store                *store.Store
-	broker               *sse.Broker
-	natsConn             *nats.Conn // when set, handleSSE reads from NATS instead of broker
-	pipeline             *pipeline.Pipeline
-	router               chi.Router
-	httpServer           *http.Server
-	// starting suppresses the deep health checks while main is still wiring
-	// dependencies. Serve begins immediately after Listen so the socket is
-	// never bound-but-silent (a client would complete the TCP handshake and
-	// then hang until the whole init phase finished), so /health has to answer
-	// during a window where the pollers and event bus do not exist yet.
+	store      *store.Store
+	broker     *sse.Broker
+	natsConn   *nats.Conn // when set, handleSSE reads from NATS instead of broker
+	pipeline   *pipeline.Pipeline
+	router     chi.Router
+	httpMu     sync.Mutex
+	httpServer *http.Server
+	// httpListener is tracked separately from httpServer because Shutdown can
+	// race with Serve after the listener has been published but before
+	// net/http has registered it internally. Closing it explicitly guarantees
+	// that the daemon never leaves a bound, unserved socket behind.
+	httpListener      net.Listener
+	shutdownRequested bool
+	// starting suppresses the deep health checks and gates every non-health
+	// route while main is still wiring dependencies. The listener is claimed
+	// before any mutable recovery work, then Serve begins as soon as this Server
+	// exists; /health therefore has to answer during a window where later
+	// callbacks and workers do not exist yet.
 	//
 	// The zero value means "ready": a Server built by New already has every
 	// dependency injected. Only main, which deliberately serves mid-wiring,
 	// calls MarkStarting. Atomic because Serve is already handling requests
 	// when main flips it back.
 	starting atomic.Bool
+	// stopping reuses the startup route gate while giving /health an honest
+	// lifecycle status. The listener remains owned during worker teardown so a
+	// launcher cannot race a replacement into the old process's cleanup window.
+	stopping             atomic.Bool
 	reloadFn             func() error
 	shutdownFn           func()
 	triggerReviewFn      func(prID int64) error
@@ -141,6 +152,18 @@ func NewWithOptions(s *store.Store, broker *sse.Broker, p *pipeline.Pipeline, ap
 	return srv
 }
 
+// Configure injects the dependencies which are unavailable when main first
+// creates the Server to claim and serve the daemon socket. It must be called
+// after MarkStarting and before MarkReady. The starting gate prevents every
+// dependency-consuming route from running while these fields are published;
+// MarkReady's atomic store then makes them visible to subsequent requests.
+func (srv *Server) Configure(s *store.Store, broker *sse.Broker, p *pipeline.Pipeline, apiToken string) {
+	srv.store = s
+	srv.broker = broker
+	srv.pipeline = p
+	srv.apiToken = apiToken
+}
+
 // SetNATSConn enables NATS-based SSE. When set, handleSSE subscribes to
 // NATS events instead of the in-memory broker, removing the 10-subscriber limit.
 func (srv *Server) SetNATSConn(conn *nats.Conn) {
@@ -172,26 +195,27 @@ var sensitiveGETPaths = []string{
 //     be readable by arbitrary browser tabs — see security issue #3).
 func (srv *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if srv.apiToken != "" {
-			needsAuth := false
-			switch r.Method {
-			case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
-				needsAuth = true
-			case http.MethodGet:
-				for _, p := range sensitiveGETPaths {
-					if r.URL.Path == p || strings.HasPrefix(r.URL.Path, p+"/") {
-						needsAuth = true
-						break
-					}
+		needsAuth := false
+		switch r.Method {
+		case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+			needsAuth = true
+		case http.MethodGet:
+			for _, p := range sensitiveGETPaths {
+				if r.URL.Path == p || strings.HasPrefix(r.URL.Path, p+"/") {
+					needsAuth = true
+					break
 				}
 			}
-			if needsAuth {
-				token := r.Header.Get("X-Heimdallm-Token")
-				// Constant-time comparison to prevent timing attacks.
-				if !hmac.Equal([]byte(token), []byte(srv.apiToken)) {
-					http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
-					return
-				}
+		}
+		// During startup only /health reaches this middleware. Avoid reading the
+		// late-injected token for a route which does not need it, so Configure can
+		// publish the token before MarkReady without racing a health request.
+		if needsAuth && srv.apiToken != "" {
+			token := r.Header.Get("X-Heimdallm-Token")
+			// Constant-time comparison to prevent timing attacks.
+			if !hmac.Equal([]byte(token), []byte(srv.apiToken)) {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
 			}
 		}
 		next.ServeHTTP(w, r)
@@ -333,67 +357,118 @@ func (srv *Server) Router() http.Handler {
 	return srv.router
 }
 
-// Listen binds the HTTP server's socket without serving on it, returning the
-// bound listener for an immediately following Serve.
+// Listen claims the daemon's HTTP socket without starting any application
+// workers. Main calls this immediately after loading config, before opening the
+// store or running destructive restart recovery, so a losing second instance
+// cannot clear live claims or prune worktrees before discovering the conflict.
 //
-// The split exists so the daemon can fail fast on a bind error *before* it
-// starts any GitHub poller. ListenAndServe reports a port collision only after
-// the pollers are already running, and a daemon that swallows that error keeps
-// polling GitHub while serving nothing: invisible to the app, but spending the
-// same hourly API budget as the daemon that did win the port. Five such
-// headless daemons exhausted the quota for hours in #646.
-//
-// Callers must call Serve right away and use MarkReady to signal readiness. A
-// bound socket that nobody is serving is worse than a closed one: the kernel
-// completes the TCP handshake into the accept backlog, so probes hang for their
-// full timeout instead of failing fast with "connection refused".
-func (srv *Server) Listen(port int, bindAddr string) (net.Listener, error) {
-	if srv.httpServer != nil {
-		return nil, errors.New("server: Listen called twice")
-	}
+// The listener is the HTTP-port ownership token (separate from main's
+// data-directory process lock). Callers must keep it open until Serve takes
+// over or startup aborts.
+func Listen(port int, bindAddr string) (net.Listener, error) {
 	addr := fmt.Sprintf("%s:%d", bindAddr, port)
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return nil, err
+	return net.Listen("tcp", addr)
+}
+
+// Serve serves the fully wired router on a listener obtained from Listen.
+// Calling Serve more than once is rejected so the original server cannot be
+// silently orphaned.
+func (srv *Server) Serve(ln net.Listener) error {
+	srv.httpMu.Lock()
+	if srv.shutdownRequested {
+		srv.httpMu.Unlock()
+		// Shutdown may run before Serve is called, when the Server has no way to
+		// know which listener main will hand it. Once it arrives, close it here so
+		// the losing startup cannot leave the ownership socket bound.
+		_ = ln.Close()
+		return http.ErrServerClosed
 	}
-	srv.httpServer = &http.Server{
-		Addr:         addr,
+	if srv.httpServer != nil {
+		srv.httpMu.Unlock()
+		return errors.New("server: Serve called twice")
+	}
+	httpServer := &http.Server{
+		Addr:         ln.Addr().String(),
 		Handler:      srv.router,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 60 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
-	return ln, nil
-}
+	srv.httpServer = httpServer
+	srv.httpListener = ln
+	srv.httpMu.Unlock()
 
-// Serve serves HTTP on a listener obtained from Listen. Returns
-// http.ErrServerClosed after a Shutdown.
-func (srv *Server) Serve(ln net.Listener) error {
-	if srv.httpServer == nil {
-		return errors.New("server: Serve called before Listen")
+	err := httpServer.Serve(ln)
+	srv.httpMu.Lock()
+	shutdownRequested := srv.shutdownRequested
+	srv.httpMu.Unlock()
+	if shutdownRequested {
+		// An explicit Shutdown can close the listener just before net/http starts
+		// tracking it, which otherwise surfaces as a raw accept error. Preserve
+		// the standard graceful-shutdown contract for every shutdown ordering.
+		return http.ErrServerClosed
 	}
-	return srv.httpServer.Serve(ln)
+	return err
 }
 
 // MarkStarting declares the server up but still wiring dependencies, so
 // /health answers 503 "starting" instead of running deep checks against
 // half-built dependencies. Call before Serve; pair with MarkReady.
-func (srv *Server) MarkStarting() { srv.starting.Store(true) }
+func (srv *Server) MarkStarting() {
+	srv.starting.Store(true)
+	srv.stopping.Store(false)
+}
 
 // MarkReady declares every dependency wired, restoring the normal /health
 // deep checks. Idempotent.
-func (srv *Server) MarkReady() { srv.starting.Store(false) }
+func (srv *Server) MarkReady() {
+	srv.stopping.Store(false)
+	srv.starting.Store(false)
+}
+
+// MarkStopping gates every dependency-consuming route while main drains work.
+// /health remains reachable and identifies the process as "stopping" until the
+// listener is finally closed.
+func (srv *Server) MarkStopping() {
+	srv.starting.Store(true)
+	// Publish the descriptive state only after the route gate is closed. A
+	// request racing this transition may briefly see "starting", but it can
+	// never slip through to dependencies after shutdown has begun.
+	srv.stopping.Store(true)
+}
 
 // Shutdown gracefully shuts down the HTTP server.
 func (srv *Server) Shutdown(ctx context.Context) error {
-	if srv.httpServer == nil {
-		return nil
+	srv.httpMu.Lock()
+	srv.shutdownRequested = true
+	httpServer := srv.httpServer
+	httpListener := srv.httpListener
+	srv.httpMu.Unlock()
+
+	var shutdownErr error
+	if httpServer != nil {
+		// Call net/http first so it marks the server as shutting down before a
+		// concurrently scheduled Serve can register the listener.
+		shutdownErr = httpServer.Shutdown(ctx)
 	}
-	return srv.httpServer.Shutdown(ctx)
+	if httpListener != nil {
+		// If Serve published the listener but had not yet registered it with
+		// net/http, Shutdown above had nothing to close. Close our tracked copy
+		// as the final ownership guarantee. net.ErrClosed is the normal case when
+		// net/http already closed it.
+		if err := httpListener.Close(); err != nil && !errors.Is(err, net.ErrClosed) && shutdownErr == nil {
+			shutdownErr = err
+		}
+	}
+	return shutdownErr
 }
 
 func (srv *Server) buildRouter() chi.Router {
 	r := chi.NewRouter()
+	// This must precede auth: while main is still wiring callbacks, /health is
+	// the only route allowed to run. In particular, no authenticated mutation
+	// may observe partially published Server fields.
+	r.Use(srv.startupMiddleware)
 	r.Use(srv.authMiddleware)
 	r.Get("/health", srv.handleHealth)
 	r.Get("/me", srv.handleMe)
@@ -436,6 +511,30 @@ func (srv *Server) buildRouter() chi.Router {
 	return r
 }
 
+// startupMiddleware exposes only the public health probe while main is wiring
+// dependencies. MarkReady's atomic Store publishes every preceding setter to
+// requests which subsequently observe starting=false.
+func (srv *Server) startupMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !srv.starting.Load() || (r.Method == http.MethodGet && r.URL.Path == "/health") {
+			next.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set(HeaderDaemon, "1")
+		w.Header().Set("Retry-After", "1")
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"status": srv.unavailableStatus(),
+		})
+	})
+}
+
+func (srv *Server) unavailableStatus() string {
+	if srv.stopping.Load() {
+		return "stopping"
+	}
+	return "starting"
+}
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -455,11 +554,12 @@ func (srv *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	// Serving starts right after the bind, long before the pollers, workers and
 	// event bus are wired, so answer honestly during that window instead of
 	// running deep checks against half-built dependencies. 503 keeps
-	// checkHealth() false (the app must not navigate into a half-ready daemon)
-	// while still being a real HTTP answer, so the app's reachability probe
-	// sees the port is taken and does not spawn a rival instance (#646).
+	// checkHealth() false for readiness consumers while still being a real HTTP
+	// answer, so the app's ownership probe sees the port is taken and does not
+	// spawn a rival instance. The UI may still enter its diagnostic surface
+	// while startup finishes (#646).
 	if srv.starting.Load() {
-		resp := map[string]any{"status": "starting"}
+		resp := map[string]any{"status": srv.unavailableStatus()}
 		if srv.version != "" {
 			resp["version"] = srv.version
 		}

--- a/daemon/internal/server/handlers.go
+++ b/daemon/internal/server/handlers.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -42,6 +43,17 @@ type Server struct {
 	pipeline             *pipeline.Pipeline
 	router               chi.Router
 	httpServer           *http.Server
+	// starting suppresses the deep health checks while main is still wiring
+	// dependencies. Serve begins immediately after Listen so the socket is
+	// never bound-but-silent (a client would complete the TCP handshake and
+	// then hang until the whole init phase finished), so /health has to answer
+	// during a window where the pollers and event bus do not exist yet.
+	//
+	// The zero value means "ready": a Server built by New already has every
+	// dependency injected. Only main, which deliberately serves mid-wiring,
+	// calls MarkStarting. Atomic because Serve is already handling requests
+	// when main flips it back.
+	starting atomic.Bool
 	reloadFn             func() error
 	shutdownFn           func()
 	triggerReviewFn      func(prID int64) error
@@ -322,7 +334,7 @@ func (srv *Server) Router() http.Handler {
 }
 
 // Listen binds the HTTP server's socket without serving on it, returning the
-// bound listener for a later Serve.
+// bound listener for an immediately following Serve.
 //
 // The split exists so the daemon can fail fast on a bind error *before* it
 // starts any GitHub poller. ListenAndServe reports a port collision only after
@@ -330,7 +342,15 @@ func (srv *Server) Router() http.Handler {
 // polling GitHub while serving nothing: invisible to the app, but spending the
 // same hourly API budget as the daemon that did win the port. Five such
 // headless daemons exhausted the quota for hours in #646.
+//
+// Callers must call Serve right away and use MarkReady to signal readiness. A
+// bound socket that nobody is serving is worse than a closed one: the kernel
+// completes the TCP handshake into the accept backlog, so probes hang for their
+// full timeout instead of failing fast with "connection refused".
 func (srv *Server) Listen(port int, bindAddr string) (net.Listener, error) {
+	if srv.httpServer != nil {
+		return nil, errors.New("server: Listen called twice")
+	}
 	addr := fmt.Sprintf("%s:%d", bindAddr, port)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -355,16 +375,14 @@ func (srv *Server) Serve(ln net.Listener) error {
 	return srv.httpServer.Serve(ln)
 }
 
-// Start binds the HTTP server to the given port and begins serving. Callers
-// that need to distinguish a bind failure from a mid-flight serve failure
-// should use Listen + Serve instead.
-func (srv *Server) Start(port int, bindAddr string) error {
-	ln, err := srv.Listen(port, bindAddr)
-	if err != nil {
-		return err
-	}
-	return srv.Serve(ln)
-}
+// MarkStarting declares the server up but still wiring dependencies, so
+// /health answers 503 "starting" instead of running deep checks against
+// half-built dependencies. Call before Serve; pair with MarkReady.
+func (srv *Server) MarkStarting() { srv.starting.Store(true) }
+
+// MarkReady declares every dependency wired, restoring the normal /health
+// deep checks. Idempotent.
+func (srv *Server) MarkReady() { srv.starting.Store(false) }
 
 // Shutdown gracefully shuts down the HTTP server.
 func (srv *Server) Shutdown(ctx context.Context) error {
@@ -426,6 +444,20 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func (srv *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
+	// Serving starts right after the bind, long before the pollers, workers and
+	// event bus are wired, so answer honestly during that window instead of
+	// running deep checks against half-built dependencies. 503 keeps
+	// checkHealth() false (the app must not navigate into a half-ready daemon)
+	// while still being a real HTTP answer, so the app's reachability probe
+	// sees the port is taken and does not spawn a rival instance (#646).
+	if srv.starting.Load() {
+		resp := map[string]any{"status": "starting"}
+		if srv.version != "" {
+			resp["version"] = srv.version
+		}
+		writeJSON(w, http.StatusServiceUnavailable, resp)
+		return
+	}
 	checks := map[string]any{
 		"nats":      srv.natsHealthCheck(),
 		"sqlite":    srv.sqliteHealthCheck(r.Context()),

--- a/daemon/internal/server/listen_test.go
+++ b/daemon/internal/server/listen_test.go
@@ -17,9 +17,11 @@ import (
 	"github.com/heimdallm/daemon/internal/store"
 )
 
-// newListenTestServer builds the smallest Server that can bind: Listen only
-// needs the router, which New always wires.
 func newListenTestServer(t *testing.T) *server.Server {
+	return newListenTestServerWithToken(t, "")
+}
+
+func newListenTestServerWithToken(t *testing.T, token string) *server.Server {
 	t.Helper()
 	s, err := store.Open(":memory:")
 	if err != nil {
@@ -29,7 +31,7 @@ func newListenTestServer(t *testing.T) *server.Server {
 	broker := sse.NewBroker()
 	broker.Start()
 	t.Cleanup(broker.Stop)
-	return server.New(s, broker, nil, "")
+	return server.New(s, broker, nil, token)
 }
 
 // freePort returns a port number nothing is listening on. Racy by nature —
@@ -57,8 +59,7 @@ func TestListen_FailsWhenPortIsOccupied(t *testing.T) {
 	defer occupied.Close()
 	port := occupied.Addr().(*net.TCPAddr).Port
 
-	srv := newListenTestServer(t)
-	ln, err := srv.Listen(port, "127.0.0.1")
+	ln, err := server.Listen(port, "127.0.0.1")
 	if err == nil {
 		ln.Close()
 		t.Fatalf("Listen on occupied port %d returned no error; the daemon would run headless", port)
@@ -79,39 +80,96 @@ func TestListen_FailsWhenPortIsOccupied(t *testing.T) {
 	}
 }
 
-// A second Listen must not silently orphan the first listener/server pair by
-// overwriting srv.httpServer.
-func TestListen_RejectsSecondCall(t *testing.T) {
+// A second Serve must not silently replace the first http.Server.
+func TestServe_RejectsSecondCall(t *testing.T) {
 	srv := newListenTestServer(t)
-	first, err := srv.Listen(freePort(t), "127.0.0.1")
+	first, err := server.Listen(0, "127.0.0.1")
 	if err != nil {
 		t.Fatalf("first Listen: %v", err)
 	}
 	defer first.Close()
-
-	second, err := srv.Listen(freePort(t), "127.0.0.1")
-	if err == nil {
-		second.Close()
-		t.Fatal("second Listen succeeded; the first listener would be orphaned")
+	firstErr := make(chan error, 1)
+	go func() { firstErr <- srv.Serve(first) }()
+	if _, err := httpGetWithRetry(fmt.Sprintf("http://%s/health", first.Addr())); err != nil {
+		t.Fatalf("first Serve never came up: %v", err)
 	}
-	if second != nil {
-		second.Close()
-		t.Fatal("second Listen returned a listener alongside an error")
+
+	second, err := server.Listen(0, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("second Listen: %v", err)
+	}
+	defer second.Close()
+	if err := srv.Serve(second); err == nil {
+		t.Fatal("second Serve succeeded; the first server would be orphaned")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	<-firstErr
+}
+
+// Shutdown may be requested before the goroutine which calls Serve is
+// scheduled. Serve must preserve that decision, close the subsequently handed
+// listener, and report the normal graceful-shutdown sentinel rather than
+// briefly accepting traffic or leaving the daemon port bound.
+func TestShutdownBeforeServe_ClosesSubsequentListener(t *testing.T) {
+	srv := newListenTestServer(t)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown before Serve: %v", err)
+	}
+
+	ln, err := server.Listen(0, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := srv.Serve(ln); !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("Serve after Shutdown = %v, want http.ErrServerClosed", err)
+	}
+
+	conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		t.Fatalf("listener %s still accepts connections after Shutdown won", addr)
 	}
 }
 
-// Serve without a prior Listen must report the misuse instead of panicking on
-// a nil httpServer.
-func TestServe_WithoutListen(t *testing.T) {
-	srv := newListenTestServer(t)
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+// Main creates a gated Server before the store and API token exist, then
+// injects them before MarkReady. Verify that the router observes both values
+// only after publication: authentication uses the late token and the handler
+// can use the late store without a nil dereference.
+func TestConfigure_PublishesDependenciesBeforeMarkReady(t *testing.T) {
+	s, err := store.Open(":memory:")
 	if err != nil {
-		t.Fatalf("listen: %v", err)
+		t.Fatalf("open store: %v", err)
 	}
-	defer ln.Close()
+	t.Cleanup(func() { s.Close() })
+	broker := sse.NewBroker()
+	broker.Start()
+	t.Cleanup(broker.Stop)
 
-	if err := srv.Serve(ln); err == nil {
-		t.Fatal("Serve without Listen returned nil error")
+	srv := server.New(nil, nil, nil, "")
+	srv.MarkStarting()
+	srv.Configure(s, broker, nil, "late-secret")
+	srv.MarkReady()
+
+	unauthenticated := httptest.NewRecorder()
+	srv.Router().ServeHTTP(unauthenticated, httptest.NewRequest(http.MethodGet, "/prs", nil))
+	if unauthenticated.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated /prs status = %d, want 401", unauthenticated.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/prs", nil)
+	req.Header.Set("X-Heimdallm-Token", "late-secret")
+	authenticated := httptest.NewRecorder()
+	srv.Router().ServeHTTP(authenticated, req)
+	if authenticated.Code != http.StatusOK {
+		t.Fatalf("authenticated /prs status = %d, want 200; body=%s", authenticated.Code, authenticated.Body.String())
 	}
 }
 
@@ -120,7 +178,7 @@ func TestServe_WithoutListen(t *testing.T) {
 // future refactor could silently restore the headless-daemon behaviour of #646.
 func TestServe_ListenerDiesMidFlight_ReturnsNonClosedError(t *testing.T) {
 	srv := newListenTestServer(t)
-	ln, err := srv.Listen(freePort(t), "127.0.0.1")
+	ln, err := server.Listen(freePort(t), "127.0.0.1")
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
@@ -153,7 +211,7 @@ func TestListen_BindsAndServeUsesTheListener(t *testing.T) {
 	srv := newListenTestServer(t)
 	port := freePort(t)
 
-	ln, err := srv.Listen(port, "127.0.0.1")
+	ln, err := server.Listen(port, "127.0.0.1")
 	if err != nil {
 		t.Fatalf("Listen on free port %d: %v", port, err)
 	}
@@ -195,11 +253,70 @@ func TestListen_BindsAndServeUsesTheListener(t *testing.T) {
 // net.ipv4.ip_nonlocal_bind=1 is set (common in load-balancer and container
 // images), which made an earlier TEST-NET-3 version of this test flaky.
 func TestListen_FailsOnUnusableBindAddr(t *testing.T) {
-	srv := newListenTestServer(t)
-	ln, err := srv.Listen(freePort(t), "not a host")
+	ln, err := server.Listen(freePort(t), "not a host")
 	if err == nil {
 		ln.Close()
 		t.Fatal("Listen on an invalid bind address returned no error")
+	}
+}
+
+func TestStartingGate_BlocksEveryRouteExceptHealth(t *testing.T) {
+	srv := newListenTestServerWithToken(t, "secret")
+	srv.MarkStarting()
+	shutdownCalled := false
+	meCalled := false
+	srv.SetShutdownFn(func() { shutdownCalled = true })
+	srv.SetMeFn(func() (string, error) {
+		meCalled = true
+		return "bot", nil
+	})
+
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/me"},
+		{http.MethodGet, "/prs"},
+		{http.MethodGet, "/events"},
+		{http.MethodGet, "/logs/stream"},
+		{http.MethodPatch, "/config"},
+		{http.MethodPost, "/shutdown"},
+		{http.MethodGet, "/not-a-route"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+			if w.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want 503", w.Code)
+			}
+			if got := w.Header().Get(server.HeaderDaemon); got != "1" {
+				t.Errorf("%s header = %q, want 1", server.HeaderDaemon, got)
+			}
+			if got := w.Header().Get("Retry-After"); got != "1" {
+				t.Errorf("Retry-After = %q, want 1", got)
+			}
+		})
+	}
+	if shutdownCalled {
+		t.Fatal("shutdown callback ran while server was starting")
+	}
+	if meCalled {
+		t.Fatal("me callback ran while server was starting")
+	}
+
+	// MarkReady publishes the callbacks and restores the normal router.
+	srv.MarkReady()
+	req := httptest.NewRequest(http.MethodGet, "/me", nil)
+	req.Header.Set("X-Heimdallm-Token", "secret")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ready /me status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !meCalled {
+		t.Fatal("ready /me did not invoke the published callback")
 	}
 }
 
@@ -237,6 +354,35 @@ func TestHealth_ReportsStartingUntilMarkReady(t *testing.T) {
 	}
 	if body["status"] == "starting" {
 		t.Error("ready: still reporting \"starting\" after MarkReady")
+	}
+}
+
+func TestMarkStopping_KeepsOwnershipVisibleAndGatesRoutes(t *testing.T) {
+	srv := newListenTestServerWithToken(t, "secret")
+	srv.MarkStopping()
+
+	health := httptest.NewRecorder()
+	srv.Router().ServeHTTP(health, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if health.Code != http.StatusServiceUnavailable {
+		t.Fatalf("health status = %d, want 503", health.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(health.Body).Decode(&body); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if body["status"] != "stopping" {
+		t.Fatalf("health status field = %v, want stopping", body["status"])
+	}
+	if got := health.Header().Get(server.HeaderDaemon); got != "1" {
+		t.Fatalf("%s header = %q, want 1", server.HeaderDaemon, got)
+	}
+
+	mutation := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	req.Header.Set("X-Heimdallm-Token", "secret")
+	srv.Router().ServeHTTP(mutation, req)
+	if mutation.Code != http.StatusServiceUnavailable {
+		t.Fatalf("gated mutation status = %d, want 503", mutation.Code)
 	}
 }
 

--- a/daemon/internal/server/listen_test.go
+++ b/daemon/internal/server/listen_test.go
@@ -1,0 +1,138 @@
+package server_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/heimdallm/daemon/internal/server"
+	"github.com/heimdallm/daemon/internal/sse"
+	"github.com/heimdallm/daemon/internal/store"
+)
+
+// newListenTestServer builds the smallest Server that can bind: Listen only
+// needs the router, which New always wires.
+func newListenTestServer(t *testing.T) *server.Server {
+	t.Helper()
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	broker := sse.NewBroker()
+	broker.Start()
+	t.Cleanup(broker.Stop)
+	return server.New(s, broker, nil, "")
+}
+
+// freePort returns a port number nothing is listening on. Racy by nature —
+// callers that need the port to stay free must bind it themselves.
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe for free port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	return port
+}
+
+// Listen must report a port collision to the caller instead of leaving the
+// daemon headless. A daemon that keeps running without an HTTP listener is
+// invisible to the app but still burns the shared GitHub API budget — that is
+// how five zombie daemons exhausted the hourly quota in #646.
+func TestListen_FailsWhenPortIsOccupied(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy port: %v", err)
+	}
+	defer occupied.Close()
+	port := occupied.Addr().(*net.TCPAddr).Port
+
+	srv := newListenTestServer(t)
+	ln, err := srv.Listen(port, "127.0.0.1")
+	if err == nil {
+		ln.Close()
+		t.Fatalf("Listen on occupied port %d returned no error; the daemon would run headless", port)
+	}
+	if ln != nil {
+		ln.Close()
+		t.Fatal("Listen returned a non-nil listener alongside an error")
+	}
+	if !errors.Is(err, syscall.EADDRINUSE) {
+		t.Fatalf("expected EADDRINUSE, got %v", err)
+	}
+}
+
+// The happy path must still bind and serve, and the returned listener must be
+// the one Serve uses — otherwise the split would silently bind twice.
+func TestListen_BindsAndServeUsesTheListener(t *testing.T) {
+	srv := newListenTestServer(t)
+	port := freePort(t)
+
+	ln, err := srv.Listen(port, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("Listen on free port %d: %v", port, err)
+	}
+	if got := ln.Addr().(*net.TCPAddr).Port; got != port {
+		t.Fatalf("listener bound to port %d, want %d", got, port)
+	}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		srv.Shutdown(shutdownCtx)
+		select {
+		case err := <-serveErr:
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				t.Errorf("Serve returned %v, want nil or ErrServerClosed", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Error("Serve did not return after Shutdown")
+		}
+	})
+
+	resp, err := httpGetWithRetry(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /health status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// Listen must not bind when the address is unusable, so a typo in bind_addr
+// fails fast at startup rather than after the pollers are already spending
+// API budget.
+func TestListen_FailsOnUnusableBindAddr(t *testing.T) {
+	srv := newListenTestServer(t)
+	ln, err := srv.Listen(freePort(t), "203.0.113.1") // TEST-NET-3, not local
+	if err == nil {
+		ln.Close()
+		t.Fatal("Listen on a non-local address returned no error")
+	}
+}
+
+func httpGetWithRetry(url string) (*http.Response, error) {
+	var lastErr error
+	for i := 0; i < 50; i++ {
+		resp, err := http.Get(url)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		time.Sleep(20 * time.Millisecond)
+	}
+	return nil, lastErr
+}

--- a/daemon/internal/server/listen_test.go
+++ b/daemon/internal/server/listen_test.go
@@ -240,6 +240,28 @@ func TestHealth_ReportsStartingUntilMarkReady(t *testing.T) {
 	}
 }
 
+// The app identifies our daemon by this header, so every /health response must
+// carry it — including the 503s. Without it the app falls back to sniffing the
+// body, and a bare {"status": ...} is the shape of most health endpoints in the
+// wild, so a foreign service would be mistaken for the daemon and no daemon
+// would ever be spawned.
+func TestHealth_AlwaysCarriesDaemonHeader(t *testing.T) {
+	srv := newListenTestServer(t)
+
+	for _, state := range []string{"starting", "ready"} {
+		if state == "starting" {
+			srv.MarkStarting()
+		} else {
+			srv.MarkReady()
+		}
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, httptest.NewRequest("GET", "/health", nil))
+		if got := w.Header().Get(server.HeaderDaemon); got != "1" {
+			t.Errorf("%s: %s header = %q, want \"1\"", state, server.HeaderDaemon, got)
+		}
+	}
+}
+
 func httpGetWithRetry(url string) (*http.Response, error) {
 	var lastErr error
 	for i := 0; i < 50; i++ {

--- a/daemon/internal/server/listen_test.go
+++ b/daemon/internal/server/listen_test.go
@@ -2,12 +2,13 @@ package server_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"syscall"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -66,8 +67,83 @@ func TestListen_FailsWhenPortIsOccupied(t *testing.T) {
 		ln.Close()
 		t.Fatal("Listen returned a non-nil listener alongside an error")
 	}
-	if !errors.Is(err, syscall.EADDRINUSE) {
-		t.Fatalf("expected EADDRINUSE, got %v", err)
+	// Assert the failure shape rather than a specific errno: EADDRINUSE is
+	// Unix-only (Windows reports WSAEADDRINUSE) and the daemon only relies on
+	// "bind failed", not on which errno said so.
+	var opErr *net.OpError
+	if !errors.As(err, &opErr) {
+		t.Fatalf("expected a *net.OpError from the failed bind, got %T: %v", err, err)
+	}
+	if opErr.Op != "listen" {
+		t.Errorf("OpError.Op = %q, want \"listen\"", opErr.Op)
+	}
+}
+
+// A second Listen must not silently orphan the first listener/server pair by
+// overwriting srv.httpServer.
+func TestListen_RejectsSecondCall(t *testing.T) {
+	srv := newListenTestServer(t)
+	first, err := srv.Listen(freePort(t), "127.0.0.1")
+	if err != nil {
+		t.Fatalf("first Listen: %v", err)
+	}
+	defer first.Close()
+
+	second, err := srv.Listen(freePort(t), "127.0.0.1")
+	if err == nil {
+		second.Close()
+		t.Fatal("second Listen succeeded; the first listener would be orphaned")
+	}
+	if second != nil {
+		second.Close()
+		t.Fatal("second Listen returned a listener alongside an error")
+	}
+}
+
+// Serve without a prior Listen must report the misuse instead of panicking on
+// a nil httpServer.
+func TestServe_WithoutListen(t *testing.T) {
+	srv := newListenTestServer(t)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	if err := srv.Serve(ln); err == nil {
+		t.Fatal("Serve without Listen returned nil error")
+	}
+}
+
+// The signal main relies on to exit non-zero: if the listener dies mid-flight,
+// Serve must return an error that is NOT ErrServerClosed. Without this, a
+// future refactor could silently restore the headless-daemon behaviour of #646.
+func TestServe_ListenerDiesMidFlight_ReturnsNonClosedError(t *testing.T) {
+	srv := newListenTestServer(t)
+	ln, err := srv.Listen(freePort(t), "127.0.0.1")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+
+	// Let Serve reach its Accept loop, then pull the listener out from under it.
+	if _, err := httpGetWithRetry(fmt.Sprintf("http://%s/health", ln.Addr().String())); err != nil {
+		t.Fatalf("server never came up: %v", err)
+	}
+	ln.Close()
+
+	select {
+	case err := <-serveErr:
+		if err == nil {
+			t.Fatal("Serve returned nil after the listener closed; main would keep polling headless")
+		}
+		if errors.Is(err, http.ErrServerClosed) {
+			t.Fatal("Serve reported ErrServerClosed for a listener failure; main would treat it as a clean shutdown")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve did not return after the listener closed")
 	}
 }
 
@@ -114,13 +190,53 @@ func TestListen_BindsAndServeUsesTheListener(t *testing.T) {
 
 // Listen must not bind when the address is unusable, so a typo in bind_addr
 // fails fast at startup rather than after the pollers are already spending
-// API budget.
+// API budget. Uses a syntactically invalid host so the result does not depend
+// on host routing: binding a non-local IP succeeds wherever
+// net.ipv4.ip_nonlocal_bind=1 is set (common in load-balancer and container
+// images), which made an earlier TEST-NET-3 version of this test flaky.
 func TestListen_FailsOnUnusableBindAddr(t *testing.T) {
 	srv := newListenTestServer(t)
-	ln, err := srv.Listen(freePort(t), "203.0.113.1") // TEST-NET-3, not local
+	ln, err := srv.Listen(freePort(t), "not a host")
 	if err == nil {
 		ln.Close()
-		t.Fatal("Listen on a non-local address returned no error")
+		t.Fatal("Listen on an invalid bind address returned no error")
+	}
+}
+
+// While main is still wiring dependencies the socket is already served, so
+// /health must say so rather than run deep checks against half-built
+// dependencies — and must stay a real HTTP answer so the app's reachability
+// probe knows the port is taken and does not spawn a rival daemon (#646).
+func TestHealth_ReportsStartingUntilMarkReady(t *testing.T) {
+	srv := newListenTestServer(t)
+	srv.MarkStarting()
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("starting: status = %d, want 503", w.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("starting: decode: %v", err)
+	}
+	if body["status"] != "starting" {
+		t.Errorf("starting: status field = %v, want \"starting\"", body["status"])
+	}
+
+	srv.MarkReady()
+	w = httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, httptest.NewRequest("GET", "/health", nil))
+	// Deliberately not asserting 200: a Server with no wired dependencies may
+	// legitimately report degraded. What matters is that it stopped saying
+	// "starting" once MarkReady ran.
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("ready: decode: %v", err)
+	}
+	if body["status"] == "starting" {
+		t.Error("ready: still reporting \"starting\" after MarkReady")
 	}
 }
 

--- a/daemon/internal/server/listen_test.go
+++ b/daemon/internal/server/listen_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -354,6 +355,88 @@ func TestHealth_ReportsStartingUntilMarkReady(t *testing.T) {
 	}
 	if body["status"] == "starting" {
 		t.Error("ready: still reporting \"starting\" after MarkReady")
+	}
+}
+
+func TestHealth_StartingIncludesVersion(t *testing.T) {
+	srv := server.NewWithOptions(nil, nil, nil, "", server.Options{Version: "v-test"})
+	srv.MarkStarting()
+
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/health", nil))
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if body["version"] != "v-test" {
+		t.Fatalf("starting health version = %v, want v-test", body["version"])
+	}
+}
+
+var errSecondListenerClose = errors.New("second listener close failed")
+
+type secondCloseErrorListener struct {
+	addr          net.Addr
+	acceptStarted chan struct{}
+	closed        chan struct{}
+	acceptOnce    sync.Once
+	closeOnce     sync.Once
+	mu            sync.Mutex
+	closeCount    int
+}
+
+func newSecondCloseErrorListener() *secondCloseErrorListener {
+	return &secondCloseErrorListener{
+		addr:          testListenerAddr("127.0.0.1:0"),
+		acceptStarted: make(chan struct{}),
+		closed:        make(chan struct{}),
+	}
+}
+
+func (l *secondCloseErrorListener) Accept() (net.Conn, error) {
+	l.acceptOnce.Do(func() { close(l.acceptStarted) })
+	<-l.closed
+	return nil, net.ErrClosed
+}
+
+func (l *secondCloseErrorListener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.closeCount++
+	if l.closeCount == 1 {
+		l.closeOnce.Do(func() { close(l.closed) })
+		return nil
+	}
+	return errSecondListenerClose
+}
+
+func (l *secondCloseErrorListener) Addr() net.Addr { return l.addr }
+
+type testListenerAddr string
+
+func (a testListenerAddr) Network() string { return "tcp" }
+func (a testListenerAddr) String() string  { return string(a) }
+
+func TestShutdownReturnsTrackedListenerCloseError(t *testing.T) {
+	srv := newListenTestServer(t)
+	ln := newSecondCloseErrorListener()
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+	select {
+	case <-ln.acceptStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve never entered Accept")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); !errors.Is(err, errSecondListenerClose) {
+		t.Fatalf("Shutdown error = %v, want %v", err, errSecondListenerClose)
+	}
+	select {
+	case <-serveErr:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve did not finish after Shutdown")
 	}
 }
 

--- a/daemon/internal/singleinstance/lock_unix.go
+++ b/daemon/internal/singleinstance/lock_unix.go
@@ -1,0 +1,77 @@
+//go:build darwin || linux
+
+// Package singleinstance owns the daemon's process-wide lifecycle lock.
+package singleinstance
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// ErrAlreadyRunning means another daemon which uses the same data directory
+// still owns the lifecycle lock.
+var ErrAlreadyRunning = errors.New("heimdallm daemon already running")
+
+// Lock is an advisory OS lock held by an open file descriptor. The kernel
+// releases it automatically on process exit, including crashes and SIGKILL.
+type Lock struct {
+	file *os.File
+	once sync.Once
+	err  error
+}
+
+// Acquire takes a non-blocking exclusive lock at path. The file is deliberately
+// never unlinked: removing a flock file creates an inode race where old and new
+// processes can each lock a different file under the same pathname.
+func Acquire(path string) (*Lock, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("single-instance: open lock file: %w", err)
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return nil, fmt.Errorf("%w: %s", ErrAlreadyRunning, path)
+		}
+		return nil, fmt.Errorf("single-instance: lock %s: %w", path, err)
+	}
+
+	// PID contents are diagnostic only; flock ownership, not this value, is the
+	// authority. Update it only after acquiring the lock so a losing process can
+	// never overwrite the active owner's PID.
+	if err := f.Truncate(0); err == nil {
+		_, err = f.Seek(0, 0)
+	}
+	if err == nil {
+		_, err = f.WriteString(strconv.Itoa(os.Getpid()) + "\n")
+	}
+	if err != nil {
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
+		return nil, fmt.Errorf("single-instance: write owner pid: %w", err)
+	}
+
+	return &Lock{file: f}, nil
+}
+
+// Close releases the lock. It is idempotent.
+func (l *Lock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	l.once.Do(func() {
+		unlockErr := unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+		closeErr := l.file.Close()
+		if unlockErr != nil {
+			l.err = fmt.Errorf("single-instance: unlock: %w", unlockErr)
+		} else if closeErr != nil {
+			l.err = fmt.Errorf("single-instance: close lock file: %w", closeErr)
+		}
+	})
+	return l.err
+}

--- a/daemon/internal/singleinstance/lock_unix_internal_test.go
+++ b/daemon/internal/singleinstance/lock_unix_internal_test.go
@@ -1,0 +1,48 @@
+//go:build darwin || linux
+
+package singleinstance
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestAcquireReportsOpenFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "daemon.lock")
+	if _, err := Acquire(path); err == nil || !strings.Contains(err.Error(), "open lock file") {
+		t.Fatalf("Acquire missing parent error = %v, want open lock file error", err)
+	}
+}
+
+func TestAcquireReleasesLockWhenOwnerPIDCannotBeWritten(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("/dev/full is the deterministic Linux write-failure device")
+	}
+	if _, err := Acquire("/dev/full"); err == nil || !strings.Contains(err.Error(), "write owner pid") {
+		t.Fatalf("Acquire /dev/full error = %v, want write owner pid error", err)
+	}
+}
+
+func TestCloseHandlesNilAndClosedDescriptors(t *testing.T) {
+	var nilLock *Lock
+	if err := nilLock.Close(); err != nil {
+		t.Fatalf("nil Close: %v", err)
+	}
+
+	lock, err := Acquire(filepath.Join(t.TempDir(), "daemon.lock"))
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := lock.file.Close(); err != nil {
+		t.Fatalf("close descriptor behind Lock: %v", err)
+	}
+	if err := lock.Close(); err == nil || !strings.Contains(err.Error(), "unlock") {
+		t.Fatalf("Close closed descriptor error = %v, want unlock error", err)
+	}
+	if _, err := os.Stat(lock.file.Name()); err != nil {
+		t.Fatalf("lock file disappeared after close error: %v", err)
+	}
+}

--- a/daemon/internal/singleinstance/lock_unix_test.go
+++ b/daemon/internal/singleinstance/lock_unix_test.go
@@ -1,0 +1,48 @@
+//go:build darwin || linux
+
+package singleinstance_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/heimdallm/daemon/internal/singleinstance"
+)
+
+func TestLockExcludesUntilOwnerFinishes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.lock")
+	first, err := singleinstance.Acquire(path)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+
+	if _, err := singleinstance.Acquire(path); !errors.Is(err, singleinstance.ErrAlreadyRunning) {
+		t.Fatalf("second Acquire error = %v, want ErrAlreadyRunning", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read lock file: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(body)), strconv.Itoa(os.Getpid()); got != want {
+		t.Fatalf("owner PID = %q, want %q", got, want)
+	}
+
+	if err := first.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	second, err := singleinstance.Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire after release: %v", err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatalf("idempotent Close: %v", err)
+	}
+}

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/activity.dart';
@@ -73,26 +74,58 @@ class ApiClient {
       final resp =
           await _client.get(_uri('/health')).timeout(const Duration(seconds: 3));
       return _looksLikeHeimdallm(resp) ? PortOwner.daemon : PortOwner.foreign;
-    } catch (_) {
+    } on TimeoutException {
       return PortOwner.none;
+    } catch (e) {
+      // Connection refused / host unreachable means nothing is listening.
+      // Matched by name rather than `on SocketException` because this file is
+      // shared with the web build, where importing dart:io does not compile.
+      if (_isSocketFailure(e)) return PortOwner.none;
+      // Otherwise we reached something that failed to speak HTTP properly (raw
+      // TCP service, malformed response, TLS on a plaintext port). Someone holds
+      // the port, so spawning would only fail on the bind — report it as foreign
+      // so the user gets the "free the port" guidance instead of a generic
+      // start failure.
+      return PortOwner.foreign;
     }
   }
+
+  static bool _isSocketFailure(Object e) =>
+      e.runtimeType.toString() == 'SocketException';
 
   /// Distinguishes our daemon from an unrelated process squatting on the port.
   /// Without this the app would silently never spawn, exhaust its retries and
   /// report a generic health failure with no hint that something else holds the
-  /// port. Every daemon response — healthy, degraded or starting — carries a
-  /// `status` field; 401 has no body to inspect but only our daemon enforces
-  /// the API token, so treat it as ours.
+  /// port.
+  ///
+  /// The [HeaderDaemon] header is the authoritative signal. The body fallback
+  /// exists only for daemons predating that header, and deliberately requires
+  /// `checks` or `version` alongside `status`: a bare `{"status": "..."}` is the
+  /// shape of most health endpoints in the wild (`{"status":"UP"}` from Spring
+  /// Boot Actuator, `{"status":"ok"}` from countless Node/Go services), and
+  /// accepting it would classify a foreign service as ours.
+  ///
+  /// A 401/403 has no body worth inspecting, but only our daemon enforces the
+  /// API token on this port, so treat it as ours. Documented tradeoff: a foreign
+  /// auth-protected service would be misread as the daemon.
+  static const _daemonHeader = 'x-heimdallm-daemon';
+
   static bool _looksLikeHeimdallm(http.Response resp) {
+    if (resp.headers.containsKey(_daemonHeader)) return true;
     if (resp.statusCode == 401 || resp.statusCode == 403) return true;
     try {
       final body = jsonDecode(resp.body);
-      return body is Map<String, dynamic> && body['status'] is String;
+      if (body is! Map<String, dynamic>) return false;
+      if (body['status'] is! String) return false;
+      return body.containsKey('checks') || body.containsKey('version');
     } catch (_) {
       return false;
     }
   }
+
+  /// The daemon port, derived from the configured base URL so error messages and
+  /// diagnostics never hardcode the default.
+  int get daemonPort => Uri.parse(_platform.apiBaseUrl).port;
 
   /// Returns the full /health payload, or null if the daemon is unreachable.
   /// Includes status, version (optional), started_at (optional, RFC3339).

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -6,6 +6,20 @@ import '../models/review.dart';
 import '../models/tracked_issue.dart';
 import '../platform/platform_services.dart';
 
+/// Who, if anyone, is answering on the daemon port. Drives the boot-path spawn
+/// decision: only [PortOwner.none] justifies starting a daemon (#646).
+enum PortOwner {
+  /// Nothing is listening (connection refused) or it never answered in time.
+  none,
+
+  /// Our daemon answered — healthy, degraded or still starting.
+  daemon,
+
+  /// Something answered but it is not Heimdallm. Spawning would fail on the
+  /// bind, so surface this to the user instead of retrying silently.
+  foreign,
+}
+
 class ApiClient {
   final http.Client _client;
   final PlatformServices _platform;
@@ -49,15 +63,32 @@ class ApiClient {
   /// Never use [checkHealth] to decide whether to spawn a daemon. A daemon that
   /// is alive but degraded answers /health with 503 — which it does whenever
   /// `last_poll` is older than twice the poll interval, i.e. exactly when
-  /// GitHub rate limits are slowing polls down. Treating that as "no daemon"
-  /// spawns a second one, which loses the port bind, keeps polling anyway and
-  /// pushes the quota further under: the feedback loop behind #646. Any HTTP
-  /// answer at all — 200, 401, 503 — means a daemon owns the port and we must
-  /// not start another.
-  Future<bool> daemonReachable() async {
+  /// GitHub rate limits are slowing polls down, and also while it is still
+  /// wiring up at boot. Treating that as "no daemon" spawns a second one, which
+  /// loses the port bind, keeps polling anyway and pushes the quota further
+  /// under: the feedback loop behind #646. Any HTTP answer at all — 200, 401,
+  /// 503 — means the port is taken and we must not start another daemon.
+  Future<PortOwner> daemonReachable() async {
     try {
-      await _client.get(_uri('/health')).timeout(const Duration(seconds: 3));
-      return true;
+      final resp =
+          await _client.get(_uri('/health')).timeout(const Duration(seconds: 3));
+      return _looksLikeHeimdallm(resp) ? PortOwner.daemon : PortOwner.foreign;
+    } catch (_) {
+      return PortOwner.none;
+    }
+  }
+
+  /// Distinguishes our daemon from an unrelated process squatting on the port.
+  /// Without this the app would silently never spawn, exhaust its retries and
+  /// report a generic health failure with no hint that something else holds the
+  /// port. Every daemon response — healthy, degraded or starting — carries a
+  /// `status` field; 401 has no body to inspect but only our daemon enforces
+  /// the API token, so treat it as ours.
+  static bool _looksLikeHeimdallm(http.Response resp) {
+    if (resp.statusCode == 401 || resp.statusCode == 403) return true;
+    try {
+      final body = jsonDecode(resp.body);
+      return body is Map<String, dynamic> && body['status'] is String;
     } catch (_) {
       return false;
     }

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -6,17 +6,18 @@ import '../models/review.dart';
 import '../models/tracked_issue.dart';
 import '../platform/platform_services.dart';
 
-/// Who, if anyone, is answering on the daemon port. Drives the boot-path spawn
-/// decision: only [PortOwner.none] justifies starting a daemon (#646).
+/// Who, if anyone, answered the daemon HTTP endpoint. A [PortOwner.none]
+/// result only permits entering [PlatformServices.spawnDaemon]; that operation
+/// performs the authoritative TCP guard immediately before process creation.
 enum PortOwner {
-  /// Nothing is listening; confirmed by an explicit TCP connection refusal.
+  /// No native HTTP responder could be identified. The guarded spawn operation
+  /// still has to prove that the TCP port is free.
   none,
 
   /// Our daemon answered — healthy, degraded or still starting.
   daemon,
 
-  /// The port is open, owned by a foreign service, or could not be proven
-  /// closed. Spawning would be unsafe, so surface it instead of retrying.
+  /// A foreign HTTP service answered, or a web proxy endpoint was unreachable.
   foreign,
 }
 
@@ -24,17 +25,14 @@ class ApiClient {
   final http.Client _client;
   final PlatformServices _platform;
   final Duration _daemonReachabilityTimeout;
-  final Duration _daemonTcpProbeTimeout;
 
   ApiClient({
     http.Client? httpClient,
     required PlatformServices platform,
     Duration daemonReachabilityTimeout = const Duration(seconds: 3),
-    Duration daemonTcpProbeTimeout = const Duration(milliseconds: 500),
   }) : _client = httpClient ?? http.Client(),
        _platform = platform,
-       _daemonReachabilityTimeout = daemonReachabilityTimeout,
-       _daemonTcpProbeTimeout = daemonTcpProbeTimeout;
+       _daemonReachabilityTimeout = daemonReachabilityTimeout;
 
   Uri _uri(String path) => Uri.parse('${_platform.apiBaseUrl}$path');
 
@@ -78,9 +76,10 @@ class ApiClient {
   ///
   /// HTTP errors are deliberately not classified by exception type. The VM
   /// client wraps SocketException in a private `_ClientSocketException`, while
-  /// web uses a different hierarchy again. Instead, every HTTP failure is
-  /// followed by a platform TCP probe. Only an explicit connection refusal
-  /// means [PortOwner.none]; an open or ambiguous port fails closed.
+  /// web uses a different hierarchy again. Native callers may proceed only to
+  /// the guarded [PlatformServices.spawnDaemon], which performs a raw TCP probe
+  /// immediately before process creation. A relative web endpoint fails closed
+  /// because a browser cannot perform that native guard.
   Future<PortOwner> daemonReachable() async {
     try {
       final resp = await _client
@@ -88,10 +87,7 @@ class ApiClient {
           .timeout(_daemonReachabilityTimeout);
       return _looksLikeHeimdallm(resp) ? PortOwner.daemon : PortOwner.foreign;
     } catch (_) {
-      final tcpState = await _platform.probeDaemonPort(
-        timeout: _daemonTcpProbeTimeout,
-      );
-      return tcpState == TcpPortState.closed
+      return Uri.parse(_platform.apiBaseUrl).isAbsolute
           ? PortOwner.none
           : PortOwner.foreign;
     }

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -43,6 +43,26 @@ class ApiClient {
     }
   }
 
+  /// Whether *something* is serving the daemon port, regardless of how healthy
+  /// it reports itself to be.
+  ///
+  /// Never use [checkHealth] to decide whether to spawn a daemon. A daemon that
+  /// is alive but degraded answers /health with 503 — which it does whenever
+  /// `last_poll` is older than twice the poll interval, i.e. exactly when
+  /// GitHub rate limits are slowing polls down. Treating that as "no daemon"
+  /// spawns a second one, which loses the port bind, keeps polling anyway and
+  /// pushes the quota further under: the feedback loop behind #646. Any HTTP
+  /// answer at all — 200, 401, 503 — means a daemon owns the port and we must
+  /// not start another.
+  Future<bool> daemonReachable() async {
+    try {
+      await _client.get(_uri('/health')).timeout(const Duration(seconds: 3));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   /// Returns the full /health payload, or null if the daemon is unreachable.
   /// Includes status, version (optional), started_at (optional, RFC3339).
   Future<Map<String, dynamic>?> fetchHealth() async {

--- a/flutter_app/lib/core/api/api_client.dart
+++ b/flutter_app/lib/core/api/api_client.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/activity.dart';
@@ -10,24 +9,32 @@ import '../platform/platform_services.dart';
 /// Who, if anyone, is answering on the daemon port. Drives the boot-path spawn
 /// decision: only [PortOwner.none] justifies starting a daemon (#646).
 enum PortOwner {
-  /// Nothing is listening (connection refused) or it never answered in time.
+  /// Nothing is listening; confirmed by an explicit TCP connection refusal.
   none,
 
   /// Our daemon answered — healthy, degraded or still starting.
   daemon,
 
-  /// Something answered but it is not Heimdallm. Spawning would fail on the
-  /// bind, so surface this to the user instead of retrying silently.
+  /// The port is open, owned by a foreign service, or could not be proven
+  /// closed. Spawning would be unsafe, so surface it instead of retrying.
   foreign,
 }
 
 class ApiClient {
   final http.Client _client;
   final PlatformServices _platform;
+  final Duration _daemonReachabilityTimeout;
+  final Duration _daemonTcpProbeTimeout;
 
-  ApiClient({http.Client? httpClient, required PlatformServices platform})
-    : _client = httpClient ?? http.Client(),
-      _platform = platform;
+  ApiClient({
+    http.Client? httpClient,
+    required PlatformServices platform,
+    Duration daemonReachabilityTimeout = const Duration(seconds: 3),
+    Duration daemonTcpProbeTimeout = const Duration(milliseconds: 500),
+  }) : _client = httpClient ?? http.Client(),
+       _platform = platform,
+       _daemonReachabilityTimeout = daemonReachabilityTimeout,
+       _daemonTcpProbeTimeout = daemonTcpProbeTimeout;
 
   Uri _uri(String path) => Uri.parse('${_platform.apiBaseUrl}$path');
 
@@ -52,7 +59,7 @@ class ApiClient {
       final resp = await _client
           .get(_uri('/health'))
           .timeout(const Duration(seconds: 3));
-      return resp.statusCode == 200;
+      return resp.statusCode == 200 && _looksLikeHeimdallm(resp);
     } catch (_) {
       return false;
     }
@@ -67,31 +74,28 @@ class ApiClient {
   /// GitHub rate limits are slowing polls down, and also while it is still
   /// wiring up at boot. Treating that as "no daemon" spawns a second one, which
   /// loses the port bind, keeps polling anyway and pushes the quota further
-  /// under: the feedback loop behind #646. Any HTTP answer at all — 200, 401,
-  /// 503 — means the port is taken and we must not start another daemon.
+  /// under: the feedback loop behind #646.
+  ///
+  /// HTTP errors are deliberately not classified by exception type. The VM
+  /// client wraps SocketException in a private `_ClientSocketException`, while
+  /// web uses a different hierarchy again. Instead, every HTTP failure is
+  /// followed by a platform TCP probe. Only an explicit connection refusal
+  /// means [PortOwner.none]; an open or ambiguous port fails closed.
   Future<PortOwner> daemonReachable() async {
     try {
-      final resp =
-          await _client.get(_uri('/health')).timeout(const Duration(seconds: 3));
+      final resp = await _client
+          .get(_uri('/health'))
+          .timeout(_daemonReachabilityTimeout);
       return _looksLikeHeimdallm(resp) ? PortOwner.daemon : PortOwner.foreign;
-    } on TimeoutException {
-      return PortOwner.none;
-    } catch (e) {
-      // Connection refused / host unreachable means nothing is listening.
-      // Matched by name rather than `on SocketException` because this file is
-      // shared with the web build, where importing dart:io does not compile.
-      if (_isSocketFailure(e)) return PortOwner.none;
-      // Otherwise we reached something that failed to speak HTTP properly (raw
-      // TCP service, malformed response, TLS on a plaintext port). Someone holds
-      // the port, so spawning would only fail on the bind — report it as foreign
-      // so the user gets the "free the port" guidance instead of a generic
-      // start failure.
-      return PortOwner.foreign;
+    } catch (_) {
+      final tcpState = await _platform.probeDaemonPort(
+        timeout: _daemonTcpProbeTimeout,
+      );
+      return tcpState == TcpPortState.closed
+          ? PortOwner.none
+          : PortOwner.foreign;
     }
   }
-
-  static bool _isSocketFailure(Object e) =>
-      e.runtimeType.toString() == 'SocketException';
 
   /// Distinguishes our daemon from an unrelated process squatting on the port.
   /// Without this the app would silently never spawn, exhaust its retries and
@@ -105,14 +109,10 @@ class ApiClient {
   /// Boot Actuator, `{"status":"ok"}` from countless Node/Go services), and
   /// accepting it would classify a foreign service as ours.
   ///
-  /// A 401/403 has no body worth inspecting, but only our daemon enforces the
-  /// API token on this port, so treat it as ours. Documented tradeoff: a foreign
-  /// auth-protected service would be misread as the daemon.
   static const _daemonHeader = 'x-heimdallm-daemon';
 
   static bool _looksLikeHeimdallm(http.Response resp) {
     if (resp.headers.containsKey(_daemonHeader)) return true;
-    if (resp.statusCode == 401 || resp.statusCode == 403) return true;
     try {
       final body = jsonDecode(resp.body);
       if (body is! Map<String, dynamic>) return false;
@@ -127,13 +127,20 @@ class ApiClient {
   /// diagnostics never hardcode the default.
   int get daemonPort => Uri.parse(_platform.apiBaseUrl).port;
 
-  /// Returns the full /health payload, or null if the daemon is unreachable.
+  /// Returns the full identified /health payload, including 503
+  /// starting/stopping/degraded responses, or null if the responder is not a
+  /// Heimdallm daemon. Diagnostics must remain available precisely when deep
+  /// health is failing.
   /// Includes status, version (optional), started_at (optional, RFC3339).
   Future<Map<String, dynamic>?> fetchHealth() async {
     try {
-      final resp = await _client.get(_uri('/health'), headers: await _authHeaders());
-      if (resp.statusCode != 200) return null;
-      return jsonDecode(resp.body) as Map<String, dynamic>;
+      final resp = await _client.get(
+        _uri('/health'),
+        headers: await _authHeaders(),
+      );
+      if (!_looksLikeHeimdallm(resp)) return null;
+      final body = jsonDecode(resp.body);
+      return body is Map<String, dynamic> ? body : null;
     } catch (_) {
       return null;
     }

--- a/flutter_app/lib/core/daemon/daemon_lifecycle.dart
+++ b/flutter_app/lib/core/daemon/daemon_lifecycle.dart
@@ -1,44 +1,15 @@
 import 'dart:io';
-import '../api/api_client.dart';
-import '../platform/platform_services.dart';
 
+/// Locates the daemon binary. Spawning itself lives in
+/// `PlatformServices.spawnDaemon`, and the "is one already running?" guard
+/// lives in the boot path (`_spawnDaemonUnlessRunning` in main.dart).
+///
+/// This class used to also own an `ensureRunning()` with its own health check,
+/// but nothing called it — the boot path had grown a second, unguarded spawn
+/// instead, which is how five daemons ended up sharing one GitHub token and
+/// exhausting the API quota (#646). Keeping a single spawn guard means a future
+/// caller cannot pick the wrong one.
 class DaemonLifecycle {
-  final int port;
-  final String daemonBinaryPath;
-  final ApiClient _client;
-  Process? _process;
-
-  DaemonLifecycle({
-    this.port = 7842,
-    required this.daemonBinaryPath,
-    ApiClient? client,
-    required PlatformServices platform,
-  }) : _client = client ?? ApiClient(platform: platform);
-
-  Future<bool> isRunning() => _client.checkHealth();
-
-  Future<void> ensureRunning() async {
-    if (await isRunning()) return;
-
-    final binary = File(daemonBinaryPath);
-    if (!binary.existsSync()) {
-      throw DaemonException('Daemon binary not found: $daemonBinaryPath');
-    }
-
-    _process = await Process.start(daemonBinaryPath, []);
-
-    for (var i = 0; i < 50; i++) {
-      await Future.delayed(const Duration(milliseconds: 100));
-      if (await isRunning()) return;
-    }
-    throw DaemonException('Daemon did not become healthy within 5 seconds');
-  }
-
-  Future<void> stop() async {
-    _process?.kill();
-    _process = null;
-  }
-
   /// Returns the daemon binary path, or null if not found.
   ///
   /// Priority:

--- a/flutter_app/lib/core/daemon/daemon_lifecycle.dart
+++ b/flutter_app/lib/core/daemon/daemon_lifecycle.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 /// Locates the daemon binary. Spawning itself lives in
-/// `PlatformServices.spawnDaemon`, and the "is one already running?" guard
-/// lives in the boot path (`_spawnDaemonUnlessRunning` in main.dart).
+/// `PlatformServices.spawnDaemon`, and the single guarded startup policy lives
+/// in `DaemonStartupCoordinator`.
 ///
 /// This class used to also own an `ensureRunning()` with its own health check,
 /// but nothing called it — the boot path had grown a second, unguarded spawn

--- a/flutter_app/lib/core/daemon/daemon_startup.dart
+++ b/flutter_app/lib/core/daemon/daemon_startup.dart
@@ -1,0 +1,93 @@
+import '../api/api_client.dart';
+import '../platform/platform_services.dart';
+
+/// Outcomes from the single guarded daemon-start path used by both initial
+/// bootstrap and retries.
+enum DaemonStartupOutcome {
+  spawned,
+  daemonPresent,
+  portOccupied,
+  spawnFailedRetryable,
+  spawnFailedTerminal,
+  spawnBudgetExhausted,
+}
+
+class DaemonStartupResult {
+  const DaemonStartupResult(this.outcome, {this.error});
+
+  final DaemonStartupOutcome outcome;
+  final Object? error;
+}
+
+/// Serializes daemon spawning and bounds every retry path.
+///
+/// The safety invariant is intentionally strict: [PlatformServices.spawnDaemon]
+/// is called only after [ApiClient.daemonReachable] proves the TCP port is
+/// closed. A healthy, degraded, starting, silent or ambiguously reachable
+/// process therefore never causes a second daemon to be launched (#646).
+class DaemonStartupCoordinator {
+  DaemonStartupCoordinator({
+    required this.api,
+    required this.platform,
+    required this.binaryPath,
+    this.maxSpawnAttempts = 4,
+  }) : assert(maxSpawnAttempts > 0);
+
+  final ApiClient api;
+  final PlatformServices platform;
+  final String binaryPath;
+  final int maxSpawnAttempts;
+
+  int _spawnAttempts = 0;
+  Future<DaemonStartupResult>? _inFlight;
+
+  int get spawnAttempts => _spawnAttempts;
+
+  Future<DaemonStartupResult> ensureAvailable() {
+    final running = _inFlight;
+    if (running != null) return running;
+
+    late final Future<DaemonStartupResult> pending;
+    pending = _ensureAvailable().whenComplete(() {
+      if (identical(_inFlight, pending)) _inFlight = null;
+    });
+    _inFlight = pending;
+    return pending;
+  }
+
+  Future<DaemonStartupResult> _ensureAvailable() async {
+    // Probe ownership before consulting the spawn budget. A slow daemon from a
+    // previous attempt may now own the port and answer 503; reporting
+    // "failed to start" in that state is both wrong and a temptation to spawn
+    // yet another process.
+    switch (await api.daemonReachable()) {
+      case PortOwner.daemon:
+        return const DaemonStartupResult(DaemonStartupOutcome.daemonPresent);
+      case PortOwner.foreign:
+        return const DaemonStartupResult(DaemonStartupOutcome.portOccupied);
+      case PortOwner.none:
+        break;
+    }
+
+    if (_spawnAttempts >= maxSpawnAttempts) {
+      return const DaemonStartupResult(
+        DaemonStartupOutcome.spawnBudgetExhausted,
+      );
+    }
+
+    // Count before spawning so a deterministic Process.start failure cannot
+    // leave the splash in an unbounded retry loop.
+    _spawnAttempts++;
+    try {
+      await platform.spawnDaemon(binaryPath);
+      return const DaemonStartupResult(DaemonStartupOutcome.spawned);
+    } catch (error) {
+      return DaemonStartupResult(
+        _spawnAttempts >= maxSpawnAttempts
+            ? DaemonStartupOutcome.spawnFailedTerminal
+            : DaemonStartupOutcome.spawnFailedRetryable,
+        error: error,
+      );
+    }
+  }
+}

--- a/flutter_app/lib/core/daemon/daemon_startup.dart
+++ b/flutter_app/lib/core/daemon/daemon_startup.dart
@@ -81,6 +81,11 @@ class DaemonStartupCoordinator {
     try {
       await platform.spawnDaemon(binaryPath);
       return const DaemonStartupResult(DaemonStartupOutcome.spawned);
+    } on DaemonPortOccupiedException catch (error) {
+      return DaemonStartupResult(
+        DaemonStartupOutcome.portOccupied,
+        error: error,
+      );
     } catch (error) {
       return DaemonStartupResult(
         _spawnAttempts >= maxSpawnAttempts

--- a/flutter_app/lib/core/platform/platform_services.dart
+++ b/flutter_app/lib/core/platform/platform_services.dart
@@ -20,6 +20,19 @@ export 'platform_services_stub.dart'
 /// be unsafe.
 enum TcpPortState { open, closed, unknown }
 
+/// Raised by [PlatformServices.spawnDaemon] when another process owns the
+/// daemon port. The guarded spawn operation is the final authority: an HTTP
+/// request can fail while a silent or still-starting process already owns the
+/// socket.
+class DaemonPortOccupiedException implements Exception {
+  const DaemonPortOccupiedException(this.port);
+
+  final int port;
+
+  @override
+  String toString() => 'Port $port is already occupied; no daemon was started.';
+}
+
 /// Platform-specific capabilities the rest of the app is free to call from
 /// shared (i.e. non-`dart:io`) code. The desktop impl wraps dart:io and the
 /// heavy packages (tray_manager, window_manager, local_notifier); the web
@@ -120,25 +133,10 @@ abstract class PlatformServices {
   Future<bool> daemonConfigExists();
   String? defaultDaemonBinaryPath();
 
-  /// Probes the configured daemon port at TCP level.
-  ///
-  /// Desktop implementations return [TcpPortState.closed] only for an
-  /// explicit connection-refused result. Timeouts, routing failures and other
-  /// ambiguous errors return [TcpPortState.unknown], which deliberately fails
-  /// closed. Web cannot open raw sockets and therefore always returns unknown.
-  Future<TcpPortState> probeDaemonPort({
-    Duration timeout = const Duration(milliseconds: 500),
-  });
-
-  /// Whether the canonical native service supervisor currently owns daemon
-  /// startup. False on platforms/installations without such a service.
-  /// Implementations must throw rather than guess when ownership cannot be
-  /// determined safely.
-  Future<bool> isDaemonSupervised();
-
-  /// Starts the daemon. Desktop implementations may delegate to the native
-  /// service supervisor instead of launching a detached process. Throws
-  /// `UnsupportedError` on web.
+  /// Starts the daemon only after proving its TCP port is free. Desktop
+  /// implementations may delegate to the native service supervisor instead of
+  /// launching a detached process. Throws [DaemonPortOccupiedException] when
+  /// the port is owned and `UnsupportedError` on web.
   Future<void> spawnDaemon(String binaryPath);
 
   /// Rebuilds the system tray context menu with current PR data.

--- a/flutter_app/lib/core/platform/platform_services.dart
+++ b/flutter_app/lib/core/platform/platform_services.dart
@@ -12,6 +12,14 @@ export 'platform_services_stub.dart'
     if (dart.library.io) 'platform_services_desktop.dart'
     if (dart.library.html) 'platform_services_web.dart';
 
+/// Result of probing the daemon's TCP port without making assumptions about
+/// the HTTP client's platform-specific exception wrappers.
+///
+/// Only [closed] is permission to spawn a daemon. Both [open] and [unknown]
+/// mean another process may own the port, so starting a second process would
+/// be unsafe.
+enum TcpPortState { open, closed, unknown }
+
 /// Platform-specific capabilities the rest of the app is free to call from
 /// shared (i.e. non-`dart:io`) code. The desktop impl wraps dart:io and the
 /// heavy packages (tray_manager, window_manager, local_notifier); the web
@@ -112,7 +120,25 @@ abstract class PlatformServices {
   Future<bool> daemonConfigExists();
   String? defaultDaemonBinaryPath();
 
-  /// Launches the daemon binary (detached). Throws `UnsupportedError` on web.
+  /// Probes the configured daemon port at TCP level.
+  ///
+  /// Desktop implementations return [TcpPortState.closed] only for an
+  /// explicit connection-refused result. Timeouts, routing failures and other
+  /// ambiguous errors return [TcpPortState.unknown], which deliberately fails
+  /// closed. Web cannot open raw sockets and therefore always returns unknown.
+  Future<TcpPortState> probeDaemonPort({
+    Duration timeout = const Duration(milliseconds: 500),
+  });
+
+  /// Whether the canonical native service supervisor currently owns daemon
+  /// startup. False on platforms/installations without such a service.
+  /// Implementations must throw rather than guess when ownership cannot be
+  /// determined safely.
+  Future<bool> isDaemonSupervised();
+
+  /// Starts the daemon. Desktop implementations may delegate to the native
+  /// service supervisor instead of launching a detached process. Throws
+  /// `UnsupportedError` on web.
   Future<void> spawnDaemon(String binaryPath);
 
   /// Rebuilds the system tray context menu with current PR data.

--- a/flutter_app/lib/core/platform/platform_services_desktop.dart
+++ b/flutter_app/lib/core/platform/platform_services_desktop.dart
@@ -21,6 +21,8 @@ typedef PlatformProcessRunner =
     Future<ProcessResult> Function(String executable, List<String> arguments);
 @visibleForTesting
 typedef DetachedDaemonStarter = Future<void> Function(String binaryPath);
+@visibleForTesting
+typedef DaemonPortProbe = Future<TcpPortState> Function(Duration timeout);
 
 /// Desktop implementation of [PlatformServices].
 ///
@@ -35,6 +37,7 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
     @visibleForTesting bool? isMacOS,
     @visibleForTesting PlatformProcessRunner? processRunner,
     @visibleForTesting DetachedDaemonStarter? detachedDaemonStarter,
+    @visibleForTesting DaemonPortProbe? daemonPortProbe,
   }) : _apiPort = apiPort,
        _tokenPath = tokenPath,
        _pidFilePath = pidFilePath,
@@ -50,7 +53,8 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
                const [],
                mode: ProcessStartMode.detached,
              );
-           });
+           }),
+       _daemonPortProbe = daemonPortProbe;
 
   final int _apiPort;
   final String? _tokenPath;
@@ -58,6 +62,7 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
   final bool _isMacOS;
   final PlatformProcessRunner _processRunner;
   final DetachedDaemonStarter _detachedDaemonStarter;
+  final DaemonPortProbe? _daemonPortProbe;
   String? _cachedToken;
   void Function(String location)? _onTrayNavigate;
 
@@ -288,10 +293,10 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
   @override
   String? defaultDaemonBinaryPath() => DaemonLifecycle.defaultBinaryPath();
 
-  @override
-  Future<TcpPortState> probeDaemonPort({
-    Duration timeout = const Duration(milliseconds: 500),
-  }) async {
+  Future<TcpPortState> _probeDaemonPort(Duration timeout) async {
+    final injected = _daemonPortProbe;
+    if (injected != null) return injected(timeout);
+
     Socket? socket;
     try {
       socket = await Socket.connect('127.0.0.1', _apiPort, timeout: timeout);
@@ -315,16 +320,24 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
   }
 
   @override
-  Future<bool> isDaemonSupervised() async {
-    if (!_isMacOS) return false;
-    return await _loadedCanonicalLaunchAgentTarget() != null;
-  }
-
-  @override
   Future<void> spawnDaemon(String binaryPath) async {
     final binary = File(binaryPath);
     if (!binary.existsSync()) {
       throw DaemonException('Daemon binary not found: $binaryPath');
+    }
+
+    // This is the final spawn gate. ApiClient can identify a daemon response,
+    // but an HTTP transport error cannot prove the TCP port is free (a silent
+    // foreign process or a daemon between bind and HTTP readiness may own it).
+    // Only an explicit connection refusal permits process creation.
+    final portState = await _probeDaemonPort(const Duration(milliseconds: 500));
+    if (portState == TcpPortState.open) {
+      throw DaemonPortOccupiedException(_apiPort);
+    }
+    if (portState != TcpPortState.closed) {
+      throw DaemonException(
+        'Could not prove that port $_apiPort is free; no daemon was started.',
+      );
     }
 
     // A loaded LaunchAgent is the canonical owner on macOS. Starting a

--- a/flutter_app/lib/core/platform/platform_services_desktop.dart
+++ b/flutter_app/lib/core/platform/platform_services_desktop.dart
@@ -1,6 +1,7 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:ui' show VoidCallback;
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 import 'package:flutter/painting.dart' show Size;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:tray_manager/tray_manager.dart';
@@ -15,6 +16,12 @@ import '../setup/repo_discovery.dart';
 import '../tray/tray_menu.dart';
 import 'platform_services.dart';
 
+@visibleForTesting
+typedef PlatformProcessRunner =
+    Future<ProcessResult> Function(String executable, List<String> arguments);
+@visibleForTesting
+typedef DetachedDaemonStarter = Future<void> Function(String binaryPath);
+
 /// Desktop implementation of [PlatformServices].
 ///
 /// Wraps dart:io, tray_manager, window_manager, flutter_local_notifications,
@@ -25,13 +32,32 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
     int apiPort = 7842,
     String? tokenPath,
     String? pidFilePath,
-  })  : _apiPort = apiPort,
-        _tokenPath = tokenPath,
-        _pidFilePath = pidFilePath;
+    @visibleForTesting bool? isMacOS,
+    @visibleForTesting PlatformProcessRunner? processRunner,
+    @visibleForTesting DetachedDaemonStarter? detachedDaemonStarter,
+  }) : _apiPort = apiPort,
+       _tokenPath = tokenPath,
+       _pidFilePath = pidFilePath,
+       _isMacOS = isMacOS ?? Platform.isMacOS,
+       _processRunner =
+           processRunner ??
+           ((executable, arguments) => Process.run(executable, arguments)),
+       _detachedDaemonStarter =
+           detachedDaemonStarter ??
+           ((binaryPath) async {
+             await Process.start(
+               binaryPath,
+               const [],
+               mode: ProcessStartMode.detached,
+             );
+           });
 
   final int _apiPort;
   final String? _tokenPath;
   final String? _pidFilePath;
+  final bool _isMacOS;
+  final PlatformProcessRunner _processRunner;
+  final DetachedDaemonStarter _detachedDaemonStarter;
   String? _cachedToken;
   void Function(String location)? _onTrayNavigate;
 
@@ -73,7 +99,9 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
       if (existing != null && existing != pid) {
         final check = await Process.run('kill', ['-0', '$existing']);
         if (check.exitCode == 0) {
-          debugPrint('Another Heimdallm instance is running (PID $existing), signalling it.');
+          debugPrint(
+            'Another Heimdallm instance is running (PID $existing), signalling it.',
+          );
           await Process.run('kill', ['-USR1', '$existing']);
           return false;
         }
@@ -88,6 +116,7 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
   void listenForActivationSignal(VoidCallback onActivate) {
     ProcessSignal.sigusr1.watch().listen((_) => onActivate());
   }
+
   @override
   Future<void> setupWindow({
     required String title,
@@ -121,11 +150,15 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
     await trayManager.setIcon(
       Platform.isLinux ? 'assets/tray_icon@2x.png' : 'assets/tray_icon.png',
     );
-    await trayManager.setContextMenu(Menu(items: [
-      MenuItem(key: 'open', label: 'Open Heimdallm'),
-      MenuItem.separator(),
-      MenuItem(key: 'quit', label: 'Quit'),
-    ]));
+    await trayManager.setContextMenu(
+      Menu(
+        items: [
+          MenuItem(key: 'open', label: 'Open Heimdallm'),
+          MenuItem.separator(),
+          MenuItem(key: 'quit', label: 'Quit'),
+        ],
+      ),
+    );
     // At this point the router isn't created yet, so we pass a no-op
     // navigation handler. main.dart calls setTrayNavigationHandler() later
     // with the real handler, which is forwarded into TrayMenu via rebind.
@@ -242,7 +275,8 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
   Future<String?> getStoredGitHubToken() => FirstRunSetup.getToken();
 
   @override
-  Future<void> storeGitHubToken(String token) => FirstRunSetup.storeToken(token);
+  Future<void> storeGitHubToken(String token) =>
+      FirstRunSetup.storeToken(token);
 
   @override
   Future<void> writeDaemonConfig(AppConfig config) =>
@@ -255,14 +289,106 @@ class DesktopPlatformServices with WindowListener implements PlatformServices {
   String? defaultDaemonBinaryPath() => DaemonLifecycle.defaultBinaryPath();
 
   @override
+  Future<TcpPortState> probeDaemonPort({
+    Duration timeout = const Duration(milliseconds: 500),
+  }) async {
+    Socket? socket;
+    try {
+      socket = await Socket.connect('127.0.0.1', _apiPort, timeout: timeout);
+      return TcpPortState.open;
+    } on SocketException catch (e) {
+      // These are ECONNREFUSED on macOS, Linux and Windows respectively. Only
+      // an explicit refusal proves no listener owns the port. Everything else
+      // (including ENETUNREACH/EHOSTUNREACH) is ambiguous and must not permit
+      // spawning a second daemon.
+      const connectionRefusedCodes = {61, 111, 10061};
+      return connectionRefusedCodes.contains(e.osError?.errorCode)
+          ? TcpPortState.closed
+          : TcpPortState.unknown;
+    } on TimeoutException {
+      return TcpPortState.unknown;
+    } catch (_) {
+      return TcpPortState.unknown;
+    } finally {
+      socket?.destroy();
+    }
+  }
+
+  @override
+  Future<bool> isDaemonSupervised() async {
+    if (!_isMacOS) return false;
+    return await _loadedCanonicalLaunchAgentTarget() != null;
+  }
+
+  @override
   Future<void> spawnDaemon(String binaryPath) async {
     final binary = File(binaryPath);
     if (!binary.existsSync()) {
       throw DaemonException('Daemon binary not found: $binaryPath');
     }
+
+    // A loaded LaunchAgent is the canonical owner on macOS. Starting a
+    // detached sibling here would move the daemon outside launchd supervision
+    // and leave the KeepAlive job retrying against the process-lifetime lock.
+    // Ask launchd to start the existing job instead. Any ambiguous inspection
+    // failure is fatal: falling back to Process.start would be unsafe because
+    // the job may still be loaded.
+    final launchAgentTarget = _isMacOS
+        ? await _loadedCanonicalLaunchAgentTarget()
+        : null;
+    if (launchAgentTarget != null) {
+      final result = await _processRunner('/bin/launchctl', [
+        'kickstart',
+        launchAgentTarget,
+      ]);
+      if (result.exitCode != 0) {
+        throw DaemonException(
+          'Could not start the supervised daemon: '
+          '${_processResultDetails(result)}',
+        );
+      }
+      return;
+    }
+
     // Detached: daemon outlives the Flutter process so in-flight reviews
     // survive window hides and dev restarts.
-    await Process.start(binaryPath, [], mode: ProcessStartMode.detached);
+    await _detachedDaemonStarter(binaryPath);
+  }
+
+  static const _canonicalLaunchAgentLabel = 'com.heimdallm.daemon';
+
+  Future<String> _canonicalLaunchAgentTarget() async {
+    final uidResult = await _processRunner('/usr/bin/id', const ['-u']);
+    final uid = '${uidResult.stdout}'.trim();
+    if (uidResult.exitCode != 0 || !RegExp(r'^\d+$').hasMatch(uid)) {
+      throw DaemonException(
+        'Could not determine the launchd user domain: '
+        '${_processResultDetails(uidResult)}',
+      );
+    }
+    return 'gui/$uid/$_canonicalLaunchAgentLabel';
+  }
+
+  Future<String?> _loadedCanonicalLaunchAgentTarget() async {
+    final target = await _canonicalLaunchAgentTarget();
+    final result = await _processRunner('/bin/launchctl', ['print', target]);
+    if (result.exitCode == 0) return target;
+
+    final details = '${result.stdout}\n${result.stderr}';
+    if (result.exitCode == 113 || details.contains('Could not find service')) {
+      return null;
+    }
+    throw DaemonException(
+      'Could not determine whether the supervised daemon is loaded: '
+      '${_processResultDetails(result)}',
+    );
+  }
+
+  static String _processResultDetails(ProcessResult result) {
+    final stderr = '${result.stderr}'.trim();
+    final stdout = '${result.stdout}'.trim();
+    final output = stderr.isNotEmpty ? stderr : stdout;
+    return output.isEmpty ? 'exit status ${result.exitCode}' : output;
   }
 
   @override

--- a/flutter_app/lib/core/platform/platform_services_web.dart
+++ b/flutter_app/lib/core/platform/platform_services_web.dart
@@ -78,7 +78,8 @@ class WebPlatformServices implements PlatformServices {
     try {
       var permission = web.Notification.permission;
       if (permission == 'default') {
-        permission = (await web.Notification.requestPermission().toDart).toDart;
+        permission =
+            (await web.Notification.requestPermission().toDart).toDart;
       }
       if (permission != 'granted') return;
 
@@ -155,23 +156,12 @@ class WebPlatformServices implements PlatformServices {
   String? defaultDaemonBinaryPath() => null;
 
   @override
-  Future<TcpPortState> probeDaemonPort({
-    Duration timeout = const Duration(milliseconds: 500),
-  }) async => TcpPortState.unknown;
-
-  @override
-  Future<bool> isDaemonSupervised() async => false;
-
-  @override
   Future<void> spawnDaemon(String binaryPath) async {
     throw UnsupportedError('spawnDaemon is not supported on web');
   }
 
   @override
-  Future<void> rebuildTrayMenu({
-    required List<PR> prs,
-    required String me,
-  }) async {}
+  Future<void> rebuildTrayMenu({required List<PR> prs, required String me}) async {}
 
   @override
   Future<List<String>> discoverReposFromPRs(String token) =>

--- a/flutter_app/lib/core/platform/platform_services_web.dart
+++ b/flutter_app/lib/core/platform/platform_services_web.dart
@@ -78,8 +78,7 @@ class WebPlatformServices implements PlatformServices {
     try {
       var permission = web.Notification.permission;
       if (permission == 'default') {
-        permission =
-            (await web.Notification.requestPermission().toDart).toDart;
+        permission = (await web.Notification.requestPermission().toDart).toDart;
       }
       if (permission != 'granted') return;
 
@@ -156,12 +155,23 @@ class WebPlatformServices implements PlatformServices {
   String? defaultDaemonBinaryPath() => null;
 
   @override
+  Future<TcpPortState> probeDaemonPort({
+    Duration timeout = const Duration(milliseconds: 500),
+  }) async => TcpPortState.unknown;
+
+  @override
+  Future<bool> isDaemonSupervised() async => false;
+
+  @override
   Future<void> spawnDaemon(String binaryPath) async {
     throw UnsupportedError('spawnDaemon is not supported on web');
   }
 
   @override
-  Future<void> rebuildTrayMenu({required List<PR> prs, required String me}) async {}
+  Future<void> rebuildTrayMenu({
+    required List<PR> prs,
+    required String me,
+  }) async {}
 
   @override
   Future<List<String>> discoverReposFromPRs(String token) =>

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -2,14 +2,19 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/api/api_client.dart';
 import '../../core/api/sse_client.dart';
+import '../../core/daemon/daemon_startup.dart';
 import '../../core/models/config_model.dart';
 import '../../core/platform/platform_services_provider.dart';
 import '../dashboard/dashboard_providers.dart';
 
 final daemonHealthProvider = FutureProvider<bool>((ref) async {
   final api = ref.watch(apiClientProvider);
-  return api.checkHealth();
+  // UI "running" state is ownership, not deep health. A degraded daemon still
+  // serves config/logs and must expose Stop/diagnostic controls instead of a
+  // misleading Start button that would attempt a duplicate (#646).
+  return await api.daemonReachable() == PortOwner.daemon;
 });
 
 final configProvider = FutureProvider<AppConfig>((ref) async {
@@ -157,18 +162,61 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
       // 2. Write config
       await platform.writeDaemonConfig(config);
 
-      // 3. Launch daemon
-      await platform.spawnDaemon(daemonBinaryPath);
+      // 3. Guard daemon launch with the same ownership check as app startup.
+      // Only an explicitly closed port is allowed to reach spawnDaemon.
+      final api = ref.read(apiClientProvider);
+      final startup = DaemonStartupCoordinator(
+        api: api,
+        platform: platform,
+        binaryPath: daemonBinaryPath,
+        maxSpawnAttempts: 1,
+      );
+      final startupResult = await startup.ensureAvailable();
+      switch (startupResult.outcome) {
+        case DaemonStartupOutcome.spawned:
+        case DaemonStartupOutcome.daemonPresent:
+          break;
+        case DaemonStartupOutcome.portOccupied:
+          throw Exception(
+            'Port ${api.daemonPort} is already occupied or could not be '
+            'proven free. No daemon was started, to avoid duplicate workers. '
+            'Stop the process listening on that port and try again.',
+          );
+        case DaemonStartupOutcome.spawnFailedRetryable:
+        case DaemonStartupOutcome.spawnFailedTerminal:
+          throw Exception(
+            'Heimdallm could not launch its daemon: '
+            '${startupResult.error ?? 'unknown process error'}. '
+            'Check that the app is installed correctly and has permission '
+            'to run its background service.',
+          );
+        case DaemonStartupOutcome.spawnBudgetExhausted:
+          throw Exception(
+            'Heimdallm exhausted its guarded daemon start attempt. '
+            'Restart the app and check the daemon log if the problem persists.',
+          );
+      }
 
       // 4. Wait up to 8 seconds for the daemon to become healthy
-      final api = ref.read(apiClientProvider);
+      var healthy = false;
       for (var i = 0; i < 80; i++) {
         await Future.delayed(const Duration(milliseconds: 100));
-        if (await api.checkHealth()) break;
+        if (await api.checkHealth()) {
+          healthy = true;
+          break;
+        }
       }
-      if (!await api.checkHealth()) {
+      if (!healthy) {
+        final existingDaemon =
+            startupResult.outcome == DaemonStartupOutcome.daemonPresent;
         throw Exception(
-          'Heimdallm could not start. Check the app installation.',
+          existingDaemon
+              ? 'A Heimdallm daemon is already running on port '
+                    '${api.daemonPort}, but it did not become healthy within '
+                    '8 seconds. No second daemon was started. Check the '
+                    'daemon log and try again.'
+              : 'Heimdallm was launched but did not become healthy within '
+                    '8 seconds. Check the app installation and daemon log.',
         );
       }
       ref.invalidate(daemonHealthProvider);

--- a/flutter_app/lib/features/config/config_providers.dart
+++ b/flutter_app/lib/features/config/config_providers.dart
@@ -147,6 +147,9 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
     required String token,
     required AppConfig config,
     required String daemonBinaryPath,
+    int maxSpawnAttempts = 1,
+    int healthCheckMaxAttempts = 80,
+    Duration healthCheckInterval = const Duration(milliseconds: 100),
   }) async {
     _mutationGeneration++;
     _serverGeneration++;
@@ -169,7 +172,7 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
         api: api,
         platform: platform,
         binaryPath: daemonBinaryPath,
-        maxSpawnAttempts: 1,
+        maxSpawnAttempts: maxSpawnAttempts,
       );
       final startupResult = await startup.ensureAvailable();
       switch (startupResult.outcome) {
@@ -199,8 +202,8 @@ class ConfigNotifier extends AsyncNotifier<AppConfig> {
 
       // 4. Wait up to 8 seconds for the daemon to become healthy
       var healthy = false;
-      for (var i = 0; i < 80; i++) {
-        await Future.delayed(const Duration(milliseconds: 100));
+      for (var i = 0; i < healthCheckMaxAttempts; i++) {
+        await Future.delayed(healthCheckInterval);
         if (await api.checkHealth()) {
           healthy = true;
           break;

--- a/flutter_app/lib/features/server/server_actions.dart
+++ b/flutter_app/lib/features/server/server_actions.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/api/api_client.dart';
+import '../../core/daemon/daemon_startup.dart';
 import '../../core/platform/platform_services_provider.dart';
 import '../../shared/widgets/toast.dart';
 import '../activity/activity_providers.dart';
@@ -11,6 +13,45 @@ import '../issues/issues_providers.dart';
 
 const kDaemonStartHealthMaxAttempts = 80;
 const kDaemonStartHealthInterval = Duration(milliseconds: 100);
+
+String _startupFailureMessage(DaemonStartupResult result, int port) {
+  switch (result.outcome) {
+    case DaemonStartupOutcome.portOccupied:
+      return 'Port $port is occupied; no daemon was started.';
+    case DaemonStartupOutcome.daemonPresent:
+      return 'Heimdallm is already running but is not healthy yet.';
+    case DaemonStartupOutcome.spawnFailedRetryable:
+    case DaemonStartupOutcome.spawnFailedTerminal:
+      return 'Could not start Heimdallm: ${result.error ?? 'unknown error'}';
+    case DaemonStartupOutcome.spawnBudgetExhausted:
+      return 'Heimdallm exhausted its guarded start attempts.';
+    case DaemonStartupOutcome.spawned:
+      return '';
+  }
+}
+
+/// Waits for the daemon to relinquish its port, not merely to become
+/// unhealthy. A degraded daemon answers /health with 503; treating that as
+/// "stopped" lets a restart race its still-running predecessor (#646).
+Future<PortOwner> waitForDaemonPortRelease(
+  ApiClient api, {
+  List<Duration> delays = const [
+    Duration(milliseconds: 200),
+    Duration(milliseconds: 300),
+    Duration(milliseconds: 500),
+    Duration(milliseconds: 800),
+    Duration(milliseconds: 1200),
+    Duration(seconds: 2),
+  ],
+}) async {
+  var owner = PortOwner.daemon;
+  for (final delay in delays) {
+    await Future<void>.delayed(delay);
+    owner = await api.daemonReachable();
+    if (owner != PortOwner.daemon) return owner;
+  }
+  return owner;
+}
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
@@ -58,8 +99,29 @@ Future<void> startDaemon(BuildContext context, WidgetRef ref) async {
 
   ref.read(daemonStartingProvider.notifier).set(true);
   try {
-    await platform.spawnDaemon(binaryPath);
     final api = ref.read(apiClientProvider);
+    final startup = DaemonStartupCoordinator(
+      api: api,
+      platform: platform,
+      binaryPath: binaryPath,
+      maxSpawnAttempts: 1,
+    );
+    final result = await startup.ensureAvailable();
+    if (result.outcome == DaemonStartupOutcome.daemonPresent) {
+      _invalidateDashboardData(ref);
+      if (context.mounted) showToast(context, 'Server is already running');
+      return;
+    }
+    if (result.outcome != DaemonStartupOutcome.spawned) {
+      if (context.mounted) {
+        showToast(
+          context,
+          _startupFailureMessage(result, api.daemonPort),
+          isError: true,
+        );
+      }
+      return;
+    }
     var healthy = false;
     for (var i = 0; i < kDaemonStartHealthMaxAttempts; i++) {
       await Future<void>.delayed(kDaemonStartHealthInterval);
@@ -84,52 +146,82 @@ Future<void> startDaemon(BuildContext context, WidgetRef ref) async {
   }
 }
 
-Future<void> refreshWhenDaemonStops(
+Future<PortOwner?> refreshWhenDaemonStops(
   BuildContext context,
   WidgetRef ref,
 ) async {
   final api = ref.read(apiClientProvider);
-  const delays = [
-    Duration(milliseconds: 200),
-    Duration(milliseconds: 300),
-    Duration(milliseconds: 500),
-    Duration(milliseconds: 800),
-    Duration(milliseconds: 1200),
-    Duration(seconds: 2),
-  ];
-
-  for (final delay in delays) {
-    await Future<void>.delayed(delay);
-    if (!context.mounted) return;
-    final healthy = await api.checkHealth();
-    if (!context.mounted) return;
-    ref.invalidate(daemonHealthProvider);
-    if (!healthy) break;
-  }
-
-  if (!context.mounted) return;
+  final owner = await waitForDaemonPortRelease(api);
+  if (!context.mounted) return null;
+  ref.invalidate(daemonHealthProvider);
   _invalidateDashboardData(ref);
+  return owner;
 }
 
 /// Stop the daemon and immediately respawn it. Used by the Server screen's
 /// Restart banner after a Listen URL change.
 Future<void> restartDaemon(BuildContext context, WidgetRef ref) async {
   final api = ref.read(apiClientProvider);
+  final platform = ref.read(platformServicesProvider);
   ref.read(daemonStartingProvider.notifier).set(true);
   try {
+    // Resolve supervisor ownership before stopping anything. On macOS an
+    // ambiguous launchctl response fails closed here, while the current daemon
+    // is still running, instead of risking an unsupervised replacement.
+    final supervised = await platform.isDaemonSupervised();
     await api.shutdownDaemon();
     if (!context.mounted) return;
     showToast(context, 'Restarting…');
-    await refreshWhenDaemonStops(context, ref);
-    // refreshWhenDaemonStops returns once /health reports unreachable.
+    final stoppedAs = await refreshWhenDaemonStops(context, ref);
     if (!context.mounted) return;
-    final platform = ref.read(platformServicesProvider);
-    final binary = platform.defaultDaemonBinaryPath();
-    if (binary == null || binary.isEmpty) {
-      showToast(context, 'Daemon binary not found', isError: true);
+    if (stoppedAs == PortOwner.foreign) {
+      showToast(
+        context,
+        'The daemon stopped, but port ${api.daemonPort} is now occupied; restart cancelled.',
+        isError: true,
+      );
       return;
     }
-    await platform.spawnDaemon(binary);
+    if (stoppedAs == PortOwner.daemon && !supervised) {
+      showToast(
+        context,
+        'Daemon did not stop; restart cancelled.',
+        isError: true,
+      );
+      return;
+    }
+    DaemonStartupResult result;
+    if (stoppedAs == PortOwner.daemon) {
+      // A macOS LaunchAgent with KeepAlive can replace the old process between
+      // two ownership probes, so the port may never be observed as closed.
+      // That supervised reappearance is already the desired restart outcome;
+      // never race it with a detached child.
+      result = const DaemonStartupResult(DaemonStartupOutcome.daemonPresent);
+    } else {
+      final binary = platform.defaultDaemonBinaryPath();
+      if (binary == null || binary.isEmpty) {
+        showToast(context, 'Daemon binary not found', isError: true);
+        return;
+      }
+      final startup = DaemonStartupCoordinator(
+        api: api,
+        platform: platform,
+        binaryPath: binary,
+        maxSpawnAttempts: 1,
+      );
+      result = await startup.ensureAvailable();
+    }
+    if (result.outcome != DaemonStartupOutcome.spawned &&
+        result.outcome != DaemonStartupOutcome.daemonPresent) {
+      if (context.mounted) {
+        showToast(
+          context,
+          _startupFailureMessage(result, api.daemonPort),
+          isError: true,
+        );
+      }
+      return;
+    }
     var healthy = false;
     for (var i = 0; i < kDaemonStartHealthMaxAttempts; i++) {
       await Future<void>.delayed(kDaemonStartHealthInterval);
@@ -137,8 +229,11 @@ Future<void> restartDaemon(BuildContext context, WidgetRef ref) async {
       if (healthy) break;
     }
     if (!context.mounted) return;
-    showToast(context, healthy ? 'Server restarted' : 'Restart timed out',
-        isError: !healthy);
+    showToast(
+      context,
+      healthy ? 'Server restarted' : 'Restart timed out',
+      isError: !healthy,
+    );
   } catch (e) {
     if (context.mounted) showToast(context, 'Error: $e', isError: true);
   } finally {

--- a/flutter_app/lib/features/server/server_actions.dart
+++ b/flutter_app/lib/features/server/server_actions.dart
@@ -14,7 +14,8 @@ import '../issues/issues_providers.dart';
 const kDaemonStartHealthMaxAttempts = 80;
 const kDaemonStartHealthInterval = Duration(milliseconds: 100);
 
-String _startupFailureMessage(DaemonStartupResult result, int port) {
+@visibleForTesting
+String daemonStartupFailureMessage(DaemonStartupResult result, int port) {
   switch (result.outcome) {
     case DaemonStartupOutcome.portOccupied:
       return 'Port $port is occupied; no daemon was started.';
@@ -116,7 +117,7 @@ Future<void> startDaemon(BuildContext context, WidgetRef ref) async {
       if (context.mounted) {
         showToast(
           context,
-          _startupFailureMessage(result, api.daemonPort),
+          daemonStartupFailureMessage(result, api.daemonPort),
           isError: true,
         );
       }
@@ -148,10 +149,18 @@ Future<void> startDaemon(BuildContext context, WidgetRef ref) async {
 
 Future<PortOwner?> refreshWhenDaemonStops(
   BuildContext context,
-  WidgetRef ref,
-) async {
+  WidgetRef ref, {
+  List<Duration> delays = const [
+    Duration(milliseconds: 200),
+    Duration(milliseconds: 300),
+    Duration(milliseconds: 500),
+    Duration(milliseconds: 800),
+    Duration(milliseconds: 1200),
+    Duration(seconds: 2),
+  ],
+}) async {
   final api = ref.read(apiClientProvider);
-  final owner = await waitForDaemonPortRelease(api);
+  final owner = await waitForDaemonPortRelease(api, delays: delays);
   if (!context.mounted) return null;
   ref.invalidate(daemonHealthProvider);
   _invalidateDashboardData(ref);
@@ -160,19 +169,32 @@ Future<PortOwner?> refreshWhenDaemonStops(
 
 /// Stop the daemon and immediately respawn it. Used by the Server screen's
 /// Restart banner after a Listen URL change.
-Future<void> restartDaemon(BuildContext context, WidgetRef ref) async {
+Future<void> restartDaemon(
+  BuildContext context,
+  WidgetRef ref, {
+  List<Duration> portReleaseDelays = const [
+    Duration(milliseconds: 200),
+    Duration(milliseconds: 300),
+    Duration(milliseconds: 500),
+    Duration(milliseconds: 800),
+    Duration(milliseconds: 1200),
+    Duration(seconds: 2),
+  ],
+}) async {
+  if (ref.read(daemonStartingProvider)) return;
+
   final api = ref.read(apiClientProvider);
   final platform = ref.read(platformServicesProvider);
   ref.read(daemonStartingProvider.notifier).set(true);
   try {
-    // Resolve supervisor ownership before stopping anything. On macOS an
-    // ambiguous launchctl response fails closed here, while the current daemon
-    // is still running, instead of risking an unsupervised replacement.
-    final supervised = await platform.isDaemonSupervised();
     await api.shutdownDaemon();
     if (!context.mounted) return;
     showToast(context, 'Restarting…');
-    final stoppedAs = await refreshWhenDaemonStops(context, ref);
+    final stoppedAs = await refreshWhenDaemonStops(
+      context,
+      ref,
+      delays: portReleaseDelays,
+    );
     if (!context.mounted) return;
     if (stoppedAs == PortOwner.foreign) {
       showToast(
@@ -182,20 +204,11 @@ Future<void> restartDaemon(BuildContext context, WidgetRef ref) async {
       );
       return;
     }
-    if (stoppedAs == PortOwner.daemon && !supervised) {
-      showToast(
-        context,
-        'Daemon did not stop; restart cancelled.',
-        isError: true,
-      );
-      return;
-    }
     DaemonStartupResult result;
     if (stoppedAs == PortOwner.daemon) {
-      // A macOS LaunchAgent with KeepAlive can replace the old process between
-      // two ownership probes, so the port may never be observed as closed.
-      // That supervised reappearance is already the desired restart outcome;
-      // never race it with a detached child.
+      // The old process may still be draining, or a service supervisor may
+      // already have replaced it. Either way, a daemon owns the port and is the
+      // only safe process to reuse; never race it with another child.
       result = const DaemonStartupResult(DaemonStartupOutcome.daemonPresent);
     } else {
       final binary = platform.defaultDaemonBinaryPath();
@@ -216,7 +229,7 @@ Future<void> restartDaemon(BuildContext context, WidgetRef ref) async {
       if (context.mounted) {
         showToast(
           context,
-          _startupFailureMessage(result, api.daemonPort),
+          daemonStartupFailureMessage(result, api.daemonPort),
           isError: true,
         );
       }

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -89,9 +89,46 @@ void sendPRNotification({
   );
 }
 
+/// Builds the real bootstrap state machine with deterministic dependencies.
+/// Production uses the private widget directly; tests use this entry point so
+/// every daemon-ownership outcome can be exercised without sockets, processes
+/// or wall-clock waits.
+@visibleForTesting
+Widget buildBootstrapAppForTest({
+  required GoRouter router,
+  required PlatformServices platform,
+  required ApiClient apiClient,
+  Duration healthPollInterval = Duration.zero,
+  int healthRetryEvery = 1,
+  int maxSpawnAttempts = 4,
+}) {
+  return ProviderScope(
+    overrides: [platformServicesProvider.overrideWithValue(platform)],
+    child: _BootstrapApp(
+      appRouter: router,
+      apiClient: apiClient,
+      healthPollInterval: healthPollInterval,
+      healthRetryEvery: healthRetryEvery,
+      maxSpawnAttempts: maxSpawnAttempts,
+    ),
+  );
+}
+
 class _BootstrapApp extends ConsumerStatefulWidget {
   final GoRouter appRouter;
-  const _BootstrapApp({required this.appRouter});
+  final ApiClient? apiClient;
+  final Duration healthPollInterval;
+  final int healthRetryEvery;
+  final int maxSpawnAttempts;
+
+  const _BootstrapApp({
+    required this.appRouter,
+    this.apiClient,
+    this.healthPollInterval = const Duration(milliseconds: 400),
+    this.healthRetryEvery = 25,
+    this.maxSpawnAttempts = 4,
+  }) : assert(healthRetryEvery > 0),
+       assert(maxSpawnAttempts > 0);
   @override
   ConsumerState<_BootstrapApp> createState() => _BootstrapAppState();
 }
@@ -115,7 +152,7 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
   }
 
   Future<void> _boot() async {
-    final api = ApiClient(platform: _platform);
+    final api = widget.apiClient ?? ApiClient(platform: _platform);
 
     // Determine port ownership before asking for credentials, config or even a
     // local daemon binary. A live daemon can legitimately answer 503 while
@@ -185,6 +222,7 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
       api: api,
       platform: _platform,
       binaryPath: binaryPath,
+      maxSpawnAttempts: widget.maxSpawnAttempts,
     );
     final initial = await startup.ensureAvailable();
     if (!_handleStartupResult(initial, api.daemonPort)) {
@@ -200,12 +238,12 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
     required DaemonStartupCoordinator startup,
   }) async {
     for (var attempt = 0; ; attempt++) {
-      await Future.delayed(const Duration(milliseconds: 400));
+      await Future.delayed(widget.healthPollInterval);
       if (await api.checkHealth()) {
         _go('/');
         return;
       }
-      if (attempt > 0 && attempt % 25 == 0) {
+      if (attempt > 0 && attempt % widget.healthRetryEvery == 0) {
         final result = await startup.ensureAvailable();
         if (!_handleStartupResult(result, api.daemonPort)) return;
       }
@@ -301,16 +339,15 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
   }
 
   void _go(String location) {
-    if (mounted) setState(() => _destination = location);
+    if (!mounted) return;
+    widget.appRouter.go(location);
+    setState(() => _destination = location);
   }
 
   @override
   Widget build(BuildContext context) {
     if (_destination != null) {
-      return HeimdallmApp(
-        router: widget.appRouter,
-        initialLocation: _destination!,
-      );
+      return HeimdallmApp(router: widget.appRouter);
     }
     if (_errorTitle != null) {
       return _ErrorApp(

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -167,7 +167,7 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
 
     _setStatus('Starting Heimdallm…');
     try {
-      await _platform.spawnDaemon(binaryPath);
+      await _spawnDaemonUnlessRunning(api, binaryPath);
     } catch (e) {
       _setError(
         title: 'Could not start daemon',
@@ -180,6 +180,22 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
 
     _setStatus('Waiting for Heimdallm…');
     await _waitForHealth(api, retryBinary: binaryPath);
+  }
+
+  /// Spawns the daemon only when nothing is answering on its port.
+  ///
+  /// The single most important invariant of the boot path: never add a second
+  /// daemon. A daemon that loses the port bind used to stay alive and keep
+  /// polling GitHub on the same token, so every redundant spawn permanently
+  /// multiplied API consumption until the hourly quota was gone (#646). The
+  /// daemon now exits on a failed bind, but the app must not rely on that —
+  /// older daemons are still out there, and not spawning is free.
+  ///
+  /// Reachability, not health, is the right question here: see
+  /// [ApiClient.daemonReachable].
+  Future<void> _spawnDaemonUnlessRunning(ApiClient api, String binaryPath) async {
+    if (await api.daemonReachable()) return;
+    await _platform.spawnDaemon(binaryPath);
   }
 
   Future<void> _waitForHealth(ApiClient api, {String? retryBinary}) async {
@@ -202,7 +218,10 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
           return;
         }
         daemonRestarts++;
-        try { await _platform.spawnDaemon(retryBinary); } catch (_) {}
+        // Guarded: a daemon that is up but reporting degraded (503) keeps
+        // failing checkHealth above, and re-spawning on that signal is what
+        // stacked five daemons on one token in #646.
+        try { await _spawnDaemonUnlessRunning(api, retryBinary); } catch (_) {}
       }
     }
   }

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'core/api/api_client.dart';
+import 'core/daemon/daemon_startup.dart';
 import 'core/models/config_model.dart';
 import 'core/platform/platform_services.dart';
 import 'core/platform/platform_services_provider.dart';
@@ -61,12 +62,12 @@ Future<void> main() async {
     debugPrint('notifier init failed: $e');
   }
 
-  runApp(ProviderScope(
-    overrides: [
-      platformServicesProvider.overrideWithValue(platform),
-    ],
-    child: _BootstrapApp(appRouter: _appRouter),
-  ));
+  runApp(
+    ProviderScope(
+      overrides: [platformServicesProvider.overrideWithValue(platform)],
+      child: _BootstrapApp(appRouter: _appRouter),
+    ),
+  );
 }
 
 /// Public entry point for features to fire notifications.
@@ -87,10 +88,6 @@ void sendPRNotification({
     },
   );
 }
-
-/// A non-Heimdallm process holds the daemon port. Distinct from a spawn failure
-/// because no amount of retrying fixes it — the user has to free the port.
-class _ForeignPortException implements Exception {}
 
 class _BootstrapApp extends ConsumerStatefulWidget {
   final GoRouter appRouter;
@@ -120,9 +117,19 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
   Future<void> _boot() async {
     final api = ApiClient(platform: _platform);
 
-    if (await api.checkHealth()) {
-      _go('/');
-      return;
+    // Determine port ownership before asking for credentials, config or even a
+    // local daemon binary. A live daemon can legitimately answer 503 while
+    // starting, stopping or degraded; it is still the authoritative process
+    // and the dashboard remains useful for diagnosis (#646).
+    switch (await api.daemonReachable()) {
+      case PortOwner.daemon:
+        _go('/');
+        return;
+      case PortOwner.foreign:
+        _setForeignPortError(api.daemonPort);
+        return;
+      case PortOwner.none:
+        break;
     }
 
     _setStatus('Detecting credentials…');
@@ -149,7 +156,9 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
           .where((p) => p.isNotEmpty)
           .toList();
       final config = AppConfig(
-        repoConfigs: {for (final r in repos) r: const RepoConfig(prEnabled: true)},
+        repoConfigs: {
+          for (final r in repos) r: const RepoConfig(prEnabled: true),
+        },
         localDirBase: localDirBase,
       );
       await _platform.storeGitHubToken(token);
@@ -160,9 +169,11 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
     if (binaryPath == null) {
       _setError(
         title: 'Daemon binary not found',
-        details: 'Heimdallm could not locate its background service.\n'
+        details:
+            'Heimdallm could not locate its background service.\n'
             'This usually means the installation is incomplete.',
-        hint: 'If you installed from a DMG, open Terminal and run:\n'
+        hint:
+            'If you installed from a DMG, open Terminal and run:\n'
             'xattr -cr /Applications/Heimdallm.app\n'
             'then relaunch the app.',
       );
@@ -170,151 +181,136 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
     }
 
     _setStatus('Starting Heimdallm…');
-    try {
-      await _spawnDaemonUnlessRunning(api, binaryPath);
-    } on _ForeignPortException {
-      _setForeignPortError(api.daemonPort);
-      return;
-    } catch (e) {
-      _setError(
-        title: 'Could not start daemon',
-        details: e.toString(),
-        hint: 'Check that Heimdallm has permission to run sub-processes.\n'
-            'Try: xattr -cr /Applications/Heimdallm.app',
-      );
+    final startup = DaemonStartupCoordinator(
+      api: api,
+      platform: _platform,
+      binaryPath: binaryPath,
+    );
+    final initial = await startup.ensureAvailable();
+    if (!_handleStartupResult(initial, api.daemonPort)) {
       return;
     }
 
     _setStatus('Waiting for Heimdallm…');
-    await _waitForHealth(api, retryBinary: binaryPath);
+    await _waitForHealth(api, startup: startup);
   }
 
-  /// Spawns the daemon only when nothing is answering on its port.
-  ///
-  /// The single most important invariant of the boot path: never add a second
-  /// daemon. A daemon that loses the port bind used to stay alive and keep
-  /// polling GitHub on the same token, so every redundant spawn permanently
-  /// multiplied API consumption until the hourly quota was gone (#646). The
-  /// daemon now exits on a failed bind, but the app must not rely on that —
-  /// older daemons are still out there, and not spawning is free.
-  ///
-  /// Reachability, not health, is the right question here: see
-  /// [ApiClient.daemonReachable].
-  /// Returns true when a daemon was actually spawned, false when the port was
-  /// already taken. Throws [_ForeignPortException] when a process that is not
-  /// Heimdallm holds the port — spawning would just fail on the bind, so that
-  /// case has to reach the user rather than be retried in silence.
-  Future<bool> _spawnDaemonUnlessRunning(ApiClient api, String binaryPath) async {
-    switch (await api.daemonReachable()) {
-      case PortOwner.daemon:
-        return false;
-      case PortOwner.foreign:
-        throw _ForeignPortException();
-      case PortOwner.none:
-        await _platform.spawnDaemon(binaryPath);
-        return true;
-    }
-  }
-
-  Future<void> _waitForHealth(ApiClient api, {String? retryBinary}) async {
-    const maxDaemonRestarts = 3;
-    // How many spawn windows to allow a daemon that owns the port but is not
-    // healthy before offering the user a way out. A "starting" daemon clears in
-    // seconds; a rate-limited one can stay degraded for hours, and blocking the
-    // splash on that locks the user out of the app entirely.
-    const maxDegradedWindows = 3;
-    var daemonRestarts = 0;
-    var degradedWindows = 0;
+  Future<void> _waitForHealth(
+    ApiClient api, {
+    required DaemonStartupCoordinator startup,
+  }) async {
     for (var attempt = 0; ; attempt++) {
       await Future.delayed(const Duration(milliseconds: 400));
       if (await api.checkHealth()) {
         _go('/');
         return;
       }
-      if (attempt > 0 && attempt % 25 == 0 && retryBinary != null) {
-        // Check the budget BEFORE spawning: counting the spawn first and then
-        // testing the limit fires the terminal error immediately after the last
-        // daemon was launched, denying it the health window the retry exists to
-        // provide.
-        if (daemonRestarts >= maxDaemonRestarts) {
-          _setError(
-            title: 'Daemon failed to start',
-            details: 'Heimdallm could not start after $maxDaemonRestarts attempts.',
-            hint: 'Try restarting the app. If the problem persists, check your installation:\n'
-                'xattr -cr /Applications/Heimdallm.app',
-          );
-          return;
-        }
-
-        // A daemon that owns the port but answers 503 keeps failing
-        // checkHealth: it is degraded (rate-limited, stale last_poll) or still
-        // wiring up, not absent. Re-spawning on that signal is what stacked
-        // five daemons on one token in #646, so we skip the spawn — and must
-        // not spend the restart budget on a spawn that never happened, or the
-        // user gets a terminal "failed to start" for a daemon that is running.
-        final bool spawned;
-        try {
-          spawned = await _spawnDaemonUnlessRunning(api, retryBinary);
-        } on _ForeignPortException {
-          _setForeignPortError(api.daemonPort);
-          return;
-        } catch (_) {
-          continue;
-        }
-
-        if (!spawned) {
-          degradedWindows++;
-          if (degradedWindows >= maxDegradedWindows) {
-            _setDegradedDaemonError();
-            return;
-          }
-          // Tell the user what we are actually waiting on, instead of leaving
-          // the splash on a generic message while nothing appears to happen.
-          _setStatus('Heimdallm is running but not ready yet — waiting…');
-          continue;
-        }
-        daemonRestarts++;
+      if (attempt > 0 && attempt % 25 == 0) {
+        final result = await startup.ensureAvailable();
+        if (!_handleStartupResult(result, api.daemonPort)) return;
       }
     }
   }
 
-  void _setForeignPortError(int port) {
+  /// Handles every result from the shared guarded startup path. Returns true
+  /// while the health loop should keep waiting, false after surfacing a
+  /// terminal error.
+  bool _handleStartupResult(DaemonStartupResult result, int port) {
+    switch (result.outcome) {
+      case DaemonStartupOutcome.spawned:
+        _setStatus('Waiting for Heimdallm…');
+        return true;
+      case DaemonStartupOutcome.daemonPresent:
+        // Reachability is enough to enter the app. Health remains visible in
+        // the dashboard; blocking the splash on a stale last_poll was the local
+        // failure mode which triggered duplicate spawn attempts in #646.
+        _go('/');
+        return false;
+      case DaemonStartupOutcome.spawnFailedRetryable:
+        _setStatus('Could not launch Heimdallm — retrying…');
+        return true;
+      case DaemonStartupOutcome.portOccupied:
+        _setForeignPortError(port);
+        return false;
+      case DaemonStartupOutcome.spawnFailedTerminal:
+        _setSpawnFailureError(result.error);
+        return false;
+      case DaemonStartupOutcome.spawnBudgetExhausted:
+        _setError(
+          title: 'Daemon failed to start',
+          details:
+              'Heimdallm exhausted its guarded start attempts without '
+              'finding a daemon on the configured port.',
+          hint:
+              'Try restarting the app. If the problem persists, check your installation:\n'
+              'xattr -cr /Applications/Heimdallm.app',
+        );
+        return false;
+    }
+  }
+
+  void _setSpawnFailureError(Object? error) {
     _setError(
-      title: 'Port $port is in use by another process',
-      details: 'Something is answering on Heimdallm\'s port, but it is not the '
-          'Heimdallm daemon. Heimdallm will not start a daemon that cannot bind '
-          'the port.',
-      hint: 'Find the process and stop it, then relaunch:\n'
+      title: 'Could not start daemon',
+      details: error?.toString() ?? 'The daemon process could not be launched.',
+      hint:
+          'Check that Heimdallm has permission to run sub-processes.\n'
+          'Try: xattr -cr /Applications/Heimdallm.app',
+    );
+  }
+
+  void _setForeignPortError(int port) {
+    if (port <= 0) {
+      _setError(
+        title: 'Daemon endpoint unavailable',
+        details:
+            'Heimdallm could not identify a daemon at the configured API '
+            'endpoint. No local process was started.',
+        hint: 'Check the daemon or reverse-proxy logs, then retry.',
+      );
+      return;
+    }
+    _setError(
+      title: 'Port $port is already occupied',
+      details:
+          'Heimdallm could not prove that its port is free. Another '
+          'process is listening, or a service on the port did not answer the '
+          'health check. No daemon was started, to avoid duplicate workers.',
+      hint:
+          'Find the process and stop it, then relaunch:\n'
           'lsof -nP -iTCP:$port -sTCP:LISTEN',
     );
   }
 
-  /// The daemon owns the port and answers, but never reports healthy. Most
-  /// often a GitHub rate-limit episode leaving `last_poll` stale, which can
-  /// last hours — so give the user an exit instead of an endless splash.
-  void _setDegradedDaemonError() {
-    _setError(
-      title: 'Heimdallm is running but not ready',
-      details: 'The daemon is answering but reports itself unhealthy. This is '
-          'usually a GitHub rate-limit episode leaving the last poll stale, '
-          'which can take a while to clear.',
-      hint: 'Retry to keep waiting, or check the daemon log:\n'
-          '~/.local/share/heimdallm/heimdallm.log',
-    );
+  void _setStatus(String s) {
+    if (mounted) setState(() => _status = s);
   }
 
-  void _setStatus(String s) { if (mounted) setState(() => _status = s); }
-  void _setError({required String title, required String details, String? hint}) {
+  void _setError({
+    required String title,
+    required String details,
+    String? hint,
+  }) {
     if (mounted) {
-      setState(() { _errorTitle = title; _errorDetails = details; _errorHint = hint; });
+      setState(() {
+        _errorTitle = title;
+        _errorDetails = details;
+        _errorHint = hint;
+      });
     }
   }
-  void _go(String location) { if (mounted) setState(() => _destination = location); }
+
+  void _go(String location) {
+    if (mounted) setState(() => _destination = location);
+  }
 
   @override
   Widget build(BuildContext context) {
     if (_destination != null) {
-      return HeimdallmApp(router: widget.appRouter, initialLocation: _destination!);
+      return HeimdallmApp(
+        router: widget.appRouter,
+        initialLocation: _destination!,
+      );
     }
     if (_errorTitle != null) {
       return _ErrorApp(
@@ -322,7 +318,11 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
         details: _errorDetails ?? '',
         hint: _errorHint,
         onRetry: () {
-          setState(() { _errorTitle = null; _errorDetails = null; _errorHint = null; });
+          setState(() {
+            _errorTitle = null;
+            _errorDetails = null;
+            _errorHint = null;
+          });
           _boot();
         },
         onQuit: _platform.quitApp,
@@ -356,14 +356,21 @@ class _SplashApp extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Image.asset('assets/icon.png', width: 96, height: 96,
-                  errorBuilder: (_, _, _) => const Icon(Icons.shield, size: 96)),
+              Image.asset(
+                'assets/icon.png',
+                width: 96,
+                height: 96,
+                errorBuilder: (_, _, _) => const Icon(Icons.shield, size: 96),
+              ),
               const SizedBox(height: 24),
-              const Text('Heimdallm',
-                  style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold)),
+              const Text(
+                'Heimdallm',
+                style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
+              ),
               const SizedBox(height: 20),
               const SizedBox(
-                width: 24, height: 24,
+                width: 24,
+                height: 24,
                 child: CircularProgressIndicator(strokeWidth: 2.5),
               ),
               const SizedBox(height: 12),
@@ -417,13 +424,20 @@ class _ErrorApp extends StatelessWidget {
                 children: [
                   const Icon(Icons.error_outline, size: 56, color: Colors.red),
                   const SizedBox(height: 20),
-                  Text(title,
-                      style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                      textAlign: TextAlign.center),
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
                   const SizedBox(height: 12),
-                  Text(details,
-                      style: const TextStyle(color: Colors.grey, fontSize: 13),
-                      textAlign: TextAlign.center),
+                  Text(
+                    details,
+                    style: const TextStyle(color: Colors.grey, fontSize: 13),
+                    textAlign: TextAlign.center,
+                  ),
                   if (hint != null) ...[
                     const SizedBox(height: 20),
                     Container(
@@ -431,12 +445,19 @@ class _ErrorApp extends StatelessWidget {
                       padding: const EdgeInsets.all(12),
                       decoration: BoxDecoration(
                         color: Colors.orange.withValues(alpha: 0.1),
-                        border: Border.all(color: Colors.orange.withValues(alpha: 0.4)),
+                        border: Border.all(
+                          color: Colors.orange.withValues(alpha: 0.4),
+                        ),
                         borderRadius: BorderRadius.circular(8),
                       ),
-                      child: Text(hint!,
-                          style: const TextStyle(fontSize: 12, fontFamily: 'monospace'),
-                          textAlign: TextAlign.left),
+                      child: Text(
+                        hint!,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontFamily: 'monospace',
+                        ),
+                        textAlign: TextAlign.left,
+                      ),
                     ),
                   ],
                   const SizedBox(height: 28),

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -173,7 +173,7 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
     try {
       await _spawnDaemonUnlessRunning(api, binaryPath);
     } on _ForeignPortException {
-      _setForeignPortError();
+      _setForeignPortError(api.daemonPort);
       return;
     } catch (e) {
       _setError(
@@ -218,7 +218,13 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
 
   Future<void> _waitForHealth(ApiClient api, {String? retryBinary}) async {
     const maxDaemonRestarts = 3;
+    // How many spawn windows to allow a daemon that owns the port but is not
+    // healthy before offering the user a way out. A "starting" daemon clears in
+    // seconds; a rate-limited one can stay degraded for hours, and blocking the
+    // splash on that locks the user out of the app entirely.
+    const maxDegradedWindows = 3;
     var daemonRestarts = 0;
+    var degradedWindows = 0;
     for (var attempt = 0; ; attempt++) {
       await Future.delayed(const Duration(milliseconds: 400));
       if (await api.checkHealth()) {
@@ -226,6 +232,20 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
         return;
       }
       if (attempt > 0 && attempt % 25 == 0 && retryBinary != null) {
+        // Check the budget BEFORE spawning: counting the spawn first and then
+        // testing the limit fires the terminal error immediately after the last
+        // daemon was launched, denying it the health window the retry exists to
+        // provide.
+        if (daemonRestarts >= maxDaemonRestarts) {
+          _setError(
+            title: 'Daemon failed to start',
+            details: 'Heimdallm could not start after $maxDaemonRestarts attempts.',
+            hint: 'Try restarting the app. If the problem persists, check your installation:\n'
+                'xattr -cr /Applications/Heimdallm.app',
+          );
+          return;
+        }
+
         // A daemon that owns the port but answers 503 keeps failing
         // checkHealth: it is degraded (rate-limited, stale last_poll) or still
         // wiring up, not absent. Re-spawning on that signal is what stacked
@@ -236,40 +256,50 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
         try {
           spawned = await _spawnDaemonUnlessRunning(api, retryBinary);
         } on _ForeignPortException {
-          _setForeignPortError();
+          _setForeignPortError(api.daemonPort);
           return;
         } catch (_) {
           continue;
         }
+
         if (!spawned) {
+          degradedWindows++;
+          if (degradedWindows >= maxDegradedWindows) {
+            _setDegradedDaemonError();
+            return;
+          }
           // Tell the user what we are actually waiting on, instead of leaving
           // the splash on a generic message while nothing appears to happen.
           _setStatus('Heimdallm is running but not ready yet — waiting…');
           continue;
         }
-
         daemonRestarts++;
-        if (daemonRestarts >= maxDaemonRestarts) {
-          _setError(
-            title: 'Daemon failed to start',
-            details: 'Heimdallm could not start after $maxDaemonRestarts attempts.',
-            hint: 'Try restarting the app. If the problem persists, check your installation:\n'
-                'xattr -cr /Applications/Heimdallm.app',
-          );
-          return;
-        }
       }
     }
   }
 
-  void _setForeignPortError() {
+  void _setForeignPortError(int port) {
     _setError(
-      title: 'Port 7842 is in use by another process',
+      title: 'Port $port is in use by another process',
       details: 'Something is answering on Heimdallm\'s port, but it is not the '
           'Heimdallm daemon. Heimdallm will not start a daemon that cannot bind '
           'the port.',
       hint: 'Find the process and stop it, then relaunch:\n'
-          'lsof -nP -iTCP:7842 -sTCP:LISTEN',
+          'lsof -nP -iTCP:$port -sTCP:LISTEN',
+    );
+  }
+
+  /// The daemon owns the port and answers, but never reports healthy. Most
+  /// often a GitHub rate-limit episode leaving `last_poll` stale, which can
+  /// last hours — so give the user an exit instead of an endless splash.
+  void _setDegradedDaemonError() {
+    _setError(
+      title: 'Heimdallm is running but not ready',
+      details: 'The daemon is answering but reports itself unhealthy. This is '
+          'usually a GitHub rate-limit episode leaving the last poll stale, '
+          'which can take a while to clear.',
+      hint: 'Retry to keep waiting, or check the daemon log:\n'
+          '~/.local/share/heimdallm/heimdallm.log',
     );
   }
 

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -88,6 +88,10 @@ void sendPRNotification({
   );
 }
 
+/// A non-Heimdallm process holds the daemon port. Distinct from a spawn failure
+/// because no amount of retrying fixes it — the user has to free the port.
+class _ForeignPortException implements Exception {}
+
 class _BootstrapApp extends ConsumerStatefulWidget {
   final GoRouter appRouter;
   const _BootstrapApp({required this.appRouter});
@@ -168,6 +172,9 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
     _setStatus('Starting Heimdallm…');
     try {
       await _spawnDaemonUnlessRunning(api, binaryPath);
+    } on _ForeignPortException {
+      _setForeignPortError();
+      return;
     } catch (e) {
       _setError(
         title: 'Could not start daemon',
@@ -193,9 +200,20 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
   ///
   /// Reachability, not health, is the right question here: see
   /// [ApiClient.daemonReachable].
-  Future<void> _spawnDaemonUnlessRunning(ApiClient api, String binaryPath) async {
-    if (await api.daemonReachable()) return;
-    await _platform.spawnDaemon(binaryPath);
+  /// Returns true when a daemon was actually spawned, false when the port was
+  /// already taken. Throws [_ForeignPortException] when a process that is not
+  /// Heimdallm holds the port — spawning would just fail on the bind, so that
+  /// case has to reach the user rather than be retried in silence.
+  Future<bool> _spawnDaemonUnlessRunning(ApiClient api, String binaryPath) async {
+    switch (await api.daemonReachable()) {
+      case PortOwner.daemon:
+        return false;
+      case PortOwner.foreign:
+        throw _ForeignPortException();
+      case PortOwner.none:
+        await _platform.spawnDaemon(binaryPath);
+        return true;
+    }
   }
 
   Future<void> _waitForHealth(ApiClient api, {String? retryBinary}) async {
@@ -208,6 +226,29 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
         return;
       }
       if (attempt > 0 && attempt % 25 == 0 && retryBinary != null) {
+        // A daemon that owns the port but answers 503 keeps failing
+        // checkHealth: it is degraded (rate-limited, stale last_poll) or still
+        // wiring up, not absent. Re-spawning on that signal is what stacked
+        // five daemons on one token in #646, so we skip the spawn — and must
+        // not spend the restart budget on a spawn that never happened, or the
+        // user gets a terminal "failed to start" for a daemon that is running.
+        final bool spawned;
+        try {
+          spawned = await _spawnDaemonUnlessRunning(api, retryBinary);
+        } on _ForeignPortException {
+          _setForeignPortError();
+          return;
+        } catch (_) {
+          continue;
+        }
+        if (!spawned) {
+          // Tell the user what we are actually waiting on, instead of leaving
+          // the splash on a generic message while nothing appears to happen.
+          _setStatus('Heimdallm is running but not ready yet — waiting…');
+          continue;
+        }
+
+        daemonRestarts++;
         if (daemonRestarts >= maxDaemonRestarts) {
           _setError(
             title: 'Daemon failed to start',
@@ -217,13 +258,19 @@ class _BootstrapAppState extends ConsumerState<_BootstrapApp> {
           );
           return;
         }
-        daemonRestarts++;
-        // Guarded: a daemon that is up but reporting degraded (503) keeps
-        // failing checkHealth above, and re-spawning on that signal is what
-        // stacked five daemons on one token in #646.
-        try { await _spawnDaemonUnlessRunning(api, retryBinary); } catch (_) {}
       }
     }
+  }
+
+  void _setForeignPortError() {
+    _setError(
+      title: 'Port 7842 is in use by another process',
+      details: 'Something is answering on Heimdallm\'s port, but it is not the '
+          'Heimdallm daemon. Heimdallm will not start a daemon that cannot bind '
+          'the port.',
+      hint: 'Find the process and stop it, then relaunch:\n'
+          'lsof -nP -iTCP:7842 -sTCP:LISTEN',
+    );
   }
 
   void _setStatus(String s) { if (mounted) setState(() => _status = s); }

--- a/flutter_app/test/core/api_client_test.dart
+++ b/flutter_app/test/core/api_client_test.dart
@@ -62,10 +62,23 @@ void main() {
     test('checkHealth returns true when daemon up', () async {
       final platform = FakePlatformServices(token: 'abc-123');
       final mockClient = MockClient(
-        (_) async => http.Response(jsonEncode({'status': 'ok'}), 200),
+        (_) async => http.Response(
+          jsonEncode({'status': 'ok', 'checks': {}}),
+          200,
+          headers: {'x-heimdallm-daemon': '1'},
+        ),
       );
       final client = ApiClient(httpClient: mockClient, platform: platform);
       expect(await client.checkHealth(), isTrue);
+    });
+
+    test('checkHealth rejects a foreign 200 health endpoint', () async {
+      final platform = FakePlatformServices(token: 'abc-123');
+      final mockClient = MockClient(
+        (_) async => http.Response(jsonEncode({'status': 'ok'}), 200),
+      );
+      final client = ApiClient(httpClient: mockClient, platform: platform);
+      expect(await client.checkHealth(), isFalse);
     });
 
     test('checkHealth returns false when daemon down', () async {
@@ -75,6 +88,38 @@ void main() {
       );
       final client = ApiClient(httpClient: mockClient, platform: platform);
       expect(await client.checkHealth(), isFalse);
+    });
+
+    test('fetchHealth preserves identified degraded diagnostics', () async {
+      final platform = FakePlatformServices(token: 'abc-123');
+      final mockClient = MockClient(
+        (_) async => http.Response(
+          jsonEncode({
+            'status': 'degraded',
+            'checks': {
+              'last_poll': {'ok': false},
+            },
+          }),
+          503,
+          headers: {'x-heimdallm-daemon': '1'},
+        ),
+      );
+      final client = ApiClient(httpClient: mockClient, platform: platform);
+
+      final health = await client.fetchHealth();
+
+      expect(health?['status'], 'degraded');
+      expect(health?['checks'], isA<Map<String, dynamic>>());
+    });
+
+    test('fetchHealth rejects a foreign successful endpoint', () async {
+      final platform = FakePlatformServices(token: 'abc-123');
+      final mockClient = MockClient(
+        (_) async => http.Response(jsonEncode({'status': 'ok'}), 200),
+      );
+      final client = ApiClient(httpClient: mockClient, platform: platform);
+
+      expect(await client.fetchHealth(), isNull);
     });
 
     test('patchOrgConfig uses encoded org route and PATCH body', () async {

--- a/flutter_app/test/core/daemon_reachable_test.dart
+++ b/flutter_app/test/core/daemon_reachable_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:heimdallm/core/api/api_client.dart';
-import 'package:heimdallm/core/platform/platform_services.dart';
 import 'package:heimdallm/core/platform/platform_services_desktop.dart';
 import 'platform/fake_platform_services.dart';
 
@@ -21,15 +20,9 @@ void main() {
     platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
   );
 
-  ApiClient clientThrowing(
-    Object error, {
-    TcpPortState tcpPortState = TcpPortState.closed,
-  }) => ApiClient(
+  ApiClient clientThrowing(Object error) => ApiClient(
     httpClient: MockClient((_) async => throw error),
-    platform: FakePlatformServices(
-      apiBaseUrl: 'http://127.0.0.1:7842',
-      tcpPortState: tcpPortState,
-    ),
+    platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
   );
 
   /// Every real daemon response carries this header; it is the authoritative
@@ -91,69 +84,58 @@ void main() {
     );
 
     test(
-      'an HTTP timeout with an open TCP port must not authorize spawn',
+      'a native HTTP timeout proceeds only to the guarded spawn operation',
       () async {
         final client = ApiClient(
           httpClient: MockClient((_) async {
             await Future<void>.delayed(const Duration(seconds: 30));
             return http.Response('{"status":"ok"}', 200);
           }),
-          platform: FakePlatformServices(
-            apiBaseUrl: 'http://127.0.0.1:7842',
-            tcpPortState: TcpPortState.open,
-          ),
+          platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
           daemonReachabilityTimeout: const Duration(milliseconds: 10),
+        );
+        expect(await client.daemonReachable(), PortOwner.none);
+      },
+    );
+
+    test(
+      'a relative web endpoint fails closed after a transport error',
+      () async {
+        final client = ApiClient(
+          httpClient: MockClient(
+            (_) async => throw http.ClientException('proxy unavailable'),
+          ),
+          platform: FakePlatformServices(apiBaseUrl: '/api'),
         );
         expect(await client.daemonReachable(), PortOwner.foreign);
       },
     );
 
     test(
-      'real package:http connection-refused wrapper is classified absent',
+      'a silent TCP listener reaches the native guarded spawn path',
       () async {
-        final reservation = await ServerSocket.bind(
-          InternetAddress.loopbackIPv4,
-          0,
-        );
-        final port = reservation.port;
-        await reservation.close();
+        final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+        final accepted = <Socket>[];
+        final subscription = server.listen(accepted.add);
+        addTearDown(() async {
+          await subscription.cancel();
+          for (final socket in accepted) {
+            socket.destroy();
+          }
+          await server.close();
+        });
 
         final httpClient = http.Client();
         addTearDown(httpClient.close);
         final client = ApiClient(
           httpClient: httpClient,
-          platform: DesktopPlatformServices(apiPort: port),
-          daemonReachabilityTimeout: const Duration(milliseconds: 250),
-          daemonTcpProbeTimeout: const Duration(milliseconds: 250),
+          platform: DesktopPlatformServices(apiPort: server.port),
+          daemonReachabilityTimeout: const Duration(milliseconds: 50),
         );
 
         expect(await client.daemonReachable(), PortOwner.none);
       },
     );
-
-    test('real silent TCP listener is occupied after HTTP timeout', () async {
-      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-      final accepted = <Socket>[];
-      final subscription = server.listen(accepted.add);
-      addTearDown(() async {
-        await subscription.cancel();
-        for (final socket in accepted) {
-          socket.destroy();
-        }
-        await server.close();
-      });
-
-      final httpClient = http.Client();
-      addTearDown(httpClient.close);
-      final client = ApiClient(
-        httpClient: httpClient,
-        platform: DesktopPlatformServices(apiPort: server.port),
-        daemonReachabilityTimeout: const Duration(milliseconds: 50),
-        daemonTcpProbeTimeout: const Duration(milliseconds: 250),
-      );
-
-      expect(await client.daemonReachable(), PortOwner.foreign);
-    });
 
     group('identity: the header is authoritative', () {
       test('header alone identifies the daemon, whatever the body', () async {
@@ -232,16 +214,12 @@ void main() {
       });
 
       test(
-        'a process that does not speak HTTP is foreign, not absent',
+        'a process that does not speak HTTP is deferred to the spawn guard',
         () async {
-          // Raw TCP service on the port: the GET fails, but someone holds the
-          // port, so spawning would just die on the bind. The user needs the
-          // "free the port" guidance, not a generic start failure.
           final client = clientThrowing(
             http.ClientException('Invalid HTTP response'),
-            tcpPortState: TcpPortState.open,
           );
-          expect(await client.daemonReachable(), PortOwner.foreign);
+          expect(await client.daemonReachable(), PortOwner.none);
         },
       );
     });

--- a/flutter_app/test/core/daemon_reachable_test.dart
+++ b/flutter_app/test/core/daemon_reachable_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:heimdallm/core/api/api_client.dart';
+import 'platform/fake_platform_services.dart';
+
+/// Regression tests for the spawn guard behind #646.
+///
+/// A degraded-but-alive daemon answers /health with 503. The boot path used to
+/// treat "not 200" as "no daemon" and spawned another one, which lost the port
+/// bind, kept polling GitHub on the same token and drove the shared quota
+/// further down — feeding back into more 503s and more spawns. Reachability has
+/// to be a separate question from health.
+void main() {
+  ApiClient clientReturning(http.Response Function() respond) => ApiClient(
+    httpClient: MockClient((_) async => respond()),
+    platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
+  );
+
+  group('daemonReachable vs checkHealth', () {
+    test('503 degraded: unhealthy, but reachable so we must not spawn', () async {
+      final client = clientReturning(() => http.Response('{"status":"degraded"}', 503));
+      expect(await client.checkHealth(), isFalse);
+      expect(
+        await client.daemonReachable(),
+        isTrue,
+        reason: 'a 503 means a daemon owns the port; spawning a second one is the #646 bug',
+      );
+    });
+
+    test('401 unauthorized: reachable, so we must not spawn', () async {
+      final client = clientReturning(() => http.Response('unauthorized', 401));
+      expect(await client.daemonReachable(), isTrue);
+    });
+
+    test('200 healthy: reachable', () async {
+      final client = clientReturning(() => http.Response('{"status":"ok"}', 200));
+      expect(await client.checkHealth(), isTrue);
+      expect(await client.daemonReachable(), isTrue);
+    });
+
+    test('connection refused: genuinely absent, so spawning is correct', () async {
+      final client = ApiClient(
+        httpClient: MockClient(
+          (_) async => throw const SocketException('Connection refused'),
+        ),
+        platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
+      );
+      expect(await client.daemonReachable(), isFalse);
+    });
+
+    test('a daemon too slow to answer counts as unreachable, not as healthy', () async {
+      final client = ApiClient(
+        httpClient: MockClient((_) async {
+          await Future<void>.delayed(const Duration(seconds: 30));
+          return http.Response('{"status":"ok"}', 200);
+        }),
+        platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
+      );
+      expect(await client.daemonReachable(), isFalse);
+      expect(await client.checkHealth(), isFalse);
+    });
+  });
+}

--- a/flutter_app/test/core/daemon_reachable_test.dart
+++ b/flutter_app/test/core/daemon_reachable_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:heimdallm/core/api/api_client.dart';
+import 'package:heimdallm/core/platform/platform_services.dart';
+import 'package:heimdallm/core/platform/platform_services_desktop.dart';
 import 'platform/fake_platform_services.dart';
 
 /// Regression tests for the spawn guard behind #646.
@@ -19,9 +21,15 @@ void main() {
     platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
   );
 
-  ApiClient clientThrowing(Object error) => ApiClient(
+  ApiClient clientThrowing(
+    Object error, {
+    TcpPortState tcpPortState = TcpPortState.closed,
+  }) => ApiClient(
     httpClient: MockClient((_) async => throw error),
-    platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
+    platform: FakePlatformServices(
+      apiBaseUrl: 'http://127.0.0.1:7842',
+      tcpPortState: tcpPortState,
+    ),
   );
 
   /// Every real daemon response carries this header; it is the authoritative
@@ -31,54 +39,120 @@ void main() {
   group('daemonReachable vs checkHealth', () {
     test('503 degraded: unhealthy, but ours — must not spawn', () async {
       final client = clientReturning(
-        () => http.Response('{"status":"degraded","checks":{}}', 503,
-            headers: daemonHeaders),
+        () => http.Response(
+          '{"status":"degraded","checks":{}}',
+          503,
+          headers: daemonHeaders,
+        ),
       );
       expect(await client.checkHealth(), isFalse);
       expect(
         await client.daemonReachable(),
         PortOwner.daemon,
-        reason: 'a 503 from our daemon means the port is ours; spawning again is the #646 bug',
+        reason:
+            'a 503 from our daemon means the port is ours; spawning again is the #646 bug',
       );
     });
 
     test('503 starting: daemon serving mid-wiring is still ours', () async {
       final client = clientReturning(
-        () => http.Response('{"status":"starting"}', 503, headers: daemonHeaders),
+        () =>
+            http.Response('{"status":"starting"}', 503, headers: daemonHeaders),
       );
       expect(await client.checkHealth(), isFalse);
       expect(await client.daemonReachable(), PortOwner.daemon);
     });
 
-    test('401 unauthorized: only our daemon enforces the token', () async {
+    test('401 without daemon identity belongs to a foreign service', () async {
       final client = clientReturning(() => http.Response('unauthorized', 401));
-      expect(await client.daemonReachable(), PortOwner.daemon);
+      expect(await client.daemonReachable(), PortOwner.foreign);
     });
 
     test('200 healthy: ours and healthy', () async {
       final client = clientReturning(
-        () => http.Response('{"status":"ok","checks":{}}', 200,
-            headers: daemonHeaders),
+        () => http.Response(
+          '{"status":"ok","checks":{}}',
+          200,
+          headers: daemonHeaders,
+        ),
       );
       expect(await client.checkHealth(), isTrue);
       expect(await client.daemonReachable(), PortOwner.daemon);
     });
 
-    test('connection refused: genuinely absent, so spawning is correct', () async {
-      final client = clientThrowing(const SocketException('Connection refused'));
-      expect(await client.daemonReachable(), PortOwner.none);
-    });
+    test(
+      'connection refused: genuinely absent, so spawning is correct',
+      () async {
+        final client = clientThrowing(
+          const SocketException('Connection refused'),
+        );
+        expect(await client.daemonReachable(), PortOwner.none);
+      },
+    );
 
-    test('a daemon too slow to answer counts as absent, not as healthy', () async {
+    test(
+      'an HTTP timeout with an open TCP port must not authorize spawn',
+      () async {
+        final client = ApiClient(
+          httpClient: MockClient((_) async {
+            await Future<void>.delayed(const Duration(seconds: 30));
+            return http.Response('{"status":"ok"}', 200);
+          }),
+          platform: FakePlatformServices(
+            apiBaseUrl: 'http://127.0.0.1:7842',
+            tcpPortState: TcpPortState.open,
+          ),
+          daemonReachabilityTimeout: const Duration(milliseconds: 10),
+        );
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      },
+    );
+
+    test(
+      'real package:http connection-refused wrapper is classified absent',
+      () async {
+        final reservation = await ServerSocket.bind(
+          InternetAddress.loopbackIPv4,
+          0,
+        );
+        final port = reservation.port;
+        await reservation.close();
+
+        final httpClient = http.Client();
+        addTearDown(httpClient.close);
+        final client = ApiClient(
+          httpClient: httpClient,
+          platform: DesktopPlatformServices(apiPort: port),
+          daemonReachabilityTimeout: const Duration(milliseconds: 250),
+          daemonTcpProbeTimeout: const Duration(milliseconds: 250),
+        );
+
+        expect(await client.daemonReachable(), PortOwner.none);
+      },
+    );
+
+    test('real silent TCP listener is occupied after HTTP timeout', () async {
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final accepted = <Socket>[];
+      final subscription = server.listen(accepted.add);
+      addTearDown(() async {
+        await subscription.cancel();
+        for (final socket in accepted) {
+          socket.destroy();
+        }
+        await server.close();
+      });
+
+      final httpClient = http.Client();
+      addTearDown(httpClient.close);
       final client = ApiClient(
-        httpClient: MockClient((_) async {
-          await Future<void>.delayed(const Duration(seconds: 30));
-          return http.Response('{"status":"ok"}', 200);
-        }),
-        platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
+        httpClient: httpClient,
+        platform: DesktopPlatformServices(apiPort: server.port),
+        daemonReachabilityTimeout: const Duration(milliseconds: 50),
+        daemonTcpProbeTimeout: const Duration(milliseconds: 250),
       );
-      expect(await client.daemonReachable(), PortOwner.none);
-      expect(await client.checkHealth(), isFalse);
+
+      expect(await client.daemonReachable(), PortOwner.foreign);
     });
 
     group('identity: the header is authoritative', () {
@@ -89,39 +163,54 @@ void main() {
         expect(await client.daemonReachable(), PortOwner.daemon);
       });
 
-      test('older daemon without the header still matches via status+checks',
-          () async {
-        final client = clientReturning(
-          () => http.Response('{"status":"ok","checks":{}}', 200),
-        );
-        expect(await client.daemonReachable(), PortOwner.daemon);
-      });
+      test(
+        'older daemon without the header still matches via status+checks',
+        () async {
+          final client = clientReturning(
+            () => http.Response('{"status":"ok","checks":{}}', 200),
+          );
+          expect(await client.daemonReachable(), PortOwner.daemon);
+        },
+      );
 
-      test('older daemon without the header matches via status+version', () async {
-        final client = clientReturning(
-          () => http.Response('{"status":"starting","version":"0.7.10"}', 503),
-        );
-        expect(await client.daemonReachable(), PortOwner.daemon);
-      });
+      test(
+        'older daemon without the header matches via status+version',
+        () async {
+          final client = clientReturning(
+            () =>
+                http.Response('{"status":"starting","version":"0.7.10"}', 503),
+          );
+          expect(await client.daemonReachable(), PortOwner.daemon);
+        },
+      );
     });
 
     group('foreign process squatting on the port', () {
-      test('Spring Boot Actuator style {"status":"UP"} is NOT our daemon',
-          () async {
-        final client = clientReturning(() => http.Response('{"status":"UP"}', 200));
-        expect(
-          await client.daemonReachable(),
-          PortOwner.foreign,
-          reason: 'a bare status field is the shape of most health endpoints; '
-              'accepting it would silently prevent the daemon from ever spawning',
-        );
-      });
+      test(
+        'Spring Boot Actuator style {"status":"UP"} is NOT our daemon',
+        () async {
+          final client = clientReturning(
+            () => http.Response('{"status":"UP"}', 200),
+          );
+          expect(
+            await client.daemonReachable(),
+            PortOwner.foreign,
+            reason:
+                'a bare status field is the shape of most health endpoints; '
+                'accepting it would silently prevent the daemon from ever spawning',
+          );
+        },
+      );
 
-      test('a bare {"status":"ok"} from some other service is NOT our daemon',
-          () async {
-        final client = clientReturning(() => http.Response('{"status":"ok"}', 200));
-        expect(await client.daemonReachable(), PortOwner.foreign);
-      });
+      test(
+        'a bare {"status":"ok"} from some other service is NOT our daemon',
+        () async {
+          final client = clientReturning(
+            () => http.Response('{"status":"ok"}', 200),
+          );
+          expect(await client.daemonReachable(), PortOwner.foreign);
+        },
+      );
 
       test('HTML from an unrelated dev server is not our daemon', () async {
         final client = clientReturning(
@@ -131,7 +220,9 @@ void main() {
       });
 
       test('JSON without a status field is not our daemon', () async {
-        final client = clientReturning(() => http.Response('{"foo":"bar"}', 200));
+        final client = clientReturning(
+          () => http.Response('{"foo":"bar"}', 200),
+        );
         expect(await client.daemonReachable(), PortOwner.foreign);
       });
 
@@ -140,13 +231,19 @@ void main() {
         expect(await client.daemonReachable(), PortOwner.foreign);
       });
 
-      test('a process that does not speak HTTP is foreign, not absent', () async {
-        // Raw TCP service on the port: the GET fails, but someone holds the
-        // port, so spawning would just die on the bind. The user needs the
-        // "free the port" guidance, not a generic start failure.
-        final client = clientThrowing(http.ClientException('Invalid HTTP response'));
-        expect(await client.daemonReachable(), PortOwner.foreign);
-      });
+      test(
+        'a process that does not speak HTTP is foreign, not absent',
+        () async {
+          // Raw TCP service on the port: the GET fails, but someone holds the
+          // port, so spawning would just die on the bind. The user needs the
+          // "free the port" guidance, not a generic start failure.
+          final client = clientThrowing(
+            http.ClientException('Invalid HTTP response'),
+            tcpPortState: TcpPortState.open,
+          );
+          expect(await client.daemonReachable(), PortOwner.foreign);
+        },
+      );
     });
   });
 

--- a/flutter_app/test/core/daemon_reachable_test.dart
+++ b/flutter_app/test/core/daemon_reachable_test.dart
@@ -19,10 +19,20 @@ void main() {
     platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
   );
 
+  ApiClient clientThrowing(Object error) => ApiClient(
+    httpClient: MockClient((_) async => throw error),
+    platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
+  );
+
+  /// Every real daemon response carries this header; it is the authoritative
+  /// identity signal.
+  const daemonHeaders = {'x-heimdallm-daemon': '1'};
+
   group('daemonReachable vs checkHealth', () {
     test('503 degraded: unhealthy, but ours — must not spawn', () async {
       final client = clientReturning(
-        () => http.Response('{"status":"degraded","checks":{}}', 503),
+        () => http.Response('{"status":"degraded","checks":{}}', 503,
+            headers: daemonHeaders),
       );
       expect(await client.checkHealth(), isFalse);
       expect(
@@ -34,7 +44,7 @@ void main() {
 
     test('503 starting: daemon serving mid-wiring is still ours', () async {
       final client = clientReturning(
-        () => http.Response('{"status":"starting"}', 503),
+        () => http.Response('{"status":"starting"}', 503, headers: daemonHeaders),
       );
       expect(await client.checkHealth(), isFalse);
       expect(await client.daemonReachable(), PortOwner.daemon);
@@ -47,19 +57,15 @@ void main() {
 
     test('200 healthy: ours and healthy', () async {
       final client = clientReturning(
-        () => http.Response('{"status":"ok","checks":{}}', 200),
+        () => http.Response('{"status":"ok","checks":{}}', 200,
+            headers: daemonHeaders),
       );
       expect(await client.checkHealth(), isTrue);
       expect(await client.daemonReachable(), PortOwner.daemon);
     });
 
     test('connection refused: genuinely absent, so spawning is correct', () async {
-      final client = ApiClient(
-        httpClient: MockClient(
-          (_) async => throw const SocketException('Connection refused'),
-        ),
-        platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
-      );
+      final client = clientThrowing(const SocketException('Connection refused'));
       expect(await client.daemonReachable(), PortOwner.none);
     });
 
@@ -75,7 +81,48 @@ void main() {
       expect(await client.checkHealth(), isFalse);
     });
 
+    group('identity: the header is authoritative', () {
+      test('header alone identifies the daemon, whatever the body', () async {
+        final client = clientReturning(
+          () => http.Response('anything', 200, headers: daemonHeaders),
+        );
+        expect(await client.daemonReachable(), PortOwner.daemon);
+      });
+
+      test('older daemon without the header still matches via status+checks',
+          () async {
+        final client = clientReturning(
+          () => http.Response('{"status":"ok","checks":{}}', 200),
+        );
+        expect(await client.daemonReachable(), PortOwner.daemon);
+      });
+
+      test('older daemon without the header matches via status+version', () async {
+        final client = clientReturning(
+          () => http.Response('{"status":"starting","version":"0.7.10"}', 503),
+        );
+        expect(await client.daemonReachable(), PortOwner.daemon);
+      });
+    });
+
     group('foreign process squatting on the port', () {
+      test('Spring Boot Actuator style {"status":"UP"} is NOT our daemon',
+          () async {
+        final client = clientReturning(() => http.Response('{"status":"UP"}', 200));
+        expect(
+          await client.daemonReachable(),
+          PortOwner.foreign,
+          reason: 'a bare status field is the shape of most health endpoints; '
+              'accepting it would silently prevent the daemon from ever spawning',
+        );
+      });
+
+      test('a bare {"status":"ok"} from some other service is NOT our daemon',
+          () async {
+        final client = clientReturning(() => http.Response('{"status":"ok"}', 200));
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      });
+
       test('HTML from an unrelated dev server is not our daemon', () async {
         final client = clientReturning(
           () => http.Response('<html><body>hello</body></html>', 200),
@@ -92,6 +139,24 @@ void main() {
         final client = clientReturning(() => http.Response('[1,2,3]', 200));
         expect(await client.daemonReachable(), PortOwner.foreign);
       });
+
+      test('a process that does not speak HTTP is foreign, not absent', () async {
+        // Raw TCP service on the port: the GET fails, but someone holds the
+        // port, so spawning would just die on the bind. The user needs the
+        // "free the port" guidance, not a generic start failure.
+        final client = clientThrowing(http.ClientException('Invalid HTTP response'));
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      });
+    });
+  });
+
+  group('daemonPort', () {
+    test('derives from the configured base URL, never hardcoded', () async {
+      final client = ApiClient(
+        httpClient: MockClient((_) async => http.Response('', 200)),
+        platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:9999'),
+      );
+      expect(client.daemonPort, 9999);
     });
   });
 }

--- a/flutter_app/test/core/daemon_reachable_test.dart
+++ b/flutter_app/test/core/daemon_reachable_test.dart
@@ -7,11 +7,12 @@ import 'platform/fake_platform_services.dart';
 
 /// Regression tests for the spawn guard behind #646.
 ///
-/// A degraded-but-alive daemon answers /health with 503. The boot path used to
-/// treat "not 200" as "no daemon" and spawned another one, which lost the port
-/// bind, kept polling GitHub on the same token and drove the shared quota
-/// further down — feeding back into more 503s and more spawns. Reachability has
-/// to be a separate question from health.
+/// A degraded-but-alive daemon answers /health with 503, and so does one that is
+/// still wiring up at boot. The boot path used to treat "not 200" as "no daemon"
+/// and spawned another one, which lost the port bind, kept polling GitHub on the
+/// same token and drove the shared quota further down — feeding back into more
+/// 503s and more spawns. Reachability has to be a separate question from health,
+/// and it has to tell our daemon apart from an unrelated port squatter.
 void main() {
   ApiClient clientReturning(http.Response Function() respond) => ApiClient(
     httpClient: MockClient((_) async => respond()),
@@ -19,25 +20,37 @@ void main() {
   );
 
   group('daemonReachable vs checkHealth', () {
-    test('503 degraded: unhealthy, but reachable so we must not spawn', () async {
-      final client = clientReturning(() => http.Response('{"status":"degraded"}', 503));
+    test('503 degraded: unhealthy, but ours — must not spawn', () async {
+      final client = clientReturning(
+        () => http.Response('{"status":"degraded","checks":{}}', 503),
+      );
       expect(await client.checkHealth(), isFalse);
       expect(
         await client.daemonReachable(),
-        isTrue,
-        reason: 'a 503 means a daemon owns the port; spawning a second one is the #646 bug',
+        PortOwner.daemon,
+        reason: 'a 503 from our daemon means the port is ours; spawning again is the #646 bug',
       );
     });
 
-    test('401 unauthorized: reachable, so we must not spawn', () async {
-      final client = clientReturning(() => http.Response('unauthorized', 401));
-      expect(await client.daemonReachable(), isTrue);
+    test('503 starting: daemon serving mid-wiring is still ours', () async {
+      final client = clientReturning(
+        () => http.Response('{"status":"starting"}', 503),
+      );
+      expect(await client.checkHealth(), isFalse);
+      expect(await client.daemonReachable(), PortOwner.daemon);
     });
 
-    test('200 healthy: reachable', () async {
-      final client = clientReturning(() => http.Response('{"status":"ok"}', 200));
+    test('401 unauthorized: only our daemon enforces the token', () async {
+      final client = clientReturning(() => http.Response('unauthorized', 401));
+      expect(await client.daemonReachable(), PortOwner.daemon);
+    });
+
+    test('200 healthy: ours and healthy', () async {
+      final client = clientReturning(
+        () => http.Response('{"status":"ok","checks":{}}', 200),
+      );
       expect(await client.checkHealth(), isTrue);
-      expect(await client.daemonReachable(), isTrue);
+      expect(await client.daemonReachable(), PortOwner.daemon);
     });
 
     test('connection refused: genuinely absent, so spawning is correct', () async {
@@ -47,10 +60,10 @@ void main() {
         ),
         platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
       );
-      expect(await client.daemonReachable(), isFalse);
+      expect(await client.daemonReachable(), PortOwner.none);
     });
 
-    test('a daemon too slow to answer counts as unreachable, not as healthy', () async {
+    test('a daemon too slow to answer counts as absent, not as healthy', () async {
       final client = ApiClient(
         httpClient: MockClient((_) async {
           await Future<void>.delayed(const Duration(seconds: 30));
@@ -58,8 +71,27 @@ void main() {
         }),
         platform: FakePlatformServices(apiBaseUrl: 'http://127.0.0.1:7842'),
       );
-      expect(await client.daemonReachable(), isFalse);
+      expect(await client.daemonReachable(), PortOwner.none);
       expect(await client.checkHealth(), isFalse);
+    });
+
+    group('foreign process squatting on the port', () {
+      test('HTML from an unrelated dev server is not our daemon', () async {
+        final client = clientReturning(
+          () => http.Response('<html><body>hello</body></html>', 200),
+        );
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      });
+
+      test('JSON without a status field is not our daemon', () async {
+        final client = clientReturning(() => http.Response('{"foo":"bar"}', 200));
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      });
+
+      test('a JSON array is not our daemon', () async {
+        final client = clientReturning(() => http.Response('[1,2,3]', 200));
+        expect(await client.daemonReachable(), PortOwner.foreign);
+      });
     });
   });
 }

--- a/flutter_app/test/core/daemon_startup_test.dart
+++ b/flutter_app/test/core/daemon_startup_test.dart
@@ -9,8 +9,7 @@ import 'package:heimdallm/core/platform/platform_services.dart';
 import 'platform/fake_platform_services.dart';
 
 class _ThrowingPlatformServices extends FakePlatformServices {
-  _ThrowingPlatformServices({required this.spawnError})
-    : super(tcpPortState: TcpPortState.closed);
+  _ThrowingPlatformServices({required this.spawnError});
 
   final Object spawnError;
 
@@ -28,11 +27,17 @@ ApiClient _apiFor(
   httpClient: MockClient((_) => response()),
   platform: platform,
   daemonReachabilityTimeout: const Duration(milliseconds: 20),
-  daemonTcpProbeTimeout: const Duration(milliseconds: 20),
 );
 
 void main() {
   const daemonHeaders = {'x-heimdallm-daemon': '1'};
+
+  test('occupied-port failures are actionable', () {
+    expect(
+      const DaemonPortOccupiedException(8123).toString(),
+      'Port 8123 is already occupied; no daemon was started.',
+    );
+  });
 
   test('an existing degraded daemon is never spawned again', () async {
     final platform = FakePlatformServices();
@@ -56,7 +61,7 @@ void main() {
   });
 
   test('a proven-closed port permits exactly one spawn attempt', () async {
-    final platform = FakePlatformServices(tcpPortState: TcpPortState.closed);
+    final platform = FakePlatformServices();
     final coordinator = DaemonStartupCoordinator(
       api: _apiFor(
         platform,
@@ -74,7 +79,7 @@ void main() {
   });
 
   test('concurrent callers share one ownership probe and one spawn', () async {
-    final platform = FakePlatformServices(tcpPortState: TcpPortState.closed);
+    final platform = FakePlatformServices();
     var probes = 0;
     final releaseProbe = Completer<void>();
     final coordinator = DaemonStartupCoordinator(
@@ -101,22 +106,27 @@ void main() {
     expect(coordinator.spawnAttempts, 1);
   });
 
-  test('an ambiguous TCP probe fails closed and never spawns', () async {
-    final platform = FakePlatformServices(tcpPortState: TcpPortState.unknown);
-    final coordinator = DaemonStartupCoordinator(
-      api: _apiFor(
-        platform,
-        () async => throw http.ClientException('timed out'),
-      ),
-      platform: platform,
-      binaryPath: '/daemon',
-    );
+  test(
+    'the final spawn guard maps an occupied port without starting',
+    () async {
+      final platform = _ThrowingPlatformServices(
+        spawnError: const DaemonPortOccupiedException(7842),
+      );
+      final coordinator = DaemonStartupCoordinator(
+        api: _apiFor(
+          platform,
+          () async => throw http.ClientException('timed out'),
+        ),
+        platform: platform,
+        binaryPath: '/daemon',
+      );
 
-    final result = await coordinator.ensureAvailable();
+      final result = await coordinator.ensureAvailable();
 
-    expect(result.outcome, DaemonStartupOutcome.portOccupied);
-    expect(platform.spawnedDaemons, isEmpty);
-  });
+      expect(result.outcome, DaemonStartupOutcome.portOccupied);
+      expect(platform.spawnedDaemons, ['/daemon']);
+    },
+  );
 
   test(
     'persistent spawn failures consume a bounded budget and keep the error',
@@ -151,7 +161,7 @@ void main() {
 
   test('reachability wins over an exhausted spawn budget', () async {
     var daemonNowOwnsPort = false;
-    final platform = FakePlatformServices(tcpPortState: TcpPortState.closed);
+    final platform = FakePlatformServices();
     final api = _apiFor(platform, () async {
       if (daemonNowOwnsPort) {
         return http.Response(
@@ -184,7 +194,7 @@ void main() {
   test(
     'successful spawns that never bind exhaust the budget without an N+1 call',
     () async {
-      final platform = FakePlatformServices(tcpPortState: TcpPortState.closed);
+      final platform = FakePlatformServices();
       final coordinator = DaemonStartupCoordinator(
         api: _apiFor(
           platform,

--- a/flutter_app/test/core/daemon_startup_test.dart
+++ b/flutter_app/test/core/daemon_startup_test.dart
@@ -1,0 +1,213 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:heimdallm/core/api/api_client.dart';
+import 'package:heimdallm/core/daemon/daemon_startup.dart';
+import 'package:heimdallm/core/platform/platform_services.dart';
+import 'platform/fake_platform_services.dart';
+
+class _ThrowingPlatformServices extends FakePlatformServices {
+  _ThrowingPlatformServices({required this.spawnError})
+    : super(tcpPortState: TcpPortState.closed);
+
+  final Object spawnError;
+
+  @override
+  Future<void> spawnDaemon(String binaryPath) async {
+    spawnedDaemons.add(binaryPath);
+    throw spawnError;
+  }
+}
+
+ApiClient _apiFor(
+  FakePlatformServices platform,
+  Future<http.Response> Function() response,
+) => ApiClient(
+  httpClient: MockClient((_) => response()),
+  platform: platform,
+  daemonReachabilityTimeout: const Duration(milliseconds: 20),
+  daemonTcpProbeTimeout: const Duration(milliseconds: 20),
+);
+
+void main() {
+  const daemonHeaders = {'x-heimdallm-daemon': '1'};
+
+  test('an existing degraded daemon is never spawned again', () async {
+    final platform = FakePlatformServices();
+    final coordinator = DaemonStartupCoordinator(
+      api: _apiFor(
+        platform,
+        () async => http.Response(
+          '{"status":"degraded","checks":{}}',
+          503,
+          headers: daemonHeaders,
+        ),
+      ),
+      platform: platform,
+      binaryPath: '/daemon',
+    );
+
+    final result = await coordinator.ensureAvailable();
+
+    expect(result.outcome, DaemonStartupOutcome.daemonPresent);
+    expect(platform.spawnedDaemons, isEmpty);
+  });
+
+  test('a proven-closed port permits exactly one spawn attempt', () async {
+    final platform = FakePlatformServices(tcpPortState: TcpPortState.closed);
+    final coordinator = DaemonStartupCoordinator(
+      api: _apiFor(
+        platform,
+        () async => throw http.ClientException('Connection refused'),
+      ),
+      platform: platform,
+      binaryPath: '/daemon',
+    );
+
+    final result = await coordinator.ensureAvailable();
+
+    expect(result.outcome, DaemonStartupOutcome.spawned);
+    expect(platform.spawnedDaemons, ['/daemon']);
+    expect(coordinator.spawnAttempts, 1);
+  });
+
+  test('concurrent callers share one ownership probe and one spawn', () async {
+    final platform = FakePlatformServices(tcpPortState: TcpPortState.closed);
+    var probes = 0;
+    final releaseProbe = Completer<void>();
+    final coordinator = DaemonStartupCoordinator(
+      api: _apiFor(platform, () async {
+        probes++;
+        await releaseProbe.future;
+        throw http.ClientException('Connection refused');
+      }),
+      platform: platform,
+      binaryPath: '/daemon',
+    );
+
+    final first = coordinator.ensureAvailable();
+    final second = coordinator.ensureAvailable();
+    releaseProbe.complete();
+    final results = await Future.wait([first, second]);
+
+    expect(
+      results.map((r) => r.outcome),
+      everyElement(DaemonStartupOutcome.spawned),
+    );
+    expect(probes, 1);
+    expect(platform.spawnedDaemons, ['/daemon']);
+    expect(coordinator.spawnAttempts, 1);
+  });
+
+  test('an ambiguous TCP probe fails closed and never spawns', () async {
+    final platform = FakePlatformServices(tcpPortState: TcpPortState.unknown);
+    final coordinator = DaemonStartupCoordinator(
+      api: _apiFor(
+        platform,
+        () async => throw http.ClientException('timed out'),
+      ),
+      platform: platform,
+      binaryPath: '/daemon',
+    );
+
+    final result = await coordinator.ensureAvailable();
+
+    expect(result.outcome, DaemonStartupOutcome.portOccupied);
+    expect(platform.spawnedDaemons, isEmpty);
+  });
+
+  test(
+    'persistent spawn failures consume a bounded budget and keep the error',
+    () async {
+      final failure = StateError('binary is not executable');
+      final platform = _ThrowingPlatformServices(spawnError: failure);
+      final coordinator = DaemonStartupCoordinator(
+        api: _apiFor(
+          platform,
+          () async => throw http.ClientException('Connection refused'),
+        ),
+        platform: platform,
+        binaryPath: '/daemon',
+        maxSpawnAttempts: 3,
+      );
+
+      expect(
+        (await coordinator.ensureAvailable()).outcome,
+        DaemonStartupOutcome.spawnFailedRetryable,
+      );
+      expect(
+        (await coordinator.ensureAvailable()).outcome,
+        DaemonStartupOutcome.spawnFailedRetryable,
+      );
+      final terminal = await coordinator.ensureAvailable();
+
+      expect(terminal.outcome, DaemonStartupOutcome.spawnFailedTerminal);
+      expect(terminal.error, same(failure));
+      expect(platform.spawnedDaemons, ['/daemon', '/daemon', '/daemon']);
+    },
+  );
+
+  test('reachability wins over an exhausted spawn budget', () async {
+    var daemonNowOwnsPort = false;
+    final platform = FakePlatformServices(tcpPortState: TcpPortState.closed);
+    final api = _apiFor(platform, () async {
+      if (daemonNowOwnsPort) {
+        return http.Response(
+          '{"status":"starting"}',
+          503,
+          headers: daemonHeaders,
+        );
+      }
+      throw http.ClientException('Connection refused');
+    });
+    final coordinator = DaemonStartupCoordinator(
+      api: api,
+      platform: platform,
+      binaryPath: '/daemon',
+      maxSpawnAttempts: 1,
+    );
+
+    expect(
+      (await coordinator.ensureAvailable()).outcome,
+      DaemonStartupOutcome.spawned,
+    );
+    daemonNowOwnsPort = true;
+    expect(
+      (await coordinator.ensureAvailable()).outcome,
+      DaemonStartupOutcome.daemonPresent,
+    );
+    expect(platform.spawnedDaemons, ['/daemon']);
+  });
+
+  test(
+    'successful spawns that never bind exhaust the budget without an N+1 call',
+    () async {
+      final platform = FakePlatformServices(tcpPortState: TcpPortState.closed);
+      final coordinator = DaemonStartupCoordinator(
+        api: _apiFor(
+          platform,
+          () async => throw http.ClientException('Connection refused'),
+        ),
+        platform: platform,
+        binaryPath: '/daemon',
+        maxSpawnAttempts: 2,
+      );
+
+      expect(
+        (await coordinator.ensureAvailable()).outcome,
+        DaemonStartupOutcome.spawned,
+      );
+      expect(
+        (await coordinator.ensureAvailable()).outcome,
+        DaemonStartupOutcome.spawned,
+      );
+      expect(
+        (await coordinator.ensureAvailable()).outcome,
+        DaemonStartupOutcome.spawnBudgetExhausted,
+      );
+      expect(platform.spawnedDaemons, ['/daemon', '/daemon']);
+    },
+  );
+}

--- a/flutter_app/test/core/platform/fake_platform_services.dart
+++ b/flutter_app/test/core/platform/fake_platform_services.dart
@@ -16,8 +16,6 @@ class FakePlatformServices implements PlatformServices {
     this.configExistsValue = true,
     this.githubToken,
     this.daemonBinaryPath,
-    this.tcpPortState = TcpPortState.unknown,
-    this.daemonSupervised = false,
   }) : _env = env ?? const {};
 
   @override
@@ -27,8 +25,6 @@ class FakePlatformServices implements PlatformServices {
   bool configExistsValue;
   String? githubToken;
   String? daemonBinaryPath;
-  TcpPortState tcpPortState;
-  bool daemonSupervised;
 
   // Records of calls for assertions.
   int loadApiTokenCalls = 0;
@@ -44,7 +40,6 @@ class FakePlatformServices implements PlatformServices {
   int quitCalls = 0;
   final List<AppConfig> writtenConfigs = [];
   final List<String> spawnedDaemons = [];
-  int probeDaemonPortCalls = 0;
   void Function(String location)? trayNavigationHandler;
 
   @override
@@ -139,17 +134,6 @@ class FakePlatformServices implements PlatformServices {
 
   @override
   String? defaultDaemonBinaryPath() => daemonBinaryPath;
-
-  @override
-  Future<TcpPortState> probeDaemonPort({
-    Duration timeout = const Duration(milliseconds: 500),
-  }) async {
-    probeDaemonPortCalls++;
-    return tcpPortState;
-  }
-
-  @override
-  Future<bool> isDaemonSupervised() async => daemonSupervised;
 
   @override
   Future<void> spawnDaemon(String binaryPath) async {

--- a/flutter_app/test/core/platform/fake_platform_services.dart
+++ b/flutter_app/test/core/platform/fake_platform_services.dart
@@ -16,6 +16,8 @@ class FakePlatformServices implements PlatformServices {
     this.configExistsValue = true,
     this.githubToken,
     this.daemonBinaryPath,
+    this.tcpPortState = TcpPortState.unknown,
+    this.daemonSupervised = false,
   }) : _env = env ?? const {};
 
   @override
@@ -25,6 +27,8 @@ class FakePlatformServices implements PlatformServices {
   bool configExistsValue;
   String? githubToken;
   String? daemonBinaryPath;
+  TcpPortState tcpPortState;
+  bool daemonSupervised;
 
   // Records of calls for assertions.
   int loadApiTokenCalls = 0;
@@ -40,6 +44,7 @@ class FakePlatformServices implements PlatformServices {
   int quitCalls = 0;
   final List<AppConfig> writtenConfigs = [];
   final List<String> spawnedDaemons = [];
+  int probeDaemonPortCalls = 0;
   void Function(String location)? trayNavigationHandler;
 
   @override
@@ -136,6 +141,17 @@ class FakePlatformServices implements PlatformServices {
   String? defaultDaemonBinaryPath() => daemonBinaryPath;
 
   @override
+  Future<TcpPortState> probeDaemonPort({
+    Duration timeout = const Duration(milliseconds: 500),
+  }) async {
+    probeDaemonPortCalls++;
+    return tcpPortState;
+  }
+
+  @override
+  Future<bool> isDaemonSupervised() async => daemonSupervised;
+
+  @override
   Future<void> spawnDaemon(String binaryPath) async {
     spawnedDaemons.add(binaryPath);
   }
@@ -143,7 +159,10 @@ class FakePlatformServices implements PlatformServices {
   final List<({List<PR> prs, String me})> trayRebuilds = [];
 
   @override
-  Future<void> rebuildTrayMenu({required List<PR> prs, required String me}) async {
+  Future<void> rebuildTrayMenu({
+    required List<PR> prs,
+    required String me,
+  }) async {
     trayRebuilds.add((prs: prs, me: me));
   }
 

--- a/flutter_app/test/core/platform/platform_services_desktop_test.dart
+++ b/flutter_app/test/core/platform/platform_services_desktop_test.dart
@@ -65,26 +65,55 @@ void main() {
     });
 
     test(
-      'probeDaemonPort reports open while a listener owns the port',
+      'spawnDaemon refuses a port already owned by another process',
       () async {
-        final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-        addTearDown(server.close);
-        final services = DesktopPlatformServices(apiPort: server.port);
+        final binary = File('${tempDir.path}/heimdalld')..writeAsStringSync('');
+        final listener = await ServerSocket.bind(
+          InternetAddress.loopbackIPv4,
+          0,
+        );
+        addTearDown(listener.close);
+        var detachedStarts = 0;
+        final services = DesktopPlatformServices(
+          apiPort: listener.port,
+          isMacOS: false,
+          detachedDaemonStarter: (_) async => detachedStarts++,
+        );
 
-        expect(await services.probeDaemonPort(), TcpPortState.open);
+        await expectLater(
+          services.spawnDaemon(binary.path),
+          throwsA(
+            isA<DaemonPortOccupiedException>().having(
+              (error) => error.port,
+              'port',
+              listener.port,
+            ),
+          ),
+        );
+        expect(detachedStarts, 0);
       },
     );
 
-    test('probeDaemonPort reports closed after an explicit refusal', () async {
-      final reservation = await ServerSocket.bind(
-        InternetAddress.loopbackIPv4,
-        0,
+    test('spawnDaemon fails closed when port ownership is ambiguous', () async {
+      final binary = File('${tempDir.path}/heimdalld')..writeAsStringSync('');
+      var detachedStarts = 0;
+      final services = DesktopPlatformServices(
+        isMacOS: false,
+        daemonPortProbe: (_) async => TcpPortState.unknown,
+        detachedDaemonStarter: (_) async => detachedStarts++,
       );
-      final port = reservation.port;
-      await reservation.close();
-      final services = DesktopPlatformServices(apiPort: port);
 
-      expect(await services.probeDaemonPort(), TcpPortState.closed);
+      await expectLater(
+        services.spawnDaemon(binary.path),
+        throwsA(
+          isA<DaemonException>().having(
+            (error) => error.message,
+            'message',
+            contains('Could not prove'),
+          ),
+        ),
+      );
+      expect(detachedStarts, 0);
     });
 
     test(
@@ -136,6 +165,7 @@ void main() {
         var detachedStarts = 0;
         final services = DesktopPlatformServices(
           isMacOS: true,
+          daemonPortProbe: (_) async => TcpPortState.closed,
           processRunner: (executable, arguments) async {
             calls.add('$executable ${arguments.join(' ')}');
             if (executable == '/usr/bin/id') {
@@ -164,6 +194,7 @@ void main() {
         final detached = <String>[];
         final services = DesktopPlatformServices(
           isMacOS: true,
+          daemonPortProbe: (_) async => TcpPortState.closed,
           processRunner: (executable, arguments) async {
             if (executable == '/usr/bin/id') {
               return ProcessResult(1, 0, '501\n', '');
@@ -186,6 +217,7 @@ void main() {
         var detachedStarts = 0;
         final services = DesktopPlatformServices(
           isMacOS: true,
+          daemonPortProbe: (_) async => TcpPortState.closed,
           processRunner: (executable, arguments) async {
             if (executable == '/usr/bin/id') {
               return ProcessResult(1, 0, '501\n', '');
@@ -216,6 +248,7 @@ void main() {
         var detachedStarts = 0;
         final services = DesktopPlatformServices(
           isMacOS: true,
+          daemonPortProbe: (_) async => TcpPortState.closed,
           processRunner: (executable, arguments) async {
             if (executable == '/usr/bin/id') {
               return ProcessResult(1, 0, '501\n', '');

--- a/flutter_app/test/core/platform/platform_services_desktop_test.dart
+++ b/flutter_app/test/core/platform/platform_services_desktop_test.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/daemon/daemon_lifecycle.dart';
+import 'package:heimdallm/core/platform/platform_services.dart';
 import 'package:heimdallm/core/platform/platform_services_desktop.dart';
 
 void main() {
@@ -23,22 +25,27 @@ void main() {
     });
 
     test('loadApiToken returns null when the file does not exist', () async {
-      final services = DesktopPlatformServices(tokenPath: '${tempDir.path}/missing');
+      final services = DesktopPlatformServices(
+        tokenPath: '${tempDir.path}/missing',
+      );
       expect(await services.loadApiToken(), isNull);
     });
 
-    test('loadApiToken caches the token; clearApiTokenCache forces re-read', () async {
-      final tokenFile = File('${tempDir.path}/api_token')
-        ..writeAsStringSync('first');
-      final services = DesktopPlatformServices(tokenPath: tokenFile.path);
+    test(
+      'loadApiToken caches the token; clearApiTokenCache forces re-read',
+      () async {
+        final tokenFile = File('${tempDir.path}/api_token')
+          ..writeAsStringSync('first');
+        final services = DesktopPlatformServices(tokenPath: tokenFile.path);
 
-      expect(await services.loadApiToken(), 'first');
-      tokenFile.writeAsStringSync('second');
-      expect(await services.loadApiToken(), 'first'); // cached
+        expect(await services.loadApiToken(), 'first');
+        tokenFile.writeAsStringSync('second');
+        expect(await services.loadApiToken(), 'first'); // cached
 
-      services.clearApiTokenCache();
-      expect(await services.loadApiToken(), 'second');
-    });
+        services.clearApiTokenCache();
+        expect(await services.loadApiToken(), 'second');
+      },
+    );
 
     test('readEnv returns the value from Platform.environment', () {
       final services = DesktopPlatformServices();
@@ -57,29 +64,61 @@ void main() {
       expect(services.apiBaseUrl, 'http://127.0.0.1:9999');
     });
 
-    test('ensureSingleInstance writes a PID file and returns true on fresh start', () async {
-      final pidFile = File('${tempDir.path}/ui.pid');
-      final services = DesktopPlatformServices(pidFilePath: pidFile.path);
-      expect(await services.ensureSingleInstance(), isTrue);
-      expect(pidFile.existsSync(), isTrue);
-      expect(int.parse(pidFile.readAsStringSync().trim()), pid);
+    test(
+      'probeDaemonPort reports open while a listener owns the port',
+      () async {
+        final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(server.close);
+        final services = DesktopPlatformServices(apiPort: server.port);
+
+        expect(await services.probeDaemonPort(), TcpPortState.open);
+      },
+    );
+
+    test('probeDaemonPort reports closed after an explicit refusal', () async {
+      final reservation = await ServerSocket.bind(
+        InternetAddress.loopbackIPv4,
+        0,
+      );
+      final port = reservation.port;
+      await reservation.close();
+      final services = DesktopPlatformServices(apiPort: port);
+
+      expect(await services.probeDaemonPort(), TcpPortState.closed);
     });
 
-    test('ensureSingleInstance overwrites a stale PID file (process gone)', () async {
-      final pidFile = File('${tempDir.path}/ui.pid')
-        // Use an impossible high PID that is extremely unlikely to exist.
-        ..writeAsStringSync('999999999');
-      final services = DesktopPlatformServices(pidFilePath: pidFile.path);
-      expect(await services.ensureSingleInstance(), isTrue);
-      expect(int.parse(pidFile.readAsStringSync().trim()), pid);
-    });
+    test(
+      'ensureSingleInstance writes a PID file and returns true on fresh start',
+      () async {
+        final pidFile = File('${tempDir.path}/ui.pid');
+        final services = DesktopPlatformServices(pidFilePath: pidFile.path);
+        expect(await services.ensureSingleInstance(), isTrue);
+        expect(pidFile.existsSync(), isTrue);
+        expect(int.parse(pidFile.readAsStringSync().trim()), pid);
+      },
+    );
 
-    test('defaultDaemonBinaryPath returns null when HEIMDALLM_DAEMON_PATH is unset and no bundled binary', () {
-      // This matches the default test environment (no bundled binary next to
-      // the Flutter test runner). Covers the "not found" path.
-      final services = DesktopPlatformServices();
-      expect(services.defaultDaemonBinaryPath(), isNull);
-    });
+    test(
+      'ensureSingleInstance overwrites a stale PID file (process gone)',
+      () async {
+        final pidFile = File('${tempDir.path}/ui.pid')
+          // Use an impossible high PID that is extremely unlikely to exist.
+          ..writeAsStringSync('999999999');
+        final services = DesktopPlatformServices(pidFilePath: pidFile.path);
+        expect(await services.ensureSingleInstance(), isTrue);
+        expect(int.parse(pidFile.readAsStringSync().trim()), pid);
+      },
+    );
+
+    test(
+      'defaultDaemonBinaryPath returns null when HEIMDALLM_DAEMON_PATH is unset and no bundled binary',
+      () {
+        // This matches the default test environment (no bundled binary next to
+        // the Flutter test runner). Covers the "not found" path.
+        final services = DesktopPlatformServices();
+        expect(services.defaultDaemonBinaryPath(), isNull);
+      },
+    );
 
     test('spawnDaemon rejects when the binary does not exist', () async {
       final services = DesktopPlatformServices();
@@ -88,5 +127,119 @@ void main() {
         throwsA(isA<Exception>()),
       );
     });
+
+    test(
+      'spawnDaemon uses the loaded canonical LaunchAgent on macOS',
+      () async {
+        final binary = File('${tempDir.path}/heimdalld')..writeAsStringSync('');
+        final calls = <String>[];
+        var detachedStarts = 0;
+        final services = DesktopPlatformServices(
+          isMacOS: true,
+          processRunner: (executable, arguments) async {
+            calls.add('$executable ${arguments.join(' ')}');
+            if (executable == '/usr/bin/id') {
+              return ProcessResult(1, 0, '501\n', '');
+            }
+            return ProcessResult(1, 0, '', '');
+          },
+          detachedDaemonStarter: (_) async => detachedStarts++,
+        );
+
+        await services.spawnDaemon(binary.path);
+
+        expect(calls, [
+          '/usr/bin/id -u',
+          '/bin/launchctl print gui/501/com.heimdallm.daemon',
+          '/bin/launchctl kickstart gui/501/com.heimdallm.daemon',
+        ]);
+        expect(detachedStarts, 0);
+      },
+    );
+
+    test(
+      'spawnDaemon falls back to detached when LaunchAgent is absent',
+      () async {
+        final binary = File('${tempDir.path}/heimdalld')..writeAsStringSync('');
+        final detached = <String>[];
+        final services = DesktopPlatformServices(
+          isMacOS: true,
+          processRunner: (executable, arguments) async {
+            if (executable == '/usr/bin/id') {
+              return ProcessResult(1, 0, '501\n', '');
+            }
+            return ProcessResult(1, 113, '', 'Could not find service');
+          },
+          detachedDaemonStarter: (path) async => detached.add(path),
+        );
+
+        await services.spawnDaemon(binary.path);
+
+        expect(detached, [binary.path]);
+      },
+    );
+
+    test(
+      'spawnDaemon fails closed when LaunchAgent inspection is ambiguous',
+      () async {
+        final binary = File('${tempDir.path}/heimdalld')..writeAsStringSync('');
+        var detachedStarts = 0;
+        final services = DesktopPlatformServices(
+          isMacOS: true,
+          processRunner: (executable, arguments) async {
+            if (executable == '/usr/bin/id') {
+              return ProcessResult(1, 0, '501\n', '');
+            }
+            return ProcessResult(1, 1, '', 'Operation not permitted');
+          },
+          detachedDaemonStarter: (_) async => detachedStarts++,
+        );
+
+        await expectLater(
+          services.spawnDaemon(binary.path),
+          throwsA(
+            isA<DaemonException>().having(
+              (error) => error.message,
+              'message',
+              contains('Could not determine whether'),
+            ),
+          ),
+        );
+        expect(detachedStarts, 0);
+      },
+    );
+
+    test(
+      'spawnDaemon never falls back when launchctl kickstart fails',
+      () async {
+        final binary = File('${tempDir.path}/heimdalld')..writeAsStringSync('');
+        var detachedStarts = 0;
+        final services = DesktopPlatformServices(
+          isMacOS: true,
+          processRunner: (executable, arguments) async {
+            if (executable == '/usr/bin/id') {
+              return ProcessResult(1, 0, '501\n', '');
+            }
+            if (arguments.first == 'print') {
+              return ProcessResult(1, 0, '', '');
+            }
+            return ProcessResult(1, 5, '', 'kickstart failed');
+          },
+          detachedDaemonStarter: (_) async => detachedStarts++,
+        );
+
+        await expectLater(
+          services.spawnDaemon(binary.path),
+          throwsA(
+            isA<DaemonException>().having(
+              (error) => error.message,
+              'message',
+              contains('Could not start the supervised daemon'),
+            ),
+          ),
+        );
+        expect(detachedStarts, 0);
+      },
+    );
   });
 }

--- a/flutter_app/test/core/platform/platform_services_web_test.dart
+++ b/flutter_app/test/core/platform/platform_services_web_test.dart
@@ -8,6 +8,7 @@
 library;
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdallm/core/platform/platform_services.dart';
 import 'package:heimdallm/core/platform/platform_services_web.dart';
 
 void main() {
@@ -35,6 +36,20 @@ void main() {
 
     test('defaultDaemonBinaryPath returns null', () {
       expect(WebPlatformServices().defaultDaemonBinaryPath(), isNull);
+    });
+
+    test(
+      'probeDaemonPort fails closed because browsers cannot open TCP sockets',
+      () async {
+        expect(
+          await WebPlatformServices().probeDaemonPort(),
+          TcpPortState.unknown,
+        );
+      },
+    );
+
+    test('isDaemonSupervised is false on web', () async {
+      expect(await WebPlatformServices().isDaemonSupervised(), isFalse);
     });
 
     test('spawnDaemon throws UnsupportedError', () async {

--- a/flutter_app/test/core/platform/platform_services_web_test.dart
+++ b/flutter_app/test/core/platform/platform_services_web_test.dart
@@ -8,7 +8,6 @@
 library;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:heimdallm/core/platform/platform_services.dart';
 import 'package:heimdallm/core/platform/platform_services_web.dart';
 
 void main() {
@@ -36,20 +35,6 @@ void main() {
 
     test('defaultDaemonBinaryPath returns null', () {
       expect(WebPlatformServices().defaultDaemonBinaryPath(), isNull);
-    });
-
-    test(
-      'probeDaemonPort fails closed because browsers cannot open TCP sockets',
-      () async {
-        expect(
-          await WebPlatformServices().probeDaemonPort(),
-          TcpPortState.unknown,
-        );
-      },
-    );
-
-    test('isDaemonSupervised is false on web', () async {
-      expect(await WebPlatformServices().isDaemonSupervised(), isFalse);
     });
 
     test('spawnDaemon throws UnsupportedError', () async {

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -6,10 +5,11 @@ import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:heimdallm/core/api/api_client.dart';
 import 'package:heimdallm/core/models/config_model.dart';
+import 'package:heimdallm/core/platform/platform_services.dart';
 import 'package:heimdallm/core/platform/platform_services_provider.dart';
 import 'package:heimdallm/core/setup/first_run_setup.dart';
 import 'package:heimdallm/features/config/config_providers.dart'
-    show ConfigNotifier, configNotifierProvider, computeGlobalDiffForTest;
+    show ConfigNotifier, configNotifierProvider, computeGlobalDiffForTest, daemonHealthProvider;
 import 'package:heimdallm/features/config/config_screen.dart';
 import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
 import 'package:heimdallm/features/repositories/repo_diff.dart';
@@ -25,6 +25,19 @@ void main() {
     registerFallbackValue(<String, dynamic>{});
   });
 
+  test('daemon running state includes degraded but reachable daemons', () async {
+    final mockApi = MockApiClient();
+    when(() => mockApi.daemonReachable())
+        .thenAnswer((_) async => PortOwner.daemon);
+    final container = ProviderContainer(
+      overrides: [apiClientProvider.overrideWithValue(mockApi)],
+    );
+    addTearDown(container.dispose);
+
+    expect(await container.read(daemonHealthProvider.future), isTrue);
+    verifyNever(() => mockApi.checkHealth());
+  });
+
   testWidgets('ConfigScreen shows current poll interval', (tester) async {
     const config = AppConfig(
       pollInterval: '5m',
@@ -35,7 +48,7 @@ void main() {
     final mockApi = MockApiClient();
     when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
     when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
-    when(() => mockApi.checkHealth()).thenAnswer((_) async => false);
+    when(() => mockApi.daemonReachable()).thenAnswer((_) async => PortOwner.none);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -74,7 +87,7 @@ void main() {
     final mockApi = MockApiClient();
     when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
     when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
-    when(() => mockApi.checkHealth()).thenAnswer((_) async => false);
+    when(() => mockApi.daemonReachable()).thenAnswer((_) async => PortOwner.none);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -120,7 +133,7 @@ void main() {
     final mockApi = MockApiClient();
     when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
     when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
-    when(() => mockApi.checkHealth()).thenAnswer((_) async => false);
+    when(() => mockApi.daemonReachable()).thenAnswer((_) async => PortOwner.none);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -161,7 +174,7 @@ void main() {
     final mockApi = MockApiClient();
     when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
     when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
-    when(() => mockApi.checkHealth()).thenAnswer((_) async => false);
+    when(() => mockApi.daemonReachable()).thenAnswer((_) async => PortOwner.none);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -474,7 +487,7 @@ void main() {
       ).toJson(),
     );
     when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
-    when(() => mockApi.checkHealth()).thenAnswer((_) async => false);
+    when(() => mockApi.daemonReachable()).thenAnswer((_) async => PortOwner.none);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -671,78 +684,95 @@ void main() {
 
   // ── saveAndStartDaemon tests ───────────────────────────────────────────────
 
-  testWidgets('saveAndStartDaemon calls platform.spawnDaemon', (tester) async {
+  test('saveAndStartDaemon spawns only after ownership reports none', () async {
     final platform = FakePlatformServices(
       daemonBinaryPath: '/fake/bin/heimdalld',
       githubToken: 'fake-token',
+      tcpPortState: TcpPortState.closed,
     );
+    final mockApi = MockApiClient();
+    when(() => mockApi.fetchConfig())
+        .thenAnswer((_) async => const AppConfig().toJson());
+    when(() => mockApi.daemonReachable())
+        .thenAnswer((_) async => PortOwner.none);
+    when(() => mockApi.checkHealth()).thenAnswer((_) async => true);
     final container = ProviderContainer(
-      // Riverpod 3 retries failed providers by default; saveAndStartDaemon's
-      // health check is expected to fail in this test, so disable retries to
-      // avoid pending timers after the test body returns.
       retry: (_, _) => null,
-      overrides: [platformServicesProvider.overrideWithValue(platform)],
+      overrides: [
+        apiClientProvider.overrideWithValue(mockApi),
+        platformServicesProvider.overrideWithValue(platform),
+      ],
     );
     addTearDown(container.dispose);
+    await container.read(configNotifierProvider.future);
 
-    // Call saveAndStartDaemon via the notifier. We don't verify daemon health
-    // (the fake's ApiClient isn't wired), but we do verify the spawn reached
-    // the platform layer at least once before the health-check loop timed out.
-    final notifier = container.read(configNotifierProvider.notifier);
+    await container.read(configNotifierProvider.notifier).saveAndStartDaemon(
+      token: 'fake-gh-token',
+      config: const AppConfig(),
+      daemonBinaryPath: '/fake/bin/heimdalld',
+    );
 
-    // Run in real-async mode so Future.delayed works without fake-async leaks.
-    await tester.runAsync(() async {
-      unawaited(
-        notifier.saveAndStartDaemon(
-          token: 'fake-gh-token',
-          config: const AppConfig(),
-          daemonBinaryPath: '/fake/bin/heimdalld',
-        ),
-      );
-      // Allow the microtasks that lead to the first spawnDaemon to run.
-      await Future.delayed(const Duration(milliseconds: 50));
-    });
-
-    expect(platform.spawnedDaemons, contains('/fake/bin/heimdalld'));
+    expect(platform.spawnedDaemons, ['/fake/bin/heimdalld']);
+    expect(container.read(configNotifierProvider), isA<AsyncData<AppConfig>>());
   });
 
-  testWidgets(
-    'saveAndStartDaemon routes daemon spawn through PlatformServices',
-    (tester) async {
-      final platform = FakePlatformServices(
-        daemonBinaryPath: '/fake/bin/heimdalld',
-        githubToken: 'fake-token',
-      );
-      final container = ProviderContainer(
-        // Riverpod 3 retries failed providers by default; saveAndStartDaemon's
-        // health check is expected to fail in this test, so disable retries to
-        // avoid pending timers after the test body returns.
-        retry: (_, _) => null,
-        overrides: [platformServicesProvider.overrideWithValue(platform)],
-      );
-      addTearDown(container.dispose);
+  test('saveAndStartDaemon reuses an existing daemon without spawning', () async {
+    final platform = FakePlatformServices();
+    final mockApi = MockApiClient();
+    when(() => mockApi.fetchConfig())
+        .thenAnswer((_) async => const AppConfig().toJson());
+    when(() => mockApi.daemonReachable())
+        .thenAnswer((_) async => PortOwner.daemon);
+    when(() => mockApi.checkHealth()).thenAnswer((_) async => true);
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        apiClientProvider.overrideWithValue(mockApi),
+        platformServicesProvider.overrideWithValue(platform),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(configNotifierProvider.future);
 
-      // Call saveAndStartDaemon via the notifier. We don't verify daemon health
-      // (the fake's ApiClient isn't wired), but we do verify the spawn reached
-      // the platform layer at least once before the health-check loop timed out.
-      final notifier = container.read(configNotifierProvider.notifier);
-      // Kick off the call but ignore its completion — we only care about the
-      // side-effect of calling spawnDaemon.
-      await tester.runAsync(() async {
-        unawaited(
-          notifier.saveAndStartDaemon(
-            token: 'fake-gh-token',
-            config: const AppConfig(),
-            daemonBinaryPath: '/fake/bin/heimdalld',
-          ),
-        );
-        // Allow the microtasks that lead to the first spawnDaemon to run.
-        await Future.delayed(const Duration(milliseconds: 50));
-      });
+    await container.read(configNotifierProvider.notifier).saveAndStartDaemon(
+      token: 'fake-gh-token',
+      config: const AppConfig(),
+      daemonBinaryPath: '/fake/bin/heimdalld',
+    );
 
-      expect(platform.spawnedDaemons, contains('/fake/bin/heimdalld'));
-    },
-  );
+    expect(platform.spawnedDaemons, isEmpty);
+    expect(container.read(configNotifierProvider), isA<AsyncData<AppConfig>>());
+  });
+
+  test('saveAndStartDaemon refuses a foreign or ambiguous port', () async {
+    final platform = FakePlatformServices();
+    final mockApi = MockApiClient();
+    when(() => mockApi.fetchConfig())
+        .thenAnswer((_) async => const AppConfig().toJson());
+    when(() => mockApi.daemonReachable())
+        .thenAnswer((_) async => PortOwner.foreign);
+    when(() => mockApi.daemonPort).thenReturn(7842);
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        apiClientProvider.overrideWithValue(mockApi),
+        platformServicesProvider.overrideWithValue(platform),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(configNotifierProvider.future);
+
+    await container.read(configNotifierProvider.notifier).saveAndStartDaemon(
+      token: 'fake-gh-token',
+      config: const AppConfig(),
+      daemonBinaryPath: '/fake/bin/heimdalld',
+    );
+
+    final result = container.read(configNotifierProvider);
+    expect(platform.spawnedDaemons, isEmpty);
+    expect(result, isA<AsyncError<AppConfig>>());
+    expect(result.error.toString(), contains('No daemon was started'));
+  });
 
   // ── AutonomousConfig ───────────────────────────────────────────────────────
 

--- a/flutter_app/test/features/config_test.dart
+++ b/flutter_app/test/features/config_test.dart
@@ -5,11 +5,14 @@ import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:heimdallm/core/api/api_client.dart';
 import 'package:heimdallm/core/models/config_model.dart';
-import 'package:heimdallm/core/platform/platform_services.dart';
 import 'package:heimdallm/core/platform/platform_services_provider.dart';
 import 'package:heimdallm/core/setup/first_run_setup.dart';
 import 'package:heimdallm/features/config/config_providers.dart'
-    show ConfigNotifier, configNotifierProvider, computeGlobalDiffForTest, daemonHealthProvider;
+    show
+        ConfigNotifier,
+        configNotifierProvider,
+        computeGlobalDiffForTest,
+        daemonHealthProvider;
 import 'package:heimdallm/features/config/config_screen.dart';
 import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
 import 'package:heimdallm/features/repositories/repo_diff.dart';
@@ -20,23 +23,39 @@ import '../core/platform/fake_platform_services.dart';
 
 class MockApiClient extends Mock implements ApiClient {}
 
+class ThrowingPlatformServices extends FakePlatformServices {
+  ThrowingPlatformServices({required this.error});
+
+  final Object error;
+
+  @override
+  Future<void> spawnDaemon(String binaryPath) async {
+    spawnedDaemons.add(binaryPath);
+    throw error;
+  }
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<String, dynamic>{});
   });
 
-  test('daemon running state includes degraded but reachable daemons', () async {
-    final mockApi = MockApiClient();
-    when(() => mockApi.daemonReachable())
-        .thenAnswer((_) async => PortOwner.daemon);
-    final container = ProviderContainer(
-      overrides: [apiClientProvider.overrideWithValue(mockApi)],
-    );
-    addTearDown(container.dispose);
+  test(
+    'daemon running state includes degraded but reachable daemons',
+    () async {
+      final mockApi = MockApiClient();
+      when(
+        () => mockApi.daemonReachable(),
+      ).thenAnswer((_) async => PortOwner.daemon);
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(mockApi)],
+      );
+      addTearDown(container.dispose);
 
-    expect(await container.read(daemonHealthProvider.future), isTrue);
-    verifyNever(() => mockApi.checkHealth());
-  });
+      expect(await container.read(daemonHealthProvider.future), isTrue);
+      verifyNever(() => mockApi.checkHealth());
+    },
+  );
 
   testWidgets('ConfigScreen shows current poll interval', (tester) async {
     const config = AppConfig(
@@ -48,7 +67,9 @@ void main() {
     final mockApi = MockApiClient();
     when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
     when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
-    when(() => mockApi.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+    when(
+      () => mockApi.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.none);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -87,7 +108,9 @@ void main() {
     final mockApi = MockApiClient();
     when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
     when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
-    when(() => mockApi.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+    when(
+      () => mockApi.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.none);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -133,7 +156,9 @@ void main() {
     final mockApi = MockApiClient();
     when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
     when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
-    when(() => mockApi.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+    when(
+      () => mockApi.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.none);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -174,7 +199,9 @@ void main() {
     final mockApi = MockApiClient();
     when(() => mockApi.fetchConfig()).thenAnswer((_) async => config.toJson());
     when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
-    when(() => mockApi.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+    when(
+      () => mockApi.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.none);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -226,14 +253,22 @@ void main() {
 
     test('rejects values below the 1m floor', () {
       for (final v in ['59s', '30s', '0s', '1ms']) {
-        expect(validatePollInterval(v), 'Must be between 1m and 24h', reason: v);
+        expect(
+          validatePollInterval(v),
+          'Must be between 1m and 24h',
+          reason: v,
+        );
       }
     });
 
     test('rejects values above the 24h ceiling', () {
       // Parseable but out of range → the range message, not a parse error.
       for (final v in ['25h', '1441m']) {
-        expect(validatePollInterval(v), 'Must be between 1m and 24h', reason: v);
+        expect(
+          validatePollInterval(v),
+          'Must be between 1m and 24h',
+          reason: v,
+        );
       }
     });
 
@@ -487,7 +522,9 @@ void main() {
       ).toJson(),
     );
     when(() => mockApi.updateConfig(any())).thenAnswer((_) async {});
-    when(() => mockApi.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+    when(
+      () => mockApi.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.none);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -608,11 +645,14 @@ void main() {
     expect(cfg.useGraphql, isFalse);
   });
 
-  test('PollingConfig.fromJson parses rate_limit_safety_threshold as int via num', () {
-    // The daemon may send it as a JSON number (double or int)
-    final cfg = PollingConfig.fromJson({'rate_limit_safety_threshold': 150});
-    expect(cfg.rateLimitSafetyThreshold, 150);
-  });
+  test(
+    'PollingConfig.fromJson parses rate_limit_safety_threshold as int via num',
+    () {
+      // The daemon may send it as a JSON number (double or int)
+      final cfg = PollingConfig.fromJson({'rate_limit_safety_threshold': 150});
+      expect(cfg.rateLimitSafetyThreshold, 150);
+    },
+  );
 
   test('AppConfig.fromJson parses nested polling object', () {
     final json = {
@@ -643,21 +683,24 @@ void main() {
     expect(cfg.polling.rateLimitSafetyThreshold, 50);
   });
 
-  test('AppConfig.fromJson uses PollingConfig defaults when polling key absent', () {
-    final json = {
-      'repositories': <String>[],
-      'server_port': 7842,
-      'poll_interval': '5m',
-      'retention_days': 90,
-      'ai_primary': 'claude',
-      'ai_fallback': '',
-      'review_mode': 'single',
-      'issue_tracking': {'enabled': false},
-    };
-    final cfg = AppConfig.fromJson(json);
-    expect(cfg.polling.adaptive, isFalse);
-    expect(cfg.polling.useEtag, isTrue);
-  });
+  test(
+    'AppConfig.fromJson uses PollingConfig defaults when polling key absent',
+    () {
+      final json = {
+        'repositories': <String>[],
+        'server_port': 7842,
+        'poll_interval': '5m',
+        'retention_days': 90,
+        'ai_primary': 'claude',
+        'ai_fallback': '',
+        'review_mode': 'single',
+        'issue_tracking': {'enabled': false},
+      };
+      final cfg = AppConfig.fromJson(json);
+      expect(cfg.polling.adaptive, isFalse);
+      expect(cfg.polling.useEtag, isTrue);
+    },
+  );
 
   test('_computeGlobalDiff emits polling diff only for changed fields', () {
     const old = AppConfig();
@@ -688,13 +731,14 @@ void main() {
     final platform = FakePlatformServices(
       daemonBinaryPath: '/fake/bin/heimdalld',
       githubToken: 'fake-token',
-      tcpPortState: TcpPortState.closed,
     );
     final mockApi = MockApiClient();
-    when(() => mockApi.fetchConfig())
-        .thenAnswer((_) async => const AppConfig().toJson());
-    when(() => mockApi.daemonReachable())
-        .thenAnswer((_) async => PortOwner.none);
+    when(
+      () => mockApi.fetchConfig(),
+    ).thenAnswer((_) async => const AppConfig().toJson());
+    when(
+      () => mockApi.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.none);
     when(() => mockApi.checkHealth()).thenAnswer((_) async => true);
     final container = ProviderContainer(
       retry: (_, _) => null,
@@ -706,51 +750,65 @@ void main() {
     addTearDown(container.dispose);
     await container.read(configNotifierProvider.future);
 
-    await container.read(configNotifierProvider.notifier).saveAndStartDaemon(
-      token: 'fake-gh-token',
-      config: const AppConfig(),
-      daemonBinaryPath: '/fake/bin/heimdalld',
-    );
+    await container
+        .read(configNotifierProvider.notifier)
+        .saveAndStartDaemon(
+          token: 'fake-gh-token',
+          config: const AppConfig(),
+          daemonBinaryPath: '/fake/bin/heimdalld',
+        );
 
     expect(platform.spawnedDaemons, ['/fake/bin/heimdalld']);
     expect(container.read(configNotifierProvider), isA<AsyncData<AppConfig>>());
   });
 
-  test('saveAndStartDaemon reuses an existing daemon without spawning', () async {
-    final platform = FakePlatformServices();
-    final mockApi = MockApiClient();
-    when(() => mockApi.fetchConfig())
-        .thenAnswer((_) async => const AppConfig().toJson());
-    when(() => mockApi.daemonReachable())
-        .thenAnswer((_) async => PortOwner.daemon);
-    when(() => mockApi.checkHealth()).thenAnswer((_) async => true);
-    final container = ProviderContainer(
-      retry: (_, _) => null,
-      overrides: [
-        apiClientProvider.overrideWithValue(mockApi),
-        platformServicesProvider.overrideWithValue(platform),
-      ],
-    );
-    addTearDown(container.dispose);
-    await container.read(configNotifierProvider.future);
+  test(
+    'saveAndStartDaemon reuses an existing daemon without spawning',
+    () async {
+      final platform = FakePlatformServices();
+      final mockApi = MockApiClient();
+      when(
+        () => mockApi.fetchConfig(),
+      ).thenAnswer((_) async => const AppConfig().toJson());
+      when(
+        () => mockApi.daemonReachable(),
+      ).thenAnswer((_) async => PortOwner.daemon);
+      when(() => mockApi.checkHealth()).thenAnswer((_) async => true);
+      final container = ProviderContainer(
+        retry: (_, _) => null,
+        overrides: [
+          apiClientProvider.overrideWithValue(mockApi),
+          platformServicesProvider.overrideWithValue(platform),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(configNotifierProvider.future);
 
-    await container.read(configNotifierProvider.notifier).saveAndStartDaemon(
-      token: 'fake-gh-token',
-      config: const AppConfig(),
-      daemonBinaryPath: '/fake/bin/heimdalld',
-    );
+      await container
+          .read(configNotifierProvider.notifier)
+          .saveAndStartDaemon(
+            token: 'fake-gh-token',
+            config: const AppConfig(),
+            daemonBinaryPath: '/fake/bin/heimdalld',
+          );
 
-    expect(platform.spawnedDaemons, isEmpty);
-    expect(container.read(configNotifierProvider), isA<AsyncData<AppConfig>>());
-  });
+      expect(platform.spawnedDaemons, isEmpty);
+      expect(
+        container.read(configNotifierProvider),
+        isA<AsyncData<AppConfig>>(),
+      );
+    },
+  );
 
   test('saveAndStartDaemon refuses a foreign or ambiguous port', () async {
     final platform = FakePlatformServices();
     final mockApi = MockApiClient();
-    when(() => mockApi.fetchConfig())
-        .thenAnswer((_) async => const AppConfig().toJson());
-    when(() => mockApi.daemonReachable())
-        .thenAnswer((_) async => PortOwner.foreign);
+    when(
+      () => mockApi.fetchConfig(),
+    ).thenAnswer((_) async => const AppConfig().toJson());
+    when(
+      () => mockApi.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.foreign);
     when(() => mockApi.daemonPort).thenReturn(7842);
     final container = ProviderContainer(
       retry: (_, _) => null,
@@ -762,16 +820,120 @@ void main() {
     addTearDown(container.dispose);
     await container.read(configNotifierProvider.future);
 
-    await container.read(configNotifierProvider.notifier).saveAndStartDaemon(
-      token: 'fake-gh-token',
-      config: const AppConfig(),
-      daemonBinaryPath: '/fake/bin/heimdalld',
-    );
+    await container
+        .read(configNotifierProvider.notifier)
+        .saveAndStartDaemon(
+          token: 'fake-gh-token',
+          config: const AppConfig(),
+          daemonBinaryPath: '/fake/bin/heimdalld',
+        );
 
     final result = container.read(configNotifierProvider);
     expect(platform.spawnedDaemons, isEmpty);
     expect(result, isA<AsyncError<AppConfig>>());
     expect(result.error.toString(), contains('No daemon was started'));
+  });
+
+  test('saveAndStartDaemon reports retryable process failures', () async {
+    final platform = ThrowingPlatformServices(error: StateError('blocked'));
+    final mockApi = MockApiClient();
+    when(
+      () => mockApi.fetchConfig(),
+    ).thenAnswer((_) async => const AppConfig().toJson());
+    when(
+      () => mockApi.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.none);
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        apiClientProvider.overrideWithValue(mockApi),
+        platformServicesProvider.overrideWithValue(platform),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(configNotifierProvider.future);
+
+    await container
+        .read(configNotifierProvider.notifier)
+        .saveAndStartDaemon(
+          token: 'fake-gh-token',
+          config: const AppConfig(),
+          daemonBinaryPath: '/fake/bin/heimdalld',
+          maxSpawnAttempts: 2,
+        );
+
+    final result = container.read(configNotifierProvider);
+    expect(result, isA<AsyncError<AppConfig>>());
+    expect(result.error.toString(), contains('blocked'));
+  });
+
+  test('saveAndStartDaemon reports terminal process failures', () async {
+    final platform = ThrowingPlatformServices(error: StateError('terminal'));
+    final mockApi = MockApiClient();
+    when(
+      () => mockApi.fetchConfig(),
+    ).thenAnswer((_) async => const AppConfig().toJson());
+    when(
+      () => mockApi.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.none);
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        apiClientProvider.overrideWithValue(mockApi),
+        platformServicesProvider.overrideWithValue(platform),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(configNotifierProvider.future);
+
+    await container
+        .read(configNotifierProvider.notifier)
+        .saveAndStartDaemon(
+          token: 'fake-gh-token',
+          config: const AppConfig(),
+          daemonBinaryPath: '/fake/bin/heimdalld',
+        );
+
+    final result = container.read(configNotifierProvider);
+    expect(result, isA<AsyncError<AppConfig>>());
+    expect(result.error.toString(), contains('terminal'));
+  });
+
+  test('saveAndStartDaemon explains an existing unhealthy daemon', () async {
+    final platform = FakePlatformServices();
+    final mockApi = MockApiClient();
+    when(
+      () => mockApi.fetchConfig(),
+    ).thenAnswer((_) async => const AppConfig().toJson());
+    when(
+      () => mockApi.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.daemon);
+    when(() => mockApi.daemonPort).thenReturn(7842);
+    when(() => mockApi.checkHealth()).thenAnswer((_) async => false);
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        apiClientProvider.overrideWithValue(mockApi),
+        platformServicesProvider.overrideWithValue(platform),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(configNotifierProvider.future);
+
+    await container
+        .read(configNotifierProvider.notifier)
+        .saveAndStartDaemon(
+          token: 'fake-gh-token',
+          config: const AppConfig(),
+          daemonBinaryPath: '/fake/bin/heimdalld',
+          healthCheckMaxAttempts: 1,
+          healthCheckInterval: Duration.zero,
+        );
+
+    final result = container.read(configNotifierProvider);
+    expect(result, isA<AsyncError<AppConfig>>());
+    expect(result.error.toString(), contains('already running on port 7842'));
+    expect(platform.spawnedDaemons, isEmpty);
   });
 
   // ── AutonomousConfig ───────────────────────────────────────────────────────
@@ -877,10 +1039,7 @@ void main() {
         'merge_method': 'merge',
         'dev_effort': 'low',
       },
-      'circuit_breaker': {
-        'per_pr_24h': 10,
-        'per_repo_hr': 50,
-      },
+      'circuit_breaker': {'per_pr_24h': 10, 'per_repo_hr': 50},
     };
 
     final cfg = AppConfig.fromJson(json);
@@ -893,86 +1052,101 @@ void main() {
     expect(cfg.circuitBreaker.perIssue24h, 3);
   });
 
-  test('AppConfig.fromJson uses defaults when autonomous/circuit_breaker absent', () {
-    final json = {
-      'repositories': <String>[],
-      'server_port': 7842,
-      'poll_interval': '5m',
-      'retention_days': 90,
-      'ai_primary': 'claude',
-      'ai_fallback': '',
-      'review_mode': 'single',
-      'issue_tracking': {'enabled': false},
-    };
+  test(
+    'AppConfig.fromJson uses defaults when autonomous/circuit_breaker absent',
+    () {
+      final json = {
+        'repositories': <String>[],
+        'server_port': 7842,
+        'poll_interval': '5m',
+        'retention_days': 90,
+        'ai_primary': 'claude',
+        'ai_fallback': '',
+        'review_mode': 'single',
+        'issue_tracking': {'enabled': false},
+      };
 
-    final cfg = AppConfig.fromJson(json);
-    expect(cfg.autonomous.enabled, isFalse);
-    expect(cfg.autonomous.mergeMethod, 'squash');
-    expect(cfg.circuitBreaker.perPr24h, 3);
-  });
+      final cfg = AppConfig.fromJson(json);
+      expect(cfg.autonomous.enabled, isFalse);
+      expect(cfg.autonomous.mergeMethod, 'squash');
+      expect(cfg.circuitBreaker.perPr24h, 3);
+    },
+  );
 
   // ── _computeGlobalDiff via ConfigNotifier.save ────────────────────────────
 
-  test('_computeGlobalDiff emits autonomous diff when enabled changes', () async {
-    final mockApi = MockApiClient();
-    Map<String, dynamic>? capturedPatch;
+  test(
+    '_computeGlobalDiff emits autonomous diff when enabled changes',
+    () async {
+      final mockApi = MockApiClient();
+      Map<String, dynamic>? capturedPatch;
 
-    const initialConfig = AppConfig();
-    when(() => mockApi.fetchConfig()).thenAnswer((_) async => initialConfig.toJson());
-    when(() => mockApi.patchConfig(any())).thenAnswer((invocation) async {
-      capturedPatch = invocation.positionalArguments[0] as Map<String, dynamic>;
-      return initialConfig.copyWith(
+      const initialConfig = AppConfig();
+      when(
+        () => mockApi.fetchConfig(),
+      ).thenAnswer((_) async => initialConfig.toJson());
+      when(() => mockApi.patchConfig(any())).thenAnswer((invocation) async {
+        capturedPatch =
+            invocation.positionalArguments[0] as Map<String, dynamic>;
+        return initialConfig
+            .copyWith(autonomous: const AutonomousConfig(enabled: true))
+            .toJson();
+      });
+
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(mockApi)],
+      );
+      addTearDown(container.dispose);
+
+      // Wait for the provider to load
+      await container.read(configNotifierProvider.future);
+
+      final updated = initialConfig.copyWith(
         autonomous: const AutonomousConfig(enabled: true),
-      ).toJson();
-    });
+      );
+      await container.read(configNotifierProvider.notifier).save(updated);
 
-    final container = ProviderContainer(
-      overrides: [apiClientProvider.overrideWithValue(mockApi)],
-    );
-    addTearDown(container.dispose);
+      expect(capturedPatch, isNotNull);
+      expect(capturedPatch!['autonomous'], isNotNull);
+      expect(capturedPatch!['autonomous']['enabled'], isTrue);
+    },
+  );
 
-    // Wait for the provider to load
-    await container.read(configNotifierProvider.future);
+  test(
+    '_computeGlobalDiff emits circuit_breaker diff when a field changes',
+    () async {
+      final mockApi = MockApiClient();
+      Map<String, dynamic>? capturedPatch;
 
-    final updated = initialConfig.copyWith(
-      autonomous: const AutonomousConfig(enabled: true),
-    );
-    await container.read(configNotifierProvider.notifier).save(updated);
+      const initialConfig = AppConfig();
+      when(
+        () => mockApi.fetchConfig(),
+      ).thenAnswer((_) async => initialConfig.toJson());
+      when(() => mockApi.patchConfig(any())).thenAnswer((invocation) async {
+        capturedPatch =
+            invocation.positionalArguments[0] as Map<String, dynamic>;
+        return initialConfig
+            .copyWith(circuitBreaker: const CircuitBreakerConfig(perPr24h: 10))
+            .toJson();
+      });
 
-    expect(capturedPatch, isNotNull);
-    expect(capturedPatch!['autonomous'], isNotNull);
-    expect(capturedPatch!['autonomous']['enabled'], isTrue);
-  });
+      final container = ProviderContainer(
+        overrides: [apiClientProvider.overrideWithValue(mockApi)],
+      );
+      addTearDown(container.dispose);
 
-  test('_computeGlobalDiff emits circuit_breaker diff when a field changes', () async {
-    final mockApi = MockApiClient();
-    Map<String, dynamic>? capturedPatch;
+      await container.read(configNotifierProvider.future);
 
-    const initialConfig = AppConfig();
-    when(() => mockApi.fetchConfig()).thenAnswer((_) async => initialConfig.toJson());
-    when(() => mockApi.patchConfig(any())).thenAnswer((invocation) async {
-      capturedPatch = invocation.positionalArguments[0] as Map<String, dynamic>;
-      return initialConfig.copyWith(
+      final updated = initialConfig.copyWith(
         circuitBreaker: const CircuitBreakerConfig(perPr24h: 10),
-      ).toJson();
-    });
+      );
+      await container.read(configNotifierProvider.notifier).save(updated);
 
-    final container = ProviderContainer(
-      overrides: [apiClientProvider.overrideWithValue(mockApi)],
-    );
-    addTearDown(container.dispose);
-
-    await container.read(configNotifierProvider.future);
-
-    final updated = initialConfig.copyWith(
-      circuitBreaker: const CircuitBreakerConfig(perPr24h: 10),
-    );
-    await container.read(configNotifierProvider.notifier).save(updated);
-
-    expect(capturedPatch, isNotNull);
-    expect(capturedPatch!['circuit_breaker'], isNotNull);
-    expect(capturedPatch!['circuit_breaker']['per_pr_24h'], 10);
-  });
+      expect(capturedPatch, isNotNull);
+      expect(capturedPatch!['circuit_breaker'], isNotNull);
+      expect(capturedPatch!['circuit_breaker']['per_pr_24h'], 10);
+    },
+  );
 
   test('never_approve_with_issues round-trips (global + repo override)', () {
     final json = {
@@ -996,10 +1170,13 @@ void main() {
     expect(cleared.neverApproveWithIssues, isNull);
   });
 
-  test('OrgConfig.hasOverride true when only never_approve_with_issues set', () {
-    const org = OrgConfig(neverApproveWithIssues: true);
-    expect(org.hasOverride, isTrue);
-  });
+  test(
+    'OrgConfig.hasOverride true when only never_approve_with_issues set',
+    () {
+      const org = OrgConfig(neverApproveWithIssues: true);
+      expect(org.hasOverride, isTrue);
+    },
+  );
 
   test('repo diff includes never_approve_with_issues when set', () {
     const oldCfg = RepoConfig();
@@ -1092,9 +1269,6 @@ void main() {
     const oldCfg = RepoConfig();
     final updated = oldCfg.copyWith(issueOrganizations: ['acme']);
     final diff = computeRepoDiff(oldCfg, updated);
-    expect(
-      (diff['issue_tracking'] as Map)['organizations'],
-      ['acme'],
-    );
+    expect((diff['issue_tracking'] as Map)['organizations'], ['acme']);
   });
 }

--- a/flutter_app/test/features/dashboard_test.dart
+++ b/flutter_app/test/features/dashboard_test.dart
@@ -15,6 +15,7 @@ import 'package:heimdallm/features/dashboard/activity_filters.dart';
 import 'package:heimdallm/features/dashboard/dashboard_providers.dart';
 import 'package:heimdallm/features/dashboard/dashboard_screen.dart';
 import 'package:heimdallm/features/issues/issues_providers.dart';
+import 'package:heimdallm/features/server/server_actions.dart';
 import '../core/platform/fake_platform_services.dart';
 
 class MockApiClient extends Mock implements ApiClient {}
@@ -92,6 +93,128 @@ Future<void> _pumpOfflineDashboard(
 }
 
 void main() {
+  test(
+    'restart waits for daemon port release, not health degradation',
+    () async {
+      final api = MockApiClient();
+      final owners = <PortOwner>[
+        PortOwner.daemon,
+        PortOwner.daemon,
+        PortOwner.none,
+      ];
+      when(
+        () => api.daemonReachable(),
+      ).thenAnswer((_) async => owners.removeAt(0));
+
+      final owner = await waitForDaemonPortRelease(
+        api,
+        delays: const [Duration.zero, Duration.zero, Duration.zero],
+      );
+
+      expect(owner, PortOwner.none);
+      verify(() => api.daemonReachable()).called(3);
+      verifyNever(() => api.checkHealth());
+    },
+  );
+
+  testWidgets(
+    'restart accepts a LaunchAgent reappearance without detached spawn',
+    (tester) async {
+      final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
+      final api = MockApiClient();
+      final owners = <PortOwner>[PortOwner.none, PortOwner.daemon];
+      when(() => api.shutdownDaemon()).thenAnswer((_) async {});
+      when(
+        () => api.daemonReachable(),
+      ).thenAnswer((_) async => owners.removeAt(0));
+      when(() => api.checkHealth()).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiClientProvider.overrideWithValue(api),
+            platformServicesProvider.overrideWithValue(platform),
+          ],
+          child: MaterialApp(
+            home: Consumer(
+              builder: (context, ref, _) => Scaffold(
+                body: FilledButton(
+                  onPressed: () => restartDaemon(context, ref),
+                  child: const Text('Restart test daemon'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Restart test daemon'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump();
+
+      expect(platform.spawnedDaemons, isEmpty);
+      expect(find.text('Server restarted'), findsOneWidget);
+      verify(() => api.daemonReachable()).called(2);
+      verify(() => api.checkHealth()).called(1);
+    },
+  );
+
+  testWidgets(
+    'restart accepts a supervised daemon that reappears before port release',
+    (tester) async {
+      final platform = FakePlatformServices(daemonSupervised: true);
+      final api = MockApiClient();
+      when(() => api.shutdownDaemon()).thenAnswer((_) async {});
+      when(
+        () => api.daemonReachable(),
+      ).thenAnswer((_) async => PortOwner.daemon);
+      when(() => api.checkHealth()).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiClientProvider.overrideWithValue(api),
+            platformServicesProvider.overrideWithValue(platform),
+          ],
+          child: MaterialApp(
+            home: Consumer(
+              builder: (context, ref, _) => Scaffold(
+                body: FilledButton(
+                  onPressed: () => restartDaemon(context, ref),
+                  child: const Text('Restart supervised daemon'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Restart supervised daemon'));
+      await tester.pump();
+      for (final delay in const [
+        Duration(milliseconds: 200),
+        Duration(milliseconds: 300),
+        Duration(milliseconds: 500),
+        Duration(milliseconds: 800),
+        Duration(milliseconds: 1200),
+        Duration(seconds: 2),
+      ]) {
+        await tester.pump(delay);
+        await tester.pump();
+      }
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump();
+
+      expect(platform.spawnedDaemons, isEmpty);
+      expect(find.text('Server restarted'), findsOneWidget);
+      verify(() => api.daemonReachable()).called(6);
+      verify(() => api.checkHealth()).called(1);
+    },
+  );
+
   test('SortNotifier handles preference load failures', () async {
     TestWidgetsFlutterBinding.ensureInitialized();
     const channel = MethodChannel('plugins.flutter.io/shared_preferences');
@@ -247,6 +370,7 @@ void main() {
     final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
     final api = MockApiClient();
     var healthChecks = 0;
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.none);
     when(() => api.checkHealth()).thenAnswer((_) async {
       healthChecks++;
       return healthChecks == 3;
@@ -287,7 +411,7 @@ void main() {
     await _pumpOfflineDashboard(tester, api: api, platform: platform);
 
     await tester.tap(find.text('Start Server'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(platform.spawnedDaemons, isEmpty);
     verifyNever(() => api.checkHealth());
@@ -300,6 +424,24 @@ void main() {
     expect(container.read(daemonStartingProvider), isFalse);
   });
 
+  testWidgets('offline dashboard accepts an already-present daemon', (
+    tester,
+  ) async {
+    final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
+    final api = MockApiClient();
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.daemon);
+    when(() => api.daemonPort).thenReturn(7842);
+
+    await _pumpOfflineDashboard(tester, api: api, platform: platform);
+
+    await tester.tap(find.text('Start Server'));
+    await tester.pumpAndSettle();
+
+    expect(platform.spawnedDaemons, isEmpty);
+    expect(find.text('Server is already running'), findsOneWidget);
+    verifyNever(() => api.checkHealth());
+  });
+
   testWidgets('offline dashboard resets start state when spawn fails', (
     tester,
   ) async {
@@ -308,15 +450,20 @@ void main() {
       spawnError: Exception('boom'),
     );
     final api = MockApiClient();
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+    when(() => api.daemonPort).thenReturn(7842);
 
     await _pumpOfflineDashboard(tester, api: api, platform: platform);
 
     await tester.tap(find.text('Start Server'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(platform.spawnedDaemons, equals(['/tmp/heimdallm']));
     verifyNever(() => api.checkHealth());
-    expect(find.text('Error: Exception: boom'), findsOneWidget);
+    expect(
+      find.text('Could not start Heimdallm: Exception: boom'),
+      findsOneWidget,
+    );
 
     final container = ProviderScope.containerOf(
       tester.element(find.byType(DashboardScreen)),
@@ -328,6 +475,7 @@ void main() {
   testWidgets('offline dashboard reports daemon start timeout', (tester) async {
     final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
     final api = MockApiClient();
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.none);
     when(() => api.checkHealth()).thenAnswer((_) async => false);
 
     await _pumpOfflineDashboard(tester, api: api, platform: platform);

--- a/flutter_app/test/features/dashboard_test.dart
+++ b/flutter_app/test/features/dashboard_test.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:heimdallm/core/api/api_client.dart';
+import 'package:heimdallm/core/daemon/daemon_startup.dart';
 import 'package:heimdallm/core/models/pr.dart';
 import 'package:heimdallm/core/models/review.dart';
 import 'package:heimdallm/core/platform/platform_services_provider.dart';
@@ -92,7 +93,74 @@ Future<void> _pumpOfflineDashboard(
   await tester.pumpAndSettle();
 }
 
+Future<void> _pumpRestartHarness(
+  WidgetTester tester, {
+  required MockApiClient api,
+  required FakePlatformServices platform,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        apiClientProvider.overrideWithValue(api),
+        platformServicesProvider.overrideWithValue(platform),
+      ],
+      child: MaterialApp(
+        home: Consumer(
+          builder: (context, ref, _) => Scaffold(
+            body: FilledButton(
+              onPressed: () => restartDaemon(
+                context,
+                ref,
+                portReleaseDelays: const [Duration.zero],
+              ),
+              child: const Text('Restart harness'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
 void main() {
+  test('daemon startup failure messages cover every guarded outcome', () {
+    expect(
+      daemonStartupFailureMessage(
+        const DaemonStartupResult(DaemonStartupOutcome.portOccupied),
+        9000,
+      ),
+      contains('Port 9000'),
+    );
+    expect(
+      daemonStartupFailureMessage(
+        const DaemonStartupResult(DaemonStartupOutcome.daemonPresent),
+        9000,
+      ),
+      contains('already running'),
+    );
+    expect(
+      daemonStartupFailureMessage(
+        const DaemonStartupResult(DaemonStartupOutcome.spawnFailedRetryable),
+        9000,
+      ),
+      contains('unknown error'),
+    );
+    expect(
+      daemonStartupFailureMessage(
+        const DaemonStartupResult(DaemonStartupOutcome.spawnBudgetExhausted),
+        9000,
+      ),
+      contains('exhausted'),
+    );
+    expect(
+      daemonStartupFailureMessage(
+        const DaemonStartupResult(DaemonStartupOutcome.spawned),
+        9000,
+      ),
+      isEmpty,
+    );
+  });
+
   test(
     'restart waits for daemon port release, not health degradation',
     () async {
@@ -165,7 +233,7 @@ void main() {
   testWidgets(
     'restart accepts a supervised daemon that reappears before port release',
     (tester) async {
-      final platform = FakePlatformServices(daemonSupervised: true);
+      final platform = FakePlatformServices();
       final api = MockApiClient();
       when(() => api.shutdownDaemon()).thenAnswer((_) async {});
       when(
@@ -214,6 +282,101 @@ void main() {
       verify(() => api.checkHealth()).called(1);
     },
   );
+
+  testWidgets('restart cancels when a foreign process claims the port', (
+    tester,
+  ) async {
+    final api = MockApiClient();
+    when(() => api.shutdownDaemon()).thenAnswer((_) async {});
+    when(
+      () => api.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.foreign);
+    when(() => api.daemonPort).thenReturn(8123);
+    final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
+    await _pumpRestartHarness(tester, api: api, platform: platform);
+
+    await tester.tap(find.text('Restart harness'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('port 8123 is now occupied'), findsOneWidget);
+    expect(platform.spawnedDaemons, isEmpty);
+  });
+
+  testWidgets('restart ignores a concurrent second request', (tester) async {
+    final api = MockApiClient();
+    final releaseShutdown = Completer<void>();
+    when(() => api.shutdownDaemon()).thenAnswer((_) => releaseShutdown.future);
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+    when(() => api.checkHealth()).thenAnswer((_) async => true);
+    final platform = FakePlatformServices(
+      daemonBinaryPath: '/tmp/heimdallm',
+    );
+    await _pumpRestartHarness(tester, api: api, platform: platform);
+
+    await tester.tap(find.text('Restart harness'));
+    await tester.pump();
+    await tester.tap(find.text('Restart harness'));
+    await tester.pump();
+
+    verify(() => api.shutdownDaemon()).called(1);
+    releaseShutdown.complete();
+    await tester.pumpAndSettle();
+    expect(platform.spawnedDaemons, ['/tmp/heimdallm']);
+  });
+
+  testWidgets('restart reuses a daemon that still owns the port', (
+    tester,
+  ) async {
+    final api = MockApiClient();
+    when(() => api.shutdownDaemon()).thenAnswer((_) async {});
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.daemon);
+    when(() => api.checkHealth()).thenAnswer((_) async => true);
+    final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
+    await _pumpRestartHarness(tester, api: api, platform: platform);
+
+    await tester.tap(find.text('Restart harness'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Server restarted'), findsOneWidget);
+    expect(platform.spawnedDaemons, isEmpty);
+  });
+
+  testWidgets('restart reports a missing binary after the port is released', (
+    tester,
+  ) async {
+    final api = MockApiClient();
+    when(() => api.shutdownDaemon()).thenAnswer((_) async {});
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+    final platform = FakePlatformServices();
+    await _pumpRestartHarness(tester, api: api, platform: platform);
+
+    await tester.tap(find.text('Restart harness'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Daemon binary not found'), findsOneWidget);
+    expect(platform.spawnedDaemons, isEmpty);
+  });
+
+  testWidgets('restart surfaces a guarded startup refusal', (tester) async {
+    final api = MockApiClient();
+    final owners = [PortOwner.none, PortOwner.foreign];
+    when(() => api.shutdownDaemon()).thenAnswer((_) async {});
+    when(
+      () => api.daemonReachable(),
+    ).thenAnswer((_) async => owners.removeAt(0));
+    when(() => api.daemonPort).thenReturn(8123);
+    final platform = FakePlatformServices(daemonBinaryPath: '/tmp/heimdallm');
+    await _pumpRestartHarness(tester, api: api, platform: platform);
+
+    await tester.tap(find.text('Restart harness'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Port 8123 is occupied; no daemon was started.'),
+      findsOneWidget,
+    );
+    expect(platform.spawnedDaemons, isEmpty);
+  });
 
   test('SortNotifier handles preference load failures', () async {
     TestWidgetsFlutterBinding.ensureInitialized();

--- a/flutter_app/test/features/server/server_screen_test.dart
+++ b/flutter_app/test/features/server/server_screen_test.dart
@@ -47,7 +47,7 @@ void main() {
           'review_mode': 'single',
           'issue_tracking': {'enabled': false},
         });
-    when(() => api.checkHealth()).thenAnswer((_) async => true);
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.daemon);
     when(() => api.fetchHealth()).thenAnswer((_) async => {'status': 'ok'});
 
     await _pump(tester, api);
@@ -70,7 +70,7 @@ void main() {
           'review_mode': 'single',
           'issue_tracking': {'enabled': false},
         });
-    when(() => api.checkHealth()).thenAnswer((_) async => true);
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.daemon);
     when(() => api.fetchHealth()).thenAnswer((_) async => {'status': 'ok'});
 
     await _pump(tester, api);
@@ -93,7 +93,7 @@ void main() {
           'review_mode': 'single',
           'issue_tracking': {'enabled': false},
         });
-    when(() => api.checkHealth()).thenAnswer((_) async => false);
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.none);
     when(() => api.fetchHealth()).thenAnswer((_) async => null);
 
     await _pump(tester, api);
@@ -115,7 +115,7 @@ void main() {
           'review_mode': 'single',
           'issue_tracking': {'enabled': false},
         });
-    when(() => api.checkHealth()).thenAnswer((_) async => true);
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.daemon);
     when(() => api.fetchHealth()).thenAnswer((_) async => {'status': 'ok'});
 
     await _pump(tester, api, initialTab: 'events');

--- a/flutter_app/test/main_bootstrap_test.dart
+++ b/flutter_app/test/main_bootstrap_test.dart
@@ -1,0 +1,293 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdallm/core/api/api_client.dart';
+import 'package:heimdallm/core/models/config_model.dart';
+import 'package:heimdallm/main.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'core/platform/fake_platform_services.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+class _ThrowingPlatformServices extends FakePlatformServices {
+  _ThrowingPlatformServices({
+    required this.error,
+    required super.githubToken,
+    required super.daemonBinaryPath,
+  });
+
+  final Object error;
+
+  @override
+  Future<void> spawnDaemon(String binaryPath) async {
+    spawnedDaemons.add(binaryPath);
+    throw error;
+  }
+}
+
+GoRouter _router() => GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (_, _) => const Scaffold(body: Text('Dashboard target')),
+    ),
+    GoRoute(
+      path: '/config',
+      builder: (_, _) => const Scaffold(body: Text('Config target')),
+    ),
+  ],
+);
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  Finder finder, {
+  int frames = 30,
+}) async {
+  for (var i = 0; i < frames; i++) {
+    await tester.pump(Duration.zero);
+    if (finder.evaluate().isNotEmpty) return;
+  }
+  fail('Widget never appeared: $finder');
+}
+
+void main() {
+  testWidgets('reachable daemon enters the application without spawning', (
+    tester,
+  ) async {
+    final api = _MockApiClient();
+    final platform = FakePlatformServices();
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.daemon);
+
+    await tester.pumpWidget(
+      buildBootstrapAppForTest(
+        router: _router(),
+        platform: platform,
+        apiClient: api,
+      ),
+    );
+    await _pumpUntil(tester, find.text('Dashboard target'));
+
+    expect(platform.spawnedDaemons, isEmpty);
+  });
+
+  testWidgets('foreign port shows diagnostics and Retry probes again', (
+    tester,
+  ) async {
+    final api = _MockApiClient();
+    final platform = FakePlatformServices();
+    final owners = [PortOwner.foreign, PortOwner.daemon];
+    when(
+      () => api.daemonReachable(),
+    ).thenAnswer((_) async => owners.removeAt(0));
+    when(() => api.daemonPort).thenReturn(7842);
+
+    await tester.pumpWidget(
+      buildBootstrapAppForTest(
+        router: _router(),
+        platform: platform,
+        apiClient: api,
+      ),
+    );
+    await _pumpUntil(tester, find.text('Port 7842 is already occupied'));
+    expect(find.textContaining('No daemon was started'), findsOneWidget);
+    expect(find.textContaining('lsof -nP'), findsOneWidget);
+
+    await tester.tap(find.text('Retry'));
+    await _pumpUntil(tester, find.text('Dashboard target'));
+    expect(platform.spawnedDaemons, isEmpty);
+  });
+
+  testWidgets('relative endpoint fails closed with proxy diagnostics', (
+    tester,
+  ) async {
+    final api = _MockApiClient();
+    when(
+      () => api.daemonReachable(),
+    ).thenAnswer((_) async => PortOwner.foreign);
+    when(() => api.daemonPort).thenReturn(0);
+
+    await tester.pumpWidget(
+      buildBootstrapAppForTest(
+        router: _router(),
+        platform: FakePlatformServices(apiBaseUrl: '/api'),
+        apiClient: api,
+      ),
+    );
+    await _pumpUntil(tester, find.text('Daemon endpoint unavailable'));
+
+    expect(find.textContaining('reverse-proxy logs'), findsOneWidget);
+  });
+
+  testWidgets('missing credentials routes into the application setup', (
+    tester,
+  ) async {
+    final api = _MockApiClient();
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+
+    await tester.pumpWidget(
+      buildBootstrapAppForTest(
+        router: _router(),
+        platform: FakePlatformServices(),
+        apiClient: api,
+      ),
+    );
+    await _pumpUntil(tester, find.text('Config target'));
+
+    verify(() => api.daemonReachable()).called(1);
+  });
+
+  testWidgets('missing bundled daemon reports an actionable install error', (
+    tester,
+  ) async {
+    final api = _MockApiClient();
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+
+    await tester.pumpWidget(
+      buildBootstrapAppForTest(
+        router: _router(),
+        platform: FakePlatformServices(githubToken: 'token'),
+        apiClient: api,
+      ),
+    );
+    await _pumpUntil(tester, find.text('Daemon binary not found'));
+
+    expect(find.textContaining('installation is incomplete'), findsOneWidget);
+    expect(find.textContaining('xattr -cr'), findsOneWidget);
+  });
+
+  testWidgets('first run writes discovered repos and starts one daemon', (
+    tester,
+  ) async {
+    final api = _MockApiClient();
+    final owners = [PortOwner.none, PortOwner.none];
+    when(
+      () => api.daemonReachable(),
+    ).thenAnswer((_) async => owners.removeAt(0));
+    when(() => api.daemonPort).thenReturn(7842);
+    when(() => api.checkHealth()).thenAnswer((_) async => true);
+    final platform = FakePlatformServices(
+      githubToken: 'token',
+      configExistsValue: false,
+      daemonBinaryPath: '/fake/heimdalld',
+      env: {'HEIMDALLM_LOCAL_DIR_BASE': '/one, /two'},
+    )..discoveredRepos = const ['org/one', 'org/two'];
+
+    await tester.pumpWidget(
+      buildBootstrapAppForTest(
+        router: _router(),
+        platform: platform,
+        apiClient: api,
+      ),
+    );
+    await _pumpUntil(tester, find.text('Dashboard target'));
+
+    expect(platform.spawnedDaemons, ['/fake/heimdalld']);
+    expect(platform.writtenConfigs, hasLength(1));
+    final AppConfig config = platform.writtenConfigs.single;
+    expect(config.repoConfigs.keys, containsAll(['org/one', 'org/two']));
+    expect(config.localDirBase, ['/one', '/two']);
+  });
+
+  testWidgets('daemon appearing during setup is reused', (tester) async {
+    final api = _MockApiClient();
+    final owners = [PortOwner.none, PortOwner.daemon];
+    when(
+      () => api.daemonReachable(),
+    ).thenAnswer((_) async => owners.removeAt(0));
+    when(() => api.daemonPort).thenReturn(7842);
+    final platform = FakePlatformServices(
+      githubToken: 'token',
+      daemonBinaryPath: '/fake/heimdalld',
+    );
+
+    await tester.pumpWidget(
+      buildBootstrapAppForTest(
+        router: _router(),
+        platform: platform,
+        apiClient: api,
+      ),
+    );
+    await _pumpUntil(tester, find.text('Dashboard target'));
+
+    expect(platform.spawnedDaemons, isEmpty);
+    verifyNever(() => api.checkHealth());
+  });
+
+  testWidgets('port claimed during setup aborts before spawn', (tester) async {
+    final api = _MockApiClient();
+    final owners = [PortOwner.none, PortOwner.foreign];
+    when(
+      () => api.daemonReachable(),
+    ).thenAnswer((_) async => owners.removeAt(0));
+    when(() => api.daemonPort).thenReturn(7842);
+    final platform = FakePlatformServices(
+      githubToken: 'token',
+      daemonBinaryPath: '/fake/heimdalld',
+    );
+
+    await tester.pumpWidget(
+      buildBootstrapAppForTest(
+        router: _router(),
+        platform: platform,
+        apiClient: api,
+      ),
+    );
+    await _pumpUntil(tester, find.text('Port 7842 is already occupied'));
+
+    expect(platform.spawnedDaemons, isEmpty);
+  });
+
+  testWidgets('retryable spawn failure becomes a terminal error', (
+    tester,
+  ) async {
+    final api = _MockApiClient();
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+    when(() => api.daemonPort).thenReturn(7842);
+    when(() => api.checkHealth()).thenAnswer((_) async => false);
+    final platform = _ThrowingPlatformServices(
+      error: StateError('cannot execute'),
+      githubToken: 'token',
+      daemonBinaryPath: '/fake/heimdalld',
+    );
+
+    await tester.pumpWidget(
+      buildBootstrapAppForTest(
+        router: _router(),
+        platform: platform,
+        apiClient: api,
+        maxSpawnAttempts: 2,
+      ),
+    );
+    await _pumpUntil(tester, find.text('Could not start daemon'));
+
+    expect(find.textContaining('cannot execute'), findsOneWidget);
+    expect(platform.spawnedDaemons, hasLength(2));
+  });
+
+  testWidgets('successful process start cannot exceed its spawn budget', (
+    tester,
+  ) async {
+    final api = _MockApiClient();
+    when(() => api.daemonReachable()).thenAnswer((_) async => PortOwner.none);
+    when(() => api.daemonPort).thenReturn(7842);
+    when(() => api.checkHealth()).thenAnswer((_) async => false);
+    final platform = FakePlatformServices(
+      githubToken: 'token',
+      daemonBinaryPath: '/fake/heimdalld',
+    );
+
+    await tester.pumpWidget(
+      buildBootstrapAppForTest(
+        router: _router(),
+        platform: platform,
+        apiClient: api,
+        maxSpawnAttempts: 1,
+      ),
+    );
+    await _pumpUntil(tester, find.text('Daemon failed to start'));
+
+    expect(platform.spawnedDaemons, ['/fake/heimdalld']);
+    expect(find.textContaining('exhausted'), findsOneWidget);
+  });
+}

--- a/scripts/macos-install.sh
+++ b/scripts/macos-install.sh
@@ -9,6 +9,7 @@ APP_UI_BIN="$APP_PATH/Contents/MacOS/Heimdallm"
 APP_DAEMON_BIN="$APP_PATH/Contents/MacOS/heimdalld"
 BUNDLE_PROCESS_PATTERN='^/Applications/Heimdallm[.]app/Contents/MacOS/(Heimdallm|heimdalld)([[:space:]]|$)'
 LAUNCHAGENT_LABEL="com.heimdallm.daemon"
+LEGACY_LAUNCHAGENT_LABEL="com.auto-pr.daemon"
 PORT="7842"
 SERVICE_READY_TIMEOUT_SECONDS="60"
 
@@ -92,21 +93,30 @@ set_user_paths() {
   DB_PATH="$DATA_DIR/heimdallm.db"
   UI_PID_PATH="$DATA_DIR/ui.pid"
   PLIST_PATH="$USER_HOME/Library/LaunchAgents/$LAUNCHAGENT_LABEL.plist"
+  LEGACY_PLIST_PATH="$USER_HOME/Library/LaunchAgents/$LEGACY_LAUNCHAGENT_LABEL.plist"
   return 0
 }
 
-# Arguments: listener PID, exact executable path, captured LaunchAgent PID.
+# Arguments: listener PID, exact executable path, captured current LaunchAgent
+# PID, captured legacy LaunchAgent PID, and the validated legacy executable.
 # Service ownership wins over bundle ownership so the classes are exclusive.
 classify_listener() {
   mi_listener_pid=${1-}
   mi_listener_executable=${2-}
   mi_launchagent_pid=${3-}
+  mi_legacy_launchagent_pid=${4-}
+  mi_legacy_launchagent_executable=${5-}
 
   if [ -z "$mi_listener_pid" ]; then
     printf '%s\n' "free"
   elif [ -n "$mi_launchagent_pid" ] &&
        [ "$mi_listener_pid" = "$mi_launchagent_pid" ]; then
     printf '%s\n' "service"
+  elif [ -n "$mi_legacy_launchagent_pid" ] &&
+       [ "$mi_listener_pid" = "$mi_legacy_launchagent_pid" ] &&
+       [ -n "$mi_legacy_launchagent_executable" ] &&
+       [ "$mi_listener_executable" = "$mi_legacy_launchagent_executable" ]; then
+    printf '%s\n' "legacy-service"
   elif [ "$mi_listener_executable" = "$APP_UI_BIN" ] ||
        [ "$mi_listener_executable" = "$APP_DAEMON_BIN" ]; then
     printf '%s\n' "bundle"
@@ -125,21 +135,25 @@ decide_install_policy() {
     absent:free) printf '%s\n' "proceed" ;;
     absent:bundle) printf '%s\n' "stop-bundle" ;;
     absent:service) printf '%s\n' "abort-inconsistent" ;;
+    absent:legacy-service) printf '%s\n' "retire-legacy" ;;
     absent:foreign) printf '%s\n' "warn" ;;
 
     present-unloaded:free) printf '%s\n' "migrate-unloaded" ;;
     present-unloaded:bundle) printf '%s\n' "stop-bundle+migrate-unloaded" ;;
     present-unloaded:service) printf '%s\n' "abort-inconsistent" ;;
+    present-unloaded:legacy-service) printf '%s\n' "retire-legacy+migrate-unloaded" ;;
     present-unloaded:foreign) printf '%s\n' "warn+migrate-unloaded" ;;
 
     loaded-enabled:free) printf '%s\n' "restart-service" ;;
     loaded-enabled:bundle) printf '%s\n' "stop-bundle+restart-service" ;;
     loaded-enabled:service) printf '%s\n' "restart-service" ;;
+    loaded-enabled:legacy-service) printf '%s\n' "retire-legacy+restart-service" ;;
     loaded-enabled:foreign) printf '%s\n' "abort-foreign" ;;
 
     loaded-disabled:free) printf '%s\n' "migrate-disabled" ;;
     loaded-disabled:bundle) printf '%s\n' "stop-bundle+migrate-disabled" ;;
     loaded-disabled:service) printf '%s\n' "migrate-disabled" ;;
+    loaded-disabled:legacy-service) printf '%s\n' "retire-legacy+migrate-disabled" ;;
     loaded-disabled:foreign) printf '%s\n' "warn+migrate-disabled" ;;
 
     *) return 1 ;;
@@ -160,6 +174,58 @@ rollback_new_move_detected() {
 
 rollback_required() {
   [ "${1-}" = "1" ] && [ "${2-}" != "1" ]
+}
+
+legacy_move_detected() {
+  [ "${1-}" = "1" ] ||
+    { [ "${2-}" = "1" ] &&
+      [ "${3-}" = "1" ] &&
+      [ "${4-}" = "1" ]; }
+}
+
+legacy_stop_detected() {
+  [ "${1-}" = "1" ] ||
+    { [ "${2-}" = "1" ] && [ "${3-}" = "1" ]; }
+}
+
+legacy_canonical_move_detected() {
+  [ "${1-}" = "1" ] ||
+    { [ "${2-}" = "1" ] &&
+      [ "${3-}" = "1" ] &&
+      [ "${4-}" = "1" ]; }
+}
+
+# Only the two historical install layouts and checkout-built daemon name are
+# accepted. A job merely reusing the old label is never enough to authorize a
+# bootout.
+validate_legacy_program_path() {
+  if [ "$#" -ne 1 ]; then
+    return 1
+  fi
+  case "$1" in
+    ""|[!/]*) return 1 ;;
+    *"//"*|*"/./"*|*"/."|*"/../"*|*"/.."|*/) return 1 ;;
+    *'
+'*) return 1 ;;
+  esac
+  case "$1" in
+    "$USER_HOME"/daemon/bin/auto-pr-daemon|\
+    "$USER_HOME"/*/daemon/bin/auto-pr-daemon|\
+    /Applications/auto-pr.app/Contents/MacOS/auto-pr-daemon|\
+    /Applications/auto_pr.app/Contents/MacOS/auto-pr-daemon)
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+safe_legacy_quarantine_path() {
+  case "${1-}" in
+    "$USER_HOME"/Library/LaunchAgents/.heimdallm-retired-auto-pr.??????)
+      [ "$1" != "$USER_HOME/Library/LaunchAgents" ]
+      ;;
+    *) return 1 ;;
+  esac
 }
 
 # The captured service PID or exact installed executables are controlled by
@@ -219,10 +285,54 @@ init_runtime_state() {
   ORIGINAL_PLIST_BACKUP=""
   LAUNCHAGENT_STATE=""
 
+  LEGACY_PLIST_PRESENT=0
+  LEGACY_PLIST_MODE=""
+  LEGACY_PLIST_FINGERPRINT=""
+  LEGACY_PROGRAM_PATH=""
+  LEGACY_JOB_PLIST_PATH=""
+  LEGACY_LOADED=0
+  LEGACY_DISABLED=0
+  LEGACY_PID=""
+  LEGACY_PID_EXECUTABLE=""
+  LEGACY_STOP_INTENDED=0
+  LEGACY_STOPPED=0
+  LEGACY_PLIST_BACKUP=""
+  LEGACY_QUARANTINE_DIR=""
+  LEGACY_QUARANTINE_PATH=""
+  LEGACY_MOVE_INTENDED=0
+  LEGACY_MOVED=0
+  LEGACY_ROLLBACK_LEAVE_UNLOADED=0
+  LEGACY_CANONICAL_STAGED_PATH=""
+  LEGACY_CANONICAL_FINGERPRINT=""
+  LEGACY_CANONICAL_MOVE_INTENDED=0
+  LEGACY_CANONICAL_CREATED=0
+
   PORT_CLASS="free"
   PORT_FOREIGN_INFO=""
   PREFLIGHT_FOREIGN_INFO=""
   RESOLVED_RELEASE=""
+}
+
+# Small command seams keep the destructive legacy migration integration-testable
+# on Linux CI while production still uses the absolute macOS system tools.
+legacy_launchctl() {
+  /bin/launchctl "$@"
+}
+
+legacy_plist_uid() {
+  /usr/bin/stat -f '%u' "$1"
+}
+
+legacy_plist_mode() {
+  /usr/bin/stat -f '%Lp' "$1"
+}
+
+legacy_plist_fingerprint() {
+  /usr/bin/cksum < "$1"
+}
+
+replace_plist_string() {
+  /usr/bin/plutil -replace "$1" -string "$2" "$3"
 }
 
 # Runtime helpers ------------------------------------------------------------
@@ -251,6 +361,7 @@ require_common_commands() {
     /bin/mv \
     /bin/ps \
     /bin/rm \
+    /bin/rmdir \
     /bin/sleep \
     /usr/bin/awk \
     /usr/bin/cksum \
@@ -306,6 +417,7 @@ resolve_invoking_user() {
 
   LAUNCH_DOMAIN="gui/$USER_UID"
   SERVICE_TARGET="$LAUNCH_DOMAIN/$LAUNCHAGENT_LABEL"
+  LEGACY_SERVICE_TARGET="$LAUNCH_DOMAIN/$LEGACY_LAUNCHAGENT_LABEL"
 }
 
 process_executable() {
@@ -458,6 +570,283 @@ current_job_plist_path() {
   printf '%s\n' "$mi_job_path"
 }
 
+legacy_launchagent_job_state() {
+  if mi_legacy_state_output=$(
+    /bin/launchctl print "$LEGACY_SERVICE_TARGET" 2>&1
+  ); then
+    printf '%s\n' "loaded"
+    return 0
+  else
+    mi_legacy_state_status=$?
+  fi
+  if [ "$mi_legacy_state_status" -eq 113 ] ||
+     printf '%s\n' "$mi_legacy_state_output" |
+       /usr/bin/grep -q "Could not find service"; then
+    printf '%s\n' "unloaded"
+    return 0
+  fi
+  error "Cannot inspect legacy LaunchAgent job:"
+  printf '%s\n' "$mi_legacy_state_output" >&2
+  return 2
+}
+
+legacy_current_job_pid() {
+  if ! mi_legacy_job_output=$(
+    /bin/launchctl print "$LEGACY_SERVICE_TARGET" 2>/dev/null
+  ); then
+    return 1
+  fi
+  mi_legacy_job_pid=$(
+    printf '%s\n' "$mi_legacy_job_output" |
+      /usr/bin/awk '$1 == "pid" && $2 == "=" && $3 ~ /^[0-9]+$/ { print $3; exit }'
+  )
+  if [ -z "$mi_legacy_job_pid" ]; then
+    return 1
+  fi
+  printf '%s\n' "$mi_legacy_job_pid"
+}
+
+legacy_current_job_plist_path() {
+  if ! mi_legacy_job_output=$(
+    /bin/launchctl print "$LEGACY_SERVICE_TARGET" 2>/dev/null
+  ); then
+    return 1
+  fi
+  mi_legacy_job_path=$(
+    printf '%s\n' "$mi_legacy_job_output" |
+      /usr/bin/awk '$1 == "path" && $2 == "=" { sub(/^[^=]*=[[:space:]]*/, ""); print; exit }'
+  )
+  if [ -z "$mi_legacy_job_path" ]; then
+    return 1
+  fi
+  printf '%s\n' "$mi_legacy_job_path"
+}
+
+read_legacy_disabled_state() {
+  if ! mi_legacy_disabled_output=$(
+    /bin/launchctl print-disabled "$LAUNCH_DOMAIN" 2>&1
+  ); then
+    error "Cannot inspect disabled legacy LaunchAgent state:"
+    printf '%s\n' "$mi_legacy_disabled_output" >&2
+    return 1
+  fi
+
+  mi_legacy_disabled_line=$(
+    printf '%s\n' "$mi_legacy_disabled_output" |
+      /usr/bin/awk -v label="\"$LEGACY_LAUNCHAGENT_LABEL\"" \
+        'index($0, label) { print; exit }'
+  )
+  case "$mi_legacy_disabled_line" in
+    "") printf '%s\n' "0" ;;
+    *"=>"*"disabled"*|*"=>"*"true"*) printf '%s\n' "1" ;;
+    *"=>"*"enabled"*|*"=>"*"false"*) printf '%s\n' "0" ;;
+    *)
+      error "Unrecognized legacy launchctl disabled-state output: $mi_legacy_disabled_line"
+      return 1
+      ;;
+  esac
+}
+
+legacy_plist_identity_matches() {
+  if ! mi_legacy_label=$(
+    /usr/bin/plutil -extract Label raw -o - "$LEGACY_PLIST_PATH" 2>/dev/null
+  ) || [ "$mi_legacy_label" != "$LEGACY_LAUNCHAGENT_LABEL" ]; then
+    return 1
+  fi
+  if ! mi_legacy_program=$(
+    /usr/bin/plutil -extract ProgramArguments.0 raw -o - \
+      "$LEGACY_PLIST_PATH" 2>/dev/null
+  ) || ! validate_legacy_program_path "$mi_legacy_program"; then
+    return 1
+  fi
+  # The historical generator emitted exactly one argument. Extra arguments
+  # make this an unknown job even if the label and executable name look right.
+  if /usr/bin/plutil -extract ProgramArguments.1 raw -o - \
+    "$LEGACY_PLIST_PATH" >/dev/null 2>&1; then
+    return 1
+  fi
+  if ! mi_legacy_run_at_load=$(
+    /usr/bin/plutil -extract RunAtLoad raw -o - \
+      "$LEGACY_PLIST_PATH" 2>/dev/null
+  ) || [ "$mi_legacy_run_at_load" != "true" ]; then
+    return 1
+  fi
+  if ! mi_legacy_keep_alive=$(
+    /usr/bin/plutil -extract KeepAlive raw -o - \
+      "$LEGACY_PLIST_PATH" 2>/dev/null
+  ) || [ "$mi_legacy_keep_alive" != "true" ]; then
+    return 1
+  fi
+  if ! mi_legacy_stdout=$(
+    /usr/bin/plutil -extract StandardOutPath raw -o - \
+      "$LEGACY_PLIST_PATH" 2>/dev/null
+  ) ||
+     [ "$mi_legacy_stdout" != \
+       "$USER_HOME/Library/Logs/auto-pr/auto-pr-daemon.log" ]; then
+    return 1
+  fi
+  if ! mi_legacy_stderr=$(
+    /usr/bin/plutil -extract StandardErrorPath raw -o - \
+      "$LEGACY_PLIST_PATH" 2>/dev/null
+  ) ||
+     [ "$mi_legacy_stderr" != \
+       "$USER_HOME/Library/Logs/auto-pr/auto-pr-daemon-error.log" ]; then
+    return 1
+  fi
+
+  LEGACY_PROGRAM_PATH=$mi_legacy_program
+  return 0
+}
+
+legacy_process_matches() {
+  mi_legacy_process_pid=${1-}
+  mi_legacy_expected_executable=${2-}
+  case "$mi_legacy_process_pid" in
+    ""|*[!0-9]*) return 1 ;;
+  esac
+  if ! mi_legacy_process_uid=$(
+    process_uid "$mi_legacy_process_pid" 2>/dev/null
+  ) || [ "$mi_legacy_process_uid" != "$USER_UID" ]; then
+    return 1
+  fi
+  if ! mi_legacy_process_executable=$(
+    process_executable "$mi_legacy_process_pid" 2>/dev/null
+  ); then
+    return 1
+  fi
+  [ "$mi_legacy_process_executable" = "$mi_legacy_expected_executable" ]
+}
+
+snapshot_legacy_launchagent() {
+  if [ -L "$LEGACY_PLIST_PATH" ]; then
+    die "Legacy LaunchAgent plist is a symlink; refusing to touch it: $LEGACY_PLIST_PATH"
+  fi
+  if [ -e "$LEGACY_PLIST_PATH" ]; then
+    if [ ! -f "$LEGACY_PLIST_PATH" ]; then
+      die "Legacy LaunchAgent plist is not a regular file: $LEGACY_PLIST_PATH"
+    fi
+    if [ "$(legacy_plist_uid "$LEGACY_PLIST_PATH")" != "$USER_UID" ]; then
+      die "Legacy LaunchAgent plist is not owned by the invoking user: $LEGACY_PLIST_PATH"
+    fi
+    if [ ! -r "$LEGACY_PLIST_PATH" ] || [ ! -w "$LEGACY_PLIST_PATH" ]; then
+      die "Legacy LaunchAgent plist must be readable and writable: $LEGACY_PLIST_PATH"
+    fi
+    if ! legacy_plist_identity_matches; then
+      die "A plist named $LEGACY_LAUNCHAGENT_LABEL exists but does not match Heimdallm's historical generated plist; leaving it untouched."
+    fi
+    LEGACY_PLIST_PRESENT=1
+    LEGACY_PLIST_MODE=$(legacy_plist_mode "$LEGACY_PLIST_PATH")
+    LEGACY_PLIST_FINGERPRINT=$(legacy_plist_fingerprint "$LEGACY_PLIST_PATH")
+  fi
+
+  if mi_legacy_job_output=$(
+    /bin/launchctl print "$LEGACY_SERVICE_TARGET" 2>&1
+  ); then
+    LEGACY_LOADED=1
+    LEGACY_PID=$(
+      printf '%s\n' "$mi_legacy_job_output" |
+        /usr/bin/awk '$1 == "pid" && $2 == "=" && $3 ~ /^[0-9]+$/ { print $3; exit }'
+    )
+    LEGACY_JOB_PLIST_PATH=$(
+      printf '%s\n' "$mi_legacy_job_output" |
+        /usr/bin/awk '$1 == "path" && $2 == "=" { sub(/^[^=]*=[[:space:]]*/, ""); print; exit }'
+    )
+  else
+    mi_legacy_job_status=$?
+    if [ "$mi_legacy_job_status" -ne 113 ] &&
+       ! printf '%s\n' "$mi_legacy_job_output" |
+         /usr/bin/grep -q "Could not find service"; then
+      error "Cannot inspect legacy LaunchAgent job:"
+      printf '%s\n' "$mi_legacy_job_output" >&2
+      exit 1
+    fi
+  fi
+
+  if [ "$LEGACY_LOADED" = "1" ] &&
+     [ "$LEGACY_PLIST_PRESENT" != "1" ]; then
+    die "Legacy LaunchAgent is loaded but its canonical plist is missing; refusing to stop an unreconstructable job."
+  fi
+  if [ "$LEGACY_LOADED" = "1" ] &&
+     [ "$LEGACY_JOB_PLIST_PATH" != "$LEGACY_PLIST_PATH" ]; then
+    die "Legacy LaunchAgent came from '$LEGACY_JOB_PLIST_PATH', not '$LEGACY_PLIST_PATH'; leaving it untouched."
+  fi
+  if [ -n "$LEGACY_PID" ]; then
+    if ! legacy_process_matches "$LEGACY_PID" "$LEGACY_PROGRAM_PATH"; then
+      die "Legacy LaunchAgent PID $LEGACY_PID does not match the validated user-owned historical daemon; leaving it untouched."
+    fi
+    LEGACY_PID_EXECUTABLE=$LEGACY_PROGRAM_PATH
+  fi
+
+  if [ "$LEGACY_PLIST_PRESENT" = "1" ] ||
+     [ "$LEGACY_LOADED" = "1" ]; then
+    if ! LEGACY_DISABLED=$(read_legacy_disabled_state); then
+      exit 1
+    fi
+  fi
+}
+
+revalidate_legacy_launchagent() {
+  mi_expected_legacy_program=$LEGACY_PROGRAM_PATH
+  if [ -L "$LEGACY_PLIST_PATH" ]; then
+    return 1
+  fi
+  mi_current_legacy_plist_present=0
+  if [ -e "$LEGACY_PLIST_PATH" ]; then
+    mi_current_legacy_plist_present=1
+  fi
+  if [ "$mi_current_legacy_plist_present" != "$LEGACY_PLIST_PRESENT" ]; then
+    return 1
+  fi
+  if [ "$LEGACY_PLIST_PRESENT" = "1" ]; then
+    if [ ! -f "$LEGACY_PLIST_PATH" ] ||
+       [ "$(legacy_plist_uid "$LEGACY_PLIST_PATH")" != "$USER_UID" ] ||
+       [ "$(legacy_plist_mode "$LEGACY_PLIST_PATH")" != "$LEGACY_PLIST_MODE" ] ||
+       [ "$(legacy_plist_fingerprint "$LEGACY_PLIST_PATH")" != "$LEGACY_PLIST_FINGERPRINT" ] ||
+       ! legacy_plist_identity_matches ||
+       [ "$LEGACY_PROGRAM_PATH" != "$mi_expected_legacy_program" ]; then
+      LEGACY_PROGRAM_PATH=$mi_expected_legacy_program
+      return 1
+    fi
+    LEGACY_PROGRAM_PATH=$mi_expected_legacy_program
+  fi
+
+  if ! mi_current_legacy_job_state=$(legacy_launchagent_job_state); then
+    return 1
+  fi
+  mi_current_legacy_loaded=0
+  if [ "$mi_current_legacy_job_state" = "loaded" ]; then
+    mi_current_legacy_loaded=1
+  fi
+  if [ "$mi_current_legacy_loaded" != "$LEGACY_LOADED" ]; then
+    return 1
+  fi
+  if [ "$mi_current_legacy_loaded" = "1" ]; then
+    if ! mi_current_legacy_job_path=$(legacy_current_job_plist_path) ||
+       [ "$mi_current_legacy_job_path" != "$LEGACY_PLIST_PATH" ]; then
+      return 1
+    fi
+    if mi_current_legacy_pid=$(legacy_current_job_pid 2>/dev/null); then
+      if ! legacy_process_matches \
+        "$mi_current_legacy_pid" "$LEGACY_PROGRAM_PATH"; then
+        return 1
+      fi
+      LEGACY_PID=$mi_current_legacy_pid
+      LEGACY_PID_EXECUTABLE=$LEGACY_PROGRAM_PATH
+    else
+      LEGACY_PID=""
+      LEGACY_PID_EXECUTABLE=""
+    fi
+  fi
+  if [ "$LEGACY_PLIST_PRESENT" = "1" ] ||
+     [ "$LEGACY_LOADED" = "1" ]; then
+    if ! mi_current_legacy_disabled=$(read_legacy_disabled_state) ||
+       [ "$mi_current_legacy_disabled" != "$LEGACY_DISABLED" ]; then
+      return 1
+    fi
+  fi
+  return 0
+}
+
 read_disabled_state() {
   if ! mi_disabled_output=$(
     /bin/launchctl print-disabled "$LAUNCH_DOMAIN" 2>&1
@@ -579,6 +968,24 @@ inspect_port() {
       fi
     fi
   fi
+  if [ "${LEGACY_LOADED:-0}" = "1" ]; then
+    if ! mi_live_legacy_job_state=$(legacy_launchagent_job_state); then
+      return 1
+    fi
+    if [ "$mi_live_legacy_job_state" = "loaded" ] &&
+       mi_live_legacy_pid=$(legacy_current_job_pid 2>/dev/null); then
+      if legacy_process_matches \
+        "$mi_live_legacy_pid" "$LEGACY_PROGRAM_PATH"; then
+        LEGACY_PID=$mi_live_legacy_pid
+        LEGACY_PID_EXECUTABLE=$LEGACY_PROGRAM_PATH
+      else
+        # Never grant ownership to a replacement process that merely reused
+        # the historical label while the installer was staging.
+        LEGACY_PID=""
+        LEGACY_PID_EXECUTABLE=""
+      fi
+    fi
+  fi
 
   mi_port_lsof_error=$(
     /usr/bin/mktemp "/tmp/heimdallm-port-lsof.XXXXXX"
@@ -624,15 +1031,21 @@ inspect_port() {
 
   mi_saw_bundle=0
   mi_saw_service=0
+  mi_saw_legacy_service=0
   mi_saw_foreign=0
   for mi_port_pid in $mi_port_pids; do
     mi_port_executable=$(process_executable "$mi_port_pid" 2>/dev/null || true)
     mi_listener_class=$(
-      classify_listener "$mi_port_pid" "$mi_port_executable" "$ORIGINAL_PID"
+      classify_listener \
+        "$mi_port_pid" "$mi_port_executable" "$ORIGINAL_PID" \
+        "$LEGACY_PID" "$LEGACY_PROGRAM_PATH"
     )
     case "$mi_listener_class" in
       service)
         mi_saw_service=1
+        ;;
+      legacy-service)
+        mi_saw_legacy_service=1
         ;;
       bundle)
         mi_saw_bundle=1
@@ -654,6 +1067,8 @@ PID $mi_port_pid ($mi_display_executable)"
     PORT_CLASS="foreign"
   elif [ "$mi_saw_service" = "1" ]; then
     PORT_CLASS="service"
+  elif [ "$mi_saw_legacy_service" = "1" ]; then
+    PORT_CLASS="legacy-service"
   elif [ "$mi_saw_bundle" = "1" ]; then
     PORT_CLASS="bundle"
   fi
@@ -817,6 +1232,24 @@ wait_for_job_unloaded() {
     return 1
   fi
   [ "$mi_wait_job_state" = "unloaded" ]
+}
+
+wait_for_legacy_job_unloaded() {
+  mi_legacy_wait_count=0
+  while [ "$mi_legacy_wait_count" -lt 6 ]; do
+    if ! mi_legacy_wait_job_state=$(legacy_launchagent_job_state); then
+      return 1
+    fi
+    if [ "$mi_legacy_wait_job_state" = "unloaded" ]; then
+      return 0
+    fi
+    /bin/sleep 1
+    mi_legacy_wait_count=$((mi_legacy_wait_count + 1))
+  done
+  if ! mi_legacy_wait_job_state=$(legacy_launchagent_job_state); then
+    return 1
+  fi
+  [ "$mi_legacy_wait_job_state" = "unloaded" ]
 }
 
 bootout_current_job() {
@@ -994,6 +1427,132 @@ restore_plist_contents_and_flag() {
   [ "$mi_restore_ok" = "1" ]
 }
 
+restore_legacy_plist_and_flag() {
+  if [ "$LEGACY_PLIST_PRESENT" != "1" ] &&
+     [ "$LEGACY_LOADED" != "1" ]; then
+    return 0
+  fi
+
+  mi_legacy_quarantine_present=0
+  if [ -n "$LEGACY_QUARANTINE_PATH" ] &&
+     { [ -e "$LEGACY_QUARANTINE_PATH" ] ||
+       [ -L "$LEGACY_QUARANTINE_PATH" ]; }; then
+    mi_legacy_quarantine_present=1
+  fi
+  mi_legacy_source_missing=0
+  if [ ! -e "$LEGACY_PLIST_PATH" ] && [ ! -L "$LEGACY_PLIST_PATH" ]; then
+    mi_legacy_source_missing=1
+  fi
+  mi_legacy_was_moved=0
+  if legacy_move_detected \
+    "$LEGACY_MOVED" \
+    "$LEGACY_MOVE_INTENDED" \
+    "$mi_legacy_source_missing" \
+    "$mi_legacy_quarantine_present"; then
+    mi_legacy_was_moved=1
+  fi
+
+  if [ "$LEGACY_PLIST_PRESENT" = "1" ]; then
+    if [ "$mi_legacy_was_moved" = "1" ]; then
+      if [ -e "$LEGACY_PLIST_PATH" ] || [ -L "$LEGACY_PLIST_PATH" ] ||
+         [ "$mi_legacy_quarantine_present" != "1" ] ||
+         [ -L "$LEGACY_QUARANTINE_PATH" ] ||
+         [ ! -f "$LEGACY_QUARANTINE_PATH" ] ||
+         [ "$(legacy_plist_fingerprint "$LEGACY_QUARANTINE_PATH")" != "$LEGACY_PLIST_FINGERPRINT" ] ||
+         ! /bin/mv "$LEGACY_QUARANTINE_PATH" "$LEGACY_PLIST_PATH"; then
+        error "Could not restore the exact retired legacy LaunchAgent plist."
+        return 1
+      fi
+    elif [ ! -f "$LEGACY_PLIST_PATH" ] ||
+         [ -L "$LEGACY_PLIST_PATH" ] ||
+         [ "$(legacy_plist_fingerprint "$LEGACY_PLIST_PATH")" != "$LEGACY_PLIST_FINGERPRINT" ]; then
+      if [ -e "$LEGACY_PLIST_PATH" ] || [ -L "$LEGACY_PLIST_PATH" ] ||
+         [ -z "$LEGACY_PLIST_BACKUP" ] ||
+         [ ! -f "$LEGACY_PLIST_BACKUP" ] ||
+         [ "$(legacy_plist_fingerprint "$LEGACY_PLIST_BACKUP")" != "$LEGACY_PLIST_FINGERPRINT" ] ||
+         ! /bin/cp -p "$LEGACY_PLIST_BACKUP" "$LEGACY_PLIST_PATH"; then
+        error "Could not restore the backed-up legacy LaunchAgent plist."
+        return 1
+      fi
+    fi
+    if ! /bin/chmod "$LEGACY_PLIST_MODE" "$LEGACY_PLIST_PATH"; then
+      error "Could not restore legacy LaunchAgent plist permissions."
+      return 1
+    fi
+  fi
+
+  LEGACY_MOVED=0
+  LEGACY_MOVE_INTENDED=0
+  if [ -n "$LEGACY_QUARANTINE_DIR" ] &&
+     [ -d "$LEGACY_QUARANTINE_DIR" ]; then
+    if safe_legacy_quarantine_path "$LEGACY_QUARANTINE_DIR" &&
+       /bin/rmdir "$LEGACY_QUARANTINE_DIR"; then
+      LEGACY_QUARANTINE_DIR=""
+      LEGACY_QUARANTINE_PATH=""
+    else
+      warn "Could not remove empty legacy recovery directory: $LEGACY_QUARANTINE_DIR"
+    fi
+  fi
+
+  if [ "$LEGACY_DISABLED" = "1" ]; then
+    if ! legacy_launchctl disable "$LEGACY_SERVICE_TARGET"; then
+      error "Could not restore disabled legacy LaunchAgent flag."
+      return 1
+    fi
+  elif ! legacy_launchctl enable "$LEGACY_SERVICE_TARGET"; then
+    error "Could not restore enabled legacy LaunchAgent flag."
+    return 1
+  fi
+  return 0
+}
+
+print_manual_legacy_recovery() {
+  warn "The legacy $LEGACY_LAUNCHAGENT_LABEL plist was restored but left unloaded for safety."
+  warn "After PID/port $PORT is free, its original loaded state can be restored with:"
+  if [ "$LEGACY_DISABLED" = "1" ]; then
+    printf '   /bin/launchctl enable "%s"\n' "$LEGACY_SERVICE_TARGET" >&2
+    printf '   /bin/launchctl bootstrap "%s" "%s"\n' \
+      "$LAUNCH_DOMAIN" "$LEGACY_PLIST_PATH" >&2
+    printf '   /bin/launchctl disable "%s"\n' \
+      "$LEGACY_SERVICE_TARGET" >&2
+  else
+    printf '   /bin/launchctl bootstrap "%s" "%s"\n' \
+      "$LAUNCH_DOMAIN" "$LEGACY_PLIST_PATH" >&2
+  fi
+}
+
+restore_legacy_loaded_state() {
+  if [ "$LEGACY_LOADED" != "1" ]; then
+    return 0
+  fi
+  if [ "$LEGACY_ROLLBACK_LEAVE_UNLOADED" = "1" ] ||
+     [ "$ORIGINAL_LOADED" = "1" ] ||
+     ! inspect_port || [ "$PORT_CLASS" != "free" ]; then
+    print_manual_legacy_recovery
+    return 1
+  fi
+
+  if [ "$LEGACY_DISABLED" = "1" ]; then
+    if legacy_launchctl enable "$LEGACY_SERVICE_TARGET" &&
+       legacy_launchctl bootstrap "$LAUNCH_DOMAIN" "$LEGACY_PLIST_PATH" &&
+       legacy_launchctl disable "$LEGACY_SERVICE_TARGET"; then
+      return 0
+    fi
+  elif legacy_launchctl bootstrap \
+    "$LAUNCH_DOMAIN" "$LEGACY_PLIST_PATH"; then
+    return 0
+  fi
+
+  error "Could not reload the original legacy LaunchAgent during rollback."
+  if legacy_launchctl bootout "$LEGACY_SERVICE_TARGET" >/dev/null 2>&1 ||
+     [ "$(legacy_launchagent_job_state 2>/dev/null || true)" = "unloaded" ]; then
+    print_manual_legacy_recovery
+    return 1
+  fi
+  error "Could not return the legacy LaunchAgent to a verified unloaded state."
+  return 2
+}
+
 print_manual_service_recovery() {
   warn "The original LaunchAgent plist was restored but left unloaded for safety."
   warn "After PID/port $PORT is free, run:"
@@ -1024,6 +1583,20 @@ print_backup_recovery() {
     warn "Manual plist recovery:"
     printf '   /bin/cp -p "%s" "%s"\n' \
       "$ORIGINAL_PLIST_BACKUP" "$PLIST_PATH" >&2
+  fi
+  if [ "${PRESERVE_TEMP:-0}" = "1" ] &&
+     [ -n "${LEGACY_PLIST_BACKUP:-}" ] &&
+     [ -f "$LEGACY_PLIST_BACKUP" ]; then
+    warn "The exact legacy LaunchAgent plist backup was preserved at:"
+    printf '   %s\n' "$LEGACY_PLIST_BACKUP" >&2
+    warn "Manual legacy plist recovery:"
+    printf '   /bin/cp -p "%s" "%s"\n' \
+      "$LEGACY_PLIST_BACKUP" "$LEGACY_PLIST_PATH" >&2
+  fi
+  if [ -n "${LEGACY_QUARANTINE_PATH:-}" ] &&
+     [ -f "$LEGACY_QUARANTINE_PATH" ]; then
+    warn "The retired legacy LaunchAgent plist remains recoverable at:"
+    printf '   %s\n' "$LEGACY_QUARANTINE_PATH" >&2
   fi
 }
 
@@ -1123,11 +1696,59 @@ rollback_install() {
   OLD_MOVE_INTENDED=0
   NEW_MOVE_INTENDED=0
 
+  if ! remove_legacy_created_canonical; then
+    PRESERVE_TEMP=1
+    mi_rollback_ok=0
+  fi
+
   if ! restore_plist_contents_and_flag; then
     if [ -n "$ORIGINAL_PLIST_BACKUP" ]; then
       PRESERVE_TEMP=1
     fi
     mi_rollback_ok=0
+  fi
+
+  if ! restore_legacy_plist_and_flag; then
+    if [ -n "$LEGACY_PLIST_BACKUP" ]; then
+      PRESERVE_TEMP=1
+    fi
+    mi_rollback_ok=0
+  fi
+
+  # A signal can arrive after launchctl completed bootout but before the shell
+  # assigned LEGACY_STOPPED. Combine the pre-command intent with observed job
+  # state so rollback never silently leaves a previously loaded service down.
+  mi_legacy_job_is_unloaded=0
+  if [ "$LEGACY_STOPPED" != "1" ] &&
+     [ "$LEGACY_STOP_INTENDED" = "1" ]; then
+    if mi_legacy_rollback_state=$(legacy_launchagent_job_state); then
+      if [ "$mi_legacy_rollback_state" = "unloaded" ]; then
+        mi_legacy_job_is_unloaded=1
+      fi
+    else
+      LEGACY_ROLLBACK_LEAVE_UNLOADED=1
+    fi
+  fi
+  if legacy_stop_detected \
+    "$LEGACY_STOPPED" "$LEGACY_STOP_INTENDED" \
+    "$mi_legacy_job_is_unloaded"; then
+    LEGACY_STOPPED=1
+  fi
+  LEGACY_STOP_INTENDED=0
+
+  if [ "$LEGACY_LOADED" = "1" ] &&
+     [ "$LEGACY_STOPPED" = "1" ] &&
+     [ "$mi_rollback_ok" = "1" ]; then
+    if restore_legacy_loaded_state; then
+      :
+    else
+      mi_legacy_restore_status=$?
+      if [ "$mi_legacy_restore_status" -eq 1 ]; then
+        mi_rollback_partial=1
+      else
+        mi_rollback_ok=0
+      fi
+    fi
   fi
 
   if [ "$ORIGINAL_LOADED" = "1" ] &&
@@ -1415,6 +2036,16 @@ prepare_transaction() {
     die "LaunchAgent disabled state changed during staging; retry the install."
   fi
 
+  if ! revalidate_legacy_launchagent; then
+    die "Legacy LaunchAgent identity or state changed during staging; leaving it untouched."
+  fi
+  if [ "$LEGACY_PLIST_PRESENT" = "1" ]; then
+    LEGACY_PLIST_BACKUP="$TEMP_DIR/original-legacy-launchagent.plist"
+    if ! /bin/cp -p "$LEGACY_PLIST_PATH" "$LEGACY_PLIST_BACKUP"; then
+      die "Could not back up the legacy LaunchAgent plist."
+    fi
+  fi
+
   ROLLBACK_ARMED=1
 }
 
@@ -1457,6 +2088,96 @@ stop_original_launchagent() {
     ROLLBACK_LEAVE_UNLOADED=1
     die "LaunchAgent PID $ORIGINAL_PID remains alive; plist restored but service will stay unloaded."
   fi
+}
+
+retire_legacy_launchagent() {
+  if [ "$LEGACY_PLIST_PRESENT" != "1" ] &&
+     [ "$LEGACY_LOADED" != "1" ]; then
+    return 0
+  fi
+
+  if ! revalidate_legacy_launchagent; then
+    die "Legacy LaunchAgent identity or state changed immediately before retirement; leaving it untouched."
+  fi
+
+  if [ "$LEGACY_LOADED" = "1" ]; then
+    info "▶  Stopping the validated legacy $LEGACY_LAUNCHAGENT_LABEL LaunchAgent..."
+    if ! mi_current_legacy_path=$(legacy_current_job_plist_path) ||
+       [ "$mi_current_legacy_path" != "$LEGACY_PLIST_PATH" ]; then
+      die "Legacy LaunchAgent plist identity changed immediately before bootout."
+    fi
+    if mi_current_legacy_pid=$(legacy_current_job_pid 2>/dev/null); then
+      if ! legacy_process_matches \
+        "$mi_current_legacy_pid" "$LEGACY_PROGRAM_PATH"; then
+        die "Legacy LaunchAgent process identity changed immediately before bootout."
+      fi
+      LEGACY_PID=$mi_current_legacy_pid
+      LEGACY_PID_EXECUTABLE=$LEGACY_PROGRAM_PATH
+    else
+      LEGACY_PID=""
+      LEGACY_PID_EXECUTABLE=""
+    fi
+
+    LEGACY_STOP_INTENDED=1
+    if legacy_launchctl bootout "$LEGACY_SERVICE_TARGET" >/dev/null 2>&1; then
+      LEGACY_STOPPED=1
+      LEGACY_STOP_INTENDED=0
+    else
+      if ! mi_legacy_job_state=$(legacy_launchagent_job_state); then
+        LEGACY_ROLLBACK_LEAVE_UNLOADED=1
+        die "Could not verify legacy LaunchAgent state after bootout failed."
+      fi
+      if [ "$mi_legacy_job_state" = "loaded" ]; then
+        LEGACY_ROLLBACK_LEAVE_UNLOADED=1
+        die "Could not boot out the legacy LaunchAgent."
+      fi
+      LEGACY_STOPPED=1
+      LEGACY_STOP_INTENDED=0
+    fi
+    if ! wait_for_legacy_job_unloaded; then
+      LEGACY_ROLLBACK_LEAVE_UNLOADED=1
+      die "Legacy LaunchAgent remains loaded after bootout."
+    fi
+    if ! wait_for_pid_exit "$LEGACY_PID" "$LEGACY_PID_EXECUTABLE"; then
+      LEGACY_ROLLBACK_LEAVE_UNLOADED=1
+      die "Legacy LaunchAgent PID $LEGACY_PID remains alive; its plist was preserved and will stay unloaded."
+    fi
+  fi
+
+  if [ "$LEGACY_PLIST_PRESENT" != "1" ]; then
+    return 0
+  fi
+  if [ -L "$LEGACY_PLIST_PATH" ] ||
+     [ ! -f "$LEGACY_PLIST_PATH" ] ||
+     [ "$(legacy_plist_uid "$LEGACY_PLIST_PATH")" != "$USER_UID" ] ||
+     [ "$(legacy_plist_mode "$LEGACY_PLIST_PATH")" != "$LEGACY_PLIST_MODE" ] ||
+     [ "$(legacy_plist_fingerprint "$LEGACY_PLIST_PATH")" != "$LEGACY_PLIST_FINGERPRINT" ]; then
+    LEGACY_ROLLBACK_LEAVE_UNLOADED=1
+    die "Legacy LaunchAgent plist changed after bootout; refusing to move it."
+  fi
+
+  if ! LEGACY_QUARANTINE_DIR=$(
+    /usr/bin/mktemp -d \
+      "$USER_HOME/Library/LaunchAgents/.heimdallm-retired-auto-pr.XXXXXX"
+  ); then
+    LEGACY_ROLLBACK_LEAVE_UNLOADED=1
+    die "Could not create a private recovery directory for the legacy plist."
+  fi
+  if ! safe_legacy_quarantine_path "$LEGACY_QUARANTINE_DIR"; then
+    LEGACY_ROLLBACK_LEAVE_UNLOADED=1
+    die "System mktemp returned an unsafe legacy recovery path: $LEGACY_QUARANTINE_DIR"
+  fi
+  LEGACY_QUARANTINE_PATH="$LEGACY_QUARANTINE_DIR/$LEGACY_LAUNCHAGENT_LABEL.plist"
+  LEGACY_MOVE_INTENDED=1
+  if ! /bin/mv "$LEGACY_PLIST_PATH" "$LEGACY_QUARANTINE_PATH"; then
+    LEGACY_ROLLBACK_LEAVE_UNLOADED=1
+    die "Could not move the retired legacy LaunchAgent plist into recovery storage."
+  fi
+  LEGACY_MOVED=1
+  LEGACY_MOVE_INTENDED=0
+
+  info "↓  Retired legacy LaunchAgent; recoverable plist preserved at:"
+  info "   $LEGACY_QUARANTINE_PATH"
 }
 
 late_port_guard_before_swap() {
@@ -1537,6 +2258,119 @@ verify_plist_program_path() {
   [ "$mi_installed_program" = "$APP_DAEMON_BIN" ]
 }
 
+safe_legacy_quarantine_member() {
+  [ -n "${LEGACY_QUARANTINE_DIR:-}" ] &&
+    safe_legacy_quarantine_path "$LEGACY_QUARANTINE_DIR" &&
+    [ "${1-}" = \
+      "$LEGACY_QUARANTINE_DIR/$LAUNCHAGENT_LABEL.plist" ]
+}
+
+create_canonical_plist_from_legacy() {
+  if [ "$ORIGINAL_PLIST_PRESENT" = "1" ] ||
+     [ "$LEGACY_PLIST_PRESENT" != "1" ]; then
+    return 1
+  fi
+  if ! safe_legacy_quarantine_path "$LEGACY_QUARANTINE_DIR" ||
+     [ -L "$LEGACY_QUARANTINE_PATH" ] ||
+     [ ! -f "$LEGACY_QUARANTINE_PATH" ] ||
+     [ "$(legacy_plist_fingerprint "$LEGACY_QUARANTINE_PATH")" != \
+       "$LEGACY_PLIST_FINGERPRINT" ]; then
+    die "Retired legacy plist is unavailable or changed; cannot create the canonical LaunchAgent."
+  fi
+  if [ -e "$PLIST_PATH" ] || [ -L "$PLIST_PATH" ]; then
+    die "Canonical LaunchAgent appeared during legacy migration; refusing to overwrite it."
+  fi
+
+  LEGACY_CANONICAL_STAGED_PATH="$LEGACY_QUARANTINE_DIR/$LAUNCHAGENT_LABEL.plist"
+  if [ -e "$LEGACY_CANONICAL_STAGED_PATH" ] ||
+     [ -L "$LEGACY_CANONICAL_STAGED_PATH" ] ||
+     ! /bin/cp -p \
+       "$LEGACY_QUARANTINE_PATH" "$LEGACY_CANONICAL_STAGED_PATH"; then
+    die "Could not stage a canonical LaunchAgent from the retired legacy plist."
+  fi
+  if ! replace_plist_string Label "$LAUNCHAGENT_LABEL" \
+       "$LEGACY_CANONICAL_STAGED_PATH" ||
+     ! replace_plist_string ProgramArguments.0 "$APP_DAEMON_BIN" \
+       "$LEGACY_CANONICAL_STAGED_PATH" ||
+     ! replace_plist_string StandardOutPath \
+       "$LOG_DIR/heimdallm-daemon.log" "$LEGACY_CANONICAL_STAGED_PATH" ||
+     ! replace_plist_string StandardErrorPath \
+       "$LOG_DIR/heimdallm-daemon-error.log" \
+       "$LEGACY_CANONICAL_STAGED_PATH" ||
+     ! /bin/chmod 600 "$LEGACY_CANONICAL_STAGED_PATH"; then
+    die "Could not convert the legacy plist to the canonical LaunchAgent schema."
+  fi
+  LEGACY_CANONICAL_FINGERPRINT=$(
+    legacy_plist_fingerprint "$LEGACY_CANONICAL_STAGED_PATH"
+  )
+
+  if ! /bin/mkdir -p "$LOG_DIR" || ! /bin/chmod 700 "$LOG_DIR"; then
+    die "Could not prepare canonical Heimdallm logs for the migrated LaunchAgent."
+  fi
+  LEGACY_CANONICAL_MOVE_INTENDED=1
+  if ! /bin/mv "$LEGACY_CANONICAL_STAGED_PATH" "$PLIST_PATH"; then
+    die "Could not publish the canonical LaunchAgent plist."
+  fi
+  LEGACY_CANONICAL_CREATED=1
+  LEGACY_CANONICAL_MOVE_INTENDED=0
+  LEGACY_CANONICAL_STAGED_PATH=""
+
+  if ! verify_plist_program_path; then
+    die "Legacy-migrated LaunchAgent does not point at the installed daemon."
+  fi
+}
+
+remove_legacy_created_canonical() {
+  if [ "$ORIGINAL_PLIST_PRESENT" = "1" ]; then
+    return 0
+  fi
+
+  mi_canonical_present=0
+  if [ -e "$PLIST_PATH" ] || [ -L "$PLIST_PATH" ]; then
+    mi_canonical_present=1
+  fi
+  mi_canonical_stage_missing=0
+  if [ -z "$LEGACY_CANONICAL_STAGED_PATH" ] ||
+     { [ ! -e "$LEGACY_CANONICAL_STAGED_PATH" ] &&
+       [ ! -L "$LEGACY_CANONICAL_STAGED_PATH" ]; }; then
+    mi_canonical_stage_missing=1
+  fi
+  mi_canonical_was_created=0
+  if legacy_canonical_move_detected \
+    "$LEGACY_CANONICAL_CREATED" \
+    "$LEGACY_CANONICAL_MOVE_INTENDED" \
+    "$mi_canonical_stage_missing" "$mi_canonical_present"; then
+    mi_canonical_was_created=1
+  fi
+
+  if [ "$mi_canonical_was_created" = "1" ]; then
+    if [ -L "$PLIST_PATH" ] || [ ! -f "$PLIST_PATH" ] ||
+       [ -z "$LEGACY_CANONICAL_FINGERPRINT" ] ||
+       [ "$(legacy_plist_fingerprint "$PLIST_PATH")" != \
+         "$LEGACY_CANONICAL_FINGERPRINT" ] ||
+       ! /bin/rm -f "$PLIST_PATH"; then
+      error "Could not safely remove the canonical plist created from legacy state."
+      return 1
+    fi
+  fi
+
+  if [ -n "$LEGACY_CANONICAL_STAGED_PATH" ] &&
+     { [ -e "$LEGACY_CANONICAL_STAGED_PATH" ] ||
+       [ -L "$LEGACY_CANONICAL_STAGED_PATH" ]; }; then
+    if ! safe_legacy_quarantine_member "$LEGACY_CANONICAL_STAGED_PATH" ||
+       [ -L "$LEGACY_CANONICAL_STAGED_PATH" ] ||
+       [ ! -f "$LEGACY_CANONICAL_STAGED_PATH" ] ||
+       ! /bin/rm -f "$LEGACY_CANONICAL_STAGED_PATH"; then
+      error "Could not safely remove the staged canonical legacy migration plist."
+      return 1
+    fi
+  fi
+  LEGACY_CANONICAL_STAGED_PATH=""
+  LEGACY_CANONICAL_MOVE_INTENDED=0
+  LEGACY_CANONICAL_CREATED=0
+  return 0
+}
+
 wait_for_loaded_service_ready() {
   mi_service_wait=0
   while [ "$mi_service_wait" -lt "$SERVICE_READY_TIMEOUT_SECONDS" ]; do
@@ -1571,7 +2405,38 @@ wait_for_loaded_service_ready() {
 }
 
 migrate_launchagent() {
+  if [ "$ORIGINAL_PLIST_PRESENT" != "1" ] &&
+     [ "$LEGACY_PLIST_PRESENT" != "1" ]; then
+    return 0
+  fi
+
   if [ "$ORIGINAL_PLIST_PRESENT" != "1" ]; then
+    info "▶  Migrating the retired legacy LaunchAgent to the canonical service..."
+    create_canonical_plist_from_legacy
+    if [ "$LEGACY_DISABLED" = "1" ]; then
+      if ! legacy_launchctl disable "$SERVICE_TARGET"; then
+        die "Could not preserve the legacy disabled LaunchAgent state."
+      fi
+    elif ! legacy_launchctl enable "$SERVICE_TARGET"; then
+      die "Could not preserve the legacy enabled LaunchAgent state."
+    fi
+
+    if [ "$LEGACY_LOADED" = "1" ] &&
+       [ "$LEGACY_DISABLED" != "1" ]; then
+      if ! inspect_port || [ "$PORT_CLASS" != "free" ]; then
+        ROLLBACK_LEAVE_UNLOADED=1
+        die "Port $PORT is not free for the canonical replacement LaunchAgent."
+      fi
+      if ! legacy_launchctl bootstrap "$LAUNCH_DOMAIN" "$PLIST_PATH"; then
+        die "Could not bootstrap the canonical replacement LaunchAgent."
+      fi
+      if ! wait_for_loaded_service_ready; then
+        die "Canonical replacement LaunchAgent did not become ready on port $PORT."
+      fi
+    elif ! mi_legacy_migrated_state=$(launchagent_job_state) ||
+         [ "$mi_legacy_migrated_state" = "loaded" ]; then
+      die "Canonical replacement LaunchAgent was unexpectedly loaded."
+    fi
     return 0
   fi
 
@@ -1643,6 +2508,12 @@ finish_install() {
   info "      History:  $DATA_DIR"
   info "      Logs:     $LOG_DIR"
   info "      Keychain: service=heimdallm, account=github-token"
+  if [ -n "$LEGACY_QUARANTINE_PATH" ] &&
+     [ -f "$LEGACY_QUARANTINE_PATH" ]; then
+    info ""
+    info "    Retired legacy LaunchAgent backup:"
+    info "      $LEGACY_QUARANTINE_PATH"
+  fi
   if [ -n "$PREFLIGHT_FOREIGN_INFO" ]; then
     info ""
     print_foreign_warning "$PREFLIGHT_FOREIGN_INFO"
@@ -1653,6 +2524,7 @@ install_macos() {
   require_install_commands
   resolve_invoking_user
   snapshot_launchagent
+  snapshot_legacy_launchagent
 
   if ! inspect_port; then
     die "Cannot safely inspect port $PORT."
@@ -1687,6 +2559,7 @@ install_macos() {
   stage_bundle
   prepare_transaction
   stop_original_launchagent
+  retire_legacy_launchagent
 
   info "▶  Stopping running app-bundle processes..."
   if ! stop_bundle_processes; then
@@ -2118,6 +2991,11 @@ print_preserved_state() {
 uninstall_macos() {
   require_common_commands
   resolve_invoking_user
+  snapshot_legacy_launchagent
+  if [ "$LEGACY_PLIST_PRESENT" = "1" ] ||
+     [ "$LEGACY_LOADED" = "1" ]; then
+    die "A validated legacy $LEGACY_LAUNCHAGENT_LABEL service still exists. Run make install-macos first so it can be migrated safely, then retry uninstall."
+  fi
 
   if ! validate_purge_value "${PURGE-}"; then
     die "Invalid PURGE value; omit PURGE to preserve data or use PURGE=1 to delete it."

--- a/scripts/test-linux-install.sh
+++ b/scripts/test-linux-install.sh
@@ -22,8 +22,8 @@
 # trace in normal output.
 #
 # The static half also ties the Makefile to the invariant it depends on: `-x` only
-# matches while the daemon and app are exec'd with an empty argv, and that lives
-# in Dart. The static tests run everywhere; only the behavioural half needs Linux.
+# matches while the daemon is exec'd with an empty argv, and that lives in Dart.
+# The static tests run everywhere; only the behavioural half needs Linux.
 
 set -eu
 
@@ -169,16 +169,15 @@ else
     "$offenders"
 fi
 
-# ── 2. Static: the spawn sites must keep passing an empty argument list ───────
+# ── 2. Static: the spawn site must keep passing an empty argument list ────────
 #
 # `-x` requires the target's whole cmdline to equal the binary path, which holds
-# only while the daemon and app are exec'd with no arguments. That invariant lives
+# only while the daemon is exec'd with no arguments. That invariant lives
 # in Dart, far from the Makefile that depends on it: if a future change adds a
-# flag to either spawn, `pkill -x -f` silently stops matching and install-linux
+# flag to the spawn, `pkill -x -f` silently stops matching and install-linux
 # again leaves the old daemon running with no error. Comments cannot catch that,
 # so it is asserted here.
-SPAWN_SITES="flutter_app/lib/core/daemon/daemon_lifecycle.dart
-flutter_app/lib/core/platform/platform_services_desktop.dart"
+SPAWN_SITES="flutter_app/lib/core/platform/platform_services_desktop.dart"
 spawn_offenders=""
 for rel in $SPAWN_SITES; do
   f="$REPO_ROOT/$rel"
@@ -187,9 +186,9 @@ for rel in $SPAWN_SITES; do
 "
     continue
   fi
-  # Counted PER FILE, not globally: a global counter would still pass if the
-  # daemon spawn moved to a new file while the other listed site kept its own.
-  # Each listed file must contribute at least one call.
+  # Counted per canonical spawn file so moving the daemon launch elsewhere
+  # cannot make this guard pass vacuously. DaemonLifecycle deliberately no
+  # longer starts processes: PlatformServices owns the single launch boundary.
   calls=$(grep -c 'Process\.start(' "$f" || true)
   if [ "${calls:-0}" -eq 0 ]; then
     spawn_offenders="$spawn_offenders$rel: no Process.start call (did the spawn move?)
@@ -212,10 +211,10 @@ done
 [ -f "$WORK/spawn_offenders" ] || : > "$WORK/spawn_offenders"
 spawn_offenders="$spawn_offenders$(cat "$WORK/spawn_offenders")"
 if [ -n "$(printf '%s' "$spawn_offenders" | tr -d '[:space:]')" ]; then
-  fail 'a daemon/app spawn breaks the pkill -x contract (arguments, or site moved)' \
+  fail 'the daemon spawn breaks the pkill -x contract (arguments, or site moved)' \
     "$spawn_offenders"
 else
-  pass 'the daemon/app spawn sites still pass an empty argument list'
+  pass 'the daemon spawn site still passes an empty argument list'
 fi
 
 # ── Behavioural half (tests 3-7): gated on Linux + /proc ─────────────────────

--- a/scripts/test-macos-install.sh
+++ b/scripts/test-macos-install.sh
@@ -137,6 +137,9 @@ assert_value "derives log path" \
 assert_value "derives LaunchAgent path" \
   "/Users/alice/Library/LaunchAgents/com.heimdallm.daemon.plist" \
   "$PLIST_PATH"
+assert_value "derives legacy LaunchAgent path" \
+  "/Users/alice/Library/LaunchAgents/com.auto-pr.daemon.plist" \
+  "$LEGACY_PLIST_PATH"
 assert_accepts "accepts Linux home for cross-platform pure tests" \
   set_user_paths "/home/alice"
 assert_rejects "rejects empty home" set_user_paths ""
@@ -164,6 +167,35 @@ assert_rejects "rejects Applications root as work path" \
   safe_application_work_path "/Applications"
 assert_rejects "rejects short staging work path suffix" \
   safe_application_work_path "/Applications/.heimdallm-staging.ABC"
+assert_accepts "accepts exact legacy quarantine path" \
+  safe_legacy_quarantine_path \
+  "/home/alice/Library/LaunchAgents/.heimdallm-retired-auto-pr.ABC123"
+assert_rejects "rejects LaunchAgents root as legacy quarantine path" \
+  safe_legacy_quarantine_path "/home/alice/Library/LaunchAgents"
+assert_rejects "rejects unrelated legacy quarantine path" \
+  safe_legacy_quarantine_path "/tmp/.heimdallm-retired-auto-pr.ABC123"
+
+# The legacy migrator accepts only paths emitted by historical Heimdallm
+# installs. The old label alone never authorizes stopping an arbitrary job.
+assert_accepts "accepts historical checkout daemon path" \
+  validate_legacy_program_path \
+  "/home/alice/work/auto-pr/daemon/bin/auto-pr-daemon"
+assert_accepts "accepts historical direct-home checkout daemon path" \
+  validate_legacy_program_path "/home/alice/daemon/bin/auto-pr-daemon"
+assert_accepts "accepts historical hyphenated app daemon path" \
+  validate_legacy_program_path \
+  "/Applications/auto-pr.app/Contents/MacOS/auto-pr-daemon"
+assert_accepts "accepts historical underscored app daemon path" \
+  validate_legacy_program_path \
+  "/Applications/auto_pr.app/Contents/MacOS/auto-pr-daemon"
+assert_rejects "rejects another user's legacy-looking daemon" \
+  validate_legacy_program_path \
+  "/Users/mallory/auto-pr/daemon/bin/auto-pr-daemon"
+assert_rejects "rejects traversal in legacy daemon path" \
+  validate_legacy_program_path \
+  "/home/alice/work/../auto-pr/daemon/bin/auto-pr-daemon"
+assert_rejects "rejects renamed binary under an allowed checkout" \
+  validate_legacy_program_path "/home/alice/work/auto-pr/daemon/bin/heimdalld"
 
 # Flutter writes ui.pid without a trailing newline; retain the assigned value
 # even though POSIX read reports EOF as a non-zero status.
@@ -180,6 +212,14 @@ assert_output "classifies empty listener as free" \
   "free" classify_listener "" "" ""
 assert_output "classifies captured PID as service-owned" \
   "service" classify_listener "42" "$APP_DAEMON_BIN" "42"
+assert_output "classifies validated legacy LaunchAgent PID separately" \
+  "legacy-service" \
+  classify_listener "41" "/home/alice/work/auto-pr/daemon/bin/auto-pr-daemon" \
+  "42" "41" "/home/alice/work/auto-pr/daemon/bin/auto-pr-daemon"
+assert_output "rejects reused legacy PID with a different executable" \
+  "foreign" \
+  classify_listener "41" "/usr/bin/python3" "42" "41" \
+  "/home/alice/work/auto-pr/daemon/bin/auto-pr-daemon"
 assert_output "classifies exact UI binary as bundle-owned" \
   "bundle" classify_listener "43" "$APP_UI_BIN" "42"
 assert_output "classifies exact daemon binary as bundle-owned" \
@@ -209,16 +249,19 @@ assert_output "purge rejects another user's installed process" \
 assert_output "purge rejects an unresolved executable" \
   "foreign" classify_purge_holder "47" "" "501" "42" "501"
 
-# Reviewed 4 × 4 LaunchAgent/listener matrix.
+# Reviewed 4 × 5 LaunchAgent/listener matrix.
 assert_policy "absent" "free" "proceed"
 assert_policy "absent" "bundle" "stop-bundle"
 assert_policy "absent" "service" "abort-inconsistent"
+assert_policy "absent" "legacy-service" "retire-legacy"
 assert_policy "absent" "foreign" "warn"
 
 assert_policy "present-unloaded" "free" "migrate-unloaded"
 assert_policy "present-unloaded" "bundle" \
   "stop-bundle+migrate-unloaded"
 assert_policy "present-unloaded" "service" "abort-inconsistent"
+assert_policy "present-unloaded" "legacy-service" \
+  "retire-legacy+migrate-unloaded"
 assert_policy "present-unloaded" "foreign" \
   "warn+migrate-unloaded"
 
@@ -226,12 +269,16 @@ assert_policy "loaded-enabled" "free" "restart-service"
 assert_policy "loaded-enabled" "bundle" \
   "stop-bundle+restart-service"
 assert_policy "loaded-enabled" "service" "restart-service"
+assert_policy "loaded-enabled" "legacy-service" \
+  "retire-legacy+restart-service"
 assert_policy "loaded-enabled" "foreign" "abort-foreign"
 
 assert_policy "loaded-disabled" "free" "migrate-disabled"
 assert_policy "loaded-disabled" "bundle" \
   "stop-bundle+migrate-disabled"
 assert_policy "loaded-disabled" "service" "migrate-disabled"
+assert_policy "loaded-disabled" "legacy-service" \
+  "retire-legacy+migrate-disabled"
 assert_policy "loaded-disabled" "foreign" \
   "warn+migrate-disabled"
 
@@ -252,6 +299,24 @@ assert_accepts "path evidence closes new-move signal window" \
   rollback_new_move_detected "0" "1" "1" "1"
 assert_accepts "completed new-app flag is authoritative" \
   rollback_new_move_detected "1" "0" "0" "0"
+assert_rejects "legacy move intent before rename is not retired" \
+  legacy_move_detected "0" "1" "0" "0"
+assert_accepts "legacy path evidence closes move signal window" \
+  legacy_move_detected "0" "1" "1" "1"
+assert_accepts "completed legacy move flag is authoritative" \
+  legacy_move_detected "1" "0" "0" "0"
+assert_rejects "legacy stop intent alone is not a completed bootout" \
+  legacy_stop_detected "0" "1" "0"
+assert_accepts "unloaded job closes legacy bootout signal window" \
+  legacy_stop_detected "0" "1" "1"
+assert_accepts "completed legacy stop flag is authoritative" \
+  legacy_stop_detected "1" "0" "0"
+assert_rejects "canonical move intent alone is not publication" \
+  legacy_canonical_move_detected "0" "1" "0" "0"
+assert_accepts "canonical path evidence closes move signal window" \
+  legacy_canonical_move_detected "0" "1" "1" "1"
+assert_accepts "completed canonical move flag is authoritative" \
+  legacy_canonical_move_detected "1" "0" "0" "0"
 
 # EXIT/signal handlers roll back only an armed, uncommitted transaction.
 assert_rejects "disarmed failed install does not roll back" \
@@ -290,6 +355,204 @@ PRESERVE_TEMP=0
 assert_accepts "cleanup removes temp after protection is cleared" cleanup
 assert_rejects "formerly protected temp directory is gone" \
   test -e "$mi_preserved_dir"
+
+# Transaction-level legacy migration tests use real temporary files and fake
+# launchctl/process seams. They run on Linux CI without touching a user's
+# LaunchAgents and cover the state transitions that pure policy tests cannot.
+run_legacy_migration_case() (
+  mi_case_loaded=$1
+  mi_case_disabled=$2
+  mi_expect_canonical_loaded=$3
+  mi_case_root=$(mktemp -d "/tmp/heimdallm-legacy-test.XXXXXX")
+  trap '/bin/rm -rf "$mi_case_root"' 0 HUP INT TERM
+  /bin/mkdir -p "$mi_case_root/Library/LaunchAgents"
+  set_user_paths "$mi_case_root"
+  USER_UID=501
+  LAUNCH_DOMAIN="gui/$USER_UID"
+  SERVICE_TARGET="$LAUNCH_DOMAIN/$LAUNCHAGENT_LABEL"
+  LEGACY_SERVICE_TARGET="$LAUNCH_DOMAIN/$LEGACY_LAUNCHAGENT_LABEL"
+  mi_case_log="$mi_case_root/launchctl.log"
+  : > "$mi_case_log"
+  printf '%s\n' "legacy plist" > "$LEGACY_PLIST_PATH"
+
+  legacy_plist_uid() { printf '%s\n' "$USER_UID"; }
+  legacy_plist_mode() { printf '%s\n' "600"; }
+  legacy_plist_fingerprint() { /usr/bin/cksum < "$1"; }
+
+  init_runtime_state
+  ORIGINAL_PLIST_PRESENT=0
+  ORIGINAL_LOADED=0
+  ORIGINAL_DISABLED=0
+  LEGACY_PLIST_PRESENT=1
+  LEGACY_PLIST_MODE=600
+  LEGACY_PLIST_FINGERPRINT=$(legacy_plist_fingerprint "$LEGACY_PLIST_PATH")
+  LEGACY_PROGRAM_PATH="$USER_HOME/work/daemon/bin/auto-pr-daemon"
+  LEGACY_LOADED=$mi_case_loaded
+  LEGACY_DISABLED=$mi_case_disabled
+  LEGACY_PID=4242
+  LEGACY_PID_EXECUTABLE=$LEGACY_PROGRAM_PATH
+  LEGACY_PLIST_BACKUP="$mi_case_root/legacy-backup.plist"
+  /bin/cp -p "$LEGACY_PLIST_PATH" "$LEGACY_PLIST_BACKUP"
+  MOCK_LEGACY_LOADED=$mi_case_loaded
+  MOCK_CANONICAL_LOADED=0
+
+  revalidate_legacy_launchagent() { return 0; }
+  legacy_current_job_plist_path() { printf '%s\n' "$LEGACY_PLIST_PATH"; }
+  legacy_current_job_pid() { printf '%s\n' "$LEGACY_PID"; }
+  legacy_process_matches() { return 0; }
+  legacy_launchagent_job_state() {
+    if [ "$MOCK_LEGACY_LOADED" = "1" ]; then
+      printf '%s\n' loaded
+    else
+      printf '%s\n' unloaded
+    fi
+  }
+  launchagent_job_state() {
+    if [ "$MOCK_CANONICAL_LOADED" = "1" ]; then
+      printf '%s\n' loaded
+    else
+      printf '%s\n' unloaded
+    fi
+  }
+  legacy_launchctl() {
+    printf '%s\n' "$*" >> "$mi_case_log"
+    case "$1:$2" in
+      bootout:"$LEGACY_SERVICE_TARGET") MOCK_LEGACY_LOADED=0 ;;
+      bootout:"$SERVICE_TARGET") MOCK_CANONICAL_LOADED=0 ;;
+      bootstrap:"$LAUNCH_DOMAIN")
+        if [ "${3-}" = "$LEGACY_PLIST_PATH" ]; then
+          MOCK_LEGACY_LOADED=1
+        elif [ "${3-}" = "$PLIST_PATH" ]; then
+          MOCK_CANONICAL_LOADED=1
+        fi
+        ;;
+    esac
+    return 0
+  }
+  wait_for_legacy_job_unloaded() { [ "$MOCK_LEGACY_LOADED" = "0" ]; }
+  wait_for_pid_exit() { return 0; }
+  replace_plist_string() {
+    printf '%s=%s\n' "$1" "$2" >> "$3"
+  }
+  verify_plist_program_path() { [ -f "$PLIST_PATH" ]; }
+  inspect_port() { PORT_CLASS=free; return 0; }
+  wait_for_loaded_service_ready() { [ "$MOCK_CANONICAL_LOADED" = "1" ]; }
+  bootout_current_job() { MOCK_CANONICAL_LOADED=0; return 0; }
+  restore_plist_contents_and_flag() { return 0; }
+  stop_bundle_processes() { return 0; }
+
+  retire_legacy_launchagent
+  [ ! -e "$LEGACY_PLIST_PATH" ]
+  [ -f "$LEGACY_QUARANTINE_PATH" ]
+  migrate_launchagent
+  [ -f "$PLIST_PATH" ]
+  [ "$MOCK_LEGACY_LOADED" = "0" ]
+  [ "$MOCK_CANONICAL_LOADED" = "$mi_expect_canonical_loaded" ]
+
+  if [ "$mi_case_loaded" = "1" ] && [ "$mi_case_disabled" = "0" ]; then
+    rollback_install
+    [ ! -e "$PLIST_PATH" ]
+    [ -f "$LEGACY_PLIST_PATH" ]
+    [ "$MOCK_CANONICAL_LOADED" = "0" ]
+    [ "$MOCK_LEGACY_LOADED" = "1" ]
+  fi
+)
+
+assert_accepts "loaded enabled legacy migrates once and rolls back exactly" \
+  run_legacy_migration_case "1" "0" "1"
+assert_accepts "loaded disabled legacy becomes disabled and unloaded canonical" \
+  run_legacy_migration_case "1" "1" "0"
+assert_accepts "unloaded legacy remains unloaded after canonical migration" \
+  run_legacy_migration_case "0" "0" "0"
+
+run_legacy_bootout_signal_window_case() (
+  mi_case_root=$(mktemp -d "/tmp/heimdallm-legacy-signal.XXXXXX")
+  trap '/bin/rm -rf "$mi_case_root"' 0 HUP INT TERM
+  /bin/mkdir -p "$mi_case_root/Library/LaunchAgents"
+  set_user_paths "$mi_case_root"
+  USER_UID=501
+  LAUNCH_DOMAIN="gui/$USER_UID"
+  SERVICE_TARGET="$LAUNCH_DOMAIN/$LAUNCHAGENT_LABEL"
+  LEGACY_SERVICE_TARGET="$LAUNCH_DOMAIN/$LEGACY_LAUNCHAGENT_LABEL"
+  printf '%s\n' "legacy plist" > "$LEGACY_PLIST_PATH"
+  init_runtime_state
+  LEGACY_PLIST_PRESENT=1
+  LEGACY_PLIST_MODE=600
+  LEGACY_PLIST_FINGERPRINT=$(/usr/bin/cksum < "$LEGACY_PLIST_PATH")
+  LEGACY_LOADED=1
+  LEGACY_DISABLED=0
+  LEGACY_STOP_INTENDED=1
+  LEGACY_STOPPED=0
+  MOCK_LEGACY_LOADED=0
+  ORIGINAL_PLIST_PRESENT=0
+  ORIGINAL_LOADED=0
+
+  legacy_plist_fingerprint() { /usr/bin/cksum < "$1"; }
+  legacy_launchagent_job_state() {
+    if [ "$MOCK_LEGACY_LOADED" = "1" ]; then
+      printf '%s\n' loaded
+    else
+      printf '%s\n' unloaded
+    fi
+  }
+  legacy_launchctl() {
+    if [ "$1" = bootstrap ]; then MOCK_LEGACY_LOADED=1; fi
+    return 0
+  }
+  inspect_port() { PORT_CLASS=free; return 0; }
+  bootout_current_job() { return 0; }
+  restore_plist_contents_and_flag() { return 0; }
+  stop_bundle_processes() { return 0; }
+
+  rollback_install
+  [ "$LEGACY_STOPPED" = "1" ]
+  [ "$MOCK_LEGACY_LOADED" = "1" ]
+)
+
+assert_accepts "rollback recovers a bootout completed inside signal window" \
+  run_legacy_bootout_signal_window_case
+
+run_signal_handler_case() (
+  mi_case_root=$(mktemp -d "/tmp/heimdallm-signal-handler.XXXXXX")
+  trap '/bin/rm -rf "$mi_case_root"' 0
+  mi_rollback_marker="$mi_case_root/rollback"
+  mi_cleanup_marker="$mi_case_root/cleanup"
+  rollback_install() { : > "$mi_rollback_marker"; }
+  cleanup() { : > "$mi_cleanup_marker"; }
+  ROLLBACK_ARMED=1
+  INSTALL_COMMITTED=0
+  if (handle_signal TERM 143); then
+    mi_signal_status=0
+  else
+    mi_signal_status=$?
+  fi
+  [ "$mi_signal_status" -eq 143 ] &&
+    [ -f "$mi_rollback_marker" ] && [ -f "$mi_cleanup_marker" ]
+)
+
+assert_accepts "TERM handler invokes rollback and cleanup with signal status" \
+  run_signal_handler_case
+
+run_legacy_uninstall_guard_case() (
+  mi_case_root=$(mktemp -d "/tmp/heimdallm-legacy-uninstall.XXXXXX")
+  trap '/bin/rm -rf "$mi_case_root"' 0 HUP INT TERM
+  mi_mutation_marker="$mi_case_root/mutated"
+  require_common_commands() { return 0; }
+  resolve_invoking_user() { return 0; }
+  snapshot_legacy_launchagent() {
+    LEGACY_PLIST_PRESENT=1
+    LEGACY_LOADED=0
+  }
+  remove_launchagent() { : > "$mi_mutation_marker"; }
+  if mi_guard_output=$(uninstall_macos 2>&1); then
+    return 1
+  fi
+  [ ! -e "$mi_mutation_marker" ] &&
+    printf '%s\n' "$mi_guard_output" | /usr/bin/grep -q "install-macos"
+)
+
+assert_accepts "uninstall rejects legacy state before any mutation" \
+  run_legacy_uninstall_guard_case
 
 if [ "$FAIL_COUNT" -ne 0 ]; then
   printf '\n%d of %d tests failed\n' "$FAIL_COUNT" "$TEST_COUNT" >&2


### PR DESCRIPTION
## Causa raíz

La app consideraba ausente cualquier daemon cuyo endpoint `/health` no devolviese 200. Un daemon degradado o todavía arrancando provocaba nuevos `Process.start`. Además, una instancia que perdía el bind del puerto podía continuar inicializando SQLite, NATS, pollers y workers sin HTTP, y el antiguo LaunchAgent `com.auto-pr.daemon` con `KeepAlive` podía relanzar binarios de checkouts históricos.

## Solución

- Adquiere un `flock` exclusivo por directorio de datos antes de configuración, SQLite o recuperación y lo conserva hasta la salida real del proceso.
- Reserva y sirve el puerto HTTP al principio; durante startup y shutdown solo expone un `/health` identificado y bloquea el resto de rutas.
- Cancela productores, workers y agentes antes de cerrar HTTP o liberar la exclusión.
- Distingue disponibilidad, salud e identidad en Flutter; serializa y limita los intentos de arranque.
- Sitúa la comprobación TCP definitiva justo antes de crear o reactivar el proceso. Solo una negativa explícita permite continuar; puerto ocupado o estado ambiguo fallan cerrados.
- Respeta el LaunchAgent canónico en macOS y usa `launchctl kickstart` sin crear un proceso detached paralelo.
- Migra de forma transaccional el LaunchAgent legacy, preserva su estado loaded/disabled y dispone de rollback ante errores o señales.
- Corrige el enrutado del primer setup y evita reinicios concurrentes desde la UI.

## Validación

- `make coverage-ci COVERAGE_BASE_REF=origin/main`
  - daemon diff: 313/339 (92,33 %)
  - Flutter diff: 226/250 (90,40 %)
  - CLI sin líneas ejecutables modificadas
- Flutter: 304/304 tests y `flutter analyze`
- `make test-install-macos`: 130/130
- `make build-web`
- `make test-cli && make lint-cli`
- `make test-compose-isolation`
- prueba local de exclusión: un segundo daemon sale con error y el único listener permanece intacto

Closes #646.
Supersedes #650.
